### PR TITLE
Fix: retain callable chip buffers by registration

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -194,9 +194,9 @@ private:
     // binaries_loaded_) is inherited from `DeviceRunnerBase`.
 
     // Group D state (`chip_callable_buffers_`, `callables_`,
-    // `orch_so_dedup_`, `aicpu_seen_callable_ids_`, `aicpu_dlopen_total_`,
+    // `aicpu_seen_callable_ids_`, `aicpu_dlopen_total_`,
     // `host_dlopen_total_`) and inner struct types
-    // (`ChipCallableBuffer`, `CallableState`, `OrchSoBuffer`) are
+    // (`ChipCallableBuffer`, `CallableState`) are
     // inherited from `DeviceRunnerBase`.
 
     // ACL lifecycle (process-wide). aclInit must run exactly once; ensure_acl_ready

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -591,7 +591,9 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in register_callable_impl", callable->child_count());
-    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
+    if (upload_and_collect_child_addrs(
+            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash
+        ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -391,7 +391,9 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in register_callable_impl", callable->child_count());
-    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
+    if (upload_and_collect_child_addrs(
+            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash
+        ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
     }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -177,9 +177,9 @@ private:
     // binaries_loaded_) is inherited from `DeviceRunnerBase`.
 
     // Group D state (`chip_callable_buffers_`, `callables_`,
-    // `orch_so_dedup_`, `aicpu_seen_callable_ids_`, `aicpu_dlopen_total_`,
+    // `aicpu_seen_callable_ids_`, `aicpu_dlopen_total_`,
     // `host_dlopen_total_`) and inner struct types
-    // (`ChipCallableBuffer`, `CallableState`, `OrchSoBuffer`) are
+    // (`ChipCallableBuffer`, `CallableState`) are
     // inherited from `DeviceRunnerBase`.
 
     // Shared collectors (`l2_swimlane_collector_`, `dump_collector_`,

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -317,7 +317,9 @@ int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(c
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in register_callable_impl", callable->child_count());
-    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
+    if (upload_and_collect_child_addrs(
+            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash
+        ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -391,7 +391,9 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in register_callable_impl", callable->child_count());
-    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
+    if (upload_and_collect_child_addrs(
+            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash
+        ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
     }

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -421,6 +421,11 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         if (rc != 0) return rc;
 
         CallableArtifacts artifacts;
+        auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
+            if (artifacts.chip_buffer_hash != 0) {
+                runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
+            }
+        });
         rc = register_callable_impl(
             reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
         );
@@ -448,17 +453,20 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         bool needs_aicpu_register = false;
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->record_host_orch_callable(
-                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
-                std::move(artifacts.signature)
+                callable_id, artifacts.chip_buffer_hash, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr,
+                std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc != 0) return rc;
             host_dlopen_guard.dismiss();
+            chip_buffer_guard.dismiss();
         } else {
             rc = runner->record_device_orch_callable(
-                callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-                artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
+                callable_id, artifacts.chip_buffer_hash, artifacts.chip_buffer_dev, artifacts.orch_so_data,
+                artifacts.orch_so_size, artifacts.func_name.c_str(), artifacts.config_name.c_str(),
+                std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc != 0) return rc;
+            chip_buffer_guard.dismiss();
             needs_aicpu_register = true;
         }
         if (needs_aicpu_register) {

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -625,7 +626,7 @@ void DeviceRunnerBase::print_handshake_results() {
 // =============================================================================
 
 uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *callable) {
-    if (callable == nullptr || callable->child_count() == 0) {
+    if (callable == nullptr) {
         return 0;
     }
     if (stream_aicpu_ == nullptr) {
@@ -638,9 +639,10 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
     // Content-hash dedup: identical bytes → return cached chip_dev.
     auto it = chip_callable_buffers_.find(layout.content_hash);
     if (it != chip_callable_buffers_.end()) {
+        it->second.refcount++;
         LOG_DEBUG(
-            "Chip callable dedup hit: chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev, it->second.total_size,
-            layout.content_hash
+            "Chip callable dedup hit: chip_dev=0x%lx, size=%zu, hash=0x%lx, refcount=%d", it->second.chip_dev,
+            it->second.total_size, layout.content_hash, it->second.refcount
         );
         return it->second.chip_dev;
     }
@@ -668,12 +670,32 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
         return 0;
     }
 
-    chip_callable_buffers_.emplace(layout.content_hash, ChipCallableBuffer{chip_dev, layout.total_size});
+    chip_callable_buffers_.emplace(layout.content_hash, ChipCallableBuffer{chip_dev, layout.total_size, 1});
     LOG_DEBUG(
         "Uploaded chip callable: chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, layout.total_size,
         callable->child_count(), layout.content_hash
     );
     return chip_dev;
+}
+
+int DeviceRunnerBase::release_chip_callable_buffer(uint64_t hash) {
+    if (hash == 0) {
+        return 0;
+    }
+    auto it = chip_callable_buffers_.find(hash);
+    if (it == chip_callable_buffers_.end()) {
+        LOG_WARN("release_chip_callable_buffer: hash=0x%lx not found", hash);
+        return 0;
+    }
+    if (--it->second.refcount <= 0) {
+        mem_alloc_.free(reinterpret_cast<void *>(it->second.chip_dev));
+        LOG_DEBUG(
+            "Freed chip callable buffer: chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev,
+            it->second.total_size, hash
+        );
+        chip_callable_buffers_.erase(it);
+    }
+    return 0;
 }
 
 int DeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid) {
@@ -776,8 +798,9 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
 }
 
 int DeviceRunnerBase::record_device_orch_callable(
-    int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name, const char *config_name,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+    int32_t callable_id, uint64_t chip_buffer_hash, uint64_t chip_dev, const void *orch_so_data, size_t orch_so_size,
+    const char *func_name, const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs,
+    std::vector<ArgDirection> signature
 ) {
     // The AICPU executor reserves `orch_so_table_[MAX_REGISTERED_CALLABLE_IDS]`
     // (declared in src/common/task_interface/callable_protocol.h) and indexes
@@ -793,6 +816,10 @@ int DeviceRunnerBase::record_device_orch_callable(
         LOG_ERROR("record_device_orch_callable: empty orch SO for callable_id=%d", callable_id);
         return -1;
     }
+    if (chip_buffer_hash == 0 || chip_dev == 0) {
+        LOG_ERROR("record_device_orch_callable: missing chip buffer for callable_id=%d", callable_id);
+        return -1;
+    }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_device_orch_callable: callable_id=%d already registered", callable_id);
         return -1;
@@ -800,52 +827,25 @@ int DeviceRunnerBase::record_device_orch_callable(
 
     const uint64_t hash = simpler::common::utils::elf_build_id_64(orch_so_data, orch_so_size);
 
-    // Hash dedup: share device buffer across callable_ids that carry the same
-    // SO bytes. Refcount drops in unregister_callable; we only free when the
-    // count hits zero.
-    auto buf_it = orch_so_dedup_.find(hash);
-    uint64_t dev_addr = 0;
-    if (buf_it == orch_so_dedup_.end()) {
-        void *buf = mem_alloc_.alloc(orch_so_size);
-        if (buf == nullptr) {
-            LOG_ERROR("record_device_orch_callable: alloc %zu bytes failed", orch_so_size);
-            return -1;
-        }
-        int rc = rtMemcpy(buf, orch_so_size, orch_so_data, orch_so_size, RT_MEMCPY_HOST_TO_DEVICE);
-        if (rc != 0) {
-            LOG_ERROR("record_device_orch_callable: rtMemcpy failed: %d", rc);
-            mem_alloc_.free(buf);
-            return rc;
-        }
-        OrchSoBuffer entry;
-        entry.dev_addr = buf;
-        entry.capacity = orch_so_size;
-        entry.refcount = 1;
-        orch_so_dedup_.emplace(hash, entry);
-        dev_addr = reinterpret_cast<uint64_t>(buf);
-        LOG_INFO_V0("record_device_orch_callable: hash=0x%lx new buffer %zu bytes", hash, orch_so_size);
-    } else {
-        buf_it->second.refcount++;
-        dev_addr = reinterpret_cast<uint64_t>(buf_it->second.dev_addr);
-        LOG_INFO_V0(
-            "record_device_orch_callable: hash=0x%lx shared buffer (refcount=%d)", hash, buf_it->second.refcount
-        );
-    }
-
     CallableState state;
     state.hash = hash;
-    state.dev_orch_so_addr = dev_addr;
+    state.chip_buffer_hash = chip_buffer_hash;
+    state.dev_orch_so_addr = chip_dev + offsetof(ChipCallable, storage_);
     state.dev_orch_so_size = orch_so_size;
     state.func_name = (func_name != nullptr) ? func_name : "";
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
     state.signature = std::move(signature);
     callables_.emplace(callable_id, std::move(state));
+    LOG_INFO_V0(
+        "record_device_orch_callable: cid=%d orch_hash=0x%lx chip_hash=0x%lx %zu bytes", callable_id, hash,
+        chip_buffer_hash, orch_so_size
+    );
     return 0;
 }
 
 int DeviceRunnerBase::record_host_orch_callable(
-    int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
+    int32_t callable_id, uint64_t chip_buffer_hash, void *host_dlopen_handle, void *host_orch_func_ptr,
     std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
@@ -858,12 +858,17 @@ int DeviceRunnerBase::record_host_orch_callable(
         LOG_ERROR("record_host_orch_callable: null handle/fn for callable_id=%d", callable_id);
         return -1;
     }
+    if (chip_buffer_hash == 0) {
+        LOG_ERROR("record_host_orch_callable: missing chip buffer for callable_id=%d", callable_id);
+        return -1;
+    }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_host_orch_callable: callable_id=%d already registered", callable_id);
         return -1;
     }
 
     CallableState state;
+    state.chip_buffer_hash = chip_buffer_hash;
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
@@ -882,19 +887,12 @@ int DeviceRunnerBase::unregister_callable(int32_t callable_id) {
     CallableState state = std::move(it->second);
     callables_.erase(it);
     aicpu_seen_callable_ids_.erase(callable_id);
+    release_chip_callable_buffer(state.chip_buffer_hash);
 
     if (state.host_dlopen_handle != nullptr) {
-        // hbg path: no orch SO refcount, just dlclose the host handle.
+        // hbg path: no device-side orch SO handle, just dlclose the host handle.
         dlclose(state.host_dlopen_handle);
         return 0;
-    }
-
-    auto buf_it = orch_so_dedup_.find(state.hash);
-    if (buf_it != orch_so_dedup_.end()) {
-        if (--buf_it->second.refcount <= 0) {
-            mem_alloc_.free(buf_it->second.dev_addr);
-            orch_so_dedup_.erase(buf_it);
-        }
     }
     return 0;
 }
@@ -929,9 +927,8 @@ int DeviceRunnerBase::bind_callable_to_runtime(
     const auto &state = it->second;
 
     // Replay each prepared kernel address into runtime.func_id_to_addr_.
-    // The kernel binaries are owned by the shared DeviceRunner pool and
-    // survive across runs — freed only by `finalize()`, never by
-    // validate_runtime_impl or `unregister_callable`.
+    // The kernel binaries live in the retained ChipCallable buffer for this
+    // callable_id and stay valid until `unregister_callable` or `finalize`.
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);
@@ -1050,8 +1047,7 @@ int DeviceRunnerBase::finalize_common() {
     // re-launches simpler_aicpu_init after the next ensure_binaries_loaded().
     aicpu_init_launched_ = false;
 
-    // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
-    // Pool semantics mirror per-fid binaries: never freed until finalize.
+    // Release any chip callable buffers callers forgot to unregister.
     for (auto &kv : chip_callable_buffers_) {
         mem_alloc_.free(reinterpret_cast<void *>(kv.second.chip_dev));
         LOG_DEBUG(
@@ -1061,15 +1057,6 @@ int DeviceRunnerBase::finalize_common() {
     }
     chip_callable_buffers_.clear();
 
-    // Release any registered-callable orch SO buffers that callers forgot to
-    // unregister. Refcounts no longer matter at this point — the device is
-    // about to be reset.
-    for (auto &kv : orch_so_dedup_) {
-        if (kv.second.dev_addr != nullptr) {
-            mem_alloc_.free(kv.second.dev_addr);
-        }
-    }
-    orch_so_dedup_.clear();
     // hbg path: dlclose any host orch handles callers forgot to unregister.
     // finalize() is the last chance; Worker.close() does not auto-unregister
     // each callable_id, so without this loop the host process leaks one

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -264,9 +264,8 @@ public:
      *
      * Pool-managed: identical buffer bytes (FNV-1a 64-bit content hash)
      * hit the dedup cache and return the cached chip_dev without
-     * reallocating. All chip buffers are bulk-freed by the subclass's
-     * `finalize()` — there is no explicit free API, mirroring the
-     * per-fid binary pool semantics.
+     * reallocating. Each successful upload retains one reference; ownership is
+     * transferred into a CallableState or released on registration failure.
      *
      * Callers compute child addresses as
      *     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
@@ -275,20 +274,20 @@ public:
      * before each run.
      *
      * @param callable  Host-side ChipCallable pointer.
-     * @return Device GM address of the ChipCallable header, or 0 on
-     *         failure (also returns 0 when callable->child_count() == 0).
+     * @return Device GM address of the ChipCallable header, or 0 on failure.
      */
     uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
+    int release_chip_callable_buffer(uint64_t hash);
 
     /**
-     * Stage a per-callable_id orchestration SO into device memory and
+     * Stage a per-callable_id orchestration SO from the retained ChipCallable and
      * remember the supporting metadata (entry/config symbol names,
-     * kernel func_id ↔ dev_addr table). Identical SO bytes across two
-     * callable_ids share one device buffer (refcounted by hash) so the
-     * worst case for an N-cid pool is N distinct device buffers, not
-     * N copies of the same SO.
+     * kernel func_id ↔ dev_addr table). The orchestration SO is the leading
+     * slice of ChipCallable::storage_ inside the retained chip buffer.
      *
      * @param callable_id   Caller-stable id, must be in [0, MAX_REGISTERED_CALLABLE_IDS).
+     * @param chip_buffer_hash  FNV-1a hash of the retained ChipCallable buffer.
+     * @param chip_dev      Device GM address of the retained ChipCallable header.
      * @param orch_so_data  Host pointer to orchestration SO bytes (owned by caller).
      * @param orch_so_size  Size of orchestration SO in bytes.
      * @param func_name     Entry symbol name (copied).
@@ -300,8 +299,9 @@ public:
      * @return 0 on success, negative on failure.
      */
     int record_device_orch_callable(
-        int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
-        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+        int32_t callable_id, uint64_t chip_buffer_hash, uint64_t chip_dev, const void *orch_so_data,
+        size_t orch_so_size, const char *func_name, const char *config_name,
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
@@ -315,16 +315,14 @@ public:
      * dlclose'd by `unregister_callable`. Increments `host_dlopen_total_`.
      */
     int record_host_orch_callable(
-        int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
+        int32_t callable_id, uint64_t chip_buffer_hash, void *host_dlopen_handle, void *host_orch_func_ptr,
         std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
-     * Drop the registered state for `callable_id`. trb path: decrement
-     * the orch SO buffer's hash-keyed refcount and free when it hits
-     * zero. hbg path: dlclose the host dlopen handle. Kernel binaries
-     * are shared across callables and only released by the subclass's
-     * `finalize()`.
+     * Drop the registered state for `callable_id`. Decrements the retained
+     * chip buffer's hash-keyed refcount and frees when it hits zero. hbg path
+     * also dlcloses the host dlopen handle.
      *
      * @return 0 on success or if the id was not registered.
      */
@@ -714,7 +712,6 @@ protected:
      *   - rtStreamDestroy for both persistent streams
      *   - aicore_bin_handle_ + binaries_loaded_ reset
      *   - chip_callable_buffers_ free + clear
-     *   - orch_so_dedup_ free + clear
      *   - callables_ dlclose-on-hbg + clear + aicpu counter reset
      *   - 3 arenas release + cached size reset
      *   - device_wall_dev_ptr_ free (before mem_alloc_.finalize)
@@ -749,26 +746,27 @@ protected:
     // the ChipCallable bytes. Each entry owns one device GM allocation
     // holding the entire ChipCallable buffer (header + storage_, with
     // each child's resolved_addr_ fixed up to its post-H2D device
-    // address). Pool-managed: identical buffer bytes share one entry
-    // across cids; the map is bulk-freed by the subclass's `finalize()`.
+    // address). Identical buffer bytes share one entry across cids; refcount
+    // drops on unregister and finalize bulk-frees any leftovers.
     struct ChipCallableBuffer {
         uint64_t chip_dev{0};  // device GM address of the ChipCallable header
         size_t total_size{0};  // byte size of the device allocation
+        int refcount{0};
     };
     std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
     // Per-callable_id registered state.
     //
-    // `callables_` maps the caller-stable callable_id to the orch SO
-    // slice + symbol names needed to launch it. `orch_so_dedup_` shares
-    // device buffers across callable_ids whose orch SO bytes have the
-    // same ELF Build-ID hash (refcounted; freed when the count hits
-    // zero). `aicpu_seen_callable_ids_` tracks which ids have completed a
-    // successful AICPU SO load so `prepare_orch_so` can advertise either a
-    // cache hit or a first-load fallback without committing early.
+    // `callables_` maps the caller-stable callable_id to the chip buffer
+    // lease, orch SO slice + symbol names needed to launch it.
+    // `aicpu_seen_callable_ids_` tracks which ids have completed a successful
+    // AICPU SO load for the monotonic dlopen counter.
     struct CallableState {
         // trb path (AICPU dlopens orch SO from device buffer)
+        // Orchestration ELF Build-ID returned by callable_hash(); distinct from
+        // chip_buffer_hash, which keys the retained buffer.
         uint64_t hash{0};
+        uint64_t chip_buffer_hash{0};
         uint64_t dev_orch_so_addr{0};
         size_t dev_orch_so_size{0};
         std::string func_name;
@@ -780,13 +778,7 @@ protected:
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};
     };
-    struct OrchSoBuffer {
-        void *dev_addr{nullptr};
-        size_t capacity{0};
-        int refcount{0};
-    };
     std::unordered_map<int32_t, CallableState> callables_;
-    std::unordered_map<uint64_t, OrchSoBuffer> orch_so_dedup_;
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;
     // Monotonic count of successful AICPU dlopens (incremented after prewarm
     // or first-run fallback succeeds; never decremented). Diverges from

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -384,6 +384,11 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
 
     try {
         CallableArtifacts artifacts;
+        auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
+            if (artifacts.chip_buffer_hash != 0) {
+                runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
+            }
+        });
         int rc = register_callable_impl(
             reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
         );
@@ -406,18 +411,21 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         bool needs_aicpu_register = false;
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->record_host_orch_callable(
-                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
-                std::move(artifacts.signature)
+                callable_id, artifacts.chip_buffer_hash, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr,
+                std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc == 0) {
                 host_dlopen_guard.dismiss();
+                chip_buffer_guard.dismiss();
             }
         } else {
             rc = runner->record_device_orch_callable(
-                callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-                artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
+                callable_id, artifacts.chip_buffer_hash, artifacts.chip_buffer_dev, artifacts.orch_so_data,
+                artifacts.orch_so_size, artifacts.func_name.c_str(), artifacts.config_name.c_str(),
+                std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc == 0) {
+                chip_buffer_guard.dismiss();
                 needs_aicpu_register = true;
             }
         }

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <stdlib.h>
 
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -414,8 +415,9 @@ int SimDeviceRunnerBase::launch_device_register(int32_t callable_id) {
 }
 
 int SimDeviceRunnerBase::record_device_orch_callable(
-    int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name, const char *config_name,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+    int32_t callable_id, uint64_t chip_buffer_hash, uint64_t chip_dev, const void *orch_so_data, size_t orch_so_size,
+    const char *func_name, const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs,
+    std::vector<ArgDirection> signature
 ) {
     // The AICPU executor reserves `orch_so_table_[MAX_REGISTERED_CALLABLE_IDS]`
     // (declared in src/common/task_interface/callable_protocol.h) and indexes
@@ -431,6 +433,10 @@ int SimDeviceRunnerBase::record_device_orch_callable(
         LOG_ERROR("record_device_orch_callable: empty orch SO for callable_id=%d", callable_id);
         return -1;
     }
+    if (chip_buffer_hash == 0 || chip_dev == 0) {
+        LOG_ERROR("record_device_orch_callable: missing chip buffer for callable_id=%d", callable_id);
+        return -1;
+    }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_device_orch_callable: callable_id=%d already registered", callable_id);
         return -1;
@@ -438,46 +444,25 @@ int SimDeviceRunnerBase::record_device_orch_callable(
 
     const uint64_t hash = simpler::common::utils::elf_build_id_64(orch_so_data, orch_so_size);
 
-    auto buf_it = orch_so_dedup_.find(hash);
-    uint64_t dev_addr = 0;
-    if (buf_it == orch_so_dedup_.end()) {
-        void *buf = mem_alloc_.alloc(orch_so_size);
-        if (buf == nullptr) {
-            LOG_ERROR("record_device_orch_callable: alloc %zu bytes failed", orch_so_size);
-            return -1;
-        }
-        // Sim shares an address space with the simulated AICPU thread, so a
-        // plain memcpy is the moral equivalent of rtMemcpy on hardware.
-        std::memcpy(buf, orch_so_data, orch_so_size);
-        OrchSoBuffer entry;
-        entry.dev_addr = buf;
-        entry.capacity = orch_so_size;
-        entry.refcount = 1;
-        orch_so_dedup_.emplace(hash, entry);
-        dev_addr = reinterpret_cast<uint64_t>(buf);
-        LOG_INFO_V0("record_device_orch_callable: hash=0x%lx new buffer %zu bytes", hash, orch_so_size);
-    } else {
-        buf_it->second.refcount++;
-        dev_addr = reinterpret_cast<uint64_t>(buf_it->second.dev_addr);
-        LOG_INFO_V0(
-            "record_device_orch_callable: hash=0x%lx shared buffer (refcount=%d)", hash, buf_it->second.refcount
-        );
-    }
-
     CallableState state;
     state.hash = hash;
-    state.dev_orch_so_addr = dev_addr;
+    state.chip_buffer_hash = chip_buffer_hash;
+    state.dev_orch_so_addr = chip_dev + offsetof(ChipCallable, storage_);
     state.dev_orch_so_size = orch_so_size;
     state.func_name = (func_name != nullptr) ? func_name : "";
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
     state.signature = std::move(signature);
     callables_.emplace(callable_id, std::move(state));
+    LOG_INFO_V0(
+        "record_device_orch_callable: cid=%d orch_hash=0x%lx chip_hash=0x%lx %zu bytes", callable_id, hash,
+        chip_buffer_hash, orch_so_size
+    );
     return 0;
 }
 
 int SimDeviceRunnerBase::record_host_orch_callable(
-    int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
+    int32_t callable_id, uint64_t chip_buffer_hash, void *host_dlopen_handle, void *host_orch_func_ptr,
     std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
@@ -490,12 +475,17 @@ int SimDeviceRunnerBase::record_host_orch_callable(
         LOG_ERROR("record_host_orch_callable: null handle/fn for callable_id=%d", callable_id);
         return -1;
     }
+    if (chip_buffer_hash == 0) {
+        LOG_ERROR("record_host_orch_callable: missing chip buffer for callable_id=%d", callable_id);
+        return -1;
+    }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_host_orch_callable: callable_id=%d already registered", callable_id);
         return -1;
     }
 
     CallableState state;
+    state.chip_buffer_hash = chip_buffer_hash;
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
@@ -514,19 +504,12 @@ int SimDeviceRunnerBase::unregister_callable(int32_t callable_id) {
     CallableState state = std::move(it->second);
     callables_.erase(it);
     aicpu_seen_callable_ids_.erase(callable_id);
+    release_chip_callable_buffer(state.chip_buffer_hash);
 
     if (state.host_dlopen_handle != nullptr) {
-        // hbg: dlclose the host handle; no orch SO refcount to decrement.
+        // hbg: dlclose the host handle; no device-side orch SO handle.
         dlclose(state.host_dlopen_handle);
         return 0;
-    }
-
-    auto buf_it = orch_so_dedup_.find(state.hash);
-    if (buf_it != orch_so_dedup_.end()) {
-        if (--buf_it->second.refcount <= 0) {
-            mem_alloc_.free(buf_it->second.dev_addr);
-            orch_so_dedup_.erase(buf_it);
-        }
     }
     return 0;
 }
@@ -597,7 +580,7 @@ void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
 }
 
 uint64_t SimDeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *callable) {
-    if (callable == nullptr || callable->child_count() == 0) {
+    if (callable == nullptr) {
         return 0;
     }
 
@@ -605,9 +588,10 @@ uint64_t SimDeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *ca
 
     auto it = chip_callable_buffers_.find(layout.content_hash);
     if (it != chip_callable_buffers_.end()) {
+        it->second.refcount++;
         LOG_DEBUG(
-            "Chip callable dedup hit (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev,
-            it->second.total_size, layout.content_hash
+            "Chip callable dedup hit (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx, refcount=%d", it->second.chip_dev,
+            it->second.total_size, layout.content_hash, it->second.refcount
         );
         return it->second.chip_dev;
     }
@@ -672,13 +656,36 @@ uint64_t SimDeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *ca
     cleanup.dismiss();
     const uint64_t chip_dev = reinterpret_cast<uint64_t>(scratch);
     chip_callable_buffers_.emplace(
-        layout.content_hash, ChipCallableBuffer{chip_dev, scratch, layout.total_size, std::move(dlopen_handles)}
+        layout.content_hash, ChipCallableBuffer{chip_dev, scratch, layout.total_size, 1, std::move(dlopen_handles)}
     );
     LOG_DEBUG(
         "Uploaded chip callable (sim): chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev,
         layout.total_size, callable->child_count(), layout.content_hash
     );
     return chip_dev;
+}
+
+int SimDeviceRunnerBase::release_chip_callable_buffer(uint64_t hash) {
+    if (hash == 0) {
+        return 0;
+    }
+    auto it = chip_callable_buffers_.find(hash);
+    if (it == chip_callable_buffers_.end()) {
+        LOG_WARN("release_chip_callable_buffer: hash=0x%lx not found", hash);
+        return 0;
+    }
+    if (--it->second.refcount <= 0) {
+        for (void *h : it->second.dlopen_handles) {
+            if (h != nullptr) dlclose(h);
+        }
+        delete[] it->second.host_scratch;
+        LOG_DEBUG(
+            "Freed chip callable buffer (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev,
+            it->second.total_size, hash
+        );
+        chip_callable_buffers_.erase(it);
+    }
+    return 0;
 }
 
 void SimDeviceRunnerBase::print_handshake_results() {
@@ -697,8 +704,7 @@ void SimDeviceRunnerBase::print_handshake_results() {
 }
 
 void SimDeviceRunnerBase::release_callable_state() {
-    // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
-    // Pool semantics mirror per-fid binaries: never freed until finalize.
+    // Release any chip callable buffers callers forgot to unregister.
     for (auto &kv : chip_callable_buffers_) {
         for (void *h : kv.second.dlopen_handles) {
             if (h != nullptr) dlclose(h);
@@ -711,13 +717,6 @@ void SimDeviceRunnerBase::release_callable_state() {
     }
     chip_callable_buffers_.clear();
 
-    // Release any prepared-callable orch SO buffers callers forgot to drop.
-    for (auto &kv : orch_so_dedup_) {
-        if (kv.second.dev_addr != nullptr) {
-            mem_alloc_.free(kv.second.dev_addr);
-        }
-    }
-    orch_so_dedup_.clear();
     // hbg path: dlclose any host orch handles callers forgot to unregister.
     // finalize() is the last chance; Worker.close() does not auto-unregister
     // each callable_id, so without this loop the host process leaks one

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -114,11 +114,12 @@ public:
     void unregister_device_memory_from_host(void *dev_ptr) { (void)dev_ptr; }
 
     int record_device_orch_callable(
-        int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
-        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+        int32_t callable_id, uint64_t chip_buffer_hash, uint64_t chip_dev, const void *orch_so_data,
+        size_t orch_so_size, const char *func_name, const char *config_name,
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
     int record_host_orch_callable(
-        int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
+        int32_t callable_id, uint64_t chip_buffer_hash, void *host_dlopen_handle, void *host_orch_func_ptr,
         std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
     int unregister_callable(int32_t callable_id);
@@ -133,6 +134,7 @@ public:
         const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
     );
     uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
+    int release_chip_callable_buffer(uint64_t hash);
     int launch_device_register(int32_t callable_id);
     int commit_device_register(int32_t callable_id);
 
@@ -271,6 +273,7 @@ protected:
         uint64_t chip_dev{0};  // (uint64_t)host_scratch
         uint8_t *host_scratch{nullptr};
         size_t total_size{0};
+        int refcount{0};
         std::vector<void *> dlopen_handles;
     };
     std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
@@ -279,6 +282,7 @@ protected:
     struct CallableState {
         // trb path
         uint64_t hash{0};
+        uint64_t chip_buffer_hash{0};
         uint64_t dev_orch_so_addr{0};
         size_t dev_orch_so_size{0};
         std::string func_name;
@@ -290,13 +294,7 @@ protected:
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};
     };
-    struct OrchSoBuffer {
-        void *dev_addr{nullptr};
-        size_t capacity{0};
-        int refcount{0};
-    };
     std::unordered_map<int32_t, CallableState> callables_;
-    std::unordered_map<uint64_t, OrchSoBuffer> orch_so_dedup_;
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;
     size_t aicpu_dlopen_total_{0};
     size_t host_dlopen_total_{0};

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -29,6 +29,7 @@
 
 #include "arg_direction.h"
 #include "callable.h"
+#include "chip_callable_layout.h"
 
 struct ChildKernelAddr {
     int func_id;
@@ -46,9 +47,9 @@ struct ChildKernelAddr {
  *   - host_build_graph: kernel_addrs + host_dlopen_handle + host_orch_func_ptr
  *                       (orch_so_* stay null since orch SO never crosses
  *                       host/device on this runtime)
- *   - tensormap_and_ringbuffer: kernel_addrs + orch_so_data + orch_so_size
- *                       + func_name + config_name (orch SO is uploaded to
- *                       device by DeviceRunner; host does no dlopen)
+ *   - tensormap_and_ringbuffer: kernel_addrs + chip buffer lease +
+ *                       orch_so_size + func_name + config_name (the orch SO
+ *                       is the leading slice of ChipCallable::storage_)
  *
  * func_name / config_name are non-empty only for the trb path; the hbg path
  * resolves its entry symbol during register_callable_impl and stores the
@@ -63,7 +64,9 @@ struct CallableArtifacts {
     std::vector<ArgDirection> signature;
     void *host_dlopen_handle{nullptr};  // hbg only
     void *host_orch_func_ptr{nullptr};  // hbg only
-    const void *orch_so_data{nullptr};  // trb only
+    uint64_t chip_buffer_hash{0};       // FNV-1a hash for the whole ChipCallable buffer
+    uint64_t chip_buffer_dev{0};        // device address of the ChipCallable header
+    const void *orch_so_data{nullptr};  // trb only; host view used for validation/hash only
     size_t orch_so_size{0};             // trb only
     std::string func_name;              // trb only (orch entry symbol)
     std::string config_name;            // trb only (orch config symbol)
@@ -73,8 +76,9 @@ struct CallableArtifacts {
  * Upload the ChipCallable buffer via `upload_fn` and compute the device-side
  * address of every child kernel.
  *
- * @param callable   ChipCallable to upload. May have child_count() == 0, in
- *                   which case `out` is cleared and 0 is returned.
+ * @param callable   ChipCallable to upload. May have child_count() == 0; the
+ *                   chip buffer is still uploaded and retained, while `out`
+ *                   remains empty on success.
  * @param upload_fn  HostApi::upload_chip_callable_buffer — declared as
  *                   `uint64_t (*)(const void *)` to avoid pulling runtime
  *                   headers into task_interface. Must not be null.
@@ -82,23 +86,24 @@ struct CallableArtifacts {
  *                   {func_id, device_addr} entry per child kernel. Caller is
  *                   responsible for validating func_id against its runtime's
  *                   RUNTIME_MAX_FUNC_ID before writing to func_id_to_addr_[].
- * @return 0 on success (including the child_count == 0 case), -1 on argument
- *         error or upload failure.
+ * @return 0 on success, -1 on argument error or upload failure.
  */
 inline int upload_and_collect_child_addrs(
-    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), std::vector<ChildKernelAddr> *out
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), std::vector<ChildKernelAddr> *out,
+    uint64_t *out_chip_dev = nullptr, uint64_t *out_chip_hash = nullptr
 ) {
     if (callable == nullptr || upload_fn == nullptr || out == nullptr) return -1;
     out->clear();
-    if (callable->child_count() <= 0) return 0;
 
+    const ChipCallableLayout layout = compute_chip_callable_layout(callable);
     uint64_t chip_dev = upload_fn(callable);
     if (chip_dev == 0) return -1;
+    if (out_chip_dev != nullptr) *out_chip_dev = chip_dev;
+    if (out_chip_hash != nullptr) *out_chip_hash = layout.content_hash;
 
-    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
     out->reserve(static_cast<size_t>(callable->child_count()));
     for (int32_t i = 0; i < callable->child_count(); ++i) {
-        uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
+        uint64_t child_dev = chip_dev + layout.header_size + callable->child_offset(i);
         out->push_back({callable->child_func_id(i), child_dev});
     }
     return 0;

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -22,17 +23,36 @@ namespace {
 
 class TestSimRunner : public SimDeviceRunnerBase {
 public:
+    ~TestSimRunner() override { finalize(); }
+
     int run(Runtime &, const CallConfig &) override { return 0; }
     int finalize() override {
+        if (finalized_) return 0;
+        finalized_ = true;
         l3_l2_orch_comm_shutdown();
-        mem_alloc_.finalize();
-        return 0;
+        release_callable_state();
+        return mem_alloc_.finalize();
+    }
+
+    size_t chip_callable_buffer_count() const { return chip_callable_buffers_.size(); }
+    int chip_callable_buffer_refcount(uint64_t hash) const {
+        auto it = chip_callable_buffers_.find(hash);
+        return it == chip_callable_buffers_.end() ? 0 : it->second.refcount;
     }
 
 private:
     int ensure_binaries_loaded() override { return 0; }
     int invoke_device_register(const RegisterCallableArgs &) override { return 0; }
+
+    bool finalized_{false};
 };
+
+std::vector<uint8_t> build_zero_child_chip_callable() {
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F', 0xaa, 0xbb};
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        nullptr, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), nullptr, nullptr, 0, "cfg_name"
+    );
+}
 
 L3L2OrchCommResponse
 submit(L3L2OrchCommClient &client, const L3L2OrchCommRequest &request, uint64_t timeout_ns = 1000000000ULL) {
@@ -101,6 +121,47 @@ TEST(L3L2OrchCommSimRunnerTest, RunnerOwnedServiceHandlesPayloadSignalAndFree) {
     EXPECT_EQ(submit(client, free_req).status, 0);
 
     EXPECT_EQ(runner.l3_l2_orch_comm_shutdown(), 0);
+}
+
+TEST(ChipCallableBufferLifetimeSimTest, IdenticalRegistrationsReleaseAfterLastUnregister) {
+    TestSimRunner runner;
+    auto chip_buf = build_zero_child_chip_callable();
+    const auto *callable = reinterpret_cast<const ChipCallable *>(chip_buf.data());
+    const ChipCallableLayout layout = compute_chip_callable_layout(callable);
+    ASSERT_NE(layout.content_hash, 0u);
+
+    const uint64_t first_dev = runner.upload_chip_callable_buffer(callable);
+    ASSERT_NE(first_dev, 0u);
+    ASSERT_EQ(
+        runner.record_device_orch_callable(
+            1, layout.content_hash, first_dev, callable->binary_data(), callable->binary_size(), callable->func_name(),
+            callable->config_name(), {}, {}
+        ),
+        0
+    );
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 1u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 1);
+
+    const uint64_t second_dev = runner.upload_chip_callable_buffer(callable);
+    ASSERT_EQ(second_dev, first_dev);
+    ASSERT_EQ(
+        runner.record_device_orch_callable(
+            2, layout.content_hash, second_dev, callable->binary_data(), callable->binary_size(), callable->func_name(),
+            callable->config_name(), {}, {}
+        ),
+        0
+    );
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 1u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 2);
+
+    EXPECT_EQ(runner.unregister_callable(1), 0);
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 1u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 1);
+
+    EXPECT_EQ(runner.unregister_callable(2), 0);
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 0u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 0);
+    EXPECT_EQ(runner.finalize(), 0);
 }
 
 }  // namespace

--- a/tests/ut/cpp/hardware/test_l3_l2_orch_comm_onboard_runner.cpp
+++ b/tests/ut/cpp/hardware/test_l3_l2_orch_comm_onboard_runner.cpp
@@ -9,6 +9,10 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <cstdlib>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "common/l3_l2_orch_comm.h"
@@ -25,12 +29,114 @@ public:
     bool l3_l2_orch_comm_supported() const override { return false; }
 };
 
+class ChipCallableTestOnboardRunner : public DeviceRunnerBase {
+public:
+    ~ChipCallableTestOnboardRunner() override { finalize(); }
+
+    int run(Runtime &, const CallConfig &) override { return 0; }
+    int finalize() override {
+        if (finalized_) return 0;
+        finalized_ = true;
+        return finalize_common();
+    }
+    bool l3_l2_orch_comm_supported() const override { return false; }
+
+    int prepare_for_upload(int device_id) {
+        int rc = attach_current_thread(device_id);
+        if (rc != 0) return rc;
+        return rtStreamCreate(&stream_aicpu_, 0);
+    }
+
+    size_t chip_callable_buffer_count() const { return chip_callable_buffers_.size(); }
+    int chip_callable_buffer_refcount(uint64_t hash) const {
+        auto it = chip_callable_buffers_.find(hash);
+        return it == chip_callable_buffers_.end() ? 0 : it->second.refcount;
+    }
+
+private:
+    bool finalized_{false};
+};
+
+std::vector<int> read_ctest_devices() {
+    std::vector<int> ids;
+    const char *count_str = std::getenv("CTEST_RESOURCE_GROUP_COUNT");
+    if (count_str == nullptr) return ids;
+
+    int group_count = std::atoi(count_str);
+    for (int group = 0; group < group_count; ++group) {
+        std::string var = "CTEST_RESOURCE_GROUP_" + std::to_string(group) + "_NPUS";
+        const char *value = std::getenv(var.c_str());
+        if (value == nullptr) continue;
+
+        std::string resources(value);
+        size_t pos = 0;
+        while ((pos = resources.find("id:", pos)) != std::string::npos) {
+            pos += 3;
+            ids.push_back(std::atoi(resources.c_str() + pos));
+        }
+    }
+    return ids;
+}
+
+std::vector<uint8_t> build_zero_child_chip_callable() {
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F', 0xaa, 0xbb};
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        nullptr, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), nullptr, nullptr, 0, "cfg_name"
+    );
+}
+
 TEST(L3L2OrchCommOnboardRunnerTest, UnsupportedRunnerInitFailsAndShutdownIsNoop) {
     UnsupportedL3L2Runner runner;
     L3L2OrchCommControlBlock control{};
 
     EXPECT_EQ(runner.l3_l2_orch_comm_init(&control, sizeof(control)), PTO_RUNTIME_ERR_UNSUPPORTED);
     EXPECT_EQ(runner.l3_l2_orch_comm_shutdown(), 0);
+}
+
+TEST(ChipCallableBufferLifetimeOnboardTest, IdenticalRegistrationsReleaseAfterLastUnregister) {
+    auto devices = read_ctest_devices();
+    ASSERT_FALSE(devices.empty()) << "need one NPU device; run with --resource-spec-file";
+
+    ChipCallableTestOnboardRunner runner;
+    ASSERT_EQ(runner.prepare_for_upload(devices.front()), 0);
+
+    auto chip_buf = build_zero_child_chip_callable();
+    const auto *callable = reinterpret_cast<const ChipCallable *>(chip_buf.data());
+    const ChipCallableLayout layout = compute_chip_callable_layout(callable);
+    ASSERT_NE(layout.content_hash, 0u);
+
+    const uint64_t first_dev = runner.upload_chip_callable_buffer(callable);
+    ASSERT_NE(first_dev, 0u);
+    ASSERT_EQ(
+        runner.record_device_orch_callable(
+            1, layout.content_hash, first_dev, callable->binary_data(), callable->binary_size(), callable->func_name(),
+            callable->config_name(), {}, {}
+        ),
+        0
+    );
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 1u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 1);
+
+    const uint64_t second_dev = runner.upload_chip_callable_buffer(callable);
+    ASSERT_EQ(second_dev, first_dev);
+    ASSERT_EQ(
+        runner.record_device_orch_callable(
+            2, layout.content_hash, second_dev, callable->binary_data(), callable->binary_size(), callable->func_name(),
+            callable->config_name(), {}, {}
+        ),
+        0
+    );
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 1u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 2);
+
+    EXPECT_EQ(runner.unregister_callable(1), 0);
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 1u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 1);
+
+    EXPECT_EQ(runner.unregister_callable(2), 0);
+    EXPECT_EQ(runner.chip_callable_buffer_count(), 0u);
+    EXPECT_EQ(runner.chip_callable_buffer_refcount(layout.content_hash), 0);
+    EXPECT_EQ(runner.finalize(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Keep one refcounted ChipCallable buffer lease per registered callable id.

Use the retained chip storage slice as the device orch SO.

This removes the second orch SO upload for registered callables.

Release the retained chip buffer on unregister and registration failure.

Fixes #1082