### PR TITLE
Add: deps_viewer transitive-reduction edge modes

### DIFF
--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -302,15 +302,42 @@ python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
 # Override task labels with a func_id -> name mapping
 python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
     --func-names outputs/<case>_<ts>/name_map_TestPA_basic.json
+
+# Transitive reduction: drop edges implied by a longer path, print what was removed
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --edge-mode reduced
+
+# Redundant-only: draw ONLY the transitively-implied edges reduced would drop
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --edge-mode omitted
 ```
+
+`--edge-mode` selects which structural `(pred, succ)` edges are drawn:
+
+- `full` (default) — every dependency edge.
+- `reduced` — the minimal (transitively-reduced) edge set: every edge already
+  implied by a longer path is dropped, e.g. `A->C` when `A->B->C` exists.
+- `omitted` — only the redundant edges `reduced` would drop (its complement),
+  for auditing exactly which dependencies are transitively covered.
+
+`reduced` and `omitted` print the redundant edges to stdout as a
+`<task> -> <task>` list, where each task uses the same label as the rendered
+graph — the bare `local` counter when every task is in ring 0, or the explicit
+`(ring, local)` tuple once any task lives in ring >= 1. Both `text` and `html`
+output honor the mode. When `-o` is omitted the graph is written to a
+mode-specific stem (`deps_viewer_reduced.*` / `deps_viewer_omitted.*`) rather
+than `deps_viewer.*` so it never clobbers a full-graph render in the same
+directory. Reduction is purely structural (it ignores the per-edge tensor/arg
+identity) and is skipped with a warning if the graph contains a cycle.
 
 ### Command-Line Options
 
 | Option | Short | Description |
 | ------ | ----- | ----------- |
 | `input` | | Path to `deps.json` (default: newest under `./outputs/`) |
-| `--output` | `-o` | Output path (default: `deps_viewer.txt` for text, `deps_viewer.html` for HTML) |
+| `--output` | `-o` | Output path (default: `deps_viewer.txt` for text, `deps_viewer.html` for HTML; `reduced`/`omitted` use the `deps_viewer_reduced.*` / `deps_viewer_omitted.*` stem) |
 | `--format` | | Output format: `text` (default) or `html` |
+| `--edge-mode` | | `full` (default) draws every edge; `reduced` draws the transitively-reduced (minimal) set; `omitted` draws only the redundant edges reduced would drop. `reduced`/`omitted` print the redundant edges and apply to both formats. |
 | `--engine` | | HTML-only Graphviz layout engine: `dot` (default), `sfdp`, `neato`, `fdp`, `circo`, `twopi` |
 | `--direction` | | HTML-only flow direction for hierarchical layouts: `LR` (default) / `TB` / `BT` / `RL` |
 | `--show-tensor-info` | | HTML-only: render per-task tensor rows and route edges to specific arg ports |

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -31,6 +31,21 @@ Usage:
     python -m simpler_setup.tools.deps_viewer DEPS_JSON
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --format text
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --format html --engine sfdp
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode reduced
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode omitted
+
+``--edge-mode`` selects which edges are drawn (structural transitive reduction,
+purely on ``(pred, succ)`` — per-edge tensor identity is ignored, and it is
+skipped with a warning if the graph contains a cycle):
+
+- ``full`` (default) — every edge.
+- ``reduced`` — the minimal edge set: drops every edge whose ordering is already
+  implied by a longer path (e.g. ``A->C`` when ``A->B->C`` exists).
+- ``omitted`` — only the redundant edges ``reduced`` would drop (its complement),
+  useful for auditing exactly which dependencies are transitively covered.
+
+``reduced`` and ``omitted`` print the redundant edges to stdout and emit in
+whichever format is selected.
 
 HTML output requires Graphviz installed (``brew install graphviz`` /
 ``apt install graphviz``). Text output does not.
@@ -41,6 +56,7 @@ import json
 import shutil
 import subprocess
 import sys
+from collections import deque
 from pathlib import Path
 
 
@@ -194,6 +210,75 @@ def _load_deps_edges(deps_path):
             task_table[tid] = entry
     _backfill_output_tensor_ids(task_table, annotations)
     return sorted(edges), sorted(nodes), annotations, tensor_table, task_table
+
+
+def _transitive_reduction(edges, nodes):
+    """DAG transitive reduction on structural ``(pred, succ)`` edges.
+
+    An edge ``(u, v)`` is redundant when ``v`` is still reachable from ``u``
+    through some other path that does not use the direct ``(u, v)`` edge — i.e.
+    the dependency it expresses is already implied by a longer chain. Reduction
+    is purely structural: it ignores the per-edge tensor / arg annotations, so a
+    ``(u, v)`` carrying its own tensor is dropped whenever the ordering it
+    encodes is transitively covered.
+
+    Runs in ``O(V·E)``: nodes are visited in reverse topological order while a
+    descendant-reachability set is accumulated per node, so each edge is tested
+    with a single set membership rather than a fresh graph walk. Assumes every
+    edge endpoint is present in ``nodes`` (the caller's contract).
+
+    Returns ``(kept_edges, removed_edges, is_dag)``. ``kept_edges`` and
+    ``removed_edges`` preserve the order of the input ``edges`` (so passing the
+    sorted list from ``_load_deps_edges`` yields sorted results without a second
+    sort). On a cyclic graph the input edges are returned unchanged with
+    ``is_dag=False`` (transitive reduction is only well-defined on a DAG); the
+    caller warns and emits the full graph.
+    """
+    succ: dict[int, set[int]] = {n: set() for n in nodes}
+    indeg: dict[int, int] = {n: 0 for n in nodes}
+    for u, v in edges:
+        if v not in succ[u]:
+            succ[u].add(v)
+            indeg[v] += 1
+
+    # Kahn topological sort doubles as the cycle check: if we can't drain every
+    # node, a cycle remains and reduction would be ill-defined. Keep the drain
+    # order so we can walk it in reverse (descendants before ancestors).
+    remaining = dict(indeg)
+    queue = deque(n for n, d in remaining.items() if d == 0)
+    topo_order: list[int] = []
+    while queue:
+        n = queue.popleft()
+        topo_order.append(n)
+        for m in succ[n]:
+            remaining[m] -= 1
+            if remaining[m] == 0:
+                queue.append(m)
+    if len(topo_order) != len(succ):
+        return list(edges), [], False
+
+    # Reverse topological order guarantees every successor's reachability set is
+    # already final before we process a node. For node u, an edge (u, v) is
+    # redundant iff v lies in the reachability set of some *other* successor of
+    # u (v is reachable via a length >= 2 path); indirect collects those.
+    reach: dict[int, set[int]] = {}
+    redundant: set[tuple[int, int]] = set()
+    for u in reversed(topo_order):
+        indirect: set[int] = set()
+        for v in succ[u]:
+            indirect |= reach[v]
+        for v in succ[u]:
+            if v in indirect:
+                redundant.add((u, v))
+        node_reach = set(succ[u])
+        node_reach |= indirect
+        reach[u] = node_reach
+
+    # edges arrives already sorted (from _load_deps_edges); filtering preserves
+    # that order, so kept/removed stay sorted without a second sort.
+    kept = [e for e in edges if e not in redundant]
+    removed = [e for e in edges if e in redundant]
+    return kept, removed, True
 
 
 def _backfill_output_tensor_ids(task_table, annotations):
@@ -1009,6 +1094,8 @@ Examples:
   %(prog)s deps.json --format text -o graph.txt
   %(prog)s deps.json --format html --engine sfdp
   %(prog)s deps.json --format html --show-tensor-info
+  %(prog)s deps.json --edge-mode reduced      # drop transitively-implied edges, print what was removed
+  %(prog)s deps.json --edge-mode omitted      # draw ONLY the transitively-implied (redundant) edges
 """,
     )
     p.add_argument("input", nargs="?", help="Path to deps.json (default: newest under ./outputs/).")
@@ -1018,6 +1105,17 @@ Examples:
         choices=["text", "html"],
         default="text",
         help="Output format: text (default) or html.",
+    )
+    p.add_argument(
+        "--edge-mode",
+        choices=["full", "reduced", "omitted"],
+        default="full",
+        help=(
+            "full (default) draws every dependency edge; reduced applies transitive reduction, keeping the "
+            "minimal edge set; omitted keeps only the redundant edges reduced would drop (the complement of "
+            "reduced). reduced/omitted print the redundant edges to stdout, are structural (pred,succ) level, "
+            "apply to both text and html, and are skipped with a warning on a cyclic graph."
+        ),
     )
     p.add_argument(
         "--engine",
@@ -1085,10 +1183,40 @@ def main(argv=None):
     if meta:
         nodes = sorted(set(nodes) | set(meta.keys()), key=_sort_task_id_key)
 
+    mode_stem = "deps_viewer"
+    if args.edge_mode in ("reduced", "omitted"):
+        kept, removed, is_dag = _transitive_reduction(edges, nodes)
+        if not is_dag:
+            print(
+                f"warning: dependency graph has a cycle; transitive reduction skipped, "
+                f"emitting full graph (--edge-mode {args.edge_mode} ignored)",
+                file=sys.stderr,
+            )
+        else:
+            fmt_task = _make_task_formatter(nodes)
+            # reduced keeps the minimal edge set; omitted keeps exactly the
+            # redundant edges that reduced would drop (the two are complements).
+            shown = kept if args.edge_mode == "reduced" else removed
+            if args.edge_mode == "reduced":
+                print(
+                    f"Transitive reduction: removed {len(removed)} redundant edge(s) of {len(edges)} ({len(kept)} kept)"
+                )
+            else:
+                print(f"Redundant edges only: showing {len(removed)} redundant edge(s) of {len(edges)}")
+            for u, v in removed:
+                print(f"  - {fmt_task(u)} -> {fmt_task(v)}")
+            edges = shown
+            # Keep only the annotations of the shown edges so annotated-edge
+            # counts (emit_text summary, the final print) stay consistent with
+            # the rendered edge set instead of counting the hidden ones.
+            shown_set = set(shown)
+            annotations = {k: v for k, v in annotations.items() if k in shown_set}
+            mode_stem = f"deps_viewer_{args.edge_mode}"
+
     out = (
         Path(args.output)
         if args.output
-        else input_path.parent / ("deps_viewer.txt" if args.format == "text" else "deps_viewer.html")
+        else input_path.parent / f"{mode_stem}.{'txt' if args.format == 'text' else 'html'}"
     )
     if args.format == "text":
         text = emit_text(

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -8,6 +8,8 @@
 # -----------------------------------------------------------------------------------------------------------
 """Contract tests for simpler_setup.tools.deps_viewer text output."""
 
+import json
+
 from simpler_setup.tools import deps_viewer
 from simpler_setup.tools.deps_viewer import _merge_task_meta_with_kernel_ids, emit_text
 
@@ -349,3 +351,115 @@ def test_main_keeps_task_metadata_when_show_tensor_info_disabled(tmp_path, monke
     assert rc == 0
     assert captured["task_table"] == {1: {"task_id": 1, "args": []}}
     assert captured["show_tensor_info"] is False
+
+
+def test_transitive_reduction_removes_implied_edge():
+    # A->B->C plus the implied shortcut A->C.
+    kept, removed, is_dag = deps_viewer._transitive_reduction([(1, 2), (1, 3), (2, 3)], [1, 2, 3])
+    assert is_dag
+    assert removed == [(1, 3)]
+    assert kept == [(1, 2), (2, 3)]
+
+
+def test_transitive_reduction_keeps_non_redundant_diamond():
+    # Diamond A->B, A->C, B->D, C->D — no edge is implied by another path.
+    edges = [(1, 2), (1, 3), (2, 4), (3, 4)]
+    kept, removed, is_dag = deps_viewer._transitive_reduction(edges, [1, 2, 3, 4])
+    assert is_dag
+    assert removed == []
+    assert kept == sorted(edges)
+
+
+def test_transitive_reduction_drops_multi_hop_shortcut():
+    # Chain A->B->C->D with a long shortcut A->D implied by three hops.
+    kept, removed, is_dag = deps_viewer._transitive_reduction([(1, 2), (2, 3), (3, 4), (1, 4)], [1, 2, 3, 4])
+    assert is_dag
+    assert removed == [(1, 4)]
+    assert kept == [(1, 2), (2, 3), (3, 4)]
+
+
+def test_transitive_reduction_detects_cycle_and_falls_back():
+    edges = [(1, 2), (2, 1)]
+    kept, removed, is_dag = deps_viewer._transitive_reduction(edges, [1, 2])
+    assert not is_dag
+    assert kept == edges
+    assert removed == []
+
+
+def _write_deps_edges(tmp_path, edges):
+    deps = {
+        "tasks": [],
+        "tensors": [],
+        "edges": [{"pred": str(p), "succ": str(s), "arg": 0, "source": "creator"} for p, s in edges],
+    }
+    path = tmp_path / "deps.json"
+    path.write_text(json.dumps(deps))
+    return path
+
+
+def test_main_reduced_mode_drops_edge_and_prints_removed(tmp_path, capsys):
+    # A(r1t1) -> B(r1t2) -> C(r1t3) plus the implied A->C shortcut.
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "reduced", "-o", str(out)])
+    assert rc == 0
+
+    text = out.read_text()
+    assert "unique_task_edges: 2" in text
+    # Annotations of the pruned edge are dropped too, so the count matches the
+    # reduced edge set instead of over-counting (was 3 before reduction).
+    assert "annotated_edges: 2" in text
+    stdout = capsys.readouterr().out
+    assert "removed 1 redundant edge(s)" in stdout
+    # ring>=1 nodes render as the explicit (ring, local) tuple.
+    assert "(1, 1) -> (1, 3)" in stdout
+
+
+def test_main_full_mode_keeps_all_edges(tmp_path, capsys):
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "-o", str(out)])
+    assert rc == 0
+    assert "unique_task_edges: 3" in out.read_text()
+    assert "Transitive reduction" not in capsys.readouterr().out
+
+
+def test_main_omitted_mode_draws_only_redundant_edges(tmp_path, capsys):
+    # A(r1t1) -> B(r1t2) -> C(r1t3) plus the implied A->C shortcut. omitted
+    # keeps ONLY the redundant A->C edge (complement of reduced).
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "omitted", "-o", str(out)])
+    assert rc == 0
+
+    text = out.read_text()
+    # Only the single redundant edge is drawn; annotations match it.
+    assert "unique_task_edges: 1" in text
+    assert "annotated_edges: 1" in text
+    # The drawn edge is the redundant A->C, not the chain edges.
+    assert "=== TASK (1, 1)" in text
+    assert "  -> (1, 3)" in text
+    assert "  -> (1, 2)" not in text
+    stdout = capsys.readouterr().out
+    assert "showing 1 redundant edge(s)" in stdout
+    assert "(1, 1) -> (1, 3)" in stdout
+
+
+def test_main_omitted_default_output_stem(tmp_path):
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "omitted"])
+    assert rc == 0
+    assert (tmp_path / "deps_viewer_omitted.txt").exists()
+    assert not (tmp_path / "deps_viewer.txt").exists()


### PR DESCRIPTION
Add --edge-mode {full,reduced,omitted} (default full, unchanged). deps.json
carries structurally redundant edges (A->C when A->B->C exists) that clutter the
graph. reduced draws the minimal edge set; omitted draws only those redundant
edges (reduced's complement). Both apply to text and html, print the redundant
edges to stdout, and are skipped with a warning on a cyclic graph.

Reduction is O(V*E): a Kahn topological sort checks for cycles and gives a drain
order, then a reverse-topo pass builds a per-node reachability set so each edge
is decided by one membership test. Annotations of hidden edges are dropped so
edge counts stay consistent, and each mode writes to its own output stem
(deps_viewer_{reduced,omitted}.*) to avoid clobbering the full-graph render.