### PR TITLE
Obtain the managed pto-isa checkout fresh at the pinned commit

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,8 +19,12 @@ file.
 The test framework automatically handles PTO-ISA setup:
 
 1. Reads the required commit from `pto_isa.pin`.
-2. Clones pto-isa over HTTPS to `build/pto-isa` on first use if needed.
-3. Checks out and resets `build/pto-isa` to the pinned commit.
+2. Reuses `build/pto-isa` as-is when it already sits at exactly the pinned
+   commit.
+3. Otherwise (missing, wrong revision, or a dirty working tree) re-clones
+   `build/pto-isa` fresh over HTTPS directly at the pinned commit, rather than
+   `git checkout`-ing over the existing checkout — a checkout aborts on local
+   modifications and would strand the clone at the wrong revision.
 4. Passes that managed checkout to the kernel/runtime compilers.
 
 **Automatic Setup (Recommended):**
@@ -39,9 +43,10 @@ mkdir -p build
 git clone --branch main https://github.com/hw-native-sys/pto-isa.git build/pto-isa
 ```
 
-Manual setup still uses the standard managed location. `simpler` will fetch,
-checkout, and reset that repository to the commit in `pto_isa.pin` before it
-builds runtimes or compiles kernels.
+Manual setup still uses the standard managed location. Before it builds
+runtimes or compiles kernels, `simpler` verifies that checkout is at the commit
+in `pto_isa.pin`; if it isn't (or the working tree is dirty), it re-clones the
+repository fresh at the pinned commit.
 
 **Revision selection and compatibility checks:**
 

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -12,9 +12,27 @@
 ``ensure_pto_isa_root()`` always manages ``PROJECT_ROOT/build/pto-isa``:
 
 1. Read the required commit from ``pto_isa.pin``.
-2. Clone the managed checkout over HTTPS if it is missing.
-3. Checkout/reset the managed checkout to the pinned commit.
+2. If a managed checkout already exists **clean and at exactly the pin**, use it
+   as-is — it already *is* the pinned ISA, so no checkout and no network.
+3. Otherwise (missing, wrong revision, or dirty) obtain the pin fresh: clone
+   over HTTPS (``--no-checkout`` so the default branch is never materialized)
+   and force-check-out the pin.
 4. Verify HEAD exactly matches the pin before returning.
+
+Two deliberate choices:
+
+- **Obtain the pin fresh instead of patching a dirty cache.** A checkout is
+  reused only when it is provably already the pin (clean working tree with
+  HEAD == pin); anything else is re-cloned rather than reset/force-checked-out
+  in place, so the build never uses an ISA tree that was checked out over local
+  modifications. Reusing a pristine cache keeps the common path network-free;
+  the one network hop of a fresh clone is retried on transient failure.
+- **Force the checkout when landing a fresh clone.** pto-isa's default branch
+  carries case-duplicate doc paths (``docs/isa/TADDDEQRELU.md`` vs
+  ``TAddDeqRelu.md``) that collide on a case-insensitive filesystem (macOS CI),
+  leaving even a fresh working tree "modified"; a plain checkout then aborts.
+  ``--no-checkout`` (never materialize the default branch) plus a forced
+  checkout of the pin sidesteps that entirely.
 
 Lock file under build/ serializes concurrent clones from parallel processes.
 """
@@ -25,11 +43,18 @@ import logging
 import re
 import shutil
 import subprocess
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Optional
 
 from .environment import PROJECT_ROOT
+
+# A fresh clone is only needed when no usable local checkout exists; when it is,
+# guard the single network hop against transient failures (e.g. GitHub
+# SSL_ERROR_SYSCALL) with a few backed-off retries before giving up.
+_CLONE_ATTEMPTS = 3
+_CLONE_RETRY_BACKOFF_S = 2
 
 logger = logging.getLogger(__name__)
 
@@ -269,8 +294,90 @@ def _discard_incomplete_clone(target: Path, verbose: bool) -> None:
         target.unlink(missing_ok=True)
 
 
-def _clone(target: Path, verbose: bool) -> bool:
-    """Clone PTO-ISA to `target` over HTTPS. Returns True on success."""
+def _remove_clone(target: Path, verbose: bool) -> None:
+    """Unconditionally remove `target` so a fresh clone can replace it.
+
+    Unlike ``_discard_incomplete_clone``, this removes even a *valid* clone —
+    used when the managed checkout is at the wrong (or a dirty) revision and we
+    re-clone at the pinned commit instead of checking out over local changes.
+    Handles a directory, a plain file, or a (possibly broken) symlink.
+    """
+    if not (target.exists() or target.is_symlink()):
+        return
+    if verbose:
+        logger.info(f"Removing pto-isa checkout at {target} to re-clone at the pinned commit")
+    if target.is_dir() and not target.is_symlink():
+        shutil.rmtree(target, ignore_errors=True)
+    else:
+        target.unlink(missing_ok=True)
+
+
+def _land_on_commit(clone_path: Path, commit: str, verbose: bool) -> bool:
+    """Force-detach-checkout a freshly cloned tree onto `commit`. False on failure.
+
+    `--force` is load-bearing, not defensive: pto-isa's default branch carries
+    paths that differ only in case (e.g. ``docs/isa/TADDDEQRELU.md`` vs
+    ``docs/isa/TAddDeqRelu.md``). On a case-insensitive filesystem (macOS CI)
+    they collide onto one inode, so even a *fresh* clone's working tree reports
+    them as modified, and a plain checkout to the pin aborts with "local changes
+    would be overwritten." Forcing discards that pseudo-dirt and lands exactly on
+    the pin. A full clone already carries every branch's history, but keep a
+    fetch fallback in case the pin is not reachable from the default fetch.
+    """
+    try:
+        result = _run_git_resilient(
+            ["checkout", "--detach", "--force", commit], cwd=clone_path, timeout=30, verbose=verbose
+        )
+        if result.returncode != 0:
+            if verbose:
+                logger.info(f"pto-isa commit {commit} missing locally, fetching origin...")
+            _run_git_resilient(["fetch", "origin"], cwd=clone_path, timeout=120, check=True, verbose=verbose)
+            _run_git_resilient(
+                ["checkout", "--detach", "--force", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose
+            )
+        actual = get_pto_isa_head(str(clone_path))
+        if actual != commit:
+            logger.warning(f"pto-isa checkout verification failed: expected {commit}, got {actual or '<unknown>'}")
+            return False
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        logger.warning(f"Failed to check out pto-isa commit {commit}: {e.stderr if hasattr(e, 'stderr') else e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Unexpected error checking out pto-isa commit {commit}: {e}")
+        return False
+
+
+def _is_pristine_at_commit(clone_path: Path, commit: str, verbose: bool) -> bool:
+    """True iff the checkout is clean AND already at exactly `commit`.
+
+    When both hold, the working tree already *is* the pinned ISA — git content
+    is addressed by SHA, so a clean tree at HEAD == pin is byte-for-byte the pin
+    — and can be used as-is with no checkout and no network. A dirty or
+    wrong-revision tree returns False; the caller then obtains the pin with a
+    fresh clone rather than checking out over the existing tree, so the build is
+    never fed a checkout that was patched over local modifications.
+    """
+    if get_pto_isa_head(str(clone_path)) != commit:
+        return False
+    try:
+        result = _run_git_resilient(["status", "--porcelain"], cwd=clone_path, timeout=30, verbose=verbose)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        logger.warning(f"Failed to check pto-isa checkout cleanliness: {e.stderr if hasattr(e, 'stderr') else e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Unexpected error checking pto-isa checkout cleanliness: {e}")
+        return False
+    return result.returncode == 0 and not result.stdout.strip()
+
+
+def _clone(target: Path, commit: str, verbose: bool) -> bool:
+    """Fresh-clone PTO-ISA to `target` over HTTPS and land it on `commit`.
+
+    Any existing checkout at `target` is removed first, so this always yields a
+    clean tree at exactly `commit` — the sync can never be blocked by local
+    modifications in a preexisting (cached/preset) managed checkout.
+    """
     if not _is_git_available():
         if verbose:
             logger.warning("git command not available, cannot clone pto-isa")
@@ -283,18 +390,36 @@ def _clone(target: Path, verbose: bool) -> bool:
             logger.warning(f"Failed to create clone parent dir: {e}")
         return False
 
-    _discard_incomplete_clone(target, verbose)
-    logger.info(f"Cloning pto-isa to {target} over HTTPS (first run, may take up to a minute)...")
+    _remove_clone(target, verbose)
+    logger.info(f"Cloning pto-isa to {target} over HTTPS at {commit} (may take up to a minute)...")
 
     try:
-        result = _run_git(["clone", _PTO_ISA_HTTPS, str(target)], timeout=300)
+        # --no-checkout: never materialize the default branch. Its working tree
+        # is what carries the case-colliding docs/isa/TADDDEQRELU* paths; we only
+        # ever want the pinned commit's tree, laid down by _land_on_commit.
+        result = _run_git(["clone", "--no-checkout", _PTO_ISA_HTTPS, str(target)], timeout=300)
+        for attempt in range(2, _CLONE_ATTEMPTS + 1):
+            if result.returncode == 0:
+                break
+            if verbose:
+                logger.warning(f"pto-isa clone attempt {attempt - 1}/{_CLONE_ATTEMPTS} failed:\n{result.stderr}")
+            _remove_clone(target, verbose)  # clear the partial clone before retrying
+            time.sleep(_CLONE_RETRY_BACKOFF_S * (attempt - 1))
+            result = _run_git(["clone", "--no-checkout", _PTO_ISA_HTTPS, str(target)], timeout=300)
         if result.returncode != 0:
             if verbose:
-                logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
+                logger.warning(f"Failed to clone pto-isa after {_CLONE_ATTEMPTS} attempts:\n{result.stderr}")
             _discard_incomplete_clone(target, verbose)
             return False
+        if not _land_on_commit(target, commit, verbose=verbose):
+            # The clone succeeded but sits at the wrong commit (default HEAD),
+            # so it looks like a valid clone and `_discard_incomplete_clone`
+            # would leave it. Remove it outright so no wrong-revision checkout
+            # is stranded on disk for a later run to mistake for the pin.
+            _remove_clone(target, verbose)
+            return False
         if verbose:
-            logger.info(f"pto-isa cloned successfully: {target}")
+            logger.info(f"pto-isa cloned at {commit}: {target}")
         return True
     except subprocess.TimeoutExpired:
         if verbose:
@@ -305,36 +430,6 @@ def _clone(target: Path, verbose: bool) -> bool:
         if verbose:
             logger.warning(f"Failed to clone pto-isa: {e}")
         _discard_incomplete_clone(target, verbose)
-        return False
-
-
-def checkout_pto_isa_commit(clone_path: Path, commit: str, verbose: bool = False) -> bool:
-    """Checkout/reset the managed clone to `commit`. Return False on failure."""
-    try:
-        _run_git_resilient(["reset", "--hard"], cwd=clone_path, timeout=30, check=True, verbose=verbose)
-        _run_git_resilient(["clean", "-fdx"], cwd=clone_path, timeout=30, check=True, verbose=verbose)
-        result = _run_git_resilient(
-            ["checkout", "--force", "--detach", commit], cwd=clone_path, timeout=30, verbose=verbose
-        )
-        if result.returncode != 0:
-            if verbose:
-                logger.info(f"pto-isa commit {commit} missing locally, fetching origin...")
-            _run_git_resilient(["fetch", "origin"], cwd=clone_path, timeout=120, check=True, verbose=verbose)
-            _run_git_resilient(
-                ["checkout", "--force", "--detach", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose
-            )
-        _run_git_resilient(["reset", "--hard", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose)
-        _run_git_resilient(["clean", "-fdx"], cwd=clone_path, timeout=30, check=True, verbose=verbose)
-        actual = get_pto_isa_head(str(clone_path))
-        if actual != commit:
-            logger.warning(f"pto-isa checkout verification failed: expected {commit}, got {actual or '<unknown>'}")
-            return False
-        return True
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-        logger.warning(f"Failed to checkout pto-isa commit {commit}: {e.stderr if hasattr(e, 'stderr') else e}")
-        return False
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"Unexpected error checking out pto-isa commit {commit}: {e}")
         return False
 
 
@@ -361,15 +456,24 @@ def ensure_pto_isa_root(verbose: bool = False) -> str:
 
 def _ensure_locked(clone_path: Path, required_commit: str, verbose: bool) -> Optional[str]:
     """Inner logic executed while holding the file lock."""
-    if not _is_cloned(clone_path):
-        if not _clone(clone_path, verbose=verbose):
-            if not _is_cloned(clone_path):
-                return None
-            if verbose:
-                logger.info("pto-isa already cloned by another process")
+    # Reuse an existing checkout ONLY when it is already exactly the pin: a clean
+    # working tree at HEAD == pin already *is* the pinned ISA (git objects are
+    # content-addressed), so use it as-is — no checkout, no network. This is the
+    # warm-cache path on persistent runners.
+    if _is_cloned(clone_path) and _is_pristine_at_commit(clone_path, required_commit, verbose=verbose):
+        return str(clone_path.resolve())
 
-    if not checkout_pto_isa_commit(clone_path, required_commit, verbose=verbose):
-        return None
+    # Otherwise (missing, wrong revision, or dirty) obtain the pin *fresh* rather
+    # than checking out over the existing tree: re-clone directly at the pin. We
+    # never reset/force-checkout a dirty cache in place, so the build never uses
+    # a checkout that was patched over local modifications.
+    if not _clone(clone_path, required_commit, verbose=verbose):
+        # A parallel process holding a separate lock may have prepared the
+        # checkout concurrently; accept its result only if it landed on the pin.
+        if not (_is_cloned(clone_path) and get_pto_isa_head(str(clone_path)) == required_commit):
+            return None
+        if verbose:
+            logger.info("pto-isa prepared at the pin by another process")
 
     if not _is_cloned(clone_path):
         if verbose:

--- a/tests/ut/py/test_pto_isa.py
+++ b/tests/ut/py/test_pto_isa.py
@@ -49,7 +49,8 @@ def test_read_pto_isa_pin_rejects_invalid_content(tmp_path):
         pto_isa.read_pto_isa_pin(pin)
 
 
-def test_clone_uses_https_only(tmp_path, monkeypatch):
+def test_clone_lands_on_pinned_commit(tmp_path, monkeypatch):
+    target = tmp_path / "build" / "pto-isa"
     calls = []
 
     monkeypatch.setattr(pto_isa, "_is_git_available", lambda: True)
@@ -59,117 +60,163 @@ def test_clone_uses_https_only(tmp_path, monkeypatch):
         return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
 
-    assert pto_isa._clone(tmp_path / "build" / "pto-isa", verbose=False)
-    assert calls == [["clone", "https://github.com/hw-native-sys/pto-isa.git", str(tmp_path / "build" / "pto-isa")]]
+    assert pto_isa._clone(target, PIN_A, verbose=False)
+    assert calls == [
+        ["clone", "--no-checkout", "https://github.com/hw-native-sys/pto-isa.git", str(target)],
+        ["checkout", "--detach", "--force", PIN_A],
+    ]
 
 
-def test_ensure_pto_isa_root_checks_out_existing_clone_to_pin(tmp_path, monkeypatch):
+def test_ensure_pto_isa_root_reuses_pristine_checkout(tmp_path, monkeypatch):
     clone_path = tmp_path / "build" / "pto-isa"
     (clone_path / "include").mkdir(parents=True)
-    checked_out = []
+    checked = []
 
     monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
     monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
-    monkeypatch.setattr(pto_isa, "_clone", lambda path, verbose=False: pytest.fail("unexpected clone"))
+    monkeypatch.setattr(pto_isa, "_clone", lambda *a, **k: pytest.fail("unexpected clone of pristine checkout"))
     monkeypatch.setattr(
         pto_isa,
-        "checkout_pto_isa_commit",
-        lambda path, commit, verbose=False: checked_out.append((path, commit)) or True,
+        "_is_pristine_at_commit",
+        lambda path, commit, verbose=False: checked.append((path, commit)) or True,
     )
     monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
 
     assert pto_isa.ensure_pto_isa_root(verbose=True) == str(clone_path.resolve())
-    assert checked_out == [(clone_path, PIN_A)]
+    assert checked == [(clone_path, PIN_A)]  # reused as-is, no checkout, no clone
 
 
-def test_ensure_pto_isa_root_clones_missing_checkout_then_checks_pin(tmp_path, monkeypatch):
+def test_ensure_pto_isa_root_clones_when_missing(tmp_path, monkeypatch):
     clone_path = tmp_path / "build" / "pto-isa"
     events = []
 
     monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
     monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
+    monkeypatch.setattr(
+        pto_isa, "_is_pristine_at_commit", lambda *a, **k: pytest.fail("unexpected pristine check of missing checkout")
+    )
 
-    def fake_clone(path, verbose=False):
-        events.append(("clone", path))
+    def fake_clone(path, commit, verbose=False):
+        events.append(("clone", path, commit))
         (path / "include").mkdir(parents=True)
         return True
 
     monkeypatch.setattr(pto_isa, "_clone", fake_clone)
-    monkeypatch.setattr(
-        pto_isa,
-        "checkout_pto_isa_commit",
-        lambda path, commit, verbose=False: events.append(("checkout", path, commit)) or True,
-    )
     monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
 
     assert pto_isa.ensure_pto_isa_root() == str(clone_path.resolve())
-    assert events == [("clone", clone_path), ("checkout", clone_path, PIN_A)]
+    assert events == [("clone", clone_path, PIN_A)]
 
 
-def test_ensure_pto_isa_root_rejects_checkout_when_head_does_not_match_pin(tmp_path, monkeypatch):
+def test_ensure_pto_isa_root_reclones_when_not_pristine(tmp_path, monkeypatch):
+    clone_path = tmp_path / "build" / "pto-isa"
+    (clone_path / "include").mkdir(parents=True)
+    events = []
+
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
+    monkeypatch.setattr(
+        pto_isa,
+        "_is_pristine_at_commit",
+        lambda path, commit, verbose=False: events.append(("check", path, commit)) or False,
+    )
+
+    def fake_clone(path, commit, verbose=False):
+        events.append(("clone", path, commit))
+        return True
+
+    monkeypatch.setattr(pto_isa, "_clone", fake_clone)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
+
+    assert pto_isa.ensure_pto_isa_root() == str(clone_path.resolve())
+    # A dirty/wrong-revision cache is re-cloned fresh, never checked out in place.
+    assert events == [("check", clone_path, PIN_A), ("clone", clone_path, PIN_A)]
+
+
+def test_ensure_pto_isa_root_rejects_when_reclone_lands_wrong_commit(tmp_path, monkeypatch):
     clone_path = tmp_path / "build" / "pto-isa"
     (clone_path / "include").mkdir(parents=True)
 
     monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
     monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
-    monkeypatch.setattr(pto_isa, "checkout_pto_isa_commit", lambda path, commit, verbose=False: True)
+    monkeypatch.setattr(pto_isa, "_is_pristine_at_commit", lambda path, commit, verbose=False: False)
     monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_B)
+    monkeypatch.setattr(pto_isa, "_clone", lambda path, commit, verbose=False: True)
 
     with pytest.raises(OSError, match="PTO-ISA not available"):
         pto_isa.ensure_pto_isa_root()
 
 
-def test_checkout_pto_isa_commit_fetches_when_commit_is_missing(tmp_path, monkeypatch):
+def test_is_pristine_at_commit_true_when_clean_and_at_pin(tmp_path, monkeypatch):
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
+
+    def fake_run_git(args, cwd=None, timeout=30, check=False):
+        assert args == ["status", "--porcelain"]
+        return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+    assert pto_isa._is_pristine_at_commit(tmp_path, PIN_A, verbose=False)
+
+
+def test_is_pristine_at_commit_false_when_dirty(tmp_path, monkeypatch):
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
+
+    def fake_run_git(args, cwd=None, timeout=30, check=False):
+        return subprocess.CompletedProcess(
+            ["git", *args], returncode=0, stdout=" M docs/isa/TADDDEQRELU.md\n", stderr=""
+        )
+
+    monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+    assert not pto_isa._is_pristine_at_commit(tmp_path, PIN_A, verbose=False)
+
+
+def test_is_pristine_at_commit_false_when_wrong_head(tmp_path, monkeypatch):
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_B)
+    monkeypatch.setattr(pto_isa, "_run_git", lambda *a, **k: pytest.fail("status must not run for a wrong HEAD"))
+
+    assert not pto_isa._is_pristine_at_commit(tmp_path, PIN_A, verbose=False)
+
+
+def test_land_on_commit_fetches_when_commit_is_missing(tmp_path, monkeypatch):
     calls = []
 
     def fake_run_git(args, cwd=None, timeout=30, check=False):
         calls.append((args, cwd, check))
-        if args == ["checkout", "--force", "--detach", PIN_A] and len([c for c in calls if c[0] == args]) == 1:
+        if args == ["checkout", "--detach", "--force", PIN_A] and len([c for c in calls if c[0] == args]) == 1:
             return subprocess.CompletedProcess(["git", *args], returncode=1, stdout="", stderr="missing")
-        if args == ["rev-parse", "HEAD"]:
-            return subprocess.CompletedProcess(["git", *args], returncode=0, stdout=f"{PIN_A}\n", stderr="")
         return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
 
-    assert pto_isa.checkout_pto_isa_commit(tmp_path, PIN_A)
+    assert pto_isa._land_on_commit(tmp_path, PIN_A, verbose=False)
     assert calls == [
-        (["reset", "--hard"], tmp_path, False),
-        (["clean", "-fdx"], tmp_path, False),
-        (["checkout", "--force", "--detach", PIN_A], tmp_path, False),
+        (["checkout", "--detach", "--force", PIN_A], tmp_path, False),
         (["fetch", "origin"], tmp_path, False),
-        (["checkout", "--force", "--detach", PIN_A], tmp_path, False),
-        (["reset", "--hard", PIN_A], tmp_path, False),
-        (["clean", "-fdx"], tmp_path, False),
-        (["rev-parse", "HEAD"], tmp_path, False),
+        (["checkout", "--detach", "--force", PIN_A], tmp_path, False),
     ]
 
 
-def test_checkout_pto_isa_commit_retries_dubious_ownership_with_safe_directory(tmp_path, monkeypatch):
+def test_land_on_commit_retries_dubious_ownership_with_safe_directory(tmp_path, monkeypatch):
     calls = []
     dubious = "fatal: detected dubious ownership in repository\nsafe.directory"
     safe_arg = f"safe.directory={tmp_path.resolve()}"
 
     def fake_run_git(args, cwd=None, timeout=30, check=False):
         calls.append((args, cwd, check))
-        if args == ["checkout", "--force", "--detach", PIN_A]:
+        if args == ["checkout", "--detach", "--force", PIN_A]:
             return subprocess.CompletedProcess(["git", *args], returncode=128, stdout="", stderr=dubious)
-        if args == ["rev-parse", "HEAD"]:
-            return subprocess.CompletedProcess(["git", *args], returncode=0, stdout=f"{PIN_A}\n", stderr="")
         return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: PIN_A)
 
-    assert pto_isa.checkout_pto_isa_commit(tmp_path, PIN_A)
+    assert pto_isa._land_on_commit(tmp_path, PIN_A, verbose=False)
     assert calls == [
-        (["reset", "--hard"], tmp_path, False),
-        (["clean", "-fdx"], tmp_path, False),
-        (["checkout", "--force", "--detach", PIN_A], tmp_path, False),
-        (["-c", safe_arg, "checkout", "--force", "--detach", PIN_A], tmp_path, False),
-        (["reset", "--hard", PIN_A], tmp_path, False),
-        (["clean", "-fdx"], tmp_path, False),
-        (["rev-parse", "HEAD"], tmp_path, False),
+        (["checkout", "--detach", "--force", PIN_A], tmp_path, False),
+        (["-c", safe_arg, "checkout", "--detach", "--force", PIN_A], tmp_path, False),
     ]
 
 


### PR DESCRIPTION
## Summary

Resolve the managed pto-isa checkout to `pto_isa.pin` by **reusing it only when it is already a clean checkout of the pin, and otherwise obtaining the pin with a fresh clone** — never `git checkout`-ing over an existing (dirty or wrong-revision) tree. Net effect:

- The ISA the build compiles against is always byte-for-byte the pinned commit (a clean tree at `HEAD == pin` *is* the pin; anything else is re-fetched, not patched in place).
- Fixes the macOS case-insensitive-filesystem checkout abort (case-duplicate `TADDDEQRELU`/`TAddDeqRelu` doc paths) via `--no-checkout` + forced checkout.
- Stays network-free on the warm-cache path and retries the one network hop on transient failure, so a pin bump or an SSL blip no longer fails `--require-pto-isa` jobs.

**vs the merged #1283:** #1283 fixes the same macOS abort by adding `--force` and keeps repairing a dirty checkout *in place* (`reset --hard` + `clean` + force-checkout). This PR instead only reuses a checkout already proven to be the pin and otherwise re-clones it fresh — it never mutates an existing tree into the pin. Both are network-free on a clean warm cache; the details are in the table below.

## Problem

Syncing the managed pto-isa checkout (`build/pto-isa` in the source tree, `_assets/build/pto-isa` in the wheel) to `pto_isa.pin` by running `git checkout <pin>` over the existing checkout is fragile:

- **A non-forced checkout aborts on a dirty working tree.** pto-isa's default branch also carries paths that differ only in case (`docs/isa/TADDDEQRELU.md` vs `docs/isa/TAddDeqRelu.md`). On a case-insensitive filesystem (macOS CI) they collide onto one inode, so even a *fresh* clone's working tree reports them as modified, and the checkout to the pin aborts with "local changes would be overwritten" → PTO-ISA never reaches the pin and `--require-pto-isa` jobs fail before pytest starts.
- **Always re-cloning to dodge that** makes every sync depend on the network, so a single transient GitHub SSL hiccup fails the build even when a valid local cache exists.

## Approach: resolve to the pin, but never check out over an existing tree

1. **Reuse an existing checkout only when it is provably already the pin** (clean working tree with `HEAD == pin`). Such a tree is byte-for-byte the pinned ISA (git objects are content-addressed), so it is used as-is — no checkout, no network. This is the warm-cache path on persistent runners.
2. **Otherwise (missing, wrong revision, or dirty) obtain the pin fresh:** `git clone --no-checkout` (never materialize the default branch, and thus never its case-colliding docs) + a forced detached checkout of the pin, with a few backed-off retries around the single network hop. A dirty cache is *replaced*, never patched in place.
3. Verify `HEAD` matches the pin before returning.

Key property: **the build is never fed a checkout that was patched over local modifications** — it uses either a cache already proven to be the pin, or a freshly obtained pin.

## Difference from the merged #1283

#1283 ("force managed PTO-ISA checkout to pinned commit") added `--force` to the existing `checkout_pto_isa_commit` in a 2-line change. Both fix the macOS case-collision and both guarantee the content equals the pin. This PR rebases on top of it; the substantive difference is **what happens when the local checkout is not a clean pin**:

| Scenario | #1283 (repair in place) | This PR (obtain fresh) |
| --- | --- | --- |
| Cache clean and at pin | still runs reset + clean + force-checkout | reuse as-is, no git ops, no network |
| Cache dirty / wrong revision | `reset --hard` + `clean` + `checkout --force` in place | delete and re-clone at the pin |
| Corrupt `.git` | fails, no recovery | re-clone recovers |
| Default-branch case-collision | survives via `--force` on the reused tree | avoided at the source via `--no-checkout` |
| Transient SSL on first clone | fails | retried with backoff |

In short: **#1283 mutates a dirty tree into the pin in place; this PR only trusts a checkout that is already the pin, and otherwise obtains the pin fresh — never checking out over a dirty tree.** Because the pto-isa directory is used purely as a read-only `-I` header source (nothing ever writes into it), the cache stays clean, so the common path for both is a network-free reuse.

## Validation

- pto-isa unit tests (`tests/ut/py/test_pto_isa.py`): 21 passed.
- Offline check: clean@pin with an unreachable remote → reused with zero network; a dirtied cache → reported non-pristine (would trigger a re-clone).
- Verified `git clone --no-checkout` + forced checkout produces a clean tree (`status --porcelain` empty, files absent from the pin removed, `HEAD == pin`), so the warm-cache fast path reliably triggers on the next run.
