### PR TITLE
feat(l3): add ibing interleaved bidirectional allreduce kernel

### DIFF
--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
@@ -28,7 +28,7 @@
  * Scratch layout (per rank, in HCCL window):
  *   [0 .. P*subchunk)              ring0 chunks (clockwise ring)
  *   [P*subchunk .. 2*P*subchunk)   ring1 chunks (counter-clockwise ring)
- *   tail                           2*(P−1)*kMaxSupportedRanks int32 barrier rows
+ *   tail                           (2*(P−1)+1)*kMaxSupportedRanks int32 barrier rows
  */
 
 #include <cstdint>
@@ -93,7 +93,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     int my_rank = static_cast<int>(commCtx->rankId);
 
-    if (nranks <= 1 || nranks > kMaxSupportedRanks || (ALLREDUCE_COUNT % static_cast<size_t>(nranks)) != 0) {
+    if (nranks <= 1 || nranks > kMaxSupportedRanks || (ALLREDUCE_COUNT % (2ULL * static_cast<size_t>(nranks))) != 0) {
         pipe_barrier(PIPE_ALL);
         return;
     }
@@ -206,7 +206,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // Phase 3: allgather — P−1 barrier rounds.
     //
     // Ring0 (cw →right): send_idx = (r - step + 1 + P) % P
-    // Ring1 (ccw →left): send_idx = (r + step + 1 + P) % P
+    // Ring1 (ccw →left): send_idx = (r + step - 1 + P) % P
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
         const int rs_rounds = nranks - 1;

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
@@ -9,35 +9,26 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Bidirectional Ring AllReduce kernel — interleaved bidirectional RS+AG
- * implementing the IBing algorithm (Zong et al., ACM TACO 2025).
+ * Bidirectional Ring AllReduce — two parallel unidirectional rings on
+ * disjoint halves of the data, sharing RoundBarrier per step.
  *
- * Communication steps halved from 2(P-1) to P-1 by sending/receiving in
- * both HCCS directions simultaneously.  Reuses TLOAD/TNOTIFY/TWAIT/TADD
- * primitives unchanged — innovation at the schedule level.
+ * Ring 0 (clockwise, →right neighbour): first half of each chunk's elements.
+ *   Uses standard unidirectional RS+AG formulas.
+ * Ring 1 (counter-clockwise, →left neighbour): second half of each chunk's
+ *   elements.  Mirrored unidirectional RS+AG formulas.
  *
- * Phase 1 (stage-in):      partition input → P chunk slots in window
- * Phase 2 (bidir RS+AG):   P-1 ring steps; first floor((P-1)/2) steps
- *                          TADD both received chunks; remaining steps
- *                          TSTORE-forward (allgather).
- * Phase 3 (stage-out):     chunks → output
+ * Both rings run reduce-scatter (P−1 barrier rounds) then allgather (P−1
+ * barrier rounds).  Total: 2(P−1) barrier rounds — same count as the
+ * unidirectional ring — but each round processes two subchunks (one per
+ * ring direction), doubling data throughput per barrier.
+ *
+ * On sim (POSIX shared memory): raw float* arithmetic into shared memory.
+ * On NPU hardware: TPUT<AtomicAdd/AtomicNone> for remote DMA writes.
  *
  * Scratch layout (per rank, in HCCL window):
- *   [0 .. P*chunk)              P chunk slots owned by this rank
- *   [P*chunk .. (P+1)*chunk)    exchange_left  — left-bound  publish buffer
- *   [(P+1)*chunk .. (P+2)*chunk) exchange_right — right-bound publish buffer
- *   tail                        (P-1) * kMaxSupportedRanks int32 barrier slots
- *
- * Two exchange buffers are required because each rank publishes two
- * different chunks per step — one TSTORE would overwrite the other before
- * the barrier.  The barrier signals both are ready.
- *
- * args layout (passed as Tensor arg slots):
- *   tensor(0) = input    (host-backed, framework-supplied device addr)
- *   tensor(1) = output   (host-backed, framework-supplied device addr)
- *   tensor(2) = scratch  (HCCL window slot, cross-rank addressable)
- *   scalar(0) = nranks
- *   scalar(1) = CommContext device pointer
+ *   [0 .. P*subchunk)              ring0 chunks (clockwise ring)
+ *   [P*subchunk .. 2*P*subchunk)   ring1 chunks (counter-clockwise ring)
+ *   tail                           2*(P−1)*kMaxSupportedRanks int32 barrier rows
  */
 
 #include <cstdint>
@@ -65,7 +56,6 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPt
     return (__gm__ T *)(ctx->windowsIn[pe] + offset);
 }
 
-// Per-round barrier row: used exactly once (AtomicAdd 0→1, TWAIT GE 1).
 AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
     for (int peer = 0; peer < nranks; ++peer) {
         if (peer == my_rank) {
@@ -99,8 +89,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
     using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
-    using Global = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
-    using TileData = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+    using GT = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
 
     int my_rank = static_cast<int>(commCtx->rankId);
 
@@ -109,191 +98,193 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         return;
     }
 
-    const int chunk_elems = static_cast<int>(ALLREDUCE_COUNT / static_cast<size_t>(nranks));
-    __gm__ float *chunks = scratch;
-    __gm__ float *exchange_left = scratch + static_cast<size_t>(nranks * chunk_elems);
-    __gm__ float *exchange_right = exchange_left + static_cast<size_t>(chunk_elems);
-    // Signal rows after float region: (P-1) rounds, kMaxSupportedRanks stride.
-    __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(exchange_right + static_cast<size_t>(chunk_elems));
+    const int subchunk_elems = static_cast<int>(ALLREDUCE_COUNT / (2 * static_cast<size_t>(nranks)));
+    const int chunk_elems = 2 * subchunk_elems;
+    const int ring_stride = nranks * subchunk_elems;
 
-    TileData chunkTile(1, chunk_elems);
-    TileData publishTile(1, chunk_elems);
-    TileData recvLeftTile(1, chunk_elems);
-    TileData recvRightTile(1, chunk_elems);
-    TASSIGN(chunkTile, 0x0);
-    TASSIGN(publishTile, 0x10000);
-    TASSIGN(recvLeftTile, 0x20000);
-    TASSIGN(recvRightTile, 0x30000);
+    __gm__ float *ring0 = scratch;                // clockwise ring — first half of each chunk
+    __gm__ float *ring1 = scratch + ring_stride;  // counter-clockwise ring — second half
+    __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>(2 * ring_stride));
 
-    ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
-    StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
+#ifndef __CPU_SIM
+    using TileSub = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+    TileSub pushTile(1, subchunk_elems);
+    TASSIGN(pushTile, 0x10000);
+#endif
 
-    // ------------------------------------------------------------------
-    // Phase 1: stage-in — partition local input into P chunk slots.
-    // ------------------------------------------------------------------
-    for (int chunk = 0; chunk < nranks; ++chunk) {
-        __gm__ float *dst = chunks + static_cast<size_t>(chunk * chunk_elems);
-        __gm__ float *src = input + static_cast<size_t>(chunk * chunk_elems);
-        Global srcG(src, chunkShape, chunkStride);
-        Global dstG(dst, chunkShape, chunkStride);
-        TLOAD(chunkTile, srcG);
-        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        TSTORE(dstG, chunkTile);
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    }
-    pipe_barrier(PIPE_ALL);
+    using TileSubStage = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+    TileSubStage stageTile(1, subchunk_elems);
+    TASSIGN(stageTile, 0x0);
+
+    ShapeDyn subShape(1, 1, 1, 1, subchunk_elems);
+    StrideDyn subStride(subchunk_elems, subchunk_elems, subchunk_elems, subchunk_elems, 1);
 
     // ------------------------------------------------------------------
-    // Phase 2: bidirectional RS+AG — P-1 ring steps.
-    //
-    // Per step s (1..P-1):
-    //   1. Publish two chunks to exchange buffers
-    //   2. RoundBarrier — notify all peers both chunks are ready
-    //   3. TLOAD from left neighbor's exchange_right + right neighbor's exchange_left
-    //   4. First floor((P-1)/2) steps: TADD both into chunks[]
-    //   5. Remaining steps: TSTORE both into chunks[] (allgather forward)
-    //
-    // Index formulas from IBing (Zong et al. 2025):
-    //   Right-bound publish:  idx = (r - s + P) % P  → exchange_right
-    //   Left-bound  publish:  idx = (r + s + P + 1) % P  → exchange_left
-    //   Receive from left:    accumulate at (left - s + P) % P
-    //   Receive from right:   accumulate at (right + s + P + 1) % P
+    // Phase 1: stage-in — split each logical chunk into ring0 (first half)
+    //           and ring1 (second half).
     // ------------------------------------------------------------------
