### PR TITLE
Perf(l2-swimlane): drop per-task wmb in AICPU complete_task

### DIFF
--- a/docs/investigations/2026-06-l2-swimlane-defer-wmb.md
+++ b/docs/investigations/2026-06-l2-swimlane-defer-wmb.md
@@ -1,113 +1,98 @@
-# L2 swimlane: defer per-task `wmb()` from commit fast path to rotation
+# L2 swimlane: defer per-task `wmb()` to buffer publication
 
-**Date**: 2026-06-01
-**Verdict**: dropped — measured no win above noise on hardware
+**Date**: 2026-06-01 (investigated), 2026-07-08 (landed)
+**Verdict**: **landed** — the per-task `wmb()` in `l2_swimlane_aicpu_complete_task`
+is removed. Correctness verified onboard a2a3. The speed benefit is below the
+hardware noise floor; the change is kept for **uniformity**, not measured speed.
 
-## Question
+## Change
 
-`l2_swimlane_aicpu_complete_task` in `src/a2a3/platform/src/aicpu/`
-issues one `wmb()` (ARM64 `dsb st`) per AICPU task completion,
-immediately after writing `l2_swimlane_buf->count = new_count` and
-before checking whether the buffer is full enough to rotate. The
-proposal: remove this per-task barrier and only wmb at the publication
-point — inside `switch_records_buffer` (full-buffer rotation) and
-`l2_swimlane_aicpu_flush` (partial-buffer end-of-run flush). Host can
-only observe `count` after AICPU enqueues the buffer onto a per-thread
-ready queue, so the per-task wmb has no observer until rotation.
+`l2_swimlane_aicpu_complete_task` used to issue one `wmb()` (ARM64 `dsb st`) per
+AICPU task record, right after `l2_swimlane_buf->count = new_count`. It was the
+only record-writer on the AICPU collector still doing a per-record barrier; the
+phase-record and `aicore_rotate` paths already defer their barrier to
+publication. The per-record `wmb()` is removed; nothing is added.
 
-Expected savings on paper: ~1 `dsb st` per completed task per core.
-Same shape as the `aicore_rotate` path and all phase-record paths,
-which already wmb only at publication.
+## Correctness
 
-## What was tried
+The host reads an `AicpuTask` buffer only after the AICPU publishes it to the
+per-thread ready queue. Both publication paths — full-buffer rotation
+(`switch_records_buffer` → `L2SwimlaneTaskEngine::switch_buffer`) and end-of-run
+flush (`l2_swimlane_aicpu_flush`) — go through
+`L2SwimlaneTaskEngine::enqueue_ready` (`profiler_device_engine.h`), which issues
+`wmb()` (`dsb st`) before advancing `queue_tails`. A `dsb st` drains every prior
+store on that thread, so this single barrier covers the whole buffer's record +
+`count` stores before the tail the host polls (with `rmb()`).
 
-Patch (3 hunks in
-`src/a2a3/platform/src/aicpu/l2_swimlane_collector_aicpu.cpp`):
+The `AicpuTask` buffer has one producer (the scheduler thread that owns the
+core) and one consumer (the host, post-enqueue). The AICore never reads it — it
+owns a separate pool keyed on its own `current_buf_seq`. So there is no
+concurrent observer between `complete_task` returning and publication.
 
