### PR TITLE
[Optimization] Parallelize AICore handshake across AICPU threads -- 3~22% Device Speedup 

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -103,8 +103,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     bool pmu_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
 
     // Per-core L2SwimlaneActiveHead channel. AICPU completes
-    // `l2_swimlane_aicpu_init` before writing `aicpu_ready = 1` in
-    // `handshake_all_cores`, and Phase 1 above has already observed
+    // `l2_swimlane_aicpu_init` (in pre_handshake_init) before any thread writes
+    // `aicpu_ready = 1` in `handshake_partition`, and Phase 1 above has already observed
     // `aicpu_ready == 1`, so the rotation-table slot is populated and the
     // first deref is safe here — off the dispatch→start critical path.
     __gm__ L2SwimlaneActiveHead *l2_swimlane_head = l2_swimlane_enabled ? get_l2_swimlane_aicore_head() : nullptr;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -119,10 +119,15 @@ struct AicpuExecutor {
 
     // ===== Thread management state =====
     std::atomic<int32_t> thread_idx_{0};
-    std::atomic<bool> initialized_{false};
     std::atomic<bool> init_done_{false};
     std::atomic<bool> init_failed_{false};
     std::atomic<bool> finished_{false};
+
+    // Parallel-handshake coordination (see AicpuExecutor::init). hs_setup_done_
+    // is published by the leader once the shared pre-handshake setup is visible;
+    // hs_arrived_ is the barrier counting threads that finished their core slice.
+    std::atomic<bool> hs_setup_done_{false};
+    std::atomic<int32_t> hs_arrived_{0};
 
     int32_t aicpu_thread_num_{0};
 
@@ -187,42 +192,73 @@ static_assert(
 // ===== AicpuExecutor Method Implementations =====
 
 int32_t AicpuExecutor::init(Runtime *runtime) {
-    bool expected = false;
-    if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
-        return 0;
-    }
-
-    LOG_INFO_V0("AicpuExecutor: Initializing");
-
     if (runtime == nullptr) {
         LOG_ERROR("runtime is nullptr");
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
 
-    // Read execution parameters from runtime. The 0 → 1 fixup runs before the
-    // sched_thread_num_ derivation so a zero input doesn't leave the scheduler
-    // count at -1.
-    aicpu_thread_num_ = runtime->dev.aicpu_thread_num;
-    if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
-    sched_thread_num_ = aicpu_thread_num_ - 1;
-    serial_orch_sched_ = runtime->dev.serial_orch_sched;
-
-    if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
+    // All AICPU threads enter init. The per-core AICore handshake is the
+    // dominant preamble cost (serial MMIO, ~217 µs of ~283 µs for 72 cores), so
+    // it is parallelized: the leader (exec_idx 0) does the shared setup, every
+    // thread handshakes a disjoint slice of cores, then the leader finishes init
+    // after a barrier. Non-leaders spin on init_done_. The affinity thread idx
+    // is already valid here (set by the gate filter before aicpu_execute) and is
+    // used both to pick the leader and to partition cores.
+    int32_t nthreads = runtime->dev.aicpu_thread_num;
+    if (nthreads == 0) nthreads = 1;
+    if (nthreads < 1 || nthreads > MAX_AICPU_THREADS) {
+        LOG_ERROR("Invalid aicpu_thread_num: %d", nthreads);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
+    int32_t tidx = platform_aicpu_affinity_thread_idx();
+    if (tidx < 0) tidx = 0;
+    const bool is_leader = (tidx == 0);
 
-    if (sched_ctx_.init(runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs()) != 0) {
-        init_failed_.store(true, std::memory_order_release);
-        return -1;
+    if (is_leader) {
+        LOG_INFO_V0("AicpuExecutor: Initializing");
+        // The 0 → 1 fixup already applied above; derive scheduler count from it.
+        aicpu_thread_num_ = nthreads;
+        sched_thread_num_ = nthreads - 1;
+        serial_orch_sched_ = runtime->dev.serial_orch_sched;
+
+        hs_arrived_.store(0, std::memory_order_relaxed);
+        if (sched_ctx_.pre_handshake_init(runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs()) != 0) {
+            init_failed_.store(true, std::memory_order_release);
+            hs_setup_done_.store(true, std::memory_order_release);
+            return -1;
+        }
+        hs_setup_done_.store(true, std::memory_order_release);
+    } else {
+        while (!hs_setup_done_.load(std::memory_order_acquire)) {
+            if (init_failed_.load(std::memory_order_acquire)) return -1;
+        }
+        if (init_failed_.load(std::memory_order_acquire)) return -1;
     }
 
-    finished_count_.store(0, std::memory_order_release);
+    // All threads: handshake this thread's slice of cores in parallel.
+    sched_ctx_.handshake_partition(runtime, tidx, nthreads);
 
-    init_done_.store(true, std::memory_order_release);
-    LOG_INFO_V0("AicpuExecutor: Init complete");
+    // Barrier: leader waits for every slice to finish, then completes init.
+    hs_arrived_.fetch_add(1, std::memory_order_acq_rel);
+    if (is_leader) {
+        while (hs_arrived_.load(std::memory_order_acquire) < nthreads) {
+        }
+        finished_count_.store(0, std::memory_order_release);
+        if (sched_ctx_.post_handshake_init(runtime) != 0) {
+            init_failed_.store(true, std::memory_order_release);
+            init_done_.store(true, std::memory_order_release);
+            return -1;
+        }
+        init_done_.store(true, std::memory_order_release);
+        LOG_INFO_V0("AicpuExecutor: Init complete");
+    } else {
+        while (!init_done_.load(std::memory_order_acquire)) {
+            if (init_failed_.load(std::memory_order_acquire)) return -1;
+        }
+        if (init_failed_.load(std::memory_order_acquire)) return -1;
+    }
     return 0;
 }
 
@@ -814,9 +850,10 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
     LOG_INFO_V0("DeInit: Runtime execution state reset");
 
-    initialized_.store(false, std::memory_order_release);
     init_done_.store(false, std::memory_order_release);
     init_failed_.store(false, std::memory_order_release);
+    hs_setup_done_.store(false, std::memory_order_release);
+    hs_arrived_.store(0, std::memory_order_release);
     thread_idx_.store(0, std::memory_order_release);
     finished_.store(false, std::memory_order_release);
 
@@ -876,12 +913,12 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     // rc / runtime_rc are declared out here because they outlive their phase.
     {
         AicpuPhaseScope preamble(AicpuPhase::Preamble);
-        g_aicpu_executor.init(runtime);
-        while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
-            if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
-                LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
-                return -1;
-            }
+        // init() barriers every thread internally until init is complete on the
+        // leader (or a thread failed), then returns the status — so a non-zero
+        // return is authoritative on all threads and no extra spin is needed.
+        if (g_aicpu_executor.init(runtime) != 0) {
+            LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
+            return -1;
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -126,8 +126,12 @@ struct AicpuExecutor {
     // Parallel-handshake coordination (see AicpuExecutor::init). hs_setup_done_
     // is published by the leader once the shared pre-handshake setup is visible;
     // hs_arrived_ is the barrier counting threads that finished their core slice.
+    // hs_thread_seq_ hands out a distinct [0, nthreads) index when the platform
+    // exposes no affinity idx (sim, where platform_aicpu_affinity_thread_idx()
+    // is -1 during init) so the threads don't all collapse to leader 0.
     std::atomic<bool> hs_setup_done_{false};
     std::atomic<int32_t> hs_arrived_{0};
+    std::atomic<int32_t> hs_thread_seq_{0};
 
     int32_t aicpu_thread_num_{0};
 
@@ -200,11 +204,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 
     // All AICPU threads enter init. The per-core AICore handshake is the
     // dominant preamble cost (serial MMIO, ~217 µs of ~283 µs for 72 cores), so
-    // it is parallelized: the leader (exec_idx 0) does the shared setup, every
+    // it is parallelized: the leader (tidx 0) does the shared setup, every
     // thread handshakes a disjoint slice of cores, then the leader finishes init
-    // after a barrier. Non-leaders spin on init_done_. The affinity thread idx
-    // is already valid here (set by the gate filter before aicpu_execute) and is
-    // used both to pick the leader and to partition cores.
+    // after a barrier. Non-leaders spin on init_done_.
     int32_t nthreads = runtime->dev.aicpu_thread_num;
     if (nthreads == 0) nthreads = 1;
     if (nthreads < 1 || nthreads > MAX_AICPU_THREADS) {
@@ -212,8 +214,26 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
+    // Each thread needs a distinct index in [0, nthreads) to pick the leader and
+    // partition the cores. Onboard the gate filter assigns it (exec_idx); sim's
+    // gate does not, so platform_aicpu_affinity_thread_idx() is -1 here for every
+    // thread — hand those a distinct index from a counter (mirrors run()'s
+    // thread_idx_++ fallback) instead of collapsing them all to leader 0, which
+    // would run pre_/post_handshake_init on every thread and race the shared
+    // scheduler state. Exactly nthreads threads reach init (the gate drops the
+    // rest), so the counter yields a gap-free [0, nthreads).
     int32_t tidx = platform_aicpu_affinity_thread_idx();
-    if (tidx < 0) tidx = 0;
+    if (tidx < 0) tidx = hs_thread_seq_.fetch_add(1, std::memory_order_acq_rel);
+    // A thread whose index still falls outside [0, nthreads) owns no core slice:
+    // handshake_partition would compute lo/hi past cores_total_num_ and index
+    // all_handshakes[]/core_exec_states_ out of bounds. Reject it here (mirrors
+    // the bounds guard already in run()). Fail only this thread and do NOT set
+    // init_failed_ — that would make the valid peers abort before their
+    // hs_arrived_ increment and hang the leader at the barrier below.
+    if (tidx >= nthreads) {
+        LOG_ERROR("AICPU affinity thread idx %d out of range [0,%d) in init", tidx, nthreads);
+        return -1;
+    }
     const bool is_leader = (tidx == 0);
 
     if (is_leader) {
@@ -243,8 +263,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     // Barrier: leader waits for every slice to finish, then completes init.
     hs_arrived_.fetch_add(1, std::memory_order_acq_rel);
     if (is_leader) {
-        while (hs_arrived_.load(std::memory_order_acquire) < nthreads) {
-        }
+        while (hs_arrived_.load(std::memory_order_acquire) < nthreads) {}
         finished_count_.store(0, std::memory_order_release);
         if (sched_ctx_.post_handshake_init(runtime) != 0) {
             init_failed_.store(true, std::memory_order_release);
@@ -854,6 +873,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     init_failed_.store(false, std::memory_order_release);
     hs_setup_done_.store(false, std::memory_order_release);
     hs_arrived_.store(0, std::memory_order_release);
+    hs_thread_seq_.store(0, std::memory_order_release);
     thread_idx_.store(0, std::memory_order_release);
     finished_.store(false, std::memory_order_release);
 
@@ -892,10 +912,11 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_register_cal
  *
  * This is called by DynTileFwkBackendKernelServer in kernel.cpp.
  * Orchestrates the complete task runtime execution:
- * 1. Initialize executor (thread-safe, first thread only)
- * 2. Wait for initialization to complete
- * 3. Execute tasks on managed cores
- * 4. Cleanup when last thread finishes
+ * 1. Initialize executor: all threads enter init(), which handshakes the cores
+ *    in parallel and barriers internally until init is complete (or a thread
+ *    failed); its return value is authoritative on every thread.
+ * 2. Execute tasks on managed cores
+ * 3. Cleanup when last thread finishes
  *
  * @param runtime Pointer to Runtime structure
  * @return 0 on success, non-zero on error

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -599,7 +599,7 @@ Private internals are split across three .cpp files by responsibility:
 
 - `scheduler_completion.cpp` — completion polling, drain protocol
 - `scheduler_dispatch.cpp` — task dispatch loop and helpers
-- `scheduler_cold_path.cpp` — exit checks, stall diagnostics, profiling, lifecycle (`init/deinit`), core management (`handshake_all_cores` / `assign_cores_to_threads` / `emergency_shutdown`), and `on_orchestration_done`
+- `scheduler_cold_path.cpp` — exit checks, stall diagnostics, profiling, lifecycle (`pre_handshake_init` / `handshake_partition` / `post_handshake_init` / `deinit`), core management (`assign_cores_to_threads` / `emergency_shutdown`), and `on_orchestration_done`
 
 `AicpuExecutor` calls neither `handshake_*`, `assign_*`, `reassign_*`, nor `emergency_shutdown` directly — they are private, invoked only by `init` and `on_orchestration_done`.
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -669,27 +669,23 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 }
 
 // =============================================================================
-// Handshake with all AICore workers; discover core type and reg address.
+// Handshake a contiguous slice of AICore workers. Runs on every AICPU thread in
+// parallel (partitioned by tidx/nthreads); the leader's pre_handshake_init has
+// already zeroed state, set cores_total_num_, and reset the counts/flag. The
+// serial per-core MMIO here is what dominates preamble, so splitting the slice
+// across threads is the whole point. Worker-id lists are built serially in
+// post_handshake_init (core-index order) once every slice has landed.
 // =============================================================================
-int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
+void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads) {
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
-    cores_total_num_ = runtime->dev.worker_count;
-
-    // Validate cores_total_num_ before using as array index
-    if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
-        return -1;
-    }
-
-    aic_count_ = 0;
-    aiv_count_ = 0;
-
-    LOG_INFO_V0("Handshaking with %d cores", cores_total_num_);
+    const int32_t total = cores_total_num_;
+    const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(tidx) * total) / nthreads);
+    const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(tidx + 1) * total) / nthreads);
 
     // Step 1: Write per-core payload addresses and send handshake signal.
     // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
     // aicpu_ready=1, so AICore reads the correct payload pointer after waking up.
-    for (int32_t i = 0; i < cores_total_num_; i++) {
+    for (int32_t i = lo; i < hi; i++) {
         all_handshakes[i].task = reinterpret_cast<uint64_t>(&payload_per_core_[i][0]);
         OUT_OF_ORDER_STORE_BARRIER();
         all_handshakes[i].aicpu_ready = 1;
@@ -699,9 +695,8 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
     // Get platform physical cores count for validation
     uint32_t max_physical_cores_count = platform_get_physical_cores_count();
 
-    // Step 2: Wait for all cores to respond, collect core type and register addresses
-    bool handshake_failed = false;
-    for (int32_t i = 0; i < cores_total_num_; i++) {
+    // Step 2: Wait for this slice's cores, init registers, collect state.
+    for (int32_t i = lo; i < hi; i++) {
         Handshake *hank = &all_handshakes[i];
 
         while (hank->aicore_regs_ready == 0) {
@@ -715,7 +710,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
                 "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
                 max_physical_cores_count
             );
-            handshake_failed = true;
+            handshake_failed_.store(true, std::memory_order_release);
             continue;
         }
 
@@ -733,8 +728,6 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
             SPIN_WAIT_HINT();
         }
 
-        CoreType type = hank->core_type;
-
         core_exec_states_[i].reg_addr = reg_addr;
         core_exec_states_[i].cond_ptr = get_reg_ptr(reg_addr, RegId::COND);
 
@@ -746,25 +739,9 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 #if !PTO2_PROFILING
         core_exec_states_[i].worker_id = i;
         core_exec_states_[i].physical_core_id = physical_core_id;
-        core_exec_states_[i].core_type = type;
+        core_exec_states_[i].core_type = hank->core_type;
 #endif
-
-        if (type == CoreType::AIC) {
-            aic_worker_ids_[aic_count_++] = i;
-            LOG_INFO_V0("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
-        } else {
-            aiv_worker_ids_[aiv_count_++] = i;
-            LOG_INFO_V0("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
-        }
     }
-
-    if (handshake_failed) {
-        emergency_shutdown(runtime);
-        return -1;
-    }
-
-    LOG_INFO_V0("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
-    return 0;
 }
 
 // =============================================================================
@@ -858,8 +835,9 @@ void SchedulerContext::emergency_shutdown(Runtime *runtime) {
 // =============================================================================
 // Lifecycle: init / deinit
 // =============================================================================
-int32_t
-SchedulerContext::init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base) {
+int32_t SchedulerContext::pre_handshake_init(
+    Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base
+) {
     always_assert(runtime != nullptr);
 
     // Zero all per-core execution state before handshake
@@ -876,7 +854,9 @@ SchedulerContext::init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched
     // value would still be 0 (only the binary enable bit has been seeded by
     // kernel.cpp at this point). Reset the cached level on disabled runs so a
     // prior enabled launch's level can't leak into the phase-record gates in
-    // scheduler_dispatch.
+    // scheduler_dispatch. This runs on the leader before it publishes
+    // hs_setup_done_, so it happens-before every thread's handshake_partition
+    // (and therefore before any aicpu_ready=1 write).
     if (is_l2_swimlane_enabled()) {
         l2_swimlane_aicpu_init(runtime->dev.worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
@@ -899,19 +879,55 @@ SchedulerContext::init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched
     }
 #endif
 
-    // Discover cores and assign to scheduler threads.
-    int32_t rc = handshake_all_cores(runtime);
-    if (rc != 0) {
-        LOG_ERROR("handshake_all_cores failed");
-        return rc;
+    // Core count is needed by every thread to compute its handshake slice.
+    cores_total_num_ = runtime->dev.worker_count;
+    if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
+        LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
+        return -1;
     }
+    aic_count_ = 0;
+    aiv_count_ = 0;
+    handshake_failed_.store(false, std::memory_order_release);
+
+    LOG_INFO_V0("Handshaking with %d cores", cores_total_num_);
+    return 0;
+}
+
+int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
+    if (handshake_failed_.load(std::memory_order_acquire)) {
+        emergency_shutdown(runtime);
+        return -1;
+    }
+
+    // Build cluster-ordered AIC/AIV worker-id lists from the discovered cores.
+    // Serial and MMIO-free — the expensive per-core handshake already ran in
+    // parallel across threads. Core-index order matches the original
+    // single-thread handshake so assign_cores_to_threads forms identical
+    // clusters. core_type / physical_core_id are read from the Handshake struct
+    // (stable after the handshake) so this stays correct under PTO2_PROFILING,
+    // where they are not mirrored into CoreExecState.
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        CoreType type = all_handshakes[i].core_type;
+        uint32_t physical_core_id = all_handshakes[i].physical_core_id;
+        uint64_t reg_addr = core_exec_states_[i].reg_addr;
+        if (type == CoreType::AIC) {
+            aic_worker_ids_[aic_count_++] = i;
+            LOG_INFO_V0("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        } else {
+            aiv_worker_ids_[aiv_count_++] = i;
+            LOG_INFO_V0("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        }
+    }
+    LOG_INFO_V0("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
+
     if (!assign_cores_to_threads()) {
         return -1;
     }
 
-    // Profiling-subsystem buffer/state init: single-threaded cold path, so the
-    // "do it once" guarantee is structural (no CAS needed). Runs after
-    // handshake_all_cores / assign_cores_to_threads because pmu_aicpu_init needs
+    // Profiling-subsystem buffer/state init: single-threaded cold path (leader
+    // only), so the "do it once" guarantee is structural (no CAS needed). Runs
+    // after the handshake / assign_cores_to_threads because pmu_aicpu_init needs
     // physical_core_ids_ / cores_total_num_. Mirrors the l2_swimlane_aicpu_init
     // convention above; the per-thread *_set_orch_thread_idx setters stay on the
     // orchestrator thread (see aicpu_executor.cpp).

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -65,7 +65,8 @@ public:
     // Leader-only: per-core state + config + swimlane buffers + core count. Must
     // be published before any thread enters handshake_partition. Returns 0 on
     // success, negative on failure.
-    int32_t pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
+    int32_t
+    pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
     // All threads: handshake this thread's contiguous slice [lo, hi) of cores
     // (partitioned by tidx/nthreads). Each core is touched by exactly one thread.
     void handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -54,14 +54,24 @@ public:
     // Lifecycle
     // =========================================================================
 
-    // Initialize scheduler state from the given runtime and thread layout.
-    // - Discovers cores via handshake_all_cores()
-    // - Assigns cores to scheduler threads
-    // - Resets task counters, payloads, per-core GlobalContext
-    // - Binds func_id_to_addr_ / initial sched_ (if rt is already known)
-    // - Captures AICore-register base (consumed by handshake_all_cores())
-    // Returns 0 on success, negative on failure (handshake / assignment error).
-    int32_t init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
+    // Initialize scheduler state from the given runtime and thread layout. Split
+    // into three parts so the per-core AICore handshake — a serial, MMIO-bound
+    // loop that dominates preamble (~217 µs of ~283 µs for 72 cores) — can run in
+    // parallel across all AICPU threads. Orchestrated by AicpuExecutor::init:
+    // the leader runs pre_handshake_init, every thread handshakes a disjoint
+    // slice of cores via handshake_partition, then the leader runs
+    // post_handshake_init after a barrier.
+    //
+    // Leader-only: per-core state + config + swimlane buffers + core count. Must
+    // be published before any thread enters handshake_partition. Returns 0 on
+    // success, negative on failure.
+    int32_t pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
+    // All threads: handshake this thread's contiguous slice [lo, hi) of cores
+    // (partitioned by tidx/nthreads). Each core is touched by exactly one thread.
+    void handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads);
+    // Leader-only, after the handshake barrier: build worker-id lists, assign
+    // cores, init profiling subsystems, read task counts, init payloads.
+    int32_t post_handshake_init(Runtime *runtime);
 
     // Reset all SchedulerContext-owned state to its post-construction defaults.
     // Called by AicpuExecutor::deinit() during per-run teardown.
@@ -157,11 +167,15 @@ private:
     int32_t aicpu_thread_num_{0};
     int32_t cores_total_num_{0};
 
-    // Cluster-ordered worker_id lists, populated by handshake_all_cores().
+    // Cluster-ordered worker_id lists, populated by post_handshake_init().
     int32_t aic_worker_ids_[RUNTIME_MAX_WORKER]{};
     int32_t aiv_worker_ids_[RUNTIME_MAX_WORKER]{};
     int32_t aic_count_{0};
     int32_t aiv_count_{0};
+
+    // Set by any thread whose slice hits an invalid physical_core_id in
+    // handshake_partition; checked by the leader in post_handshake_init.
+    std::atomic<bool> handshake_failed_{false};
 
     // Platform AICore-register base array (set by AicpuExecutor before init()).
     uint64_t regs_{0};
@@ -176,9 +190,6 @@ private:
     // =========================================================================
     // Core management (scheduler_cold_path.cpp)
     // =========================================================================
-
-    // Handshake with all AICore workers; populates core_exec_states_, worker id lists.
-    int32_t handshake_all_cores(Runtime *runtime);
 
     // Assign discovered cores (cluster = 1 AIC + 2 AIV) round-robin across scheduler threads.
     bool assign_cores_to_threads();


### PR DESCRIPTION
# Human Summary

Currently, upstream/main has a single thread handle the handshake for all compute cores. This is a fixed cost that represents a significant part of the kernel running time. This PR parallelizes the process among the other AICPU cores, obtaining  an up to 22% speedup.

The effect is mostly notable on small kernels, whose fixed runtime component is more significant. This improvements is complementary to that of https://github.com/hw-native-sys/simpler/pull/1137 which improves the dynamic aspect, favoring large kernels with many small tasks.

# AI Summary

Every time the runtime starts a run, it does a "roll call" of all 72 AICore
compute units — greeting each one and setting up its registers before any work
can begin. Today **one** AICPU thread does this roll call **one core at a time**,
while the other three threads sit idle waiting. That serial roll call takes
**~217 µs of the ~283 µs startup** on a2a3, and because it's a *fixed* cost paid
every single run, it hurts short jobs the most.

This PR has **all four AICPU threads greet the cores in parallel**, each handling
a quarter of them. Startup drops from **~283 µs to ~85 µs**, which takes **~172 µs
off the device time of every run** — **−7.5% on qwen3-14B decode** and **up to
−22% on small workloads**. The actual compute is untouched; only the startup gets
faster. Correctness is unchanged (golden-verified on 8 cases).

---

## The problem

Before any tasks run, the scheduler has to *discover* the AICore units it will
dispatch to. For each core it: waits for the core to boot and report in, reads
its physical ID, initializes its control registers over MMIO, and waits for the
core to acknowledge. This "handshake" happens **fresh on every round** (the cores
exit at the end of each round and are relaunched).

The catch: this loop ran **serially on a single thread**. On the Ascend AICPU,
MMIO register access is strictly serial (~95 ns per access, no pipelining — a
documented hardware constraint), so greeting 72 cores one-by-one is slow by
construction. Meanwhile the other three AICPU threads spun idle, doing nothing
but waiting for the one thread to finish.

We profiled it directly: of the ~283 µs startup ("preamble") on qwen3-14B decode,
**~217 µs (82%) was the serial per-core handshake work**. Only ~11 µs was
unavoidable (waiting for the first core to physically boot).

Because this cost is *fixed per round*, it's a small slice of a big job but a
huge slice of a small one — e.g. ~26% of a simple matmul's device time, and it
was a major contributor to why small workloads looked slow.

## The fix

The hardware guidance is explicit: *the only way to speed up cross-core polling
is to use more threads*. So we do exactly that.

`SchedulerContext::init` is split into three phases:

1. **`pre_handshake_init`** (leader thread only): the shared setup — zero the
   per-core state, wire configuration, initialize profiling/swimlane buffers,
   and record the core count. Published to the other threads via a flag.
2. **`handshake_partition`** (all four threads): each thread greets a disjoint,
   contiguous slice of the cores (18 each for 72). Because the slices don't
   overlap, there's no contention — the expensive MMIO work now runs four-wide.
3. **`post_handshake_init`** (leader thread only, after a barrier): the cheap
   bookkeeping — build the ordered AIC/AIV worker lists, assign cores to
   scheduler threads, initialize dispatch payloads.

`AicpuExecutor::init` orchestrates the three phases with a simple barrier: the
leader publishes "setup done", all threads handshake their slice and report in,
and the leader waits for all of them before finishing. Startup timing:

```
                serial (before)            parallel (after)
  broadcast     ~35 us                     ~9 us  (split 4 ways)
  boot wait     ~11 us                     ~11 us (unavoidable, physical)
  per-core work ~217 us  <-- the tax       ~55 us (split 4 ways)
  ---------------------------------------------------------------
  handshake     ~263 us                    ~75 us
```

## Results

Direct A/B of **this PR vs `upstream/main`** (both the same upstream runtime, so
this isolates the handshake change), back-to-back on the same NPU (device 2),
100 rounds each, trimmed-80. **Device** time is the metric of record (on-NPU
wall clock):

| Workload | upstream/main | this PR | change |
| --- | ---: | ---: | ---: |
| paged_attention_unroll C2 | 866.5 µs | 675.3 µs | **−22.1%** |
| pa_unroll_manual_scope C2 | 854.3 µs | 678.9 µs | **−20.5%** |
| benchmark_bgemm | 962.5 µs | 790.3 µs | **−17.9%** |
| alternating_matmul_add | 987.2 µs | 815.9 µs | **−17.4%** |
| paged_attention_unroll C1 | 1448.2 µs | 1261.0 µs | −12.9% |
| pa_unroll_manual_scope C1 | 1430.9 µs | 1261.2 µs | −11.9% |
| **qwen3_14b_decode** | 2409.8 µs | 2228.3 µs | **−7.5%** |
| batch_paged_attention | 3400.9 µs | 3270.6 µs | −3.8% |

Every workload improves by a near-constant **~172 µs** — the tell-tale signature
of removing a *fixed* overhead. The relative win scales inversely with job size:
biggest on the small workloads that the fixed cost dominated, smallest on the
long-running ones. The compute window itself is unchanged (−0.3% to +2.0%,
noise), because this only touches startup — not scheduling or kernel execution.

## Correctness

Golden-verified (output compared against a PyTorch reference) on a deliberately
diverse spread, all **PASSED**:

- `vector_example` — tiny, simple graph
- `benchmark_bgemm` — AIC matrix-multiply (Case0, Bgemm64)
- `paged_attention` — 65,792-task orchestration-heavy run (Case1) + a small case
- `qwen3_14b_decode` — dense two-layer transformer decode

The 65k-task and multi-scope cases are the strongest exercise of the new
multi-thread partition + barrier path.

## Why it's safe

- **No new config or feature flag** — parallelizing the handshake is always
  correct, so it's unconditional.
- **No data races** — each core is handshaked by exactly one thread (contiguous,
  gap-free partition), so the per-core writes never overlap.
- **Ordering preserved** — the AIC/AIV worker lists are rebuilt in the same
  core-index order as before, so core-to-thread assignment is identical.
- **Memory ordering** — a setup failure is stored before the "setup done" flag
  (both release/acquire), so a failing init can never let a thread proceed. The
  swimlane-buffer init still happens before any core is signaled.
- **Profiling-agnostic** — under `PTO2_PROFILING` the post-pass reads core type
  and physical ID from the Handshake struct, so it works whether or not
  profiling is compiled in.

## Files changed (5)

All in `src/a2a3/runtime/tensormap_and_ringbuffer/`:

- `runtime/scheduler/scheduler_cold_path.cpp` — split `init` into
  `pre_handshake_init` / `post_handshake_init`; replace `handshake_all_cores`
  with the sliced `handshake_partition`.
- `runtime/scheduler/scheduler_context.h` — updated declarations; added the
  `handshake_failed_` flag.
- `aicpu/aicpu_executor.cpp` — parallel init orchestration + barrier; removed
  the dead single-leader CAS.
- `aicore/aicore_executor.cpp` — comment updated to reference the new function.
- `docs/RUNTIME_LOGIC.md` — doc updated to reference the new functions.

## Notes for reviewers

- The Results table is a direct A/B of this branch against `upstream/main` — both
  built from the same upstream runtime and run back-to-back on the same NPU — so
  it isolates the handshake change with nothing else varying. The ~85 µs startup
  and per-phase handshake breakdown come from direct profiling of the same
  optimization.
- A separate, pre-existing defect was noticed during this work: the L2 swimlane
  collector produces no data on the `tensormap_and_ringbuffer` runtime. It is
  unrelated to this change and tracked separately.