-    int round = 0;
-    int reduce_steps = (nranks - 1) / 2;  // floor((P-1)/2)
-    if (nranks == 2) {
-        reduce_steps = 1;  // P=2: single step must always reduce (no forwarding needed)
-    }
-
-    for (int step = 1; step < nranks; ++step) {
-        const int left = (my_rank - 1 + nranks) % nranks;
-        const int right = (my_rank + 1) % nranks;
-
-        // Indices for the two chunks to publish this step.
-        const int right_send_idx = (my_rank - step + nranks) % nranks;
-        const int left_send_idx = (my_rank + step + nranks + 1) % nranks;
-
-        // Publish right-bound chunk → exchange_right.
+    for (int c = 0; c < nranks; ++c) {
+        // ring0 ← first half of chunk c.
         {
-            Global srcG(chunks + static_cast<size_t>(right_send_idx * chunk_elems), chunkShape, chunkStride);
-            Global dstG(exchange_right, chunkShape, chunkStride);
-            TLOAD(publishTile, srcG);
+            __gm__ float *dst = ring0 + static_cast<size_t>(c * subchunk_elems);
+            __gm__ float *src = input + static_cast<size_t>(c * chunk_elems);
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            TLOAD(stageTile, srcG);
             set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-            TSTORE(dstG, publishTile);
+            TSTORE(dstG, stageTile);
             set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
             wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         }
-
-        // Publish left-bound chunk → exchange_left.
+        // ring1 ← second half of chunk c.
         {
-            Global srcG(chunks + static_cast<size_t>(left_send_idx * chunk_elems), chunkShape, chunkStride);
-            Global dstG(exchange_left, chunkShape, chunkStride);
-            TLOAD(publishTile, srcG);
+            __gm__ float *dst = ring1 + static_cast<size_t>(c * subchunk_elems);
+            __gm__ float *src = input + static_cast<size_t>(c * chunk_elems + subchunk_elems);
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            TLOAD(stageTile, srcG);
             set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
-            TSTORE(dstG, publishTile);
+            TSTORE(dstG, stageTile);
             set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
             wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
         }
-        pipe_barrier(PIPE_ALL);
+    }
+    pipe_barrier(PIPE_ALL);
 
-        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
-        ++round;
+    const int left = (my_rank - 1 + nranks) % nranks;
+    const int right = (my_rank + 1) % nranks;
 
-        // Indices where received data accumulates locally.
-        const int acc_from_left_idx = (left - step + nranks) % nranks;
-        const int acc_from_right_idx = (right + step + nranks + 1) % nranks;
+    // ------------------------------------------------------------------
+    // Phase 2: reduce-scatter — P−1 barrier rounds.
+    //
+    // Ring0 (cw →right): send_idx = (r - s + P) % P
+    //   Pushes ring0[send_idx] to right neighbour at same index.
+    // Ring1 (ccw →left): send_idx = (r + s + P) % P
+    //   Pushes ring1[send_idx] to left neighbour at same index.
+    // ------------------------------------------------------------------
+    for (int step = 1; step < nranks; ++step) {
+        RoundBarrier(commCtx, signal_base + (step - 1) * kMaxSupportedRanks, my_rank, nranks);
 
-        // TLOAD from left neighbor's exchange_right.
+        // Ring0: push ring0[(r - step + P) % P] → right's ring0[same index].
         {
-            __gm__ float *remote_buf = CommRemotePtr(commCtx, exchange_right, left);
-            Global remoteG(remote_buf, chunkShape, chunkStride);
-            TLOAD(recvLeftTile, remoteG);
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            const int idx = (my_rank - step + nranks) % nranks;
+            __gm__ float *src = ring0 + static_cast<size_t>(idx * subchunk_elems);
+            __gm__ float *dst = CommRemotePtr(commCtx, src, right);
+#if defined(__CPU_SIM)
+            for (int i = 0; i < subchunk_elems; ++i) {
+                dst[i] += src[i];
+            }
+#else
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
+#endif
         }
 
-        // TLOAD from right neighbor's exchange_left.
+        // Ring1: push ring1[(r + step + P) % P] → left's ring1[same index].
         {
-            __gm__ float *remote_buf = CommRemotePtr(commCtx, exchange_left, right);
-            Global remoteG(remote_buf, chunkShape, chunkStride);
-            TLOAD(recvRightTile, remoteG);
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-        }
-
-        if (step <= reduce_steps) {
-            // --- Reduce phase: TADD both received chunks ---
-
-            // TADD from left into acc_from_left_idx.
-            {
-                Global accG(chunks + static_cast<size_t>(acc_from_left_idx * chunk_elems), chunkShape, chunkStride);
-                TLOAD(chunkTile, accG);
-                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
-                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
-                TADD(chunkTile, chunkTile, recvLeftTile);
-                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                TSTORE(accG, chunkTile);
-                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            const int idx = (my_rank + step + nranks) % nranks;
+            __gm__ float *src = ring1 + static_cast<size_t>(idx * subchunk_elems);
+            __gm__ float *dst = CommRemotePtr(commCtx, src, left);
+#if defined(__CPU_SIM)
+            for (int i = 0; i < subchunk_elems; ++i) {
+                dst[i] += src[i];
             }
-
-            // TADD from right into acc_from_right_idx.
-            {
-                Global accG(chunks + static_cast<size_t>(acc_from_right_idx * chunk_elems), chunkShape, chunkStride);
-                TLOAD(chunkTile, accG);
-                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
-                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
-                TADD(chunkTile, chunkTile, recvRightTile);
-                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-                TSTORE(accG, chunkTile);
-                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
-                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
-            }
-        } else {
-            // --- Allgather phase: TSTORE-forward both received chunks ---
-
-            {
-                Global dstG(chunks + static_cast<size_t>(acc_from_left_idx * chunk_elems), chunkShape, chunkStride);
-                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                TSTORE(dstG, recvLeftTile);
-                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            }
-
-            {
-                Global dstG(chunks + static_cast<size_t>(acc_from_right_idx * chunk_elems), chunkShape, chunkStride);
-                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-                TSTORE(dstG, recvRightTile);
-                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
-                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
-            }
+#else
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
+#endif
         }
 
         pipe_barrier(PIPE_ALL);
     }
 
     // ------------------------------------------------------------------
-    // Phase 3: stage-out — write concatenated chunks into local output.
+    // Phase 3: allgather — P−1 barrier rounds.
+    //
+    // Ring0 (cw →right): send_idx = (r - step + 1 + P) % P
+    // Ring1 (ccw →left): send_idx = (r + step + 1 + P) % P
     // ------------------------------------------------------------------
-    for (int chunk = 0; chunk < nranks; ++chunk) {
-        __gm__ float *dst = output + static_cast<size_t>(chunk * chunk_elems);
-        __gm__ float *src = chunks + static_cast<size_t>(chunk * chunk_elems);
-        Global srcG(src, chunkShape, chunkStride);
-        Global dstG(dst, chunkShape, chunkStride);
-        TLOAD(chunkTile, srcG);
-        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        TSTORE(dstG, chunkTile);
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    for (int step = 1; step < nranks; ++step) {
+        const int rs_rounds = nranks - 1;
+        RoundBarrier(commCtx, signal_base + (rs_rounds + step - 1) * kMaxSupportedRanks, my_rank, nranks);
+
+        // Ring0 AG.
+        {
+            const int idx = (my_rank - step + 1 + nranks) % nranks;
+            __gm__ float *src = ring0 + static_cast<size_t>(idx * subchunk_elems);
+            __gm__ float *dst = CommRemotePtr(commCtx, src, right);
+#if defined(__CPU_SIM)
+            for (int i = 0; i < subchunk_elems; ++i) {
+                dst[i] = src[i];
+            }
+#else
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
+#endif
+        }
+
+        // Ring1 AG: send_idx = (r + step - 1 + P) % P
+        // The chunk was received from rank r+1 in the previous AG step.
+        {
+            const int idx = (my_rank + step - 1 + nranks) % nranks;
+            __gm__ float *src = ring1 + static_cast<size_t>(idx * subchunk_elems);
+            __gm__ float *dst = CommRemotePtr(commCtx, src, left);
+#if defined(__CPU_SIM)
+            for (int i = 0; i < subchunk_elems; ++i) {
+                dst[i] = src[i];
+            }
+#else
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
+#endif
+        }
+
+        pipe_barrier(PIPE_ALL);
+    }
+
+    // Final sync barrier: ensure all AG writes are globally visible before
+    // stage-out reads from ring0/ring1.  Without this, remote writes from
+    // other ranks may not have propagated to shared memory yet.
+    if (nranks > 1) {
+        RoundBarrier(commCtx, signal_base + (2 * (nranks - 1)) * kMaxSupportedRanks, my_rank, nranks);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 4: stage-out — recombine ring0 and ring1 halves into output.
+    // ------------------------------------------------------------------
+    for (int c = 0; c < nranks; ++c) {
+        // First half of chunk c ← ring0.
+        {
+            __gm__ float *dst = output + static_cast<size_t>(c * chunk_elems);
+            __gm__ float *src = ring0 + static_cast<size_t>(c * subchunk_elems);
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            TLOAD(stageTile, srcG);
+            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            TSTORE(dstG, stageTile);
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        }
+        // Second half of chunk c ← ring1.
+        {
+            __gm__ float *dst = output + static_cast<size_t>(c * chunk_elems + subchunk_elems);
+            __gm__ float *src = ring1 + static_cast<size_t>(c * subchunk_elems);
+            GT srcG(src, subShape, subStride);
+            GT dstG(dst, subShape, subStride);
+            TLOAD(stageTile, srcG);
+            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstG, stageTile);
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+        }
     }
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Bidirectional Ring AllReduce kernel — interleaved bidirectional RS+AG
+ * implementing the IBing algorithm (Zong et al., ACM TACO 2025).
+ *
+ * Communication steps halved from 2(P-1) to P-1 by sending/receiving in
+ * both HCCS directions simultaneously.  Reuses TLOAD/TNOTIFY/TWAIT/TADD
+ * primitives unchanged — innovation at the schedule level.
+ *
+ * Phase 1 (stage-in):      partition input → P chunk slots in window
+ * Phase 2 (bidir RS+AG):   P-1 ring steps; first floor((P-1)/2) steps
+ *                          TADD both received chunks; remaining steps
+ *                          TSTORE-forward (allgather).
+ * Phase 3 (stage-out):     chunks → output
+ *
+ * Scratch layout (per rank, in HCCL window):
+ *   [0 .. P*chunk)              P chunk slots owned by this rank
+ *   [P*chunk .. (P+1)*chunk)    exchange_left  — left-bound  publish buffer
+ *   [(P+1)*chunk .. (P+2)*chunk) exchange_right — right-bound publish buffer
+ *   tail                        (P-1) * kMaxSupportedRanks int32 barrier slots
+ *
+ * Two exchange buffers are required because each rank publishes two
+ * different chunks per step — one TSTORE would overwrite the other before
+ * the barrier.  The barrier signals both are ready.
+ *
+ * args layout (passed as Tensor arg slots):
+ *   tensor(0) = input    (host-backed, framework-supplied device addr)
+ *   tensor(1) = output   (host-backed, framework-supplied device addr)
+ *   tensor(2) = scratch  (HCCL window slot, cross-rank addressable)
+ *   scalar(0) = nranks
+ *   scalar(1) = CommContext device pointer
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t ALLREDUCE_COUNT = 256;
+static constexpr int kMaxSupportedRanks = 16;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPtr, int pe) {
+    uint64_t localBase = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = (uint64_t)localPtr - localBase;
+    return (__gm__ T *)(ctx->windowsIn[pe] + offset);
+}
+
+// Per-round barrier row: used exactly once (AtomicAdd 0→1, TWAIT GE 1).
+AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) {
+            continue;
+        }
+        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_row + my_rank, peer);
+        pto::comm::Signal sig(remote_signal);
+        pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    }
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) {
+            continue;
+        }
+        pto::comm::Signal sig(signal_row + peer);
+        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
+    }
+    pipe_barrier(PIPE_ALL);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *scratch_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    int nranks = static_cast<int>(args[3]);
+    __gm__ CommContext *commCtx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+
+    __gm__ float *input = reinterpret_cast<__gm__ float *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
+    __gm__ float *scratch =
+        reinterpret_cast<__gm__ float *>(scratch_tensor->buffer.addr) + scratch_tensor->start_offset;
+
+    using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Global = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
+    using TileData = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+
+    int my_rank = static_cast<int>(commCtx->rankId);
+
+    if (nranks <= 1 || nranks > kMaxSupportedRanks || (ALLREDUCE_COUNT % static_cast<size_t>(nranks)) != 0) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+
+    const int chunk_elems = static_cast<int>(ALLREDUCE_COUNT / static_cast<size_t>(nranks));
+    __gm__ float *chunks = scratch;
+    __gm__ float *exchange_left = scratch + static_cast<size_t>(nranks * chunk_elems);
+    __gm__ float *exchange_right = exchange_left + static_cast<size_t>(chunk_elems);
+    // Signal rows after float region: (P-1) rounds, kMaxSupportedRanks stride.
+    __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(exchange_right + static_cast<size_t>(chunk_elems));
+
+    TileData chunkTile(1, chunk_elems);
+    TileData publishTile(1, chunk_elems);
+    TileData recvLeftTile(1, chunk_elems);
+    TileData recvRightTile(1, chunk_elems);
+    TASSIGN(chunkTile, 0x0);
+    TASSIGN(publishTile, 0x10000);
+    TASSIGN(recvLeftTile, 0x20000);
+    TASSIGN(recvRightTile, 0x30000);
+
+    ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
+    StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
+
+    // ------------------------------------------------------------------
+    // Phase 1: stage-in — partition local input into P chunk slots.
+    // ------------------------------------------------------------------
+    for (int chunk = 0; chunk < nranks; ++chunk) {
+        __gm__ float *dst = chunks + static_cast<size_t>(chunk * chunk_elems);
+        __gm__ float *src = input + static_cast<size_t>(chunk * chunk_elems);
+        Global srcG(src, chunkShape, chunkStride);
+        Global dstG(dst, chunkShape, chunkStride);
+        TLOAD(chunkTile, srcG);
+        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, chunkTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    }
+    pipe_barrier(PIPE_ALL);
+
+    // ------------------------------------------------------------------
+    // Phase 2: bidirectional RS+AG — P-1 ring steps.
+    //
+    // Per step s (1..P-1):
+    //   1. Publish two chunks to exchange buffers
+    //   2. RoundBarrier — notify all peers both chunks are ready
+    //   3. TLOAD from left neighbor's exchange_right + right neighbor's exchange_left
+    //   4. First floor((P-1)/2) steps: TADD both into chunks[]
+    //   5. Remaining steps: TSTORE both into chunks[] (allgather forward)
+    //
+    // Index formulas from IBing (Zong et al. 2025):
+    //   Right-bound publish:  idx = (r - s + P) % P  → exchange_right
+    //   Left-bound  publish:  idx = (r + s + P + 1) % P  → exchange_left
+    //   Receive from left:    accumulate at (left - s + P) % P
+    //   Receive from right:   accumulate at (right + s + P + 1) % P
+    // ------------------------------------------------------------------
+    int round = 0;
+    int reduce_steps = (nranks - 1) / 2;  // floor((P-1)/2)
+    if (nranks == 2) {
+        reduce_steps = 1;  // P=2: single step must always reduce (no forwarding needed)
+    }
+
+    for (int step = 1; step < nranks; ++step) {
+        const int left = (my_rank - 1 + nranks) % nranks;
+        const int right = (my_rank + 1) % nranks;
+
+        // Indices for the two chunks to publish this step.
+        const int right_send_idx = (my_rank - step + nranks) % nranks;
+        const int left_send_idx = (my_rank + step + nranks + 1) % nranks;
+
+        // Publish right-bound chunk → exchange_right.
+        {
+            Global srcG(chunks + static_cast<size_t>(right_send_idx * chunk_elems), chunkShape, chunkStride);
+            Global dstG(exchange_right, chunkShape, chunkStride);
+            TLOAD(publishTile, srcG);
+            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            TSTORE(dstG, publishTile);
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        }
+
+        // Publish left-bound chunk → exchange_left.
+        {
+            Global srcG(chunks + static_cast<size_t>(left_send_idx * chunk_elems), chunkShape, chunkStride);
+            Global dstG(exchange_left, chunkShape, chunkStride);
+            TLOAD(publishTile, srcG);
+            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstG, publishTile);
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+        }
+        pipe_barrier(PIPE_ALL);
+
+        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
+        ++round;
+
+        // Indices where received data accumulates locally.
+        const int acc_from_left_idx = (left - step + nranks) % nranks;
+        const int acc_from_right_idx = (right + step + nranks + 1) % nranks;
+
+        // TLOAD from left neighbor's exchange_right.
+        {
+            __gm__ float *remote_buf = CommRemotePtr(commCtx, exchange_right, left);
+            Global remoteG(remote_buf, chunkShape, chunkStride);
+            TLOAD(recvLeftTile, remoteG);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        }
+
+        // TLOAD from right neighbor's exchange_left.
+        {
+            __gm__ float *remote_buf = CommRemotePtr(commCtx, exchange_left, right);
+            Global remoteG(remote_buf, chunkShape, chunkStride);
+            TLOAD(recvRightTile, remoteG);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        }
+
+        if (step <= reduce_steps) {
+            // --- Reduce phase: TADD both received chunks ---
+
+            // TADD from left into acc_from_left_idx.
+            {
+                Global accG(chunks + static_cast<size_t>(acc_from_left_idx * chunk_elems), chunkShape, chunkStride);
+                TLOAD(chunkTile, accG);
+                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+                TADD(chunkTile, chunkTile, recvLeftTile);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                TSTORE(accG, chunkTile);
+                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            }
+
+            // TADD from right into acc_from_right_idx.
+            {
+                Global accG(chunks + static_cast<size_t>(acc_from_right_idx * chunk_elems), chunkShape, chunkStride);
+                TLOAD(chunkTile, accG);
+                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
+                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
+                TADD(chunkTile, chunkTile, recvRightTile);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                TSTORE(accG, chunkTile);
+                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+            }
+        } else {
+            // --- Allgather phase: TSTORE-forward both received chunks ---
+
+            {
+                Global dstG(chunks + static_cast<size_t>(acc_from_left_idx * chunk_elems), chunkShape, chunkStride);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                TSTORE(dstG, recvLeftTile);
+                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            }
+
+            {
+                Global dstG(chunks + static_cast<size_t>(acc_from_right_idx * chunk_elems), chunkShape, chunkStride);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                TSTORE(dstG, recvRightTile);
+                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+            }
+        }
+
+        pipe_barrier(PIPE_ALL);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 3: stage-out — write concatenated chunks into local output.
+    // ------------------------------------------------------------------
+    for (int chunk = 0; chunk < nranks; ++chunk) {
+        __gm__ float *dst = output + static_cast<size_t>(chunk * chunk_elems);
+        __gm__ float *src = chunks + static_cast<size_t>(chunk * chunk_elems);
+        Global srcG(src, chunkShape, chunkStride);
+        Global dstG(dst, chunkShape, chunkStride);
+        TLOAD(chunkTile, srcG);
+        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, chunkTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    }
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -22,14 +22,16 @@
  * Right-bound:  r pushes chunks[(r - s + P) % P]         → rank r+1
  * Left-bound:   r pushes chunks[(r + s + 1 + P) % P]    → rank r-1
  *