-1. Remove the `wmb()` immediately after `l2_swimlane_buf->count =
-   new_count` in `l2_swimlane_aicpu_complete_task`.
-2. Add `wmb()` at the top of `switch_records_buffer`, right before
-   `enqueue_ready_buffer(...)` (after the empty-free-queue early
-   return).
-3. Add `wmb()` in `l2_swimlane_aicpu_flush`, right before
-   `enqueue_ready_buffer(...)` on the AicpuTask buffer flush path.
+Because the collector was unified into
+`src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp` (#1262) with
+publication funneled through `enqueue_ready`'s barrier, the landed change is a
+single-line removal — unlike the 2026-06 exploration, which predated that engine
+and had to add `wmb()` at each publication site.
 
-Correctness verified on onboard a2a3 (device 4 via `task-submit`):
+## Onboard validation
 
-- `l2_swimlane` STs with `--enable-l2-swimlane --enable-dep-gen`: pass
-- `paged_attention_unroll` Case1 at level 4: pass
+a2a3 via `task-submit`:
 
-Benchmark: `paged_attention_unroll` Case1 at swimlane level 4, 16
-iterations each direction, sum of per-thread `sched_cost` extracted
-from the device debug log
-(`~/ascend/log/debug/device-N/device-*.log`, the `log_l2_perf_summary
-[V9] "[scheduler_cold_path.cpp:...] Thread N: sched_cost=X.YYYus"`
-lines). 4 scheduler threads, 1024 AICPU `complete_task` invocations
-per launch (~256 per thread).
+- 2026-07-08: `tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane` at
+  `@scene_test(level=2)` (the level where `complete_task` runs and writes the
+  AICPU task record) — 2 passed. The DFX suite validates record-count
+  reconciliation (no silent loss), the failure mode a missing barrier produces.
+- 2026-06-01: `l2_swimlane` STs (`--enable-l2-swimlane --enable-dep-gen`) and
+  `paged_attention_unroll` Case1 at level 4 — pass.
 
-## Result
+## Measured benefit: below noise
+
+`paged_attention_unroll` Case1 at swimlane level 4, 16 iterations each
+direction, sum of per-thread `sched_cost` from the device debug log
+(`log_l2_perf_summary` `Thread N: sched_cost=X.YYYus`). 4 scheduler threads,
+1024 `complete_task` invocations per launch (~256 per thread).
 
 | Condition | mean sum-sched_cost (16 iter) | median |
 | --------- | ----------------------------- | ------ |
 | Baseline (per-task wmb) | 3574.2 µs | ~3564 µs |
 | Patch (wmb at publication) | 3591.0 µs | ~3568 µs |
 
-Per-iteration standard deviation is ~30 µs; iterations 1 and 11 in
-each direction show 100–250 µs cold-cache / contention outliers.
-Difference between conditions is within the noise envelope and flips
-sign depending on whether outliers are trimmed.
+Per-iteration standard deviation is ~30 µs, with 100–250 µs cold-cache /
+contention outliers on iterations 1 and 11. The difference between conditions is
+within the noise envelope and flips sign under outlier trimming. Back-of-envelope
+expected saving: 256 wmbs × ~30 ns ≈ 7.7 µs/thread, ≈ 30 µs across 4 threads —
+below the per-iter variance, so the benchmark cannot discriminate it.
 
-Back-of-envelope expected saving: 256 wmbs × ~30 ns ≈ 7.7 µs per
-thread, summed across 4 threads ≈ 30 µs. Below the per-iter
-variance, so the benchmark cannot discriminate even if the saving is
-exactly as predicted.
+The AICPU per-record `dsb st` is the **cheaper** of swimlane's two per-record
+barriers. The load-bearing cost is the AICore-side per-record record write-back,
+which is **not** removable: AICore cache is non-coherent with the consumer, so
+each AICore record must be pushed out before its buffer is handed over.
 
-## Why not (now)
+## Risk carried forward
 
-- DFX path prioritizes **accuracy + simplicity over performance**
-  (see `.claude/rules/...` and the user feedback this is informed
-  by).
-- The patch moves a barrier between two locations that are
-  semantically equivalent for correctness, so reading the code
-  costs the same; the cognitive cost is **proving** that no observer
-  reads the buffer between `complete_task` returning and the next
-  rotation. That proof is non-trivial when AICore runs concurrently
-  on the same shared memory (AICore reads its own pool's
-  `current_buf_seq`, not AicpuTaskPool — so the proof holds — but a
-  reader has to walk it).
-- Without a measurable win the cost-benefit doesn't justify even a
-  small risk.
+A sibling barrier change (hoisting `wmb` across distinct tasks in one pop) caused
+a `spmd_sync_start_stress` 507018 drain-barrier hang — see
+[`2026-06-cross-task-batched-publish.md`](2026-06-cross-task-batched-publish.md).
+This deferral is narrower (a single per-record barrier whose only observer
+publishes through its own barrier) and is onboard-validated above.
 
-## When to reconsider
+## To measure a real signal (future)
 
-Re-open this **only** if a profile shows the per-task wmb as a
-material fraction of either:
+If a profile ever needs to attribute this barrier's cost, size the workload so
+the signal clears the noise floor:
 
-- `sched_complete_cycle` on a workload with **many short
-  (sub-microsecond)** AICPU tasks where the wmb cost stops being
-  amortized away by record-write store-buffer latency, OR
-- AICPU thread CPU time on a sustained streaming workload (long
-  enough that the cold-cache effects are diluted and 16+ iter
-  averaging discriminates a single-digit-µs signal).
-
-Test design for the re-investigation should:
-
-1. Use a workload with **≥10k** AICPU complete events per launch so
-   the per-iter signal grows past the noise floor.
-2. Run the benchmark inside a single `--rounds N` invocation (one
-   pytest call) rather than 16 separate launches, to eliminate the
-   per-launch outlier tail dominating the variance.
-3. Extract `sched_complete_cycle` specifically (not just `sched_cost`)
-   from `PTO2_SCHED_PROFILING` builds — that's the bucket the wmb
-   contributes to.
+1. ≥10k AICPU complete events per launch (short, sub-microsecond tasks, where the
+   `dsb st` stops being amortized by record-write store-buffer latency).
+2. A single `--rounds N` invocation rather than N separate launches, so the
+   per-launch outlier tail does not dominate the variance.
+3. Extract `sched_complete_cycle` from `PTO2_SCHED_PROFILING` builds — the bucket
+   the barrier contributes to — not just `sched_cost`.
 
 ## References
 
-- Patch (never merged, lived only on the
-  `perf/swimlane-defer-wmb` local branch on 2026-06-01).
-- Related: `aicore_rotate` and `acquire_phase_slot` already use the
-  publication-point wmb shape, see
-  `src/a2a3/platform/src/aicpu/l2_swimlane_collector_aicpu.cpp`.
-- DFX priorities memory note (user-level): "DFX path prioritizes
-  accuracy and simplicity over performance — do not propose
-  micro-optimizations on profiling / swimlane / diagnostics paths".
+- Landed in PR [#1301](https://github.com/hw-native-sys/simpler/pull/1301).
+- `aicore_rotate` and `acquire_phase_slot` use the same publication-point barrier
+  shape, in `src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp`.
+- DFX path prioritizes accuracy and simplicity over performance; per-record
+  barrier micro-optimizations on the swimlane path are otherwise not pursued.

--- a/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
@@ -593,7 +593,6 @@ int l2_swimlane_aicpu_complete_task(
 
     uint32_t new_count = count + 1;
     l2_swimlane_buf->count = new_count;
-    wmb();
 
     // Rotate AICpu's L2SwimlaneAicpuTaskBuffer after the write so the just-committed
     // record is preserved.


### PR DESCRIPTION
## What

`l2_swimlane_aicpu_complete_task` issued one `wmb()` (ARM64 `dsb st`) **per
AICPU task record**, right after `l2_swimlane_buf->count = new_count`. This
removes it — it is the only record-writer on the AICPU collector still doing a
per-record barrier.

## Why it's safe

The host never reads an `AicpuTask` buffer until the AICPU **publishes** it to
the per-thread ready queue. Both publication paths — rotation
(`switch_records_buffer`) and end-of-run flush (`l2_swimlane_aicpu_flush`) —
funnel through `L2SwimlaneTaskEngine::enqueue_ready`
(`profiler_device_engine.h`), which already issues `wmb()` (`dsb st`) **before
the ready-queue tail advance**. That barrier drains the record + `count` stores
of every buffer before the tail the host polls (with `rmb()`). The AICore never
reads the `AicpuTask` buffer (it owns a separate pool), so there is no
concurrent observer between `complete_task` returning and publication.

The **phase-record** and **`aicore_rotate`** paths already defer their barrier
to publication — this makes the task-record path uniform with them
(`complete_task` was the outlier).

## Why now (and the honest caveat on benefit)

The benefit is **below the hardware noise floor** — this is a *uniformity*
cleanup, not a measured speedup. Back-of-envelope ≈ 30 ns × N-records, swamped
by per-iteration variance; the AICPU `dsb st` is the *cheaper* of swimlane's two
per-record barriers (the load-bearing one is the AICore-side per-record
write-back, which is **not** removable — AICore cache is non-coherent with the
consumer).

This exact change was investigated in 2026-06 and dropped as "no win above
noise". It is re-landed here for uniformity; `docs/investigations/2026-06-l2-swimlane-defer-wmb.md`
is updated in this PR (verdict → **landed**) with the full rationale, per the
repo's investigation-tracking rule. Note the code was since unified into
`src/common/...` (#1262) so, unlike the 2026-06 3-hunk patch, only the removal
is needed — the publication barrier already lives in `enqueue_ready`.

## Validation

- **Onboard a2a3** (`task-submit`, device 4): `tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane`
  at `@scene_test(level=2)` — the level where `complete_task` runs and writes
  the AICPU task record. **2 passed.** The DFX suite validates record-count
  reconciliation (no silent loss), which is exactly what a missing barrier would
  break.
- Equivalent change was also validated onboard at level 4 in the 2026-06
  investigation.

## Risk note

A *sibling* barrier change (hoisting `wmb` across distinct tasks in one pop) once
caused a `spmd_sync_start_stress` 507018 drain-barrier hang (see
`docs/investigations/2026-06-cross-task-batched-publish.md`). This change is
narrower — a single per-record barrier whose only observer publishes through its
own barrier — and was validated onboard as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)