### PR TITLE
refactor(a2a3/tensormap): direct-only early-dispatch, drop auto-chain

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -846,6 +846,7 @@ static TaskOutputTensors submit_task_common(
     }
 
     payload.init(args, result, prepared.alloc_result, layout);
+    cur_slot_state.allow_early_resolve = args.allow_early_resolve();
 #if PTO2_PROFILING
     if (is_dump_args_enabled()) {
         if (args.scalar_count() > 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -257,7 +257,6 @@ struct PTO2TaskPayload {
     // fanin_actual_count  <=>  every producer is flagged-and-dispatched or was
     // pre-completed  =>  this task is an early-dispatch candidate (push early_dispatch_queue).
     std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: flagged-dispatched + pre-completed producers
-    bool allow_early_resolve{false};         // codegen hint copied from Arg in PTO2TaskPayload::init
     // Lock-free claim state shared by the stagers (Hook 1, possibly several AICPU
     // threads concurrently) and the completion-path release: 0=NONE, 1=STAGING,
     // 3=DISPATCHED (2=STAGED is unused now). STAGING is the STABLE gated state —
@@ -268,8 +267,6 @@ struct PTO2TaskPayload {
     // (self-ring), so no doorbell is ever missed.
     std::atomic<uint8_t> spec_state{0};
     std::atomic<uint8_t> dispatch_propagated{0};  // PRODUCER side: once-guard for fanout propagation
-    std::atomic<uint8_t> spec_chain_active{0};    // inherited early-dispatch flag (auto-chain past codegen flag)
-    uint8_t spec_chain_depth{0};                  // auto-chain depth; inherited = parent+1, capped
     // === Cache lines 9-72 (4096B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 73-74 (128B) — scalars ===
@@ -340,20 +337,16 @@ struct PTO2TaskPayload {
         // structures); prepare_task only allocates/binds. prefetch() warms this
         // line (offset 512) so these writes land in warm cache.
         //
-        // spec_state / staged_core_mask / dispatch_fanin / spec_chain_* are all
-        // CONSUMER-side: a task with allow_early_resolve == false still has them
-        // touched when one of ITS producers is flagged (propagate_dispatch_fanin
-        // bumps dispatch_fanin and may CAS spec_state / set the auto-chain flag on
-        // any consumer, independent of the consumer's own hint). So they MUST be
-        // zeroed here unconditionally — no per-task allow_early_resolve gating.
-        allow_early_resolve = args.allow_early_resolve();
+        // spec_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
+        // task whose own allow_early_resolve is false still has them touched when
+        // one of ITS producers is flagged (propagate_dispatch_fanin bumps
+        // dispatch_fanin and may CAS spec_state on any consumer, independent of the
+        // consumer's own hint). So they MUST be zeroed here unconditionally.
         spec_state.store(PTO2_SPEC_NONE, std::memory_order_relaxed);
         for (int w = 0; w < PTO2_SPEC_CORE_MASK_WORDS; w++)
             staged_core_mask[w].store(0, std::memory_order_relaxed);
         dispatch_fanin.store(0, std::memory_order_relaxed);
         dispatch_propagated.store(0, std::memory_order_relaxed);
-        spec_chain_active.store(0, std::memory_order_relaxed);
-        spec_chain_depth = 0;
     }
 };
 
@@ -437,7 +430,12 @@ struct alignas(64) PTO2TaskSlotState {
     // sequenced before on_subtask_complete's acq_rel fetch_add and the read
     // after, so all earlier subtasks' writes are visible to the last subtask.
     std::atomic<bool> any_subtask_deferred{false};
-    uint8_t _async_pad{0};
+    // Codegen early-dispatch hint, copied from Arg at submit. Lives on slot_state
+    // (not payload) so the wiring fanin walk and the propagate_dispatch_fanin gate
+    // read it from the already-hot slot_state cache line instead of chasing the
+    // producer's cold payload. Repurposes the former padding byte, so the struct
+    // stays 64 bytes.
+    bool allow_early_resolve{false};
     int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
@@ -487,10 +485,11 @@ struct alignas(64) PTO2TaskSlotState {
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx.store(0, std::memory_order_relaxed);
         any_subtask_deferred.store(false, std::memory_order_relaxed);
-        // Note: payload spec fields (spec_state / staged_core_mask / dispatch_fanin /
-        // spec_chain_*) are NOT reset here — this method skips the payload by
-        // contract. They are (re)initialized in PTO2TaskPayload::init on every
-        // submit, before the slot becomes visible to the scheduler.
+        allow_early_resolve = false;  // safe default; the normal submit path overwrites from Arg
+        // Note: payload spec fields (spec_state / staged_core_mask / dispatch_fanin)
+        // are NOT reset here — this method skips the payload by contract. They are
+        // (re)initialized in PTO2TaskPayload::init on every submit, before the slot
+        // becomes visible to the scheduler.
     }
 
     // === Per-task fanout spinlock ===

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -819,9 +819,14 @@ struct PTO2SchedulerState {
 
         if (wfanin != 0) {
             int32_t early_finished = 0;
+            bool early_disqualified = false;  // an unflagged producer => C can never early-dispatch
             for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
                 producer->lock_fanout();
                 int32_t pstate = producer->task_state.load(std::memory_order_acquire);
+                // A single unflagged producer makes dispatch_fanin unreachable to
+                // fanin_actual_count (it never bumps), so once we've seen one, stop
+                // paying for the flag read on the remaining producers.
+                if (!early_disqualified && !producer->allow_early_resolve) early_disqualified = true;
                 if (pstate >= PTO2_TASK_COMPLETED) {
                     early_finished++;
                 } else {
@@ -830,15 +835,16 @@ struct PTO2SchedulerState {
                 producer->unlock_fanout();
             });
 
-            // Seed dispatch_fanin with producers already complete at wiring
-            // time (e.g. buffer-creator tasks that finished before this
-            // consumer entered the graph). Such producers never dispatch at
-            // runtime, so they can never bump dispatch_fanin via the fanout
-            // walk; without this seed the candidate compare
-            // (dispatch_fanin == fanin_actual_count) would be unreachable
-            // whenever any producer is pre-completed. Mirrors the
-            // early_finished seed that ready_fanin gets via init_rc.
-            if (early_finished != 0) {
+            // Seed dispatch_fanin only when EVERY producer is codegen-flagged: then
+            // every pre-completed producer is flagged too, so early_finished is
+            // exactly the flagged-pre-completed count the candidate compare
+            // (dispatch_fanin == fanin_actual_count) expects. Such producers never
+            // dispatch at runtime, so they can never bump dispatch_fanin via the
+            // fanout walk; the seed accounts for them up front. If any producer is
+            // unflagged, leave dispatch_fanin at 0 — that producer never bumps it, so
+            // the consumer can never become an early-dispatch candidate. (The ready
+            // seed below still counts ALL pre-completed producers, flag-independent.)
+            if (!early_disqualified && early_finished != 0) {
                 wp->dispatch_fanin.fetch_add(early_finished, std::memory_order_acq_rel);
             }
 
@@ -1015,9 +1021,6 @@ struct PTO2SchedulerState {
         *dmb = (tk << 32) | tk;  // 64-bit STR: high=low=token releases the gated AICore
     }
 
-    // auto-chain depth cap: a candidate inherits the flag only while depth < this.
-    static constexpr uint8_t PTO2_SPEC_CHAIN_MAX = 4;
-
     // Event-driven candidate detection (the dual of fanin_refcount/ready). Call when a
     // FLAGGED producer `p` DISPATCHES (starts running): walk its fanout and bump each
     // consumer's dispatch_fanin. A consumer whose dispatch_fanin reaches
@@ -1025,13 +1028,12 @@ struct PTO2SchedulerState {
     // already complete when the consumer was wired) is an early-dispatch candidate:
     // CAS NONE->STAGING (exactly-once) and push to early_dispatch_queue for the idle drain to
     // pre-stage. Once-guarded per producer so an SPMD producer's block-by-block
-    // dispatch propagates once. Replaces the old per-iteration pass-1 PULL scan.
+    // dispatch propagates once. Only codegen-flagged producers propagate: a task's
+    // successors early-dispatch off its DIRECT producers' marks, never an inherited chain.
     void propagate_dispatch_fanin(PTO2TaskSlotState &p) {
-        if (!(p.payload->allow_early_resolve || p.payload->spec_chain_active.load(std::memory_order_acquire)))
-            return;  // only flagged (codegen or inherited) producers propagate
+        if (!p.allow_early_resolve) return;  // only codegen-flagged (direct) producers propagate
         if (p.payload->dispatch_propagated.exchange(1, std::memory_order_acq_rel) != 0)
             return;  // already propagated once
-        uint8_t child_depth = static_cast<uint8_t>(p.payload->spec_chain_depth + 1);
         p.lock_fanout();
         PTO2DepListEntry *edge = p.fanout_head;  // snapshot head, walk lock-free (fanout stable by dispatch)
         p.unlock_fanout();
@@ -1040,9 +1042,10 @@ struct PTO2SchedulerState {
             // Compare to fanin_actual_count (the real producer-edge count), NOT
             // fanin_count: fanin_count = fanin_actual_count + 1 (a self/wiring +1 that
             // ready_fanin gets but dispatch_fanin does not). dispatch_fanin starts at
-            // the wiring-time early_finished seed (producers already complete) and is
-            // bumped here by flagged producers; reaching fanin_actual_count means every
-            // producer is flagged-dispatched or was pre-completed.
+            // the wiring-time flagged-pre-completed seed and is bumped here by flagged
+            // producers; reaching fanin_actual_count means every producer is
+            // flagged-dispatched or was pre-completed. An unflagged producer leaves the
+            // seed short and never bumps, so this stays unreachable for that consumer.
             int32_t nf = c->payload->dispatch_fanin.fetch_add(1, std::memory_order_acq_rel) + 1;
             if (nf != c->payload->fanin_actual_count) continue;
             if (c->active_mask.requires_sync_start()) continue;  // sync_start can't be block-by-block pre-staged
@@ -1054,10 +1057,6 @@ struct PTO2SchedulerState {
                     expect, PTO2_SPEC_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
                 ))
                 continue;
-            if (child_depth < PTO2_SPEC_CHAIN_MAX) {  // auto-chain: C propagates to ITS consumers
-                c->payload->spec_chain_depth = child_depth;
-                c->payload->spec_chain_active.store(1, std::memory_order_release);
-            }
             early_dispatch_queue.push(c);
         }
     }
@@ -1105,10 +1104,11 @@ struct PTO2SchedulerState {
             }
         }
         // This pre-staged consumer was just released by its doorbell — it starts
-        // running NOW, so propagate dispatch_fanin to ITS consumers (auto-chain,
-        // knob A). Defer it via the sink so it runs after the whole fanout walk:
-        // doing it inline here would delay the doorbells of later consumers in the
-        // same producer's fanout. Fallback to inline if no sink / sink full.
+        // running NOW, so propagate dispatch_fanin to ITS consumers (only if it is
+        // itself codegen-flagged; the gate inside no-ops otherwise). Defer it via the
+        // sink so it runs after the whole fanout walk: doing it inline here would
+        // delay the doorbells of later consumers in the same producer's fanout.
+        // Fallback to inline if no sink / sink full.
         if (sink == nullptr || !sink->push(&slot_state)) {
             propagate_dispatch_fanin(slot_state);
         }

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -241,6 +241,177 @@ TEST_F(WiringTest, WireTaskMixedProducerStates) {
 }
 
 // =============================================================================
+// Early-dispatch seed (direct-only): a consumer becomes an early-dispatch
+// candidate ONLY when every producer is codegen-flagged (allow_early_resolve,
+// now a slot_state field). A single unflagged producer leaves dispatch_fanin
+// short forever. Auto-chain inheritance was removed, so flagged-ness is the
+// producer's own static hint — never propagated down a chain.
+// =============================================================================
+
+TEST_F(WiringTest, WireTaskAllFlaggedPrecompletedSeedsDispatchFanin) {
+    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) PTO2TaskSlotState producer_slots[2];
+    alignas(64) PTO2TaskPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    PTO2TaskDescriptor desc{};
+
+    for (int i = 0; i < 2; i++) {
+        init_slot(producer_slots[i], PTO2_TASK_COMPLETED, 1, 2);
+        producer_slots[i].allow_early_resolve = true;  // codegen-flagged
+    }
+
+    init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
+    payload.fanin_actual_count = 2;
+    payload.fanin_inline_slot_states[0] = &producer_slots[0];
+    payload.fanin_inline_slot_states[1] = &producer_slots[1];
+    task_slot.payload = &payload;
+    task_slot.task = &desc;
+
+    auto &rss = sched.ring_sched_states[0];
+    sched.wire_task(rss, &task_slot, 2);
+
+    // Every producer flagged + pre-completed -> seeded to fanin_actual_count, so
+    // the consumer is already an early-dispatch candidate at wiring time.
+    EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);
+}
+
+TEST_F(WiringTest, WireTaskUnflaggedPrecompletedProducerDoesNotSeed) {
+    // Regression: an unflagged producer already complete at wiring must NOT seed
+    // dispatch_fanin. It never dispatches, so it can never be the flagged-and-
+    // dispatched contributor the candidate compare expects; seeding it would let
+    // the consumer become an early-dispatch candidate it should stay off.
+    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) PTO2TaskSlotState producer;
+    alignas(64) PTO2TaskPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    PTO2TaskDescriptor desc{};
+
+    init_slot(producer, PTO2_TASK_COMPLETED, 1, 1);
+    producer.allow_early_resolve = false;  // unflagged
+
+    init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
+    payload.fanin_actual_count = 1;
+    payload.fanin_inline_slot_states[0] = &producer;
+    task_slot.payload = &payload;
+    task_slot.task = &desc;
+
+    auto &rss = sched.ring_sched_states[0];
+    sched.wire_task(rss, &task_slot, 1);
+
+    EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // NOT seeded (direct-only)
+    // Readiness is unaffected: early_finished(1) + 1 == fanin_count(2) -> ready.
+    EXPECT_GE(task_slot.fanin_refcount.load(), task_slot.fanin_count);
+}
+
+TEST_F(WiringTest, WireTaskOneUnflaggedProducerDisqualifiesSeed) {
+    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) PTO2TaskSlotState producers[2];
+    alignas(64) PTO2TaskPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    PTO2TaskDescriptor desc{};
+
+    init_slot(producers[0], PTO2_TASK_COMPLETED, 1, 2);
+    producers[0].allow_early_resolve = true;  // flagged
+    init_slot(producers[1], PTO2_TASK_COMPLETED, 1, 2);
+    producers[1].allow_early_resolve = false;  // one unflagged -> disqualifies
+
+    init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
+    payload.fanin_actual_count = 2;
+    payload.fanin_inline_slot_states[0] = &producers[0];
+    payload.fanin_inline_slot_states[1] = &producers[1];
+    task_slot.payload = &payload;
+    task_slot.task = &desc;
+
+    auto &rss = sched.ring_sched_states[0];
+    sched.wire_task(rss, &task_slot, 2);
+
+    EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // disqualified: seed stays 0
+}
+
+TEST_F(WiringTest, EarlyDispatchReachesCandidateWhenAllFlagged) {
+    // A flagged, still-pending producer seeds nothing at wiring (not
+    // pre-completed); its DISPATCH propagates and bumps the consumer to
+    // fanin_actual_count, making it an early-dispatch candidate.
+    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) PTO2TaskSlotState producer;
+    alignas(64) PTO2TaskPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    PTO2TaskDescriptor desc{};
+
+    init_slot(producer, PTO2_TASK_PENDING, 1, 1);
+    producer.allow_early_resolve = true;
+
+    init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
+    payload.fanin_actual_count = 1;
+    payload.fanin_inline_slot_states[0] = &producer;
+    task_slot.payload = &payload;
+    task_slot.task = &desc;
+
+    auto &rss = sched.ring_sched_states[0];
+    sched.wire_task(rss, &task_slot, 1);
+    EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // pending -> nothing seeded yet
+
+    sched.propagate_dispatch_fanin(producer);
+    EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);
+}
+
+TEST_F(WiringTest, EarlyDispatchBlockedByUnflaggedProducer) {
+    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) PTO2TaskSlotState p_flagged, q_unflagged;
+    alignas(64) PTO2TaskPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    PTO2TaskDescriptor desc{};
+
+    init_slot(p_flagged, PTO2_TASK_PENDING, 1, 1);
+    p_flagged.allow_early_resolve = true;
+    init_slot(q_unflagged, PTO2_TASK_PENDING, 1, 1);
+    q_unflagged.allow_early_resolve = false;
+
+    init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
+    payload.fanin_actual_count = 2;
+    payload.fanin_inline_slot_states[0] = &p_flagged;
+    payload.fanin_inline_slot_states[1] = &q_unflagged;
+    task_slot.payload = &payload;
+    task_slot.task = &desc;
+
+    auto &rss = sched.ring_sched_states[0];
+    sched.wire_task(rss, &task_slot, 2);
+    EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // q unflagged -> disqualified seed
+
+    sched.propagate_dispatch_fanin(p_flagged);    // bumps to 1
+    sched.propagate_dispatch_fanin(q_unflagged);  // gate returns, no bump
+    EXPECT_EQ(payload.dispatch_fanin.load(), 1);  // never reaches 2 -> not a candidate
+}
+
+TEST_F(WiringTest, UnflaggedProducerDoesNotPropagate) {
+    // Auto-chain removed: an unflagged producer never propagates, so its
+    // consumers' dispatch_fanin stays untouched even after it dispatches, and the
+    // once-guard is not even consumed (the gate returns first).
+    alignas(64) PTO2TaskSlotState producer, consumer;
+    alignas(64) PTO2TaskPayload prod_payload, cons_payload;
+    memset(&prod_payload, 0, sizeof(prod_payload));
+    memset(&cons_payload, 0, sizeof(cons_payload));
+
+    init_slot(producer, PTO2_TASK_PENDING, 1, 1);
+    producer.allow_early_resolve = false;  // unflagged
+    producer.payload = &prod_payload;
+
+    init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
+    consumer.payload = &cons_payload;
+    cons_payload.fanin_actual_count = 1;
+
+    PTO2DepListEntry dep{};
+    dep.slot_state = &consumer;
+    dep.next = nullptr;
+    producer.fanout_head = &dep;
+
+    sched.propagate_dispatch_fanin(producer);
+
+    EXPECT_EQ(cons_payload.dispatch_fanin.load(), 0);       // no bump
+    EXPECT_EQ(prod_payload.dispatch_propagated.load(), 0);  // gate returned before once-guard
+}
+
+// =============================================================================
 // on_task_complete: notifies consumers via fanout chain
 // =============================================================================
 