- * On CPU sim (POSIX shared memory): exchange buffers snapshot source
- * chunks before pushing, avoiding intra-round read/write races.
- * On NPU hardware (HCCL window): direct TPUT<AtomicAdd/AtomicNone>.
+ * Exchange buffers snapshot source chunks before pushing on all platforms,
+ * avoiding intra-round read/write races where a remote TPUT can modify a
+ * chunk between the right-bound and left-bound TLOAD within the same step.
+ * The double-barrier scheme ensures (a) prior writes are globally visible,
+ * (b) all snapshots complete, before any push reads the exchange buffers.
  *
  * Scratch layout (per rank, in HCCL window):
  *   [0 .. P*chunk_elems)                   P working chunks
- *   [P*chunk .. (P+1)*chunk)               exchange_right (CPU sim snapshot)
- *   [(P+1)*chunk .. (P+2)*chunk)          exchange_left  (CPU sim snapshot)
+ *   [P*chunk .. (P+1)*chunk)               exchange_right (snapshot buffer)
+ *   [(P+1)*chunk .. (P+2)*chunk)          exchange_left  (snapshot buffer)
  *   tail                   (2*(P-1)+1) * kMaxSupportedRanks int32 signals
  *
  * Divisibility: requires ALLREDUCE_COUNT % nranks == 0.
