### PR TITLE
refactor(a2a3/early-dispatch): align acquisition and ordering with normal dispatch

### DIFF
--- a/src/a2a3/platform/include/common/l2_swimlane_profiling.h
+++ b/src/a2a3/platform/include/common/l2_swimlane_profiling.h
@@ -508,13 +508,13 @@ enum class L2SwimlaneSchedPhaseKind : uint32_t {
                         // tasks_processed = wired count.
     Dummy = 4,          // dummy_drain outer bar: covers handling of all dummies
                         // popped this iter. tasks_processed = dummy_got count.
-    EarlyDispatch = 5,  // try_speculative_early_dispatch: speculative pre-staging
+    EarlyDispatch = 5,  // try_early_dispatch: early-dispatch pre-staging
                         // of a flagged producer's consumer's gated blocks.
                         // tasks_processed = blocks staged this pass.
     // Inner (parent: Complete | Dummy)
     Resolve = 6,  // on_task_complete: walk consumer list, decrement fanin,
                   // push newly-ready successors, ring doorbells for
-                  // speculative hits. tasks_processed = # consumers visited.
+                  // early-dispatch hits. tasks_processed = # consumers visited.
     // Separate-lane (Worker View pid=4 AICPU_N)
     DummyTask = 7,  // Per-dummy identity marker (zero-width). tasks_processed
                     // = task_token_raw low 32 bits so deps.json flow arrows

--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -93,7 +93,7 @@ __aicore__ inline uint64_t read_reg(RegId reg) {
  * Read the high 32 bits of DATA_MAIN_BASE.
  *
  * AICore reads the full 64-bit SPR via MOV; the high half is the
- * speculative-dispatch doorbell written by AICPU (low half stays the dispatch
+ * early-dispatch doorbell written by AICPU (low half stays the dispatch
  * token). Read-only on the AICore side, so this is always valid (unlike writes
  * to DATA_MAIN_BASE, which the SPR-write port rejects).
  */

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -163,7 +163,7 @@ inline uint64_t read_reg(RegId reg) {
 }
 
 /**
- * Read the high 32 bits of DATA_MAIN_BASE (speculative-dispatch doorbell).
+ * Read the high 32 bits of DATA_MAIN_BASE (early-dispatch doorbell).
  * The high word lives one 32-bit slot above the dispatch token.
  */
 inline uint32_t read_dmb_high32() {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -141,7 +141,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // `start_time - receive_time`.
             //
             // Common path (not_ready == 0): the new task_id is itself the ready
-            // signal, so receive_time is the true ready moment. Speculative path
+            // signal, so receive_time is the true ready moment. Early-dispatch path
             // (not_ready == 1): receive_time stays at pickup — before the
             // doorbell wait — so it precedes the producer's end_time; the host
             // folds it to start_time for those tasks (detected when receive
@@ -156,7 +156,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // Invalidate payload buffer (AICPU updates its content each dispatch)
             dcci(exec_payload, ENTIRE_DATA_CACHE);
 
-            // Speculative early-dispatch gate. A not-ready task was staged on
+            // Early-dispatch gate. A not-ready task was staged on
             // this core before its dependencies resolved; wait until AICPU rings
             // the doorbell (DATA_MAIN_BASE high 32 == task_id) before executing.
             // The ACK is deferred until AFTER the gate so the scheduler keeps the

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
@@ -54,9 +54,9 @@ public:
     using L0TaskArgs::add_scalar;
     using L0TaskArgs::add_scalars;
     using L0TaskArgs::add_scalars_i32;
-    using L0TaskArgs::allow_early_resolve;  // speculative early-dispatch hint (getter)
+    using L0TaskArgs::allow_early_resolve;  // early-dispatch hint (getter)
     using L0TaskArgs::copy_scalars_from;
-    using L0TaskArgs::set_allow_early_resolve;  // speculative early-dispatch hint (setter)
+    using L0TaskArgs::set_allow_early_resolve;  // early-dispatch hint (setter)
 
     // Error / status — forward to Arg
     using L0TaskArgs::error_msg;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -81,7 +81,7 @@ struct alignas(64) PTO2DispatchPayload {
      *  args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
     GlobalContext global_context;
 
-    /** Speculative early-dispatch gate. 0 = ready: AICore executes on pickup.
+    /** Early-dispatch gate. 0 = ready: AICore executes on pickup.
      *  1 = not-ready: AICore waits until AICPU rings the doorbell
      *  (DATA_MAIN_BASE high 32 == this dispatch's reg_task_id) before executing. */
     volatile uint32_t not_ready;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -451,7 +451,7 @@ static bool prepare_task(
     out->slot_state->bind_buffers(out->payload, out->task);
 
     // prepare_task does NO payload writes: all payload content (tensors/scalars +
-    // early-dispatch spec fields) is initialized in PTO2TaskPayload::init, the
+    // early-dispatch fields) is initialized in PTO2TaskPayload::init, the
     // single payload-init point, which runs before the scheduler wiring push.
 
     // Fields already reset by advance_ring_pointers (eager reset after CONSUMED):

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -213,12 +213,12 @@ struct PTO2TaskDescriptor {
  * by bulk tensor and scalar data. Small fanins stay fully inline; larger
  * fanins spill into a per-ring ring buffer slice.
  */
-// Speculative early-dispatch claim states for PTO2TaskPayload::spec_state.
-enum PTO2SpecState : uint8_t {
-    PTO2_SPEC_NONE = 0,       // not pre-staged
-    PTO2_SPEC_STAGING = 1,    // Hook 1 claimed it; staging in progress
-    PTO2_SPEC_STAGED = 2,     // staged on a core, gated; staged_* fields valid
-    PTO2_SPEC_DISPATCHED = 3  // routed via the normal dispatch path (no pre-stage)
+// Early-dispatch claim states for PTO2TaskPayload::early_dispatch_state.
+enum PTO2EarlyDispatchState : uint8_t {
+    PTO2_EARLY_DISPATCH_NONE = 0,       // not pre-staged
+    PTO2_EARLY_DISPATCH_STAGING = 1,    // Hook 1 claimed it; staging in progress
+    PTO2_EARLY_DISPATCH_STAGED = 2,     // staged on a core, gated; staged_* fields valid
+    PTO2_EARLY_DISPATCH_DISPATCHED = 3  // routed via the normal dispatch path (no pre-stage)
 };
 
 // A pre-staged consumer occupies one core per gated subtask block. WHICH cores
@@ -228,7 +228,7 @@ enum PTO2SpecState : uint8_t {
 // chip's core count (RUNTIME_MAX_WORKER = 72; no two-level pre-dispatch means
 // gated cores in flight <= core count), NOT by block_num — so a wide SPMD
 // consumer can pre-stage all its idle cores. 2 words = 128 bits >= 72.
-inline constexpr int PTO2_SPEC_CORE_MASK_WORDS = 2;
+inline constexpr int PTO2_EARLY_DISPATCH_CORE_MASK_WORDS = 2;
 
 struct PTO2TaskPayload {
     // === Cache lines 0-8 (576B) — metadata + inline fanin ===
@@ -238,11 +238,11 @@ struct PTO2TaskPayload {
     int32_t fanin_spill_start{0};   // Linear start index in fanin spill pool (0 = no spill)
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
-    // Speculative early-dispatch metadata (AICPU-side only). Ordered by descending
+    // Early-dispatch metadata (AICPU-side only). Ordered by descending
     // alignment (8B mask, 4B fanin, then 1B flags) so the block packs with no
     // internal padding. Kept here after the fanin array (not moved up front): on
     // cache line 8 it shares only with the rarely-touched fanin tail, whereas in
-    // line 0 the spec atomics (written during staging) would false-share with
+    // line 0 the early-dispatch atomics (written during staging) would false-share with
     // tensor_count/scalar_count (read by build_payload at dispatch). Fits in the 40B
     // between the fanin array (offset 536) and the 64B-aligned tensors[] (offset
     // 576), so sizeof and tensors[] are unchanged.
@@ -250,12 +250,12 @@ struct PTO2TaskPayload {
     // Bitmask of global core_ids this consumer is pre-staged (gated) on. Set with
     // atomic fetch_or by concurrent stagers; read by release. (Re)initialized in
     // PTO2TaskPayload::init before the slot can be staged again.
-    std::atomic<uint64_t> staged_core_mask[PTO2_SPEC_CORE_MASK_WORDS]{};
+    std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
     // Early-dispatch CANDIDATE detection (event-driven, dual of fanin_refcount):
     // seeded at wiring with producers already complete, then a flagged producer's
     // DISPATCH bumps each consumer's dispatch_fanin. dispatch_fanin ==
     // fanin_actual_count  <=>  every producer is flagged-and-dispatched or was
-    // pre-completed  =>  this task is an early-dispatch candidate (push early_dispatch_queue).
+    // pre-completed  =>  this task is an early-dispatch candidate (push early_dispatch_queues[shape]).
     std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: flagged-dispatched + pre-completed producers
     // Lock-free claim state shared by the stagers (Hook 1, possibly several AICPU
     // threads concurrently) and the completion-path release: 0=NONE, 1=STAGING,
@@ -265,7 +265,7 @@ struct PTO2TaskPayload {
     // Release does STAGING->DISPATCHED then rings the mask; a thread that stages a
     // block AFTER release flipped DISPATCHED rings that block's doorbell itself
     // (self-ring), so no doorbell is ever missed.
-    std::atomic<uint8_t> spec_state{0};
+    std::atomic<uint8_t> early_dispatch_state{0};
     std::atomic<uint8_t> dispatch_propagated{0};  // PRODUCER side: once-guard for fanout propagation
     // === Cache lines 9-72 (4096B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
@@ -279,7 +279,7 @@ struct PTO2TaskPayload {
     /**
      * Prefetch (for write) the regions init() is about to fill so the stores land
      * in warm cache. tensor_count/scalar_count come from the Arg — the payload's
-     * own counts are not set until init(). Warms the early-dispatch spec block at
+     * own counts are not set until init(). Warms the early-dispatch block at
      * offset 536 (cache line 8) too. A member fn lowers to the same prefetch
      * instructions as a free function (`this` is just a register), no cache impact.
      */
@@ -294,7 +294,7 @@ struct PTO2TaskPayload {
         __builtin_prefetch(this, 1, 3);
         __builtin_prefetch(reinterpret_cast<const char *>(this) + 64, 1, 3);
         __builtin_prefetch(reinterpret_cast<const char *>(this) + 128, 1, 3);
-        __builtin_prefetch(reinterpret_cast<const char *>(this) + 512, 1, 3);  // spec fields (cache line 8)
+        __builtin_prefetch(reinterpret_cast<const char *>(this) + 512, 1, 3);  // early-dispatch fields (cache line 8)
     }
 
     /**
@@ -331,19 +331,19 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
-        // Speculative early-dispatch metadata — the single init point for these
+        // Early-dispatch metadata — the single init point for these
         // fields. reset_for_reuse MUST NOT touch the payload (it runs on the
         // scheduler's advance-ring path and would pull this cold cache line across
         // structures); prepare_task only allocates/binds. prefetch() warms this
         // line (offset 512) so these writes land in warm cache.
         //
-        // spec_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
+        // early_dispatch_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
         // task whose own allow_early_resolve is false still has them touched when
         // one of ITS producers is flagged (propagate_dispatch_fanin bumps
-        // dispatch_fanin and may CAS spec_state on any consumer, independent of the
+        // dispatch_fanin and may CAS early_dispatch_state on any consumer, independent of the
         // consumer's own hint). So they MUST be zeroed here unconditionally.
-        spec_state.store(PTO2_SPEC_NONE, std::memory_order_relaxed);
-        for (int w = 0; w < PTO2_SPEC_CORE_MASK_WORDS; w++)
+        early_dispatch_state.store(PTO2_EARLY_DISPATCH_NONE, std::memory_order_relaxed);
+        for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_core_mask[w].store(0, std::memory_order_relaxed);
         dispatch_fanin.store(0, std::memory_order_relaxed);
         dispatch_propagated.store(0, std::memory_order_relaxed);
@@ -441,7 +441,7 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
     int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
     int16_t logical_block_num{1};                // Total logical blocks (set by orchestrator)
-    // Next block to dispatch. Atomic so concurrent speculative stagers can each
+    // Next block to dispatch. Atomic so concurrent early-dispatch stagers can each
     // claim a distinct block via CAS; normal dispatch (ready-queue serialized)
     // uses plain relaxed load/store. The two phases never overlap in time (staging
     // happens before release; normal dispatch of the remainder happens after).
@@ -486,7 +486,7 @@ struct alignas(64) PTO2TaskSlotState {
         next_block_idx.store(0, std::memory_order_relaxed);
         any_subtask_deferred.store(false, std::memory_order_relaxed);
         allow_early_resolve = false;  // safe default; the normal submit path overwrites from Arg
-        // Note: payload spec fields (spec_state / staged_core_mask / dispatch_fanin)
+        // Note: payload early-dispatch fields (early_dispatch_state / staged_core_mask / dispatch_fanin)
         // are NOT reset here — this method skips the payload by contract. They are
         // (re)initialized in PTO2TaskPayload::init on every submit, before the slot
         // becomes visible to the scheduler.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -222,7 +222,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
 
-    // Speculative early-dispatch hint (codegen-author set, off by default). When
+    // Early-dispatch hint (codegen-author set, off by default). When
     // true, the scheduler may stage this task on an idle core before its producer
     // finishes, gating execution on the DATA_MAIN_BASE doorbell — only safe when
     // the author knows the task's data dependencies allow it. Read in-process by

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -33,13 +33,13 @@
 
 #include "common/core_type.h"
 #include "utils/device_arena.h"
-#include "aicpu/platform_regs.h"  // get_reg_ptr / RegId for the speculative doorbell
+#include "aicpu/platform_regs.h"  // get_reg_ptr / RegId for the early-dispatch doorbell
 #include "pto_async_wait.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 
-#include "aicpu/device_time.h"  // get_sys_cnt_aicpu (weak; used by spec doorbell timing too)
+#include "aicpu/device_time.h"  // get_sys_cnt_aicpu (weak; used by early-dispatch doorbell timing too)
 #if PTO2_SCHED_PROFILING
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
 #define PTO2_SCHED_CYCLE_LAP(acc)   \
@@ -533,7 +533,7 @@ struct CompletionStats {
 struct PTO2SchedulerLayout {
     size_t off_ready_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_dummy_ready_queue_slots;
-    size_t off_early_dispatch_queue_slots;
+    size_t off_early_dispatch_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_dep_pool_entries[PTO2_MAX_RING_DEPTH];
     size_t off_wiring_spsc_buffer;
     uint64_t ready_queue_capacity;
@@ -975,7 +975,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    // Speculative early-dispatch release. If the now-ready task was pre-staged
+    // Early-dispatch release. If the now-ready task was pre-staged
     // (gated on a core), ring its DATA_MAIN_BASE high-32 doorbell RIGHT HERE in
     // the completion path — the moment its last producer's FIN satisfies fanin —
     // instead of routing it through the ready queue and waiting for the dispatch
@@ -988,32 +988,37 @@ struct PTO2SchedulerState {
     // (the stager): CAS NONE->DISPATCHED wins => not pre-staged; lose => STAGED
     // (spin past the brief STAGING window so the mask is visible), then ring.
 
-    // Per-core speculative doorbell table. Hook 1 records each gated core's
+    // Per-core early-dispatch doorbell table. Hook 1 records each gated core's
     // (reg_addr, dispatch token) here at stage time; the completion-path release
     // reads it back for the cores set in the consumer's staged_core_mask. One
     // global table indexed by core_id (not per-task): gated cores in flight are
     // bounded by the chip's core count (no two-level pre-dispatch), so this is the
     // natural capacity and removes the old per-task 3-doorbell cap.
-    struct SpecDoorbell {
+    struct EarlyDispatchDoorbell {
         uint64_t addr{0};
         uint32_t token{0};
     };
-    SpecDoorbell spec_doorbell_table[PTO2_SPEC_CORE_MASK_WORDS * 64]{};
+    EarlyDispatchDoorbell early_dispatch_doorbell_table[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS * 64]{};
 
-    // Cross-thread early-dispatch work queue (a PTO2ReadyQueue MPMC instance,
-    // arena-backed — reserved/wired in pto_runtime2_init alongside the ready queues).
+    // Cross-thread early-dispatch work queues, one PTO2ReadyQueue MPMC instance per
+    // resource shape (AIC/AIV/MIX) — arena-backed, reserved/wired in pto_runtime2_init
+    // alongside the per-shape ready queues, and indexed the same way. A candidate is
+    // pushed to the queue for its own shape (active_mask.to_shape()) so the drain can
+    // pop per shape and size the pop to that shape's free cores, exactly as normal
+    // dispatch pops ready_queues[shape].
+    //
     // A consumer's SPMD blocks span cores owned by several AICPU threads, but only a
     // thread RUNNING the consumer's producer discovers it (via the producer's
     // fanout). When that producer is thread-local (e.g. a 16-block AIV op filling one
     // thread's cores), the other threads never see the consumer and its blocks on
     // their cores can't pre-stage. The first claimer pushes the partially-staged
-    // consumer here; every idle thread's early_dispatch pass pops one, stages a range onto
-    // ITS OWN cores (range-claim via next_block_idx), and re-pushes if blocks remain
-    // — exactly mirroring how a partially-dispatched SPMD task is re-pushed to the
-    // ready queue (scheduler_dispatch: pop -> claim -> re-push). A stale/released
+    // consumer here; every idle thread's early_dispatch pass pops one, stages a range
+    // onto ITS OWN cores (range-claim via next_block_idx), and re-pushes if blocks
+    // remain — exactly mirroring how a partially-dispatched SPMD task is re-pushed to
+    // the ready queue (scheduler_dispatch: pop -> claim -> re-push). A stale/released
     // entry fails the STAGING check on pop and is dropped; a push that overflows is
     // logged and the consumer's blocks fall back to normal dispatch.
-    PTO2ReadyQueue early_dispatch_queue;
+    PTO2ReadyQueue early_dispatch_queues[PTO2_NUM_RESOURCE_SHAPES];
 
     static inline void ring_one_doorbell(uint64_t reg_addr, uint32_t token) {
         volatile uint64_t *dmb = reinterpret_cast<volatile uint64_t *>(get_reg_ptr(reg_addr, RegId::DATA_MAIN_BASE));
@@ -1026,7 +1031,7 @@ struct PTO2SchedulerState {
     // consumer's dispatch_fanin. A consumer whose dispatch_fanin reaches
     // fanin_actual_count (= every producer is either flagged-and-dispatched, or was
     // already complete when the consumer was wired) is an early-dispatch candidate:
-    // CAS NONE->STAGING (exactly-once) and push to early_dispatch_queue for the idle drain to
+    // CAS NONE->STAGING (exactly-once) and push to early_dispatch_queues[shape] for the idle drain to
     // pre-stage. Once-guarded per producer so an SPMD producer's block-by-block
     // dispatch propagates once. Only codegen-flagged producers propagate: a task's
     // successors early-dispatch off its DIRECT producers' marks, never an inherited chain.
@@ -1052,19 +1057,19 @@ struct PTO2SchedulerState {
             PTO2ResourceShape shape = c->active_mask.to_shape();
             if (shape != PTO2ResourceShape::AIC && shape != PTO2ResourceShape::AIV && shape != PTO2ResourceShape::MIX)
                 continue;
-            uint8_t expect = PTO2_SPEC_NONE;  // exactly-once: only the CAS winner enqueues
-            if (!c->payload->spec_state.compare_exchange_strong(
-                    expect, PTO2_SPEC_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+            uint8_t expect = PTO2_EARLY_DISPATCH_NONE;  // exactly-once: only the CAS winner enqueues
+            if (!c->payload->early_dispatch_state.compare_exchange_strong(
+                    expect, PTO2_EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
                 ))
                 continue;
-            early_dispatch_queue.push(c);
+            early_dispatch_queues[static_cast<int32_t>(shape)].push(c);
         }
     }
 
-    // Collects consumers released via the speculative-doorbell path during a
+    // Collects consumers released via the early-dispatch-doorbell path during a
     // single on_task_complete fanout walk, so their dispatch_fanin
     // propagation runs AFTER the walk — never between two siblings' doorbells.
-    struct SpecReleaseSink {
+    struct EarlyDispatchReleaseSink {
         static constexpr int CAP = 32;
         PTO2TaskSlotState *items[CAP];
         int n = 0;
@@ -1075,32 +1080,34 @@ struct PTO2SchedulerState {
         }
     };
 
-    inline bool try_speculative_release(PTO2TaskSlotState &slot_state, SpecReleaseSink *sink = nullptr) {
+    inline bool try_early_dispatch_release(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         // Never staged => CAS NONE->DISPATCHED wins => dispatch normally.
-        uint8_t expect = PTO2_SPEC_NONE;
-        if (slot_state.payload->spec_state.compare_exchange_strong(
-                expect, PTO2_SPEC_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
+        if (slot_state.payload->early_dispatch_state.compare_exchange_strong(
+                expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
             )) {
             return false;
         }
         // Staged (STAGING). Flip STAGING->DISPATCHED, THEN read the mask. seq_cst
         // gives a total order with the concurrent stagers, each of which OR-s its
-        // core into the mask and THEN loads spec_state: a stager whose bit lands
+        // core into the mask and THEN loads early_dispatch_state: a stager whose bit lands
         // before this CAS is read here and rung; a stager whose bit lands after
         // sees DISPATCHED and rings that core itself (self-ring in
         // stage_consumer_blocks). Either way every gated core's doorbell fires once
         // (a double-ring is harmless — the AICore already matched). This replaces
         // the old transient-STAGING spin: STAGING is now the stable gated state.
-        expect = PTO2_SPEC_STAGING;
-        slot_state.payload->spec_state.compare_exchange_strong(
-            expect, PTO2_SPEC_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        expect = PTO2_EARLY_DISPATCH_STAGING;
+        slot_state.payload->early_dispatch_state.compare_exchange_strong(
+            expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
         );
-        for (int w = 0; w < PTO2_SPEC_CORE_MASK_WORDS; w++) {
+        for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
                 int core_id = w * 64 + __builtin_ctzll(bits);
                 bits &= bits - 1;
-                ring_one_doorbell(spec_doorbell_table[core_id].addr, spec_doorbell_table[core_id].token);
+                ring_one_doorbell(
+                    early_dispatch_doorbell_table[core_id].addr, early_dispatch_doorbell_table[core_id].token
+                );
             }
         }
         // This pre-staged consumer was just released by its doorbell — it starts
@@ -1119,16 +1126,16 @@ struct PTO2SchedulerState {
         return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
     }
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, SpecReleaseSink *sink = nullptr) {
+    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
 
         if (new_refcount == slot_state.fanin_count) {
-            // Speculative early-dispatch: pre-staged tasks are released by doorbell
+            // Early-dispatch: pre-staged tasks are released by doorbell
             // here, skipping the ready-queue round-trip entirely.
-            if (try_speculative_release(slot_state, sink)) return true;
+            if (try_early_dispatch_release(slot_state, sink)) return true;
             push_ready_routed(&slot_state);
             return true;
         }
@@ -1137,15 +1144,16 @@ struct PTO2SchedulerState {
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     bool release_fanin_and_check_ready(
-        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait, SpecReleaseSink *sink = nullptr
+        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        EarlyDispatchReleaseSink *sink = nullptr
     ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
-            // Speculative early-dispatch: pre-staged tasks are released by doorbell
+            // Early-dispatch: pre-staged tasks are released by doorbell
             // here, skipping the ready-queue round-trip entirely.
-            if (try_speculative_release(slot_state, sink)) return true;
+            if (try_early_dispatch_release(slot_state, sink)) return true;
             // Dummy slots go to dummy_ready_queue; everything else to the per-shape
             // ready_queues[]. Use the profiling-aware push so atomic_count / push_wait
             // stay consistent with the non-dummy path.
@@ -1208,7 +1216,7 @@ struct PTO2SchedulerState {
      * Called exactly once when all subtasks of a task are done (i.e.,
      * on_subtask_complete returned true). Walks the consumer (fanout) list,
      * decrements each consumer's fanin, pushes newly-ready ones, and rings
-     * doorbells for speculative hits.
+     * doorbells for early-dispatch hits.
      *
      * Non-PROFILING returns the consumer-walk count (= edges traversed). The
      * Resolve swimlane bar reads it to label the bar with how many successors
@@ -1268,14 +1276,14 @@ struct PTO2SchedulerState {
         // on_task_complete runs — so a released consumer never reads stale
         // producer output. (Batching used to align the released wave, but pushed
         // every doorbell to the end of the walk, defeating the whole point of
-        // speculative early-dispatch: minimal producer-end -> consumer-start.)
+        // early-dispatch: minimal producer-end -> consumer-start.)
 #if PTO2_SCHED_PROFILING
         uint64_t fanout_atomics = 0, push_wait = 0;
 #endif
         // Doorbells for released pre-staged consumers fire INLINE in the walk
         // below; their dispatch_fanin propagation is collected here and replayed
         // after the walk, so no consumer's doorbell waits on a sibling's propagate.
-        SpecReleaseSink rel_sink;
+        EarlyDispatchReleaseSink rel_sink;
         while (current != nullptr) {
             PTO2TaskSlotState &consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -57,7 +57,7 @@ SlotTransition SchedulerContext::decide_slot_transition(
                 t.running_done = true;
                 t.running_freed = true;
             } else if (pending_gated) {
-                // Case 3.3: running FIN, pending is a SPECULATIVE GATED task. The
+                // Case 3.3: running FIN, pending is a EARLY-DISPATCH GATED task. The
                 // Case 3.1 "wait for the pending's ack" shortcut assumes the AICore
                 // immediately runs the pending task; a gated task instead spins on
                 // its doorbell and never acks until its producer completes — and
@@ -184,7 +184,7 @@ void SchedulerContext::complete_slot_task(
 #endif
 #if PTO2_PROFILING
         // Time Resolve (walk the consumer list, decrement each consumer's
-        // fanin, push the newly-ready ones, ring doorbells for speculative
+        // fanin, push the newly-ready ones, ring doorbells for early-dispatch
         // hits) so it renders as a child bar nested inside this iteration's
         // Complete bar. The 1 µs floor below filters out the ~88% of tasks
         // with 1-2 consumers (~500 ns Resolve) so only the long broadcast /
@@ -306,17 +306,17 @@ void SchedulerContext::check_running_cores_for_completion(
         int32_t core_id = tracker.get_core_id_by_offset(bit_pos);
         CoreExecState &core = core_exec_states_[core_id];
 
-        // Skip gated speculative cores. A STAGED task is parked on this core
+        // Skip gated early-dispatch cores. A STAGED task is parked on this core
         // waiting for its doorbell — it physically cannot ACK/FIN yet, so
         // reading its COND (MMIO, and the core is hot-spinning on its own SPR)
         // every poll is pure waste that drags out the completion phase. The
-        // doorbell (try_speculative_release) flips spec_state to DISPATCHED, at
+        // doorbell (try_early_dispatch_release) flips early_dispatch_state to DISPATCHED, at
         // which point the core becomes pollable again and its FIN is caught.
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
             PTO2TaskSlotState *rs = core.running_slot_state;
             if (rs != nullptr && rs->payload != nullptr &&
-                rs->payload->spec_state.load(std::memory_order_relaxed) == PTO2_SPEC_STAGING) {
+                rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) {
                 continue;
             }
         }
@@ -339,13 +339,14 @@ void SchedulerContext::check_running_cores_for_completion(
         }
 #endif
 
-        // A pending task is "gated" when it is a speculative pre-stage still
+        // A pending task is "gated" when it is a early-dispatch pre-stage still
         // waiting on its doorbell (STAGED): it will not ack on the producer's FIN,
         // so the Case 3.1 wait-for-pending-ack shortcut would deadlock. Detect it
         // so decide_slot_transition completes the running FIN and promotes it.
         bool pending_gated =
             (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr &&
-             core.pending_slot_state->payload->spec_state.load(std::memory_order_relaxed) == PTO2_SPEC_STAGING);
+             core.pending_slot_state->payload->early_dispatch_state.load(std::memory_order_relaxed) ==
+                 PTO2_EARLY_DISPATCH_STAGING);
         SlotTransition t = decide_slot_transition(
             reg_task_id, reg_state, core.running_reg_task_id, core.pending_reg_task_id, pending_gated
         );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -255,11 +255,16 @@ private:
         bool &entered_drain, bool &made_progress, bool &try_pushed
     );
 
-    // Speculative early-dispatch (Hook 1). After normal dispatch leaves idle
-    // cores spare, pre-stage the consumers of any RUNNING flagged producer onto
-    // those cores with not_ready=1 (gated). Touches no dependency state — the
-    // task is released by the doorbell at its normal ready-pop (Hook 2).
-    int32_t try_speculative_early_dispatch(int32_t thread_idx);
+    // Early-dispatch (Hook 1). Mirrors dispatch_ready_tasks: owns its
+    // own gating (off-PMU, this thread has a spare slot, and no normal ready work
+    // is queued) and sets made_progress / try_pushed when it stages, so the caller
+    // is a single unconditional call like normal dispatch. After normal dispatch
+    // leaves idle cores spare, pre-stage the consumers of any RUNNING flagged
+    // producer onto those cores with not_ready=1 (gated). Touches no dependency
+    // state — the task is released by the doorbell at its normal ready-pop (Hook 2).
+    int32_t try_early_dispatch(
+        int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+    );
 
     // Stage the already-claimed range [start, start+count) of consumer `c` onto
     // thread_idx's idle (RUNNING slot) then pending (gated-pending, promote-on-FIN)
@@ -271,6 +276,13 @@ private:
         int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
         CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
     );
+
+    // Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
+    // pre-stage claimed block ranges onto this thread's free cores of `shape` for the
+    // given phase (IDLE -> onto idle cores in the RUNNING slot; PENDING -> onto a
+    // running core's gated pending slot). Pop is sized to the shape's capacity exactly
+    // as dispatch_shape sizes normal dispatch. Returns the number of blocks staged.
+    int32_t early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase);
 
     // One pass of "Phase 4" in the resolve_and_dispatch loop: IDLE-stage dispatch
     // for MIX then (if no mix residual) AIC/AIV; then PENDING-stage dispatch with
@@ -302,6 +314,15 @@ private:
     // extra/missed AIC/AIV skip and self-corrects on the next loop iteration.
     bool has_residual_mix() const {
         return sched_->ready_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size() > 0;
+    }
+
+    // Early-dispatch analog of has_residual_mix: true if MIX early-dispatch candidates
+    // remain queued. has_residual_mix reads the normal MIX ready queue, which is empty
+    // whenever the Phase-4b early pass runs (it is gated on all ready_queues being
+    // empty), so early-dispatch MIX priority needs its own residual check against
+    // early_dispatch_queues[MIX]. Same relaxed-size snapshot caveat as has_residual_mix.
+    bool has_residual_early_mix() const {
+        return sched_->early_dispatch_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size() > 0;
     }
 
     // =========================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -45,10 +45,11 @@ namespace {
 inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
 }
 
-// The speculative core bitmask (PTO2_SPEC_CORE_MASK_WORDS * 64 bits) must cover
+// The early-dispatch core bitmask (PTO2_EARLY_DISPATCH_CORE_MASK_WORDS * 64 bits) must cover
 // every global core_id, and the per-core doorbell table is sized to match.
 static_assert(
-    RUNTIME_MAX_WORKER <= PTO2_SPEC_CORE_MASK_WORDS * 64, "staged_core_mask too small for RUNTIME_MAX_WORKER cores"
+    RUNTIME_MAX_WORKER <= PTO2_EARLY_DISPATCH_CORE_MASK_WORDS * 64,
+    "staged_core_mask too small for RUNTIME_MAX_WORKER cores"
 );
 
 const char *SchedulerContext::shape_name(PTO2ResourceShape shape) {
@@ -133,11 +134,12 @@ void SchedulerContext::build_payload(
     dispatch_payload.local_context.async_ctx = async_ctx;
     dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
     dispatch_payload.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
-    // Speculative early-dispatch: a task being staged (Hook 1 set spec_state to
+    // Early-dispatch: a task being staged (Hook 1 set early_dispatch_state to
     // STAGING before this call) is gated — the AICore must wait for the
     // DATA_MAIN_BASE high-32 doorbell. All other dispatches run on pickup.
     dispatch_payload.not_ready =
-        (slot_state.payload->spec_state.load(std::memory_order_relaxed) == PTO2_SPEC_STAGING) ? 1 : 0;
+        (slot_state.payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) ? 1 :
+                                                                                                                    0;
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
@@ -377,9 +379,9 @@ void SchedulerContext::dispatch_shape(
                 }
             }
 
-            // (Speculative pre-staged tasks never reach this ready-pop: they are
+            // (Early-dispatch pre-staged tasks never reach this ready-pop: they are
             // released by their doorbell in release_fanin_and_check_ready the
-            // instant their last producer completes — see try_speculative_release.)
+            // instant their last producer completes — see try_early_dispatch_release.)
 
             if (slot_state->active_mask.requires_sync_start()) {
                 if (is_pending) {
@@ -555,7 +557,7 @@ void SchedulerContext::dispatch_ready_tasks(
 //
 // Self-ring: release flips STAGING->DISPATCHED then rings the mask. A block staged
 // after that flip isn't in the mask release read, so this thread rings it here. The
-// seq_cst order between "OR mask then load spec_state" (here) and "store DISPATCHED
+// seq_cst order between "OR mask then load early_dispatch_state" (here) and "store DISPATCHED
 // then read mask" (release) guarantees every gated core's doorbell fires.
 int32_t SchedulerContext::stage_consumer_blocks(
     int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
@@ -565,7 +567,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
     // Stamp the real pre-stage time (NOT 0) so the swimlane shows these blocks
     // dispatched during the producer's run, not at trace start.
     uint64_t early_dispatch_ts = get_sys_cnt_aicpu();
-    uint64_t my_cores[PTO2_SPEC_CORE_MASK_WORDS] = {0};  // cores this thread gated (for self-ring)
+    uint64_t my_cores[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};  // cores this thread gated (for self-ring)
     int32_t staged = 0;
     int32_t block = start;
     // Mirror the normal flush_publish (scheduler_dispatch.cpp wmb()+publish loop):
@@ -593,26 +595,27 @@ int32_t SchedulerContext::stage_consumer_blocks(
         for (int i = 0; i < n; i++) {
             publish_subtask_to_core(handles[i], early_dispatch_ts);
             int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
-            sched_->spec_doorbell_table[cid].addr = handles[i].reg_addr;
-            sched_->spec_doorbell_table[cid].token = handles[i].reg_task_id;
+            sched_->early_dispatch_doorbell_table[cid].addr = handles[i].reg_addr;
+            sched_->early_dispatch_doorbell_table[cid].token = handles[i].reg_task_id;
             my_cores[cid >> 6] |= (1ULL << (cid & 63));
         }
     }
     // Publish all this thread's gated cores into the shared mask in one OR per word
     // (vs one per subtask) so release sees them; seq_cst keeps the self-ring order.
-    for (int w = 0; w < PTO2_SPEC_CORE_MASK_WORDS; w++)
+    for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
         if (my_cores[w] != 0) c->payload->staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
     // If release already flipped DISPATCHED, it may have read the mask before our
     // bits landed — ring our own cores so none is left gated forever.
-    if (staged > 0 && c->payload->spec_state.load(std::memory_order_seq_cst) == PTO2_SPEC_DISPATCHED) {
-        for (int w = 0; w < PTO2_SPEC_CORE_MASK_WORDS; w++) {
+    if (staged > 0 &&
+        c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_DISPATCHED) {
+        for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = my_cores[w];
             while (bits != 0) {
                 int cid = w * 64 + __builtin_ctzll(bits);
                 bits &= bits - 1;
                 PTO2SchedulerState::ring_one_doorbell(
-                    sched_->spec_doorbell_table[cid].addr, sched_->spec_doorbell_table[cid].token
+                    sched_->early_dispatch_doorbell_table[cid].addr, sched_->early_dispatch_doorbell_table[cid].token
                 );
             }
         }
@@ -620,64 +623,68 @@ int32_t SchedulerContext::stage_consumer_blocks(
     return staged;
 }
 
-// Early-dispatch drain (idle pass). Candidates are pushed to early_dispatch_queue
-// EVENT-DRIVEN by propagate_dispatch_fanin (a flagged producer's dispatch bumps its
-// consumers' dispatch_fanin; reaching fanin_count enqueues the consumer) — there is
-// no per-iteration PULL scan here anymore. This pass only DRAINS the queue.
-// Returns the number of blocks staged this pass (for the EarlyDispatch swimlane bar).
-int32_t SchedulerContext::try_speculative_early_dispatch(int32_t thread_idx) {
-    constexpr int PTO2_EARLY_DISPATCH_DRAIN_MAX = 8;  // bounded pops per pass
+// Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
+// pre-stage claimed block ranges onto this thread's `shape` cores for `phase`. IDLE
+// stages onto idle cores (RUNNING slot, gated); PENDING stages onto a running core's
+// gated pending slot. Candidates are pushed to the shape's queue EVENT-DRIVEN by
+// propagate_dispatch_fanin, so the shape is the queue index (no per-consumer
+// to_shape()). Returns the number of blocks staged.
+int32_t
+SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
     CoreTracker &tracker = core_trackers_[thread_idx];
-    int32_t total_staged = 0;
+    int32_t s = static_cast<int32_t>(shape);
+    bool is_mix = (shape == PTO2ResourceShape::MIX);
+    bool is_idle = (phase == CoreTracker::DispatchPhase::IDLE);
 
-    // Drain the queue — mirrors the normal SPMD dispatch path. Batch-pop up to
-    // DRAIN_MAX consumers in one queue op (fewer CAS than one pop per consumer, like
-    // normal dispatch's pop_ready_tasks_batch), then for each: CLAIM a range sized to
-    // THIS thread's free cores by advancing next_block_idx with a CAS (atomic —
-    // next_block_idx is shared with normal dispatch, which also claims it if release
-    // routes the consumer to the ready queue, so a plain store could double-dispatch),
-    // RE-PUSH it for peers, THEN do the expensive prepare+publish. Re-pushing before
-    // staging lets peers claim the next range and stage CONCURRENTLY — a wide consumer
-    // (online_softmax, 48 blocks) is filled by all idle threads in parallel. When this
-    // thread's cores run out mid-batch, the unprocessed remainder is pushed back for
-    // peers (mirrors normal's push_batch of the unconsumed tail).
-    PTO2TaskSlotState *batch[PTO2_EARLY_DISPATCH_DRAIN_MAX];
-    int got = sched_->early_dispatch_queue.pop_batch(batch, PTO2_EARLY_DISPATCH_DRAIN_MAX);
+    // Size the pop exactly as dispatch_shape does: MIX to the cluster count, else the
+    // phase's dispatchable-core count. Skip the queue entirely when no core is free
+    // for this shape+phase (avoids a pointless pop + immediate push-back).
+    CoreTracker::BitStates cores =
+        is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
+    if (!cores.has_value()) return 0;
+
+    int32_t total_staged = 0;
+    PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
+    // bounded by the shape's capacity so the stack buffer always holds it. Then for
+    // each consumer: CLAIM a range sized to THIS thread's free cores by advancing
+    // next_block_idx with a CAS (atomic — next_block_idx is shared with normal
+    // dispatch, which also claims it if release routes the consumer to the ready
+    // queue, so a plain store could double-dispatch), RE-PUSH it for peers, THEN do
+    // the expensive prepare+publish. Re-pushing before staging lets peers claim the
+    // next range and stage CONCURRENTLY — a wide consumer (online_softmax, 48 blocks)
+    // is filled by all idle threads in parallel. When cores run out mid-batch the
+    // unprocessed remainder is pushed back for peers (mirrors normal's push_batch of
+    // the unconsumed tail).
+    int got = sched_->early_dispatch_queues[s].pop_batch(batch, cores.count());
     for (int bi = 0; bi < got; bi++) {
         PTO2TaskSlotState *c = batch[bi];
-        if (c->payload->spec_state.load(std::memory_order_acquire) != PTO2_SPEC_STAGING) continue;  // released
-        PTO2ResourceShape shape = c->active_mask.to_shape();
-        CoreTracker::BitStates idle, pend;
-        if (shape == PTO2ResourceShape::MIX) {
-            // Active-mask-aware whole-cluster selection, matching normal dispatch's
-            // classify_mix_cluster: only the task's used cores must be idle (running
-            // placement) or running + pending-free (pending placement). Unused cores
-            // in the cluster are ignored, so early dispatch no longer strands a MIX
-            // whose unused AIV is busy. One inline scan fills BOTH buckets because
-            // early dispatch needs them at once (freecores + two-bucket staging),
-            // unlike normal dispatch which is phase-split and handles one per call.
+        if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
+            continue;  // released
+
+        // The single free-core bucket for this phase. For MIX, an active-mask-aware
+        // whole-cluster scan keeps only the clusters whose placement matches the phase
+        // (RUNNING placement for IDLE, PENDING placement for PENDING), matching normal
+        // dispatch's classify_mix_cluster — unused cores in the cluster are ignored, so
+        // a MIX whose unused AIV is busy is not stranded. For AIC/AIV it is just the
+        // phase's dispatchable cores.
+        CoreTracker::BitStates bucket;
+        if (is_mix) {
+            auto wanted = is_idle ? CoreTracker::MixPlacement::RUNNING : CoreTracker::MixPlacement::PENDING;
             uint8_t cmask = c->active_mask.core_mask();
             CoreTracker::BitStates candidates = tracker.get_cluster_offset_states();
             while (candidates.has_value()) {
                 int32_t cluster_offset = candidates.pop_first();
-                switch (tracker.classify_mix_cluster(cluster_offset, cmask)) {
-                case CoreTracker::MixPlacement::RUNNING:
-                    idle |= CoreTracker::BitStates(1ULL << cluster_offset);
-                    break;
-                case CoreTracker::MixPlacement::PENDING:
-                    pend |= CoreTracker::BitStates(1ULL << cluster_offset);
-                    break;
-                default:
-                    break;
+                if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
+                    bucket |= CoreTracker::BitStates(1ULL << cluster_offset);
                 }
             }
         } else {
-            idle = tracker.get_idle_core_offset_states(shape);
-            pend = tracker.get_pending_core_offset_states(shape);
+            bucket = tracker.get_dispatchable_cores(shape, phase);
         }
-        int32_t freecores = (idle.has_value() ? idle.count() : 0) + (pend.has_value() ? pend.count() : 0);
-        if (freecores == 0) {  // no free cores of this shape — give this + the unprocessed rest back and stop
-            sched_->early_dispatch_queue.push_batch(&batch[bi], got - bi);
+        int32_t freecores = bucket.has_value() ? bucket.count() : 0;
+        if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
+            sched_->early_dispatch_queues[s].push_batch(&batch[bi], got - bi);
             break;
         }
         // CAS-claim a contiguous range [start, start+claim) sized to this thread's
@@ -699,12 +706,96 @@ int32_t SchedulerContext::try_speculative_early_dispatch(int32_t thread_idx) {
         if (claim == 0) continue;  // nothing left to claim -> drop (no re-push)
         // Re-push for concurrent peers BEFORE the expensive staging.
         if (start + claim < c->logical_block_num) {
-            if (!sched_->early_dispatch_queue.push(c))
+            if (!sched_->early_dispatch_queues[s].push(c))
                 LOG_INFO_V9(
-                    "[SPEC] queue full on re-push, consumer=%" PRId64, static_cast<int64_t>(c->task->task_id.raw)
+                    "[EARLY_DISPATCH] queue full on re-push, consumer=%" PRId64,
+                    static_cast<int64_t>(c->task->task_id.raw)
                 );
         }
-        total_staged += stage_consumer_blocks(thread_idx, c, shape, start, claim, idle, pend);
+        // stage_consumer_blocks fills the idle bucket (RUNNING slot) then the pend
+        // bucket (gated pending); pass this phase's bucket in the matching slot and an
+        // empty other so only the phase's cores are staged.
+        CoreTracker::BitStates empty(0ULL);
+        total_staged += is_idle ? stage_consumer_blocks(thread_idx, c, shape, start, claim, bucket, empty) :
+                                  stage_consumer_blocks(thread_idx, c, shape, start, claim, empty, bucket);
+    }
+    return total_staged;
+}
+
+// Early-dispatch drain (idle pass), mirroring dispatch_ready_tasks: owns its own
+// gating and progress-flag updates, and orders staging the same way — MIX strict
+// priority, IDLE stage before PENDING stage, cross-thread idle gating
+// (MIX-IDLE ▶ c/v-IDLE ▶ MIX-PEND ▶ c/v-PEND). sync_start doesn't apply here (those
+// tasks are excluded from early dispatch at push time, propagate_dispatch_fanin).
+// Returns the number of blocks staged this pass (for the EarlyDispatch swimlane bar).
+int32_t SchedulerContext::try_early_dispatch(
+    int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+) {
+    using Phase = CoreTracker::DispatchPhase;
+
+    // Gate, owned here rather than by the caller (mirrors dispatch_ready_tasks
+    // withholding PENDING under PMU internally):
+    //   - pmu_active: staging gated work perturbs the single-issue PMU windows the
+    //     same way dual-issue PENDING dispatch does, so early dispatch is off.
+    //   - has_any_free_slot: this thread has no spare capacity to stage onto (a
+    //     purely local read; a fully-occupied thread bails before touching shared
+    //     queues).
+    //   - ready_queues empty: normal dispatch strictly precedes early — there is no
+    //     real ready task to delay only when every ready queue is drained.
+    if (pmu_active || !tracker.has_any_free_slot()) return 0;
+    for (int s = 0; s < PTO2_NUM_RESOURCE_SHAPES; s++) {
+        if (sched_->ready_queues[s].size() > 0) return 0;
+    }
+
+    // AIC/AIV order toggled by thread parity for shape-level load balancing, matching
+    // dispatch_ready_tasks. MIX is handled explicitly at the top of each stage.
+    static constexpr PTO2ResourceShape kAicAivOrder[2][2] = {
+        {PTO2ResourceShape::AIC, PTO2ResourceShape::AIV},
+        {PTO2ResourceShape::AIV, PTO2ResourceShape::AIC},
+    };
+    const PTO2ResourceShape *aic_aiv = kAicAivOrder[thread_idx & 1];
+
+    int32_t total_staged = 0;
+
+    // ===== IDLE stage =====
+    total_staged += early_dispatch_shape(thread_idx, PTO2ResourceShape::MIX, Phase::IDLE);
+
+    // MIX strict priority: with MIX candidates still queued, AIC/AIV yield this pass so
+    // the residual mix keeps its clusters. Uses the early-queue residual (the normal
+    // MIX ready queue is empty whenever this pass runs).
+    bool skip_aic_aiv = has_residual_early_mix();
+    if (!skip_aic_aiv) {
+        for (int i = 0; i < 2; i++) {
+            total_staged += early_dispatch_shape(thread_idx, aic_aiv[i], Phase::IDLE);
+        }
+    }
+
+    // ===== PENDING stage =====
+    // MIX-PENDING gate: skip when a peer has an idle MIX-capable cluster — that peer's
+    // next IDLE-MIX pass pulls the mix candidate from the shared queue at lower latency.
+    if (!has_idle_in_other_threads(thread_idx, PTO2ResourceShape::MIX)) {
+        total_staged += early_dispatch_shape(thread_idx, PTO2ResourceShape::MIX, Phase::PENDING);
+    }
+
+    // Re-check residual mix after MIX-PENDING; escalate the skip if it left residual.
+    if (!skip_aic_aiv && has_residual_early_mix()) {
+        skip_aic_aiv = true;
+    }
+    // AIC/AIV-PENDING, each gated on no peer being idle for that shape (a skip is a
+    // delay, not a loss — the peer pulls from the shared queue on its next IDLE pass).
+    if (!skip_aic_aiv) {
+        for (int i = 0; i < 2; i++) {
+            PTO2ResourceShape s = aic_aiv[i];
+            if (has_idle_in_other_threads(thread_idx, s)) continue;
+            total_staged += early_dispatch_shape(thread_idx, s, Phase::PENDING);
+        }
+    }
+
+    // Staging is dispatch work: reset the idle/stall clock and route this iter's tail
+    // cycles to the dispatch accumulator, exactly as normal dispatch does.
+    if (total_staged > 0) {
+        made_progress = true;
+        try_pushed = true;
     }
     return total_staged;
 }
@@ -1147,29 +1238,17 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
 #endif
 
-        // Phase 4b: early-dispatch onto spare cores. Runs only when this thread
-        // has spare capacity AND no real ready work is queued. Two gates, cheapest
-        // and most-local first:
-        //   1. has_any_free_slot() — reads only this thread's core tracker (no
-        //      shared/atomic access). A fully-occupied thread skips here, never
-        //      touching the shared ready_queues or the shared early_dispatch_queue.
-        //   2. ready_queues empty — keeps early-dispatch from delaying a real ready
-        //      task (there is none to delay when empty).
-        // pmu_active also disables it: dispatch_ready_tasks already withholds
-        // PENDING dispatch under PMU to preserve single-issue windows, and staging
-        // gated work would perturb the same windows. The old try_pushed gate is
-        // gone on purpose — discovery is event-driven (propagate_dispatch_fanin),
-        // so this pass only drains the queue, and spare cores left after a partial
-        // dispatch get pre-staged the same iteration instead of waiting a round.
-        bool run_early_dispatch = !pmu_active && tracker.has_any_free_slot();
-        for (int s = 0; run_early_dispatch && s < PTO2_NUM_RESOURCE_SHAPES; s++) {
-            if (sched_->ready_queues[s].size() > 0) run_early_dispatch = false;
-        }
+        // Phase 4b: early-dispatch onto spare cores, mirroring the Phase 4 call
+        // shape. try_early_dispatch owns its own gating (off-PMU, this
+        // thread has a spare slot, no normal ready work queued) and updates
+        // made_progress / try_pushed, so this is a single unconditional call — it
+        // returns 0 without staging when gated out.
 #if PTO2_PROFILING
         bool early_dispatch_record = l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES;
         uint64_t early_dispatch_t0 = early_dispatch_record ? get_sys_cnt_aicpu() : 0;
 #endif
-        [[maybe_unused]] int32_t staged_count = run_early_dispatch ? try_speculative_early_dispatch(thread_idx) : 0;
+        [[maybe_unused]] int32_t staged_count =
+            try_early_dispatch(thread_idx, tracker, pmu_active, made_progress, try_pushed);
 #if PTO2_PROFILING
         // Emit an EarlyDispatch bar so a staging-dominated iteration is attributed
         // to early-dispatch rather than disappearing into a blank gap.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -215,7 +215,17 @@ public:
     // ~pending_occupied_ over all cores is exactly "has a free slot". Purely
     // local (no shared/atomic access) — used to skip early dispatch, and its
     // shared-queue pop, when this thread has no capacity at all.
-    bool has_any_free_slot() const { return ((~pending_occupied_) & (aic_mask_ | aiv_mask_)).has_value(); }
+    // BitStates of every core on this thread with a free slot to stage onto: a
+    // core is unavailable only when running AND its pending slot is occupied.
+    // Idle cores keep pending_occupied_ clear by invariant, so ~pending_occupied_
+    // over aic|aiv is exactly "has a free slot". Spans AIC+AIV, so its .count() is
+    // an upper bound on the early-dispatch drain's per-shape pop (never exceeds the
+    // thread's total free cores), and .has_value() is the has_any_free_slot()
+    // predicate that gates the Phase-4b early-dispatch pass. Purely local (no
+    // shared/atomic access).
+    BitStates get_free_slot_states() const { return (~pending_occupied_) & (aic_mask_ | aiv_mask_); }
+
+    bool has_any_free_slot() const { return get_free_slot_states().has_value(); }
 
     template <CoreType CT>
     int32_t get_running_count() const {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -141,7 +141,9 @@ PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_ca
         layout.off_ready_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     }
     layout.off_dummy_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
-    layout.off_early_dispatch_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
+    }
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         // Force a cache-line base so writes from scheduler thread 0 (sole
         // writer of this ring's dep_pool) do not invalidate adjacent
@@ -181,10 +183,13 @@ bool PTO2SchedulerState::init_data_from_layout(
         )) {
         return false;
     }
-    if (!ready_queue_init_data_from_layout(
-            &sched->early_dispatch_queue, arena, layout.off_early_dispatch_queue_slots, PTO2_EARLY_DISPATCH_QUEUE_SIZE
-        )) {
-        return false;
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        if (!ready_queue_init_data_from_layout(
+                &sched->early_dispatch_queues[i], arena, layout.off_early_dispatch_queue_slots[i],
+                PTO2_EARLY_DISPATCH_QUEUE_SIZE
+            )) {
+            return false;
+        }
     }
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
@@ -221,7 +226,9 @@ void PTO2SchedulerState::reset_for_reuse(const PTO2SchedulerLayout &layout, void
         sched->ready_queues[i].reset_for_reuse();
     }
     sched->dummy_ready_queue.reset_for_reuse();
-    sched->early_dispatch_queue.reset_for_reuse();
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->early_dispatch_queues[i].reset_for_reuse();
+    }
 
     sched->wiring.queue.reset_for_reuse();
     sched->wiring.batch_count = 0;
@@ -239,7 +246,11 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
         ready_queue_wire_arena_pointers(&sched->ready_queues[i], arena, layout.off_ready_queue_slots[i]);
     }
     ready_queue_wire_arena_pointers(&sched->dummy_ready_queue, arena, layout.off_dummy_ready_queue_slots);
-    ready_queue_wire_arena_pointers(&sched->early_dispatch_queue, arena, layout.off_early_dispatch_queue_slots);
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        ready_queue_wire_arena_pointers(
+            &sched->early_dispatch_queues[i], arena, layout.off_early_dispatch_queue_slots[i]
+        );
+    }
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].dep_pool.base =
             static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
@@ -258,7 +269,9 @@ void PTO2SchedulerState::destroy() {
         ready_queue_destroy(&sched->ready_queues[i]);
     }
     ready_queue_destroy(&sched->dummy_ready_queue);
-    ready_queue_destroy(&sched->early_dispatch_queue);
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        ready_queue_destroy(&sched->early_dispatch_queues[i]);
+    }
 }
 
 // =============================================================================

--- a/src/a5/platform/include/common/l2_swimlane_profiling.h
+++ b/src/a5/platform/include/common/l2_swimlane_profiling.h
@@ -508,13 +508,13 @@ enum class L2SwimlaneSchedPhaseKind : uint32_t {
                         // tasks_processed = wired count.
     Dummy = 4,          // dummy_drain outer bar: covers handling of all dummies
                         // popped this iter. tasks_processed = dummy_got count.
-    EarlyDispatch = 5,  // try_speculative_early_dispatch: speculative pre-staging
+    EarlyDispatch = 5,  // try_early_dispatch: early-dispatch pre-staging
                         // of a flagged producer's consumer's gated blocks.
                         // tasks_processed = blocks staged this pass.
     // Inner (parent: Complete | Dummy)
     Resolve = 6,  // on_task_complete: walk consumer list, decrement fanin,
                   // push newly-ready successors, ring doorbells for
-                  // speculative hits. tasks_processed = # consumers visited.
+                  // early-dispatch hits. tasks_processed = # consumers visited.
     // Separate-lane (Worker View pid=4 AICPU_N)
     DummyTask = 7,  // Per-dummy identity marker (zero-width). tasks_processed
                     // = task_token_raw low 32 bits so deps.json flow arrows


### PR DESCRIPTION
## What

Unifies the early-dispatch (ed) path in the a2a3 `tensormap_and_ringbuffer`
scheduler with the normal-dispatch (nd) path so the scheduler's two task sources
share the same primitives — pop sizing, gate helpers, staging, ordering, and
progress accounting. This change:

1. **Sizes the drain pop to free-slot count, not a fixed 8** — ed drained a
   hardcoded 8 consumers per pass while nd sizes its pop to available capacity.
   Both now use the same `BitStates.count()` sizing (new
   `CoreTracker::get_free_slot_states()` primitive; `has_any_free_slot()`
   re-expressed on top of it).

2. **Splits the early-dispatch queue per resource shape** — the single
   shape-mixed `early_dispatch_queue` becomes `early_dispatch_queues[3]`,
   mirroring the per-shape `ready_queues[]`. Candidates bucket by
   `active_mask.to_shape()` at push time; the drain pops per shape with the shape
   known as the queue index (reserve/init/wire/reset/destroy loop over the three
   queues, symmetric with `ready_queues[]`).

3. **Gives ed MIX-priority two-stage ordering** — the same ordering nd uses: MIX
   strict priority, IDLE stage before PENDING stage, cross-thread idle gating —
   MIX-IDLE ▶ c/v-IDLE ▶ MIX-PEND ▶ c/v-PEND. New `early_dispatch_shape()` (the ed
   analog of `dispatch_shape`) reuses `has_idle_in_other_threads` and stages onto
   only the phase's bucket; new `has_residual_early_mix()` for the MIX gate
   (`has_residual_mix` reads the normal MIX ready queue, empty when ed runs).

4. **Encapsulates gating + updates progress flags** — ed's gate (off-PMU,
   `has_any_free_slot`, all ready_queues empty) moves inside `try_early_dispatch`
   (mirroring how `dispatch_ready_tasks` owns its own PMU/gating), so the caller
   is a single unconditional call; `made_progress`/`try_pushed` are set when
   staging, so an iteration that only early-stages is no longer miscounted as
   idle.

5. **Drops all "speculative"/"spec" naming** for the ed path — it is just
   early-dispatch now. Pure behavior-neutral rename:
   `try_speculative_early_dispatch` → `try_early_dispatch`,
   `try_speculative_release` → `try_early_dispatch_release`, enum
   `PTO2SpecState` → `PTO2EarlyDispatchState` (values `PTO2_SPEC_*` →
   `PTO2_EARLY_DISPATCH_*`, integer values unchanged), `spec_state` →
   `early_dispatch_state`, `spec_doorbell_table` →
   `early_dispatch_doorbell_table`, `SpecDoorbell` → `EarlyDispatchDoorbell`,
   `SpecReleaseSink` → `EarlyDispatchReleaseSink`, the `[SPEC]` log tag, and all
   speculative/spec comments. CPU load-speculation and launch/hardware
   "spec"(ification) terms are deliberately left unchanged.

## Why

The two dispatch sources had diverged: nd sized pops to capacity, ordered by
MIX-priority / IDLE-then-PENDING, and updated the loop's progress flags from a
single encapsulated call; ed used a flat fixed-8 drain over a mixed queue with
caller-side gating and no progress-flag updates. Aligning them makes the
scheduler's two task sources behave consistently and share the same primitives.

## Scope / notes

- **a2a3 only** — the a5 `tensormap_and_ringbuffer` runtime has no early-dispatch
  path (the rename additionally tidies one mirrored comment in the shared a5
  `l2_swimlane_profiling.h`).
- **PMU**: ed stays fully disabled under PMU (unchanged); nd already does
  IDLE-only under PMU. Aligning ed to IDLE-only under PMU was considered and
  dropped — a gated core polls DMB (MMIO) while waiting for its doorbell, which
  would perturb the single-issue measurement windows PMU relies on.
- **Parallel skeleton** (not folded into `dispatch_shape`): early staging is
  gated pre-stage + doorbell, distinct from normal immediate dispatch.
- **Docs**: no design doc describes the early-dispatch queue/ordering; the
  `early_dispatch` L2-swimlane bar (name and semantics) is unchanged, so no doc
  update is needed.

## Testing

a2a3sim: ~15 SPMD / MIX / dependency-heavy scene tests pass
(`spmd_multiblock_mix`/`_aiv`, `spmd_starvation`, `spmd_sync_start`/`_stress`,
paged_attention family, `alternating_matmul_add`, `fanin_lookup_perf`,
`mixed_example`, `dummy_task`) — no deadlock, no golden drift, no timeout/stall
regression. Built + resynced + tested against latest upstream/main. a2a3 onboard
not run (box is a5 silicon); sim is the silicon-agnostic path — onboard left to
CI.

