### PR TITLE
fix(a2a3/tensormap): flag alloc-tensor creators so they don't block early-dispatch

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -1073,6 +1073,15 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const L0TaskArgs &args) {
         // required so scope_end can release the producer-side reference and
         // drive the slot to CONSUMED, but worker dispatch fields are never
         // observed for hidden alloc tasks.
+        //
+        // Flag the creator so it does NOT suppress its consumers' early-dispatch.
+        // Under the direct-only model an unflagged producer disqualifies its
+        // consumer, and a pre-completed producer only seeds dispatch_fanin when
+        // flagged. A buffer allocation is pure memory whose output is ready at
+        // creation — it should always be transparent, never a barrier. Unlike a
+        // codegen task there is no Arg-driven hint to honor here, so mark it
+        // unconditionally.
+        prepared.slot_state->allow_early_resolve = true;
         prepared.slot_state->task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
     }
     orch->inline_completed_tasks++;

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -411,6 +411,38 @@ TEST_F(WiringTest, UnflaggedProducerDoesNotPropagate) {
     EXPECT_EQ(prod_payload.dispatch_propagated.load(), 0);  // gate returned before once-guard
 }
 
+TEST_F(WiringTest, FlaggedPrecompletedCreatorTransparentToEarlyDispatch) {
+    // Models the alloc-creator case: a consumer depends on a pre-completed,
+    // FLAGGED buffer creator (alloc_tensors flags its inline-completed task) plus
+    // a flagged, still-pending compute producer. The creator must be transparent
+    // (seeded), not a disqualifier: once the compute producer dispatches, the
+    // consumer reaches fanin_actual_count and becomes an early-dispatch candidate.
+    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) PTO2TaskSlotState creator, compute;
+    alignas(64) PTO2TaskPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    PTO2TaskDescriptor desc{};
+
+    init_slot(creator, PTO2_TASK_COMPLETED, 1, 1);
+    creator.allow_early_resolve = true;  // alloc creator: flagged -> transparent
+    init_slot(compute, PTO2_TASK_PENDING, 1, 1);
+    compute.allow_early_resolve = true;  // flagged compute producer
+
+    init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
+    payload.fanin_actual_count = 2;
+    payload.fanin_inline_slot_states[0] = &creator;
+    payload.fanin_inline_slot_states[1] = &compute;
+    task_slot.payload = &payload;
+    task_slot.task = &desc;
+
+    auto &rss = sched.ring_sched_states[0];
+    sched.wire_task(rss, &task_slot, 2);
+    EXPECT_EQ(payload.dispatch_fanin.load(), 1);  // creator seeded (transparent), not disqualified
+
+    sched.propagate_dispatch_fanin(compute);                               // compute dispatches -> bumps to 2
+    EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);  // candidate
+}
+
 // =============================================================================
 // on_task_complete: notifies consumers via fanout chain
 // =============================================================================


### PR DESCRIPTION
Follow-up to #1285 (direct-only early-dispatch).

## Problem

Under the direct-only model, an **unflagged producer disqualifies its consumer**
from early-dispatch, and a **pre-completed producer only seeds `dispatch_fanin`
when flagged**.

`alloc_tensors` builds a hidden task that **completes INLINE at submit**
(`pto_orchestrator.cpp`), so it is a pre-completed producer — and it carried no
`allow_early_resolve` flag (defaulted `false`). Every consumer that reads an
alloc'd buffer therefore had an unflagged pre-completed producer, which
**disqualified it from early-dispatch entirely**. Because alloc'd buffers are
pervasive inputs, this silently defeats early-dispatch for most real graphs.

A buffer allocation is pure memory whose output is ready at creation — it must
be **transparent**, never a barrier.

## Fix

Flag the creator unconditionally (`allow_early_resolve = true`) on the
inline-complete path. Unlike a codegen task there is no `Arg`-driven hint to
honor: an alloc creator should never suppress its consumers' early-dispatch.

This keeps the **"unflagged = suppress"** invariant clean and **deterministic**
— a consumer early-dispatches iff every producer is flagged, independent of
which producers happened to race to completion before wiring. Intentional
barriers still use a **dummy** task, which is *scheduled* (not inline-completed)
and can be left unflagged to suppress.

## Testing

- `WiringTest.FlaggedPrecompletedCreatorTransparentToEarlyDispatch`: a flagged
  pre-completed creator + a flagged pending compute producer — the creator is
  seeded (transparent) and the consumer reaches the candidate once the compute
  producer dispatches. cpput `WiringTest` **19/19** pass.
- a2a3 `tensormap_and_ringbuffer` onboard smoke passes; runtime compiles clean.