### PR TITLE
test(simt): unify scatter kernel on templated MSCATTER, drop __CPU_SIM fork

### DIFF
--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/aiv/kernel_simt_scatter.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/aiv/kernel_simt_scatter.cpp
@@ -77,16 +77,13 @@ static __aicore__ void simt_scatter_impl(__gm__ float *src, __gm__ int32_t *idx,
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-    // Element-scatter on both sim and onboard. The CPU sim backend exposes
-    // only a non-templated MSCATTER whose impl is already per-element, while
-    // the a5 onboard backend defaults the non-templated form to Coalesce::Row
-    // and gates the templated overloads behind PTO_NPU_ARCH_A5, so onboard
-    // must select Coalesce::Elem explicitly. See pto-isa#164.
-#ifdef __CPU_SIM
-    MSCATTER(outGlobal, srcTile, idxTile);
-#else
+    // Element-scatter on both sim and onboard via one instruction. The
+    // non-templated MSCATTER defaults to Coalesce::Row, so element-scatter
+    // must select Coalesce::Elem explicitly. pto-isa#166 (pinned via
+    // simpler#1156) opens the templated overloads to __CPU_SIM as well as
+    // PTO_NPU_ARCH_A5, so the same explicit call now compiles and runs
+    // identically on both backends — no __CPU_SIM fork. See pto-isa#164/#166.
     MSCATTER<Coalesce::Elem, ScatterAtomicOp::None, ScatterOOB::Skip>(outGlobal, srcTile, idxTile);
-#endif
 
     pipe_sync();
 }


### PR DESCRIPTION
## What

Remove the `#ifdef __CPU_SIM` fork in the SIMT element-scatter ST kernel
([`kernel_simt_scatter.cpp`](tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/aiv/kernel_simt_scatter.cpp))
so both the CPU simulator and a5 onboard issue the **same** instruction:

```cpp
MSCATTER<Coalesce::Elem, ScatterAtomicOp::None, ScatterOOB::Skip>(outGlobal, srcTile, idxTile);
```

## Why

The fork existed because pto-isa previously gated the templated `MSCATTER`
overloads behind `PTO_NPU_ARCH_A5` only — they weren't visible to the CPU
simulator, so the sim path had to fall back to the non-templated form
(pto-isa#164). The templated overloads were later opened to `__CPU_SIM` as
well as `PTO_NPU_ARCH_A5` (pto-isa#166), so the explicit templated call now
compiles and runs identically on both backends.

This branch is based on current `main`, whose `pto_isa.pin` (`83d01313`) is a
descendant of `016396b5` (bumped in #1156, the pto-isa#166 mechanism). At that
pin the `__CPU_SIM` guard on the templated overload is present, which is what
lets the sim compile the explicit call.

### Caveat — non-templated form is still not portable

Only the *templated* overload was unified. The non-templated
`MSCATTER(dst, src, idx)` still picks each backend's own default:
`Coalesce::Elem` on CPU sim (`pto/cpu/MScatter.hpp`) vs `Coalesce::Row` on
a5 onboard (`pto/npu/a5/MScatter.hpp`). So the explicit
`MSCATTER<Coalesce::Elem, ...>` is the only instruction that behaves the same
on both — hence keeping the template arguments rather than relying on the
non-templated default.

## Testing

- `--platform a5sim`: `1 passed` (run against the branch's pinned pto-isa
  `83d01313`, i.e. the same pin CI uses — no `--pto-isa-commit` override).
- Onboard a5 call site is **unchanged** by this cleanup (it already used this
  exact instruction), so a5 behavior is unaffected. An a5 onboard rerun via
  CI's `st-onboard-a5` closes the loop — not available on the current a2a3 dev
  box.

## Relationship to #1160

Supersedes #1160 (same change, by @ChaoZheng109). That PR's branch was cut
before #1156 landed and still pinned the pre-pto-isa#166 revision
`ddafa8da`, where the templated overload is not visible under `__CPU_SIM` —
so its `st-sim-a5` failed to compile (`'Coalesce' was not declared in this
scope`). This branch is the same one-line cleanup, rebased onto current `main`
so it builds against the correct pin.

Closes #1159
