### PR TITLE
Add: deps_viewer transitive-reduction edge mode

### DIFF
--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -302,15 +302,30 @@ python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
 # Override task labels with a func_id -> name mapping
 python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
     --func-names outputs/<case>_<ts>/name_map_TestPA_basic.json
+
+# Transitive reduction: drop edges implied by a longer path, print what was removed
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --edge-mode reduced
 ```
+
+`--edge-mode reduced` removes every dependency edge that is already implied by a
+longer path — e.g. `A->C` is dropped when `A->B->C` exists — so the graph shows
+only the minimal (transitively-reduced) edge set. The removed edges are printed
+to stdout as an `r<ring>t<local> -> r<ring>t<local>` list, and both `text` and
+`html` output honor the mode. When `-o` is omitted the reduced graph is written
+to the `deps_viewer_reduced.*` stem (rather than `deps_viewer.*`) so it never
+clobbers a full-graph render in the same directory. Reduction is purely
+structural (it ignores the per-edge tensor/arg identity) and is skipped with a
+warning if the graph contains a cycle.
 
 ### Command-Line Options
 
 | Option | Short | Description |
 | ------ | ----- | ----------- |
 | `input` | | Path to `deps.json` (default: newest under `./outputs/`) |
-| `--output` | `-o` | Output path (default: `deps_viewer.txt` for text, `deps_viewer.html` for HTML) |
+| `--output` | `-o` | Output path (default: `deps_viewer.txt` for text, `deps_viewer.html` for HTML; `--edge-mode reduced` uses the `deps_viewer_reduced.*` stem) |
 | `--format` | | Output format: `text` (default) or `html` |
+| `--edge-mode` | | `full` (default) draws every edge; `reduced` applies transitive reduction, dropping edges implied by a longer path and printing the removed edges. Applies to both formats. |
 | `--engine` | | HTML-only Graphviz layout engine: `dot` (default), `sfdp`, `neato`, `fdp`, `circo`, `twopi` |
 | `--direction` | | HTML-only flow direction for hierarchical layouts: `LR` (default) / `TB` / `BT` / `RL` |
 | `--show-tensor-info` | | HTML-only: render per-task tensor rows and route edges to specific arg ports |

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -31,6 +31,13 @@ Usage:
     python -m simpler_setup.tools.deps_viewer DEPS_JSON
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --format text
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --format html --engine sfdp
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode reduced
+
+``--edge-mode reduced`` applies transitive reduction: it drops every edge whose
+ordering is already implied by a longer dependency path (e.g. ``A->C`` when
+``A->B->C`` exists), prints the removed edges to stdout, and emits the reduced
+graph in whichever format is selected. It is purely structural (ignores per-edge
+tensor identity) and is skipped with a warning if the graph contains a cycle.
 
 HTML output requires Graphviz installed (``brew install graphviz`` /
 ``apt install graphviz``). Text output does not.
@@ -41,6 +48,7 @@ import json
 import shutil
 import subprocess
 import sys
+from collections import deque
 from pathlib import Path
 
 
@@ -194,6 +202,69 @@ def _load_deps_edges(deps_path):
             task_table[tid] = entry
     _backfill_output_tensor_ids(task_table, annotations)
     return sorted(edges), sorted(nodes), annotations, tensor_table, task_table
+
+
+def _transitive_reduction(edges, nodes):
+    """DAG transitive reduction on structural ``(pred, succ)`` edges.
+
+    An edge ``(u, v)`` is redundant when ``v`` is still reachable from ``u``
+    through some other path that does not use the direct ``(u, v)`` edge — i.e.
+    the dependency it expresses is already implied by a longer chain. Reduction
+    is purely structural: it ignores the per-edge tensor / arg annotations, so a
+    ``(u, v)`` carrying its own tensor is dropped whenever the ordering it
+    encodes is transitively covered.
+
+    Returns ``(kept_edges, removed_edges, is_dag)``. On a cyclic graph the input
+    edges are returned unchanged with ``is_dag=False`` (transitive reduction is
+    only well-defined on a DAG); the caller warns and emits the full graph.
+    """
+    succ: dict[int, set[int]] = {n: set() for n in nodes}
+    indeg: dict[int, int] = {n: 0 for n in nodes}
+    for u, v in edges:
+        succ.setdefault(u, set())
+        succ.setdefault(v, set())
+        indeg.setdefault(u, 0)
+        if v not in succ[u]:
+            succ[u].add(v)
+            indeg[v] = indeg.get(v, 0) + 1
+
+    # Kahn topological sort doubles as the cycle check: if we can't drain every
+    # node, a cycle remains and reduction would be ill-defined.
+    remaining = dict(indeg)
+    queue = deque(n for n, d in remaining.items() if d == 0)
+    visited = 0
+    while queue:
+        n = queue.popleft()
+        visited += 1
+        for m in succ[n]:
+            remaining[m] -= 1
+            if remaining[m] == 0:
+                queue.append(m)
+    if visited != len(succ):
+        return list(edges), [], False
+
+    def _reachable_avoiding_direct(src, dst):
+        # Can we get from src to dst WITHOUT taking the direct (src, dst) edge?
+        stack = [c for c in succ[src] if c != dst]
+        seen = set(stack)
+        while stack:
+            node = stack.pop()
+            if node == dst:
+                return True
+            for c in succ[node]:
+                if c not in seen:
+                    seen.add(c)
+                    stack.append(c)
+        return False
+
+    kept: list[tuple[int, int]] = []
+    removed: list[tuple[int, int]] = []
+    for u, v in edges:
+        if _reachable_avoiding_direct(u, v):
+            removed.append((u, v))
+        else:
+            kept.append((u, v))
+    return sorted(kept), sorted(removed), True
 
 
 def _backfill_output_tensor_ids(task_table, annotations):
@@ -1009,6 +1080,7 @@ Examples:
   %(prog)s deps.json --format text -o graph.txt
   %(prog)s deps.json --format html --engine sfdp
   %(prog)s deps.json --format html --show-tensor-info
+  %(prog)s deps.json --edge-mode reduced      # drop transitively-implied edges, print what was removed
 """,
     )
     p.add_argument("input", nargs="?", help="Path to deps.json (default: newest under ./outputs/).")
@@ -1018,6 +1090,16 @@ Examples:
         choices=["text", "html"],
         default="text",
         help="Output format: text (default) or html.",
+    )
+    p.add_argument(
+        "--edge-mode",
+        choices=["full", "reduced"],
+        default="full",
+        help=(
+            "full (default) draws every dependency edge; reduced applies transitive reduction, dropping edges "
+            "already implied by a longer path and printing the removed edges to stdout. Structural (pred,succ) "
+            "level; applies to both text and html. Skipped with a warning on a cyclic graph."
+        ),
     )
     p.add_argument(
         "--engine",
@@ -1085,10 +1167,27 @@ def main(argv=None):
     if meta:
         nodes = sorted(set(nodes) | set(meta.keys()), key=_sort_task_id_key)
 
+    reduced = False
+    if args.edge_mode == "reduced":
+        kept, removed, is_dag = _transitive_reduction(edges, nodes)
+        if not is_dag:
+            print(
+                "warning: dependency graph has a cycle; transitive reduction skipped, emitting full graph",
+                file=sys.stderr,
+            )
+        else:
+            fmt_task = _make_task_formatter(sorted(nodes, key=_sort_task_id_key))
+            print(f"Transitive reduction: removed {len(removed)} redundant edge(s) of {len(edges)} ({len(kept)} kept)")
+            for u, v in removed:
+                print(f"  - {fmt_task(u)} -> {fmt_task(v)}")
+            edges = kept
+            reduced = True
+
+    default_stem = "deps_viewer_reduced" if reduced else "deps_viewer"
     out = (
         Path(args.output)
         if args.output
-        else input_path.parent / ("deps_viewer.txt" if args.format == "text" else "deps_viewer.html")
+        else input_path.parent / f"{default_stem}.{'txt' if args.format == 'text' else 'html'}"
     )
     if args.format == "text":
         text = emit_text(

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -8,6 +8,8 @@
 # -----------------------------------------------------------------------------------------------------------
 """Contract tests for simpler_setup.tools.deps_viewer text output."""
 
+import json
+
 from simpler_setup.tools import deps_viewer
 from simpler_setup.tools.deps_viewer import _merge_task_meta_with_kernel_ids, emit_text
 
@@ -349,3 +351,76 @@ def test_main_keeps_task_metadata_when_show_tensor_info_disabled(tmp_path, monke
     assert rc == 0
     assert captured["task_table"] == {1: {"task_id": 1, "args": []}}
     assert captured["show_tensor_info"] is False
+
+
+def test_transitive_reduction_removes_implied_edge():
+    # A->B->C plus the implied shortcut A->C.
+    kept, removed, is_dag = deps_viewer._transitive_reduction([(1, 2), (1, 3), (2, 3)], [1, 2, 3])
+    assert is_dag
+    assert removed == [(1, 3)]
+    assert kept == [(1, 2), (2, 3)]
+
+
+def test_transitive_reduction_keeps_non_redundant_diamond():
+    # Diamond A->B, A->C, B->D, C->D — no edge is implied by another path.
+    edges = [(1, 2), (1, 3), (2, 4), (3, 4)]
+    kept, removed, is_dag = deps_viewer._transitive_reduction(edges, [1, 2, 3, 4])
+    assert is_dag
+    assert removed == []
+    assert kept == sorted(edges)
+
+
+def test_transitive_reduction_drops_multi_hop_shortcut():
+    # Chain A->B->C->D with a long shortcut A->D implied by three hops.
+    kept, removed, is_dag = deps_viewer._transitive_reduction([(1, 2), (2, 3), (3, 4), (1, 4)], [1, 2, 3, 4])
+    assert is_dag
+    assert removed == [(1, 4)]
+    assert kept == [(1, 2), (2, 3), (3, 4)]
+
+
+def test_transitive_reduction_detects_cycle_and_falls_back():
+    edges = [(1, 2), (2, 1)]
+    kept, removed, is_dag = deps_viewer._transitive_reduction(edges, [1, 2])
+    assert not is_dag
+    assert kept == edges
+    assert removed == []
+
+
+def _write_deps_edges(tmp_path, edges):
+    deps = {
+        "tasks": [],
+        "tensors": [],
+        "edges": [{"pred": str(p), "succ": str(s), "arg": 0, "source": "creator"} for p, s in edges],
+    }
+    path = tmp_path / "deps.json"
+    path.write_text(json.dumps(deps))
+    return path
+
+
+def test_main_reduced_mode_drops_edge_and_prints_removed(tmp_path, capsys):
+    # A(r1t1) -> B(r1t2) -> C(r1t3) plus the implied A->C shortcut.
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "reduced", "-o", str(out)])
+    assert rc == 0
+
+    assert "unique_task_edges: 2" in out.read_text()
+    stdout = capsys.readouterr().out
+    assert "removed 1 redundant edge(s)" in stdout
+    # ring>=1 nodes render as the explicit (ring, local) tuple.
+    assert "(1, 1) -> (1, 3)" in stdout
+
+
+def test_main_full_mode_keeps_all_edges(tmp_path, capsys):
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "-o", str(out)])
+    assert rc == 0
+    assert "unique_task_edges: 3" in out.read_text()
+    assert "Transitive reduction" not in capsys.readouterr().out


### PR DESCRIPTION
deps.json records the full producer->consumer edge set, which includes structurally redundant edges: an A->C edge whose ordering is already implied by a longer path A->B->C. These clutter the rendered graph without adding information.

Add --edge-mode {full,reduced} (default full, unchanged behavior). In reduced mode deps_viewer computes a DAG transitive reduction on the structural (pred,succ) edges, drops the implied edges from both text and html output, and prints the removed edges to stdout. Reduction is purely structural (ignores per-edge tensor/arg identity) and is skipped with a warning if the graph contains a cycle (transitive reduction is only well-defined on a DAG).

When -o is omitted the reduced graph is written to the deps_viewer_reduced.* stem so it never clobbers a full-graph render in the same directory.

Cycle detection reuses a Kahn topological sort; redundancy is decided per edge by a reachability search from the predecessor that avoids the direct edge. Add unit coverage for the reduction (implied edge, diamond with no redundancy, multi-hop shortcut, cycle fallback) and the reduced vs full main() paths.