### PR TITLE
refactor: extract AICPU device profiler engine

### DIFF
--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -1,13 +1,16 @@
 # Profiling Framework
 
-Shared host-side infrastructure that the PMU, L2Swimlane, DepGen,
-TensorDump, and ScopeStats collectors are built on. The framework headers
-live in
+Shared profiling infrastructure that the PMU, L2Swimlane, DepGen,
+TensorDump, and ScopeStats collectors are built on. The host-side framework
+headers live in
 [`src/common/platform/include/host/`](../src/common/platform/include/host/)
 and are consumed verbatim by both a2a3 and a5 collectors (PR #944
-unified the previously-divergent per-arch copies into one set). This page
-describes the shape; §8 covers the a5-specific transport deviations that
-the collectors themselves still carry.
+unified the previously-divergent per-arch copies into one set). The AICPU
+device-side producer algorithms live in
+[`src/common/platform/include/aicpu/profiler_device_engine.h`](../src/common/platform/include/aicpu/profiler_device_engine.h)
+and are shared by the device writers that publish buffers into those host
+collectors. This page describes both halves; §8 covers the a5-specific
+transport deviations that the collectors themselves still carry.
 
 The per-collector pages
 ([pmu-profiling.md](dfx/pmu-profiling.md),
@@ -42,9 +45,14 @@ Each profiling subsystem needs the same plumbing on the host:
 - A teardown sequence that flushes the device queues and host shards without
   losing late entries.
 
+The AICPU producer side has a matching repeated shape: wait for ready-queue
+space, publish a full buffer, wait for a free replacement, install it as the
+current buffer, and account dropped records if bounded backpressure expires.
+
 Before unification this was near-identical control flow repeated across
-collectors. The framework collapses it to one implementation parameterized
-on a small per-subsystem trait.
+collectors. The framework collapses the host side to one implementation
+parameterized on a small per-subsystem trait, and the device side to
+`DeviceProfilerEngine<Module>` plus small local AICPU module traits.
 
 ## 2. Layered view
 
@@ -72,6 +80,22 @@ on a small per-subsystem trait.
               │  Dump / Scope modules             │  ─ DataHeader / ReadyEntry / FreeQueue
               └────────────────────────────────┘  ─ kBufferKinds / kReadyQueueSize
                                                   ─ resolve_entry / for_each_instance
+
+  AICPU device side:
+
+                ┌──────────────────────────────────────────┐
+                │  AICPU writer files                      │  record fill / flush / local state
+                │  pmu / l2 / dep_gen / dump / scope       │  subsystem hooks
+                └─────────────┬────────────────────────────┘
+                              │ uses
+                ┌─────────────▼────────────────────────────┐
+                │  DeviceProfilerEngine<DeviceModule>      │  ready/free/switch algorithms
+                └─────────────┬────────────────────────────┘
+                              │ DeviceModule trait wires layout into algorithms
+                ┌─────────────▼────────────────────────────┐
+                │  XxxDeviceModule                         │  DataHeader / State / FreeQueue
+                │                                          │  write_ready_entry / drop hooks
+                └──────────────────────────────────────────┘
 ```
 
 `ProfilerBase` is the owner: it holds `BufferPoolManager manager_` as a
@@ -206,6 +230,53 @@ and only has to provide:
   buffers (`release_owned_buffers`) and drop the mapping table
   (`clear_mappings`).
 
+### 3.5 `DeviceProfilerEngine<Module>` — AICPU producer algorithm layer
+
+Defined in
+[`profiler_device_engine.h`](../src/common/platform/include/aicpu/profiler_device_engine.h).
+This is the device-side counterpart to `ProfilerAlgorithms<Module>`: it
+owns the AICPU producer control flow, while each subsystem keeps its record
+schema, flush/finalize behavior, and small layout hooks locally.
+
+The engine currently provides:
+
+- `wait_for_ready_queue_space` — bounded wait for a per-thread ready queue
+  slot.
+- `wait_for_free_queue_entry` — bounded wait for a replacement buffer in a
+  free queue, with acquire ordering before reading `buffer_ptrs[]`.
+- `enqueue_ready` — write the ready entry, `wmb()`, then advance
+  `queue_tails[q]`.
+- `pop_free` — pop a free buffer, clear its count, install
+  `current_buf_ptr/current_buf_seq`, update any local cache hook, then
+  publish with `wmb()`.
+- `switch_buffer` — enqueue the full current buffer, clear current state,
+  advance seq, then try to install a replacement; on enqueue failure it
+  accounts dropped records, clears count, and keeps the workload moving.
+
+Each AICPU writer defines a local `XxxDeviceModule` trait with:
+
+| Member | Purpose |
+| ------ | ------- |
+| `Context` | Per-call context such as header pointer, ready-queue thread, core/pool id, or local cache pointer |
+| `using DataHeader / State / FreeQueue / Buffer` | Device shared-memory layout types |
+| `kReadyQueueSize`, `kSlotCount`, `kBackpressureWaitCycles` | Queue geometry and bounded wait budget |
+| `header(ctx)`, `ready_thread(ctx)`, `free_queue(state)` | Locate the shared header and queues |
+| `current_ptr/set_current_ptr`, `current_seq/set_current_seq` | Access the active device buffer state |
+| `count/set_count` | Access the active buffer's record count |
+| `write_ready_entry(ctx, tail, ptr, seq)` | Fill subsystem-specific ready-entry fields (`core_index`, `kind`, `thread_index`, `instance_index`, …) |
+| `account_dropped`, `on_enqueue_failed`, `on_no_replacement` | Preserve subsystem-specific drop accounting and logs |
+| `on_pop_success`, `on_current_cleared`, `on_null_free_slot`, `on_switch_complete` | Preserve local caches and optional switch logs |
+
+Current users:
+
+- ScopeStats, DepGen, TensorDump, and PMU use the engine for
+  ready/free/switch.
+- L2Swimlane uses the engine for ready enqueue / free wait primitives and
+  AICPU task-buffer pop/switch.
+- L2Swimlane scheduler/orchestrator phase pools and AICore rotation remain
+  local special cases. Their seq recovery, retry, and AICore-visible head
+  publishing rules differ from standard `switch_buffer`.
+
 ## 4. End-to-end data flow
 
 ```text
@@ -320,7 +391,13 @@ Two things follow:
    and AICPU can include.
 2. Write a `XxxModule` struct satisfying the contract in §3.3. Multi-kind
    modules also implement `kind_of`.
-3. Write a `XxxCollector : public profiling_common::ProfilerBase<XxxCollector, XxxModule>`:
+3. If the subsystem has an AICPU device writer, define a local
+   `XxxDeviceModule` satisfying §3.5 and use
+   `profiling_device::DeviceProfilerEngine<XxxDeviceModule>` for
+   ready/free/switch control flow. Keep record fill, flush/finalize, and
+   unusual cross-core protocols local unless their semantics match the
+   standard engine contract.
+4. Write a `XxxCollector : public profiling_common::ProfilerBase<XxxCollector, XxxModule>`:
    - `init(...)`: `rtMalloc` + register pre-allocated buffers, populate
      the shared header, call `register_mapping` per buffer, then call
      `set_memory_context(...)`.
@@ -329,7 +406,7 @@ Two things follow:
    - `kIdleTimeoutSec`, `kSubsystemName`.
    - `finalize(unregister, free)`: `release_owned_buffers` + free
      collector-owned buffers + `clear_mappings` + `clear_memory_context`.
-4. Wire it into `device_runner` so `start(tf)` is called before the
+5. Wire it into `device_runner` so `start(tf)` is called before the
    kernel launch and `stop()` before `finalize`.
 
 Existing collectors are the canonical examples:

--- a/src/a2a3/platform/shared/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a2a3/platform/shared/aicpu/pmu_collector_aicpu.cpp
@@ -28,8 +28,8 @@
 
 #include <cstring>
 
-#include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
+#include "aicpu/profiler_device_engine.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -104,91 +104,73 @@ static void pmu_read_counters(uint64_t reg_base, PmuRecord *out) {
 // Internal: enqueue full buffer to per-thread ready_queue
 // ---------------------------------------------------------------------------
 
-static bool wait_for_ready_queue_space(PmuDataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
-    if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
-        return false;
+struct PmuDeviceModule {
+    struct Context {
+        PmuDataHeader *header;
+        int thread_idx;
+        int core_id;
+    };
+
+    using DataHeader = PmuDataHeader;
+    using State = PmuBufferState;
+    using FreeQueue = PmuFreeQueue;
+    using Buffer = PmuBuffer;
+
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
+    static constexpr uint64_t kBackpressureWaitCycles = kPmuQueueBackpressureWaitCycles;
+
+    static DataHeader *header(Context ctx) { return ctx.header; }
+    static int ready_thread(Context ctx) { return ctx.thread_idx; }
+    static FreeQueue *free_queue(State *state) { return &state->free_queue; }
+
+    static uint64_t current_ptr(State *state) { return state->current_buf_ptr; }
+    static void set_current_ptr(State *state, uint64_t ptr) { state->current_buf_ptr = ptr; }
+    static uint32_t current_seq(State *state) { return state->current_buf_seq; }
+    static void set_current_seq(State *state, uint32_t seq) { state->current_buf_seq = seq; }
+
+    static uint32_t count(Buffer *buffer) { return buffer->count; }
+    static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
+
+    static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        ctx.header->queues[ctx.thread_idx][tail].core_index = static_cast<uint32_t>(ctx.core_id);
+        ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
     }
-    const uint32_t capacity = PLATFORM_PMU_READYQUEUE_SIZE;
-    const uint64_t start = get_sys_cnt_aicpu();
 
-    do {
-        uint32_t current_tail = header->queue_tails[thread_idx];
-        uint32_t current_head = header->queue_heads[thread_idx];
-        uint32_t next_tail = (current_tail + 1) % capacity;
-        if (next_tail != current_head) {
-            *tail_out = current_tail;
-            *head_out = current_head;
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kPmuQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
-}
-
-static bool wait_for_free_queue_entry(PmuFreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
-    if (free_queue == nullptr) {
-        return false;
+    static void account_dropped(Context, State *state, uint32_t count) { state->dropped_record_count += count; }
+    static void on_pop_success(Context, State *, Buffer *) {}
+    static void on_current_cleared(Context, State *) {}
+    static void on_no_replacement(Context, State *) {}
+    static void on_null_free_slot(Context, State *) {}
+    static void on_enqueue_failed(Context ctx, State *, Buffer *) {
+        LOG_ERROR(
+            "Thread %d: Core %d failed to enqueue PMU buffer (ready_queue full), data lost!", ctx.thread_idx,
+            ctx.core_id
+        );
     }
-    const uint64_t start = get_sys_cnt_aicpu();
+    static void on_switch_complete(Context ctx, State *, Buffer *buffer) {
+        if (buffer != nullptr) {
+            LOG_INFO_V0(
+                "Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", ctx.thread_idx, ctx.core_id,
+                reinterpret_cast<uint64_t>(buffer)
+            );
+        }
+    }
+};
 
-    do {
-        uint32_t head = free_queue->head;
-        uint32_t tail = free_queue->tail;
-        if (head != tail) {
-            *head_out = head;
-            *tail_out = tail;
-            rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kPmuQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
+using PmuEngine = profiling_device::DeviceProfilerEngine<PmuDeviceModule>;
+
+static PmuDeviceModule::Context pmu_context(int core_id, int thread_idx) {
+    return PmuDeviceModule::Context{s_pmu_header, thread_idx, core_id};
 }
 
 static int enqueue_pmu_ready_buffer(int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq) {
-    uint32_t capacity = PLATFORM_PMU_READYQUEUE_SIZE;
-    uint32_t current_tail = 0;
-    uint32_t current_head = 0;
-    if (!wait_for_ready_queue_space(s_pmu_header, thread_idx, &current_tail, &current_head)) {
-        return -1;
-    }
-
-    uint32_t next_tail = (current_tail + 1) % capacity;
-    s_pmu_header->queues[thread_idx][current_tail].core_index = core_index;
-    s_pmu_header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
-    s_pmu_header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
-    wmb();  // publish: entry fields visible before the tail advance
-    s_pmu_header->queue_tails[thread_idx] = next_tail;
-    return 0;
+    return PmuEngine::enqueue_ready(pmu_context(static_cast<int>(core_index), thread_idx), buffer_ptr, buffer_seq);
 }
 
 static PmuBuffer *try_pop_pmu_buffer(int core_id, PmuBufferState *state, uint32_t next_seq) {
-    (void)core_id;
-    if (state == nullptr) {
-        return nullptr;
-    }
-    uint32_t head = 0;
-    uint32_t tail = 0;
-    if (!wait_for_free_queue_entry(&state->free_queue, &head, &tail)) {
-        return nullptr;
-    }
-
-    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PMU_SLOT_COUNT];
-    state->free_queue.head = head + 1;
-    if (new_buf_ptr == 0) {
-        return nullptr;
-    }
-
-    PmuBuffer *new_buf = reinterpret_cast<PmuBuffer *>(new_buf_ptr);
-    new_buf->count = 0;
-    state->current_buf_ptr = new_buf_ptr;
-    state->current_buf_seq = next_seq;
-    wmb();
-    return new_buf;
+    return PmuEngine::pop_free(pmu_context(core_id, /*thread_idx=*/0), state, next_seq);
 }
 
 // ---------------------------------------------------------------------------
@@ -201,37 +183,7 @@ static void pmu_switch_buffer(int core_id, int thread_idx) {
         return;
     }
 
-    PmuBuffer *full_buf = reinterpret_cast<PmuBuffer *>(state->current_buf_ptr);
-    if (full_buf == nullptr) {
-        return;
-    }
-
-    // Enqueue full buffer to ready_queue
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_pmu_ready_buffer(thread_idx, static_cast<uint32_t>(core_id), state->current_buf_ptr, seq);
-    if (rc != 0) {
-        LOG_ERROR(
-            "Thread %d: Core %d failed to enqueue PMU buffer (ready_queue full), data lost!", thread_idx, core_id
-        );
-        state->dropped_record_count += full_buf->count;
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    uint32_t next_seq = seq + 1;
-    state->current_buf_ptr = 0;
-    state->current_buf_seq = next_seq;
-    wmb();
-
-    PmuBuffer *new_buf = try_pop_pmu_buffer(core_id, state, next_seq);
-    if (new_buf == nullptr) {
-        return;
-    }
-    LOG_INFO_V0(
-        "Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", thread_idx, core_id,
-        reinterpret_cast<uint64_t>(new_buf)
-    );
+    PmuEngine::switch_buffer(pmu_context(core_id, thread_idx), state);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/a5/platform/shared/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a5/platform/shared/aicpu/pmu_collector_aicpu.cpp
@@ -32,8 +32,8 @@
 
 #include <cstring>
 
-#include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
+#include "aicpu/profiler_device_engine.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -110,91 +110,73 @@ static void pmu_stop(uint64_t reg_base, uint32_t saved_ctrl0, uint32_t saved_ctr
 // Internal: enqueue full buffer to per-thread ready_queue
 // ---------------------------------------------------------------------------
 
-static bool wait_for_ready_queue_space(PmuDataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
-    if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
-        return false;
+struct PmuDeviceModule {
+    struct Context {
+        PmuDataHeader *header;
+        int thread_idx;
+        int core_id;
+    };
+
+    using DataHeader = PmuDataHeader;
+    using State = PmuBufferState;
+    using FreeQueue = PmuFreeQueue;
+    using Buffer = PmuBuffer;
+
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
+    static constexpr uint64_t kBackpressureWaitCycles = kPmuQueueBackpressureWaitCycles;
+
+    static DataHeader *header(Context ctx) { return ctx.header; }
+    static int ready_thread(Context ctx) { return ctx.thread_idx; }
+    static FreeQueue *free_queue(State *state) { return &state->free_queue; }
+
+    static uint64_t current_ptr(State *state) { return state->current_buf_ptr; }
+    static void set_current_ptr(State *state, uint64_t ptr) { state->current_buf_ptr = ptr; }
+    static uint32_t current_seq(State *state) { return state->current_buf_seq; }
+    static void set_current_seq(State *state, uint32_t seq) { state->current_buf_seq = seq; }
+
+    static uint32_t count(Buffer *buffer) { return buffer->count; }
+    static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
+
+    static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        ctx.header->queues[ctx.thread_idx][tail].core_index = static_cast<uint32_t>(ctx.core_id);
+        ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
     }
-    const uint32_t capacity = PLATFORM_PMU_READYQUEUE_SIZE;
-    const uint64_t start = get_sys_cnt_aicpu();
 
-    do {
-        uint32_t current_tail = header->queue_tails[thread_idx];
-        uint32_t current_head = header->queue_heads[thread_idx];
-        uint32_t next_tail = (current_tail + 1) % capacity;
-        if (next_tail != current_head) {
-            *tail_out = current_tail;
-            *head_out = current_head;
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kPmuQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
-}
-
-static bool wait_for_free_queue_entry(PmuFreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
-    if (free_queue == nullptr) {
-        return false;
+    static void account_dropped(Context, State *state, uint32_t count) { state->dropped_record_count += count; }
+    static void on_pop_success(Context, State *, Buffer *) {}
+    static void on_current_cleared(Context, State *) {}
+    static void on_no_replacement(Context, State *) {}
+    static void on_null_free_slot(Context, State *) {}
+    static void on_enqueue_failed(Context ctx, State *, Buffer *) {
+        LOG_ERROR(
+            "Thread %d: Core %d failed to enqueue PMU buffer (ready_queue full), data lost!", ctx.thread_idx,
+            ctx.core_id
+        );
     }
-    const uint64_t start = get_sys_cnt_aicpu();
+    static void on_switch_complete(Context ctx, State *, Buffer *buffer) {
+        if (buffer != nullptr) {
+            LOG_INFO_V0(
+                "Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", ctx.thread_idx, ctx.core_id,
+                reinterpret_cast<uint64_t>(buffer)
+            );
+        }
+    }
+};
 
-    do {
-        uint32_t head = free_queue->head;
-        uint32_t tail = free_queue->tail;
-        if (head != tail) {
-            *head_out = head;
-            *tail_out = tail;
-            rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kPmuQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
+using PmuEngine = profiling_device::DeviceProfilerEngine<PmuDeviceModule>;
+
+static PmuDeviceModule::Context pmu_context(int core_id, int thread_idx) {
+    return PmuDeviceModule::Context{s_pmu_header, thread_idx, core_id};
 }
 
 static int enqueue_pmu_ready_buffer(int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq) {
-    uint32_t capacity = PLATFORM_PMU_READYQUEUE_SIZE;
-    uint32_t current_tail = 0;
-    uint32_t current_head = 0;
-    if (!wait_for_ready_queue_space(s_pmu_header, thread_idx, &current_tail, &current_head)) {
-        return -1;
-    }
-
-    uint32_t next_tail = (current_tail + 1) % capacity;
-    s_pmu_header->queues[thread_idx][current_tail].core_index = core_index;
-    s_pmu_header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
-    s_pmu_header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
-    wmb();  // publish: entry fields visible before the tail advance
-    s_pmu_header->queue_tails[thread_idx] = next_tail;
-    return 0;
+    return PmuEngine::enqueue_ready(pmu_context(static_cast<int>(core_index), thread_idx), buffer_ptr, buffer_seq);
 }
 
 static PmuBuffer *try_pop_pmu_buffer(int core_id, PmuBufferState *state, uint32_t next_seq) {
-    (void)core_id;
-    if (state == nullptr) {
-        return nullptr;
-    }
-    uint32_t head = 0;
-    uint32_t tail = 0;
-    if (!wait_for_free_queue_entry(&state->free_queue, &head, &tail)) {
-        return nullptr;
-    }
-
-    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PMU_SLOT_COUNT];
-    state->free_queue.head = head + 1;
-    if (new_buf_ptr == 0) {
-        return nullptr;
-    }
-
-    PmuBuffer *new_buf = reinterpret_cast<PmuBuffer *>(new_buf_ptr);
-    new_buf->count = 0;
-    state->current_buf_ptr = new_buf_ptr;
-    state->current_buf_seq = next_seq;
-    wmb();
-    return new_buf;
+    return PmuEngine::pop_free(pmu_context(core_id, /*thread_idx=*/0), state, next_seq);
 }
 
 // ---------------------------------------------------------------------------
@@ -208,38 +190,7 @@ static void pmu_switch_buffer(int core_id, int thread_idx) {
         return;
     }
 
-    PmuBuffer *full_buf = reinterpret_cast<PmuBuffer *>(state->current_buf_ptr);
-    if (full_buf == nullptr) {
-        return;
-    }
-
-    // Enqueue full buffer to ready_queue
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_pmu_ready_buffer(thread_idx, static_cast<uint32_t>(core_id), state->current_buf_ptr, seq);
-    if (rc != 0) {
-        LOG_ERROR(
-            "Thread %d: Core %d failed to enqueue PMU buffer (ready_queue full), data lost!", thread_idx, core_id
-        );
-        state->dropped_record_count += full_buf->count;
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    uint32_t next_seq = seq + 1;
-    state->current_buf_ptr = 0;
-    state->current_buf_seq = next_seq;
-    wmb();
-
-    PmuBuffer *new_buf = try_pop_pmu_buffer(core_id, state, next_seq);
-    if (new_buf == nullptr) {
-        return;
-    }
-
-    LOG_INFO_V0(
-        "Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", thread_idx, core_id,
-        reinterpret_cast<uint64_t>(new_buf)
-    );
+    PmuEngine::switch_buffer(pmu_context(core_id, thread_idx), state);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/platform/include/aicpu/profiler_device_engine.h
+++ b/src/common/platform/include/aicpu/profiler_device_engine.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "aicpu/device_time.h"
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+
+namespace profiling_device {
+
+// Common AICPU-side producer algorithm for profiling collectors.
+//
+// Module supplies the concrete shared-memory layout and subsystem-specific
+// ready-entry/drop hooks; this engine owns the queue handoff and buffer-switch
+// control flow.
+template <typename Module>
+struct DeviceProfilerEngine {
+    using Context = typename Module::Context;
+    using DataHeader = typename Module::DataHeader;
+    using State = typename Module::State;
+    using FreeQueue = typename Module::FreeQueue;
+    using Buffer = typename Module::Buffer;
+
+    static bool wait_for_ready_queue_space(DataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
+        if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
+            return false;
+        }
+
+        const uint64_t start = get_sys_cnt_aicpu();
+        do {
+            uint32_t current_tail = header->queue_tails[thread_idx];
+            uint32_t current_head = header->queue_heads[thread_idx];
+            uint32_t next_tail = (current_tail + 1) % Module::kReadyQueueSize;
+            if (next_tail != current_head) {
+                *tail_out = current_tail;
+                *head_out = current_head;
+                return true;
+            }
+            if (Module::kBackpressureWaitCycles == 0) {
+                break;
+            }
+            if (get_sys_cnt_aicpu() - start >= Module::kBackpressureWaitCycles) {
+                break;
+            }
+        } while (true);
+
+        return false;
+    }
+
+    static bool wait_for_free_queue_entry(FreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
+        if (free_queue == nullptr) {
+            return false;
+        }
+
+        const uint64_t start = get_sys_cnt_aicpu();
+        do {
+            uint32_t head = free_queue->head;
+            uint32_t tail = free_queue->tail;
+            if (head != tail) {
+                *head_out = head;
+                *tail_out = tail;
+                rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
+                return true;
+            }
+            if (Module::kBackpressureWaitCycles == 0) {
+                break;
+            }
+            if (get_sys_cnt_aicpu() - start >= Module::kBackpressureWaitCycles) {
+                break;
+            }
+        } while (true);
+
+        return false;
+    }
+
+    static int enqueue_ready(Context ctx, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        DataHeader *header = Module::header(ctx);
+        int q = Module::ready_thread(ctx);
+        uint32_t current_tail = 0;
+        uint32_t current_head = 0;
+        if (!wait_for_ready_queue_space(header, q, &current_tail, &current_head)) {
+            return -1;
+        }
+
+        uint32_t next_tail = (current_tail + 1) % Module::kReadyQueueSize;
+        Module::write_ready_entry(ctx, current_tail, buffer_ptr, buffer_seq);
+        wmb();  // publish: entry fields visible before the tail advance
+        header->queue_tails[q] = next_tail;
+        return 0;
+    }
+
+    static Buffer *pop_free(Context ctx, State *state, uint32_t next_seq) {
+        if (state == nullptr) {
+            return nullptr;
+        }
+
+        FreeQueue *free_queue = Module::free_queue(state);
+        uint32_t head = 0;
+        uint32_t tail = 0;
+        if (!wait_for_free_queue_entry(free_queue, &head, &tail)) {
+            return nullptr;
+        }
+
+        uint64_t buf_ptr = free_queue->buffer_ptrs[head % Module::kSlotCount];
+        rmb();  // acquire-strengthening: order buffer_ptrs read before taking ownership via head advance
+        free_queue->head = head + 1;
+        if (buf_ptr == 0) {
+            Module::on_null_free_slot(ctx, state);
+            return nullptr;
+        }
+
+        auto *buf = reinterpret_cast<Buffer *>(buf_ptr);
+        Module::set_count(buf, 0);
+        wmb();
+        Module::set_current_ptr(state, buf_ptr);
+        Module::set_current_seq(state, next_seq);
+        Module::on_pop_success(ctx, state, buf);
+        wmb();
+        return buf;
+    }
+
+    static void switch_buffer(Context ctx, State *state) {
+        if (state == nullptr) {
+            return;
+        }
+
+        auto *full_buf = reinterpret_cast<Buffer *>(Module::current_ptr(state));
+        if (full_buf == nullptr) {
+            return;
+        }
+
+        uint32_t seq = Module::current_seq(state);
+        int rc = enqueue_ready(ctx, Module::current_ptr(state), seq);
+        if (rc != 0) {
+            Module::account_dropped(ctx, state, Module::count(full_buf));
+            Module::on_enqueue_failed(ctx, state, full_buf);
+            Module::set_count(full_buf, 0);
+            wmb();
+            return;
+        }
+
+        uint32_t next_seq = seq + 1;
+        Module::set_current_ptr(state, 0);
+        Module::set_current_seq(state, next_seq);
+        Module::on_current_cleared(ctx, state);
+        wmb();
+
+        Buffer *new_buf = pop_free(ctx, state, next_seq);
+        if (new_buf == nullptr) {
+            Module::on_no_replacement(ctx, state);
+        }
+        Module::on_switch_complete(ctx, state, new_buf);
+    }
+};
+
+}  // namespace profiling_device

--- a/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -30,7 +30,7 @@
 
 #include <cstring>
 
-#include "aicpu/device_time.h"
+#include "aicpu/profiler_device_engine.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -59,124 +59,69 @@ void dep_gen_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thr
 // Internal: enqueue full buffer to per-thread ready_queue
 // ---------------------------------------------------------------------------
 
-static bool
-wait_for_ready_queue_space(DepGenDataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
-    if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
-        return false;
+struct DepGenDeviceModule {
+    struct Context {
+        DepGenDataHeader *header;
+        int thread_idx;
+    };
+
+    using DataHeader = DepGenDataHeader;
+    using State = DepGenBufferState;
+    using FreeQueue = DepGenFreeQueue;
+    using Buffer = DepGenBuffer;
+
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_DEP_GEN_SLOT_COUNT;
+    static constexpr uint64_t kBackpressureWaitCycles = kDepGenQueueBackpressureWaitCycles;
+
+    static DataHeader *header(Context ctx) { return ctx.header; }
+    static int ready_thread(Context ctx) { return ctx.thread_idx; }
+    static FreeQueue *free_queue(State *state) { return &state->free_queue; }
+
+    static uint64_t current_ptr(State *state) { return state->current_buf_ptr; }
+    static void set_current_ptr(State *state, uint64_t ptr) { state->current_buf_ptr = ptr; }
+    static uint32_t current_seq(State *state) { return state->current_buf_seq; }
+    static void set_current_seq(State *state, uint32_t seq) { state->current_buf_seq = seq; }
+
+    static uint32_t count(Buffer *buffer) { return buffer->count; }
+    static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
+
+    static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        ctx.header->queues[ctx.thread_idx][tail].instance_index = 0;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
     }
-    const uint32_t capacity = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
-    const uint64_t start = get_sys_cnt_aicpu();
 
-    do {
-        uint32_t current_tail = header->queue_tails[thread_idx];
-        uint32_t current_head = header->queue_heads[thread_idx];
-        uint32_t next_tail = (current_tail + 1) % capacity;
-        if (next_tail != current_head) {
-            *tail_out = current_tail;
-            *head_out = current_head;
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kDepGenQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
-}
-
-static bool wait_for_free_queue_entry(DepGenFreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
-    if (free_queue == nullptr) {
-        return false;
+    static void account_dropped(Context, State *state, uint32_t count) { state->dropped_record_count += count; }
+    static void on_pop_success(Context, State *, Buffer *) {}
+    static void on_current_cleared(Context, State *) {}
+    static void on_no_replacement(Context, State *) {}
+    static void on_null_free_slot(Context, State *) {}
+    static void on_enqueue_failed(Context, State *, Buffer *buffer) {
+        LOG_ERROR("dep_gen: failed to enqueue full buffer (ready_queue full), %u records dropped", buffer->count);
     }
-    const uint64_t start = get_sys_cnt_aicpu();
+    static void on_switch_complete(Context, State *, Buffer *) {}
+};
 
-    do {
-        uint32_t head = free_queue->head;
-        uint32_t tail = free_queue->tail;
-        if (head != tail) {
-            *head_out = head;
-            *tail_out = tail;
-            rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kDepGenQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
+using DepGenEngine = profiling_device::DeviceProfilerEngine<DepGenDeviceModule>;
+
+static DepGenDeviceModule::Context dep_gen_context() {
+    return DepGenDeviceModule::Context{s_dep_gen_header, s_orch_thread_idx};
 }
 
 static int enqueue_dep_gen_ready_buffer(uint64_t buffer_ptr, uint32_t buffer_seq) {
-    int q = s_orch_thread_idx;
-    uint32_t capacity = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
-    uint32_t current_tail = 0;
-    uint32_t current_head = 0;
-    if (!wait_for_ready_queue_space(s_dep_gen_header, q, &current_tail, &current_head)) {
-        return -1;
-    }
-
-    uint32_t next_tail = (current_tail + 1) % capacity;
-    s_dep_gen_header->queues[q][current_tail].instance_index = 0;
-    s_dep_gen_header->queues[q][current_tail].buffer_ptr = buffer_ptr;
-    s_dep_gen_header->queues[q][current_tail].buffer_seq = buffer_seq;
-    wmb();  // publish: entry fields visible before the tail advance
-    s_dep_gen_header->queue_tails[q] = next_tail;
-    return 0;
+    return DepGenEngine::enqueue_ready(dep_gen_context(), buffer_ptr, buffer_seq);
 }
 
 static DepGenBuffer *try_pop_dep_gen_buffer(uint32_t next_seq) {
-    if (s_dep_gen_state == nullptr) {
-        return nullptr;
-    }
-    uint32_t head = 0;
-    uint32_t tail = 0;
-    if (!wait_for_free_queue_entry(&s_dep_gen_state->free_queue, &head, &tail)) {
-        return nullptr;
-    }
-
-    uint64_t new_buf_ptr = s_dep_gen_state->free_queue.buffer_ptrs[head % PLATFORM_DEP_GEN_SLOT_COUNT];
-    s_dep_gen_state->free_queue.head = head + 1;
-    if (new_buf_ptr == 0) {
-        return nullptr;
-    }
-
-    DepGenBuffer *new_buf = reinterpret_cast<DepGenBuffer *>(new_buf_ptr);
-    new_buf->count = 0;
-    s_dep_gen_state->current_buf_ptr = new_buf_ptr;
-    s_dep_gen_state->current_buf_seq = next_seq;
-    wmb();
-    return new_buf;
+    return DepGenEngine::pop_free(dep_gen_context(), s_dep_gen_state, next_seq);
 }
 
 // ---------------------------------------------------------------------------
 // Internal: switch the current buffer
 // ---------------------------------------------------------------------------
 
-static void dep_gen_switch_buffer() {
-    if (s_dep_gen_state == nullptr) {
-        return;
-    }
-    DepGenBuffer *full_buf = reinterpret_cast<DepGenBuffer *>(s_dep_gen_state->current_buf_ptr);
-    if (full_buf == nullptr) {
-        return;
-    }
-
-    uint32_t seq = s_dep_gen_state->current_buf_seq;
-    int rc = enqueue_dep_gen_ready_buffer(s_dep_gen_state->current_buf_ptr, seq);
-    if (rc != 0) {
-        LOG_ERROR("dep_gen: failed to enqueue full buffer (ready_queue full), %u records dropped", full_buf->count);
-        s_dep_gen_state->dropped_record_count += full_buf->count;
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    uint32_t next_seq = seq + 1;
-    s_dep_gen_state->current_buf_ptr = 0;
-    s_dep_gen_state->current_buf_seq = next_seq;
-    wmb();
-
-    (void)try_pop_dep_gen_buffer(next_seq);
-}
+static void dep_gen_switch_buffer() { DepGenEngine::switch_buffer(dep_gen_context(), s_dep_gen_state); }
 
 // ---------------------------------------------------------------------------
 // Public interface

--- a/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 
 #include "aicpu/platform_regs.h"
+#include "aicpu/profiler_device_engine.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -109,50 +110,83 @@ L2SwimlaneLevel get_l2_swimlane_level() { return g_l2_swimlane_level; }
 
 static constexpr uint64_t kL2SwimlaneQueueBackpressureWaitCycles = PLATFORM_PROF_SYS_CNT_FREQ / 50000;  // 20 us
 
-static bool
-wait_for_ready_queue_space(L2SwimlaneDataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
-    if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
-        return false;
-    }
-    const uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
-    const uint64_t start = get_sys_cnt_aicpu();
+struct L2SwimlaneTaskDeviceModule {
+    struct Context {
+        L2SwimlaneDataHeader *header;
+        int thread_idx;
+        uint32_t core_index;
+        L2SwimlaneBufferKind kind;
+        L2SwimlaneAicpuTaskBuffer **current_buf;
+    };
 
-    do {
-        uint32_t current_tail = header->queue_tails[thread_idx];
-        uint32_t current_head = header->queue_heads[thread_idx];
-        uint32_t next_tail = (current_tail + 1) % capacity;
-        if (next_tail != current_head) {
-            *tail_out = current_tail;
-            *head_out = current_head;
-            return true;
+    using DataHeader = L2SwimlaneDataHeader;
+    using State = L2SwimlaneAicpuTaskPool;
+    using FreeQueue = L2SwimlaneFreeQueue;
+    using Buffer = L2SwimlaneAicpuTaskBuffer;
+
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_PROF_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_PROF_SLOT_COUNT;
+    static constexpr uint64_t kBackpressureWaitCycles = kL2SwimlaneQueueBackpressureWaitCycles;
+
+    static DataHeader *header(Context ctx) { return ctx.header; }
+    static int ready_thread(Context ctx) { return ctx.thread_idx; }
+    static FreeQueue *free_queue(State *state) { return &state->free_queue; }
+
+    static uint64_t current_ptr(State *state) { return state->head.current_buf_ptr; }
+    static void set_current_ptr(State *state, uint64_t ptr) { state->head.current_buf_ptr = ptr; }
+    static uint32_t current_seq(State *state) { return state->head.current_buf_seq; }
+    static void set_current_seq(State *state, uint32_t seq) { state->head.current_buf_seq = seq; }
+
+    static uint32_t count(Buffer *buffer) { return buffer->count; }
+    static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
+
+    static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        ctx.header->queues[ctx.thread_idx][tail].core_index = ctx.core_index;
+        ctx.header->queues[ctx.thread_idx][tail].kind = ctx.kind;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
+    }
+
+    static void account_dropped(Context, State *state, uint32_t count) {
+        state->head.dropped_record_count = state->head.dropped_record_count + count;
+    }
+    static void on_pop_success(Context ctx, State *, Buffer *buffer) {
+        if (ctx.current_buf != nullptr) {
+            *ctx.current_buf = buffer;
         }
-        if (get_sys_cnt_aicpu() - start >= kL2SwimlaneQueueBackpressureWaitCycles) {
-            break;
+    }
+    static void on_current_cleared(Context ctx, State *) {
+        if (ctx.current_buf != nullptr) {
+            *ctx.current_buf = nullptr;
         }
-    } while (true);
-    return false;
+    }
+    static void on_no_replacement(Context, State *) {}
+    static void on_null_free_slot(Context, State *) {}
+    static void on_enqueue_failed(Context ctx, State *, Buffer *) {
+        LOG_ERROR(
+            "Thread %d: Core %u failed to enqueue buffer (queue full), data lost!", ctx.thread_idx, ctx.core_index
+        );
+    }
+    static void on_switch_complete(Context ctx, State *, Buffer *buffer) {
+        if (buffer != nullptr) {
+            LOG_INFO_V0(
+                "Thread %d: Core %u switched to new buffer (addr=0x%lx)", ctx.thread_idx, ctx.core_index,
+                reinterpret_cast<uint64_t>(buffer)
+            );
+        }
+    }
+};
+
+using L2SwimlaneTaskEngine = profiling_device::DeviceProfilerEngine<L2SwimlaneTaskDeviceModule>;
+
+static L2SwimlaneTaskDeviceModule::Context l2_task_context(
+    int thread_idx, uint32_t core_index, L2SwimlaneBufferKind kind, L2SwimlaneAicpuTaskBuffer **current_buf
+) {
+    return L2SwimlaneTaskDeviceModule::Context{s_l2_swimlane_header, thread_idx, core_index, kind, current_buf};
 }
 
 static bool wait_for_free_queue_entry(L2SwimlaneFreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
-    if (free_queue == nullptr) {
-        return false;
-    }
-    const uint64_t start = get_sys_cnt_aicpu();
-
-    do {
-        uint32_t head = free_queue->head;
-        uint32_t tail = free_queue->tail;
-        if (head != tail) {
-            *head_out = head;
-            *tail_out = tail;
-            rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kL2SwimlaneQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
+    return L2SwimlaneTaskEngine::wait_for_free_queue_entry(free_queue, head_out, tail_out);
 }
 
 /**
@@ -170,49 +204,17 @@ static int enqueue_ready_buffer(
     L2SwimlaneDataHeader *header, int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq,
     L2SwimlaneBufferKind kind
 ) {
-    uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
-    uint32_t current_tail = 0;
-    uint32_t current_head = 0;
-
-    if (!wait_for_ready_queue_space(header, thread_idx, &current_tail, &current_head)) {
-        return -1;
-    }
-    uint32_t next_tail = (current_tail + 1) % capacity;
-
-    header->queues[thread_idx][current_tail].core_index = core_index;
-    header->queues[thread_idx][current_tail].kind = kind;
-    header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
-    header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
-    wmb();  // publish: entry fields visible before the tail advance
-    header->queue_tails[thread_idx] = next_tail;
-
-    return 0;
+    auto ctx = L2SwimlaneTaskDeviceModule::Context{header, thread_idx, core_index, kind, nullptr};
+    return L2SwimlaneTaskEngine::enqueue_ready(ctx, buffer_ptr, buffer_seq);
 }
 
 static L2SwimlaneAicpuTaskBuffer *
 try_pop_records_buffer(int core_id, L2SwimlaneAicpuTaskPool *state, uint32_t next_seq) {
-    uint32_t head = 0;
-    uint32_t tail = 0;
-    if (!wait_for_free_queue_entry(&state->free_queue, &head, &tail)) {
-        return nullptr;
-    }
-
-    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-    rmb();
-    state->free_queue.head = head + 1;
-    if (new_buf_ptr == 0) {
-        return nullptr;
-    }
-
-    auto *new_buf = reinterpret_cast<L2SwimlaneAicpuTaskBuffer *>(new_buf_ptr);
-    new_buf->count = 0;
-    wmb();
-
-    state->head.current_buf_ptr = new_buf_ptr;
-    state->head.current_buf_seq = next_seq;
-    s_current_aicpu_task_buffers[core_id] = new_buf;
-    wmb();
-    return new_buf;
+    return L2SwimlaneTaskEngine::pop_free(
+        l2_task_context(/*thread_idx=*/0, static_cast<uint32_t>(core_id), L2SwimlaneBufferKind::AicpuTask,
+                        &s_current_aicpu_task_buffers[core_id]),
+        state, next_seq
+    );
 }
 
 void l2_swimlane_aicpu_init(int worker_count) {
@@ -346,40 +348,17 @@ static void switch_records_buffer(int core_id, int thread_idx) {
         return;
     }
 
-    L2SwimlaneAicpuTaskBuffer *full_buf = s_current_aicpu_task_buffers[core_id];
+    auto *full_buf = s_current_aicpu_task_buffers[core_id];
     if (full_buf == nullptr) {
         return;
     }
-
     LOG_INFO_V0("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
-
-    uint32_t seq = state->head.current_buf_seq;
-    uint64_t full_buf_ptr = state->head.current_buf_ptr;
-    int rc = enqueue_ready_buffer(
-        s_l2_swimlane_header, thread_idx, core_id, full_buf_ptr, seq, L2SwimlaneBufferKind::AicpuTask
-    );
-    if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
-        state->head.dropped_record_count = state->head.dropped_record_count + full_buf->count;
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    uint32_t next_seq = seq + 1;
-    state->head.current_buf_ptr = 0;
-    state->head.current_buf_seq = next_seq;
-    s_current_aicpu_task_buffers[core_id] = nullptr;
-    wmb();
-
-    L2SwimlaneAicpuTaskBuffer *new_buf = try_pop_records_buffer(core_id, state, next_seq);
-    if (new_buf == nullptr) {
-        return;
-    }
-
-    LOG_INFO_V0(
-        "Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id,
-        reinterpret_cast<uint64_t>(new_buf)
+    L2SwimlaneTaskEngine::switch_buffer(
+        l2_task_context(
+            thread_idx, static_cast<uint32_t>(core_id), L2SwimlaneBufferKind::AicpuTask,
+            &s_current_aicpu_task_buffers[core_id]
+        ),
+        state
     );
 }
 

--- a/src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
@@ -21,7 +21,7 @@
 #include "aicpu/scope_stats_collector_aicpu.h"
 #include <cstring>
 
-#include "aicpu/device_time.h"
+#include "aicpu/profiler_device_engine.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/scope_stats.h"
@@ -89,120 +89,70 @@ inline void copy_basename(char (&dst)[32], const char *src) {
     }
 }
 
-// Enqueue a full buffer onto the orchestrator thread's ready_queue. Returns 0
-// on success, -1 if the queue is full or the orch thread index is unset.
-bool wait_for_ready_queue_space(ScopeStatsDataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
-    if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
-        return false;
+struct ScopeStatsDeviceModule {
+    struct Context {
+        ScopeStatsDataHeader *header;
+        int thread_idx;
+    };
+
+    using DataHeader = ScopeStatsDataHeader;
+    using State = ScopeStatsBufferState;
+    using FreeQueue = ScopeStatsFreeQueue;
+    using Buffer = ScopeStatsBuffer;
+
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_SCOPE_STATS_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_SCOPE_STATS_SLOT_COUNT;
+    static constexpr uint64_t kBackpressureWaitCycles = kScopeStatsQueueBackpressureWaitCycles;
+
+    static DataHeader *header(Context ctx) { return ctx.header; }
+    static int ready_thread(Context ctx) { return ctx.thread_idx; }
+    static FreeQueue *free_queue(State *state) { return &state->free_queue; }
+
+    static uint64_t current_ptr(State *state) { return state->current_buf_ptr; }
+    static void set_current_ptr(State *state, uint64_t ptr) { state->current_buf_ptr = ptr; }
+    static uint32_t current_seq(State *state) { return state->current_buf_seq; }
+    static void set_current_seq(State *state, uint32_t seq) { state->current_buf_seq = seq; }
+
+    static uint32_t count(Buffer *buffer) { return buffer->count; }
+    static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
+
+    static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        ctx.header->queues[ctx.thread_idx][tail].instance_index = 0;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
     }
-    const uint32_t capacity = PLATFORM_SCOPE_STATS_READYQUEUE_SIZE;
-    const uint64_t start = get_sys_cnt_aicpu();
 
-    do {
-        uint32_t current_tail = header->queue_tails[thread_idx];
-        uint32_t current_head = header->queue_heads[thread_idx];
-        uint32_t next_tail = (current_tail + 1) % capacity;
-        if (next_tail != current_head) {
-            *tail_out = current_tail;
-            *head_out = current_head;
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kScopeStatsQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
-}
+    static void account_dropped(Context, State *state, uint32_t count) { state->dropped_record_count += count; }
+    static void on_pop_success(Context, State *, Buffer *) {}
+    static void on_current_cleared(Context, State *) {}
+    static void on_no_replacement(Context, State *) {}
+    static void on_enqueue_failed(Context, State *, Buffer *) {}
+    static void on_null_free_slot(Context, State *) {}
+    static void on_switch_complete(Context, State *, Buffer *) {}
+};
 
-bool wait_for_free_queue_entry(ScopeStatsFreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
-    if (free_queue == nullptr) {
-        return false;
-    }
-    const uint64_t start = get_sys_cnt_aicpu();
+using ScopeStatsEngine = profiling_device::DeviceProfilerEngine<ScopeStatsDeviceModule>;
 
-    do {
-        uint32_t head = free_queue->head;
-        uint32_t tail = free_queue->tail;
-        if (head != tail) {
-            *head_out = head;
-            *tail_out = tail;
-            rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kScopeStatsQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
+ScopeStatsDeviceModule::Context scope_stats_context() {
+    return ScopeStatsDeviceModule::Context{s_scope_stats_header, s_orch_thread_idx};
 }
 
 int enqueue_ready_buffer(uint64_t buffer_ptr, uint32_t buffer_seq) {
-    int q = s_orch_thread_idx;
-    uint32_t capacity = PLATFORM_SCOPE_STATS_READYQUEUE_SIZE;
-    uint32_t current_tail = 0;
-    uint32_t current_head = 0;
-    if (!wait_for_ready_queue_space(s_scope_stats_header, q, &current_tail, &current_head)) {
-        return -1;
-    }
-
-    uint32_t next_tail = (current_tail + 1) % capacity;
-    s_scope_stats_header->queues[q][current_tail].instance_index = 0;
-    s_scope_stats_header->queues[q][current_tail].buffer_ptr = buffer_ptr;
-    s_scope_stats_header->queues[q][current_tail].buffer_seq = buffer_seq;
-    // Single hand-off barrier: drain every record written into the buffer plus
-    // the ready-entry fields above before the host can observe the advanced
-    // tail. Replaces the former per-record wmb() in scope_stats_end().
-    wmb();
-    s_scope_stats_header->queue_tails[q] = next_tail;
-    return 0;
+    return ScopeStatsEngine::enqueue_ready(scope_stats_context(), buffer_ptr, buffer_seq);
 }
 
 // Pop a free buffer into current_buf_ptr. Returns true if one was available.
 bool pop_free_buffer() {
     if (s_scope_stats_state == nullptr) return false;
-    uint32_t head = 0;
-    uint32_t tail = 0;
-    if (!wait_for_free_queue_entry(&s_scope_stats_state->free_queue, &head, &tail)) {
-        return false;
-    }
-
-    uint64_t buf_ptr = s_scope_stats_state->free_queue.buffer_ptrs[head % PLATFORM_SCOPE_STATS_SLOT_COUNT];
-    s_scope_stats_state->free_queue.head = head + 1;
-    if (buf_ptr == 0) {
-        return false;
-    }
-    s_scope_stats_state->current_buf_ptr = buf_ptr;
-    reinterpret_cast<ScopeStatsBuffer *>(buf_ptr)->count = 0;
-    wmb();
-    return true;
+    return ScopeStatsEngine::pop_free(
+               scope_stats_context(), s_scope_stats_state, s_scope_stats_state->current_buf_seq
+           ) != nullptr;
 }
 
 // Commit the full current buffer to the ready_queue before popping a
 // replacement. If no replacement is available, later records drop until host
 // replenishes free_queue.
-void switch_buffer() {
-    if (s_scope_stats_state == nullptr) {
-        return;
-    }
-    ScopeStatsBuffer *full_buf = reinterpret_cast<ScopeStatsBuffer *>(s_scope_stats_state->current_buf_ptr);
-    if (full_buf == nullptr) {
-        return;
-    }
-
-    uint32_t seq = s_scope_stats_state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_scope_stats_state->current_buf_ptr, seq);
-    if (rc != 0) {
-        s_scope_stats_state->dropped_record_count += full_buf->count;
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    s_scope_stats_state->current_buf_ptr = 0;
-    s_scope_stats_state->current_buf_seq = seq + 1;
-    wmb();
-    (void)pop_free_buffer();
-}
+void switch_buffer() { ScopeStatsEngine::switch_buffer(scope_stats_context(), s_scope_stats_state); }
 
 // Unroll a wrapping heap byte offset into a monotonic value using the
 // accumulated wrap count for this ring/side and the registered heap capacity.

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -23,7 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "aicpu/device_time.h"
+#include "aicpu/profiler_device_engine.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -345,92 +345,84 @@ bool try_log_dump_args_layout_mismatch() {
 /**
  * Enqueue a full dump metadata buffer to the thread's ready queue.
  */
-static bool wait_for_ready_queue_space(DumpDataHeader *header, int thread_idx, uint32_t *tail_out, uint32_t *head_out) {
-    if (header == nullptr || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
-        return false;
+struct DumpDeviceModule {
+    struct Context {
+        DumpDataHeader *header;
+        int thread_idx;
+    };
+
+    using DataHeader = DumpDataHeader;
+    using State = DumpBufferState;
+    using FreeQueue = DumpFreeQueue;
+    using Buffer = DumpMetaBuffer;
+
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_DUMP_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_DUMP_SLOT_COUNT;
+    static constexpr uint64_t kBackpressureWaitCycles = kDumpQueueBackpressureWaitCycles;
+
+    static DataHeader *header(Context ctx) { return ctx.header; }
+    static int ready_thread(Context ctx) { return ctx.thread_idx; }
+    static FreeQueue *free_queue(State *state) { return &state->free_queue; }
+
+    static uint64_t current_ptr(State *state) { return state->current_buf_ptr; }
+    static void set_current_ptr(State *state, uint64_t ptr) { state->current_buf_ptr = ptr; }
+    static uint32_t current_seq(State *state) { return state->current_buf_seq; }
+    static void set_current_seq(State *state, uint32_t seq) { state->current_buf_seq = seq; }
+
+    static uint32_t count(Buffer *buffer) { return buffer->count; }
+    static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
+
+    static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        ctx.header->queues[ctx.thread_idx][tail].thread_index = static_cast<uint32_t>(ctx.thread_idx);
+        ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
+        ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
     }
-    const uint32_t capacity = PLATFORM_DUMP_READYQUEUE_SIZE;
-    const uint64_t start = get_sys_cnt_aicpu();
 
-    do {
-        uint32_t current_tail = header->queue_tails[thread_idx];
-        uint32_t current_head = header->queue_heads[thread_idx];
-        uint32_t next_tail = (current_tail + 1) % capacity;
-        if (next_tail != current_head) {
-            *tail_out = current_tail;
-            *head_out = current_head;
-            return true;
-        }
-        if (get_sys_cnt_aicpu() - start >= kDumpQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
-}
+    static void account_dropped(Context, State *state, uint32_t count) { account_dropped_records(state, count); }
+    static void on_pop_success(Context ctx, State *, Buffer *buffer) { s_current_dump_buf[ctx.thread_idx] = buffer; }
+    static void on_current_cleared(Context ctx, State *) { s_current_dump_buf[ctx.thread_idx] = nullptr; }
+    static void on_null_free_slot(Context, State *) {}
 
-static bool wait_for_free_queue_entry(DumpFreeQueue *free_queue, uint32_t *head_out, uint32_t *tail_out) {
-    if (free_queue == nullptr) {
-        return false;
+    static void on_enqueue_failed(Context ctx, State *, Buffer *) {
+        if (!s_logged_ready_queue_full[ctx.thread_idx]) {
+            s_logged_ready_queue_full[ctx.thread_idx] = true;
+            LOG_WARN(
+                "Args dump ready queue full on thread %d after bounded wait, "
+                "dropping current metadata buffer. Increase PLATFORM_DUMP_READYQUEUE_SIZE.",
+                ctx.thread_idx
+            );
+        }
     }
-    const uint64_t start = get_sys_cnt_aicpu();
 
-    do {
-        uint32_t head = free_queue->head;
-        uint32_t tail = free_queue->tail;
-        if (head != tail) {
-            *head_out = head;
-            *tail_out = tail;
-            rmb();  // acquire: order the tail read above before the caller's buffer_ptrs read
-            return true;
+    static void on_no_replacement(Context ctx, State *) {
+        if (!s_logged_no_free_meta_buffer[ctx.thread_idx]) {
+            s_logged_no_free_meta_buffer[ctx.thread_idx] = true;
+            LOG_WARN(
+                "Args dump published a full metadata buffer on thread %d but no replacement was available; "
+                "records will drop until recovery. Increase PLATFORM_DUMP_BUFFERS_PER_THREAD.",
+                ctx.thread_idx
+            );
         }
-        if (get_sys_cnt_aicpu() - start >= kDumpQueueBackpressureWaitCycles) {
-            break;
-        }
-    } while (true);
-    return false;
+    }
+
+    static void on_switch_complete(Context ctx, State *, Buffer *) { s_buffers_switched[ctx.thread_idx]++; }
+};
+
+using DumpEngine = profiling_device::DeviceProfilerEngine<DumpDeviceModule>;
+
+static DumpDeviceModule::Context dump_context(int thread_idx) {
+    return DumpDeviceModule::Context{s_dump_header, thread_idx};
 }
 
 static int enqueue_dump_ready_buffer(int thread_idx, uint64_t buffer_ptr, uint32_t buffer_seq) {
-    uint32_t capacity = PLATFORM_DUMP_READYQUEUE_SIZE;
-    uint32_t current_tail = 0;
-    uint32_t current_head = 0;
-    if (!wait_for_ready_queue_space(s_dump_header, thread_idx, &current_tail, &current_head)) {
-        return -1;
-    }
-
-    uint32_t next_tail = (current_tail + 1) % capacity;
-    s_dump_header->queues[thread_idx][current_tail].thread_index = static_cast<uint32_t>(thread_idx);
-    s_dump_header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
-    s_dump_header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
-    wmb();  // publish: entry fields visible before the tail advance
-    s_dump_header->queue_tails[thread_idx] = next_tail;
-
-    return 0;
+    return DumpEngine::enqueue_ready(dump_context(thread_idx), buffer_ptr, buffer_seq);
 }
 
 static DumpMetaBuffer *try_pop_dump_meta_buffer(int thread_idx, DumpBufferState *state, uint32_t next_seq) {
     if (thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS || state == nullptr) {
         return nullptr;
     }
-    uint32_t head = 0;
-    uint32_t tail = 0;
-    if (!wait_for_free_queue_entry(&state->free_queue, &head, &tail)) {
-        return nullptr;
-    }
-
-    uint64_t new_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_DUMP_SLOT_COUNT];
-    state->free_queue.head = head + 1;
-    if (new_ptr == 0) {
-        return nullptr;
-    }
-
-    DumpMetaBuffer *new_buf = reinterpret_cast<DumpMetaBuffer *>(new_ptr);
-    new_buf->count = 0;
-    s_current_dump_buf[thread_idx] = new_buf;
-    state->current_buf_ptr = new_ptr;
-    state->current_buf_seq = next_seq;
-    wmb();
-    return new_buf;
+    return DumpEngine::pop_free(dump_context(thread_idx), state, next_seq);
 }
 
 /**
@@ -447,42 +439,7 @@ static int switch_dump_meta_buffer(int thread_idx) {
     if (state == nullptr || cur == nullptr) {
         return -1;
     }
-
-    uint64_t buf_addr = reinterpret_cast<uint64_t>(cur);
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_dump_ready_buffer(thread_idx, buf_addr, seq);
-    if (rc != 0) {
-        account_dropped_records(state, cur->count);
-        cur->count = 0;
-        wmb();
-        if (!s_logged_ready_queue_full[thread_idx]) {
-            s_logged_ready_queue_full[thread_idx] = true;
-            LOG_WARN(
-                "Args dump ready queue full on thread %d after bounded wait, "
-                "dropping current metadata buffer. Increase PLATFORM_DUMP_READYQUEUE_SIZE.",
-                thread_idx
-            );
-        }
-        return 0;
-    }
-
-    uint32_t next_seq = seq + 1;
-    s_current_dump_buf[thread_idx] = nullptr;
-    state->current_buf_ptr = 0;
-    state->current_buf_seq = next_seq;
-    wmb();
-
-    if (try_pop_dump_meta_buffer(thread_idx, state, next_seq) == nullptr && !s_logged_no_free_meta_buffer[thread_idx]) {
-        s_logged_no_free_meta_buffer[thread_idx] = true;
-        LOG_WARN(
-            "Args dump published a full metadata buffer on thread %d but no replacement was available; "
-            "records will drop until recovery. Increase PLATFORM_DUMP_BUFFERS_PER_THREAD.",
-            thread_idx
-        );
-    }
-
-    s_buffers_switched[thread_idx]++;
-
+    DumpEngine::switch_buffer(dump_context(thread_idx), state);
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1247.

This PR introduces a shared AICPU-side profiling device engine, `DeviceProfilerEngine<Module>`, as the device-side counterpart to the host `ProfilerAlgorithms<Module>` pattern. The goal is not just to extract low-level wait helpers; it is to centralize the common producer-side enqueue/pop/switch buffer operation layer that had been duplicated across AICPU collectors.

The shared engine now owns the common ready-queue handoff, free-queue pop/install, and current-buffer switch flow. Each collector keeps only its subsystem-specific record fill, flush/finalize, state shape, and local hooks.

## What Changed

- Added `src/common/platform/include/aicpu/profiler_device_engine.h`.
- Migrated the common AICPU producer buffer flow for:
  - ScopeStats
  - DepGen on a2a3 and a5
  - TensorDump / ArgsDump
  - PMU on a2a3 and a5
  - the standard L2Swimlane AICPU task buffer path on a2a3 and a5
- Updated `docs/profiling-framework.md` to document the new device-side profiling layer.
- Updated the issue plan under the external working notes with the implementation and validation status.

## Design Notes

`DeviceProfilerEngine<Module>` is intentionally header-only and trait-driven, matching the existing host-side design style. The module trait supplies the collector-specific types, queue sizes, wait limits, pointer/sequence accessors, ready-entry writer, and event hooks.

The engine covers the shared flow:

1. wait for ready-queue space
2. enqueue the current buffer to the ready queue
3. wait for a free-queue entry
4. pop and install the next writable buffer
5. preserve the existing drop-accounting and memory-barrier behavior through module hooks

L2Swimlane is only partially normalized by design. Its AICPU task buffer path now uses the shared engine, while phase-pool switching/recovery and AICore rotation remain local because they have different sequence, retry, drop, and AICore-visible head semantics. Forcing those paths into the generic engine would make the common abstraction less clear and risk changing L2-specific behavior.

## Validation

Build and static checks:

- `python -m pip install --no-build-isolation -e .`
- `cmake --build /data/jinzongquan/simpler/build/ut_cpp_issue1253 -j2`
- `git diff --check`
- commit-time pre-commit hooks: headers, English-only, EOF, trailing whitespace, clang-format, clang-tidy, cpplint, markdownlint

Unit tests:

- `test_a2a3_orchestrator_fanin`
- `test_a5_orchestrator_fanin`
- `test_scope_stats_collector`
- `test_a2a3_scope_stats_collector`

a2a3 onboard ST:

- ScopeStats
- DepGen
- DepGen chain
- ArgsDump / TensorDump with `--dump-args 1`, `--dump-args 2`, and `--dump-args 3`
- PMU
- L2Swimlane
- L2Swimlane mixed

a5sim ST:

- DepGen
- ArgsDump
- PMU

Known validation note:

- a5sim L2Swimlane currently segfaults with `--enable-l2-swimlane 1/2/3/4` on this branch.
- The same `--enable-l2-swimlane 1` scenario was reproduced on a clean `main` worktree, so this appears to be a pre-existing main-branch issue rather than a regression from this PR.

## Risk / Follow-up

- The refactor touches device-side queue handoff and memory-barrier-sensitive paths. The implementation keeps the barriers explicit in the shared engine and was onboard-validated on a2a3, but a5 onboard validation is still recommended before merge if available.
- L2Swimlane is intentionally not fully collapsed into the generic engine. The remaining local code is the part where L2 behavior genuinely differs from ScopeStats, DepGen, TensorDump, and PMU.
