### PR TITLE
Fix: use TPUT in sim L3 worker examples

### DIFF
--- a/examples/workers/l3/allreduce_distributed/README.md
+++ b/examples/workers/l3/allreduce_distributed/README.md
@@ -90,7 +90,7 @@ allreduce_distributed/
 1. **Host tensors**: Each rank owns a private input/output tensor via `torch.share_memory_()`.
 2. **Communication domain**: `orch.allocate_domain()` creates an HCCL window for cross-rank communication.
 3. **Kernel dispatch**: `main.py` compiles the selected kernel based on `--mode` and submits it to each chip.
-4. **Barrier + remote read**: Kernels use PTO-ISA `TNOTIFY`/`TWAIT` for synchronization and `TLOAD` via `CommRemotePtr` for cross-rank reads.
+4. **Barrier + cross-rank data movement**: Kernels use PTO-ISA `TNOTIFY`/`TWAIT` for synchronization. Pull-style modes use `TLOAD` via `CommRemotePtr`; push-style modes use `TPUT` via `CommRemotePtr`.
 5. **Golden check**: Output verified against `sum_r(i + r*100)` for all ranks.
 
 ## When to Use Which Mode

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
@@ -22,8 +22,7 @@
  * unidirectional ring — but each round processes two subchunks (one per
  * ring direction), doubling data throughput per barrier.
  *
- * On sim (POSIX shared memory): raw float* arithmetic into shared memory.
- * On NPU hardware: TPUT<AtomicAdd/AtomicNone> for remote DMA writes.
+ * Remote writes use TPUT<AtomicAdd/AtomicNone> on both sim and NPU hardware.
  *
  * Scratch layout (per rank, in HCCL window):
  *   [0 .. P*subchunk)              ring0 chunks (clockwise ring)
@@ -106,11 +105,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     __gm__ float *ring1 = scratch + ring_stride;  // counter-clockwise ring — second half
     __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>(2 * ring_stride));
 
-#ifndef __CPU_SIM
     using TileSub = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
     TileSub pushTile(1, subchunk_elems);
     TASSIGN(pushTile, 0x10000);
-#endif
 
     using TileSubStage = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
     TileSubStage stageTile(1, subchunk_elems);
@@ -172,15 +169,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
             const int idx = (my_rank - step + nranks) % nranks;
             __gm__ float *src = ring0 + static_cast<size_t>(idx * subchunk_elems);
             __gm__ float *dst = CommRemotePtr(commCtx, src, right);
-#if defined(__CPU_SIM)
-            for (int i = 0; i < subchunk_elems; ++i) {
-                dst[i] += src[i];
-            }
-#else
             GT srcG(src, subShape, subStride);
             GT dstG(dst, subShape, subStride);
             pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
-#endif
         }
 
         // Ring1: push ring1[(r + step + P) % P] → left's ring1[same index].
@@ -188,15 +179,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
             const int idx = (my_rank + step + nranks) % nranks;
             __gm__ float *src = ring1 + static_cast<size_t>(idx * subchunk_elems);
             __gm__ float *dst = CommRemotePtr(commCtx, src, left);
-#if defined(__CPU_SIM)
-            for (int i = 0; i < subchunk_elems; ++i) {
-                dst[i] += src[i];
-            }
-#else
             GT srcG(src, subShape, subStride);
             GT dstG(dst, subShape, subStride);
             pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
-#endif
         }
 
         pipe_barrier(PIPE_ALL);
@@ -217,15 +202,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
             const int idx = (my_rank - step + 1 + nranks) % nranks;
             __gm__ float *src = ring0 + static_cast<size_t>(idx * subchunk_elems);
             __gm__ float *dst = CommRemotePtr(commCtx, src, right);
-#if defined(__CPU_SIM)
-            for (int i = 0; i < subchunk_elems; ++i) {
-                dst[i] = src[i];
-            }
-#else
             GT srcG(src, subShape, subStride);
             GT dstG(dst, subShape, subStride);
             pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
-#endif
         }
 
         // Ring1 AG: send_idx = (r + step - 1 + P) % P
@@ -234,15 +213,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
             const int idx = (my_rank + step - 1 + nranks) % nranks;
             __gm__ float *src = ring1 + static_cast<size_t>(idx * subchunk_elems);
             __gm__ float *dst = CommRemotePtr(commCtx, src, left);
-#if defined(__CPU_SIM)
-            for (int i = 0; i < subchunk_elems; ++i) {
-                dst[i] = src[i];
-            }
-#else
             GT srcG(src, subShape, subStride);
             GT dstG(dst, subShape, subStride);
             pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
-#endif
         }
 
         pipe_barrier(PIPE_ALL);

--- a/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -108,11 +108,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
     StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
 
-#ifndef __CPU_SIM
     using TilePush = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
     TilePush pushTile(1, chunk_elems);
     TASSIGN(pushTile, 0x10000);
-#endif
 
     using TileStage = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
     TileStage stageTile(1, chunk_elems);
