### PR TITLE
Update profiling buffer pool to SPSC

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -488,10 +488,12 @@ normal execution continues.
 space so the host can read device buffers directly.
 `TensorDumpCollector` runs split mgmt threads and collector shards on top of a
 [`BufferPoolManager<DumpModule>`](../src/common/platform/include/host/buffer_pool_manager.h):
-drain/refill shards poll SPSC ready queues and recycle full metadata
-buffers **while kernels are still executing**, a replenish thread keeps
-free queues topped up, and collector shards drain the host hand-off queues
-into `on_buffer_collected`.
+drain/refill shards poll SPSC ready queues and refill free queues from
+shard-local recycled lanes **while kernels are still executing**. Collector
+shards drain the host hand-off queues into `on_buffer_collected`, then the
+replenish thread folds done buffers back into recycled lanes and, for
+modules that declare a recycled watermark, tops those lanes up by batched
+allocation without writing device free queues.
 
 ```text
         HOST                                         DEVICE
@@ -507,7 +509,7 @@ into `on_buffer_collected`.
 │   │ drain/refill shard │ │               │     dump_arg_record()    │
 │   │ + replenish thread │ │ SPSC ready    │     → write to arena     │
 │   │   poll ready queue │<┼──queues──────<│     → append record      │
-│   │   recycle buffers  │─┼──free queue──>│     → push to ready_q    │
+│   │   refill freeQ     │─┼──free queue──>│     → push to ready_q    │
 │   └────────────────────┘ │               │   dispatch kernel        │
 │   ┌────────────────────┐ │               │   wait FIN               │
 │   │ collector shard    │ │               │   AFTER_COMPLETION       │
@@ -609,7 +611,7 @@ the buffer's records.
 │   for each ready entry:  │               │     pop next from free_q │
 │     copy buf from device │<──memcpy─────<│                          │
 │     resolve host ptr     │               │ dump_args_flush():       │
-│     push to L2 ready_q   │               │   push remaining buffers │
+│     push to host ready_q │               │   push remaining buffers │
 │   advance queue_heads,   │               │   to ready_q             │
 │     refill free_queues   │               │                          │
 │   write_range_to_device  │──memcpy──────>│                          │

--- a/docs/dfx/dfx-buffer-capacity-audit.md
+++ b/docs/dfx/dfx-buffer-capacity-audit.md
@@ -29,9 +29,13 @@ over-provisioned pools frees **~66 MB, zero ABI**.
 
 The 5 subsystems share an **SPSC + ProfilerBase** contract: the device writes
 records into a buffer, rotates when full and pops an empty buffer from the
-free_queue; a host mgmt thread concurrently recycles full buffers and refills
-empties. **When a buffer is full and the free_queue is empty, the record is
-dropped** (no back-pressure on the dispatch hot path — a deliberate invariant).
+free_queue; the host drain/replenish mgmt path concurrently returns
+collector-done buffers to recycled lanes and refills free queues from those
+lanes. Modules can also ask the replenish thread to keep recycled lanes above
+host-side watermarks by batched allocation; only the drain path writes device
+free queues. **When a buffer is full and the free_queue is empty, the record
+is dropped** (no back-pressure on the dispatch hot path — a deliberate
+invariant).
 
 - **Criterion**: each pool's `configured / actually-needed` ratio should be
   roughly consistent across subsystems — over-provisioning wastes memory,

--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -651,10 +651,15 @@ cross-direction read on the hot path.
 
 **Sizing.** `PLATFORM_AICORE_BUFFER_SIZE = 1024` (power of two, modulo
 lowers to AND) and `PLATFORM_AICORE_BUFFERS_PER_CORE = 4` (1 active +
-3 recycled). Host-side `BufferPoolManager` refills the recycled pool
-from the ready queue while the session runs, so session length is
-bounded only by how fast the host drains — not by the per-core buffer
-sum.
+3 recycled). Host-side `BufferPoolManager` drains full buffers through
+the collector, returns them via done → replenish → recycled lanes, and
+the owning drain shard refills the device free queue from that lane. The
+replenish thread also keeps recycled lanes above their host-side watermarks
+by batched allocation, but it never writes device free queues. These
+watermarks are steady-state low-water marks: AICPU-task keeps half of the
+init-seeded surplus per shard, while AICore-task has no init surplus and only
+keeps a minimal reserve batch. Session length is bounded only by how fast the
+host closes that loop — not by the per-core buffer sum.
 
 **Measured impact.** Hardware bench on a2a3 paged_attention_unroll
 Case1 with swimlane=4: rotation design delivers sched -4 µs / orch -19 µs
@@ -668,10 +673,11 @@ sched overhead per session as price for unbounded session length).
 space so the host can read device buffers directly.
 `L2SwimlaneCollector` runs split mgmt threads and collector shards on top of a
 [`BufferPoolManager<L2SwimlaneModule>`](../../src/common/platform/include/host/buffer_pool_manager.h):
-drain/refill shards poll SPSC ready queues and recycle full buffers
-**while kernels are still executing**, a replenish thread keeps free
-queues topped up, and collector shards drain the host hand-off queues into
-`on_buffer_collected`.
+drain/refill shards poll SPSC ready queues and refill free queues from
+shard-local recycled lanes **while kernels are still executing**. Collector
+shards drain the host hand-off queues into `on_buffer_collected`, then the
+replenish thread folds done buffers back into recycled lanes and tops up
+optional recycled watermarks.
 
 `L2SwimlaneModule` declares four buffer kinds going through one ready
 queue per AICPU thread:
@@ -701,7 +707,7 @@ are single-kind.
 │   │ drain/refill shard │ │ queues        │   record (kind 0); fill  │
 │   │ + replenish thread │ │<──4 kinds────<│   func_id / dispatch /   │
 │   │   poll ready queue │<┼──multiplexed──│   finish; rotate buffer  │
-│   │   recycle buffers  │─┼──free queue──>│   when full              │
+│   │   refill freeQ     │─┼──free queue──>│   when full              │
 │   └────────────────────┘ │               │ AICPU scheduler thread:  │
 │   ┌────────────────────┐ │               │   per work iter: write   │
 │   │ collector shard    │ │               │   SchedPhaseRecord       │
@@ -798,8 +804,10 @@ whatever the host shadow held at the start of the tick. Per-buffer
 payloads (`L2SwimlaneAicpuTaskBuffer` / `L2SwimlaneAicpuPhaseBuffer`)
 are pulled on demand inside `ProfilerAlgorithms::process_entry` after
 a popped ready-entry resolves to its host shadow. `BufferPoolManager`'s
-`release_owned_buffers` frees the device pointer via the
-collector's `release_fn` and the paired shadow via `std::free()`.
+`release_owned_buffers` canonicalizes carved sub-buffers back to the
+registered allocation block before calling the collector's `release_fn`;
+paired host shadows are released later by `clear_mappings()` or on init
+rollback by `release_all_owned()`.
 
 ```text
         HOST                                         DEVICE
@@ -825,7 +833,7 @@ collector's `release_fn` and the paired shadow via `std::free()`.
 │   for each ready entry:  │               │                          │
 │     copy buf from device │<──memcpy─────<│                          │
 │     resolve host ptr     │               │                          │
-│     push to L2 ready_q   │               │                          │
+│     push to host ready_q │               │                          │
 │   advance queue_heads,   │               │                          │
 │     refill free_queues   │               │                          │
 │   write_range_to_device  │──memcpy──────>│                          │

--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -218,8 +218,13 @@ collected_on_host + dropped == total              (a2a3, 2 buckets)
 AICPU reads the 8 PMU counters via MMIO (`read_reg(reg_base, PMU_CNTi)`)
 directly into a `PmuRecord` on every task FIN. Buffers rotate through
 an SPSC free queue per core; full buffers flow through a per-thread
-ready queue to host drain/refill shards that recycle them, while
-collector shards stream records to CSV during execution.
+ready queue to host drain/refill shards. Drain refills free queues from
+shard-local recycled lanes; collector shards stream records to CSV during
+execution, and the replenish thread folds done buffers back into recycled
+lanes and tops up optional recycled watermarks without writing device free
+queues. PMU has no init-seeded recycled surplus by default, so the runtime
+watermark is only a minimal reserve batch rather than a core-count-scaled
+extra allocation target.
 
 ```text
         HOST                                         DEVICE
@@ -236,7 +241,7 @@ collector shards stream records to CSV during execution.
 │   │ drain/refill shard │ │               │     into records[count]  │
 │   │ + replenish thread │ │ SPSC ready    │   if buffer full:        │
 │   │   poll ready queue │<┼──queues──────<│     push ready entry,    │
-│   │   recycle buffers  │─┼──free queue──>│     pop next buffer      │
+│   │   refill freeQ     │─┼──free queue──>│     pop next buffer      │
 │   └────────────────────┘ │               │                          │
 │   ┌────────────────────┐ │ shared mem    │ pmu_aicpu_flush():       │
 │   │ collector shard    │ │ mapping       │   push remaining full    │
@@ -279,8 +284,9 @@ init_pmu()
   pmu_collector_.init(num_aicore, num_threads, csv_path, event_type, ...)
   kernel_args_.args.pmu_data_base = pmu_collector_.get_pmu_shm_device_ptr()
 start(tf)                       ← spawn split mgmt threads (drain AICPU ready
-                                  queues, refills free queues, and runs
-                                  background replenish via BufferPoolManager)
+                                  queues and refill free queues from
+                                  recycled lanes; replenish drains done
+                                  buffers into recycled lanes)
                                   + collector shards (drain host hand-off,
                                   append to CSV)
 launch AICPU / AICore
@@ -361,7 +367,7 @@ still pulled on demand inside
 │   for each ready entry:  │               │     records[count]       │
 │     copy buf from device │<──memcpy─────<│   fill func_id/core_type │
 │     resolve host ptr     │               │   ++count                │
-│     push to L2 ready_q   │               │   if buffer full:        │
+│     push to host ready_q │               │   if buffer full:        │
 │   advance queue_heads,   │               │     push ready entry,    │
 │     refill free_queues   │               │     pop next from free_q │
 │   write_range_to_device  │──memcpy──────>│                          │
@@ -602,12 +608,12 @@ covers every core that produced records.
 **Dropped records on a2a3.** `PmuBufferState::dropped_record_count`
 nonzero means the AICPU could not get a free buffer in time
 (`free_queue` empty). Increase `PLATFORM_PMU_BUFFERS_PER_CORE` so the
-mgmt thread has more headroom to recycle buffers.
+host drain/replenish path has more buffer headroom.
 
 **Dropped records on a5.** `PmuBufferState::dropped_record_count`
 nonzero means the AICPU could not get a free buffer in time
 (`free_queue` empty). Increase `PLATFORM_PMU_BUFFERS_PER_CORE` so the
-collector thread has more headroom to recycle buffers.
+host drain/replenish path has more buffer headroom.
 
 ## 9. Related docs
 

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -30,15 +30,17 @@ breakdown of `simpler_run` (host stages + AICPU phase subdivision).
 
 Each profiling subsystem needs the same plumbing on the host:
 
-- A management path that polls the AICPU's per-thread SPSC ready queues
-  and recycles full buffers back to the device while kernels are still
-  running. A module may opt into split drain/refill threads plus a
-  replenish thread.
+- A management path that polls the AICPU's per-thread SPSC ready queues,
+  refills device free queues from shard-local recycled lanes, and recycles
+  collector-returned buffers while kernels are still running. A module may
+  opt into split drain/refill threads plus a replenish thread. Runtime
+  allocation, when enabled, is confined to the replenish thread and publishes
+  only to host-side recycled lanes.
 - Collector thread shards that drain host-side hand-off queues and copy
   records out of each ready buffer.
 - A pool of pre-registered device buffers (allocated up-front, refilled on
-  demand) keyed by "kind". PMU, DepGen, TensorDump, and ScopeStats have one
-  kind; L2Swimlane has four.
+  demand from host-side watermarks) keyed by "kind". PMU, DepGen,
+  TensorDump, and ScopeStats have one kind; L2Swimlane has four.
 - A dev↔host pointer map so the management thread can resolve a device
   pointer popped off a ready queue to the host-mapped pointer the collector
   thread will read.
@@ -64,14 +66,14 @@ parameterized on a small per-subsystem trait, and the device side to
                               │ public ProfilerBase<Derived, Module>
                 ┌─────────────▼────────────────────────────┐
                 │  ProfilerBase<Derived, Module>           │  Thread orchestration
-                │  ─ owns mgmt + collector thread(s)       │  ─ start/stop lifecycle
+                │  ─ owns drain/replenish + collector      │  ─ start/stop lifecycle
                 │  ─ runs ProfilerAlgorithms<Module>       │  ─ consume → notify_copy_done
                 └─────────────┬────────────────────────────┘
                               │ has-a
                 ┌─────────────▼────────────────────────────┐
                 │  BufferPoolManager<Module>               │  Data structures (no threads)
-                │  ─ ready/done queue shards               │  ─ recycled pools (per kind)
-                │  ─ alloc_and_register / resolve_host_ptr │  ─ MemoryOps (type-erased)
+                │  ─ ready/done/recycled SPSC shards       │  ─ retired holding pool
+                │  ─ block allocation / resolve_host_ptr   │  ─ MemoryOps (type-erased)
                 └──────────────────────────────────────────┘
                               ▲
                               │ Module trait wires layout into algorithms
@@ -79,6 +81,7 @@ parameterized on a small per-subsystem trait, and the device side to
               │  Pmu / L2Swimlane / DepGen /      │  Pure static trait (no state)
               │  Dump / Scope modules             │  ─ DataHeader / ReadyEntry / FreeQueue
               └────────────────────────────────┘  ─ kBufferKinds / kReadyQueueSize
+                                                  ─ kHostPoolQueueSize / kHostRecycledQueueSize
                                                   ─ resolve_entry / for_each_instance
 
   AICPU device side:
@@ -113,24 +116,31 @@ subsystem's shared-memory layout is shaped.
 Defined in [`buffer_pool_manager.h`](../src/common/platform/include/host/buffer_pool_manager.h).
 Owns:
 
-- `ready_shards_` — mgmt → collector hand-off shards, each guarded by
-  mutex+cv.
-- `done_shards_` — collector → mgmt recycle shards, each guarded by mutex.
-- `recycled_[shard][kind]` — shard-local pool of free device buffers,
-  guarded by one mutex per shard/kind.
-- `dev_to_host_` — single source of truth for `resolve_host_ptr`.
+- `ready_shards_` — mgmt drain → collector hand-off shards, each backed by a
+  fixed-capacity SPSC ring plus a cv wakeup for blocking waits.
+- `done_shards_` — collector → replenish recycle shards, each backed by a
+  fixed-capacity SPSC ring. The producer is the collector shard; the single
+  consumer is the replenish thread.
+- `recycled_[shard][kind]` — shard-local SPSC lanes of free device buffers;
+  runtime drain reads the owning shard while replenish writes returned buffers
+  and optional watermark allocations.
+- `retired_[shard][kind]` — mutex-protected exceptional holding pools for
+  buffers that were removed from a queue but could not be published to the
+  next queue. They are drained only during teardown.
+- `dev_to_host_` / block ranges — source of truth for `resolve_host_ptr`,
+  including carved sub-buffers from one registered allocation block.
 - `MemoryOps` — type-erased `alloc / reg / free_` callbacks, plus the
   `shared_mem_host` and `device_id` stashed once at start.
 
 Owns no threads. Every entry point is documented as one of:
 
-- mgmt-only or internally locked (`drain_done_into_recycled`, recycled
-  pool ops),
-- collector-only (`notify_copy_done`, one shard per collector),
-- shared with internal locking (`push_to_ready` / `wait_pop_ready` /
-  `try_pop_ready`),
-- start/stop-only (`set_memory_context`, `release_owned_buffers`,
-  `clear_mappings`).
+- lane-owned SPSC operations (`push_to_ready`, `push_recycled`,
+  `pop_recycled`, `drain_done_into_recycled`),
+- collector producer operations (`notify_copy_done`, one shard per collector),
+- shared operations with narrow internal locking for blocking waits / mappings
+  (`wait_pop_ready`, `resolve_host_ptr`),
+- lifecycle / exceptional operations (`retire_unqueued_buffer`,
+  `set_memory_context`, `release_owned_buffers`, `clear_mappings`).
 
 ### 3.2 `ProfilerBase<Derived, Module>` — control layer
 
@@ -142,9 +152,12 @@ Provides:
 - Split mgmt threads — `mgmt_drain_loop` drains ready queues and refills the
   originating free queue from the current drain shard's local recycled pool
   (`ProfilerAlgorithms<Module>::process_entry` per popped entry), while
-  `mgmt_replenish_loop` only drains done buffers into shard-local recycled
-  pools. A one-shot `proactive_replenish` seeds every free queue before the
-  threads start. Split drain threads do not bulk-mirror the whole
+  `mgmt_replenish_loop` drains done buffers into shard-local recycled pools
+  and keeps optional recycled watermarks topped up by batched allocation. The
+  replenish thread never writes device free queues, so the drain hot path
+  stays allocation-free and remains the only runtime writer to free queues.
+  A one-shot `proactive_replenish` seeds every free queue before the threads
+  start. Split drain threads do not bulk-mirror the whole
   shared-memory region; they refresh only their queue indices / entries
   before advancing `queue_heads`. On an empty scan, split drain does a short
   busy-poll window before falling back to the 10 us sleep, so micro-bursts
@@ -166,14 +179,24 @@ is where the unified algorithms live:
 - `try_pop_aicpu_entry` — barrier-correct head/tail advance over the
   per-thread ready queue, with a range-check guard against device-side
   corruption.
-- `process_entry` — shard-local fallback (local recycled → local done →
-  other recycled shard → alloc) to refill the originating free_queue until
-  it is full or no buffer is available, then resolve host_ptr and push to
-  ready.
-- `proactive_replenish` — drain done, then top every (kind, instance)
-  free queue up to `kSlotCount`, batch-allocating `batch_size(kind)`
-  buffers when the recycled pool of a kind drains mid-fill so recovery
-  from a double-empty condition takes one tick instead of N.
+- `process_entry` — resolve/copy the popped buffer, refill the originating
+  free queue only from the current drain shard's local recycled lane, then
+  push to the host ready shard. Runtime drain does not allocate and does not
+  consume done shards directly. If the host ready shard is full, the
+  undelivered buffer is retired rather than written to the done shard, keeping
+  the done shard's producer side collector-only.
+- `proactive_replenish` — before worker threads start, top every
+  (kind, instance) free queue up to `kSlotCount` and optionally warm
+  recycled lanes. If recycled is dry while filling free queues it
+  batch-allocates one registered block and carves it into `batch_size(kind)`
+  buffers.
+- `replenish_recycled_pools` — startup/runtime helper used by
+  `proactive_replenish` and `mgmt_replenish_loop` to keep per-kind,
+  per-shard recycled lanes above `recycled_warm_target`. Each pass allocates
+  `max(kSlotCount, target - current)` buffers when a lane is below target:
+  small gaps still amortize HAL registration across a slot-sized block, while
+  large gaps return to the watermark in one allocation. It allocates into
+  recycled lanes only; it does not publish to device free queues.
 
 ### 3.3 `Module` — trait layer
 
@@ -189,10 +212,13 @@ the required members are:
 | `using DataHeader / ReadyEntry / ReadyBufferInfo / FreeQueue` | Layout types |
 | `kBufferKinds` | Number of buffer kinds inside each recycled shard |
 | `kReadyQueueSize`, `kSlotCount` | AICPU ready queue / free queue depth |
+| `kHostPoolQueueSize` | Optional host done ring depth |
+| `kHostRecycledQueueSize` | Optional per-kind, per-shard recycled ring depth; defaults to `kHostPoolQueueSize` |
 | `kSubsystemName` | Tag used in framework log lines |
 | `kMgmtDrainThreadCount` | Optional; number of mgmt drain shards (defaults to 1) |
 | `kCollectorThreadCount` | Optional number of collector / host ready-queue shards |
 | `refresh_replenish_metadata(mgr, header)` | Optional hook to refresh cached queue metadata before a replenish pass |
+| `recycled_warm_target(kind[, shard]) → int` | Optional startup/runtime low-water mark for shard-local recycled lanes |
 | `header_from_shm(void*) → DataHeader*` | Cast shared-memory base to header |
 | `batch_size(int kind) → int` | Per-kind batch-alloc count |
 | `resolve_entry(shm, header, q, entry) → optional<EntrySite>` | Map a popped ready entry to (kind, free_queue, buffer_size, partial info); return `nullopt` to drop |
@@ -282,33 +308,33 @@ Current users:
 ```text
   AICPU                       mgmt thread(s)                    collector shard(s)
   ─────                       ──────────────                    ──────────────────
