### PR TITLE
Fix: place MIX subtasks per-core instead of uniform cluster placement

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -48,10 +48,10 @@ inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all 
  * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
  *
  * Multi-subtask tasks (2+ active slots) are all scheduled as MIX. Dispatch
- * chooses one cluster, then uses active_mask to decide which cores in that
- * cluster must be placed together: all used cores idle -> running placement;
- * all used cores already running with free pending slots -> pending placement;
- * mixed used-core state is rejected and retried later.
+ * chooses one cluster, then places each core named by active_mask by its own
+ * state: idle cores take their running slot, already-running cores take their
+ * pending slot. A cluster is usable as long as no used core's pending slot is
+ * occupied; unused cores in the cluster are ignored.
  *
  * DUMMY is a synthetic shape for dep-only tasks (no AICore dispatch). Tasks
  * with an empty core_mask route to a dedicated DUMMY ready queue and are

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -235,21 +235,21 @@ int SchedulerContext::prepare_block_for_dispatch(
         uint8_t cmask = slot_state.active_mask.core_mask();
         int n = 0;
         if (cmask & PTO2_SUBTASK_MASK_AIC) {
+            bool p = to_pending && !tracker.is_aic_core_idle(core_offset);
             out_handles[n++] = prepare_subtask_to_core(
-                thread_idx, tracker.get_aic_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIC, to_pending,
-                block_idx
+                thread_idx, tracker.get_aic_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIC, p, block_idx
             );
         }
         if (cmask & PTO2_SUBTASK_MASK_AIV0) {
+            bool p = to_pending && !tracker.is_aiv0_core_idle(core_offset);
             out_handles[n++] = prepare_subtask_to_core(
-                thread_idx, tracker.get_aiv0_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV0, to_pending,
-                block_idx
+                thread_idx, tracker.get_aiv0_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV0, p, block_idx
             );
         }
         if (cmask & PTO2_SUBTASK_MASK_AIV1) {
+            bool p = to_pending && !tracker.is_aiv1_core_idle(core_offset);
             out_handles[n++] = prepare_subtask_to_core(
-                thread_idx, tracker.get_aiv1_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV1, to_pending,
-                block_idx
+                thread_idx, tracker.get_aiv1_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV1, p, block_idx
             );
         }
 #if PTO2_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -324,9 +324,14 @@ public:
     // Runtime MIX dispatch uses classify_mix_cluster() so the decision follows the task's active_mask.
     enum class MixPlacement : uint8_t { RUNNING, PENDING, REJECT };
 
-    // A MIX block must place all cores named by active_mask the same way:
-    // all idle means running placement, all running means pending placement,
-    // and any mixed state is retried later.
+    // Placement for the cores named by active_mask, ignoring cores this task does
+    // not use. All used cores idle -> RUNNING placement (each to its running slot).
+    // Otherwise -> PENDING placement: at dispatch each used core is filled per its
+    // own state -- an idle core takes its running slot (and is marked running, so
+    // the completion poller, which scans only running cores, tracks its FIN), an
+    // already-running core takes its pending slot and executes after its in-flight
+    // task. REJECT only when a used core's pending slot is already occupied (no free
+    // slot) or the mask is empty.
     MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
         BitStates used(0ULL);
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
@@ -346,10 +351,7 @@ public:
         if (idle.count() == used.count()) {
             return MixPlacement::RUNNING;
         }
-        if (!idle.has_value()) {
-            return MixPlacement::PENDING;
-        }
-        return MixPlacement::REJECT;
+        return MixPlacement::PENDING;
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -48,10 +48,10 @@ inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all 
  * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
  *
  * Multi-subtask tasks (2+ active slots) are all scheduled as MIX. Dispatch
- * chooses one cluster, then uses active_mask to decide which cores in that
- * cluster must be placed together: all used cores idle -> running placement;
- * all used cores already running with free pending slots -> pending placement;
- * mixed used-core state is rejected and retried later.
+ * chooses one cluster, then places each core named by active_mask by its own
+ * state: idle cores take their running slot, already-running cores take their
+ * pending slot. A cluster is usable as long as no used core's pending slot is
+ * occupied; unused cores in the cluster are ignored.
  *
  * DUMMY is a synthetic shape for dep-only tasks (no AICore dispatch). Tasks
  * with an empty core_mask route to a dedicated DUMMY ready queue and are

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -211,21 +211,24 @@ void SchedulerContext::dispatch_mix_block_to_cluster(
     CoreTracker &tracker = core_trackers_[thread_idx];
     uint8_t cmask = slot_state.active_mask.core_mask();
     if (cmask & PTO2_SUBTASK_MASK_AIC) {
+        bool aic_to_pending = to_pending && !tracker.is_aic_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
-            to_pending, block_idx
+            aic_to_pending, block_idx
         );
     }
     if (cmask & PTO2_SUBTASK_MASK_AIV0) {
+        bool aiv0_to_pending = to_pending && !tracker.is_aiv0_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
-            to_pending, block_idx
+            aiv0_to_pending, block_idx
         );
     }
     if (cmask & PTO2_SUBTASK_MASK_AIV1) {
+        bool aiv1_to_pending = to_pending && !tracker.is_aiv1_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
-            to_pending, block_idx
+            aiv1_to_pending, block_idx
         );
     }
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -306,9 +306,14 @@ public:
     // Runtime MIX dispatch uses classify_mix_cluster() so the decision follows the task's active_mask.
     enum class MixPlacement : uint8_t { RUNNING, PENDING, REJECT };
 