@@ -216,46 +214,22 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
         // Right-bound push.
         {
-#ifdef __CPU_SIM
-            __gm__ float *src = exchange_right;
-            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
-            if (fwd) {
-                for (int i = 0; i < chunk_elems; ++i)
-                    dst[i] = src[i];
-            } else {
-                for (int i = 0; i < chunk_elems; ++i)
-                    dst[i] += src[i];
-            }
-#else
             __gm__ float *src = exchange_right;
             __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
             GT srcG(src, chunkShape, chunkStride);
             GT dstG(dst, chunkShape, chunkStride);
             if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
             else pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
-#endif
         }
 
         // Left-bound push.
         {
-#ifdef __CPU_SIM
-            __gm__ float *src = exchange_left;
-            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
-            if (fwd) {
-                for (int i = 0; i < chunk_elems; ++i)
-                    dst[i] = src[i];
-            } else {
-                for (int i = 0; i < chunk_elems; ++i)
-                    dst[i] += src[i];
-            }
-#else
             __gm__ float *src = exchange_left;
             __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
             GT srcG(src, chunkShape, chunkStride);
             GT dstG(dst, chunkShape, chunkStride);
             if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
             else pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
-#endif
         }
 
         pipe_barrier(PIPE_ALL);

--- a/examples/workers/l3/ep_dispatch_combine/kernels/aiv/combine.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/aiv/combine.cpp
@@ -162,15 +162,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                 __gm__ bfloat16_t *dst_row_local = routed_y_buf_local + r * D;
                 __gm__ bfloat16_t *dst_row_remote = CommRemotePtr(comm_ctx, dst_row_local, dst);
 
-#if defined(__CPU_SIM)
-                for (int i = 0; i < D; ++i) {
-                    dst_row_remote[i] = src_row[i];
-                }
-#else
                 RowBfG src_g(src_row);
                 RowBfG dst_g(dst_row_remote);
                 pto::comm::TPUT(dst_g, src_g, push_tile);
-#endif
             }
         }
     }

--- a/examples/workers/l3/ep_dispatch_combine/kernels/aiv/dispatch.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/aiv/dispatch.cpp
@@ -373,45 +373,27 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         __gm__ bfloat16_t *x_dst_local = recv_x_local + row * D;
         __gm__ bfloat16_t *x_dst_remote = CommRemotePtr(comm_ctx, x_dst_local, dst);
 
-#if defined(__CPU_SIM)
-        for (int i = 0; i < D; ++i) {
-            x_dst_remote[i] = x_src[i];
-        }
-#else
         XGlobal x_src_g(x_src);
         XGlobal x_dst_g(x_dst_remote);
         pto::comm::TPUT(x_dst_g, x_src_g, x_tile);
-#endif
 
         // Channel 2: weight (FP32, 1xW_PAD); host pre-packed [w, 0, …, 0]
         __gm__ float *w_src = w_padded + r * W_PAD;
         __gm__ float *w_dst_local = recv_w_local + row * W_PAD;
         __gm__ float *w_dst_remote = CommRemotePtr(comm_ctx, w_dst_local, dst);
 
-#if defined(__CPU_SIM)
-        for (int i = 0; i < W_PAD; ++i) {
-            w_dst_remote[i] = w_src[i];
-        }
-#else
         WGlobal w_src_g(w_src);
         WGlobal w_dst_g(w_dst_remote);
         pto::comm::TPUT(w_dst_g, w_src_g, w_tile);
-#endif
 
         // Channel 3: idx (INT32, 1xIDX_PAD); host pre-packed [r, 0, …, 0]
         __gm__ int32_t *idx_src = idx_padded + r * IDX_PAD;
         __gm__ int32_t *idx_dst_local = recv_idx_local + row * IDX_PAD;
         __gm__ int32_t *idx_dst_remote = CommRemotePtr(comm_ctx, idx_dst_local, dst);
 
-#if defined(__CPU_SIM)
-        for (int i = 0; i < IDX_PAD; ++i) {
-            idx_dst_remote[i] = idx_src[i];
-        }
-#else
         IGlobal idx_src_g(idx_src);
         IGlobal idx_dst_g(idx_dst_remote);
         pto::comm::TPUT(idx_dst_g, idx_src_g, idx_tile);
-#endif
     }
     pipe_barrier(PIPE_ALL);
 

--- a/examples/workers/l3/ffn_tp_parallel/kernels/aiv/kernel_allreduce_sum.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/aiv/kernel_allreduce_sum.cpp
@@ -107,14 +107,8 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         }
         __gm__ float *remote_mailbox_base = CommRemotePtr(comm_ctx, mailbox_ptr, peer);
         __gm__ float *remote_slot_ptr = remote_mailbox_base + my_rank * kElemsPerPartial;
-#if defined(__CPU_SIM)
-        for (int i = 0; i < kElemsPerPartial; ++i) {
-            remote_slot_ptr[i] = partial_local_ptr[i];
-        }
-#else
         MatrixGlobal remote_slot(remote_slot_ptr);
         pto::comm::TPUT(remote_slot, partial_local_global, staging_tile);
-#endif
     }
     pipe_barrier(PIPE_ALL);
 


### PR DESCRIPTION
- Remove stale CPU-sim scalar copy fallbacks around TPUT calls now that the pinned PTO-ISA CPU backend has correct destination-first TPUT semantics.
- Keep the ibing snapshot CPU-sim branch because it models a separate visibility constraint, not the old TPUT direction workaround.