### PR TITLE
fix(a2a3/tensormap): propagate early-dispatch from the sync_start drain path

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -513,6 +513,14 @@ void SchedulerContext::drain_worker_dispatch(int32_t block_num) {
         }
     }
 
+    // The drain path IS this sync_start producer's dispatch, so it must bump its
+    // consumers' dispatch_fanin like the normal dispatch path
+    // (scheduler_dispatch.cpp, post-publish) -- otherwise a consumer whose only
+    // flagged producer is a sync_start (drain-dispatched) task never becomes an
+    // early-dispatch candidate. Idempotent via propagate's dispatch_propagated
+    // once-guard; the internal gate no-ops for an unflagged producer.
+    sched_->propagate_dispatch_fanin(*slot_state);
+
     // All blocks dispatched -- clear drain state.
     // Release fence ensures tracker mutations are visible to threads that
     // acquire-load sync_start_pending == 0 and resume normal operation.


### PR DESCRIPTION
## Summary

`propagate_dispatch_fanin` — the event that turns a **flagged producer's
dispatch** into early-dispatch candidacy for its consumers — was only called on
the **normal ready-pop dispatch path** (`scheduler_dispatch.cpp:457`). A
`sync_start` task dispatches through the **separate drain path**
(`handle_drain_mode` → `drain_worker_dispatch` in `scheduler_completion.cpp`),
which never propagated.

Consequence: any consumer whose **only flagged producer is a sync_start
(drain-dispatched) task** never became an early-dispatch candidate — it wasn't
gated and it had spare (idle/pending) cores to stage onto; the *candidate-enqueue
event itself* was simply missing.

## Fix

After `drain_worker_dispatch` publishes all of the drained producer's blocks
(the producer is now dispatched), call `propagate_dispatch_fanin` once —
mirroring the normal path's post-publish propagate.

- **Idempotent** via propagate's `dispatch_propagated` once-guard.
- The internal gate no-ops for an unflagged producer, so calling it
  unconditionally is cheap (same as the normal path).
- **Scoped exactly to the gap**: only `sync_start` tasks reach the drain path
  (`scheduler_dispatch.cpp` re-queues a non-sync_start task that doesn't fit, so
  it propagates via the normal path on eventual dispatch).

## Testing

- **a2a3 hardware** — qwen3-14B `decode_fwd` (2-layer) early-dispatched-task
  count **35 → 83** with the fix. The **+48** are exactly the 24 `out_proj`
  tiles/layer whose sole producer is the `sync_start` `fa_fused` — previously
  stuck out of early-dispatch, now pre-staged onto pending slots while `fa_fused`
  runs.
- `spmd_sync_start` / `_aiv` / `_edge` / `_stress` scene tests pass (no drain
  regression).
- cpput `WiringTest` 19/19 pass.

## Testing checklist
- [x] Simulation / cpput tests pass
- [x] Hardware (a2a3) tests pass