### PR DESCRIPTION
> **Note:** the PR direction changed. It previously added an opt-in
> `block_early_resolve` barrier flag; it now makes **unflagged = suppress**
> the default and removes the speculative auto-chain. Reviewed history below.

## Summary

Early-dispatch (ED) makes a consumer a pre-staging candidate once its
`dispatch_fanin == fanin_actual_count`. This PR restricts ED to fire **only
from producers the codegen directly marked** (`allow_early_resolve`): a
task's successors pre-stage off its DIRECT producers' marks, never an
inherited multi-hop chain. A single unflagged producer keeps its consumer
off ED — no per-consumer marking, no opt-in barrier task needed.

## Changes

- **Remove the speculative auto-chain.** Drop `spec_chain_active` /
  `spec_chain_depth` payload fields, the `PTO2_SPEC_CHAIN_MAX = 4` depth cap,
  and the inheritance block in `propagate_dispatch_fanin`. The gate is now a
  plain `allow_early_resolve` check — flagged-ness is a producer's own static
  codegen hint, never propagated down a chain.
- **Move `allow_early_resolve` payload → slot_state.** It repurposes the
  `_async_pad` byte (`PTO2TaskSlotState` stays 64 B). The wiring fanin walk
  and the propagate gate now read the flag from the already-hot slot_state
  cache line instead of chasing the producer's cold payload (line 8, ~500 B
  away from anything the walk touches).
