### PR TITLE
Update: improve L2 swimlane SPMD flow anchors

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -35,10 +35,11 @@ available.
   [§3.5](#35-dependency-arrows-from-dep_gen).
 - **AICPU scheduler phases** — per-iteration breakdown into six
   mutually time-exclusive **outer** phases (`complete` / `dispatch`
-  / `release` / `wire` / `dummy` / `early_dispatch`), one **inner**
-  phase that nests inside its parent outer (`resolve`, parent =
-  Complete or Dummy), and one **separate-lane** phase
-  (`dummy_task`, rendered on Worker View AICPU_N rather than on the
+  / `release` / `wire` / `dummy` / `early_dispatch`), one logical
+  **inner** phase (`resolve`, parent = Complete or Dummy) rendered on a
+  sibling scheduler sub-lane with the same `Sched_N` label and adjacent tid,
+  and one **separate-lane**
+  phase (`dummy_task`, rendered on Worker View AICPU_N rather than on the
   sched lane). Idle iterations no longer emit a record on a2a3; the
   host tooling reconstructs idle spans from the gap between
   consecutive work records on the same thread. See §3.2 for the
@@ -231,16 +232,17 @@ field but render differently in Perfetto:
 | `wire` | outer | sched | tasks wired by `drain_wiring_queue` this iter |
 | `dummy` | outer | sched | dummies handled by `dummy_drain` this iter |
 | `early_dispatch` | outer | sched | blocks staged by speculative early-dispatch this pass |
-| `resolve` | inner | sched (nests in `complete` or `dummy`) | consumers visited in `on_task_complete` |
+| `resolve` | inner | sched sub-lane, same `Sched_N` label as its outer lane | consumers visited in `on_task_complete` |
 | `dummy_task` | separate-lane | Worker View AICPU_N (pid=4) | dummy `task_id` low 32 bits (deps.json flow target) |
 
 Outer phases are mutually time-exclusive within an iter — each
 emit advances the per-thread phase anchor (`_t0_phase`). Inner
-phases (`resolve`) don't advance the anchor; Perfetto nests them
-under the parent outer bar via time containment. Separate-lane
-phases are routed to a different lane by the converter (Worker
-View AICPU_N), so they never overlap visually with the sched
-lane bars even when their timestamps fall inside an outer span.
+phases (`resolve`) don't advance the anchor; the converter renders
+them on a sibling `Sched_N` tid so flow arrows attach to the outer
+`complete`/`dummy` lane instead of being visually captured by the inner
+slice. Separate-lane phases are routed to a different lane by the converter
+(Worker View AICPU_N), so they never overlap visually with the sched lane
+bars even when their timestamps fall inside an outer span.
 
 Legacy phases (`scan` / `poll` / `idle` / `fanout` / `prestage`)
 are still parsed for old captures but current a2a3/a5 builds no
@@ -285,20 +287,29 @@ in. The trace contains:
   blocks coloured by `phase` (level >= 3). The six outer phases
   (`complete` / `dispatch` / `release` / `wire` / `dummy` /
   `early_dispatch`) appear as sibling bars on each scheduler
-  thread's lane; the `resolve` inner phase nests inside its
-  parent (`complete` or `dummy`).
+  thread's first `Sched_N` lane; the `resolve` inner phase appears on an
+  adjacent `Sched_N` sub-lane.
 - **Scheduler View** (pid=3) — task-execution overlay using AICPU
   dispatch/finish timestamps (level >= 2), with the same labels
   as Worker View.
 - **Worker View** (pid=4) — one swim-lane per physical worker:
-  - `AIC_N` — matrix cores (kernel exec from level >= 1)
-  - `AIV_N` — vector cores (kernel exec from level >= 1)
+  - `AIC_N` — matrix cores (receive → kernel end from level >= 1)
+  - `AIV_N` — vector cores (receive → kernel end from level >= 1)
   - `AICPU_N` — AICPU acting as worker; carries `dummy_task`
     zero-width markers (one per dummy drained by the sched
     thread on AICPU N) and `alloc` bars (from `alloc_tensors()`
     calls that the orchestrator on AICPU 0 inline-completed).
     Both are activities the AICPU performs as a worker, so they
     share the same lane tier as AIC/AIV.
+  AIC/AIV hover args keep both `kernel-duration-us` and
+  `local_setup_us`; the old standalone setup preview bar is folded
+  into the task bar.
+
+`merged_swimlane.json` no longer emits separate `setup` X events.
+For AIC/AIV tasks, the Worker View task bar starts at `receive_time_us`
+and ends at `end_time_us`; the kernel-only duration remains available as
+`kernel-duration-us`, and the receive→start setup interval remains
+available as `local_setup_us` in the task's hover args.
 
 **Task labeling (AICore View and AICPU View) depends entirely on
 whether a `deps.json` is present** (see
@@ -458,11 +469,27 @@ that something dropped on the way from dep_gen to converter.
 
 **SPMD dependency arrows.** For logical tasks with `block_num > 1`,
 dependency / `hb_violation` flows connect via **anchor pairing** on
-physical core lanes — there is no dedicated `SPMD (block-level)` track.
+the Worker View and Scheduler View task lanes — there is no dedicated
+`SPMD (block-level)` track.
 
-SPMD tasks use the minimum-`core_id` subtask row per `core_type` as the
-dependency anchor; MIX-type SPMD tasks pick the minimum separately for
-AIC and AIV.
+SPMD tasks use the earliest-start subtask row for each
+`(func_id, task_id)` group as the dependency anchor. This keeps one
+representative endpoint per logical function within a task in each view
+and makes the task-dependency arrows share the same anchor records
+as the `complete` flow. The anchor decision includes both the function
+identity and the logical `task_id` (ring/local id), so MIX tasks that
+share a `task_id` across AIC/AIV functions keep separate anchors. The
+converter does not draw one arrow per subtask instance.
+
+**`complete` arrows.** Like the dependency mirror, the per-task
+`complete` flow (task → the pid=2 `complete` phase that observed its
+last subtask FIN) is drawn from **both** task views on the same anchor
+rows: the Worker View source anchors on the kernel slice (`end_time_us`),
+the Scheduler View source anchors on the AICPU `finish_time_us`. Both
+mirrors land on the identical pid=2 endpoint (thread + timestamp), so
+clicking the task in either view surfaces the arrow without changing
+completion attribution. The Scheduler View mirror is skipped for an
+anchor with no AICPU finish (its pid=3 bar does not exist).
 
 Non-SPMD tasks (including MIX multi-slot kernels with `block_num == 1`)
 keep every subtask row as an endpoint (N×N pairing unchanged).
@@ -506,9 +533,8 @@ What the swimlane shows:
   so Perfetto draws arrows between predecessor and successor tasks
   — see [§3.5](#35-dependency-arrows-from-dep_gen). Without
   `deps.json` the trace is correct but unarrowed. For SPMD tasks,
-  dependency arrows use the minimum-`core_id` subtask row per
-  `core_type` as the anchor; MIX-type SPMD tasks pick the
-  minimum-`core_id` subtask separately for AIC and AIV.
+  dependency arrows use the earliest-start subtask row per
+  `(func_id, task_id)` group as the anchor.
 - **Scheduler-loop time decomposition.** Per-iteration AICPU
   phase records show how long the scheduler spent in each of
   its two work phases (complete / dispatch); idle is recovered

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -223,8 +223,8 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
         # Column count varies (v2: 5, v3: 6); only the timing columns matter
         # for base_time tracking. For v3, the per-task receive_time =
         # start_cycles - receive_to_start_cycles is earlier than start_cycles
-        # itself; track it so the v3 setup-bar (ts = receive_time) doesn't
-        # land at a negative offset relative to the kernel-bar base.
+        # itself; track it so Worker View task bars that start at receive_time
+        # don't land at a negative offset relative to the kernel start.
         start_c = int(row[3])
         end_c = int(row[4])
         r2s_c = int(row[5]) if len(row) > 5 else 0
@@ -526,19 +526,28 @@ def _identify_spmd_task_ids(task_map, deps_block_map=None):
 
 
 def _dependency_flow_anchor_rows(task_id, task_map, spmd_task_ids):
-    """Dependency anchor rows: all subtask rows for non-SPMD; min core_id per core_type for SPMD."""
+    """Dependency anchor rows.
+
+    Non-SPMD keeps every subtask row. SPMD collapses rows by
+    ``(func_id, task_id)`` and keeps the earliest-start row in each group, so
+    MIX tasks with shared task_id but distinct AIC/AIV func_id values remain
+    visible as separate dependency endpoints.
+    """
     recs = task_map.get(task_id, [])
     if not recs:
         return []
     if task_id not in spmd_task_ids:
         return recs
-    by_type: dict[str, dict] = {}
+    by_func: dict[int, dict] = {}
     for row in recs:
-        core_type = row.get("core_type") or "unknown"
-        prev = by_type.get(core_type)
-        if prev is None or row["core_id"] < prev["core_id"]:
-            by_type[core_type] = row
-    return list(by_type.values())
+        func_id = row.get("func_id", -1)
+        prev = by_func.get(func_id)
+        if prev is None or (row.get("start_time_us", float("inf")), row.get("core_id", 0)) < (
+            prev.get("start_time_us", float("inf")),
+            prev.get("core_id", 0),
+        ):
+            by_func[func_id] = row
+    return list(by_func.values())
 
 
 def _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids):
@@ -1129,15 +1138,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             for succ in succs:
                 fanin_map[succ].append(pred)
 
-    # One clock period at the AICore counter resolution. The device counter
-    # ticks at 50 MHz on a2a3 (20 ns) — sub-period local_setup intervals are
-    # noise (warm dcci is cycle-zero), so don't emit invisible zero-width bars.
-    _SETUP_MIN_US = 0.02
-
     for task in tasks:
         tid = core_to_tid[task["core_id"]]
-        ts = task["start_time_us"]
-        dur = task["duration_us"]
+        local_setup_us = task.get("local_setup_us", 0.0) or 0.0
+        receive_time_us = task.get("receive_time_us")
+        ts = receive_time_us if receive_time_us is not None else task["start_time_us"]
+        dur = task["end_time_us"] - ts
 
         # func_id is already resolved (level=1 records recovered from
         # dep_gen's kernel_ids up front; see the pre-pass above). Without a
@@ -1154,35 +1160,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         fanout_str = f"{len(fanout_ids)}: [" + ", ".join(format_task_display(x) for x in fanout_ids) + "]"
         fanin_str = f"{len(fanin_ids)}: [" + ", ".join(format_task_display(x) for x in fanin_ids) + "]"
 
-        # Setup bar (receive → start): visualises AICore-local critical-path
-        # prep (dcci + ack for the common path, ack-only for speculation-hit
-        # path — see docs/investigations/2026-06-aicore-cold-start-warmup.md).
-        # Same `name` across all setup bars → Perfetto auto-assigns one
-        # consistent color, distinct from kernel bars. Emit only when above
-        # one clock period; warm-cache dcci+ack lands sub-period and would
-        # render as an invisible zero-width slice.
-        local_setup_us = task.get("local_setup_us", 0.0) or 0.0
-        receive_time_us = task.get("receive_time_us")
-        if local_setup_us >= _SETUP_MIN_US and receive_time_us is not None:
-            events.append(
-                {
-                    "args": {
-                        "event-hint": f"setup: dcci+ack for Task:{tdisp} CoreId:{task['core_id']}",
-                        "local_setup_us": local_setup_us,
-                        "taskId": task["task_id"],
-                    },
-                    "cat": "event",
-                    "id": event_id,
-                    "name": "setup",
-                    "ph": "X",
-                    "pid": 4,
-                    "tid": tid,
-                    "ts": receive_time_us,
-                    "dur": local_setup_us,
-                }
-            )
-            event_id += 1
-
         events.append(
             {
                 "args": {
@@ -1190,6 +1167,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "fanout-hint": fanout_str,
                     "fanin-hint": fanin_str,
                     "duration-us": dur,
+                    "kernel-duration-us": task["duration_us"],
+                    "local_setup_us": local_setup_us,
                     "taskId": task["task_id"],
                 },
                 "cat": "event",
@@ -1382,6 +1361,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
 
     # AICPU Scheduler phase events (l2_swimlane_level >= 3)
     if scheduler_phases:
+
+        def sched_lane_tid(thread_idx, lane=0):
+            return 30000 + thread_idx * 10 + lane
+
         # Process metadata
         events.append(
             {"args": {"name": "AICPU Scheduler"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 2}
@@ -1491,7 +1474,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         DUMMY_BAR_MIN_DUR_US = 0.02  # noqa: N806
 
         for thread_idx, thread_records in enumerate(scheduler_phases):
-            tid = 3000 + thread_idx
+            tid = sched_lane_tid(thread_idx, 0)
+            resolve_tid = sched_lane_tid(thread_idx, 1)
 
             # Thread name metadata
             events.append(
@@ -1504,6 +1488,17 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "tid": tid,
                 }
             )
+            if any(record.get("phase") == "resolve" for record in thread_records):
+                events.append(
+                    {
+                        "args": {"name": f"Sched_{thread_idx}"},
+                        "cat": "__metadata",
+                        "name": "thread_name",
+                        "ph": "M",
+                        "pid": 2,
+                        "tid": resolve_tid,
+                    }
+                )
 
             # Render work phases (complete / dispatch) plus the real operations
             # that otherwise hide inside an idle stretch (poll = completion-scan
@@ -1584,6 +1579,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     finishes_count = finishes_per_complete.get(id(record), 0)
                     phase_args["finishes_processed"] = finishes_count
                 display_name = f"{phase}({tasks_processed})"
+                event_tid = resolve_tid if phase == "resolve" else tid
                 events.append(
                     {
                         "args": phase_args,
@@ -1592,7 +1588,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         "name": display_name,
                         "ph": "X",
                         "pid": 2,
-                        "tid": tid,
+                        "tid": event_tid,
                         "ts": start_us,
                         "dur": dur,
                     }
@@ -1845,9 +1841,13 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # N cores, the earlier N-1 subtasks just bump the slot's
     # completed_subtasks counter inside whatever complete phase happened to
     # poll them; only the LAST subtask's finish actually completes the
-    # task. So per task: take max(finish_time_us) across its subtasks, find
-    # the complete phase that CONTAINS that time, draw one arrow from that
-    # subtask's core lane to the complete phase start.
+    # task. So per task: take max(finish_time_us) across its subtasks and
+    # find the complete phase that CONTAINS that time. The visual arrow starts
+    # on the same earliest-start Worker View subtask slice used by SPMD
+    # dependency arrows, then lands at the last subtask's AICPU finish
+    # timestamp inside the complete phase. This keeps the related SPMD flow
+    # arrows anchored on one visible record without changing completion
+    # attribution semantics.
     #
     # Outbound: per-consumer, gated on full fanin. Each consumer in
     # deps.json has multiple producer fanin edges; refcount += 1 fires
@@ -1876,19 +1876,21 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         # For each task: completion = LAST subtask's finish observation.
         # The owning thread is determined by core_to_thread of that last
         # subtask's core — typical case is the same thread observed
-        # earlier subtasks too, but we don't assume. The source anchor for
-        # the flow arrow is the last subtask's AICore slice (its end_us)
-        # so the user can click the AICore task block in Perfetto and see
-        # the outbound complete arrow.
+        # earlier subtasks too, but we don't assume. The flow starts on the
+        # earliest-start Worker View subtask slice and ends at the LAST
+        # subtask's AICPU finish timestamp, preserving completion attribution
+        # while keeping related SPMD arrows on the same record.
         task_to_complete: dict[int, dict] = {}
         task_last_subtask: dict[int, tuple[float, float, int]] = {}  # tid -> (last_end_us, last_finish_us, core_id)
+        task_anchor_subtasks: dict[int, list[dict]] = {}
         for tid, recs in tasks_by_id.items():
             valid_finishes = [
                 (r.get("finish_time_us"), r.get("end_time_us"), r["core_id"])
                 for r in recs
                 if r.get("finish_time_us") is not None and r["finish_time_us"] >= 0 and r.get("end_time_us") is not None
             ]
-            if not valid_finishes:
+            anchor_rows = _dependency_flow_anchor_rows(tid, task_map, spmd_task_ids)
+            if not valid_finishes or not anchor_rows:
                 continue
             last_finish_us, last_end_us, last_cid = max(valid_finishes, key=lambda x: x[0])
             if last_cid >= len(core_to_thread):
@@ -1897,6 +1899,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if owning_thread < 0 or owning_thread >= len(complete_phases_by_thread):
                 continue
             task_last_subtask[tid] = (last_end_us, last_finish_us, last_cid)
+            task_anchor_subtasks[tid] = anchor_rows
             # Find the complete phase that CONTAINS this last_finish_us.
             # Fall back to the next-starting complete if none contains
             # (rare: AICore reported the finish but the scheduler hadn't
@@ -1915,42 +1918,86 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if chosen is not None:
                 task_to_complete[tid] = chosen
 
-        # ---- Inbound: one arrow per task, anchored on the AICore slice ----
-        # Source ts = end_us - epsilon so it lands INSIDE the AICore task
-        # X event (last subtask of this task on its core). Without this
-        # anchoring Perfetto can't bind the flow to a slice and the arrow
-        # is invisible when you click the task. Same convention as the
-        # existing `dependency` arrows.
+        # ---- Inbound: one arrow per anchor, mirrored on Worker View and Scheduler View ----
+        # Source ts = <bar end> - epsilon so it lands INSIDE the task X event
+        # selected by _dependency_flow_anchor_rows(). Without this anchoring
+        # Perfetto can't bind the flow to a slice and the arrow is invisible
+        # when you click the task. Same convention as the `dependency` arrows,
+        # and — like the Scheduler View dependency mirror — the complete flow
+        # is drawn in both task views so clicking the task in either lands the
+        # arrow. The pid=2 endpoint (thread + ts) is identical for both mirrors,
+        # so completion attribution is unchanged; only the source view differs.
         FLOW_EPSILON_US = 0.01
         for tid, comp in task_to_complete.items():
-            last_end_us, _last_finish_us, last_cid = task_last_subtask[tid]
-            src_tid = core_to_tid[last_cid]
+            _last_end_us, last_finish_us, last_cid = task_last_subtask[tid]
             owning_thread = core_to_thread[last_cid]
-            dst_tid = 3000 + owning_thread
-            events.append(
-                {
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "complete",
-                    "ph": "s",
-                    "pid": 4,
-                    "tid": src_tid,
-                    "ts": last_end_us - FLOW_EPSILON_US,
-                }
-            )
-            events.append(
-                {
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "complete",
-                    "ph": "f",
-                    "pid": 2,
-                    "tid": dst_tid,
-                    "ts": comp["start_time_us"],
-                    "bp": "e",
-                }
-            )
-            flow_id += 1
+            dst_tid = sched_lane_tid(owning_thread, 0)
+            dst_ts = comp["start_time_us"]
+            if comp["start_time_us"] <= last_finish_us <= comp["end_time_us"]:
+                dst_ts = last_finish_us
+            for anchor in task_anchor_subtasks[tid]:
+                # Worker View (pid=4): anchor on the kernel slice (end_time_us).
+                src_tid = core_to_tid[anchor["core_id"]]
+                src_event_id = task_to_event_id.get((tid, anchor["core_id"]))
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "complete",
+                        "ph": "s",
+                        "pid": 4,
+                        "tid": src_tid,
+                        "ts": anchor["end_time_us"] - FLOW_EPSILON_US,
+                        **({"bind_id": src_event_id} if src_event_id is not None else {}),
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "complete",
+                        "ph": "f",
+                        "pid": 2,
+                        "tid": dst_tid,
+                        "ts": dst_ts,
+                        "bp": "e",
+                    }
+                )
+                flow_id += 1
+
+                # Scheduler View (pid=3): mirror on the AICPU dispatch→finish
+                # bar (source ts = finish_time_us). Skip when this anchor has
+                # no AICPU finish — its pid=3 bar doesn't exist to bind to.
+                anchor_finish_us = anchor.get("finish_time_us")
+                if anchor_finish_us is None or anchor_finish_us <= 0:
+                    continue
+                sched_src_tid = task_to_aicpu_tid.get((tid, anchor["core_id"]), core_to_tid[anchor["core_id"]])
+                sched_src_event_id = task_to_aicpu_event_id.get((tid, anchor["core_id"]))
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "complete",
+                        "ph": "s",
+                        "pid": 3,
+                        "tid": sched_src_tid,
+                        "ts": anchor_finish_us - FLOW_EPSILON_US,
+                        **({"bind_id": sched_src_event_id} if sched_src_event_id is not None else {}),
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "complete",
+                        "ph": "f",
+                        "pid": 2,
+                        "tid": dst_tid,
+                        "ts": dst_ts,
+                        "bp": "e",
+                    }
+                )
+                flow_id += 1
 
         # ---- Outbound: per-consumer, gated on full fanin ----
         if deps_edges is not None:
@@ -2011,7 +2058,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                             triggered.append(consumer)
                 if not triggered:
                     continue
-                src_tid = 3000 + comp_thr
+                src_tid = sched_lane_tid(comp_thr, 0)
                 for consumer in triggered:
                     if consumer not in earliest_dispatch_us:
                         continue
@@ -2042,7 +2089,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                             "name": "complete→ready",
                             "ph": "f",
                             "pid": 2,
-                            "tid": 3000 + d_thr,
+                            "tid": sched_lane_tid(d_thr, 0),
                             "ts": d_us,
                             "bp": "e",
                         }
@@ -2095,7 +2142,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             matched_thread = core_to_sched_thread.get(task["core_id"])
 
             if matched_thread is not None:
-                sched_tid = 3000 + matched_thread
+                sched_tid = sched_lane_tid(matched_thread, 0)
                 core_tid = core_to_tid[task["core_id"]]
                 aicpu_tid = task_to_aicpu_tid.get((task["task_id"], task["core_id"]), core_tid)
 
@@ -2195,7 +2242,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 if matched_thread is None:
                     continue
 
-                sched_tid = 3000 + matched_thread
+                sched_tid = sched_lane_tid(matched_thread, 0)
 
                 anchor = orch_anchor_by_task.get(tid)
                 if anchor is None:

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -13,10 +13,10 @@ import json
 from simpler_setup.tools import swimlane_converter as sc
 
 
-def _task_row(task_id, core_id, core_type="aiv", *, dispatch=10.0, start=11.0, end=20.0, receive=10.5):
+def _task_row(task_id, core_id, core_type="aiv", *, func_id=0, dispatch=10.0, start=11.0, end=20.0, receive=10.5):
     return {
         "task_id": task_id,
-        "func_id": 0,
+        "func_id": func_id,
         "core_id": core_id,
         "core_type": core_type,
         "start_time_us": start,
@@ -176,12 +176,12 @@ def test_spmd_mix_to_mix_uses_anchor_cartesian_product(tmp_path):
     pred_id = 100
     succ_id = 200
     tasks = [
-        _task_row(pred_id, 0, "aic", dispatch=10.0, start=11.0, end=20.0),
-        _task_row(pred_id, 1, "aiv", dispatch=10.1, start=11.1, end=20.1),
-        _task_row(pred_id, 3, "aiv", dispatch=10.3, start=11.3, end=20.3),
-        _task_row(succ_id, 4, "aic", dispatch=30.0, start=31.0, end=40.0, receive=30.5),
-        _task_row(succ_id, 5, "aiv", dispatch=30.1, start=31.1, end=40.1, receive=30.6),
-        _task_row(succ_id, 7, "aiv", dispatch=30.3, start=31.3, end=40.3, receive=30.8),
+        _task_row(pred_id, 0, "aic", func_id=1, dispatch=10.0, start=11.0, end=20.0),
+        _task_row(pred_id, 1, "aiv", func_id=2, dispatch=10.1, start=11.1, end=20.1),
+        _task_row(pred_id, 3, "aiv", func_id=2, dispatch=10.3, start=11.3, end=20.3),
+        _task_row(succ_id, 4, "aic", func_id=1, dispatch=30.0, start=31.0, end=40.0, receive=30.5),
+        _task_row(succ_id, 5, "aiv", func_id=2, dispatch=30.1, start=31.1, end=40.1, receive=30.6),
+        _task_row(succ_id, 7, "aiv", func_id=2, dispatch=30.3, start=31.3, end=40.3, receive=30.8),
     ]
     deps_edges = {pred_id: [succ_id]}
     deps_block_map = {pred_id: 3, succ_id: 3}
@@ -198,9 +198,9 @@ def test_spmd_aiv_only_pred_connects_to_mix_spmd_succ_both_anchors(tmp_path):
     tasks = [
         _task_row(pred_id, 24, "aiv", dispatch=10.0, start=11.0, end=20.0),
         _task_row(pred_id, 30, "aiv", dispatch=10.3, start=11.3, end=20.3),
-        _task_row(succ_id, 0, "aic", dispatch=30.0, start=31.0, end=40.0, receive=30.5),
-        _task_row(succ_id, 24, "aiv", dispatch=30.1, start=31.1, end=40.1, receive=30.6),
-        _task_row(succ_id, 27, "aiv", dispatch=30.3, start=31.3, end=40.3, receive=30.8),
+        _task_row(succ_id, 0, "aic", func_id=1, dispatch=30.0, start=31.0, end=40.0, receive=30.5),
+        _task_row(succ_id, 24, "aiv", func_id=2, dispatch=30.1, start=31.1, end=40.1, receive=30.6),
+        _task_row(succ_id, 27, "aiv", func_id=2, dispatch=30.3, start=31.3, end=40.3, receive=30.8),
     ]
     deps_edges = {pred_id: [succ_id]}
     deps_block_map = {pred_id: 16, succ_id: 24}
@@ -252,19 +252,19 @@ def test_spmd_fallback_without_block_map(tmp_path):
     assert flow[0]["tid"] == _core_tid(0)
 
 
-def test_dependency_flow_anchor_rows_picks_min_core_per_type():
+def test_dependency_flow_anchor_rows_picks_earliest_start_per_func_id():
     task_map = {
         1: [
-            _task_row(1, 5, "aiv"),
-            _task_row(1, 0, "aiv"),
-            _task_row(1, 2, "aic"),
-            _task_row(1, 7, "aic"),
+            _task_row(1, 5, "aiv", func_id=2, start=15.0),
+            _task_row(1, 0, "aiv", func_id=2, start=12.0),
+            _task_row(1, 2, "aic", func_id=1, start=13.0),
+            _task_row(1, 7, "aic", func_id=1, start=17.0),
         ]
     }
     rows = sc._dependency_flow_anchor_rows(1, task_map, {1})
     assert len(rows) == 2
-    by_type = {r["core_type"]: r["core_id"] for r in rows}
-    assert by_type == {"aic": 2, "aiv": 0}
+    by_func = {r["func_id"]: r["core_id"] for r in rows}
+    assert by_func == {1: 2, 2: 0}
 
 
 def test_identify_spmd_task_ids_respects_authoritative_block_num_one():
@@ -295,3 +295,75 @@ def test_spmd_cross_type_single_anchor_pair(tmp_path):
 
     out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
     assert _count_dependency_flow_starts(out, pid=4) == 1
+
+
+def _complete_flows(trace_path):
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    return [e for e in events if e.get("cat") == "flow" and e.get("name") == "complete"]
+
+
+def _aicpu_tid(core_id):
+    # Non-overlapping single-task-per-core cases keep the base Scheduler View lane.
+    return 10000 + core_id * 10
+
+
+def test_complete_flow_mirrored_on_scheduler_view(tmp_path):
+    # One SPMD task across 4 cores, all on scheduler thread 0. A single
+    # complete phase (thread 0) contains every subtask finish.
+    task_id = 100
+    tasks = [
+        _task_row(task_id, core_id, dispatch=10.0 + core_id, start=11.0 + core_id, end=20.0 + core_id)
+        for core_id in range(4)
+    ]
+    deps_edges = {}
+    deps_block_map = {task_id: 4}
+    # finish_time_us = end + 1.0, so subtask finishes span 21.0 .. 24.0.
+    scheduler_phases = [[{"phase": "complete", "start_time_us": 20.0, "end_time_us": 25.0}]]
+    core_to_thread = [0, 0, 0, 0]
+
+    out = tmp_path / "trace.json"
+    sc.generate_chrome_trace_json(
+        tasks,
+        str(out),
+        deps_edges=deps_edges,
+        deps_block_map=deps_block_map,
+        scheduler_phases=scheduler_phases,
+        core_to_thread=core_to_thread,
+    )
+
+    flows = _complete_flows(out)
+    starts_p4 = [e for e in flows if e.get("ph") == "s" and e.get("pid") == 4]
+    starts_p3 = [e for e in flows if e.get("ph") == "s" and e.get("pid") == 3]
+    # SPMD single-func anchor collapses the 4 subtasks to one anchor row;
+    # complete is mirrored on both task views for that anchor.
+    assert len(starts_p4) == 1
+    assert len(starts_p3) == 1
+
+    p4 = starts_p4[0]
+    p3 = starts_p3[0]
+    anchor_core = 0  # earliest-start subtask
+    anchor = next(t for t in tasks if t["core_id"] == anchor_core)
+    # Worker View source anchors on the kernel slice end; Scheduler View source
+    # anchors on the AICPU finish. Both minus one epsilon (0.01).
+    assert p4["tid"] == _core_tid(anchor_core)
+    assert p4["ts"] == anchor["end_time_us"] - 0.01
+    assert p3["tid"] == _aicpu_tid(anchor_core)
+    assert p3["ts"] == anchor["finish_time_us"] - 0.01
+
+    # Both mirrors land on the same pid=2 complete-phase endpoint.
+    finishes = [e for e in flows if e.get("ph") == "f"]
+    assert len(finishes) == 2
+    assert all(e["pid"] == 2 for e in finishes)
+    assert len({e["tid"] for e in finishes}) == 1
+    assert len({e["ts"] for e in finishes}) == 1
+
+
+def test_complete_flow_worker_view_only_without_scheduler_phases(tmp_path):
+    # Without scheduler_phases the complete-flow block is skipped entirely:
+    # neither view gets a complete arrow (regression guard on the gate).
+    task_id = 100
+    tasks = [_task_row(task_id, 0)]
+
+    out = _generate_trace(tasks, {}, {task_id: 1}, tmp_path)
+    assert _complete_flows(out) == []


### PR DESCRIPTION
- Collapse SPMD dependency anchors by func_id and task_id using the earliest-start subtask so MIX AIC/AIV tasks stay distinct.
- Fold AIC/AIV setup preview into the Worker View task bar while keeping kernel and setup durations in hover args.
- Render resolve on a sibling scheduler lane and anchor complete flows on the same representative SPMD task slices as dependency flows.
- Update the L2 swimlane documentation to describe the new lane and anchor semantics.