-  write record into         drain_done_into_recycled
+  write record into         try_pop_aicpu_entry(q)
   current free buffer       ──────────────────────────►
-                            try_pop_aicpu_entry(q)
                             process_entry:
-                              pop local recycled / local done / alloc
-                                (top up originating free_queue)
                               resolve_host_ptr
+                              pop recycled[q]
+                                (top up originating free_queue)
                               push_to_ready(shard q) ─────────► wait_pop_ready(q)
                                                                 Derived::on_buffer_collected
                                                                   (copy records out)
                                                                 notify_copy_done(q)
                             ◄────────────────────────────────── done shard q
-                            (next tick) drain into recycled
 
                                           ▲
                                           │
-                            split runtime replenish:
-                            drain done into shard-local
-                            recycled pools only.
+                            replenish thread:
+                            done shard q → recycled[q]
 ```
 
 The queue shards plus the shard-local recycled pools and the dev↔host map all
 live in the single `BufferPoolManager` instance owned by `ProfilerBase`.
 Each ready shard has one collector consumer; each done shard is written by
-its matching collector and drained into the same recycled shard. Split drain
-refills the originating free queue on the hot path; split replenish no longer
-writes free queues at runtime.
+its matching collector and drained by the replenish thread into the same
+recycled shard. Split drain refills the originating free queue on the hot
+path from `recycled[q]`; replenish does not write free queues at runtime.
+Backpressure fallbacks that cannot publish a buffer to ready/free/recycled
+place it in `retired_[q][kind]`, which is outside the hot SPSC path and is
+released at teardown.
 
 ## 5. Lifecycle
 
@@ -322,14 +348,16 @@ writes free queues at runtime.
     assemble MemoryOps from stashed callbacks (sim mode installs an
       identity reg wrapper so register == nullptr is supported uniformly)
     manager_.set_memory_context(ops, shm_host, device_id)
-    spawn mgmt thread(s)    ← started first; mgmt writes host ready shards
+    spawn drain mgmt thread(s)
+    spawn replenish mgmt thread
+                              ← started first; mgmt writes host ready shards
     spawn collector thread(s)
 
     ... AICPU / AICore execute ...
 
   ProfilerBase::stop()
     mgmt_running_ = false
-    join mgmt thread(s)     ← mgmt final-drain flushes the last entries into
+    join mgmt thread(s)     ← drain final-pass flushes the last entries into
                               ready shards before exiting
     execution_complete_ = true
     join collector thread(s)← each shard drains once more, then exits
@@ -349,7 +377,7 @@ any shard.
 
 `Derived::finalize` is responsible for the buffers the collector still
 owns at stop time (`free_queue` slots and `current_buf_ptr`); the
-framework only releases what it had in recycled / done / ready. This
+framework only releases what it had in recycled / retired / done / ready. This
 split matters because the AICPU may still be referencing free-queue
 buffers via shared memory until execution ends, so they cannot be freed
 mid-run by the framework.
@@ -358,18 +386,19 @@ mid-run by the framework.
 
 | State | Reader(s) | Writer(s) | Synchronization |
 | ----- | --------- | --------- | --------------- |
-| `ready_shards_[q]` | collector q | mgmt drain q | shard mutex + cv |
-| `done_shards_[q]` | mgmt / replenish | collector q | shard mutex |
-| `recycled_[shard][kind]` | drain shard / replenish | drain shard / replenish | shard/kind mutex |
-| `dev_to_host_` | mgmt (`alloc_and_register`, `resolve_host_ptr`) | mgmt | `mapping_mutex_`; collector touches it only in `release_owned_buffers` / `clear_mappings`, after `stop()` has joined mgmt |
+| `ready_shards_[q]` | collector q | mgmt drain q | fixed-capacity SPSC ring; cv only wakes blocking waits |
+| `done_shards_[q]` | replenish | collector q | fixed-capacity SPSC ring |
+| `recycled_[shard][kind]` | drain shard at runtime | replenish | fixed-capacity SPSC ring; startup code may pop any shard before threads start |
+| `retired_[shard][kind]` | teardown | exceptional fallback paths | mutex-protected holding pool; not used by the hot recycle path |
+| `dev_to_host_` / block ranges | mgmt (`resolve_host_ptr`) | init/startup allocation | `mapping_mutex_`; collector touches it only in `release_owned_buffers` / `clear_mappings`, after `stop()` has joined mgmt |
 | `MemoryOps` / `shared_mem_host_` / `device_id_` | both threads | start-only | `set_memory_context` is called once before threads spawn; read-only afterwards |
 | AICPU per-thread ready queues (`header->queues[q]`) | mgmt (head advance) | AICPU (tail advance) | `read_range_from_device` in split drain, then `write_range_to_device` for `queue_heads[q]` |
-| Per-instance `FreeQueue` | AICPU (head advance) | mgmt (tail advance) | per-free-queue writer lock; host refreshes `head` before writing `buffer_ptrs[]` / `tail` |
+| Per-instance `FreeQueue` | AICPU (head advance) | owning drain shard (tail advance) | SPSC ownership; host refreshes `head` before writing `buffer_ptrs[]` / `tail` |
 
 Two things follow:
 
-- `dev_to_host_` has a narrow mapping lock; recycled pools are split by
-  collector shard and kind so the hot drain/refill path mostly stays local.
+- `dev_to_host_` has a narrow mapping lock; ready/done/recycled hand-off is
+  SPSC by shard, so the hot drain/refill path stays on the owning lane.
 - Device-side queue backpressure is bounded for the profiling writers that
   use this protocol. If the host does not make ready-queue space or
   free-queue entries visible within the short wait budget, AICPU records a
@@ -461,11 +490,12 @@ changes capture that:
    `ProfilerAlgorithms::process_entry` after resolving the host pointer
    for a popped ready entry. The bulk `mirror_shm_to_device` is kept
    for init/teardown where AICPU is not yet running or has exited.
-3. **`release_owned_buffers` frees the paired host shadow.** When the
-   framework recycles a device buffer at finalize time, it also frees the
-   `malloc()`'d shadow tracked in `dev_to_host_`. `clear_mappings()` does
-   the same for any remaining mappings (per-state buffers and the shm
-   region itself).
+3. **Teardown has one device-release path and one shadow-release path.**
+   `release_owned_buffers` canonicalizes any carved sub-buffer back to its
+   registered allocation block before calling the collector's `release_fn`.
+   Paired `malloc()` shadows tracked in `dev_to_host_` are released by
+   `clear_mappings()` after collector-owned queues/current buffers have been
+   handled, or by `release_all_owned()` on init rollback.
 
 Most collectors keep `reconcile_counters` passive — same shape as a2a3. It
 pulls the post-`stop()` `BufferState`s, logs an error if any

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -123,7 +123,8 @@ constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
  * Host dynamically allocates buffers and writes addresses into these slots.
  * Device reads slot addresses when switching buffers.
  * Using slots: provides full pipeline depth for buffer recycling.
- * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
+ * Runtime drain never allocates; the host replenish slow path may batch-allocate
+ * registered blocks to keep recycled lanes above their watermarks.
  */
 constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
 

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -16,7 +16,7 @@
  * Architecture:
  * - BufferPoolManager<PmuModule>: shared split-mgmt infrastructure that polls
  *   per-thread ready queues, drains done-queue shards, and replenishes the
- *   per-core free_queues from a unified recycled pool.
+ *   per-core free_queues from shard-local recycled lanes.
  * - PmuCollector: collector thread shards pop full PmuBuffers from the manager
  *   and append them to the CSV file.
  *
@@ -71,10 +71,9 @@
 /**
  * One buffer kind (PmuBuffer); per-core buffer states. The collector
  * pre-allocates PLATFORM_PMU_BUFFERS_PER_CORE buffers per core at init time
- * to absorb steady-state load. process_entry refills the originating core's
- * free_queue with exactly one buffer (recycled → drain done → alloc), and
- * proactive_replenish tops up to SLOT_COUNT with a batch alloc when the
- * recycled pool drains.
+ * to absorb steady-state load. Runtime refill uses the owning drain shard's
+ * local recycled lanes; proactive_replenish may batch-allocate before
+ * drain and collector threads start.
  */
 
 /**
@@ -97,6 +96,10 @@ struct PmuModule {
 
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
+    static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
+    static constexpr uint32_t kMaxCoresPerCollectorShard =
+        (PLATFORM_MAX_CORES + PLATFORM_MAX_AICPU_THREADS - 1) / PLATFORM_MAX_AICPU_THREADS;
+    static constexpr uint32_t kHostRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
     static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "PmuModule";
     static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
@@ -110,6 +113,17 @@ struct PmuModule {
     static constexpr int batch_size(int /*kind*/) {
         constexpr int kBatch = PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT;
         return kBatch < 1 ? 1 : kBatch;
+    }
+
+    static constexpr int recycled_warm_target(int /*kind*/) {
+        // Keep half of the init-seeded surplus per shard as the steady-state
+        // low-water mark. PMU normally has no init surplus, so retain one
+        // minimal reserve batch instead of scaling by core count.
+        constexpr int kSurplusPerCore = (PLATFORM_PMU_BUFFERS_PER_CORE > PLATFORM_PMU_SLOT_COUNT) ?
+                                            (PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT) :
+                                            0;
+        constexpr int kInitialSurplus = kSurplusPerCore * static_cast<int>(kMaxCoresPerCollectorShard);
+        return kInitialSurplus > 0 ? (kInitialSurplus + 1) / 2 : 1;
     }
 
     static DataHeader *header_from_shm(void *shm) { return get_pmu_header(shm); }
@@ -190,8 +204,7 @@ public:
      * `num_cores * PLATFORM_PMU_BUFFERS_PER_CORE` PmuBuffers. The first
      * PLATFORM_PMU_SLOT_COUNT buffers per core are pushed directly into that
      * core's free_queue; the surplus go into the BufferPoolManager's shared
-     * recycled pool (no per-core affinity — any core can borrow from the pool
-     * via the mgmt thread's proactive_replenish).
+     * recycled lanes, sharded by the owning AICPU thread/core affinity.
      *
      * @param num_cores                    Number of AICore instances in use
      * @param num_threads                  Number of AICPU scheduling threads

--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -21,6 +21,7 @@
 
 #include "host/pmu_collector.h"
 
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <iomanip>
@@ -29,6 +30,35 @@
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
+
+namespace {
+
+int owner_recycled_shard_for_core(int core_index, int thread_count) {
+    int cluster_index = core_index / PLATFORM_CORES_PER_BLOCKDIM;
+    return cluster_index % thread_count;
+}
+
+bool recycled_seed_capacity_is_sufficient(int num_cores, int thread_count, int surplus_per_core, size_t capacity) {
+    if (surplus_per_core <= 0) return true;
+    std::array<int, PLATFORM_MAX_AICPU_THREADS> per_shard{};
+    for (int core = 0; core < num_cores; core++) {
+        per_shard[static_cast<size_t>(owner_recycled_shard_for_core(core, thread_count))] += surplus_per_core;
+    }
+
+    bool ok = true;
+    for (int shard = 0; shard < thread_count; shard++) {
+        if (static_cast<size_t>(per_shard[static_cast<size_t>(shard)]) <= capacity) continue;
+        LOG_ERROR(
+            "PMU recycled seed exceeds lane capacity: shard=%d need=%d capacity=%zu "
+            "(num_cores=%d thread_count=%d)",
+            shard, per_shard[static_cast<size_t>(shard)], capacity, num_cores, thread_count
+        );
+        ok = false;
+    }
+    return ok;
+}
+
+}  // namespace
 
 PmuCollector::~PmuCollector() { stop(); }
 
@@ -44,6 +74,13 @@ int PmuCollector::init(
         LOG_ERROR("PmuCollector::init: invalid arguments");
         return -1;
     }
+    if (num_cores > PLATFORM_MAX_CORES || num_threads > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "PmuCollector::init: dimensions out of range (cores=%d/%d threads=%d/%d)", num_cores, PLATFORM_MAX_CORES,
+            num_threads, PLATFORM_MAX_AICPU_THREADS
+        );
+        return -1;
+    }
 
     num_cores_ = num_cores;
     num_threads_ = num_threads;
@@ -55,6 +92,14 @@ int PmuCollector::init(
     execution_complete_.store(false, std::memory_order_release);
     if (csv_file_.is_open()) {
         csv_file_.close();
+    }
+    constexpr int kPmuSurplusPerCore = (PLATFORM_PMU_BUFFERS_PER_CORE > PLATFORM_PMU_SLOT_COUNT) ?
+                                           (PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT) :
+                                           0;
+    if (!recycled_seed_capacity_is_sufficient(
+            num_cores, num_threads, kPmuSurplusPerCore, decltype(manager_)::kRecycledQueueCapacity
+        )) {
+        return -1;
     }
 
     // ---- Allocate shared header + buffer-state region ----
@@ -119,8 +164,12 @@ int PmuCollector::init(
                 state->free_queue.tail = tail + 1;
                 wmb();
             } else {
-                // Surplus buffers go into the recycled pool, available to any core.
-                manager_.push_recycled(0, dev_ptr);
+                // Surplus buffers go into the cluster owner shard so runtime
+                // drain consumes the same recycled lane it owns.
+                int shard = owner_recycled_shard_for_core(c, num_threads);
+                if (!manager_.push_recycled(0, dev_ptr, shard)) {
+                    (void)manager_.retire_unqueued_buffer(0, dev_ptr, shard);
+                }
             }
         }
     }

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -150,7 +150,8 @@ constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
  * Host dynamically allocates buffers and writes addresses into these slots.
  * Device reads slot addresses when switching buffers.
  * Using slots: provides full pipeline depth for buffer recycling.
- * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
+ * Runtime drain never allocates; the host replenish slow path may batch-allocate
+ * registered blocks to keep recycled lanes above their watermarks.
  */
 constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
 

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -16,7 +16,7 @@
  * Architecture:
  * - BufferPoolManager<PmuModule>: shared split-mgmt infrastructure that polls
  *   per-thread ready queues, drains done-queue shards, and replenishes the
- *   per-core free_queues from a unified recycled pool.
+ *   per-core free_queues from shard-local recycled lanes.
  * - PmuCollector: collector thread shards pop full PmuBuffers from the manager
  *   and append them to the CSV file.
  *
@@ -77,10 +77,9 @@
 /**
  * One buffer kind (PmuBuffer); per-core buffer states. The collector
  * pre-allocates PLATFORM_PMU_BUFFERS_PER_CORE buffers per core at init time
- * to absorb steady-state load. process_entry refills the originating
- * core's free_queue with exactly one buffer (recycled → drain done →
- * alloc), and proactive_replenish tops up to SLOT_COUNT with a batch alloc
- * when the recycled pool drains.
+ * to absorb steady-state load. Runtime refill uses the owning drain shard's
+ * local recycled lanes; proactive_replenish may batch-allocate before
+ * drain and collector threads start.
  */
 
 /**
@@ -103,6 +102,10 @@ struct PmuModule {
 
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
+    static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
+    static constexpr uint32_t kMaxCoresPerCollectorShard =
+        (PLATFORM_MAX_CORES + PLATFORM_MAX_AICPU_THREADS - 1) / PLATFORM_MAX_AICPU_THREADS;
+    static constexpr uint32_t kHostRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
     static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "PmuModule";
     static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
@@ -116,6 +119,17 @@ struct PmuModule {
     static constexpr int batch_size(int /*kind*/) {
         constexpr int kBatch = PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT;
         return kBatch < 1 ? 1 : kBatch;
+    }
+
+    static constexpr int recycled_warm_target(int /*kind*/) {
+        // Keep half of the init-seeded surplus per shard as the steady-state
+        // low-water mark. PMU normally has no init surplus, so retain one
+        // minimal reserve batch instead of scaling by core count.
+        constexpr int kSurplusPerCore = (PLATFORM_PMU_BUFFERS_PER_CORE > PLATFORM_PMU_SLOT_COUNT) ?
+                                            (PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT) :
+                                            0;
+        constexpr int kInitialSurplus = kSurplusPerCore * static_cast<int>(kMaxCoresPerCollectorShard);
+        return kInitialSurplus > 0 ? (kInitialSurplus + 1) / 2 : 1;
     }
 
     static DataHeader *header_from_shm(void *shm) { return get_pmu_header(shm); }
@@ -198,7 +212,7 @@ public:
      * `num_cores * PLATFORM_PMU_BUFFERS_PER_CORE` PmuBuffers. The first
      * PLATFORM_PMU_SLOT_COUNT buffers per core are pushed directly into
      * that core's free_queue; the surplus go into the BufferPoolManager's
-     * shared recycled pool.
+     * shard-local recycled lanes.
      *
      * @param num_cores                         Number of AICore instances in use
      * @param num_threads                       Number of AICPU scheduling threads

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -26,6 +26,7 @@
 
 #include "host/pmu_collector.h"
 
+#include <array>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -35,6 +36,35 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 #include "host/profiling_copy.h"
+
+namespace {
+
+int owner_recycled_shard_for_core(int core_index, int thread_count) {
+    int cluster_index = core_index / PLATFORM_CORES_PER_BLOCKDIM;
+    return cluster_index % thread_count;
+}
+
+bool recycled_seed_capacity_is_sufficient(int num_cores, int thread_count, int surplus_per_core, size_t capacity) {
+    if (surplus_per_core <= 0) return true;
+    std::array<int, PLATFORM_MAX_AICPU_THREADS> per_shard{};
+    for (int core = 0; core < num_cores; core++) {
+        per_shard[static_cast<size_t>(owner_recycled_shard_for_core(core, thread_count))] += surplus_per_core;
+    }
+
+    bool ok = true;
+    for (int shard = 0; shard < thread_count; shard++) {
+        if (static_cast<size_t>(per_shard[static_cast<size_t>(shard)]) <= capacity) continue;
+        LOG_ERROR(
+            "PMU recycled seed exceeds lane capacity: shard=%d need=%d capacity=%zu "
+            "(num_cores=%d thread_count=%d)",
+            shard, per_shard[static_cast<size_t>(shard)], capacity, num_cores, thread_count
+        );
+        ok = false;
+    }
+    return ok;
+}
+
+}  // namespace
 
 PmuCollector::~PmuCollector() { stop(); }
 
@@ -50,6 +80,13 @@ int PmuCollector::init(
         LOG_ERROR("PmuCollector::init: invalid arguments");
         return -1;
     }
+    if (num_cores > PLATFORM_MAX_CORES || num_threads > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "PmuCollector::init: dimensions out of range (cores=%d/%d threads=%d/%d)", num_cores, PLATFORM_MAX_CORES,
+            num_threads, PLATFORM_MAX_AICPU_THREADS
+        );
+        return -1;
+    }
     if (initialized_) {
         LOG_ERROR("PmuCollector already initialized");
         return -1;
@@ -63,6 +100,14 @@ int PmuCollector::init(
     total_collected_ = 0;
     if (csv_file_.is_open()) {
         csv_file_.close();
+    }
+    constexpr int kPmuSurplusPerCore = (PLATFORM_PMU_BUFFERS_PER_CORE > PLATFORM_PMU_SLOT_COUNT) ?
+                                           (PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT) :
+                                           0;
+    if (!recycled_seed_capacity_is_sufficient(
+            num_cores, num_threads, kPmuSurplusPerCore, decltype(manager_)::kRecycledQueueCapacity
+        )) {
+        return -1;
     }
 
     // Stash callbacks on the base up-front so alloc_paired_buffer sees
@@ -145,7 +190,10 @@ int PmuCollector::init(
                 state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
                 state->free_queue.tail = tail + 1;
             } else {
-                manager_.push_recycled(0, dev_ptr);
+                int shard = owner_recycled_shard_for_core(c, num_threads);
+                if (!manager_.push_recycled(0, dev_ptr, shard)) {
+                    (void)manager_.retire_unqueued_buffer(0, dev_ptr, shard);
+                }
             }
         }
     }
@@ -410,8 +458,8 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCa
         }
     }
 
-    // Release framework-owned buffers (recycled pool, ready_queue,
-    // done_queue). release_owned_buffers also frees their host shadows.
+    // Release framework-owned device allocations (recycled pool,
+    // ready_queue, done_queue). Host shadows are freed by clear_mappings().
     manager_.release_owned_buffers([&](void *p) {
         release_dev(p);
     });

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -11,14 +11,15 @@
 
 /**
  * @file buffer_pool_manager.h
- * @brief Generic buffer-pool data structure shared by L2Swimlane, TensorDump,
- *        and PMU collectors. Owns:
+ * @brief Generic buffer-pool data structure shared by L2Swimlane, PMU,
+ *        DepGen, TensorDump, and ScopeStats collectors. Owns:
  *
- *   - ready_queue shard(s) (mgmt → collector) with mutex/cv,
- *   - done_queue shard(s) (collector → mgmt) with mutex,
- *   - shard-local per-kind recycled-buffer pools,
- *   - dev↔host pointer mapping table,
- *   - alloc_and_register / free_buffer / resolve_host_ptr helpers.
+ *   - ready_queue shard(s) (mgmt → collector) as SPSC rings,
+ *   - done_queue shard(s) (collector → mgmt) as SPSC rings,
+ *   - shard-local per-kind recycled-buffer SPSC rings,
+ *   - mutex-protected retired-buffer pools for exceptional teardown paths,
+ *   - dev↔host pointer mapping table with block-range resolution,
+ *   - batched block allocation / free_buffer / resolve_host_ptr helpers.
  *
  * Owns no threads. ProfilerBase drives the mgmt loop and forwards memory
  * context here once via set_memory_context(). The Module concept contract
@@ -47,16 +48,17 @@
  *      `copy_buffer_from_device` inside ProfilerAlgorithms::process_entry
  *      before delivering it to the collector.
  *
- * `release_owned_buffers` frees both the device pointer (via `release_fn`)
- * and any paired host shadow that the framework itself malloc'd. Ownership
- * is tracked explicitly in `malloc_shadows_`: only shadows allocated via
- * `default_host_shadow_register` or the `copy_to_device_` branch of
+ * `release_owned_buffers` releases device allocations via the collector's
+ * `release_fn`, canonicalizing carved sub-buffers back to their registered
+ * block base first. Paired host shadows that the framework malloc'd are
+ * released later by `clear_mappings()` or immediately by `release_all_owned()`.
+ * Ownership is tracked explicitly in `malloc_shadows_`: only shadows allocated
+ * via `default_host_shadow_register` or the `copy_to_device_` branch of
  * `ProfilerBase::alloc_paired_buffer` are added to the set, so HAL-managed
  * mappings (e.g. `halHostRegister` results on a2a3 onboard) never see a
- * spurious `std::free`. The earlier `host_ptr != dev_ptr` alias check is
- * not sufficient on its own — `halHostRegister` returns a host VA that
- * may or may not coincide with the device VA, and feeding either case to
- * `std::free` is UB.
+ * spurious `std::free`. The earlier `host_ptr != dev_ptr` alias check is not
+ * sufficient on its own — `halHostRegister` returns a host VA that may or may
+ * not coincide with the device VA, and feeding either case to `std::free` is UB.
  *
  * Platforms with SVM (a2a3: halHostRegister maps device pointers into host
  * address space) leave `copy_to_device` / `copy_from_device` null and pass
@@ -70,6 +72,7 @@
 #ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_BUFFER_POOL_MANAGER_H_
 #define SRC_COMMON_PLATFORM_INCLUDE_HOST_BUFFER_POOL_MANAGER_H_
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -78,8 +81,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <limits>
 #include <mutex>
-#include <queue>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -148,6 +151,127 @@ struct ProfilerModuleCollectorThreadCount<Module, std::void_t<decltype(Module::k
     static constexpr int value = Module::kCollectorThreadCount;
 };
 
+template <typename Module, typename = void>
+struct ProfilerModuleHostQueueCapacity {
+    static constexpr size_t value = 1024;
+};
+
+template <typename Module>
+struct ProfilerModuleHostQueueCapacity<Module, std::void_t<decltype(Module::kReadyQueueSize)>> {
+    static constexpr size_t value = Module::kReadyQueueSize > 0 ? Module::kReadyQueueSize : 1;
+};
+
+template <typename Module, typename = void>
+struct ProfilerModuleHostPoolQueueCapacity {
+    static constexpr size_t value = 1024;
+};
+
+template <typename Module>
+struct ProfilerModuleHostPoolQueueCapacity<Module, std::void_t<decltype(Module::kHostPoolQueueSize)>> {
+    static constexpr size_t value = Module::kHostPoolQueueSize > 0 ? Module::kHostPoolQueueSize : 1;
+};
+
+template <typename Module, typename = void>
+struct ProfilerModuleHostRecycledQueueCapacity {
+    static constexpr size_t value = ProfilerModuleHostPoolQueueCapacity<Module>::value;
+};
+
+template <typename Module>
+struct ProfilerModuleHostRecycledQueueCapacity<Module, std::void_t<decltype(Module::kHostRecycledQueueSize)>> {
+    static constexpr size_t value = Module::kHostRecycledQueueSize > 0 ? Module::kHostRecycledQueueSize : 1;
+};
+
+template <typename T, size_t Capacity>
+class SpscRing {
+    static_assert(Capacity > 0, "SpscRing capacity must be > 0");
+
+public:
+    bool push(const T &item) {
+        uint64_t head = head_.load(std::memory_order_relaxed);
+        uint64_t tail = tail_.load(std::memory_order_acquire);
+        if (head - tail >= Capacity) {
+            return false;
+        }
+        entries_[head % Capacity] = item;
+        head_.store(head + 1, std::memory_order_release);
+        return true;
+    }
+
+    bool pop(T &out) {
+        uint64_t tail = tail_.load(std::memory_order_relaxed);
+        uint64_t head = head_.load(std::memory_order_acquire);
+        if (tail == head) {
+            return false;
+        }
+        out = entries_[tail % Capacity];
+        tail_.store(tail + 1, std::memory_order_release);
+        return true;
+    }
+
+    bool empty() const {
+        uint64_t tail = tail_.load(std::memory_order_acquire);
+        uint64_t head = head_.load(std::memory_order_acquire);
+        return tail == head;
+    }
+
+    size_t size() const {
+        uint64_t tail = tail_.load(std::memory_order_acquire);
+        uint64_t head = head_.load(std::memory_order_acquire);
+        uint64_t count = head - tail;
+        return count > Capacity ? Capacity : static_cast<size_t>(count);
+    }
+
+    void clear() {
+        T ignored{};
+        while (pop(ignored)) {}
+    }
+
+private:
+    std::array<T, Capacity> entries_{};
+    alignas(64) std::atomic<uint64_t> head_{0};
+    alignas(64) std::atomic<uint64_t> tail_{0};
+};
+
+class RetiredPool {
+public:
+    bool push(void *item) {
+        std::scoped_lock<std::mutex> lock(mutex_);
+        try {
+            entries_.push_back(item);
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
+
+    bool pop(void *&out) {
+        std::scoped_lock<std::mutex> lock(mutex_);
+        if (entries_.empty()) return false;
+        out = entries_.back();
+        entries_.pop_back();
+        return true;
+    }
+
+    void clear() {
+        std::scoped_lock<std::mutex> lock(mutex_);
+        entries_.clear();
+    }
+
+    bool empty() const {
+        std::scoped_lock<std::mutex> lock(mutex_);
+        return entries_.empty();
+    }
+
+    size_t size() const {
+        std::scoped_lock<std::mutex> lock(mutex_);
+        return entries_.size();
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<void *> entries_;
+};
+
 template <typename Module>
 class BufferPoolManager {
     // Static checks for the Module concept. Required type aliases trigger
@@ -162,10 +286,12 @@ public:
     using ReadyBufferInfo = typename Module::ReadyBufferInfo;
     static constexpr int kCollectorShardCount = ProfilerModuleCollectorThreadCount<Module>::value;
     static_assert(kCollectorShardCount >= 1, "Module::kCollectorThreadCount must be >= 1");
+    static constexpr size_t kReadyQueueCapacity = ProfilerModuleHostQueueCapacity<Module>::value;
+    static constexpr size_t kPoolQueueCapacity = ProfilerModuleHostPoolQueueCapacity<Module>::value;
+    static constexpr size_t kRecycledQueueCapacity = ProfilerModuleHostRecycledQueueCapacity<Module>::value;
+    static constexpr size_t kHostQueueCapacity = kReadyQueueCapacity;
 
-    BufferPoolManager() :
-        ready_shards_(kCollectorShardCount),
-        done_shards_(kCollectorShardCount) {}
+    BufferPoolManager() = default;
     ~BufferPoolManager() = default;
 
     BufferPoolManager(const BufferPoolManager &) = delete;
@@ -173,9 +299,9 @@ public:
 
     /**
      * Configure the buffer pool's memory context. Called by ProfilerBase::start()
-     * before any allocator-touching method (alloc_and_register / free_buffer /
-     * resolve_host_ptr / drain_done_into_recycled triggered by the mgmt loop)
-     * is invoked. Must NOT be called concurrently with the mgmt thread.
+     * before any allocator-touching method (alloc_and_register_block /
+     * free_buffer / resolve_host_ptr / drain_done_into_recycled) is invoked.
+     * Must NOT be called concurrently with the mgmt thread.
      *
      * @param ops              Memory-op callbacks (alloc/reg/free/copy_*).
      * @param shared_mem_dev   Device base of the subsystem's shared memory.
@@ -200,58 +326,49 @@ public:
      * to the collector and must be released by it (the AICPU may still be
      * referencing them via shared memory until execution ends).
      *
-     * For each unique device pointer freed, the paired host shadow is
-     * `std::free`d ONLY if it lives in `malloc_shadows_` (i.e. the
-     * framework itself malloc'd it via `default_host_shadow_register` or
-     * `ProfilerBase::alloc_paired_buffer`'s copy-to-device branch). HAL
-     * mappings (e.g. `halHostRegister` results) are never freed here.
-     *
-     * `release_fn(dev_ptr)` is invoked once per unique pointer; the
-     * collector is expected to call its free_cb on the device pointer.
+     * `release_fn(dev_ptr)` is invoked once per unique allocation base.
+     * Carved sub-buffers from the same registered block are canonicalized
+     * back to that block base before invoking release_fn.
      *
      * Only safe to call after ProfilerBase::stop() has joined the mgmt thread.
      */
     template <typename ReleaseFn>
     void release_owned_buffers(const ReleaseFn &release_fn) {
-        std::unordered_map<void *, bool> seen;
+        std::unordered_set<void *> seen;
         auto release_once = [&](void *p) {
             if (p == nullptr) return;
-            if (seen.emplace(p, true).second) {
-                auto it = dev_to_host_.find(p);
-                void *host_ptr = (it != dev_to_host_.end()) ? it->second : nullptr;
-                release_fn(p);
-                if (host_ptr != nullptr && malloc_shadows_.erase(host_ptr) > 0) {
-                    std::free(host_ptr);
-                }
-                if (it != dev_to_host_.end()) {
-                    dev_to_host_.erase(it);
-                }
+            void *release_ptr = release_pointer_for(p);
+            if (release_ptr != nullptr && seen.insert(release_ptr).second) {
+                release_fn(release_ptr);
             }
         };
 
         for (auto &shard_pools : recycled_) {
             for (auto &pool : shard_pools) {
-                for (void *p : pool)
+                void *p = nullptr;
+                while (pool.pop(p)) {
                     release_once(p);
-                pool.clear();
-            }
-        }
-        {
-            for (auto &shard : done_shards_) {
-                std::scoped_lock<std::mutex> lock(shard.mutex);
-                while (!shard.queue.empty()) {
-                    release_once(shard.queue.front().dev_ptr);
-                    shard.queue.pop();
                 }
             }
         }
-        {
-            for (auto &shard : ready_shards_) {
-                std::scoped_lock<std::mutex> lock(shard.mutex);
-                while (!shard.queue.empty()) {
-                    release_once(shard.queue.front().dev_buffer_ptr);
-                    shard.queue.pop();
+        for (auto &shard_pools : retired_) {
+            for (auto &pool : shard_pools) {
+                void *p = nullptr;
+                while (pool.pop(p)) {
+                    release_once(p);
                 }
+            }
+        }
+        for (auto &shard : done_shards_) {
+            DoneInfo info{};
+            while (shard.queue.pop(info)) {
+                release_once(info.dev_ptr);
+            }
+        }
+        for (auto &shard : ready_shards_) {
+            ReadyBufferInfo info{};
+            while (shard.queue.pop(info)) {
+                release_once(info.dev_buffer_ptr);
             }
         }
     }
@@ -266,11 +383,13 @@ public:
      */
     void clear_mappings() {
         for (auto &kv : dev_to_host_) {
-            if (kv.second != nullptr && malloc_shadows_.count(kv.second) > 0) {
+            if (kv.second != nullptr && malloc_shadows_.erase(kv.second) > 0) {
                 std::free(kv.second);
             }
         }
         dev_to_host_.clear();
+        block_ranges_.clear();
+        released_allocations_.clear();
         malloc_shadows_.clear();
     }
 
@@ -284,8 +403,8 @@ public:
      * not run.
      *
      * Drains recycled/done/ready first (just discards — release goes via
-     * dev_to_host_ to avoid double-free) and then iterates the full
-     * dev→host map. Each unique dev_ptr is released exactly once.
+     * dev_to_host_ to avoid double-free) and then iterates the full mapping
+     * table. Each unique allocation base is released exactly once.
      */
     template <typename ReleaseFn>
     void release_all_owned(const ReleaseFn &release_fn) {
@@ -293,26 +412,33 @@ public:
             for (auto &pool : shard_pools)
                 pool.clear();
         }
+        for (auto &shard_pools : retired_) {
+            for (auto &pool : shard_pools)
+                pool.clear();
+        }
         for (auto &shard : done_shards_) {
-            std::scoped_lock<std::mutex> lock(shard.mutex);
-            std::queue<DoneInfo>().swap(shard.queue);
+            shard.queue.clear();
         }
         for (auto &shard : ready_shards_) {
-            std::scoped_lock<std::mutex> lock(shard.mutex);
-            std::queue<ReadyBufferInfo>().swap(shard.queue);
+            shard.queue.clear();
         }
-        for (auto &kv : dev_to_host_) {
+        std::unordered_set<void *> release_ptrs;
+        for (const auto &kv : dev_to_host_) {
             if (kv.first != nullptr) {
-                release_fn(kv.first);
+                if (void *release_ptr = allocation_base_for_locked(kv.first); release_ptr != nullptr) {
+                    release_ptrs.insert(release_ptr);
+                }
             }
-            // erase-based check (matches release_owned_buffers): atomic
-            // check-and-remove guards against a double-free if any duplicate
-            // mapping ever sneaks into dev_to_host_.
-            if (kv.second != nullptr && malloc_shadows_.erase(kv.second) > 0) {
-                std::free(kv.second);
-            }
+        }
+        for (void *p : release_ptrs) {
+            release_fn(p);
+        }
+        for (void *host_ptr : malloc_shadows_) {
+            std::free(host_ptr);
         }
         dev_to_host_.clear();
+        block_ranges_.clear();
+        released_allocations_.clear();
         malloc_shadows_.clear();
     }
 
@@ -427,35 +553,34 @@ public:
     // ready_queue shards: mgmt threads push, collector threads pop
     // -------------------------------------------------------------------------
 
-    void push_to_ready(const ReadyBufferInfo &info, int shard_index = 0) {
+    bool push_to_ready(const ReadyBufferInfo &info, int shard_index = 0) {
         auto &shard = ready_shards_[normalize_shard(shard_index)];
-        {
-            std::scoped_lock<std::mutex> lock(shard.mutex);
-            shard.queue.push(info);
+        if (!shard.queue.push(info)) {
+            LOG_ERROR("BufferPoolManager: ready queue full for shard=%d capacity=%zu", shard_index, kHostQueueCapacity);
+            return false;
         }
+        shard.notify_epoch.fetch_add(1, std::memory_order_release);
         shard.cv.notify_one();
+        return true;
     }
 
     bool try_pop_ready(ReadyBufferInfo &out, int shard_index = 0) {
         auto &shard = ready_shards_[normalize_shard(shard_index)];
-        std::scoped_lock<std::mutex> lock(shard.mutex);
-        if (shard.queue.empty()) return false;
-        out = shard.queue.front();
-        shard.queue.pop();
-        return true;
+        return shard.queue.pop(out);
     }
 
     bool wait_pop_ready(ReadyBufferInfo &out, std::chrono::milliseconds timeout, int shard_index = 0) {
         auto &shard = ready_shards_[normalize_shard(shard_index)];
-        std::unique_lock<std::mutex> lock(shard.mutex);
-        if (!shard.cv.wait_for(lock, timeout, [&shard] {
-                return !shard.queue.empty();
+        if (shard.queue.pop(out)) return true;
+
+        uint64_t seen = shard.notify_epoch.load(std::memory_order_acquire);
+        std::unique_lock<std::mutex> lock(shard.wait_mutex);
+        if (!shard.cv.wait_for(lock, timeout, [&shard, seen] {
+                return shard.notify_epoch.load(std::memory_order_acquire) != seen || !shard.queue.empty();
             })) {
             return false;
         }
-        out = shard.queue.front();
-        shard.queue.pop();
-        return true;
+        return shard.queue.pop(out);
     }
 
     // -------------------------------------------------------------------------
@@ -464,10 +589,21 @@ public:
     // right kind.
     // -------------------------------------------------------------------------
 
-    void notify_copy_done(void *dev_ptr, int kind, int shard_index = 0) {
+    bool notify_copy_done(void *dev_ptr, int kind, int shard_index = 0) {
         auto &shard = done_shards_[normalize_shard(shard_index)];
-        std::scoped_lock<std::mutex> lock(shard.mutex);
-        shard.queue.push(DoneInfo{dev_ptr, kind});
+        if (!shard.queue.push(DoneInfo{dev_ptr, kind})) {
+            LOG_ERROR(
+                "BufferPoolManager: done queue full for shard=%d kind=%d capacity=%zu", shard_index, kind,
+                kPoolQueueCapacity
+            );
+            return false;
+        }
+        return true;
+    }
+
+    bool try_pop_done(DoneInfo &out, int shard_index = 0) {
+        auto &shard = done_shards_[normalize_shard(shard_index)];
+        return shard.queue.pop(out);
     }
 
     // -------------------------------------------------------------------------
@@ -475,15 +611,55 @@ public:
     // -------------------------------------------------------------------------
 
     /**
-     * Allocate a new device buffer and pair it with a host shadow via
-     * ops_.reg. Tracks the resulting dev→host mapping so resolve_host_ptr()
-     * can find it on subsequent ready-queue pops.
+     * Allocate one device block, register it once, carve it into fixed-size
+     * buffers, then publish the carved buffer starts to one or more recycled
+     * lanes. The block mapping lets resolve_host_ptr() translate any carved
+     * device pointer by range offset, so the HAL registration cost is paid once
+     * per batch rather than once per buffer.
+     */
+    size_t allocate_recycled_batch(int kind, size_t buffer_size, int count, int shard_index = -1) {
+        if (count <= 0 || buffer_size == 0) return 0;
+
+        constexpr size_t kCarveAlignment = 64;
+        size_t stride = align_up(buffer_size, kCarveAlignment);
+        if (stride == 0 || static_cast<size_t>(count) > std::numeric_limits<size_t>::max() / stride) {
+            LOG_ERROR(
+                "BufferPoolManager: invalid block allocation request size=%zu count=%d stride=%zu", buffer_size, count,
+                stride
+            );
+            return 0;
+        }
+        size_t block_size = stride * static_cast<size_t>(count);
+        void *host_base = nullptr;
+        void *dev_base = alloc_and_register_block(block_size, &host_base);
+        if (dev_base == nullptr) return 0;
+        (void)host_base;
+
+        size_t published = 0;
+        auto dev_addr = reinterpret_cast<uintptr_t>(dev_base);
+        for (int i = 0; i < count; i++) {
+            void *dev_ptr = reinterpret_cast<void *>(dev_addr + stride * static_cast<size_t>(i));
+            int target_shard = shard_index >= 0 ? shard_index : i;
+            if (push_recycled(kind, dev_ptr, target_shard) || retire_unqueued_buffer(kind, dev_ptr, target_shard)) {
+                published++;
+            }
+        }
+        if (published == 0) {
+            LOG_ERROR("BufferPoolManager: failed to publish any carved buffers from block %p", dev_base);
+        }
+        return published;
+    }
+
+    /**
+     * Allocate a new device block and pair it with a host shadow via
+     * ops_.reg. Tracks a range mapping so resolve_host_ptr() can handle
+     * carved sub-buffers.
      *
      * @param size              Byte size to allocate.
      * @param[out] host_ptr_out Host shadow pointer.
      * @return                  Device pointer, or nullptr on failure.
      */
-    void *alloc_and_register(size_t size, void **host_ptr_out) {
+    void *alloc_and_register_block(size_t size, void **host_ptr_out) {
         void *dev_ptr = ops_.alloc(size);
         if (dev_ptr == nullptr) {
             *host_ptr_out = nullptr;
@@ -504,6 +680,11 @@ public:
         {
             std::scoped_lock<std::mutex> lock(mapping_mutex_);
             dev_to_host_[dev_ptr] = host_ptr;
+            block_ranges_.push_back(
+                BlockRange{
+                    reinterpret_cast<uintptr_t>(dev_ptr), reinterpret_cast<uintptr_t>(dev_ptr) + size, dev_ptr, host_ptr
+                }
+            );
         }
         return dev_ptr;
     }
@@ -515,19 +696,35 @@ public:
      */
     void free_buffer(void *dev_ptr) {
         if (dev_ptr == nullptr) return;
+        void *release_ptr = nullptr;
+        if (!claim_release_pointer(dev_ptr, &release_ptr)) return;
+
         void *host_ptr = nullptr;
         bool free_host_shadow = false;
         {
             std::scoped_lock<std::mutex> lock(mapping_mutex_);
-            auto it = dev_to_host_.find(dev_ptr);
+            auto it = dev_to_host_.find(release_ptr);
             host_ptr = (it != dev_to_host_.end()) ? it->second : nullptr;
             if (it != dev_to_host_.end()) {
                 dev_to_host_.erase(it);
             }
+            block_ranges_.erase(
+                std::remove_if(
+                    block_ranges_.begin(), block_ranges_.end(),
+                    [release_ptr](const BlockRange &range) {
+                        return range.dev_base == release_ptr;
+                    }
+                ),
+                block_ranges_.end()
+            );
             free_host_shadow = (host_ptr != nullptr && malloc_shadows_.erase(host_ptr) > 0);
         }
         if (ops_.free_) {
-            ops_.free_(dev_ptr);
+            ops_.free_(release_ptr);
+        }
+        {
+            std::scoped_lock<std::mutex> lock(mapping_mutex_);
+            released_allocations_.erase(release_ptr);
         }
         if (free_host_shadow) {
             std::free(host_ptr);
@@ -536,12 +733,17 @@ public:
 
     /**
      * Resolve a device pointer to the host-mapped pointer recorded at
-     * alloc_and_register / register_mapping time.
+     * alloc_and_register_block / register_mapping time. Mappings are built
+     * during init/proactive refill and are immutable while mgmt/collector
+     * threads run, so this hot path is read-only and lock-free.
      */
-    void *resolve_host_ptr(void *dev_ptr) {
-        std::scoped_lock<std::mutex> lock(mapping_mutex_);
-        auto it = dev_to_host_.find(dev_ptr);
-        if (it != dev_to_host_.end()) return it->second;
+    void *resolve_host_ptr(void *dev_ptr) const {
+        const auto &exact_mappings = dev_to_host_;
+        auto it = exact_mappings.find(dev_ptr);
+        if (it != exact_mappings.end()) return it->second;
+        if (void *host_ptr = resolve_host_ptr_from_range(dev_ptr); host_ptr != nullptr) {
+            return host_ptr;
+        }
         LOG_ERROR("BufferPoolManager: no host mapping for dev_ptr=%p", dev_ptr);
         return nullptr;
     }
@@ -559,8 +761,8 @@ public:
     /**
      * Claim ownership of a host shadow that the framework malloc'd. Only
      * shadows tracked here are `std::free`d by `clear_mappings()`,
-     * `release_owned_buffers()`, and `free_buffer()` — HAL-managed
-     * mappings (e.g. `halHostRegister` results) must NOT be added here.
+     * `release_all_owned()`, and `free_buffer()` — HAL-managed mappings
+     * (e.g. `halHostRegister` results) must NOT be added here.
      */
     void add_malloc_shadow(void *host_ptr) {
         if (host_ptr != nullptr) {
@@ -576,34 +778,50 @@ public:
      */
     void *pop_recycled(int kind, int shard_index = 0) {
         auto shard = normalize_shard(shard_index);
-        std::scoped_lock<std::mutex> lock(recycled_mutexes_[shard][kind]);
         auto &pool = recycled_[shard][kind];
-        if (pool.empty()) return nullptr;
-        void *p = pool.back();
-        pool.pop_back();
-        return p;
+        void *p = nullptr;
+        return pool.pop(p) ? p : nullptr;
     }
 
-    void *pop_recycled_any(int kind, int preferred_shard = 0) {
-        if (void *p = pop_recycled(kind, preferred_shard); p != nullptr) return p;
-        const auto preferred = normalize_shard(preferred_shard);
-        for (size_t s = 0; s < recycled_.size(); s++) {
-            if (s == preferred) continue;
-            if (void *p = pop_recycled(kind, static_cast<int>(s)); p != nullptr) return p;
+    void *pop_recycled_for_startup(int kind) {
+        for (size_t shard = 0; shard < recycled_.size(); shard++) {
+            if (void *p = pop_recycled(kind, static_cast<int>(shard)); p != nullptr) return p;
         }
         return nullptr;
     }
 
-    void push_recycled(int kind, void *dev_ptr, int shard_index = 0) {
+    bool push_recycled(int kind, void *dev_ptr, int shard_index = 0) {
         auto shard = normalize_shard(shard_index);
-        std::scoped_lock<std::mutex> lock(recycled_mutexes_[shard][kind]);
-        recycled_[shard][kind].push_back(dev_ptr);
+        if (!recycled_[shard][kind].push(dev_ptr)) {
+            LOG_ERROR(
+                "BufferPoolManager: recycled queue full for shard=%zu kind=%d capacity=%zu", shard, kind,
+                kRecycledQueueCapacity
+            );
+            return false;
+        }
+        return true;
+    }
+
+    bool retire_unqueued_buffer(int kind, void *dev_ptr, int shard_index = 0) {
+        auto shard = normalize_shard(shard_index);
+        if (!retired_[shard][kind].push(dev_ptr)) {
+            LOG_ERROR(
+                "BufferPoolManager: failed to park retired buffer for shard=%zu kind=%d dev_ptr=%p", shard, kind,
+                dev_ptr
+            );
+            return false;
+        }
+        return true;
+    }
+
+    size_t recycled_count(int kind, int shard_index) const {
+        auto shard = normalize_shard(shard_index);
+        return recycled_[shard][kind].size();
     }
 
     size_t recycled_count(int kind) const {
         size_t total = 0;
         for (size_t shard = 0; shard < recycled_.size(); shard++) {
-            std::scoped_lock<std::mutex> lock(recycled_mutexes_[shard][kind]);
             total += recycled_[shard][kind].size();
         }
         return total;
@@ -612,34 +830,26 @@ public:
     bool recycled_empty() const {
         for (size_t shard = 0; shard < recycled_.size(); shard++) {
             for (int kind = 0; kind < Module::kBufferKinds; kind++) {
-                std::scoped_lock<std::mutex> lock(recycled_mutexes_[shard][kind]);
                 if (!recycled_[shard][kind].empty()) return false;
             }
         }
         return true;
     }
 
-    template <typename Fn>
-    decltype(auto) with_free_queue_writer(const void *queue_key, Fn &&fn) {
-        std::scoped_lock<std::mutex> lock(free_queue_mutexes_[free_queue_lock_index(queue_key)]);
-        return fn();
-    }
-
     /**
-     * Drain everything currently in done queue shards back into the per-kind
-     * recycled pool. May be called from Module::process_entry when its
-     * primary recycled pool ran out, to harvest buffers the collector freed
-     * in the meantime.
+     * Drain everything currently in a done queue shard back into that shard's
+     * per-kind recycled pool. Runtime callers keep this single-consumer: the
+     * replenish thread is the only runtime consumer for done shards.
      */
     size_t drain_done_into_recycled(int shard_index) {
         auto &shard = done_shards_[normalize_shard(shard_index)];
         size_t drained = 0;
-        std::scoped_lock<std::mutex> lock(shard.mutex);
-        while (!shard.queue.empty()) {
-            const DoneInfo &info = shard.queue.front();
-            push_recycled(info.kind, info.dev_ptr, shard_index);
-            shard.queue.pop();
-            drained++;
+        DoneInfo info{};
+        while (shard.queue.pop(info)) {
+            if (push_recycled(info.kind, info.dev_ptr, shard_index) ||
+                retire_unqueued_buffer(info.kind, info.dev_ptr, shard_index)) {
+                drained++;
+            }
         }
         return drained;
     }
@@ -652,25 +862,108 @@ public:
         return drained;
     }
 
+    /**
+     * Return the device pointer that owns this allocation. For carved buffers
+     * this is the registered block base; for legacy one-buffer mappings it is
+     * the pointer itself.
+     */
+    void *release_pointer_for(void *dev_ptr) const {
+        std::scoped_lock<std::mutex> lock(mapping_mutex_);
+        return allocation_base_for_locked(dev_ptr);
+    }
+
+    /**
+     * Claim an allocation for release. Multiple carved sub-buffers can point
+     * into the same registered block; only the first claim returns true.
+     */
+    bool claim_release_pointer(void *dev_ptr, void **release_ptr_out) {
+        if (release_ptr_out == nullptr) return false;
+        std::scoped_lock<std::mutex> lock(mapping_mutex_);
+        void *release_ptr = tracked_allocation_base_for_locked(dev_ptr);
+        if (release_ptr == nullptr) {
+            *release_ptr_out = nullptr;
+            return false;
+        }
+        if (!released_allocations_.insert(release_ptr).second) {
+            *release_ptr_out = release_ptr;
+            return false;
+        }
+        *release_ptr_out = release_ptr;
+        return true;
+    }
+
     void *shared_mem_dev() const { return shared_mem_dev_; }
     void *shared_mem_host() const { return shared_mem_host_; }
     int device_id() const { return device_id_; }
 
 private:
+    using ReadyRing = SpscRing<ReadyBufferInfo, kReadyQueueCapacity>;
+    using DoneRing = SpscRing<DoneInfo, kPoolQueueCapacity>;
+    using RecycledRing = SpscRing<void *, kRecycledQueueCapacity>;
+
+    struct BlockRange {
+        uintptr_t dev_begin;
+        uintptr_t dev_end;
+        void *dev_base;
+        void *host_base;
+    };
+
     struct ReadyQueueShard {
-        std::mutex mutex;
+        ReadyRing queue;
+        std::mutex wait_mutex;
         std::condition_variable cv;
-        std::queue<ReadyBufferInfo> queue;
+        std::atomic<uint64_t> notify_epoch{0};
     };
 
     struct DoneQueueShard {
-        std::mutex mutex;
-        std::queue<DoneInfo> queue;
+        DoneRing queue;
     };
 
     static size_t normalize_shard(int shard_index) {
         if (shard_index < 0) return 0;
         return static_cast<size_t>(shard_index) % static_cast<size_t>(kCollectorShardCount);
+    }
+
+    static size_t align_up(size_t value, size_t alignment) {
+        if (alignment == 0) return value;
+        size_t rem = value % alignment;
+        if (rem == 0) return value;
+        if (value > std::numeric_limits<size_t>::max() - (alignment - rem)) return 0;
+        return value + (alignment - rem);
+    }
+
+    void *allocation_base_for_locked(void *dev_ptr) const {
+        if (dev_ptr == nullptr) return nullptr;
+        uintptr_t addr = reinterpret_cast<uintptr_t>(dev_ptr);
+        for (const auto &range : block_ranges_) {
+            if (addr >= range.dev_begin && addr < range.dev_end) {
+                return range.dev_base;
+            }
+        }
+        return dev_ptr;
+    }
+
+    void *tracked_allocation_base_for_locked(void *dev_ptr) const {
+        if (dev_ptr == nullptr) return nullptr;
+        uintptr_t addr = reinterpret_cast<uintptr_t>(dev_ptr);
+        for (const auto &range : block_ranges_) {
+            if (addr >= range.dev_begin && addr < range.dev_end) {
+                return range.dev_base;
+            }
+        }
+        return dev_to_host_.find(dev_ptr) != dev_to_host_.end() ? dev_ptr : nullptr;
+    }
+
+    void *resolve_host_ptr_from_range(void *dev_ptr) const {
+        if (dev_ptr == nullptr) return nullptr;
+        uintptr_t addr = reinterpret_cast<uintptr_t>(dev_ptr);
+        for (const auto &range : block_ranges_) {
+            if (addr >= range.dev_begin && addr < range.dev_end) {
+                uintptr_t offset = addr - range.dev_begin;
+                return reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(range.host_base) + offset);
+            }
+        }
+        return nullptr;
     }
 
     // Subsystem inputs (set by ProfilerBase::start via set_memory_context).
@@ -681,24 +974,18 @@ private:
     MemoryOps ops_;
 
     // mgmt → collector
-    std::vector<ReadyQueueShard> ready_shards_;
+    std::array<ReadyQueueShard, kCollectorShardCount> ready_shards_;
 
     // collector → mgmt
-    std::vector<DoneQueueShard> done_shards_;
+    std::array<DoneQueueShard, kCollectorShardCount> done_shards_;
 
     // Host-side pointer mappings are shared across all collector shards.
     mutable std::mutex mapping_mutex_;
-    static constexpr size_t kFreeQueueLockStripes = 64;
 
-    static size_t free_queue_lock_index(const void *queue_key) {
-        auto raw = reinterpret_cast<uintptr_t>(queue_key);
-        return (raw >> 6) % kFreeQueueLockStripes;
-    }
-
-    std::array<std::mutex, kFreeQueueLockStripes> free_queue_mutexes_;
-
-    // dev → host mapping (single source of truth for resolve_host_ptr)
+    // dev → host exact mappings plus block ranges for carved buffers.
     std::unordered_map<void *, void *> dev_to_host_;
+    std::vector<BlockRange> block_ranges_;
+    std::unordered_set<void *> released_allocations_;
 
     // Host shadows the framework itself malloc'd (via
     // `default_host_shadow_register` or `ProfilerBase::alloc_paired_buffer`'s
@@ -707,8 +994,11 @@ private:
     std::unordered_set<void *> malloc_shadows_;
 
     // Local recycled buffer pools indexed by collector shard, then Module-defined kind id.
-    std::array<std::array<std::vector<void *>, Module::kBufferKinds>, kCollectorShardCount> recycled_;
-    mutable std::array<std::array<std::mutex, Module::kBufferKinds>, kCollectorShardCount> recycled_mutexes_;
+    std::array<std::array<RecycledRing, Module::kBufferKinds>, kCollectorShardCount> recycled_;
+
+    // Error-path holding pools for buffers removed from recycled_ or popped
+    // from device ready queues but not published to a collector/free_queue.
+    std::array<std::array<RetiredPool, Module::kBufferKinds>, kCollectorShardCount> retired_;
 };
 
 }  // namespace profiling_common

--- a/src/common/platform/include/host/dep_gen_collector.h
+++ b/src/common/platform/include/host/dep_gen_collector.h
@@ -17,7 +17,7 @@
  * Architecture:
  * - BufferPoolManager<DepGenModule>: shared mgmt-thread infrastructure that
  *   polls per-thread ready queues, drains done-queue shards, and replenishes
- *   the single instance's free_queue from a unified recycled pool.
+ *   the single instance's free_queue from shard-local recycled lanes.
  * - DepGenCollector: collector thread shards pop full DepGenBuffers from the
  *   manager and append their DepGenRecords to an in-memory vector consumed by
  *   host replay after device execution completes.
@@ -85,14 +85,15 @@ struct DepGenModule {
 
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
+    static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_AICPU_THREADS * PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE;
     static constexpr uint32_t kSlotCount = PLATFORM_DEP_GEN_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "DepGenModule";
     static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
     static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
 
     /**
-     * Buffers grown by proactive_replenish are batch-allocated up to the
-     * per-instance ceiling minus the slot count.
+     * Startup-only batch allocation size for proactive_replenish when the
+     * recycled lanes need additional buffers before drain threads start.
      */
     static constexpr int batch_size(int /*kind*/) {
         constexpr int kBatch = PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE - PLATFORM_DEP_GEN_SLOT_COUNT;
@@ -174,7 +175,7 @@ public:
      * Allocates a DepGenDataHeader + 1 DepGenBufferState, plus
      * PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE DepGenBuffers. The first
      * PLATFORM_DEP_GEN_SLOT_COUNT buffers go directly into the free_queue;
-     * the surplus go into BufferPoolManager's shared recycled pool.
+     * the surplus go into BufferPoolManager's shard-local recycled lanes.
      *
      * @param num_threads     Number of AICPU scheduling threads (so the
      *                        DataHeader sizes its per-thread ready queues)

--- a/src/common/platform/include/host/l2_swimlane_collector.h
+++ b/src/common/platform/include/host/l2_swimlane_collector.h
@@ -84,15 +84,33 @@ struct L2SwimlaneModule {
 
     static constexpr int kBufferKinds = 4;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_PROF_READYQUEUE_SIZE;
+    static constexpr uint32_t kHostPoolQueueSize =
+        PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE +
+        PLATFORM_MAX_AICPU_THREADS * (PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD + PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD) +
+        PLATFORM_MAX_CORES * PLATFORM_AICORE_BUFFERS_PER_CORE;
+    static constexpr uint32_t kMaxCoresPerCollectorShard =
+        (PLATFORM_MAX_CORES + PLATFORM_MAX_AICPU_THREADS - 1) / PLATFORM_MAX_AICPU_THREADS;
+    static constexpr uint32_t kAicpuTaskRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE;
+    static constexpr uint32_t kAicoreTaskRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_AICORE_BUFFERS_PER_CORE;
+    static constexpr uint32_t kPhaseRecycledQueueSize =
+        (PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD > PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD ?
+             PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD :
+             PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD) *
+        2;
+    static constexpr uint32_t kHostRecycledQueueSize =
+        (kAicpuTaskRecycledQueueSize > kAicoreTaskRecycledQueueSize ?
+             (kAicpuTaskRecycledQueueSize > kPhaseRecycledQueueSize ? kAicpuTaskRecycledQueueSize :
+                                                                      kPhaseRecycledQueueSize) :
+             (kAicoreTaskRecycledQueueSize > kPhaseRecycledQueueSize ? kAicoreTaskRecycledQueueSize :
+                                                                       kPhaseRecycledQueueSize));
     static constexpr uint32_t kSlotCount = PLATFORM_PROF_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "L2SwimlaneModule";
     static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
     static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
 
     /**
-     * batch_size for proactive_replenish's alloc fallback. Sized so that a
-     * fully empty recycled pool refills to the configured per-instance
-     * ceiling in one tick. Sched and orch phase pools are sized independently
+     * Startup-only batch allocation size for proactive_replenish. Sched and
+     * orch phase pools are sized independently
      * (PLATFORM_PROF_{SCHED,ORCH}_BUFFERS_PER_THREAD).
      */
     static constexpr int batch_size(int kind) {
@@ -116,6 +134,33 @@ struct L2SwimlaneModule {
             break;
         }
         return b < 1 ? 1 : b;
+    }
+
+    // The recycled watermark is a steady-state low-water mark, not an
+    // additional startup preallocation target. Keep half of the init-seeded
+    // surplus per shard; kinds with no surplus keep a minimal reserve.
+    static constexpr int half_initial_surplus_warm_target(int buffers_per_core) {
+        int surplus_per_core = buffers_per_core > static_cast<int>(PLATFORM_PROF_SLOT_COUNT) ?
+                                   buffers_per_core - static_cast<int>(PLATFORM_PROF_SLOT_COUNT) :
+                                   0;
+        int initial_surplus = surplus_per_core * static_cast<int>(kMaxCoresPerCollectorShard);
+        return initial_surplus > 0 ? (initial_surplus + 1) / 2 : 1;
+    }
+
+    static constexpr int recycled_warm_target(int kind) {
+        constexpr int kAicpuTaskWarmTarget = half_initial_surplus_warm_target(PLATFORM_PROF_BUFFERS_PER_CORE);
+        constexpr int kAicoreTaskWarmTarget = half_initial_surplus_warm_target(PLATFORM_AICORE_BUFFERS_PER_CORE);
+
+        switch (static_cast<L2SwimlaneBufferKind>(kind)) {
+        case L2SwimlaneBufferKind::AicpuTask:
+            return kAicpuTaskWarmTarget;
+        case L2SwimlaneBufferKind::AicoreTask:
+            return kAicoreTaskWarmTarget;
+        case L2SwimlaneBufferKind::AicpuSchedPhase:
+        case L2SwimlaneBufferKind::AicpuOrchPhase:
+            return 0;
+        }
+        return 0;
     }
 
     static int kind_of(const ReadyBufferInfo &info) { return static_cast<int>(info.type); }

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -11,10 +11,12 @@
 
 /**
  * @file profiler_base.h
- * @brief CRTP scaffolding shared by L2Swimlane / Dump / PMU collectors.
+ * @brief CRTP scaffolding shared by L2Swimlane, PMU, DepGen, TensorDump,
+ *        and ScopeStats collectors.
  *
- * Owns the BufferPoolManager<Module>, the mgmt thread(s) that poll AICPU
- * ready queues / recycle buffers, and the collector poll thread(s).
+ * Owns the BufferPoolManager<Module>, drain/replenish mgmt thread(s) that
+ * poll AICPU ready queues and recycle collector-done buffers, and the
+ * collector poll thread(s).
  *
  * Module concept contract
  * -----------------------
@@ -36,6 +38,11 @@
  *   // Constants
  *   static constexpr int      kBufferKinds;    // L2Swimlane=4, Dump=1, PMU=1.
  *   static constexpr uint32_t kReadyQueueSize; // Per-thread ready-queue depth.
+ *   // Optional: host-side done ring depth (defaults to 1024).
+ *   static constexpr uint32_t kHostPoolQueueSize;
+ *   // Optional: shard-local per-kind recycled ring depth.
+ *   // Defaults to kHostPoolQueueSize.
+ *   static constexpr uint32_t kHostRecycledQueueSize;
  *   static constexpr uint32_t kSlotCount;      // FreeQueue::buffer_ptrs[] length.
  *   static constexpr const char* kSubsystemName; // "PMU" / "L2Swimlane" / "Dump".
  *   // Optional: number of mgmt drain shards (defaults to 1).
@@ -49,7 +56,7 @@
  *   // Header pointer cast (host_ptr → DataHeader*)
  *   static DataHeader* header_from_shm(void* shared_mem_host);
  *
- *   // Per-kind alloc batch size for proactive_replenish's batch-alloc fallback.
+ *   // Per-kind alloc batch size for proactive_replenish's free-queue fallback.
  *   static int batch_size(int kind);
  *
  *   // Required only when kBufferKinds > 1: discriminate which recycled bin
@@ -74,14 +81,18 @@
  * ------------
  *
  *   process_entry          replenishes the originating free_queue from the
- *                          current drain shard's local recycled pool until
- *                          the free_queue is full or no buffer is available.
- *   proactive_replenish    fills to kSlotCount across all instances of every
- *                          kind. When recycled drains it batch-allocates
- *                          `batch_size(kind)` buffers at once to amortize the
- *                          allocator cost. Split-mgmt collectors use this
- *                          only before threads start; runtime replenish only
- *                          drains collector-done buffers into local pools.
+ *                          current drain shard's local recycled pool. It does
+ *                          not allocate on the runtime hot path.
+ *   proactive_replenish    fills to kSlotCount across all instances before
+ *                          drain/collector threads start. If recycled is dry,
+ *                          it allocates one registered block and carves it
+ *                          into a batch of buffers.
+ *   mgmt_replenish_loop    drains collector-done buffers back into recycled
+ *                          lanes and keeps optional per-kind recycled watermarks
+ *                          topped up in batches of max(kSlotCount, gap). It
+ *                          never writes device free_queues, so
+ *                          the drain hot path remains allocation-free and owns
+ *                          all runtime free_queue publication.
  *
  * The above two algorithms live in ProfilerAlgorithms<Module>; Module only
  * supplies the data-access traits above. Implementors must NOT zero `count`
@@ -159,11 +170,14 @@
 #ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_PROFILER_BASE_H_
 #define SRC_COMMON_PLATFORM_INCLUDE_HOST_PROFILER_BASE_H_
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <thread>
 #include <type_traits>
@@ -218,16 +232,16 @@ using ProfFreeCallback = std::function<int(void *dev_ptr)>;
 // `default_host_shadow_register` was previously a free function; it has been
 // folded into a lambda inside `ProfilerBase::start()` so the shadow it
 // malloc's can be registered with the manager's `malloc_shadows_` set for
-// safe teardown via `clear_mappings()` / `release_owned_buffers()`. See
+// safe teardown via `clear_mappings()` / `release_all_owned()`. See
 // `ProfilerBase::start()` for the inline definition.
 
 /**
  * RAII scope guard for collector `init()` rollback. On destruction (without
  * `commit()`) it (1) calls `manager.release_all_owned(release_fn)` to free
- * every framework-tracked dev_ptr + host shadow, and (2) releases any extra
- * direct dev_ptrs the collector added via `add_direct_ptr()` (used for
- * pointers the collector owns outside the framework — e.g. PMU per-core
- * `PmuAicoreRing` allocations on a5).
+ * every framework-tracked device allocation and malloc shadow, and (2)
+ * releases any extra direct dev_ptrs the collector added via `add_direct_ptr()`
+ * (used for pointers the collector owns outside the framework — e.g. PMU
+ * per-core `PmuAicoreRing` allocations on a5).
  *
  * Pattern:
  *   int Collector::init(...) {
@@ -390,9 +404,7 @@ struct ProfilerAlgorithms {
     }
 
     // Refill the originating pool's free_queue from this drain shard's local
-    // recycled pool, then push the popped buffer's ReadyBufferInfo to the
-    // collector LAST. Skips the push if host_ptr resolution fails — handing a
-    // null pointer to on_buffer_collected would crash the collector thread.
+    // recycled pool before handing the full buffer to the collector.
     //
     // a5 specifics: after resolving the popped buffer's host shadow, copy
     // the buffer contents from device to host before delivery. The host
@@ -416,19 +428,20 @@ struct ProfilerAlgorithms {
             );
             return;
         }
-
         (void)top_up_free_queue(mgr, site.kind, *site.free_queue, site.buffer_size, q);
 
-        mgr.push_to_ready(site.info, q);
+        if (!mgr.push_to_ready(site.info, q)) {
+            (void)mgr.retire_unqueued_buffer(site.kind, site.info.dev_buffer_ptr, q);
+        }
     }
 
-    // Drain done_queue into local recycled pools, then top up every (kind,
-    // instance) free_queue to kSlotCount. Split-mgmt collectors call this only
-    // before threads start; their runtime replenish loop only drains done.
+    // Top up every (kind, instance) free_queue to kSlotCount before worker
+    // threads start. At runtime each drain shard only refills its own lane.
     template <typename Mgr>
     static uint64_t proactive_replenish(Mgr &mgr, DataHeader *header) {
-        mgr.drain_done_into_recycled();
-        return replenish_free_queues(mgr, header);
+        uint64_t pushed = replenish_free_queues(mgr, header);
+        pushed += replenish_recycled_pools(mgr, header);
+        return pushed;
     }
 
     template <typename Mgr>
@@ -436,12 +449,74 @@ struct ProfilerAlgorithms {
         uint64_t pushed = 0;
         refresh_replenish_metadata(mgr, header, 0);
         Module::for_each_instance(mgr.shared_mem_host(), header, [&](int kind, FreeQueue *fq, size_t buf_size) {
-            pushed += top_up_free_queue(mgr, kind, *fq, buf_size);
+            pushed += top_up_free_queue(mgr, kind, *fq, buf_size, /*shard_index=*/-1);
         });
         return pushed;
     }
 
+    // Keep shard-local recycled pools above the optional Module watermark.
+    // Used both by startup proactive_replenish and by the runtime replenish
+    // thread. It allocates only into host-side recycled lanes; it does not
+    // touch device free_queues. A small gap still allocates a slot-sized batch
+    // to amortize registration; a large gap is filled in one allocation.
+    template <typename Mgr>
+    static uint64_t replenish_recycled_pools(Mgr &mgr, DataHeader *header) {
+        std::array<size_t, Module::kBufferKinds> buffer_sizes{};
+        Module::for_each_instance(mgr.shared_mem_host(), header, [&](int kind, FreeQueue *, size_t buf_size) {
+            if (kind >= 0 && kind < Module::kBufferKinds && buffer_sizes[static_cast<size_t>(kind)] == 0) {
+                buffer_sizes[static_cast<size_t>(kind)] = buf_size;
+            }
+        });
+
+        uint64_t pushed = 0;
+        for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+            if (buffer_sizes[static_cast<size_t>(kind)] == 0) continue;
+            for (int shard = 0; shard < static_cast<int>(Mgr::kCollectorShardCount); shard++) {
+                size_t target = clamped_recycled_warm_target<Mgr>(kind, shard);
+                if (target == 0) continue;
+                size_t current = mgr.recycled_count(kind, shard);
+                if (current >= target) continue;
+                size_t gap = target - current;
+                size_t batch_count = std::max(static_cast<size_t>(Module::kSlotCount), gap);
+                int batch = batch_count > static_cast<size_t>(std::numeric_limits<int>::max()) ?
+                                std::numeric_limits<int>::max() :
+                                static_cast<int>(batch_count);
+                pushed += mgr.allocate_recycled_batch(kind, buffer_sizes[static_cast<size_t>(kind)], batch, shard);
+            }
+        }
+        return pushed;
+    }
+
 private:
+    static int recycled_warm_target(int kind, int shard) { return recycled_warm_target_impl(kind, shard, 0); }
+
+    template <typename M = Module>
+    static auto recycled_warm_target_impl(int kind, int shard, int) -> decltype(M::recycled_warm_target(kind, shard)) {
+        return M::recycled_warm_target(kind, shard);
+    }
+
+    template <typename M = Module>
+    static auto recycled_warm_target_impl(int kind, int, long) -> decltype(M::recycled_warm_target(kind)) {
+        return M::recycled_warm_target(kind);
+    }
+
+    static int recycled_warm_target_impl(int, int, ...) { return 0; }
+
+    template <typename Mgr>
+    static size_t clamped_recycled_warm_target(int kind, int shard) {
+        int target = recycled_warm_target(kind, shard);
+        if (target <= 0) return 0;
+        size_t requested = static_cast<size_t>(target);
+        if (requested > Mgr::kRecycledQueueCapacity) {
+            LOG_WARN(
+                "%s: recycled warm target too large for shard=%d kind=%d: target=%zu capacity=%zu; clamping",
+                Module::kSubsystemName, shard, kind, requested, Mgr::kRecycledQueueCapacity
+            );
+            return Mgr::kRecycledQueueCapacity;
+        }
+        return requested;
+    }
+
     template <typename Mgr, typename M = Module>
     static auto refresh_replenish_metadata(Mgr &mgr, DataHeader *header, int)
         -> decltype(M::refresh_replenish_metadata(mgr, header), void()) {
@@ -454,34 +529,21 @@ private:
     // Fallback used by drain-shard free_queue top-up.
     template <typename Mgr>
     static void *obtain_buffer(Mgr &mgr, int kind, size_t buf_size, int shard_index) {
+        if (shard_index < 0) {
+            if (void *p = mgr.pop_recycled_for_startup(kind); p != nullptr) return p;
+            (void)mgr.allocate_recycled_batch(kind, buf_size, Module::batch_size(kind), shard_index);
+            return mgr.pop_recycled_for_startup(kind);
+        }
+
         void *p = mgr.pop_recycled(kind, shard_index);
         if (p != nullptr) return p;
-        mgr.drain_done_into_recycled(shard_index);
-        p = mgr.pop_recycled(kind, shard_index);
-        if (p != nullptr) return p;
-        p = mgr.pop_recycled_any(kind, shard_index);
-        if (p != nullptr) return p;
 
-        const int batch = Module::batch_size(kind);
-        for (int i = 0; i < batch; i++) {
-            void *host_ptr = nullptr;
-            void *dev = mgr.alloc_and_register(buf_size, &host_ptr);
-            if (dev == nullptr) break;
-            mgr.push_recycled(kind, dev, shard_index);
-        }
-        p = mgr.pop_recycled(kind, shard_index);
-        if (p == nullptr) {
-            LOG_WARN(
-                "%s: alloc failed for %zu bytes (kind=%d) — increase BUFFERS_PER_* to reduce drops",
-                Module::kSubsystemName, buf_size, kind
-            );
-        }
-        return p;
+        return nullptr;
     }
 
     // Append one buffer pointer to a per-instance free_queue if it has
-    // capacity. The manager serializes host writers so split drain shards and
-    // non-split/proactive refill paths never race on free_queue.tail.
+    // capacity. The queue owner is the drain shard for that AICPU producer;
+    // proactive_replenish calls this only before drain threads start.
     //
     // a5: write the new slot and the advanced tail back to device via
     // `write_range_to_device` so AICPU sees the refill without us bulk
@@ -490,52 +552,49 @@ private:
     // the corresponding pointer.
     template <typename Mgr>
     static bool try_push_to_free_queue(Mgr &mgr, FreeQueue &fq, void *dev_ptr) {
-        return mgr.with_free_queue_writer(&fq, [&]() {
-            if (mgr.read_range_from_device(&fq.head, sizeof(fq.head)) != 0) {
-                LOG_ERROR("%s: failed to refresh free_queue head", Module::kSubsystemName);
-                return false;
-            }
-            rmb();
-            uint32_t fq_head = fq.head;
-            uint32_t fq_tail = fq.tail;
-            if (fq_tail - fq_head >= Module::kSlotCount) {
-                return false;
-            }
-            uint32_t slot_idx = fq_tail % Module::kSlotCount;
-            uint64_t old_slot = fq.buffer_ptrs[slot_idx];
-            fq.buffer_ptrs[slot_idx] = reinterpret_cast<uint64_t>(dev_ptr);
-            wmb();
-            if (mgr.write_range_to_device(&fq.buffer_ptrs[slot_idx], sizeof(fq.buffer_ptrs[slot_idx])) != 0) {
-                fq.buffer_ptrs[slot_idx] = old_slot;
-                LOG_ERROR("%s: failed to publish free_queue slot", Module::kSubsystemName);
-                return false;
-            }
-            fq.tail = fq_tail + 1;
-            wmb();
-            if (mgr.write_range_to_device(&fq.tail, sizeof(fq.tail)) != 0) {
-                fq.tail = fq_tail;
-                fq.buffer_ptrs[slot_idx] = old_slot;
-                LOG_ERROR("%s: failed to publish free_queue tail", Module::kSubsystemName);
-                return false;
-            }
-            return true;
-        });
+        if (mgr.read_range_from_device(&fq.head, sizeof(fq.head)) != 0) {
+            LOG_ERROR("%s: failed to refresh free_queue head", Module::kSubsystemName);
+            return false;
+        }
+        rmb();
+        uint32_t fq_head = fq.head;
+        uint32_t fq_tail = fq.tail;
+        if (fq_tail - fq_head >= Module::kSlotCount) {
+            return false;
+        }
+        uint32_t slot_idx = fq_tail % Module::kSlotCount;
+        uint64_t old_slot = fq.buffer_ptrs[slot_idx];
+        fq.buffer_ptrs[slot_idx] = reinterpret_cast<uint64_t>(dev_ptr);
+        wmb();
+        if (mgr.write_range_to_device(&fq.buffer_ptrs[slot_idx], sizeof(fq.buffer_ptrs[slot_idx])) != 0) {
+            fq.buffer_ptrs[slot_idx] = old_slot;
+            LOG_ERROR("%s: failed to publish free_queue slot", Module::kSubsystemName);
+            return false;
+        }
+        fq.tail = fq_tail + 1;
+        wmb();
+        if (mgr.write_range_to_device(&fq.tail, sizeof(fq.tail)) != 0) {
+            fq.tail = fq_tail;
+            fq.buffer_ptrs[slot_idx] = old_slot;
+            LOG_ERROR("%s: failed to publish free_queue tail", Module::kSubsystemName);
+            return false;
+        }
+        return true;
     }
 
     template <typename Mgr>
     static bool free_queue_has_space(Mgr &mgr, FreeQueue &fq) {
-        return mgr.with_free_queue_writer(&fq, [&]() {
-            if (mgr.read_range_from_device(&fq.head, sizeof(fq.head)) != 0) {
-                LOG_ERROR("%s: failed to refresh free_queue head", Module::kSubsystemName);
-                return false;
-            }
-            rmb();
-            return fq.tail - fq.head < Module::kSlotCount;
-        });
+        if (mgr.read_range_from_device(&fq.head, sizeof(fq.head)) != 0) {
+            LOG_ERROR("%s: failed to refresh free_queue head", Module::kSubsystemName);
+            return false;
+        }
+        rmb();
+        return fq.tail - fq.head < Module::kSlotCount;
     }
 
-    // Fill one (kind, instance) free_queue to kSlotCount from one drain
-    // shard's local recycled pool, batch-allocating when that shard is dry.
+    // Fill one (kind, instance) free_queue to kSlotCount. Startup uses any
+    // recycled lane and may batch-allocate; runtime uses only the drain
+    // shard's local recycled lane and returns when it is dry.
     template <typename Mgr>
     static uint64_t top_up_free_queue(Mgr &mgr, int kind, FreeQueue &fq, size_t buf_size, int shard_index = 0) {
         uint64_t pushed = 0;
@@ -544,7 +603,8 @@ private:
             void *new_dev = obtain_buffer(mgr, kind, buf_size, shard_index);
             if (new_dev == nullptr) return pushed;
             if (!try_push_to_free_queue(mgr, fq, new_dev)) {
-                mgr.push_recycled(kind, new_dev, shard_index);
+                (void)mgr.retire_unqueued_buffer(kind, new_dev, shard_index);
+                LOG_ERROR("%s: failed to return recycled buffer to free_queue", Module::kSubsystemName);
                 return pushed;
             }
             pushed++;
@@ -685,10 +745,17 @@ public:
             (void)ProfilerAlgorithms<Module>::proactive_replenish(manager_, header);
         }
 
+        constexpr int kDrainThreads = ProfilerModuleDrainThreadCount<Module>::value;
+        constexpr int kCollectorThreads = ProfilerModuleCollectorThreadCount<Module>::value;
+        static_assert(kDrainThreads >= 1, "kMgmtDrainThreadCount must be >= 1");
+        static_assert(kCollectorThreads >= 1, "kCollectorThreadCount must be >= 1");
+        static_assert(
+            kCollectorThreads % kDrainThreads == 0,
+            "SPSC host queues require each collector shard to be fed by one drain thread"
+        );
+
         mgmt_running_.store(true, std::memory_order_release);
         {
-            constexpr int kDrainThreads = ProfilerModuleDrainThreadCount<Module>::value;
-            static_assert(kDrainThreads >= 1, "kMgmtDrainThreadCount must be >= 1");
             if constexpr (kDrainThreads == 1) {
                 if (thread_factory) {
                     mgmt_thread_ = thread_factory([this]() {
@@ -718,8 +785,6 @@ public:
             }
         }
 
-        constexpr int kCollectorThreads = ProfilerModuleCollectorThreadCount<Module>::value;
-        static_assert(kCollectorThreads >= 1, "kCollectorThreadCount must be >= 1");
         if constexpr (kCollectorThreads == 1) {
             if (thread_factory) {
                 collector_thread_ = thread_factory([this]() {
@@ -743,12 +808,12 @@ public:
     }
 
     /**
-     * Stop the mgmt thread, drain whatever it pushes during its final pass,
-     * and join the collector. Idempotent. Caller is guaranteed on return
-     * that mgmt's L1 ringbuffer and the host-side ready queue shard(s) are
-     * empty and Derived::on_buffer_collected has been called for every
-     * entry that was in either queue. Framework-owned buffers are NOT freed
-     * here — Derived's finalize() must do that.
+     * Stop the drain/replenish mgmt threads, drain whatever the drain side
+     * pushes during its final pass, and join the collector. Idempotent. Caller
+     * is guaranteed on return that mgmt's L1 ringbuffer and the host-side
+     * ready queue shard(s) are empty and Derived::on_buffer_collected has been
+     * called for every entry that was in either queue. Framework-owned buffers
+     * are NOT freed here — Derived's finalize() must do that.
      *
      * Order matters: stop+join mgmt first so its final-drain pass is fully
      * landed in L2 BEFORE we tell poll to exit. Otherwise mgmt's last batch
@@ -817,14 +882,16 @@ protected:
      */
     void release_one_buffer(void *dev_ptr, ProfUnregisterCallback unregister_cb, const ProfFreeCallback &free_cb) {
         if (dev_ptr == nullptr) return;
+        void *release_ptr = nullptr;
+        if (!manager_.claim_release_pointer(dev_ptr, &release_ptr)) return;
         if (unregister_cb != nullptr) {
-            int rc = unregister_cb(dev_ptr, device_id_);
+            int rc = unregister_cb(release_ptr, device_id_);
             if (rc != 0) {
-                LOG_ERROR("halHostUnregister failed for dev_ptr %p: %d", dev_ptr, rc);
+                LOG_ERROR("halHostUnregister failed for dev_ptr %p: %d", release_ptr, rc);
             }
         }
         if (free_cb) {
-            free_cb(dev_ptr);
+            free_cb(release_ptr);
         }
     }
 
@@ -838,8 +905,8 @@ protected:
      *     identity-mapped view of the same memory.
      *   - non-SVM platform (a5):   `copy_to_device_` is installed →
      *     malloc a paired host shadow, zero it, push the zeros to the
-     *     device side. The host shadow lives until release_one_buffer
-     *     `std::free()`s it.
+     *     device side. The host shadow lives until BufferPoolManager teardown
+     *     via `clear_mappings()` or `release_all_owned()`.
      *   - SVM platform (a2a3 sim): `register_cb_` null AND `copy_to_device_`
      *     null → identity-map (host_ptr == dev_ptr).
      *
@@ -932,10 +999,13 @@ private:
     }
 
     void mgmt_replenish_loop() {
+        DataHeader *header = Module::header_from_shm(manager_.shared_mem_host());
+        using Alg = ProfilerAlgorithms<Module>;
         while (mgmt_running_.load(std::memory_order_relaxed)) {
             size_t drained = manager_.drain_done_into_recycled();
+            uint64_t replenished = Alg::replenish_recycled_pools(manager_, header);
 
-            if (drained == 0) {
+            if (drained == 0 && replenished == 0) {
                 std::this_thread::sleep_for(std::chrono::microseconds(10));
             }
         }
@@ -998,9 +1068,9 @@ private:
             static_cast<Derived *>(this)->on_buffer_collected(info);
         }
         if constexpr (Module::kBufferKinds > 1) {
-            manager_.notify_copy_done(info.dev_buffer_ptr, Module::kind_of(info), shard_index);
+            (void)manager_.notify_copy_done(info.dev_buffer_ptr, Module::kind_of(info), shard_index);
         } else {
-            manager_.notify_copy_done(info.dev_buffer_ptr, 0, shard_index);
+            (void)manager_.notify_copy_done(info.dev_buffer_ptr, 0, shard_index);
         }
     }
 

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -14,8 +14,9 @@
  * @brief Host-side scope_stats streaming collector + NDJSON export.
  *
  * Architecture mirrors PmuCollector: BufferPoolManager<ScopeStatsModule> runs
- * split mgmt threads (poll per-thread ready queues, recycle buffers, refill the
- * single instance's free_queue); ScopeStatsCollector's collector thread shards
+ * split mgmt threads (drain polls per-thread ready queues and refills the
+ * single instance's free_queue from recycled lanes; replenish returns done
+ * buffers to recycled lanes). ScopeStatsCollector's collector thread shards
  * append each full buffer's ScopeStatsRecords to an in-memory vector. After
  * stop(), write_jsonl() renders them to
  * <output_dir>/scope_stats/scope_stats.jsonl.
@@ -87,6 +88,8 @@ struct ScopeStatsModule {
 
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_SCOPE_STATS_READYQUEUE_SIZE;
+    static constexpr uint32_t kHostPoolQueueSize =
+        PLATFORM_MAX_AICPU_THREADS * PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE;
     static constexpr uint32_t kSlotCount = PLATFORM_SCOPE_STATS_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "ScopeStatsModule";
     static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -34,6 +34,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -61,9 +62,9 @@
 /**
  * One buffer kind (DumpMetaBuffer); one ready_queue per AICPU thread.
  * Per-thread arena buffers are owned by the collector itself, not the
- * framework. process_entry refills the originating thread's free_queue
- * with exactly one buffer; proactive_replenish tops up to SLOT_COUNT and
- * batch-allocates when the recycled pool drains.
+ * framework. Runtime refill uses the owning drain shard's local
+ * recycled/done lanes; proactive_replenish may batch-allocate before drain
+ * and collector threads start.
  */
 
 /**
@@ -84,15 +85,15 @@ struct DumpModule {
 
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_DUMP_READYQUEUE_SIZE;
+    static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_AICPU_THREADS * PLATFORM_DUMP_BUFFERS_PER_THREAD;
     static constexpr uint32_t kSlotCount = PLATFORM_DUMP_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "DumpModule";
     static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
     static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
 
     /**
-     * Tensor-dump bursts can be very large; the batch is sized so a fully
-     * empty recycled pool refills to the configured per-thread ceiling in
-     * one tick.
+     * Tensor-dump bursts can be very large; this is the startup-only batch
+     * size used when proactive_replenish needs to grow recycled lanes.
      */
     static constexpr int batch_size(int /*kind*/) {
         constexpr int kBatch = PLATFORM_DUMP_BUFFERS_PER_THREAD - PLATFORM_DUMP_SLOT_COUNT;

--- a/src/common/platform/shared/host/dep_gen_collector.cpp
+++ b/src/common/platform/shared/host/dep_gen_collector.cpp
@@ -91,6 +91,7 @@ int DepGenCollector::init(
     const size_t buf_size = sizeof(DepGenBuffer);
     DepGenBufferState *state = get_dep_gen_buffer_state(shm_host_local, 0);
 
+    const int owner_shard = (num_threads > 0) ? (num_threads - 1) : 0;
     for (int b = 0; b < PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE; b++) {
         void *host_ptr = nullptr;
         void *dev_ptr = alloc_paired_buffer(buf_size, &host_ptr);
@@ -108,7 +109,9 @@ int DepGenCollector::init(
             state->free_queue.tail = tail + 1;
             wmb();
         } else {
-            manager_.push_recycled(0, dev_ptr);
+            if (!manager_.push_recycled(0, dev_ptr, owner_shard)) {
+                (void)manager_.retire_unqueued_buffer(0, dev_ptr, owner_shard);
+            }
         }
     }
 
@@ -284,8 +287,8 @@ void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, const Dep
         state->free_queue.head = tail;
     }
 
-    // Release framework-owned buffers (recycled pool, ready_queue,
-    // done_queue). release_owned_buffers also frees their host shadows.
+    // Release framework-owned device allocations (recycled pool,
+    // ready_queue, done_queue). Host shadows are freed by clear_mappings().
     manager_.release_owned_buffers([&](void *p) {
         release_dev_once(p);
     });

--- a/src/common/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/l2_swimlane_collector.cpp
@@ -20,6 +20,7 @@
 
 #include "host/l2_swimlane_collector.h"
 
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <cinttypes>
@@ -42,6 +43,37 @@
 // Sched / orch phase records route through separate BufferKinds; no
 // parse-time discriminator function is needed (the device-side type tag is
 // the source of truth).
+
+namespace {
+
+int owner_recycled_shard_for_core(int core_index, int thread_count) {
+    int cluster_index = core_index / PLATFORM_CORES_PER_BLOCKDIM;
+    return cluster_index % thread_count;
+}
+
+bool recycled_seed_capacity_is_sufficient(
+    const char *label, int num_cores, int thread_count, int surplus_per_core, size_t capacity
+) {
+    if (surplus_per_core <= 0) return true;
+    std::array<int, PLATFORM_MAX_AICPU_THREADS> per_shard{};
+    for (int core = 0; core < num_cores; core++) {
+        per_shard[static_cast<size_t>(owner_recycled_shard_for_core(core, thread_count))] += surplus_per_core;
+    }
+
+    bool ok = true;
+    for (int shard = 0; shard < thread_count; shard++) {
+        if (static_cast<size_t>(per_shard[static_cast<size_t>(shard)]) <= capacity) continue;
+        LOG_ERROR(
+            "%s recycled seed exceeds lane capacity: shard=%d need=%d capacity=%zu "
+            "(num_cores=%d thread_count=%d)",
+            label, shard, per_shard[static_cast<size_t>(shard)], capacity, num_cores, thread_count
+        );
+        ok = false;
+    }
+    return ok;
+}
+
+}  // namespace
 
 L2SwimlaneCollector::~L2SwimlaneCollector() {
     stop();
@@ -71,6 +103,12 @@ int L2SwimlaneCollector::initialize(
 
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
+        return -1;
+    }
+    if (aicpu_thread_num <= 0 || aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "Invalid number of AICPU threads: %d (valid range: 1-%d)", aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS
+        );
         return -1;
     }
 
@@ -178,6 +216,16 @@ int L2SwimlaneCollector::initialize(
     // Step 5: Initialize L2SwimlaneAicpuTaskPools. Seed as many buffers as
     // the device-side free_queue can hold; any remaining buffers stay in the
     // host recycled pool.
+    constexpr int kAicpuInitialFreeCount = (PLATFORM_PROF_BUFFERS_PER_CORE < PLATFORM_PROF_SLOT_COUNT) ?
+                                               PLATFORM_PROF_BUFFERS_PER_CORE :
+                                               PLATFORM_PROF_SLOT_COUNT;
+    constexpr int kAicpuSurplusPerCore = PLATFORM_PROF_BUFFERS_PER_CORE - kAicpuInitialFreeCount;
+    if (!recycled_seed_capacity_is_sufficient(
+            "L2SwimlaneAicpuTask", num_aicore, aicpu_thread_num, kAicpuSurplusPerCore,
+            decltype(manager_)::kRecycledQueueCapacity
+        )) {
+        return -1;
+    }
     for (int i = 0; i < num_aicore; i++) {
         L2SwimlaneAicpuTaskPool *state = get_perf_buffer_state(perf_host_ptr, i);
         memset(state, 0, sizeof(L2SwimlaneAicpuTaskPool));
@@ -187,9 +235,7 @@ int L2SwimlaneCollector::initialize(
         state->head.current_buf_ptr = 0;
         state->head.current_buf_seq = 0;
 
-        const int initial_free_count = (PLATFORM_PROF_BUFFERS_PER_CORE < PLATFORM_PROF_SLOT_COUNT) ?
-                                           PLATFORM_PROF_BUFFERS_PER_CORE :
-                                           PLATFORM_PROF_SLOT_COUNT;
+        const int initial_free_count = kAicpuInitialFreeCount;
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
             void *host_buf_ptr = nullptr;
             void *dev_buf_ptr = alloc_paired_buffer(sizeof(L2SwimlaneAicpuTaskBuffer), &host_buf_ptr);
@@ -204,7 +250,11 @@ int L2SwimlaneCollector::initialize(
             if (s < initial_free_count) {
                 state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
             } else {
-                manager_.push_recycled(static_cast<int>(ProfBufferType::AICPU_TASK), dev_buf_ptr);
+                int shard = owner_recycled_shard_for_core(i, aicpu_thread_num);
+                int kind = static_cast<int>(ProfBufferType::AICPU_TASK);
+                if (!manager_.push_recycled(kind, dev_buf_ptr, shard)) {
+                    (void)manager_.retire_unqueued_buffer(kind, dev_buf_ptr, shard);
+                }
             }
         }
         wmb();
@@ -214,13 +264,21 @@ int L2SwimlaneCollector::initialize(
 
     // Step 5b: Initialize L2SwimlaneAicoreTaskPools — per-core AICore rotation
     // channel + buffer pool. Same SPSC pattern as the AICPU pool above.
+    constexpr int kAicoreInitialFreeCount = (PLATFORM_AICORE_BUFFERS_PER_CORE < PLATFORM_PROF_SLOT_COUNT) ?
+                                                PLATFORM_AICORE_BUFFERS_PER_CORE :
+                                                PLATFORM_PROF_SLOT_COUNT;
+    constexpr int kAicoreSurplusPerCore = PLATFORM_AICORE_BUFFERS_PER_CORE - kAicoreInitialFreeCount;
+    if (!recycled_seed_capacity_is_sufficient(
+            "L2SwimlaneAicoreTask", num_aicore, aicpu_thread_num, kAicoreSurplusPerCore,
+            decltype(manager_)::kRecycledQueueCapacity
+        )) {
+        return -1;
+    }
     for (int i = 0; i < num_aicore; i++) {
         L2SwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(perf_host_ptr, num_aicore, i);
         memset(ac_state, 0, sizeof(L2SwimlaneAicoreTaskPool));
 
-        const int initial_free_count = (PLATFORM_AICORE_BUFFERS_PER_CORE < PLATFORM_PROF_SLOT_COUNT) ?
-                                           PLATFORM_AICORE_BUFFERS_PER_CORE :
-                                           PLATFORM_PROF_SLOT_COUNT;
+        const int initial_free_count = kAicoreInitialFreeCount;
         for (int s = 0; s < PLATFORM_AICORE_BUFFERS_PER_CORE; s++) {
             void *host_buf_ptr = nullptr;
             void *dev_buf_ptr = alloc_paired_buffer(sizeof(L2SwimlaneAicoreTaskBuffer), &host_buf_ptr);
@@ -235,7 +293,11 @@ int L2SwimlaneCollector::initialize(
             if (s < initial_free_count) {
                 ac_state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
             } else {
-                manager_.push_recycled(static_cast<int>(ProfBufferType::AICORE_TASK), dev_buf_ptr);
+                int shard = owner_recycled_shard_for_core(i, aicpu_thread_num);
+                int kind = static_cast<int>(ProfBufferType::AICORE_TASK);
+                if (!manager_.push_recycled(kind, dev_buf_ptr, shard)) {
+                    (void)manager_.retire_unqueued_buffer(kind, dev_buf_ptr, shard);
+                }
             }
         }
         wmb();
@@ -308,7 +370,14 @@ int L2SwimlaneCollector::initialize(
                 if (s < initial_free_count) {
                     state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
                 } else {
-                    manager_.push_recycled(static_cast<int>(recycle_kind), dev_buf_ptr);
+                    int shard = t;
+                    if (recycle_kind == ProfBufferType::AICPU_ORCH_PHASE) {
+                        shard = (aicpu_thread_num > 0) ? (aicpu_thread_num - 1) : 0;
+                    }
+                    int kind = static_cast<int>(recycle_kind);
+                    if (!manager_.push_recycled(kind, dev_buf_ptr, shard)) {
+                        (void)manager_.retire_unqueued_buffer(kind, dev_buf_ptr, shard);
+                    }
                 }
             }
             wmb();

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -96,6 +96,7 @@ int ScopeStatsCollector::init(
     const size_t buf_size = sizeof(ScopeStatsBuffer);
     ScopeStatsBufferState *state = get_scope_stats_buffer_state(shm_host_local, 0);
 
+    const int owner_shard = (num_threads > 0) ? (num_threads - 1) : 0;
     for (int b = 0; b < PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE; b++) {
         void *host_ptr = nullptr;
         void *dev_ptr = alloc_paired_buffer(buf_size, &host_ptr);
@@ -110,7 +111,9 @@ int ScopeStatsCollector::init(
             state->free_queue.buffer_ptrs[tail % PLATFORM_SCOPE_STATS_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
             state->free_queue.tail = tail + 1;
         } else {
-            manager_.push_recycled(0, dev_ptr);
+            if (!manager_.push_recycled(0, dev_ptr, owner_shard)) {
+                (void)manager_.retire_unqueued_buffer(0, dev_ptr, owner_shard);
+            }
         }
     }
 
@@ -359,8 +362,8 @@ void ScopeStatsCollector::finalize(ScopeStatsUnregisterCallback unregister_cb, c
         state->free_queue.head = tail;
     }
 
-    // Release framework-owned buffers (recycled pool, ready_queue,
-    // done_queue). release_owned_buffers also frees their host shadows.
+    // Release framework-owned device allocations (recycled pool,
+    // ready_queue, done_queue). Host shadows are freed by clear_mappings().
     manager_.release_owned_buffers([&](void *p) {
         release_dev(p);
     });

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -138,7 +138,9 @@ int TensorDumpCollector::initialize(
                 state->free_queue.buffer_ptrs[tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
                 state->free_queue.tail = tail + 1;
             } else {
-                manager_.push_recycled(0, dev_ptr);
+                if (!manager_.push_recycled(0, dev_ptr, t)) {
+                    (void)manager_.retire_unqueued_buffer(0, dev_ptr, t);
+                }
             }
         }
     }
@@ -747,9 +749,8 @@ int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const Du
         }
     }
 
-    // Release framework-owned buffers (recycled pools, ready_queue,
-    // done_queue). release_owned_buffers also frees the paired host shadows
-    // for these (and erases their mappings).
+    // Release framework-owned device allocations (recycled pools,
+    // ready_queue, done_queue). Host shadows are freed by clear_mappings().
     manager_.release_owned_buffers([&](void *p) {
         release_dev(p);
     });

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -379,7 +379,13 @@ target_include_directories(test_runtime_orch_so PRIVATE
 )
 add_common_utils_test(test_device_arena common/test_device_arena.cpp)
 add_common_utils_test(test_buffer_pool_manager common/test_buffer_pool_manager.cpp)
+target_sources(test_buffer_pool_manager PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/unified_log_host.cpp
+)
 target_include_directories(test_buffer_pool_manager PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
 )
 add_common_utils_test(test_l3_l2_orch_comm common/test_l3_l2_orch_comm.cpp)

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -10,11 +10,17 @@
  */
 
 #include "host/buffer_pool_manager.h"
+#include "host/profiler_base.h"
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <set>
+#include <thread>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -34,20 +40,198 @@ struct TestModule {
 
     static constexpr int kBufferKinds = 2;
     static constexpr int kCollectorThreadCount = 4;
+    static constexpr uint32_t kReadyQueueSize = 4;
+};
+
+struct SplitCapacityModule {
+    using DataHeader = TestHeader;
+    using ReadyEntry = TestReadyEntry;
+    using ReadyBufferInfo = TestReadyBufferInfo;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr int kCollectorThreadCount = 1;
+    static constexpr uint32_t kReadyQueueSize = 2;
+    static constexpr uint32_t kHostPoolQueueSize = 5;
+};
+
+struct SplitDoneRecycledCapacityModule {
+    using DataHeader = TestHeader;
+    using ReadyEntry = TestReadyEntry;
+    using ReadyBufferInfo = TestReadyBufferInfo;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr int kCollectorThreadCount = 1;
+    static constexpr uint32_t kReadyQueueSize = 2;
+    static constexpr uint32_t kHostPoolQueueSize = 5;
+    static constexpr uint32_t kHostRecycledQueueSize = 3;
+};
+
+struct AlgorithmFreeQueue {
+    volatile uint32_t head{0};
+    volatile uint32_t tail{1};
+    volatile uint64_t buffer_ptrs[1]{};
+};
+
+struct AlgorithmHeader {
+    AlgorithmFreeQueue free_queue;
+};
+
+struct AlgorithmReadyEntry {
+    uint64_t buffer_ptr{0};
+};
+
+struct AlgorithmReadyBufferInfo {
+    void *dev_buffer_ptr{nullptr};
+    void *host_buffer_ptr{nullptr};
+};
+
+struct AlgorithmModule {
+    using DataHeader = AlgorithmHeader;
+    using ReadyEntry = AlgorithmReadyEntry;
+    using ReadyBufferInfo = AlgorithmReadyBufferInfo;
+    using FreeQueue = AlgorithmFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr int kCollectorThreadCount = 1;
+    static constexpr uint32_t kReadyQueueSize = 1;
+    static constexpr uint32_t kHostPoolQueueSize = 4;
+    static constexpr uint32_t kSlotCount = 1;
+    static constexpr const char *kSubsystemName = "AlgorithmModule";
+
+    static DataHeader *header_from_shm(void *shared_mem_host) { return static_cast<DataHeader *>(shared_mem_host); }
+
+    static int batch_size(int /*kind*/) { return 1; }
+
+    static std::optional<profiling_common::EntrySite<AlgorithmModule>>
+    resolve_entry(void * /*shm_host*/, DataHeader *header, int /*q*/, const ReadyEntry &entry) {
+        return profiling_common::EntrySite<AlgorithmModule>{
+            0,
+            &header->free_queue,
+            sizeof(uint64_t),
+            AlgorithmReadyBufferInfo{reinterpret_cast<void *>(entry.buffer_ptr), nullptr},
+        };
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void * /*shm_host*/, DataHeader *header, Cb &&cb) {
+        cb(0, &header->free_queue, sizeof(uint64_t));
+    }
+};
+
+struct WarmRecycledModule {
+    using DataHeader = AlgorithmHeader;
+    using ReadyEntry = AlgorithmReadyEntry;
+    using ReadyBufferInfo = AlgorithmReadyBufferInfo;
+    using FreeQueue = AlgorithmFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr int kCollectorThreadCount = 2;
+    static constexpr uint32_t kReadyQueueSize = 1;
+    static constexpr uint32_t kHostPoolQueueSize = 8;
+    static constexpr uint32_t kHostRecycledQueueSize = 3;
+    static constexpr uint32_t kSlotCount = 1;
+    static constexpr const char *kSubsystemName = "WarmRecycledModule";
+
+    static DataHeader *header_from_shm(void *shared_mem_host) { return static_cast<DataHeader *>(shared_mem_host); }
+
+    static int batch_size(int /*kind*/) { return 1; }
+
+    static int recycled_warm_target(int /*kind*/, int shard) { return shard + 1; }
+
+    static std::optional<profiling_common::EntrySite<WarmRecycledModule>>
+    resolve_entry(void * /*shm_host*/, DataHeader *header, int /*q*/, const ReadyEntry &entry) {
+        return profiling_common::EntrySite<WarmRecycledModule>{
+            0,
+            &header->free_queue,
+            sizeof(uint64_t),
+            AlgorithmReadyBufferInfo{reinterpret_cast<void *>(entry.buffer_ptr), nullptr},
+        };
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void * /*shm_host*/, DataHeader *header, Cb &&cb) {
+        cb(0, &header->free_queue, sizeof(uint64_t));
+    }
+};
+
+struct WarmBatchModule {
+    using DataHeader = AlgorithmHeader;
+    using ReadyEntry = AlgorithmReadyEntry;
+    using ReadyBufferInfo = AlgorithmReadyBufferInfo;
+    using FreeQueue = AlgorithmFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr int kCollectorThreadCount = 1;
+    static constexpr uint32_t kReadyQueueSize = 1;
+    static constexpr uint32_t kHostPoolQueueSize = 16;
+    static constexpr uint32_t kHostRecycledQueueSize = 16;
+    static constexpr uint32_t kSlotCount = 4;
+    static constexpr const char *kSubsystemName = "WarmBatchModule";
+
+    static DataHeader *header_from_shm(void *shared_mem_host) { return static_cast<DataHeader *>(shared_mem_host); }
+
+    static int batch_size(int /*kind*/) { return 1; }
+
+    static int recycled_warm_target(int /*kind*/, int /*shard*/) { return 6; }
+
+    static std::optional<profiling_common::EntrySite<WarmBatchModule>>
+    resolve_entry(void * /*shm_host*/, DataHeader *header, int /*q*/, const ReadyEntry &entry) {
+        return profiling_common::EntrySite<WarmBatchModule>{
+            0,
+            &header->free_queue,
+            sizeof(uint64_t),
+            AlgorithmReadyBufferInfo{reinterpret_cast<void *>(entry.buffer_ptr), nullptr},
+        };
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void * /*shm_host*/, DataHeader *header, Cb &&cb) {
+        cb(0, &header->free_queue, sizeof(uint64_t));
+    }
 };
 
 void *ptr(uintptr_t value) { return reinterpret_cast<void *>(value); }
 
 }  // namespace
 
+TEST(SpscRingTest, ConcurrentProducerConsumerPreservesFifo) {
+    profiling_common::SpscRing<uint64_t, 1024> ring;
+    constexpr uint64_t kItems = 100000;
+    std::atomic<bool> producer_done{false};
+
+    std::thread producer([&]() {
+        for (uint64_t i = 0; i < kItems; i++) {
+            while (!ring.push(i)) {
+                std::this_thread::yield();
+            }
+        }
+        producer_done.store(true, std::memory_order_release);
+    });
+
+    uint64_t expected = 0;
+    while (expected < kItems) {
+        uint64_t value = 0;
+        if (ring.pop(value)) {
+            ASSERT_EQ(value, expected);
+            expected++;
+            continue;
+        }
+        ASSERT_FALSE(producer_done.load(std::memory_order_acquire) && ring.empty());
+        std::this_thread::yield();
+    }
+
+    producer.join();
+    EXPECT_TRUE(ring.empty());
+}
+
 TEST(BufferPoolManagerShardingTest, ReadyShardsAreIndependent) {
     using Manager = profiling_common::BufferPoolManager<TestModule>;
     static_assert(Manager::kCollectorShardCount == 4);
 
     Manager manager;
-    manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000), 0}, 0);
-    manager.push_to_ready(TestReadyBufferInfo{ptr(0x2000), 1}, 1);
-    manager.push_to_ready(TestReadyBufferInfo{ptr(0x5000), 5}, 5);  // normalizes to shard 1
+    ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000), 0}, 0));
+    ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x2000), 1}, 1));
+    ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x5000), 5}, 5));  // normalizes to shard 1
 
     TestReadyBufferInfo out;
     EXPECT_FALSE(manager.try_pop_ready(out, 2));
@@ -66,6 +250,40 @@ TEST(BufferPoolManagerShardingTest, ReadyShardsAreIndependent) {
     EXPECT_FALSE(manager.try_pop_ready(out, 1));
 }
 
+TEST(BufferPoolManagerShardingTest, ReadyShardReportsFullAndPreservesOrder) {
+    using Manager = profiling_common::BufferPoolManager<TestModule>;
+
+    Manager manager;
+    for (uintptr_t i = 0; i < Manager::kHostQueueCapacity; i++) {
+        ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000 + i), static_cast<uint32_t>(i)}, 0));
+    }
+    EXPECT_FALSE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x9999), 99}, 0));
+
+    TestReadyBufferInfo out;
+    for (uintptr_t i = 0; i < Manager::kHostQueueCapacity; i++) {
+        ASSERT_TRUE(manager.try_pop_ready(out, 0));
+        EXPECT_EQ(out.dev_buffer_ptr, ptr(0x1000 + i));
+        EXPECT_EQ(out.shard_marker, static_cast<uint32_t>(i));
+    }
+    EXPECT_FALSE(manager.try_pop_ready(out, 0));
+}
+
+TEST(BufferPoolManagerShardingTest, WaitPopReadyWakesOnProducer) {
+    using namespace std::chrono_literals;
+    profiling_common::BufferPoolManager<TestModule> manager;
+
+    std::thread producer([&]() {
+        std::this_thread::sleep_for(20ms);
+        EXPECT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x7000), 7}, 2));
+    });
+
+    TestReadyBufferInfo out;
+    ASSERT_TRUE(manager.wait_pop_ready(out, 500ms, 2));
+    EXPECT_EQ(out.dev_buffer_ptr, ptr(0x7000));
+    EXPECT_EQ(out.shard_marker, 7u);
+    producer.join();
+}
+
 TEST(BufferPoolManagerShardingTest, DoneShardsRecycleByKind) {
     profiling_common::BufferPoolManager<TestModule> manager;
 
@@ -76,6 +294,7 @@ TEST(BufferPoolManagerShardingTest, DoneShardsRecycleByKind) {
     EXPECT_EQ(manager.drain_done_into_recycled(), 3u);
     EXPECT_EQ(manager.recycled_count(0), 1u);
     EXPECT_EQ(manager.recycled_count(1), 2u);
+    EXPECT_EQ(manager.recycled_count(1, 1), 2u);
 
     EXPECT_EQ(manager.pop_recycled(0), ptr(0x1000));
 
@@ -85,11 +304,256 @@ TEST(BufferPoolManagerShardingTest, DoneShardsRecycleByKind) {
     EXPECT_EQ(kind_one, (std::set<void *>{ptr(0x2000), ptr(0x5000)}));
 }
 
+TEST(BufferPoolManagerShardingTest, DrainDoneCanTargetOneShard) {
+    profiling_common::BufferPoolManager<TestModule> manager;
+
+    ASSERT_TRUE(manager.notify_copy_done(ptr(0x1000), /*kind=*/0, /*shard_index=*/0));
+    ASSERT_TRUE(manager.notify_copy_done(ptr(0x2000), /*kind=*/0, /*shard_index=*/1));
+
+    EXPECT_EQ(manager.drain_done_into_recycled(/*shard_index=*/1), 1u);
+    EXPECT_EQ(manager.recycled_count(0, 0), 0u);
+    EXPECT_EQ(manager.recycled_count(0, 1), 1u);
+    EXPECT_EQ(manager.pop_recycled(0, 1), ptr(0x2000));
+
+    EXPECT_EQ(manager.drain_done_into_recycled(/*shard_index=*/0), 1u);
+    EXPECT_EQ(manager.pop_recycled(0, 0), ptr(0x1000));
+}
+
+TEST(BufferPoolManagerShardingTest, DoneShardCarriesKindAndDevicePointer) {
+    profiling_common::BufferPoolManager<TestModule> manager;
+
+    ASSERT_TRUE(manager.notify_copy_done(ptr(0x1000), /*kind=*/1, /*shard_index=*/2));
+
+    profiling_common::DoneInfo out{};
+    ASSERT_TRUE(manager.try_pop_done(out, /*shard_index=*/2));
+    EXPECT_EQ(out.dev_ptr, ptr(0x1000));
+    EXPECT_EQ(out.kind, 1);
+    EXPECT_FALSE(manager.try_pop_done(out, /*shard_index=*/2));
+}
+
+TEST(BufferPoolManagerShardingTest, StartupRecyclePopCanUseAnyShard) {
+    profiling_common::BufferPoolManager<TestModule> manager;
+
+    ASSERT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x1000), /*shard_index=*/2));
+    ASSERT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x2000), /*shard_index=*/3));
+
+    std::set<void *> popped;
+    popped.insert(manager.pop_recycled_for_startup(/*kind=*/0));
+    popped.insert(manager.pop_recycled_for_startup(/*kind=*/0));
+    EXPECT_EQ(popped, (std::set<void *>{ptr(0x1000), ptr(0x2000)}));
+    EXPECT_EQ(manager.pop_recycled_for_startup(/*kind=*/0), nullptr);
+}
+
+TEST(BufferPoolManagerShardingTest, PoolQueuesUseCapacityIndependentFromReadyQueue) {
+    using Manager = profiling_common::BufferPoolManager<SplitCapacityModule>;
+
+    Manager manager;
+    EXPECT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000), 0}, 0));
+    EXPECT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1001), 1}, 0));
+    EXPECT_FALSE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1002), 2}, 0));
+
+    for (uintptr_t i = 0; i < SplitCapacityModule::kHostPoolQueueSize; i++) {
+        EXPECT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x2000 + i), 0)) << i;
+    }
+    EXPECT_FALSE(manager.push_recycled(/*kind=*/0, ptr(0x2999), 0));
+
+    profiling_common::BufferPoolManager<SplitCapacityModule> done_manager;
+    for (uintptr_t i = 0; i < SplitCapacityModule::kHostPoolQueueSize; i++) {
+        EXPECT_TRUE(done_manager.notify_copy_done(ptr(0x3000 + i), /*kind=*/0, 0)) << i;
+    }
+    EXPECT_FALSE(done_manager.notify_copy_done(ptr(0x3999), /*kind=*/0, 0));
+}
+
+TEST(BufferPoolManagerShardingTest, DoneAndRecycledQueuesCanUseDifferentCapacities) {
+    using Manager = profiling_common::BufferPoolManager<SplitDoneRecycledCapacityModule>;
+
+    Manager manager;
+    for (uintptr_t i = 0; i < SplitDoneRecycledCapacityModule::kHostPoolQueueSize; i++) {
+        EXPECT_TRUE(manager.notify_copy_done(ptr(0x3000 + i), /*kind=*/0, 0)) << i;
+    }
+    EXPECT_FALSE(manager.notify_copy_done(ptr(0x3999), /*kind=*/0, 0));
+
+    for (uintptr_t i = 0; i < SplitDoneRecycledCapacityModule::kHostRecycledQueueSize; i++) {
+        EXPECT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x4000 + i), 0)) << i;
+    }
+    EXPECT_FALSE(manager.push_recycled(/*kind=*/0, ptr(0x4999), 0));
+}
+
+TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsAllocatesToRuntimeWatermarks) {
+    using Manager = profiling_common::BufferPoolManager<WarmRecycledModule>;
+
+    Manager manager;
+    AlgorithmHeader header{};
+    profiling_common::MemoryOps ops;
+    ops.alloc = [](size_t size) {
+        return std::malloc(size);
+    };
+    ops.reg = [](void *dev_ptr, size_t /*size*/, int /*device_id*/, void **host_ptr_out) {
+        *host_ptr_out = dev_ptr;
+        return 0;
+    };
+    ops.free_ = [](void *dev_ptr) {
+        std::free(dev_ptr);
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, &header, sizeof(header), 0);
+
+    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmRecycledModule>::replenish_recycled_pools(manager, &header), 3u);
+    EXPECT_EQ(manager.recycled_count(0, 0), 1u);
+    EXPECT_EQ(manager.recycled_count(0, 1), 2u);
+    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmRecycledModule>::replenish_recycled_pools(manager, &header), 0u);
+
+    manager.release_owned_buffers([](void *p) {
+        std::free(p);
+    });
+    manager.clear_mappings();
+}
+
+TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsUsesSlotSizedBatchForSmallGap) {
+    using Manager = profiling_common::BufferPoolManager<WarmBatchModule>;
+
+    Manager manager;
+    AlgorithmHeader header{};
+    int alloc_calls = 0;
+    profiling_common::MemoryOps ops;
+    ops.alloc = [&](size_t size) {
+        alloc_calls++;
+        return std::malloc(size);
+    };
+    ops.reg = [](void *dev_ptr, size_t /*size*/, int /*device_id*/, void **host_ptr_out) {
+        *host_ptr_out = dev_ptr;
+        return 0;
+    };
+    ops.free_ = [](void *dev_ptr) {
+        std::free(dev_ptr);
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, &header, sizeof(header), 0);
+
+    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmBatchModule>::replenish_recycled_pools(manager, &header), 6u);
+    EXPECT_EQ(manager.recycled_count(0, 0), 6u);
+    EXPECT_EQ(alloc_calls, 1);
+
+    EXPECT_NE(manager.pop_recycled(0, 0), nullptr);
+    EXPECT_NE(manager.pop_recycled(0, 0), nullptr);
+    EXPECT_EQ(manager.recycled_count(0, 0), 4u);
+
+    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmBatchModule>::replenish_recycled_pools(manager, &header), 4u);
+    EXPECT_EQ(manager.recycled_count(0, 0), 8u);
+    EXPECT_EQ(alloc_calls, 2);
+
+    manager.release_owned_buffers([](void *p) {
+        std::free(p);
+    });
+    manager.clear_mappings();
+}
+
+TEST(BufferPoolManagerShardingTest, ProcessEntryReadyFullDoesNotPublishDoneFromDrainThread) {
+    using Manager = profiling_common::BufferPoolManager<AlgorithmModule>;
+
+    Manager manager;
+    AlgorithmHeader header{};
+    void *dev_ptr = ptr(0x7000);
+    manager.register_mapping(dev_ptr, dev_ptr);
+
+    ASSERT_TRUE(manager.push_to_ready(AlgorithmReadyBufferInfo{ptr(0x1111), ptr(0x1111)}, 0));
+
+    profiling_common::ProfilerAlgorithms<AlgorithmModule>::process_entry(
+        manager, &header, 0, AlgorithmReadyEntry{reinterpret_cast<uint64_t>(dev_ptr)}
+    );
+
+    profiling_common::DoneInfo done{};
+    EXPECT_FALSE(manager.try_pop_done(done, 0));
+
+    AlgorithmReadyBufferInfo ready{};
+    ASSERT_TRUE(manager.try_pop_ready(ready, 0));
+    EXPECT_EQ(ready.dev_buffer_ptr, ptr(0x1111));
+    EXPECT_FALSE(manager.try_pop_ready(ready, 0));
+
+    std::vector<void *> released;
+    manager.release_owned_buffers([&](void *p) {
+        released.push_back(p);
+    });
+    EXPECT_EQ(released, (std::vector<void *>{dev_ptr}));
+}
+
+TEST(BufferPoolManagerShardingTest, BlockBatchCarvesRangeMappingsAndReleasesBaseOnce) {
+    using Manager = profiling_common::BufferPoolManager<TestModule>;
+
+    Manager manager;
+    profiling_common::MemoryOps ops;
+    ops.alloc = [](size_t size) {
+        return std::malloc(size);
+    };
+    ops.reg = [](void *dev_ptr, size_t /*size*/, int /*device_id*/, void **host_ptr_out) {
+        *host_ptr_out = dev_ptr;
+        return 0;
+    };
+    ops.free_ = [](void *dev_ptr) {
+        std::free(dev_ptr);
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, nullptr, 0, 0);
+
+    ASSERT_EQ(manager.allocate_recycled_batch(/*kind=*/0, /*buffer_size=*/32, /*count=*/3, /*shard_index=*/1), 3u);
+
+    std::vector<void *> buffers;
+    for (int i = 0; i < 3; i++) {
+        void *p = manager.pop_recycled(/*kind=*/0, /*shard_index=*/1);
+        ASSERT_NE(p, nullptr);
+        buffers.push_back(p);
+    }
+    EXPECT_EQ(manager.pop_recycled(/*kind=*/0, /*shard_index=*/1), nullptr);
+
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(buffers[1]) - reinterpret_cast<uintptr_t>(buffers[0]), 64u);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(buffers[2]) - reinterpret_cast<uintptr_t>(buffers[1]), 64u);
+    EXPECT_EQ(manager.resolve_host_ptr(buffers[0]), buffers[0]);
+
+    void *inner_dev = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(buffers[1]) + 7);
+    EXPECT_EQ(manager.resolve_host_ptr(inner_dev), inner_dev);
+
+    for (void *p : buffers) {
+        ASSERT_TRUE(manager.push_recycled(/*kind=*/0, p, /*shard_index=*/1));
+    }
+
+    std::vector<void *> released;
+    manager.release_owned_buffers([&](void *p) {
+        released.push_back(p);
+        std::free(p);
+    });
+    ASSERT_EQ(released.size(), 1u);
+    EXPECT_EQ(released[0], buffers[0]);
+    manager.clear_mappings();
+}
+
+TEST(BufferPoolManagerShardingTest, FreeBufferAllowsAllocationAddressReuse) {
+    using Manager = profiling_common::BufferPoolManager<TestModule>;
+
+    Manager manager;
+    std::vector<void *> released;
+    profiling_common::MemoryOps ops;
+    ops.free_ = [&](void *dev_ptr) {
+        released.push_back(dev_ptr);
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, nullptr, 0, 0);
+
+    void *dev_ptr = ptr(0x7000);
+    manager.register_mapping(dev_ptr, nullptr);
+    manager.free_buffer(dev_ptr);
+
+    manager.register_mapping(dev_ptr, nullptr);
+    manager.free_buffer(dev_ptr);
+
+    EXPECT_EQ(released, (std::vector<void *>{dev_ptr, dev_ptr}));
+}
+
 TEST(BufferPoolManagerShardingTest, ReleaseOwnedBuffersVisitsAllShards) {
     profiling_common::BufferPoolManager<TestModule> manager;
-    manager.push_recycled(/*kind=*/0, ptr(0x1000));
-    manager.push_to_ready(TestReadyBufferInfo{ptr(0x2000), 2}, /*shard_index=*/2);
-    manager.notify_copy_done(ptr(0x3000), /*kind=*/1, /*shard_index=*/3);
+    ASSERT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x1000)));
+    ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x2000), 2}, /*shard_index=*/2));
+    ASSERT_TRUE(manager.notify_copy_done(ptr(0x3000), /*kind=*/1, /*shard_index=*/3));
+    ASSERT_TRUE(manager.retire_unqueued_buffer(/*kind=*/1, ptr(0x4000), /*shard_index=*/2));
 
     std::vector<void *> released;
     manager.release_owned_buffers([&](void *p) {
@@ -97,7 +561,8 @@ TEST(BufferPoolManagerShardingTest, ReleaseOwnedBuffersVisitsAllShards) {
     });
 
     EXPECT_EQ(
-        std::set<void *>(released.begin(), released.end()), (std::set<void *>{ptr(0x1000), ptr(0x2000), ptr(0x3000)})
+        std::set<void *>(released.begin(), released.end()),
+        (std::set<void *>{ptr(0x1000), ptr(0x2000), ptr(0x3000), ptr(0x4000)})
     );
     EXPECT_TRUE(manager.recycled_empty());
 


### PR DESCRIPTION
## Summary
- Move the shared profiling buffer pool to per-lane SPSC ready, done, and recycled queues.
- Keep an independent replenish thread for done-to-recycled recycling while drain lanes refill free queues from shard-local recycled lanes.
- Preserve SPSC ownership on fallback paths: ready-full drain now retires undelivered buffers instead of writing done, and retired buffers use a mutex-protected exceptional holding pool.
- Apply the shared buffer-pool path across L2 Swimlane, PMU, DepGen, ScopeStats, and TensorDump, with updated C++ unit tests and docs.
- Leave the local L2 synthetic benchmark tooling out of this PR.

## Testing
- `CCACHE_DIR=/tmp/simpler-ccache cmake --build tests/ut/cpp/build --target test_buffer_pool_manager`
- `tests/ut/cpp/build/test_buffer_pool_manager` (12/12 passed)
- `CCACHE_DIR=/tmp/simpler-ccache cmake --build tests/ut/cpp/build`
- `ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure` (54/54 passed after rerun outside sandbox; sandboxed run blocked the socket test with `Operation not permitted`)
- `CCACHE_DIR=/tmp/simpler-ccache .venv/bin/python -m pip install --no-build-isolation -e .`
- `git diff --check`
- GitHub PR checks for `893b1f16`: all checks passed.

## Benchmark
- Local synthetic benchmark tooling remains outside this PR; all benchmarked trees used the same local synthetic producer tool.

### Baseline vs PR head before review fix
- `task-submit`: `task_20260707_203817_92120128835`, baseline and current run sequentially on the same NPU 2.
- Baseline: latest `upstream/main` at `3aa7f26d`.
- Current benchmarked tree: PR head `a712db9b`.
- Host read throughput over 5 runs:
  - mean: baseline `3.3754 GB/s`, current `3.8195 GB/s`, `+13.16%`
  - median: baseline `3.5904 GB/s`, current `3.8208 GB/s`, `+6.42%`

### Latest PR head retest
- `task-submit`: `task_20260707_231640_262842832235`, latest PR head `893b1f16` plus the same local synthetic WIP, on NPU 3.
- The local WIP run did not print the synthetic summary line, so host receive was derived from `l2_swimlane_records.json` as `records * 32 bytes / 5 ms`.
- Per-run host receive: `3.8208`, `3.8208`, `3.8208`, `1.9456`, `3.8016 GB/s` (run 4 was a retained low outlier).
- Summary vs latest baseline:
  - mean: baseline `3.3754 GB/s`, latest retest `3.4419 GB/s`, `+1.97%`
  - median: baseline `3.5904 GB/s`, latest retest `3.8208 GB/s`, `+6.42%`
  - stable 4-run mean, excluding the low outlier only as a steady-state reference: `3.8160 GB/s`, `+13.05%`

## Notes
- The latest review fix keeps done shards collector-produced only. Exceptional fallback buffers go to retired holding pools and are released at teardown.
- The latest retest indicates the review-fix changes did not introduce host-read throughput degradation.

close #1251 