- **`wire_task` seed.** Seed `dispatch_fanin` only when EVERY producer is
  flagged, short-circuiting the flag read once a first unflagged producer is
  seen. This also fixes a pre-existing leak: an unflagged producer already
  complete at wiring time was counted into the dispatch seed, letting a
  consumer become an ED candidate it should stay off.

## Invariant

A producer unflagged at wiring stays unflagged (static hint), so the
short-circuit disqualification is sound — this is exactly why it depends on
removing the auto-chain. `dispatch_fanin` reaches `fanin_actual_count` iff
every producer is flagged-and-dispatched or flagged-and-pre-completed; one
unflagged producer leaves it short forever. Readiness (`fanin_refcount`) is
untouched — **task ordering is unchanged**.

## Testing

- `tests/ut/cpp/a2a3/test_wiring.cpp`: +6 `WiringTest` cases — all-flagged
  pre-completed seeds; unflagged pre-completed does NOT seed (regression);
  one unflagged producer disqualifies; flagged-pending reaches the candidate
  via `propagate_dispatch_fanin`; unflagged producer blocks it; unflagged
  producer never propagates (no auto-chain). cpput `WiringTest` 18/18 pass.
- Full a2a3 `tensormap_and_ringbuffer` st suite (34 tests) passes onboard.
- Both runtimes compile clean.