### PR TITLE
Refactor: shard profiling collector accumulation

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -495,6 +495,13 @@ replenish thread folds done buffers back into recycled lanes and, for
 modules that declare a recycled watermark, tops those lanes up by batched
 allocation without writing device free queues.
 
+Each collector appends metadata to its own vector, so collectors do not
+serialize on the manifest accumulator. Payloads still share one `args.bin`:
+the narrow writer lock assigns the next binary offset and enqueues the payload
+in the same order, while metadata insertion stays outside that lock. Export
+joins the writer, folds the shard-local vectors together, and sorts the merged
+metadata by `(task_id, stage, arg_index, role)` before writing JSON.
+
 ```text
         HOST                                         DEVICE
 ┌──────────────────────────┐               ┌──────────────────────────┐
@@ -556,8 +563,8 @@ the base class owns split mgmt threads, collector shards, and the
 only supplies the dump-specific pieces — the `DumpModule` trait
 that describes the shared-memory layout, `initialize` that
 allocates and pre-fills free queues, an `on_buffer_collected`
-callback that gathers payload bytes into the in-memory record
-list, plus `reconcile_counters` / `export_dump_files` /
+callback that gathers payload bytes and appends metadata to a shard-local
+record list, plus `reconcile_counters` / `export_dump_files` /
 `finalize`. The mgmt/collector threading, buffer pooling, and `Module`
 trait pattern are shared with PMU and L2Swimlane — see
 [profiling-framework.md](../profiling-framework.md) for the
@@ -622,7 +629,7 @@ the buffer's records.
 │   wait_pop_ready         │               │                          │
 │   on_buffer_collected →  │               │                          │
 │     copy arena slice     │<──memcpy─────<│                          │
-│     extract DumpedTensors│               │                          │
+│     extract DumpedArgs   │               │                          │
 │     queue to writer thrd │               │                          │
 │   notify_copy_done       │               │                          │
 │                          │               │                          │

--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -247,7 +247,8 @@ extra allocation target.
 │   │ collector shard    │ │ mapping       │   push remaining full    │
 │   │   read records via │<┼──────────────<│   buffers to ready_q     │
 │   │   host mapping     │ │               │                          │
-│   │   append to CSV    │ │               │                          │
+│   │   append to shard  │ │               │                          │
+│   │   temp CSV         │ │               │                          │
 │   └────────────────────┘ │               └──────────────────────────┘
 │                          │
 │ stop()                   │
@@ -288,11 +289,12 @@ start(tf)                       ← spawn split mgmt threads (drain AICPU ready
                                   recycled lanes; replenish drains done
                                   buffers into recycled lanes)
                                   + collector shards (drain host hand-off,
-                                  append to CSV)
+                                  append to shard-local temp CSV files)
 launch AICPU / AICore
 rtStreamSynchronize             ← wait for kernel completion
 stop()                          ← join mgmt/replenish → join collectors
-reconcile_counters()            ← assert collected + dropped == total;
+reconcile_counters()            ← merge shard files into pmu.csv, then assert
+                                  collected + dropped == total;
                                   any non-empty current_buf_ptr is a
                                   flush bug, logged as ERROR
 finalize(unregister, free)
@@ -305,11 +307,16 @@ the base class owns split mgmt threads, collector shards, and the
 `BufferPoolManager<PmuModule>` they share. `PmuCollector` only supplies
 the PMU-specific pieces — the `PmuModule` trait that describes the
 shared-memory layout, an `init()` that allocates and pre-fills the free
-queues, an `on_buffer_collected()` callback that appends records to the
-CSV, and `reconcile_counters()` / `finalize()`. The mgmt/collector threading,
-buffer pooling, and `Module` trait pattern are shared with ArgsDump
-and L2Swimlane — see [profiling-framework.md](../profiling-framework.md) for
-the framework reference.
+queues, an `on_buffer_collected()` callback that appends records to a
+shard-local temporary CSV, and `reconcile_counters()` / `finalize()` that
+merge those files into `pmu.csv`. A failed merge preserves the temporary
+files and does not count their rows as successfully exported. Successful
+reconciliation removes the temporary files. An abrupt process exit can leave
+them in the CSV directory; the next `start()` for the same output path removes
+those stale run-scoped files before collector threads launch. The
+mgmt/collector threading, buffer pooling, and `Module` trait pattern are shared
+with ArgsDump and L2Swimlane — see
+[profiling-framework.md](../profiling-framework.md) for the framework reference.
 
 ### 5.3 a5 — same framework, host-shadow transport (DAV_3510, 10 counters)
 
@@ -377,7 +384,7 @@ still pulled on demand inside
 │ poll thread:             │               │                          │
 │   wait_pop_ready         │               │                          │
 │   on_buffer_collected →  │               │                          │
-│     write_buffer_to_csv  │               │                          │
+│     write shard temp CSV │               │                          │
 │   notify_copy_done       │               │                          │
 │                          │               │                          │
 │ rtStreamSynchronize      │               │                          │
@@ -452,7 +459,8 @@ pmu_collector_.start(thread_factory)   ← mgmt + poll threads
 launch AICPU / AICore
 rtStreamSynchronize
 pmu_collector_.stop()                  ← join mgmt + poll, drain final batch
-pmu_collector_.reconcile_counters()    ← collected + dropped + mismatch == device_total
+pmu_collector_.reconcile_counters()    ← merge shard files, then verify
+                                          collected + dropped + mismatch == device_total
 pmu_collector_.finalize(free)
 ```
 
@@ -493,7 +501,7 @@ device-side counters.
 | Counter readout | AICPU MMIO `read_reg` | AICore MMIO `ld_dev` |
 | Per-core staging | direct write into `records[count]` | dual-issue slots, AICPU commits on FIN |
 | Buffer model | rotating pool (free + ready queues, SPSC protocol) | identical |