-    // A MIX block must place all cores named by active_mask the same way:
-    // all idle means running placement, all running means pending placement,
-    // and any mixed state is retried later.
+    // Placement for the cores named by active_mask, ignoring cores this task does
+    // not use. All used cores idle -> RUNNING placement (each to its running slot).
+    // Otherwise -> PENDING placement: at dispatch each used core is filled per its
+    // own state -- an idle core takes its running slot (and is marked running, so
+    // the completion poller, which scans only running cores, tracks its FIN), an
+    // already-running core takes its pending slot and executes after its in-flight
+    // task. REJECT only when a used core's pending slot is already occupied (no free
+    // slot) or the mask is empty.
     MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
         BitStates used(0ULL);
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
@@ -328,10 +333,7 @@ public:
         if (idle.count() == used.count()) {
             return MixPlacement::RUNNING;
         }
-        if (!idle.has_value()) {
-            return MixPlacement::PENDING;
-        }
-        return MixPlacement::REJECT;
+        return MixPlacement::PENDING;
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -211,32 +211,30 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
     EXPECT_EQ(out[1], &slot_b);
 }
 
-TEST(CoreTrackerTest, MixPendingRejectsPartiallyRunningCluster) {
+TEST(CoreTrackerTest, MixPartiallyRunningClusterAdmittedAsPerCorePlacement) {
     CoreTracker tracker;
     tracker.init(1);
     tracker.set_cluster(0, 0, 1, 2);
 
     constexpr int32_t cluster_offset = 0;
-    tracker.change_core_state(cluster_offset + 1);  // AIV0 running, AIC/AIV1 idle
+    tracker.change_core_state(cluster_offset + 1);  // AIV0 running (unrelated task), AIC/AIV1 idle
     tracker.clear_pending_occupied(cluster_offset + 1);
 
     EXPECT_TRUE(tracker.is_aic_core_idle(cluster_offset));
     EXPECT_FALSE(tracker.is_aiv0_core_idle(cluster_offset));
     EXPECT_TRUE(tracker.is_aiv1_core_idle(cluster_offset));
 
-    const bool would_place_aic_pending = !tracker.is_aic_core_idle(cluster_offset);
-    const bool would_place_aiv0_pending = !tracker.is_aiv0_core_idle(cluster_offset);
-    const bool would_place_aiv1_pending = !tracker.is_aiv1_core_idle(cluster_offset);
-    EXPECT_FALSE(would_place_aic_pending);
-    EXPECT_TRUE(would_place_aiv0_pending);
-    EXPECT_FALSE(would_place_aiv1_pending);
+    // A 1C2V MIX task is admitted on this partial cluster as a PENDING placement.
+    // Per-core dispatch then puts the idle AIC/AIV1 on their running slots (marked
+    // running so the completion poller tracks them) and the busy AIV0 on its pending
+    // slot, executing after the in-flight AIV-only task.
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0 | PTO2_SUBTASK_MASK_AIV1;
+    EXPECT_EQ(tracker.classify_mix_cluster(cluster_offset, used_mask), CoreTracker::MixPlacement::PENDING);
 
+    // Not all used cores are idle, so the IDLE phase skips this cluster; it is
+    // consumed by the PENDING phase.
     auto idle = tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX);
     EXPECT_FALSE(idle.has_value());
-
-    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
-    EXPECT_FALSE(pending.has_value()) << "Pending admission here would split one MIX block across running AIC/AIV1 "
-                                      << "placement and pending AIV0 placement.";
 }
 
 TEST(CoreTrackerTest, MixPendingAcceptsFullyRunningClusterWithFreePendingSlots) {
@@ -311,7 +309,7 @@ TEST(CoreTrackerTest, MixClassifyAllowsPendingForUsedRunningCoresOnly) {
     EXPECT_EQ(placement, CoreTracker::MixPlacement::PENDING);
 }
 
-TEST(CoreTrackerTest, MixClassifyRejectsMixedUsedCores) {
+TEST(CoreTrackerTest, MixClassifyAdmitsMixedUsedCoresAsPending) {
     CoreTracker tracker;
     tracker.init(1);
     tracker.set_cluster(0, 0, 1, 2);
@@ -319,8 +317,10 @@ TEST(CoreTrackerTest, MixClassifyRejectsMixedUsedCores) {
     constexpr int32_t cluster_offset = 0;
     tracker.change_core_state(cluster_offset + 1);  // AIV0 running while AIC is idle
 
+    // Mixed used-core state (AIC idle, AIV0 running) is admitted as PENDING; the
+    // idle AIC takes its running slot and the busy AIV0 takes its pending slot.
     auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
-    EXPECT_EQ(placement, CoreTracker::MixPlacement::REJECT);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::PENDING);
 }
 
 TEST(CoreTrackerTest, MixClassifyRejectsOccupiedPendingSlotInUsedMask) {

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -201,32 +201,30 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
     EXPECT_EQ(out[1], &slot_b);
 }
 
-TEST(CoreTrackerTest, MixPendingRejectsPartiallyRunningCluster) {
+TEST(CoreTrackerTest, MixPartiallyRunningClusterAdmittedAsPerCorePlacement) {
     CoreTracker tracker;
     tracker.init(1);
     tracker.set_cluster(0, 0, 1, 2);
 
     constexpr int32_t cluster_offset = 0;
-    tracker.change_core_state(cluster_offset + 1);  // AIV0 running, AIC/AIV1 idle
+    tracker.change_core_state(cluster_offset + 1);  // AIV0 running (unrelated task), AIC/AIV1 idle
     tracker.clear_pending_occupied(cluster_offset + 1);
 
     EXPECT_TRUE(tracker.is_aic_core_idle(cluster_offset));
     EXPECT_FALSE(tracker.is_aiv0_core_idle(cluster_offset));
     EXPECT_TRUE(tracker.is_aiv1_core_idle(cluster_offset));
 
-    const bool would_place_aic_pending = !tracker.is_aic_core_idle(cluster_offset);
-    const bool would_place_aiv0_pending = !tracker.is_aiv0_core_idle(cluster_offset);
-    const bool would_place_aiv1_pending = !tracker.is_aiv1_core_idle(cluster_offset);
-    EXPECT_FALSE(would_place_aic_pending);
-    EXPECT_TRUE(would_place_aiv0_pending);
-    EXPECT_FALSE(would_place_aiv1_pending);
+    // A 1C2V MIX task is admitted on this partial cluster as a PENDING placement.
+    // Per-core dispatch then puts the idle AIC/AIV1 on their running slots (marked
+    // running so the completion poller tracks them) and the busy AIV0 on its pending
+    // slot, executing after the in-flight AIV-only task.
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0 | PTO2_SUBTASK_MASK_AIV1;
+    EXPECT_EQ(tracker.classify_mix_cluster(cluster_offset, used_mask), CoreTracker::MixPlacement::PENDING);
 
+    // Not all used cores are idle, so the IDLE phase skips this cluster; it is
+    // consumed by the PENDING phase.
     auto idle = tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX);
     EXPECT_FALSE(idle.has_value());
-
-    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
-    EXPECT_FALSE(pending.has_value()) << "Pending admission here would split one MIX block across running AIC/AIV1 "
-                                      << "placement and pending AIV0 placement.";
 }
 
 TEST(CoreTrackerTest, MixPendingAcceptsFullyRunningClusterWithFreePendingSlots) {
@@ -301,7 +299,7 @@ TEST(CoreTrackerTest, MixClassifyAllowsPendingForUsedRunningCoresOnly) {
     EXPECT_EQ(placement, CoreTracker::MixPlacement::PENDING);
 }
 
-TEST(CoreTrackerTest, MixClassifyRejectsMixedUsedCores) {
+TEST(CoreTrackerTest, MixClassifyAdmitsMixedUsedCoresAsPending) {
     CoreTracker tracker;
     tracker.init(1);
     tracker.set_cluster(0, 0, 1, 2);
@@ -309,8 +307,10 @@ TEST(CoreTrackerTest, MixClassifyRejectsMixedUsedCores) {
     constexpr int32_t cluster_offset = 0;
     tracker.change_core_state(cluster_offset + 1);  // AIV0 running while AIC is idle
 
+    // Mixed used-core state (AIC idle, AIV0 running) is admitted as PENDING; the
+    // idle AIC takes its running slot and the busy AIV0 takes its pending slot.
     auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
-    EXPECT_EQ(placement, CoreTracker::MixPlacement::REJECT);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::PENDING);
 }
 
 TEST(CoreTrackerTest, MixClassifyRejectsOccupiedPendingSlotInUsedMask) {


### PR DESCRIPTION
## Summary

PR #1097 required every core named by a MIX task's `active_mask` to be in the
same state: all-idle → running placement, all-running → pending placement, and
any **mixed** state was rejected and retried later. This made a MIX task wait
whenever one of its cores was busy with an unrelated task, even when the other
cores were idle and could start immediately.

That uniform restriction was a scheduler-side workaround for #851, whose real
cause is incore (AICore cross-core) synchronization — now confirmed robust to
arbitrary subtask start skew. With that guarantee the scheduler no longer needs
to keep a MIX block's cores in lockstep.

### Changes

- **`classify_mix_cluster`** (a2a3 + a5): a cluster is usable whenever no used
  core's pending slot is occupied — all used cores idle → `RUNNING`, any other
  state → `PENDING` (was `REJECT` for mixed).
- **Per-core slot selection** restored in the MIX dispatch helpers
  (`dispatch_mix_block_to_cluster` on a5, `prepare_block_for_dispatch` on a2a3):
  `to_pending = to_pending && !is_core_idle(core)`. An idle core takes its
  running slot and is marked running so the completion poller (which scans only
  running cores) tracks its FIN; an already-running core takes its pending slot
  and is promoted on completion.
- IDLE phase still claims fully-idle clusters first, so idle cores are always
  preferred ("idle 优先, otherwise pending").
- a2a3 **early-dispatch** is covered transitively — it shares
  `classify_mix_cluster` and funnels placement through
  `prepare_block_for_dispatch`; no early-dispatch-specific edit needed.
- **sync_start drain** is unchanged: `RUNNING` placement still means all used
  cores idle, so `get_mix_running_cluster_offset_states` / drain accounting are
  untouched.
- Updated the two PR #1097 `CoreTracker` unit tests on both arches to assert
  the new per-core admission (mixed used-core state → `PENDING`).

## Testing

- [x] ut-cpp: `test_scheduler`, `test_scheduler_state`, `test_a5_scheduler_state`
  pass (both arches, 10/10 `CoreTracker` cases each)
- [ ] Hardware regression: AIV-only × MIX interleave on a partially-busy cluster
  (e.g. the `models/deepseek` MoE path from #851) no longer conflicts — pending

Relates to #851, revisits #1097.