@@ -143,33 +145,28 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     //   Steps 1..⌊P/2⌋:     reduce  — AtomicAdd pushes from exchange buffers.
     //   Steps ⌊P/2⌋+1..P−1: forward — AtomicNone pushes (allgather).
     //
-    // CPU sim uses a double-barrier scheme:
+    // CPU sim and NPU both use a double-barrier scheme:
     //   1. Barrier A: ensure prior writes are globally visible.
     //   2. Snapshot:  copy src chunks → exchange buffers.
     //   3. Barrier B: ensure all snapshots complete.
     //   4. Push:      write exchange buffers → neighbour's chunks[].
     //
-    // This replicates the MPI exchange-buffer semantics of the original
-    // IBing paper in shared memory.  On NPU hardware the snapshots and
-    // second barrier are unnecessary (HCCL provides ordering guarantees).
+    // This replicates MPI exchange-buffer semantics.  Without snapshots,
+    // a remote TPUT can modify chunks[idx_l] between the right-bound and
+    // left-bound TLOAD within the same step, double-counting data.
     // ------------------------------------------------------------------
     const int left = (my_rank - 1 + nranks) % nranks;
     const int right = (my_rank + 1) % nranks;
     const int reduce_steps = nranks / 2;
 
     for (int step = 1; step < nranks; ++step) {
-#ifdef __CPU_SIM
         // Barrier A: all prior writes globally visible.
         RoundBarrier(commCtx, signal_base + (2 * (step - 1)) * kMaxSupportedRanks, my_rank, nranks);
-#else
-        RoundBarrier(commCtx, signal_base + (step - 1) * kMaxSupportedRanks, my_rank, nranks);
-#endif
 
         const int idx_r = (my_rank - step + nranks) % nranks;
         const int idx_l = (my_rank + step + nranks + 1) % nranks;
         const bool fwd = (step > reduce_steps);
 
-#ifdef __CPU_SIM
         // Snapshot source chunks into exchange buffers.
         for (int i = 0; i < chunk_elems; ++i)
             exchange_right[i] = chunks[static_cast<size_t>(idx_r * chunk_elems) + i];
@@ -178,7 +175,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
         // Barrier B: all snapshots complete — safe to push.
         RoundBarrier(commCtx, signal_base + (2 * (step - 1) + 1) * kMaxSupportedRanks, my_rank, nranks);
-#endif
 
         // Right-bound push.
         {
@@ -193,8 +189,8 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                     dst[i] += src[i];
             }
 #else
-            __gm__ float *src = chunks + static_cast<size_t>(idx_r * chunk_elems);
-            __gm__ float *dst = CommRemotePtr(commCtx, src, right);
+            __gm__ float *src = exchange_right;
+            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
             GT srcG(src, chunkShape, chunkStride);
             GT dstG(dst, chunkShape, chunkStride);
             if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
@@ -215,8 +211,8 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                     dst[i] += src[i];
             }
 #else
-            __gm__ float *src = chunks + static_cast<size_t>(idx_l * chunk_elems);
-            __gm__ float *dst = CommRemotePtr(commCtx, src, left);
+            __gm__ float *src = exchange_left;
+            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
             GT srcG(src, chunkShape, chunkStride);
             GT dstG(dst, chunkShape, chunkStride);
             if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
@@ -231,11 +227,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // Final sync: ensure all pushes are globally visible before stage-out.
     // ------------------------------------------------------------------
     if (nranks > 1) {
-#ifdef __CPU_SIM
         RoundBarrier(commCtx, signal_base + (2 * (nranks - 1)) * kMaxSupportedRanks, my_rank, nranks);
-#else
-        RoundBarrier(commCtx, signal_base + (nranks - 1) * kMaxSupportedRanks, my_rank, nranks);
-#endif
     }
 
     // ------------------------------------------------------------------

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -168,10 +168,48 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         const bool fwd = (step > reduce_steps);
 
         // Snapshot source chunks into exchange buffers.
+        //
+        // On NPU the snapshot stays on the MTE pipeline (TLOAD → TSTORE)
+        // so that pipe_barrier(PIPE_ALL) in the following RoundBarrier
+        // guarantees the exchange buffers are visible to subsequent MTE
+        // TLOADs inside TPUT.  Scalar-write snapshots are not flushed by
+        // PIPE_ALL and produce stale reads (zero accumulation).
+        //
+        // On CPU sim, scalar pointer writes into POSIX shm are sufficient
+        // because all ranks map the same physical pages and RoundBarrier's
+        // seq_cst atomics provide cross-process ordering.
+#ifdef __CPU_SIM
         for (int i = 0; i < chunk_elems; ++i)
             exchange_right[i] = chunks[static_cast<size_t>(idx_r * chunk_elems) + i];
         for (int i = 0; i < chunk_elems; ++i)
             exchange_left[i] = chunks[static_cast<size_t>(idx_l * chunk_elems) + i];
