### PR TITLE
Fix PTO-ISA checkout dirty state recovery

### DIFF
--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -313,13 +313,15 @@ def checkout_pto_isa_commit(clone_path: Path, commit: str, verbose: bool = False
     try:
         _run_git_resilient(["reset", "--hard"], cwd=clone_path, timeout=30, check=True, verbose=verbose)
         _run_git_resilient(["clean", "-fdx"], cwd=clone_path, timeout=30, check=True, verbose=verbose)
-        result = _run_git_resilient(["checkout", "--detach", commit], cwd=clone_path, timeout=30, verbose=verbose)
+        result = _run_git_resilient(
+            ["checkout", "--force", "--detach", commit], cwd=clone_path, timeout=30, verbose=verbose
+        )
         if result.returncode != 0:
             if verbose:
                 logger.info(f"pto-isa commit {commit} missing locally, fetching origin...")
             _run_git_resilient(["fetch", "origin"], cwd=clone_path, timeout=120, check=True, verbose=verbose)
             _run_git_resilient(
-                ["checkout", "--detach", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose
+                ["checkout", "--force", "--detach", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose
             )
         _run_git_resilient(["reset", "--hard", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose)
         _run_git_resilient(["clean", "-fdx"], cwd=clone_path, timeout=30, check=True, verbose=verbose)

--- a/tests/ut/py/test_pto_isa.py
+++ b/tests/ut/py/test_pto_isa.py
@@ -125,7 +125,7 @@ def test_checkout_pto_isa_commit_fetches_when_commit_is_missing(tmp_path, monkey
 
     def fake_run_git(args, cwd=None, timeout=30, check=False):
         calls.append((args, cwd, check))
-        if args == ["checkout", "--detach", PIN_A] and len([c for c in calls if c[0] == args]) == 1:
+        if args == ["checkout", "--force", "--detach", PIN_A] and len([c for c in calls if c[0] == args]) == 1:
             return subprocess.CompletedProcess(["git", *args], returncode=1, stdout="", stderr="missing")
         if args == ["rev-parse", "HEAD"]:
             return subprocess.CompletedProcess(["git", *args], returncode=0, stdout=f"{PIN_A}\n", stderr="")
@@ -137,9 +137,9 @@ def test_checkout_pto_isa_commit_fetches_when_commit_is_missing(tmp_path, monkey
     assert calls == [
         (["reset", "--hard"], tmp_path, False),
         (["clean", "-fdx"], tmp_path, False),
-        (["checkout", "--detach", PIN_A], tmp_path, False),
+        (["checkout", "--force", "--detach", PIN_A], tmp_path, False),
         (["fetch", "origin"], tmp_path, False),
-        (["checkout", "--detach", PIN_A], tmp_path, False),
+        (["checkout", "--force", "--detach", PIN_A], tmp_path, False),
         (["reset", "--hard", PIN_A], tmp_path, False),
         (["clean", "-fdx"], tmp_path, False),
         (["rev-parse", "HEAD"], tmp_path, False),
@@ -153,7 +153,7 @@ def test_checkout_pto_isa_commit_retries_dubious_ownership_with_safe_directory(t
 
     def fake_run_git(args, cwd=None, timeout=30, check=False):
         calls.append((args, cwd, check))
-        if args == ["checkout", "--detach", PIN_A]:
+        if args == ["checkout", "--force", "--detach", PIN_A]:
             return subprocess.CompletedProcess(["git", *args], returncode=128, stdout="", stderr=dubious)
         if args == ["rev-parse", "HEAD"]:
             return subprocess.CompletedProcess(["git", *args], returncode=0, stdout=f"{PIN_A}\n", stderr="")
@@ -165,8 +165,8 @@ def test_checkout_pto_isa_commit_retries_dubious_ownership_with_safe_directory(t
     assert calls == [
         (["reset", "--hard"], tmp_path, False),
         (["clean", "-fdx"], tmp_path, False),
-        (["checkout", "--detach", PIN_A], tmp_path, False),
-        (["-c", safe_arg, "checkout", "--detach", PIN_A], tmp_path, False),
+        (["checkout", "--force", "--detach", PIN_A], tmp_path, False),
+        (["-c", safe_arg, "checkout", "--force", "--detach", PIN_A], tmp_path, False),
         (["reset", "--hard", PIN_A], tmp_path, False),
         (["clean", "-fdx"], tmp_path, False),
         (["rev-parse", "HEAD"], tmp_path, False),


### PR DESCRIPTION
## Summary

- Force the managed PTO-ISA checkout to detach at the pinned commit, discarding dirty tracked files in that dependency checkout.
- Keep the existing reset/clean/fetch/verification flow unchanged.
- Update PTO-ISA unit tests to expect the forced checkout command.

## Background

macOS sim CI can fail before pytest starts when the installed managed checkout under `simpler_setup/_assets/build/pto-isa` contains local changes. In that state, plain `git checkout --detach <pin>` refuses to move to `pto_isa.pin` and `--require-pto-isa` exits early.

The managed PTO-ISA directory is not a user workspace; it is expected to match `pto_isa.pin`. Forcing checkout is therefore the right recovery behavior for this dependency cache.

## Verification

- `python -m pytest tests/ut/py/test_pto_isa.py -q`
- `git diff --check`


## Issue

Fixes #1284