-| Host threads | split mgmt + collector shards, streams during execution | same split mgmt + collector shards (7 = `PLATFORM_MAX_AICPU_THREADS` vs a2a3's 4) |
+| Host threads | split mgmt + collector shards, writes shard-local temp files during execution and merges at reconcile | same split mgmt + collector shards (7 = `PLATFORM_MAX_AICPU_THREADS` vs a2a3's 4) |
 | Host-class shape | `ProfilerBase<PmuCollector, PmuModule>` | identical |
 | Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
 | `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
@@ -508,8 +516,9 @@ counter-read code paths are skipped.
 
 When enabled, the dominant per-task overhead is the MMIO counter read
 (8 reads on a2a3, 10 on a5) plus a single record copy. On both
-architectures, streaming keeps host-side work off the critical path —
-the collector shards drain buffers concurrently with kernel execution.
+architectures, shard-local streaming keeps host-side work off the critical
+path without serializing collectors on one output stream. Reconciliation
+merges the bounded temporary files into the final CSV after collection stops.
 Both a2a3 and a5 use split mgmt plus collector shards (a5 with 7 shards,
 a2a3 with 4). a5's copy hooks add `rtMemcpy` round-trips that a2a3's
 shared memory avoids, but these overlap with device execution.

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -240,10 +240,14 @@ and
 Each collector inherits as `class XxxCollector : public ProfilerBase<XxxCollector, XxxModule>`
 and only has to provide:
 
-- `void on_buffer_collected(const ReadyBufferInfo& info)` — copy the
-  records out of `info.host_buffer_ptr` and update collector-specific
-  state (CSV row, in-memory aggregator, file writer thread, …). The
-  framework calls `manager_.notify_copy_done(...)` afterwards; **Derived
+- `void on_buffer_collected(const ReadyBufferInfo& info)` or the optional
+  shard-aware overload `void on_buffer_collected(const ReadyBufferInfo& info,
+  int collector_shard)` — copy records out of `info.host_buffer_ptr` and
+  update collector-specific state (CSV row, in-memory aggregator, file writer
+  thread, …). PMU and ArgsDump use the shard id for lock-free local
+  accumulation. DepGen and ScopeStats have one orchestrator producer, so they
+  retain their single-accumulator path. The framework calls
+  `manager_.notify_copy_done(...)` afterwards; **Derived
   must not call it directly.**
 - `static constexpr int kIdleTimeoutSec` — bound on no-progress idle in
   the collector loop. Use the subsystem's `PLATFORM_*_TIMEOUT_SECONDS`

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -18,24 +18,25 @@
  *   per-thread ready queues, drains done-queue shards, and replenishes the
  *   per-core free_queues from shard-local recycled lanes.
  * - PmuCollector: collector thread shards pop full PmuBuffers from the manager
- *   and append them to the CSV file.
+ *   and append them to shard-local temporary CSV files.
  *
  * Lifecycle:
  *   init()                       — Allocate header + per-core states + PmuBuffers
  *                                  (pre-fills free_queues; rest go into the
  *                                  recycled pool). Calls set_memory_context()
  *                                  on the base so start(tf) can launch threads.
- *   start(tf)                    — Inherited from ProfilerBase: assembles
- *                                  MemoryOps from the stashed callbacks and
- *                                  launches the mgmt + collector threads.
+ *   start(tf)                    — Reset run-scoped CSV shards, then launch the
+ *                                  mgmt + collector threads through
+ *                                  ProfilerBase.
  *   [device execution]
  *   stop()                       — Stop mgmt → join mgmt → signal collectors →
  *                                  drain ready shards → join collectors, in
  *                                  that order. On return both thread exits and
  *                                  queue drains are complete.
- *   reconcile_counters()         — Sanity-check PmuBufferState::current_buf_ptr
- *                                  (any non-zero pointer with records is a
- *                                  device-flush bug, logged as ERROR) and run
+ *   reconcile_counters()         — Merge CSV shards, sanity-check
+ *                                  PmuBufferState::current_buf_ptr (any
+ *                                  non-zero pointer with records is a
+ *                                  device-flush bug, logged as ERROR), and run
  *                                  the device-side cross-check:
  *                                  collected + dropped == total.
  *   finalize()                   — Free all device memory and unregister.
@@ -53,9 +54,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
-#include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "common/memory_barrier.h"
@@ -223,6 +222,8 @@ public:
         const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
     );
 
+    void start(const profiling_common::ThreadFactory &thread_factory);
+
     /**
      * Device pointer to the PmuDataHeader. Set kernel_args.pmu_data_base
      * to this after init() succeeds so the AICPU side can find the
@@ -234,7 +235,7 @@ public:
      * Per-buffer callback invoked by ProfilerBase's poll loop. Flushes
      * records to CSV.
      */
-    void on_buffer_collected(const PmuReadyBufferInfo &info);
+    void on_buffer_collected(const PmuReadyBufferInfo &info, int collector_shard);
 
     /**
      * After stop(), perform purely-passive accounting:
@@ -259,6 +260,13 @@ public:
     bool is_initialized() const { return initialized_; }
 
 private:
+    struct alignas(64) CollectorShardCounters {
+        uint64_t total_collected{0};
+    };
+    static_assert(
+        sizeof(CollectorShardCounters) % 64 == 0, "CollectorShardCounters must not share cache lines across shards"
+    );
+
     bool initialized_ = false;
     int num_cores_ = 0;
     int num_threads_ = 0;
@@ -274,13 +282,18 @@ private:
     // unregister-vs-free-only behavior in finalize.
     bool buffers_registered_ = false;
 
-    // CSV output. File is opened lazily on the first record write so that a
-    // hung device run that produces no records does not leave a header-only
-    // CSV on disk.
+    // CSV output. Collector shards stream rows into shard-local temp files on
+    // the hot path; stop-time reconciliation merges them into the final CSV so
+    // collector threads do not contend on one ofstream mutex or retain all rows
+    // in heap memory.
     std::string csv_path_;
     std::string csv_header_;
     std::ofstream csv_file_;
-    std::mutex csv_mutex_;
+    std::vector<std::string> csv_shard_paths_;
+    std::vector<std::ofstream> csv_shard_files_;
+    std::vector<CollectorShardCounters> collector_counters_;
+    std::atomic<bool> csv_shard_io_failed_{false};
+    bool csv_shards_finalized_{false};
 
     // Running total of records written to CSV. Used at drain time to verify
     // collected + device-side dropped == device-side total.
@@ -289,8 +302,14 @@ private:
     PmuDataHeader *pmu_header() const { return get_pmu_header(shm_host_); }
     PmuBufferState *pmu_state(int core_id) const { return get_pmu_buffer_state(shm_host_, core_id); }
 
-    void write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr);
-    void ensure_csv_open_unlocked();
+    size_t normalize_collector_shard(int collector_shard) const;
+    void reset_collector_shards();
+    void append_buffer_to_csv_shard(int core_id, int thread_idx, const void *buf_host_ptr, int collector_shard);
+    bool flush_collector_shards_to_csv();
+    bool ensure_csv_shard_open(size_t shard);
+    bool ensure_csv_open();
+    bool close_csv_shards();
+    void cleanup_csv_shards();
 };
 
 // ---------------------------------------------------------------------------

--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <ios>
 #include <unordered_set>
@@ -88,7 +89,7 @@ int PmuCollector::init(
     csv_path_ = csv_path;
     buffers_registered_ = (register_cb != nullptr);
 
-    total_collected_ = 0;
+    reset_collector_shards();
     execution_complete_.store(false, std::memory_order_release);
     if (csv_file_.is_open()) {
         csv_file_.close();
@@ -210,21 +211,111 @@ int PmuCollector::init(
     return 0;
 }
 
+void PmuCollector::start(const profiling_common::ThreadFactory &thread_factory) {
+    if (shm_host_ == nullptr) return;
+    reset_collector_shards();
+    profiling_common::ProfilerBase<PmuCollector, PmuModule>::start(thread_factory);
+}
+
 // ---------------------------------------------------------------------------
 // CSV writing
 // ---------------------------------------------------------------------------
 
-void PmuCollector::ensure_csv_open_unlocked() {
-    if (csv_file_.is_open()) return;
+size_t PmuCollector::normalize_collector_shard(int collector_shard) const {
+    const size_t shard_count = csv_shard_files_.size();
+    const bool valid_shard = collector_shard >= 0 && static_cast<size_t>(collector_shard) < shard_count;
+    if (!valid_shard) {
+        assert(false && "collector_shard out of range");
+        return shard_count;
+    }
+    return static_cast<size_t>(collector_shard);
+}
+
+bool PmuCollector::close_csv_shards() {
+    bool success = true;
+    for (size_t shard = 0; shard < csv_shard_files_.size(); shard++) {
+        auto &file = csv_shard_files_[shard];
+        if (file.is_open()) {
+            file.flush();
+            if (!file.good()) {
+                LOG_ERROR("PmuCollector: failed to flush CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                success = false;
+            }
+            file.close();
+            if (file.fail()) {
+                LOG_ERROR("PmuCollector: failed to close CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                success = false;
+            }
+        }
+    }
+    if (!success) {
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+    }
+    return success;
+}
+
+void PmuCollector::cleanup_csv_shards() {
+    for (const auto &path : csv_shard_paths_) {
+        if (path.empty()) continue;
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+}
+
+void PmuCollector::reset_collector_shards() {
+    (void)close_csv_shards();
+    cleanup_csv_shards();
+
+    const size_t shard_count = static_cast<size_t>(PmuModule::kCollectorThreadCount);
+    csv_shard_paths_.clear();
+    csv_shard_paths_.reserve(shard_count);
+    for (size_t shard = 0; shard < shard_count; shard++) {
+        csv_shard_paths_.push_back(csv_path_ + ".shard" + std::to_string(shard) + ".tmp");
+    }
+    csv_shard_files_.clear();
+    csv_shard_files_.resize(shard_count);
+    collector_counters_.assign(shard_count, {});
+    total_collected_ = 0;
+    csv_shard_io_failed_.store(false, std::memory_order_relaxed);
+    csv_shards_finalized_ = false;
+}
+
+bool PmuCollector::ensure_csv_open() {
+    if (csv_file_.is_open()) return csv_file_.good();
+    csv_file_.clear();
     csv_file_.open(csv_path_, std::ios::out | std::ios::trunc);
     if (!csv_file_.is_open()) {
         LOG_ERROR("PmuCollector: failed to open CSV file: %s", csv_path_.c_str());
-        return;
+        return false;
     }
     csv_file_ << csv_header_;
+    if (!csv_file_.good()) {
+        LOG_ERROR("PmuCollector: failed to write CSV header: %s", csv_path_.c_str());
+        return false;
+    }
+    return true;
 }
 
-void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr) {
+bool PmuCollector::ensure_csv_shard_open(size_t shard) {
+    if (shard >= csv_shard_files_.size() || shard >= csv_shard_paths_.size()) {
+        LOG_ERROR("PmuCollector: invalid CSV shard index %zu", shard);
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+        return false;
+    }
+    auto &file = csv_shard_files_[shard];
+    if (file.is_open()) return true;
+    file.open(csv_shard_paths_[shard], std::ios::out | std::ios::trunc);
+    if (!file.is_open()) {
+        LOG_ERROR("PmuCollector: failed to open CSV shard file: %s", csv_shard_paths_[shard].c_str());
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+        return false;
+    }
+    return true;
+}
+
+void PmuCollector::append_buffer_to_csv_shard(
+    int core_id, int thread_idx, const void *buf_host_ptr, int collector_shard
+) {
     const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(buf_host_ptr);
     uint32_t n = buf->count;
     if (n > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
@@ -232,39 +323,109 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
     }
     if (n == 0) return;
 
-    std::scoped_lock<std::mutex> lock(csv_mutex_);
-    ensure_csv_open_unlocked();
-    if (!csv_file_.is_open()) return;
-    total_collected_ += n;
+    const size_t shard = normalize_collector_shard(collector_shard);
+    if (!ensure_csv_shard_open(shard)) return;
 
     const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type_);
     if (evt == nullptr) {
         evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
     }
+
+    auto &rows = csv_shard_files_[shard];
     for (uint32_t i = 0; i < n; i++) {
         const PmuRecord &r = buf->records[i];
-        csv_file_ << thread_idx << ',' << core_id << ',';
-        csv_file_ << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec
-                  << std::setfill(' ');
-        csv_file_ << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
+        rows << thread_idx << ',' << core_id << ',';
+        rows << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec << std::setfill(' ');
+        rows << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
         for (int k = 0; k < PMU_COUNTER_COUNT_A2A3; k++) {
             const char *name = evt->counter_names[k];
             if (name == nullptr || name[0] == '\0') {
                 continue;
             }
-            csv_file_ << ',' << r.pmu_counters[k];
+            rows << ',' << r.pmu_counters[k];
         }
-        csv_file_ << ',' << static_cast<uint32_t>(event_type_) << '\n';
+        rows << ',' << static_cast<uint32_t>(event_type_) << '\n';
     }
-    csv_file_.flush();
+    if (!rows.good()) {
+        LOG_ERROR("PmuCollector: failed to write CSV shard file: %s", csv_shard_paths_[shard].c_str());
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+        return;
+    }
+    collector_counters_[shard].total_collected += n;
+}
+
+bool PmuCollector::flush_collector_shards_to_csv() {
+    if (csv_shards_finalized_) {
+        return true;
+    }
+
+    const bool shards_closed = close_csv_shards();
+    if (!shards_closed || csv_shard_io_failed_.load(std::memory_order_relaxed)) {
+        LOG_ERROR("PmuCollector: CSV shard output failed; preserving shard files for diagnosis");
+        return false;
+    }
+
+    uint64_t collected_candidate = 0;
+    bool has_rows = false;
+    for (size_t shard = 0; shard < collector_counters_.size(); shard++) {
+        collected_candidate += collector_counters_[shard].total_collected;
+        has_rows = has_rows || collector_counters_[shard].total_collected != 0;
+    }
+
+    if (has_rows) {
+        if (csv_file_.is_open()) {
+            csv_file_.close();
+        }
+        if (!ensure_csv_open()) {
+            if (csv_file_.is_open()) {
+                csv_file_.close();
+                std::error_code ec;
+                std::filesystem::remove(csv_path_, ec);
+            }
+            return false;
+        }
+        for (size_t shard = 0; shard < csv_shard_paths_.size(); shard++) {
+            if (collector_counters_[shard].total_collected == 0) continue;
+            std::ifstream shard_file(csv_shard_paths_[shard], std::ios::binary);
+            if (!shard_file.is_open()) {
+                LOG_ERROR("PmuCollector: failed to read CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                csv_file_.close();
+                std::error_code ec;
+                std::filesystem::remove(csv_path_, ec);
+                return false;
+            }
+            csv_file_ << shard_file.rdbuf();
+            if (shard_file.bad() || !csv_file_.good()) {
+                LOG_ERROR("PmuCollector: failed to merge CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                csv_file_.close();
+                std::error_code ec;
+                std::filesystem::remove(csv_path_, ec);
+                return false;
+            }
+        }
+        csv_file_.flush();
+        if (!csv_file_.good()) {
+            LOG_ERROR("PmuCollector: failed to flush merged CSV file: %s", csv_path_.c_str());
+            csv_file_.close();
+            std::error_code ec;
+            std::filesystem::remove(csv_path_, ec);
+            return false;
+        }
+    }
+    total_collected_ = collected_candidate;
+    cleanup_csv_shards();
+    csv_shards_finalized_ = true;
+    return true;
 }
 
 // ---------------------------------------------------------------------------
 // ProfilerBase callback
 // ---------------------------------------------------------------------------
 
-void PmuCollector::on_buffer_collected(const PmuReadyBufferInfo &info) {
-    write_buffer_to_csv(static_cast<int>(info.core_index), static_cast<int>(info.thread_index), info.host_buffer_ptr);
+void PmuCollector::on_buffer_collected(const PmuReadyBufferInfo &info, int collector_shard) {
+    append_buffer_to_csv_shard(
+        static_cast<int>(info.core_index), static_cast<int>(info.thread_index), info.host_buffer_ptr, collector_shard
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -281,6 +442,7 @@ void PmuCollector::reconcile_counters() {
     if (shm_host_ == nullptr) return;
 
     rmb();
+    flush_collector_shards_to_csv();
 
     // After stop(), pmu_aicpu_flush_buffers should have either enqueued the
     // active buffer (success → current_buf_ptr=0) or counted it as dropped
@@ -352,6 +514,7 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCa
 
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
     stop();
+    flush_collector_shards_to_csv();
 
     if (csv_file_.is_open()) {
         csv_file_.close();
@@ -399,6 +562,17 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCa
     }
 
     initialized_ = false;
+    (void)close_csv_shards();
+    if (csv_shards_finalized_) {
+        cleanup_csv_shards();
+    }
+    csv_shard_paths_.clear();
+    csv_shard_paths_.shrink_to_fit();
+    csv_shard_files_.clear();
+    csv_shard_files_.shrink_to_fit();
+    collector_counters_.clear();
+    collector_counters_.shrink_to_fit();
+    csv_shards_finalized_ = false;
     clear_memory_context();
     LOG_INFO_V0("PMU collector finalized");
 }

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -18,7 +18,7 @@
  *   per-thread ready queues, drains done-queue shards, and replenishes the
  *   per-core free_queues from shard-local recycled lanes.
  * - PmuCollector: collector thread shards pop full PmuBuffers from the manager
- *   and append them to the CSV file.
+ *   and append them to shard-local temporary CSV files.
  *
  * a5 specifics: device↔host transfers go through profiling_copy.h. The
  * framework's mgmt loop mirrors the shm region per tick; per-buffer
@@ -30,17 +30,18 @@
  *                                  go into the recycled pool). Calls
  *                                  set_memory_context() on the base so
  *                                  start(tf) can launch threads.
- *   start(tf)                    — Inherited from ProfilerBase: assembles
- *                                  MemoryOps from the stashed callbacks
- *                                  and launches the mgmt + collector threads.
+ *   start(tf)                    — Reset run-scoped CSV shards, then launch the
+ *                                  mgmt + collector threads through
+ *                                  ProfilerBase.
  *   [device execution]
  *   stop()                       — Stop mgmt → join mgmt → signal collectors →
  *                                  drain ready shards → join collectors, in
  *                                  that order. On return both thread exits and
  *                                  queue drains are complete.
- *   reconcile_counters()         — Sanity-check PmuBufferState::current_buf_ptr
- *                                  (any non-zero pointer with records is a
- *                                  device-flush bug, logged as ERROR) and
+ *   reconcile_counters()         — Merge CSV shards, sanity-check
+ *                                  PmuBufferState::current_buf_ptr (any
+ *                                  non-zero pointer with records is a
+ *                                  device-flush bug, logged as ERROR), and
  *                                  run the device-side cross-check
  *                                  collected + dropped == total.
  *   finalize()                   — Free all device memory and unregister.
@@ -58,10 +59,8 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
-#include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "common/memory_barrier.h"
@@ -232,6 +231,8 @@ public:
         const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
     );
 
+    void start(const profiling_common::ThreadFactory &thread_factory);
+
     /**
      * Device pointer to the PmuDataHeader. Set kernel_args.pmu_data_base
      * to this after init() succeeds so the AICPU side can find the shared
@@ -250,7 +251,7 @@ public:
      * Per-buffer callback invoked by ProfilerBase's poll loop. Flushes
      * records to CSV.
      */
-    void on_buffer_collected(const PmuReadyBufferInfo &info);
+    void on_buffer_collected(const PmuReadyBufferInfo &info, int collector_shard);
 
     /**
      * After stop(), perform purely-passive accounting:
@@ -275,6 +276,13 @@ public:
     bool is_initialized() const { return initialized_; }
 
 private:
+    struct alignas(64) CollectorShardCounters {
+        uint64_t total_collected{0};
+    };
+    static_assert(
+        sizeof(CollectorShardCounters) % 64 == 0, "CollectorShardCounters must not share cache lines across shards"
+    );
+
     bool initialized_ = false;
     int num_cores_ = 0;
     int num_threads_ = 0;
@@ -290,13 +298,18 @@ private:
     void *aicore_ring_addrs_dev_ = nullptr;
     void *aicore_ring_addrs_host_ = nullptr;
 
-    // CSV output. File is opened lazily on the first record write so that
-    // a hung device run that produces no records does not leave a
-    // header-only CSV on disk.
+    // CSV output. Collector shards stream rows into shard-local temp files on
+    // the hot path; stop-time reconciliation merges them into the final CSV so
+    // collector threads do not contend on one ofstream mutex or retain all rows
+    // in heap memory.
     std::string csv_path_;
     std::string csv_header_;
     std::ofstream csv_file_;
-    std::mutex csv_mutex_;
+    std::vector<std::string> csv_shard_paths_;
+    std::vector<std::ofstream> csv_shard_files_;
+    std::vector<CollectorShardCounters> collector_counters_;
+    std::atomic<bool> csv_shard_io_failed_{false};
+    bool csv_shards_finalized_{false};
 
     // Running total of records written to CSV. Used at reconcile time to
     // verify collected + dropped == device_total.
@@ -305,8 +318,14 @@ private:
     PmuDataHeader *pmu_header() const { return get_pmu_header(shm_host_); }
     PmuBufferState *pmu_state(int core_id) const { return get_pmu_buffer_state(shm_host_, core_id); }
 
-    void write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr);
-    void ensure_csv_open_unlocked();
+    size_t normalize_collector_shard(int collector_shard) const;
+    void reset_collector_shards();
+    void append_buffer_to_csv_shard(int core_id, int thread_idx, const void *buf_host_ptr, int collector_shard);
+    bool flush_collector_shards_to_csv();
+    bool ensure_csv_shard_open(size_t shard);
+    bool ensure_csv_open();
+    bool close_csv_shards();
+    void cleanup_csv_shards();
 };
 
 // ---------------------------------------------------------------------------

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <ios>
 
@@ -97,7 +98,7 @@ int PmuCollector::init(
     event_type_ = event_type;
     csv_path_ = csv_path;
 
-    total_collected_ = 0;
+    reset_collector_shards();
     if (csv_file_.is_open()) {
         csv_file_.close();
     }
@@ -248,21 +249,111 @@ int PmuCollector::init(
     return 0;
 }
 
+void PmuCollector::start(const profiling_common::ThreadFactory &thread_factory) {
+    if (shm_host_ == nullptr) return;
+    reset_collector_shards();
+    profiling_common::ProfilerBase<PmuCollector, PmuModule>::start(thread_factory);
+}
+
 // ---------------------------------------------------------------------------
 // CSV writing
 // ---------------------------------------------------------------------------
 
-void PmuCollector::ensure_csv_open_unlocked() {
-    if (csv_file_.is_open()) return;
+size_t PmuCollector::normalize_collector_shard(int collector_shard) const {
+    const size_t shard_count = csv_shard_files_.size();
+    const bool valid_shard = collector_shard >= 0 && static_cast<size_t>(collector_shard) < shard_count;
+    if (!valid_shard) {
+        assert(false && "collector_shard out of range");
+        return shard_count;
+    }
+    return static_cast<size_t>(collector_shard);
+}
+
+bool PmuCollector::close_csv_shards() {
+    bool success = true;
+    for (size_t shard = 0; shard < csv_shard_files_.size(); shard++) {
+        auto &file = csv_shard_files_[shard];
+        if (file.is_open()) {
+            file.flush();
+            if (!file.good()) {
+                LOG_ERROR("PmuCollector: failed to flush CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                success = false;
+            }
+            file.close();
+            if (file.fail()) {
+                LOG_ERROR("PmuCollector: failed to close CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                success = false;
+            }
+        }
+    }
+    if (!success) {
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+    }
+    return success;
+}
+
+void PmuCollector::cleanup_csv_shards() {
+    for (const auto &path : csv_shard_paths_) {
+        if (path.empty()) continue;
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+}
+
+void PmuCollector::reset_collector_shards() {
+    (void)close_csv_shards();
+    cleanup_csv_shards();
+
+    const size_t shard_count = static_cast<size_t>(PmuModule::kCollectorThreadCount);
+    csv_shard_paths_.clear();
+    csv_shard_paths_.reserve(shard_count);
+    for (size_t shard = 0; shard < shard_count; shard++) {
+        csv_shard_paths_.push_back(csv_path_ + ".shard" + std::to_string(shard) + ".tmp");
+    }
+    csv_shard_files_.clear();
+    csv_shard_files_.resize(shard_count);
+    collector_counters_.assign(shard_count, {});
+    total_collected_ = 0;
+    csv_shard_io_failed_.store(false, std::memory_order_relaxed);
+    csv_shards_finalized_ = false;
+}
+
+bool PmuCollector::ensure_csv_open() {
+    if (csv_file_.is_open()) return csv_file_.good();
+    csv_file_.clear();
     csv_file_.open(csv_path_, std::ios::out | std::ios::trunc);
     if (!csv_file_.is_open()) {
         LOG_ERROR("PmuCollector: failed to open CSV file: %s", csv_path_.c_str());
-        return;
+        return false;
     }
     csv_file_ << csv_header_;
+    if (!csv_file_.good()) {
+        LOG_ERROR("PmuCollector: failed to write CSV header: %s", csv_path_.c_str());
+        return false;
+    }
+    return true;
 }
 
-void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr) {
+bool PmuCollector::ensure_csv_shard_open(size_t shard) {
+    if (shard >= csv_shard_files_.size() || shard >= csv_shard_paths_.size()) {
+        LOG_ERROR("PmuCollector: invalid CSV shard index %zu", shard);
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+        return false;
+    }
+    auto &file = csv_shard_files_[shard];
+    if (file.is_open()) return true;
+    file.open(csv_shard_paths_[shard], std::ios::out | std::ios::trunc);
+    if (!file.is_open()) {
+        LOG_ERROR("PmuCollector: failed to open CSV shard file: %s", csv_shard_paths_[shard].c_str());
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+        return false;
+    }
+    return true;
+}
+
+void PmuCollector::append_buffer_to_csv_shard(
+    int core_id, int thread_idx, const void *buf_host_ptr, int collector_shard
+) {
     const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(buf_host_ptr);
     uint32_t n = buf->count;
     if (n > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
@@ -270,39 +361,109 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
     }
     if (n == 0) return;
 
-    std::scoped_lock<std::mutex> lock(csv_mutex_);
-    ensure_csv_open_unlocked();
-    if (!csv_file_.is_open()) return;
-    total_collected_ += n;
+    const size_t shard = normalize_collector_shard(collector_shard);
+    if (!ensure_csv_shard_open(shard)) return;
 
     const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type_);
     if (evt == nullptr) {
         evt = &PMU_EVENTS_A5_PIPE_UTIL;
     }
+
+    auto &rows = csv_shard_files_[shard];
     for (uint32_t i = 0; i < n; i++) {
         const PmuRecord &r = buf->records[i];
-        csv_file_ << thread_idx << ',' << core_id << ',';
-        csv_file_ << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec
-                  << std::setfill(' ');
-        csv_file_ << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
+        rows << thread_idx << ',' << core_id << ',';
+        rows << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec << std::setfill(' ');
+        rows << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
         for (int k = 0; k < PMU_COUNTER_COUNT_A5; k++) {
             const char *name = evt->counter_names[k];
             if (name == nullptr || name[0] == '\0') {
                 continue;
             }
-            csv_file_ << ',' << r.pmu_counters[k];
+            rows << ',' << r.pmu_counters[k];
         }
-        csv_file_ << ',' << static_cast<uint32_t>(event_type_) << '\n';
+        rows << ',' << static_cast<uint32_t>(event_type_) << '\n';
     }
-    csv_file_.flush();
+    if (!rows.good()) {
+        LOG_ERROR("PmuCollector: failed to write CSV shard file: %s", csv_shard_paths_[shard].c_str());
+        csv_shard_io_failed_.store(true, std::memory_order_relaxed);
+        return;
+    }
+    collector_counters_[shard].total_collected += n;
+}
+
+bool PmuCollector::flush_collector_shards_to_csv() {
+    if (csv_shards_finalized_) {
+        return true;
+    }
+
+    const bool shards_closed = close_csv_shards();
+    if (!shards_closed || csv_shard_io_failed_.load(std::memory_order_relaxed)) {
+        LOG_ERROR("PmuCollector: CSV shard output failed; preserving shard files for diagnosis");
+        return false;
+    }
+
+    uint64_t collected_candidate = 0;
+    bool has_rows = false;
+    for (size_t shard = 0; shard < collector_counters_.size(); shard++) {
+        collected_candidate += collector_counters_[shard].total_collected;
+        has_rows = has_rows || collector_counters_[shard].total_collected != 0;
+    }
+
+    if (has_rows) {
+        if (csv_file_.is_open()) {
+            csv_file_.close();
+        }
+        if (!ensure_csv_open()) {
+            if (csv_file_.is_open()) {
+                csv_file_.close();
+                std::error_code ec;
+                std::filesystem::remove(csv_path_, ec);
+            }
+            return false;
+        }
+        for (size_t shard = 0; shard < csv_shard_paths_.size(); shard++) {
+            if (collector_counters_[shard].total_collected == 0) continue;
+            std::ifstream shard_file(csv_shard_paths_[shard], std::ios::binary);
+            if (!shard_file.is_open()) {
+                LOG_ERROR("PmuCollector: failed to read CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                csv_file_.close();
+                std::error_code ec;
+                std::filesystem::remove(csv_path_, ec);
+                return false;
+            }
+            csv_file_ << shard_file.rdbuf();
+            if (shard_file.bad() || !csv_file_.good()) {
+                LOG_ERROR("PmuCollector: failed to merge CSV shard file: %s", csv_shard_paths_[shard].c_str());
+                csv_file_.close();
+                std::error_code ec;
+                std::filesystem::remove(csv_path_, ec);
+                return false;
+            }
+        }
+        csv_file_.flush();
+        if (!csv_file_.good()) {
+            LOG_ERROR("PmuCollector: failed to flush merged CSV file: %s", csv_path_.c_str());
+            csv_file_.close();
+            std::error_code ec;
+            std::filesystem::remove(csv_path_, ec);
+            return false;
+        }
+    }
+    total_collected_ = collected_candidate;
+    cleanup_csv_shards();
+    csv_shards_finalized_ = true;
+    return true;
 }
 
 // ---------------------------------------------------------------------------
 // ProfilerBase callback
 // ---------------------------------------------------------------------------
 
-void PmuCollector::on_buffer_collected(const PmuReadyBufferInfo &info) {
-    write_buffer_to_csv(static_cast<int>(info.core_index), static_cast<int>(info.thread_index), info.host_buffer_ptr);
+void PmuCollector::on_buffer_collected(const PmuReadyBufferInfo &info, int collector_shard) {
+    append_buffer_to_csv_shard(
+        static_cast<int>(info.core_index), static_cast<int>(info.thread_index), info.host_buffer_ptr, collector_shard
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -325,6 +486,7 @@ void PmuCollector::reconcile_counters() {
         profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
     }
     rmb();
+    flush_collector_shards_to_csv();
 
     // After stop(), pmu_aicpu_flush_buffers should have either enqueued the
     // active buffer (success → current_buf_ptr=0) or counted it as dropped
@@ -424,6 +586,7 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCa
 
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
     stop();
+    flush_collector_shards_to_csv();
 
     if (csv_file_.is_open()) {
         csv_file_.close();
@@ -493,6 +656,17 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCa
     manager_.clear_mappings();
 
     initialized_ = false;
+    (void)close_csv_shards();
+    if (csv_shards_finalized_) {
+        cleanup_csv_shards();
+    }
+    csv_shard_paths_.clear();
+    csv_shard_paths_.shrink_to_fit();
+    csv_shard_files_.clear();
+    csv_shard_files_.shrink_to_fit();
+    collector_counters_.clear();
+    collector_counters_.shrink_to_fit();
+    csv_shards_finalized_ = false;
     clear_memory_context();
     LOG_INFO_V0("PMU collector finalized");
 }

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -229,6 +229,8 @@ public:
         const DumpFreeCallback &free_cb, const std::string &output_prefix, DumpArgsLevel dump_args_level
     );
 
+    void start(const profiling_common::ThreadFactory &thread_factory);
+
     /**
      * Per-buffer callback invoked by ProfilerBase's poll loop. Pulls the
      * relevant portion of the originating thread's arena from device, copies
@@ -236,7 +238,7 @@ public:
      * queues payloads to the writer thread. The writer thread is started
      * lazily on the first invocation per run.
      */
-    void on_buffer_collected(const DumpReadyBufferInfo &info);
+    void on_buffer_collected(const DumpReadyBufferInfo &info, int collector_shard);
 
     /**
      * Write collected dumps to <output_prefix>/args_dump/{*.bin, *.json}.
@@ -274,6 +276,13 @@ public:
     void *get_dump_shm_device_ptr() const { return dump_shared_mem_dev_; }
 
 private:
+    struct alignas(64) CollectorShardCounters {
+        uint64_t total_collected{0};
+    };
+    static_assert(
+        sizeof(CollectorShardCounters) % 64 == 0, "CollectorShardCounters must not share cache lines across shards"
+    );
+
     void *dump_shared_mem_dev_{nullptr};
     int num_dump_threads_{0};
 
@@ -291,27 +300,35 @@ private:
     };
     std::vector<ArenaInfo> arenas_;
 
-    // Collected dump args (metadata only; payloads live in args.bin)
+    // Merged dump args (metadata only; payloads live in args.bin).
+    // Collector shards append to collected_by_collector_ on the hot path, then
+    // export folds those shards into collected_ before sorting/writing JSON.
     std::vector<DumpedArg> collected_;
-    std::mutex collected_mutex_;
+    std::vector<std::vector<DumpedArg>> collected_by_collector_;
+    std::vector<CollectorShardCounters> collector_counters_;
+    bool collector_shards_merged_{false};
+    std::atomic<uint64_t> total_metadata_collected_{0};
 
     // Stats
-    uint32_t total_dropped_record_count_{0};
-    uint32_t total_truncated_count_{0};
-    uint32_t total_overwrite_count_{0};
+    std::atomic<uint32_t> total_dropped_record_count_{0};
+    std::atomic<uint32_t> total_truncated_count_{0};
+    std::atomic<uint32_t> total_overwrite_count_{0};
 
     // Run-scoped state for the writer thread (lazily started on first
     // on_buffer_collected and joined by export_dump_files).
     std::chrono::steady_clock::time_point run_start_time_;
-    std::chrono::steady_clock::time_point last_progress_time_;
+    std::atomic<int64_t> last_progress_ms_{0};
     bool writer_started_{false};
 
-    void process_dump_buffer(const DumpReadyBufferInfo &info);
+    size_t normalize_collector_shard(int collector_shard) const;
+    void reset_collector_shards();
+    void merge_collector_shards();
+    void process_dump_buffer(const DumpReadyBufferInfo &info, int collector_shard);
     void start_writer_thread_once();
 
     // Writer thread: streams arg payloads to a single args.bin
     std::thread writer_thread_;
-    std::mutex collector_state_mutex_;
+    std::mutex writer_start_mutex_;
     std::mutex write_mutex_;
     std::condition_variable write_cv_;
     std::queue<DumpedArg> write_queue_;

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -30,6 +30,7 @@
 #include "data_type.h"
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <cstring>
@@ -47,6 +48,47 @@
 
 ArgsDumpCollector::~ArgsDumpCollector() { stop(); }
 
+static int64_t steady_clock_ms(std::chrono::steady_clock::time_point tp) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
+}
+
+size_t ArgsDumpCollector::normalize_collector_shard(int collector_shard) const {
+    const size_t shard_count = collected_by_collector_.size();
+    const bool valid_shard = collector_shard >= 0 && static_cast<size_t>(collector_shard) < shard_count;
+    if (!valid_shard) {
+        assert(false && "collector_shard out of range");
+        return shard_count;
+    }
+    return static_cast<size_t>(collector_shard);
+}
+
+void ArgsDumpCollector::reset_collector_shards() {
+    const size_t shard_count = static_cast<size_t>(DumpModule::kCollectorThreadCount);
+    collected_.clear();
+    collected_by_collector_.assign(shard_count, {});
+    collector_counters_.assign(shard_count, {});
+    collector_shards_merged_ = false;
+    total_metadata_collected_.store(0, std::memory_order_relaxed);
+}
+
+void ArgsDumpCollector::merge_collector_shards() {
+    if (collector_shards_merged_) {
+        return;
+    }
+
+    size_t total_records = 0;
+    for (const auto &shard_records : collected_by_collector_) {
+        total_records += shard_records.size();
+    }
+
+    collected_.clear();
+    collected_.reserve(total_records);
+    for (const auto &shard_records : collected_by_collector_) {
+        collected_.insert(collected_.end(), shard_records.begin(), shard_records.end());
+    }
+    collector_shards_merged_ = true;
+}
+
 int ArgsDumpCollector::initialize(
     int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
     const DumpFreeCallback &free_cb, const std::string &output_prefix, DumpArgsLevel dump_args_level
@@ -59,6 +101,11 @@ int ArgsDumpCollector::initialize(
     num_dump_threads_ = num_dump_threads;
     output_prefix_ = output_prefix;
     dump_args_level_ = dump_args_level;
+    reset_collector_shards();
+    total_dropped_record_count_.store(0, std::memory_order_relaxed);
+    total_truncated_count_.store(0, std::memory_order_relaxed);
+    total_overwrite_count_.store(0, std::memory_order_relaxed);
+    last_progress_ms_.store(0, std::memory_order_relaxed);
 
     // Stash the memory context on the base up-front so alloc_paired_buffer
     // (which reads alloc_cb_/register_cb_/free_cb_/device_id_)
@@ -167,7 +214,14 @@ int ArgsDumpCollector::initialize(
     return 0;
 }
 
+void ArgsDumpCollector::start(const profiling_common::ThreadFactory &thread_factory) {
+    if (shm_host_ == nullptr) return;
+    reset_collector_shards();
+    profiling_common::ProfilerBase<ArgsDumpCollector, DumpModule>::start(thread_factory);
+}
+
 void ArgsDumpCollector::start_writer_thread_once() {
+    std::scoped_lock<std::mutex> lock(writer_start_mutex_);
     if (writer_started_) return;
     writer_started_ = true;
 
@@ -187,12 +241,12 @@ void ArgsDumpCollector::start_writer_thread_once() {
     writer_done_.store(false);
     bytes_written_.store(0);
     run_start_time_ = std::chrono::steady_clock::now();
-    last_progress_time_ = run_start_time_;
+    last_progress_ms_.store(steady_clock_ms(run_start_time_), std::memory_order_relaxed);
 
     writer_thread_ = std::thread(&ArgsDumpCollector::writer_loop, this);
 }
 
-void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
+void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info, int collector_shard) {
     DumpMetaBuffer *buf = reinterpret_cast<DumpMetaBuffer *>(info.host_buffer_ptr);
     uint32_t count = buf->count;
 
@@ -205,6 +259,9 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         );
         return;
     }
+
+    const size_t shard = normalize_collector_shard(collector_shard);
+    uint64_t records_appended = 0;
 
     // a5: pull the relevant portion of the originating thread's arena from
     // device. arena_write_offset was mirrored into shm_host_ at the top of
@@ -223,7 +280,7 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
     for (uint32_t i = 0; i < count; i++) {
         const ArgsDumpRecord &rec = buf->records[i];
 
-        DumpedArg dt;
+        DumpedArg dt{};
         dt.task_id = rec.task_id;
         // rec is read from device shared memory (untrusted): clamp func_count so a
         // corrupt oversized value can't drive an out-of-bounds read of the
@@ -263,7 +320,7 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         std::memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
         std::memcpy(dt.strides, rec.strides, sizeof(dt.strides));
 
-        if (dt.truncated && ++total_truncated_count_ == 1) {
+        if (dt.truncated && total_truncated_count_.fetch_add(1, std::memory_order_relaxed) == 0) {
             LOG_WARN("Args dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
         }
 
@@ -275,7 +332,7 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
             uint64_t high_water = ai.high_water;
             if (high_water > arena_sz && rec.payload_offset < high_water - arena_sz) {
                 dt.overwritten = true;
-                if (++total_overwrite_count_ == 1) {
+                if (total_overwrite_count_.fetch_add(1, std::memory_order_relaxed) == 0) {
                     LOG_WARN(
                         "Args dump overwrite detected: host drain was slower than arena reuse. "
                         "Increase PLATFORM_DUMP_BUFFERS_PER_THREAD."
@@ -304,42 +361,48 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         dt.payload_size = dt.bytes.size();
 
         bool has_payload = dt.kind == ArgsDumpKind::TENSOR && !dt.overwritten && !dt.bytes.empty();
-        dt.bin_offset = has_payload ? next_bin_offset_ : 0;
         if (has_payload) {
-            next_bin_offset_ += dt.payload_size;
-        }
-
-        // Store metadata-only copy in collected_ (no payload bytes)
-        DumpedArg meta = dt;
-        meta.bytes.clear();
-        {
-            std::scoped_lock<std::mutex> lock(collected_mutex_);
-            collected_.push_back(std::move(meta));
-        }
-
-        // Enqueue full tensor (with payload) to writer thread
-        if (has_payload) {
+            std::vector<uint8_t> payload = std::move(dt.bytes);
+            DumpedArg writer_item = dt;
+            writer_item.bytes = std::move(payload);
             {
                 std::scoped_lock<std::mutex> lock(write_mutex_);
-                write_queue_.push(std::move(dt));
+                dt.bin_offset = next_bin_offset_;
+                writer_item.bin_offset = next_bin_offset_;
+                next_bin_offset_ += dt.payload_size;
+                write_queue_.push(std::move(writer_item));
             }
+            collected_by_collector_[shard].push_back(std::move(dt));
             write_cv_.notify_one();
+        } else {
+            dt.bin_offset = 0;
+            dt.bytes.clear();
+            collected_by_collector_[shard].push_back(std::move(dt));
         }
+        records_appended++;
+    }
+
+    if (records_appended > 0) {
+        collector_counters_[shard].total_collected += records_appended;
+        total_metadata_collected_.fetch_add(records_appended, std::memory_order_relaxed);
     }
 }
 
-void ArgsDumpCollector::on_buffer_collected(const DumpReadyBufferInfo &info) {
-    std::scoped_lock<std::mutex> lock(collector_state_mutex_);
+void ArgsDumpCollector::on_buffer_collected(const DumpReadyBufferInfo &info, int collector_shard) {
     start_writer_thread_once();
-    process_dump_buffer(info);
+    process_dump_buffer(info, collector_shard);
 
     auto now = std::chrono::steady_clock::now();
-    if (std::chrono::duration_cast<std::chrono::seconds>(now - last_progress_time_).count() >= 5) {
+    int64_t now_ms = steady_clock_ms(now);
+    int64_t last_ms = last_progress_ms_.load(std::memory_order_relaxed);
+    if (now_ms - last_ms >= 5000 &&
+        last_progress_ms_.compare_exchange_strong(last_ms, now_ms, std::memory_order_relaxed)) {
         auto elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(now - run_start_time_).count();
         LOG_INFO_V0(
-            "Collecting: %zu args, %.1f GB written (%lds)", collected_.size(), bytes_written_.load() / 1e9, elapsed_s
+            "Collecting: %lu args, %.1f GB written (%lds)",
+            static_cast<unsigned long>(total_metadata_collected_.load(std::memory_order_relaxed)),
+            bytes_written_.load() / 1e9, elapsed_s
         );
-        last_progress_time_ = now;
     }
 }
 
@@ -371,7 +434,7 @@ void ArgsDumpCollector::reconcile_counters() {
     for (int t = 0; t < num_dump_threads_; t++) {
         DumpBufferState *state = get_dump_buffer_state(shm_host_, t);
 
-        total_dropped_record_count_ += state->dropped_record_count;
+        total_dropped_record_count_.fetch_add(state->dropped_record_count, std::memory_order_relaxed);
         dropped_total += state->dropped_record_count;
 
         uint64_t cur_ptr = state->current_buf_ptr;
@@ -389,7 +452,7 @@ void ArgsDumpCollector::reconcile_counters() {
         info.dev_buffer_ptr = reinterpret_cast<void *>(cur_ptr);
         info.host_buffer_ptr = host_ptr;
         info.buffer_seq = state->current_buf_seq;
-        on_buffer_collected(info);
+        on_buffer_collected(info, static_cast<int>(t));
         recovered_threads++;
         LOG_WARN(
             "Dump reconcile: thread %d had an un-flushed buffer (count=%u) — device flush did not run "
@@ -563,13 +626,19 @@ int ArgsDumpCollector::export_dump_files() {
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - run_start_time_)
                 .count();
         LOG_INFO_V0(
-            "Collected %zu args, wrote %.1f GB to disk (%.1fs)", collected_.size(), bytes_written_.load() / 1e9,
-            elapsed_ms / 1000.0
+            "Collected %lu args, wrote %.1f GB to disk (%.1fs)",
+            static_cast<unsigned long>(total_metadata_collected_.load(std::memory_order_relaxed)),
+            bytes_written_.load() / 1e9, elapsed_ms / 1000.0
         );
     }
 
+    merge_collector_shards();
     if (collected_.empty()) {
         LOG_WARN("No args dump data to export");
+        reset_collector_shards();
+        total_dropped_record_count_.store(0, std::memory_order_relaxed);
+        total_truncated_count_.store(0, std::memory_order_relaxed);
+        total_overwrite_count_.store(0, std::memory_order_relaxed);
         writer_started_ = false;
         return 0;
     }
@@ -622,9 +691,9 @@ int ArgsDumpCollector::export_dump_files() {
     json << "  \"input_args\": " << num_input_args << ",\n";
     json << "  \"output_args\": " << num_output_args << ",\n";
     json << "  \"inout_args\": " << num_inout_args << ",\n";
-    json << "  \"truncated_args\": " << total_truncated_count_ << ",\n";
-    json << "  \"dropped_records\": " << total_dropped_record_count_ << ",\n";
-    json << "  \"dropped_overwrite\": " << total_overwrite_count_ << ",\n";
+    json << "  \"truncated_args\": " << total_truncated_count_.load(std::memory_order_relaxed) << ",\n";
+    json << "  \"dropped_records\": " << total_dropped_record_count_.load(std::memory_order_relaxed) << ",\n";
+    json << "  \"dropped_overwrite\": " << total_overwrite_count_.load(std::memory_order_relaxed) << ",\n";
     if (dump_args_level_ == DumpArgsLevel::FULL_JSON_ONLY) {
         json << "  \"bin_file\": null,\n";
     } else {
@@ -677,18 +746,24 @@ int ArgsDumpCollector::export_dump_files() {
     auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(export_end - export_start).count();
     LOG_INFO_V0("Wrote JSON manifest (%zu args) to %s (%ldms)", collected_.size(), run_dir_.c_str(), total_ms);
 
-    if (total_truncated_count_ > 0 || total_dropped_record_count_ > 0 || total_overwrite_count_ > 0) {
+    uint32_t truncated = total_truncated_count_.load(std::memory_order_relaxed);
+    uint32_t dropped = total_dropped_record_count_.load(std::memory_order_relaxed);
+    uint32_t overwritten = total_overwrite_count_.load(std::memory_order_relaxed);
+    if (truncated > 0 || dropped > 0 || overwritten > 0) {
         LOG_WARN(
-            "Args dump anomalies: truncated=%u, dropped_records=%u, overwritten=%u", total_truncated_count_,
-            total_dropped_record_count_, total_overwrite_count_
+            "Args dump anomalies: truncated=%u, dropped_records=%u, overwritten=%u", truncated, dropped, overwritten
         );
     }
 
     // Clear state so subsequent runs don't accumulate data from previous runs
     collected_.clear();
-    total_dropped_record_count_ = 0;
-    total_truncated_count_ = 0;
-    total_overwrite_count_ = 0;
+    collected_by_collector_.clear();
+    collector_counters_.clear();
+    collector_shards_merged_ = false;
+    total_metadata_collected_.store(0, std::memory_order_relaxed);
+    total_dropped_record_count_.store(0, std::memory_order_relaxed);
+    total_truncated_count_.store(0, std::memory_order_relaxed);
+    total_overwrite_count_.store(0, std::memory_order_relaxed);
     writer_started_ = false;
     for (auto &ai : arenas_) {
         ai.high_water = 0;
@@ -786,9 +861,13 @@ int ArgsDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const Dump
     // Reset state
     num_dump_threads_ = 0;
     collected_.clear();
-    total_dropped_record_count_ = 0;
-    total_truncated_count_ = 0;
-    total_overwrite_count_ = 0;
+    collected_by_collector_.clear();
+    collector_counters_.clear();
+    collector_shards_merged_ = false;
+    total_metadata_collected_.store(0, std::memory_order_relaxed);
+    total_dropped_record_count_.store(0, std::memory_order_relaxed);
+    total_truncated_count_.store(0, std::memory_order_relaxed);
+    total_overwrite_count_.store(0, std::memory_order_relaxed);
     writer_started_ = false;
     clear_memory_context();
 

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -535,6 +535,59 @@ target_link_libraries(test_scope_stats_collector PRIVATE
 add_test(NAME test_scope_stats_collector COMMAND test_scope_stats_collector)
 set_tests_properties(test_scope_stats_collector PROPERTIES LABELS "no_hardware")
 
+function(add_pmu_collector_test name platform)
+    add_executable(${name}
+        common/test_pmu_collector.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/${platform}/platform/shared/host/pmu_collector.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/${platform}/platform/sim/host/profiling_copy.cpp
+        ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/${platform}/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common
+    )
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
+endfunction()
+
+add_pmu_collector_test(test_pmu_collector_a2a3 a2a3)
+add_pmu_collector_test(test_pmu_collector_a5 a5)
+
+function(add_args_dump_collector_test name platform)
+    add_executable(${name}
+        common/test_args_dump_collector.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/args_dump_collector.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/${platform}/platform/sim/host/profiling_copy.cpp
+        ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/${platform}/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common
+    )
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
+endfunction()
+
+add_args_dump_collector_test(test_args_dump_collector_a2a3 a2a3)
+add_args_dump_collector_test(test_args_dump_collector_a5 a5)
+
 # Per-callable_id orch SO file naming regression (see rtStreamSynchronize
 # 507018 root cause). Compiles the a2a3 onboard `create_orch_so_file`
 # against the test source so it runs on no-hw runners too.

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/args_dump_collector.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+void *test_alloc(size_t size) { return std::calloc(1, size); }
+
+int test_free(void *ptr) {
+    std::free(ptr);
+    return 0;
+}
+
+}  // namespace
+
+TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
+    const std::filesystem::path test_dir =
+        std::filesystem::temp_directory_path() / ("args_dump_collector_test_" + std::to_string(::getpid()));
+    std::filesystem::remove_all(test_dir);
+    ASSERT_TRUE(std::filesystem::create_directories(test_dir));
+
+    constexpr int kRecordsPerShard = 32;
+    constexpr int kShardCount = DumpModule::kCollectorThreadCount;
+    ArgsDumpCollector collector;
+    ASSERT_EQ(
+        collector.initialize(1, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL_JSON_ONLY), 0
+    );
+
+    std::vector<DumpMetaBuffer> buffers(kShardCount);
+    std::atomic<int> ready_workers{0};
+    std::atomic<bool> start_workers{false};
+    std::vector<std::thread> workers;
+    workers.reserve(kShardCount);
+    for (int shard = 0; shard < kShardCount; shard++) {
+        workers.emplace_back([&collector, &buffers, &ready_workers, &start_workers, shard] {
+            DumpMetaBuffer &buffer = buffers[shard];
+            buffer.count = kRecordsPerShard;
+            for (int record = 0; record < kRecordsPerShard; record++) {
+                ArgsDumpRecord &entry = buffer.records[record];
+                entry.task_id = static_cast<uint64_t>(shard * kRecordsPerShard + record);
+                entry.role = static_cast<uint8_t>(ArgsDumpRole::INPUT);
+                entry.stage = static_cast<uint8_t>(ArgsDumpStage::BEFORE_DISPATCH);
+                entry.kind = static_cast<uint8_t>(ArgsDumpKind::SCALAR);
+                entry.arg_index = static_cast<uint32_t>(record);
+                entry.func_ids[0] = static_cast<uint16_t>(shard);
+                entry.func_count = 1;
+            }
+
+            DumpReadyBufferInfo info{};
+            info.thread_index = 0;
+            info.host_buffer_ptr = &buffer;
+            ready_workers.fetch_add(1, std::memory_order_release);
+            while (!start_workers.load(std::memory_order_acquire)) {}
+            collector.on_buffer_collected(info, shard);
+        });
+    }
+    while (ready_workers.load(std::memory_order_acquire) != kShardCount) {}
+    start_workers.store(true, std::memory_order_release);
+    for (auto &worker : workers) {
+        worker.join();
+    }
+
+    ASSERT_EQ(collector.export_dump_files(), 0);
+    const std::filesystem::path manifest_path = test_dir / "args_dump" / "args_dump.json";
+    std::ifstream manifest_file(manifest_path);
+    ASSERT_TRUE(manifest_file.is_open());
+    const std::string manifest{std::istreambuf_iterator<char>(manifest_file), std::istreambuf_iterator<char>()};
+    EXPECT_NE(manifest.find("\"total_args\": " + std::to_string(kShardCount * kRecordsPerShard)), std::string::npos);
+
+    collector.finalize(nullptr, test_free);
+    std::filesystem::remove_all(test_dir);
+}

--- a/tests/ut/cpp/common/test_pmu_collector.cpp
+++ b/tests/ut/cpp/common/test_pmu_collector.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/pmu_collector.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+void *test_alloc(size_t size) { return std::calloc(1, size); }
+
+int test_free(void *ptr) {
+    std::free(ptr);
+    return 0;
+}
+
+}  // namespace
+
+TEST(PmuCollectorTest, PreservesShardFilesWhenFinalCsvCannotBeOpened) {
+    const std::filesystem::path test_dir =
+        std::filesystem::temp_directory_path() / ("pmu_collector_failure_test_" + std::to_string(::getpid()));
+    const std::filesystem::path csv_path = test_dir / "pmu.csv";
+    const std::filesystem::path shard_path = test_dir / "pmu.csv.shard0.tmp";
+    std::filesystem::remove_all(test_dir);
+    ASSERT_TRUE(std::filesystem::create_directories(csv_path));
+
+    PmuCollector collector;
+    ASSERT_EQ(
+        collector.init(1, 1, csv_path.string(), PmuEventType::PIPE_UTILIZATION, test_alloc, nullptr, test_free, 0), 0
+    );
+
+    PmuBuffer buffer{};
+    buffer.count = 1;
+    PmuReadyBufferInfo info{};
+    info.core_index = 0;
+    info.thread_index = 0;
+    info.host_buffer_ptr = &buffer;
+    collector.on_buffer_collected(info, 0);
+    ASSERT_TRUE(std::filesystem::exists(shard_path));
+
+    auto *state = get_pmu_buffer_state(collector.get_pmu_shm_device_ptr(), 0);
+    state->total_record_count = 1;
+    collector.reconcile_counters();
+    EXPECT_TRUE(std::filesystem::exists(shard_path));
+    EXPECT_TRUE(std::filesystem::is_directory(csv_path));
+
+    collector.finalize(nullptr, test_free);
+    EXPECT_TRUE(std::filesystem::exists(shard_path));
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST(PmuCollectorTest, MergesConcurrentShardWritesIntoFinalCsv) {
+    const std::filesystem::path test_dir =
+        std::filesystem::temp_directory_path() / ("pmu_collector_merge_test_" + std::to_string(::getpid()));
+    const std::filesystem::path csv_path = test_dir / "pmu.csv";
+    std::filesystem::remove_all(test_dir);
+    ASSERT_TRUE(std::filesystem::create_directories(test_dir));
+
+    constexpr int kRecordsPerShard = 64;
+    constexpr int kShardCount = PmuModule::kCollectorThreadCount;
+    PmuCollector collector;
+    ASSERT_EQ(
+        collector.init(
+            1, kShardCount, csv_path.string(), PmuEventType::PIPE_UTILIZATION, test_alloc, nullptr, test_free, 0
+        ),
+        0
+    );
+
+    std::atomic<int> ready_workers{0};
+    std::atomic<bool> start_workers{false};
+    std::vector<std::thread> workers;
+    workers.reserve(kShardCount);
+    for (int shard = 0; shard < kShardCount; shard++) {
+        workers.emplace_back([&collector, &ready_workers, &start_workers, shard] {
+            PmuBuffer buffer{};
+            buffer.count = 1;
+            PmuReadyBufferInfo info{};
+            info.core_index = 0;
+            info.thread_index = static_cast<uint32_t>(shard);
+            info.host_buffer_ptr = &buffer;
+
+            ready_workers.fetch_add(1, std::memory_order_release);
+            while (!start_workers.load(std::memory_order_acquire)) {}
+            for (int record = 0; record < kRecordsPerShard; record++) {
+                buffer.records[0].task_id = static_cast<uint64_t>(shard * kRecordsPerShard + record);
+                collector.on_buffer_collected(info, shard);
+            }
+        });
+    }
+    while (ready_workers.load(std::memory_order_acquire) != kShardCount) {}
+    start_workers.store(true, std::memory_order_release);
+    for (auto &worker : workers) {
+        worker.join();
+    }
+
+    auto *state = get_pmu_buffer_state(collector.get_pmu_shm_device_ptr(), 0);
+    state->total_record_count = kShardCount * kRecordsPerShard;
+    collector.reconcile_counters();
+
+    EXPECT_TRUE(std::filesystem::is_regular_file(csv_path));
+    for (int shard = 0; shard < kShardCount; shard++) {
+        EXPECT_FALSE(std::filesystem::exists(csv_path.string() + ".shard" + std::to_string(shard) + ".tmp"));
+    }
+    std::ifstream csv(csv_path);
+    std::string line;
+    int line_count = 0;
+    while (std::getline(csv, line)) {
+        line_count++;
+    }
+    EXPECT_EQ(line_count, 1 + kShardCount * kRecordsPerShard);
+
+    collector.finalize(nullptr, test_free);
+    std::filesystem::remove_all(test_dir);
+}


### PR DESCRIPTION
## Summary
- Shard PMU CSV accumulation by collector thread on both a2a3 and a5, removing the shared output lock from the collection hot path.
- Accumulate ArgsDump metadata in collector-local shards while keeping payload writes ordered through the existing writer queue.
- Merge shard-local outputs during stop/export, preserve PMU shard files when export fails, and document the run-scoped cleanup behavior.
- Add concurrent regression coverage for PMU and ArgsDump shard collection and final output merging.

## Scope audit
- TensorDump was renamed to ArgsDump on the latest `main`; the ArgsDump changes in this PR are the corresponding TensorDump optimization tracked by #1281.
- DepGen and ScopeStats were audited but intentionally left on their existing single-accumulator paths. Each currently has one orchestrator producer and therefore one active collector ownership path, so their accumulation mutexes do not have the cross-shard hot-path contention addressed by this PR.
- Their existing split drain/collector and shard-local buffer-pool behavior from the shared profiling framework remains unchanged. This follows #1281's requirement to apply accumulation sharding only where it is applicable.

## Design
- Each collector writes only to its own PMU temporary CSV file or ArgsDump metadata shard during collection.
- PMU shard files are merged into the final CSV after collection stops. Failed exports retain the shard files for diagnosis or retry.
- ArgsDump payload offsets remain serialized by the writer queue; only metadata accumulation is sharded and merged before JSON export.
- The output format and collector-to-device queue flow remain unchanged.

## Testing
- Full PR CI passed, including pre-commit, C++ UT, a2a3/a5 simulation, a2a3/a5 onboard, and profiling-flags smoke tests.
- Added and passed `test_pmu_collector` for concurrent a2a3/a5 shard collection and CSV merge behavior.
- Added and passed `test_args_dump_collector` for concurrent metadata sharding, payload ordering, and final JSON merge behavior.
- Ran the existing L2 synthetic producer as a no-regression control against latest `main`: 5 paired runs on the same A3 device at 30.0288 GB/s for 5 ms produced median host receive rates of 2.0992 GB/s (baseline) and 2.0800 GB/s (current). L2 is unchanged by this PR, so this result is not used as evidence of PMU/ArgsDump throughput improvement.

closes #1281
Refs #1237