+#else
+        // exchange_right ← chunks[idx_r]
+        {
+            __gm__ float *src_r = chunks + static_cast<size_t>(idx_r * chunk_elems);
+            GT srcG_r(src_r, chunkShape, chunkStride);
+            GT dstG_r(exchange_right, chunkShape, chunkStride);
+            TLOAD(stageTile, srcG_r);
+            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            TSTORE(dstG_r, stageTile);
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        }
+        // exchange_left ← chunks[idx_l]
+        {
+            __gm__ float *src_l = chunks + static_cast<size_t>(idx_l * chunk_elems);
+            GT srcG_l(src_l, chunkShape, chunkStride);
+            GT dstG_l(exchange_left, chunkShape, chunkStride);
+            TLOAD(stageTile, srcG_l);
+            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstG_l, stageTile);
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+        }
+        pipe_barrier(PIPE_ALL);
+#endif
 
         // Barrier B: all snapshots complete — safe to push.
         RoundBarrier(commCtx, signal_base + (2 * (step - 1) + 1) * kMaxSupportedRanks, my_rank, nranks);

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * IBing Interleaved Bidirectional Ring AllReduce — faithful implementation
+ * of the algorithm by Zong et al., ACM TACO 2025.
+ *
+ * Unlike the two-ring bidirectional_ring variant (which runs separate RS
+ * and AG phases, 2(P-1)+1 barriers), this kernel implements the true
+ * IBing interleaved schedule: P-1 bidirectional rounds, each round
+ * pushing one chunk clockwise and one counter-clockwise, with the
+ * first ⌊P/2⌋ steps using AtomicAdd (reduce-scatter) and the remaining
+ * steps using AtomicNone (allgather-forward).
+ *
+ * Right-bound:  r pushes chunks[(r - s + P) % P]         → rank r+1
+ * Left-bound:   r pushes chunks[(r + s + 1 + P) % P]    → rank r-1
+ *
+ * On CPU sim (POSIX shared memory): exchange buffers snapshot source
+ * chunks before pushing, avoiding intra-round read/write races.
+ * On NPU hardware (HCCL window): direct TPUT<AtomicAdd/AtomicNone>.
+ *
+ * Scratch layout (per rank, in HCCL window):
+ *   [0 .. P*chunk_elems)                   P working chunks
+ *   [P*chunk .. (P+1)*chunk)               exchange_right (CPU sim snapshot)
+ *   [(P+1)*chunk .. (P+2)*chunk)          exchange_left  (CPU sim snapshot)
+ *   tail                   (2*(P-1)+1) * kMaxSupportedRanks int32 signals
+ *
+ * Divisibility: requires ALLREDUCE_COUNT % nranks == 0.
+ */
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t ALLREDUCE_COUNT = 256;
+static constexpr int kMaxSupportedRanks = 16;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPtr, int pe) {
+    uint64_t localBase = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = (uint64_t)localPtr - localBase;
+    return (__gm__ T *)(ctx->windowsIn[pe] + offset);
+}
+
+AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) continue;
+        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_row + my_rank, peer);
+        pto::comm::Signal sig(remote_signal);
+        pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    }
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) continue;
+        pto::comm::Signal sig(signal_row + peer);
+        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
+    }
+    pipe_barrier(PIPE_ALL);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *scratch_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    int nranks = static_cast<int>(args[3]);
+    __gm__ CommContext *commCtx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+
+    __gm__ float *input = reinterpret_cast<__gm__ float *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
+    __gm__ float *scratch =
+        reinterpret_cast<__gm__ float *>(scratch_tensor->buffer.addr) + scratch_tensor->start_offset;
+
+    using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using GT = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
+
+    int my_rank = static_cast<int>(commCtx->rankId);
+
+    if (nranks <= 1 || nranks > kMaxSupportedRanks || (ALLREDUCE_COUNT % static_cast<size_t>(nranks)) != 0) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+
+    const int chunk_elems = static_cast<int>(ALLREDUCE_COUNT / static_cast<size_t>(nranks));
+    __gm__ float *chunks = scratch;
+    __gm__ float *exchange_right = scratch + static_cast<size_t>(nranks * chunk_elems);
+    __gm__ float *exchange_left = exchange_right + static_cast<size_t>(chunk_elems);
+    __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(exchange_left + static_cast<size_t>(chunk_elems));
+
+    ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
+    StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
+
+#ifndef __CPU_SIM
+    using TilePush = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+    TilePush pushTile(1, chunk_elems);
+    TASSIGN(pushTile, 0x10000);
+#endif
+
+    using TileStage = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+    TileStage stageTile(1, chunk_elems);
+    TASSIGN(stageTile, 0x0);
+
+    // ------------------------------------------------------------------
+    // Phase 1: stage-in — copy P chunks from input to scratch.
+    // ------------------------------------------------------------------
+    for (int c = 0; c < nranks; ++c) {
+        __gm__ float *dst = chunks + static_cast<size_t>(c * chunk_elems);
+        __gm__ float *src = input + static_cast<size_t>(c * chunk_elems);
+        GT srcG(src, chunkShape, chunkStride);
+        GT dstG(dst, chunkShape, chunkStride);
+        TLOAD(stageTile, srcG);
+        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, stageTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    }
+    pipe_barrier(PIPE_ALL);
+
+    // ------------------------------------------------------------------
+    // Phase 2: IBing interleaved RS+AG — P−1 rounds.
+    //
+    // In each step s ∈ [1, P−1]:
+    //   - Push chunk (r - s + P) % P to right neighbour.
+    //   - Push chunk (r + s + 1 + P) % P to left neighbour.
+    //
+    //   Steps 1..⌊P/2⌋:     reduce  — AtomicAdd pushes from exchange buffers.
+    //   Steps ⌊P/2⌋+1..P−1: forward — AtomicNone pushes (allgather).
+    //
+    // CPU sim uses a double-barrier scheme:
+    //   1. Barrier A: ensure prior writes are globally visible.
+    //   2. Snapshot:  copy src chunks → exchange buffers.
+    //   3. Barrier B: ensure all snapshots complete.
+    //   4. Push:      write exchange buffers → neighbour's chunks[].
+    //
+    // This replicates the MPI exchange-buffer semantics of the original
+    // IBing paper in shared memory.  On NPU hardware the snapshots and
+    // second barrier are unnecessary (HCCL provides ordering guarantees).
+    // ------------------------------------------------------------------
+    const int left = (my_rank - 1 + nranks) % nranks;
+    const int right = (my_rank + 1) % nranks;
+    const int reduce_steps = nranks / 2;
+
+    for (int step = 1; step < nranks; ++step) {
+#ifdef __CPU_SIM
+        // Barrier A: all prior writes globally visible.
+        RoundBarrier(commCtx, signal_base + (2 * (step - 1)) * kMaxSupportedRanks, my_rank, nranks);
+#else
+        RoundBarrier(commCtx, signal_base + (step - 1) * kMaxSupportedRanks, my_rank, nranks);
+#endif
+
+        const int idx_r = (my_rank - step + nranks) % nranks;
+        const int idx_l = (my_rank + step + nranks + 1) % nranks;
+        const bool fwd = (step > reduce_steps);
+
+#ifdef __CPU_SIM
+        // Snapshot source chunks into exchange buffers.
+        for (int i = 0; i < chunk_elems; ++i)
+            exchange_right[i] = chunks[static_cast<size_t>(idx_r * chunk_elems) + i];
+        for (int i = 0; i < chunk_elems; ++i)
+            exchange_left[i] = chunks[static_cast<size_t>(idx_l * chunk_elems) + i];
+
+        // Barrier B: all snapshots complete — safe to push.
+        RoundBarrier(commCtx, signal_base + (2 * (step - 1) + 1) * kMaxSupportedRanks, my_rank, nranks);
+#endif
+
+        // Right-bound push.
+        {
+#ifdef __CPU_SIM
+            __gm__ float *src = exchange_right;
+            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
+            if (fwd) {
+                for (int i = 0; i < chunk_elems; ++i)
+                    dst[i] = src[i];
+            } else {
+                for (int i = 0; i < chunk_elems; ++i)
+                    dst[i] += src[i];
+            }
+#else
+            __gm__ float *src = chunks + static_cast<size_t>(idx_r * chunk_elems);
+            __gm__ float *dst = CommRemotePtr(commCtx, src, right);
+            GT srcG(src, chunkShape, chunkStride);
+            GT dstG(dst, chunkShape, chunkStride);
+            if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
+            else pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
+#endif
+        }
+
+        // Left-bound push.
+        {
+#ifdef __CPU_SIM
+            __gm__ float *src = exchange_left;
+            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
+            if (fwd) {
+                for (int i = 0; i < chunk_elems; ++i)
+                    dst[i] = src[i];
+            } else {
+                for (int i = 0; i < chunk_elems; ++i)
+                    dst[i] += src[i];
+            }
+#else
+            __gm__ float *src = chunks + static_cast<size_t>(idx_l * chunk_elems);
+            __gm__ float *dst = CommRemotePtr(commCtx, src, left);
+            GT srcG(src, chunkShape, chunkStride);
+            GT dstG(dst, chunkShape, chunkStride);
+            if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
+            else pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
+#endif
+        }
+
+        pipe_barrier(PIPE_ALL);
+    }
+
+    // ------------------------------------------------------------------
+    // Final sync: ensure all pushes are globally visible before stage-out.
+    // ------------------------------------------------------------------
+    if (nranks > 1) {
+#ifdef __CPU_SIM
+        RoundBarrier(commCtx, signal_base + (2 * (nranks - 1)) * kMaxSupportedRanks, my_rank, nranks);
+#else
+        RoundBarrier(commCtx, signal_base + (nranks - 1) * kMaxSupportedRanks, my_rank, nranks);
+#endif
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 3: stage-out — copy P fully-reduced chunks to output.
+    // ------------------------------------------------------------------
+    for (int c = 0; c < nranks; ++c) {
+        __gm__ float *dst = output + static_cast<size_t>(c * chunk_elems);
+        __gm__ float *src = chunks + static_cast<size_t>(c * chunk_elems);
+        GT srcG(src, chunkShape, chunkStride);
+        GT dstG(dst, chunkShape, chunkStride);
+        TLOAD(stageTile, srcG);
+        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, stageTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    }
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_bidirectional_ring_orch.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_bidirectional_ring_orch.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Bidirectional Ring AllReduce orchestration — kernel shim.
+ *
+ * Three Tensor args (the kernel reads ``Tensor->buffer.addr`` + start_offset
+ * to get the real device pointer) plus two scalars:
+ *
+ *   tensor(0) input   INPUT           (plain device mem, staged in by bootstrap)
+ *   tensor(1) output  OUTPUT_EXISTING (plain device mem, flushed by bootstrap)
+ *   tensor(2) scratch INOUT           (HCCL window; bidir RS+AG in AIV kernel)
+ *   scalar(0) nranks
+ *   scalar(1) CommContext device pointer
+ *
+ * INOUT on scratch expresses that the kernel both writes (stage-in, publish)
+ * and reads (remote TLOAD from exchange buffers) it.
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+allreduce_bidirectional_ring_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 5,  // 3 tensors + 2 scalars
+    };
+}
+
+__attribute__((visibility("default"))) void allreduce_bidirectional_ring_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
+
+    L0TaskArgs params;
+    params.add_input(input);
+    params.add_output(output);
+    params.add_inout(scratch);
+    params.add_scalar(orch_args.scalar(0));  // nranks
+    params.add_scalar(orch_args.scalar(1));  // CommContext
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_ibing_orch.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_ibing_orch.cpp
@@ -9,20 +9,19 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Bidirectional Ring AllReduce orchestration — kernel shim.
+ * IBing AllReduce orchestration — kernel shim.
  *
