### PR TITLE
CI: finish #1268 rename — profiling-flags-smoke uses SIMPLER_ macro names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,10 +345,10 @@ jobs:
   # off") so log scrubbing the failing leg pinpoints the specific gate:
   #
   #   SIMPLER_DFX (default=1, covered by every other CI job)
-  #   ├── pto2-off:         -DPTO2_PROFILING=0   (no profiling at all)
-  #   ├── orch:             -DPTO2_ORCH_PROFILING=1
-  #   │   └── orch-tensormap:  + -DPTO2_TENSORMAP_PROFILING=1
-  #   ├── sched:            -DPTO2_SCHED_PROFILING=1
+  #   ├── dfx-off:         -DSIMPLER_DFX=0   (no profiling at all)
+  #   ├── orch:             -DSIMPLER_ORCH_PROFILING=1
+  #   │   └── orch-tensormap:  + -DSIMPLER_TENSORMAP_PROFILING=1
+  #   ├── sched:            -DSIMPLER_SCHED_PROFILING=1
   #   ├── orch-sched:       ORCH=1 + SCHED=1   (both sub-flags on, tensormap off)
   #   └── all-on:           ORCH=1 + SCHED=1 + TENSORMAP=1
   #
@@ -414,14 +414,14 @@ jobs:
           # Combo names paired with their CXX defines. Parallel arrays (not
           # an associative array) so the loop iteration order is deterministic
           # and the log reads top-to-bottom in hierarchy order.
-          COMBO_NAMES=(pto2-off orch orch-tensormap sched orch-sched all-on)
+          COMBO_NAMES=(dfx-off orch orch-tensormap sched orch-sched all-on)
           COMBO_DEFS=(
-            "-DPTO2_PROFILING=0"
-            "-DPTO2_ORCH_PROFILING=1"
-            "-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1"
-            "-DPTO2_SCHED_PROFILING=1"
-            "-DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1"
-            "-DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1"
+            "-DSIMPLER_DFX=0"
+            "-DSIMPLER_ORCH_PROFILING=1"
+            "-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_TENSORMAP_PROFILING=1"
+            "-DSIMPLER_SCHED_PROFILING=1"
+            "-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_SCHED_PROFILING=1"
+            "-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_SCHED_PROFILING=1 -DSIMPLER_TENSORMAP_PROFILING=1"
           )
           ARCHES=(a2a3sim a5sim)
           FAIL=()

--- a/docs/dfx/l2-timing.md
+++ b/docs/dfx/l2-timing.md
@@ -105,7 +105,7 @@ directly** — there is no longer a Python parser for it:
 
 ```bash
 # build the runtime with the deep-dive lines compiled in
-CXX="g++ -DPTO2_SCHED_PROFILING=1" python simpler_setup/build_runtimes.py --platforms a2a3
+CXX="g++ -DSIMPLER_SCHED_PROFILING=1" python simpler_setup/build_runtimes.py --platforms a2a3
 # run, then grep the device log by eye
 grep -E 'orch_start=|sched_start=|Scheduler summary' \
     ~/ascend/log/debug/device-0/device-*.log

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -372,10 +372,10 @@ This overrides the defaults in `profiling_config.h` without changing source.
 
 ```bash
 # Example: disable all profiling code
-CXXFLAGS="-DPTO2_PROFILING=0" pip install --no-build-isolation -e .
+CXXFLAGS="-DSIMPLER_DFX=0" pip install --no-build-isolation -e .
 
 # Example: enable orchestrator and tensormap profiling
-CXXFLAGS="-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1" \
+CXXFLAGS="-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_TENSORMAP_PROFILING=1" \
     pip install --no-build-isolation -e .
 ```
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -342,10 +342,10 @@ This overrides the defaults in `profiling_config.h` without changing source.
 
 ```bash
 # Example: disable all profiling code
-CXXFLAGS="-DPTO2_PROFILING=0" pip install --no-build-isolation -e .
+CXXFLAGS="-DSIMPLER_DFX=0" pip install --no-build-isolation -e .
 
 # Example: enable orchestrator and tensormap profiling
-CXXFLAGS="-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1" \
+CXXFLAGS="-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_TENSORMAP_PROFILING=1" \
     pip install --no-build-isolation -e .
 ```
 


### PR DESCRIPTION
## Summary

#1268 renamed the profiling config macros (`PTO2_PROFILING` → `SIMPLER_DFX`,
`PTO2_{ORCH,SCHED,TENSORMAP}_PROFILING` → `SIMPLER_*`) but left the
`profiling-flags-smoke` CI combo defines and the docs on the old `PTO2_` names.

**Impact:** the stale `-DPTO2_*` flags now define *nonexistent* macros, so every
combo builds with the default `SIMPLER_DFX=1` — `profiling-flags-smoke` silently
stopped exercising the `=0` and sub-flag permutations it exists to cover
(regressions under `SIMPLER_DFX=0`, e.g. `-Werror=unused` on profiling-only
vars, no longer caught).

### Changes

- **`.github/workflows/ci.yml`**: `COMBO_DEFS` + the hierarchy comment → `SIMPLER_`
  names; rename the now-misleading `pto2-off` combo label to `dfx-off`.
- **docs** (`profiling_levels.md` a2a3+a5, `docs/dfx/l2-timing.md`): `CXXFLAGS`
  build examples → `SIMPLER_` names.

No code changes — config/docs only. The new names match
`src/common/task_interface/profiling_config.h`
(`SIMPLER_DFX`, `SIMPLER_ORCH_PROFILING`, `SIMPLER_SCHED_PROFILING`,
`SIMPLER_TENSORMAP_PROFILING`).

## Testing

- [x] Verified all 6 combos build with the new `SIMPLER_*` names
  (`CXX="g++ -DSIMPLER_DFX=0 ..." build_runtimes.py --platforms a2a3sim` etc.)
- [ ] CI `profiling-flags-smoke` (now actually exercising the permutations)