- * Three Tensor args (the kernel reads ``Tensor->buffer.addr`` + start_offset
- * to get the real device pointer) plus two scalars:
+ * Three Tensor args plus two scalars:
  *
  *   tensor(0) input   INPUT           (plain device mem, staged in by bootstrap)
  *   tensor(1) output  OUTPUT_EXISTING (plain device mem, flushed by bootstrap)
- *   tensor(2) scratch INOUT           (HCCL window; bidir RS+AG in AIV kernel)
+ *   tensor(2) scratch INOUT           (HCCL window; IBing interleaved RS+AG in AIV kernel)
  *   scalar(0) nranks
  *   scalar(1) CommContext device pointer
  *
  * INOUT on scratch expresses that the kernel both writes (stage-in, push
- * to neighbours) and receives (remote atomic-add pushes from neighbours
- * into its own ring0/ring1 slots).
+ * to neighbours) and is updated by neighbours (remote atomic pushes
+ * land directly in the local chunks[] array).
  */
 
 #include <stdint.h>
@@ -32,14 +31,14 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-allreduce_bidirectional_ring_orchestration_config(const L2TaskArgs &orch_args) {
+allreduce_ibing_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void allreduce_bidirectional_ring_orchestration(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void allreduce_ibing_orchestration(const L2TaskArgs &orch_args) {
     const Tensor &input = orch_args.tensor(0).ref();
     const Tensor &output = orch_args.tensor(1).ref();
     const Tensor &scratch = orch_args.tensor(2).ref();

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -140,9 +140,8 @@ def compute_scratch_params(mode: str, nranks: int) -> tuple[int, int, int]:
         scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
     elif mode == "ibing":
         # IBing interleaved: (P+2)*chunk_elems floats + 2*(P-1)+1 signal rows.
-        # CPU sim uses two RoundBarriers per step (snapshot barrier + push barrier),
-        # needing 2*(P-1)+1 rows.  NPU uses only P rows but we allocate for the
-        # CPU sim worst case.
+        # Double-barrier scheme (Barrier A + Barrier B per step) needs 2*(P-1)+1
+        # signal rows on all platforms (unified sim and NPU path).
         chunk_elems = ALLREDUCE_COUNT // nranks
         float_elems = (nranks + 2) * chunk_elems
         signal_tail_nbytes = (2 * (nranks - 1) + 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -225,6 +225,10 @@ def run(
     # Ring requires ALLREDUCE_COUNT divisible by nranks; bidirectional_ring
     # (two-ring design) requires ALLREDUCE_COUNT divisible by 2*nranks.
     # ibing requires ALLREDUCE_COUNT divisible by nranks (contiguous chunks).
+    # ibing is limited to P=2: for P>=4 the AtomicNone forward phase overwrites
+    # peer chunks that are not yet fully reduced (shared-memory push-model race).
+    if mode == "ibing" and nranks != 2:
+        raise ValueError(f"ibing mode is only supported for nranks=2, got nranks={nranks}")
     if mode in ("twophase", "ring", "ibing") and ALLREDUCE_COUNT % nranks != 0:
         raise ValueError(f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={nranks} for {mode} mode")
     if mode in ("bidirectional_ring",) and ALLREDUCE_COUNT % (2 * nranks) != 0:

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """End-to-end distributed allreduce with selectable algorithm variant.
 
-Four algorithm modes are available via --mode:
+Five algorithm modes are available via --mode:
 
   onephase   (default) Mesh direct: read full vector from all peers, accumulate.
              Best for small P (2-4), simplest implementation.
@@ -20,10 +20,13 @@ Four algorithm modes are available via --mode:
   ring       Ring RS+AG: chunked reduce-scatter + allgather with neighbor barriers.
              Best for large P (8+), bandwidth-optimal (2*(P-1)/P * N).
 
-  bidirectional_ring  Bidirectional interleaved ring RS+AG implementing the IBing
-             algorithm (Zong et al., ACM TACO 2025).  Communication steps halved
-             from 2(P-1) to P-1 by sending/receiving in both HCCS directions
-             simultaneously.  Best for small-N (α-dominated) workloads.
+  bidirectional_ring  Two-ring bidirectional RS+AG on disjoint data halves.
+             Same 2(P-1) barrier count as unidirectional ring but doubles data
+             throughput per barrier by exploiting both HCCS directions.
+
+  ibing      IBing paper-faithful interleaved RS+AG (Zong et al., ACM TACO 2025).
+             P-1 rounds, exchange buffers, mixed AtomicAdd/AtomicNone phases.
+             Verified for P=2 (no forward phase).
 
 Each rank owns a private input/output tensor; cross-rank communication happens
 strictly inside the kernel, via a communication window scratch slot.
@@ -75,6 +78,7 @@ KERNEL_MAP = {
     "twophase": "kernels/aiv/allreduce_twophase_kernel.cpp",
     "ring": "kernels/aiv/allreduce_ring_kernel.cpp",
     "bidirectional_ring": "kernels/aiv/allreduce_bidirectional_ring_kernel.cpp",
+    "ibing": "kernels/aiv/allreduce_ibing_kernel.cpp",
 }
 ORCH_MAP = {
     "onephase": (
@@ -96,6 +100,11 @@ ORCH_MAP = {
         "kernels/orchestration/allreduce_bidirectional_ring_orch.cpp",
         "allreduce_bidirectional_ring_orchestration",
         "allreduce_bidirectional_ring_orchestration_config",
+    ),
+    "ibing": (
+        "kernels/orchestration/allreduce_ibing_orch.cpp",
+        "allreduce_ibing_orchestration",
+        "allreduce_ibing_orchestration_config",
     ),
 }
 
@@ -124,10 +133,18 @@ def compute_scratch_params(mode: str, nranks: int) -> tuple[int, int, int]:
         signal_tail_nbytes = 2 * (nranks - 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
         scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
     elif mode == "bidirectional_ring":
-        # Two-ring design: ALLREDUCE_COUNT floats + (2*(P-1)+1) signal rows.
-        # The +1 accounts for the final sync barrier between AG and stage-out.
+        # Two-ring push design: ALLREDUCE_COUNT floats + (2*(P-1)+1) signal rows.
         subchunk_elems = ALLREDUCE_COUNT // (2 * nranks)
         float_elems = 2 * nranks * subchunk_elems  # = ALLREDUCE_COUNT
+        signal_tail_nbytes = (2 * (nranks - 1) + 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
+        scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
+    elif mode == "ibing":
+        # IBing interleaved: (P+2)*chunk_elems floats + 2*(P-1)+1 signal rows.
+        # CPU sim uses two RoundBarriers per step (snapshot barrier + push barrier),
+        # needing 2*(P-1)+1 rows.  NPU uses only P rows but we allocate for the
+        # CPU sim worst case.
+        chunk_elems = ALLREDUCE_COUNT // nranks
+        float_elems = (nranks + 2) * chunk_elems
         signal_tail_nbytes = (2 * (nranks - 1) + 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
         scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
     else:
@@ -208,9 +225,10 @@ def run(
 
     # Ring requires ALLREDUCE_COUNT divisible by nranks; bidirectional_ring
     # (two-ring design) requires ALLREDUCE_COUNT divisible by 2*nranks.
-    if mode in ("twophase", "ring") and ALLREDUCE_COUNT % nranks != 0:
+    # ibing requires ALLREDUCE_COUNT divisible by nranks (contiguous chunks).
+    if mode in ("twophase", "ring", "ibing") and ALLREDUCE_COUNT % nranks != 0:
         raise ValueError(f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={nranks} for {mode} mode")
-    if mode == "bidirectional_ring" and ALLREDUCE_COUNT % (2 * nranks) != 0:
+    if mode in ("bidirectional_ring",) and ALLREDUCE_COUNT % (2 * nranks) != 0:
         raise ValueError(
             f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by 2*nranks={2 * nranks} for {mode} mode"
         )
@@ -304,11 +322,12 @@ def main() -> int:
     parser.add_argument(
         "-m",
         "--mode",
-        choices=["onephase", "twophase", "ring", "bidirectional_ring"],
+        choices=["onephase", "twophase", "ring", "bidirectional_ring", "ibing"],
         default="onephase",
         help=(
             "Allreduce algorithm variant: onephase (mesh direct), twophase (mesh RS+AG), "
-            "ring (ring RS+AG), bidirectional_ring (interleaved bidirectional ring RS+AG)."
+            "ring (ring RS+AG), bidirectional_ring (two-ring push RS+AG), "
+            "ibing (IBing interleaved bidirectional, Zong et al. 2025)."
         ),
     )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """End-to-end distributed allreduce with selectable algorithm variant.
 
-Three algorithm modes are available via --mode:
+Four algorithm modes are available via --mode:
 
   onephase   (default) Mesh direct: read full vector from all peers, accumulate.
              Best for small P (2-4), simplest implementation.
@@ -20,6 +20,11 @@ Three algorithm modes are available via --mode:
   ring       Ring RS+AG: chunked reduce-scatter + allgather with neighbor barriers.
              Best for large P (8+), bandwidth-optimal (2*(P-1)/P * N).
 
+  bidirectional_ring  Bidirectional interleaved ring RS+AG implementing the IBing
+             algorithm (Zong et al., ACM TACO 2025).  Communication steps halved
+             from 2(P-1) to P-1 by sending/receiving in both HCCS directions
+             simultaneously.  Best for small-N (α-dominated) workloads.
+
 Each rank owns a private input/output tensor; cross-rank communication happens
 strictly inside the kernel, via a communication window scratch slot.
 
@@ -27,6 +32,7 @@ Run examples:
     python main.py -p a2a3sim -d 0-1 --mode onephase
     python main.py -p a2a3sim -d 0-3 --mode twophase
     python main.py -p a2a3sim -d 0-3 --mode ring
+    python main.py -p a2a3sim -d 0-3 --mode bidirectional_ring
 
 """
 
@@ -68,6 +74,7 @@ KERNEL_MAP = {
     "onephase": "kernels/aiv/allreduce_onephase_kernel.cpp",
     "twophase": "kernels/aiv/allreduce_twophase_kernel.cpp",
     "ring": "kernels/aiv/allreduce_ring_kernel.cpp",
+    "bidirectional_ring": "kernels/aiv/allreduce_bidirectional_ring_kernel.cpp",
 }
 ORCH_MAP = {
     "onephase": (
@@ -84,6 +91,11 @@ ORCH_MAP = {
         "kernels/orchestration/allreduce_ring_orch.cpp",
         "allreduce_ring_orchestration",
         "allreduce_ring_orchestration_config",
+    ),
+    "bidirectional_ring": (
+        "kernels/orchestration/allreduce_bidirectional_ring_orch.cpp",
+        "allreduce_bidirectional_ring_orchestration",
+        "allreduce_bidirectional_ring_orchestration_config",
     ),
 }
 
@@ -110,6 +122,12 @@ def compute_scratch_params(mode: str, nranks: int) -> tuple[int, int, int]:
         chunk_elems = ALLREDUCE_COUNT // nranks
         float_elems = (nranks + 1) * chunk_elems
         signal_tail_nbytes = 2 * (nranks - 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
+        scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
+    elif mode == "bidirectional_ring":
+        # Bidirectional ring: (nranks+2) * chunk_elems floats (P chunks + 2 exchange) + (P-1) signal rows.
+        chunk_elems = ALLREDUCE_COUNT // nranks
+        float_elems = (nranks + 2) * chunk_elems
+        signal_tail_nbytes = (nranks - 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
         scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
     else:
         raise ValueError(f"Unsupported allreduce mode: {mode!r}. Expected one of {tuple(KERNEL_MAP.keys())}.")
@@ -187,8 +205,8 @@ def run(
     if not (2 <= nranks <= K_MAX_SUPPORTED_RANKS):
         raise ValueError(f"allreduce needs between 2 and {K_MAX_SUPPORTED_RANKS} devices, got {nranks} ({device_ids})")
 
-    # Ring and twophase require ALLREDUCE_COUNT divisible by nranks.
-    if mode in ("twophase", "ring") and ALLREDUCE_COUNT % nranks != 0:
+    # Ring and bidirectional_ring require ALLREDUCE_COUNT divisible by nranks.
+    if mode in ("twophase", "ring", "bidirectional_ring") and ALLREDUCE_COUNT % nranks != 0:
         raise ValueError(f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={nranks} for {mode} mode")
 
     float_elems, scratch_nbytes, window_size = compute_scratch_params(mode, nranks)
@@ -280,9 +298,12 @@ def main() -> int:
     parser.add_argument(
         "-m",
         "--mode",
-        choices=["onephase", "twophase", "ring"],
+        choices=["onephase", "twophase", "ring", "bidirectional_ring"],
         default="onephase",
-        help="Allreduce algorithm variant: onephase (mesh direct), twophase (mesh RS+AG), ring (ring RS+AG).",
+        help=(
+            "Allreduce algorithm variant: onephase (mesh direct), twophase (mesh RS+AG), "
+            "ring (ring RS+AG), bidirectional_ring (interleaved bidirectional ring RS+AG)."
+        ),
     )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -124,10 +124,11 @@ def compute_scratch_params(mode: str, nranks: int) -> tuple[int, int, int]:
         signal_tail_nbytes = 2 * (nranks - 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
         scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
     elif mode == "bidirectional_ring":
-        # Bidirectional ring: (nranks+2) * chunk_elems floats (P chunks + 2 exchange) + (P-1) signal rows.
-        chunk_elems = ALLREDUCE_COUNT // nranks
-        float_elems = (nranks + 2) * chunk_elems
-        signal_tail_nbytes = (nranks - 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
+        # Two-ring design: ALLREDUCE_COUNT floats + (2*(P-1)+1) signal rows.
+        # The +1 accounts for the final sync barrier between AG and stage-out.
+        subchunk_elems = ALLREDUCE_COUNT // (2 * nranks)
+        float_elems = 2 * nranks * subchunk_elems  # = ALLREDUCE_COUNT
+        signal_tail_nbytes = (2 * (nranks - 1) + 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
         scratch_nbytes = float_elems * DTYPE_NBYTES + signal_tail_nbytes
     else:
         raise ValueError(f"Unsupported allreduce mode: {mode!r}. Expected one of {tuple(KERNEL_MAP.keys())}.")
@@ -205,9 +206,14 @@ def run(
     if not (2 <= nranks <= K_MAX_SUPPORTED_RANKS):
         raise ValueError(f"allreduce needs between 2 and {K_MAX_SUPPORTED_RANKS} devices, got {nranks} ({device_ids})")
 
-    # Ring and bidirectional_ring require ALLREDUCE_COUNT divisible by nranks.
-    if mode in ("twophase", "ring", "bidirectional_ring") and ALLREDUCE_COUNT % nranks != 0:
+    # Ring requires ALLREDUCE_COUNT divisible by nranks; bidirectional_ring
+    # (two-ring design) requires ALLREDUCE_COUNT divisible by 2*nranks.
+    if mode in ("twophase", "ring") and ALLREDUCE_COUNT % nranks != 0:
         raise ValueError(f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={nranks} for {mode} mode")
+    if mode == "bidirectional_ring" and ALLREDUCE_COUNT % (2 * nranks) != 0:
+        raise ValueError(
+            f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by 2*nranks={2 * nranks} for {mode} mode"
+        )
 
     float_elems, scratch_nbytes, window_size = compute_scratch_params(mode, nranks)
 

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -48,9 +48,12 @@ def test_allreduce_distributed_multi_rank(st_platform, st_device_ids, n_devices,
 
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(4)
-def test_allreduce_distributed_ibing_unsupported_ranks(st_platform, st_device_ids):
-    """ibing mode should raise ValueError for nranks != 2."""
-    assert len(st_device_ids) == 4
+@pytest.mark.device_count(2)
+def test_allreduce_distributed_ibing_unsupported_ranks(st_platform):
+    """ibing mode should raise ValueError for nranks != 2.
+
+    Uses synthetic 4-rank device IDs: run() validates nranks before worker init,
+    so no 4-device pool is required (2-device CI can run this case).
+    """
     with pytest.raises(ValueError, match="ibing mode is only supported for nranks=2"):
-        run([int(d) for d in st_device_ids], platform=st_platform, mode="ibing")
+        run([0, 1, 2, 3], platform=st_platform, mode="ibing")

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -16,7 +16,7 @@ from .main import run
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
-@pytest.mark.parametrize("mode", ["onephase", "twophase", "ring"])
+@pytest.mark.parametrize("mode", ["onephase", "twophase", "ring", "bidirectional_ring"])
 def test_allreduce_distributed(st_platform, st_device_ids, mode):
     """Test all three allreduce modes with 2 devices."""
     assert len(st_device_ids) == 2
@@ -32,10 +32,14 @@ def test_allreduce_distributed(st_platform, st_device_ids, mode):
         pytest.param(4, "onephase", marks=pytest.mark.device_count(4)),
         pytest.param(4, "twophase", marks=pytest.mark.device_count(4)),
         pytest.param(4, "ring", marks=pytest.mark.device_count(4)),
+        # TODO(#37): P=4 bidirectional_ring validation pending — IBing index
+        # formulas need refinement for P≥4 to prevent orphan chunk data loss
+        # during the forward phase. P=2 passes golden.
+        # pytest.param(4, "bidirectional_ring", marks=pytest.mark.device_count(4)),
     ],
 )
 def test_allreduce_distributed_multi_rank(st_platform, st_device_ids, n_devices, mode):
-    """Test all three allreduce modes with 4 devices.
+    """Test all allreduce modes with 4 devices.
 
     a5 onboard CI exposes only 2 NPUs, so >2-rank tests run on a2a3 hardware
     and both sims only.

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""ST for examples/workers/l3/allreduce_distributed — all three algorithm modes."""
+"""ST for examples/workers/l3/allreduce_distributed — all five tested algorithm modes."""
 
 import pytest
 
@@ -16,9 +16,9 @@ from .main import run
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
-@pytest.mark.parametrize("mode", ["onephase", "twophase", "ring", "bidirectional_ring"])
+@pytest.mark.parametrize("mode", ["onephase", "twophase", "ring", "bidirectional_ring", "ibing"])
 def test_allreduce_distributed(st_platform, st_device_ids, mode):
-    """Test all three allreduce modes with 2 devices."""
+    """Test all allreduce modes with 2 devices."""
     assert len(st_device_ids) == 2
     rc = run([int(d) for d in st_device_ids], platform=st_platform, mode=mode)
     assert rc == 0

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -44,3 +44,13 @@ def test_allreduce_distributed_multi_rank(st_platform, st_device_ids, n_devices,
     assert len(st_device_ids) == n_devices
     rc = run([int(d) for d in st_device_ids], platform=st_platform, mode=mode)
     assert rc == 0
+
+
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.device_count(4)
+def test_allreduce_distributed_ibing_unsupported_ranks(st_platform, st_device_ids):
+    """ibing mode should raise ValueError for nranks != 2."""
+    assert len(st_device_ids) == 4
+    with pytest.raises(ValueError, match="ibing mode is only supported for nranks=2"):
+        run([int(d) for d in st_device_ids], platform=st_platform, mode="ibing")

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -32,10 +32,7 @@ def test_allreduce_distributed(st_platform, st_device_ids, mode):
         pytest.param(4, "onephase", marks=pytest.mark.device_count(4)),
         pytest.param(4, "twophase", marks=pytest.mark.device_count(4)),
         pytest.param(4, "ring", marks=pytest.mark.device_count(4)),
-        # TODO(#37): P=4 bidirectional_ring validation pending — IBing index
-        # formulas need refinement for P≥4 to prevent orphan chunk data loss
-        # during the forward phase. P=2 passes golden.
-        # pytest.param(4, "bidirectional_ring", marks=pytest.mark.device_count(4)),
+        pytest.param(4, "bidirectional_ring", marks=pytest.mark.device_count(4)),
     ],
 )
 def test_allreduce_distributed_multi_rank(st_platform, st_device_ids, n_devices, mode):


### PR DESCRIPTION
## Summary

- Adds `--mode bidirectional_ring`: a two-ring adaptation that exploits both HCCS directions simultaneously. **Verified on NPU hardware for P=2 and P=4.**
- Adds `--mode ibing`: a faithful port of the IBing P−1 interleaved bidirectional ring AllReduce algorithm (Zong et al., ACM TACO 2025). **Verified on NPU hardware for P=2 only.**

## `bidirectional_ring` mode

Two parallel unidirectional rings on disjoint data halves (ring0 clockwise, ring1 counter-clockwise), sharing `RoundBarrier` per step. Each ring independently runs standard RS+AG, which is trivially correct because subchunk writes never conflict — every subchunk has a single writer per round.

- **Barrier rounds:** `2(P−1)+1` — same asymptotic as a unidirectional ring, but each round moves two subchunks (one per direction), doubling data throughput per barrier
- **Primitives:** `TPUT<AtomicAdd>` (reduce-scatter), `TPUT<AtomicNone>` (allgather) — push-model DMA
- **Scratch:** `ALLREDUCE_COUNT` floats + `(2(P−1)+1) × kMaxSupportedRanks` int32 signal rows
- **Divisibility:** requires `ALLREDUCE_COUNT % (2 × nranks) == 0`
- **Verification:**
  - [x] Sim Docker: P=2, P=4 golden match
  - [x] NPU hardware (Ascend 910B2): P=2 and P=4, `max_diff = 0.0`

## `ibing` mode — P=2 only

Implements the paper's exact P−1 interleaved RS+AG schedule with exchange buffers and a double-barrier scheme, replicating MPI's separate send/receive semantics. Uses the paper's index formulas (right-bound `r−s`, left-bound `r+s+1`) and the `⌊P/2⌋` reduce/forward split with mixed `AtomicAdd`/`AtomicNone` phases.

- **Barrier rounds:** `P−1` — matches the paper's asymptotic. For P=2 this is 1 round (vs. 3 for `bidirectional_ring`)
- **Exchange buffers:** `exchange_right`/`exchange_left` snapshot source chunks before each push. The double-barrier scheme (Barrier A → snapshot → Barrier B → push) prevents intra-round read/write races
- **NPU MTE pipeline fix:** On NPU, the snapshot uses `TLOAD`/`TSTORE` on the MTE pipeline rather than scalar writes, so that `pipe_barrier(PIPE_ALL)` inside `RoundBarrier` properly flushes the exchange buffers before `TPUT` reads them. Scalar-write snapshots are not drained by `PIPE_ALL` and produce stale reads (zero accumulation)
- **Verification:**
  - [x] Sim Docker: P=2 golden match
  - [x] NPU hardware (Ascend 910B2): P=2, `max_diff = 0.0`

### Why P≥4 is not supported

This is a **fundamental algorithmic limitation**, not a bug awaiting a fix.

The IBing paper targets MPI clusters where `Isend`/`Irecv` provides separate buffer spaces. The forward (allgather) phase writes into a receive buffer that is distinct from the working array. MPI then assembles the result by reading both buffers — the local contribution is never overwritten.

simpler uses `TPUT`, a push-model primitive where the sender writes directly into the receiver's `chunks[]` working array. After `⌊P/2⌋` reduce steps, no chunk is fully reduced — each is missing exactly one rank's contribution. During the forward phase, `TPUT<AtomicNone>` overwrites these partially-reduced chunks:

- `TPUT<AtomicNone>` is destructive overwrite — it destroys partial sums
- `TPUT<AtomicAdd>` would double-count contributions already present in the chunk

Neither mode produces correct results. No available pto-isa primitive changes this — the `⌊P/2⌋` reduce-step count is algorithmically insufficient for the interleaved schedule at P≥4 in a shared-memory model where sender and receiver share the same working array. This is precisely why `bidirectional_ring` exists as the practical alternative — it separates RS and AG into distinct phases with P−1 steps each, guaranteeing full reduction before forwarding begins.

See the extended analysis in `doc/bidirectional-ring-allreduce-development-report.md` for a step-by-step P=4 trace.

## Files

| File | Status |
|------|--------|
| `kernels/aiv/allreduce_bidirectional_ring_kernel.cpp` | new — 290 lines |
| `kernels/orchestration/allreduce_bidirectional_ring_orch.cpp` | new — 56 lines |
| `kernels/aiv/allreduce_ibing_kernel.cpp` | new — 287 lines |
| `kernels/orchestration/allreduce_ibing_orch.cpp` | new — 55 lines |
| `main.py` | modified — adds both modes |
| `test_allreduce.py` | modified — both modes in P=2 parametrization; `bidirectional_ring` in P=4 |

## Test plan

- [x] Sim Docker: all 9 test configurations pass (5× P=2 + 4× P=4)
- [x] Pre-commit: all hooks green (check-headers, clang-format, cpplint, ruff, pyright)
- [x] NPU hardware (Ascend 910B2): `bidirectional_ring` P=2 and P=4, `ibing` P=2 — all `max_diff = 0.0`
- [x] Regression: existing `ring`, `onephase`, `twophase` modes verified on NPU hardware

## Limitations

| Limitation | Impact | Mitigation |
|-----------|--------|------------|
| `ibing` P=2 only | Cannot use for P≥4 | Use `bidirectional_ring` instead |
| `bidirectional_ring` requires `ALLREDUCE_COUNT % (2×P) == 0` | Doesn't work with odd-sized vectors at high P | Pad data or use `ring`/`twophase` |
| `bidirectional_ring` uses `2(P−1)+1` barriers, not P−1 | For large P, barrier count matches unidirectional ring | Doubles data throughput per barrier |