### PR TITLE
Fix: decouple tensor-dump args mask pool from runtime ring depth

### DIFF
--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -44,7 +44,6 @@
 #include <cstdint>
 
 #include "common/platform_config.h"
-#include "host_build_graph/runtime/pto_runtime2_types.h"
 
 // =============================================================================
 // Constants
@@ -84,9 +83,6 @@ using TensorDumpArgMask = uint64_t;
 // Zero preserves legacy "dump all tasks" behavior unless selective mode is enabled.
 constexpr TensorDumpArgMask TENSOR_DUMP_ARG_MASK_NONE = 0;
 constexpr uint32_t TENSOR_DUMP_ARG_MASK_BITS = 64;
-constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_RINGS = PTO2_MAX_RING_DEPTH;
-constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_SLOTS = PTO2_TASK_WINDOW_SIZE;
-constexpr uint32_t TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK = TENSOR_DUMP_MASK_POOL_MAX_SLOTS - 1;
 constexpr uint8_t TENSOR_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
 
 // Max kernel ids a record carries: one per active subtask of a task (its mix

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -48,7 +48,6 @@
 #include <cstdint>
 
 #include "common/platform_config.h"
-#include "host_build_graph/runtime/pto_runtime2_types.h"
 
 // =============================================================================
 // Constants
@@ -88,9 +87,6 @@ using TensorDumpArgMask = uint64_t;
 // Zero preserves legacy "dump all tasks" behavior unless selective mode is enabled.
 constexpr TensorDumpArgMask TENSOR_DUMP_ARG_MASK_NONE = 0;
 constexpr uint32_t TENSOR_DUMP_ARG_MASK_BITS = 64;
-constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_RINGS = PTO2_MAX_RING_DEPTH;
-constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_SLOTS = PTO2_TASK_WINDOW_SIZE;
-constexpr uint32_t TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK = TENSOR_DUMP_MASK_POOL_MAX_SLOTS - 1;
 constexpr uint8_t TENSOR_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
 
 // Max kernel ids a record carries: one per active subtask of a task (its mix

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -130,14 +130,13 @@ static void clear_dump_args_tables() {
     }
 }
 
-static bool resolve_dump_args_task_slot(uint64_t task_id, uint32_t *idx_out) {
-    uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
-    if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
-        return false;
-    }
-    uint32_t slot = static_cast<uint32_t>(task_id) & TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK;
-    *idx_out = (ring_id * TENSOR_DUMP_MASK_POOL_MAX_SLOTS + slot) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
-    return true;
+// task_id is an opaque 64-bit key (globally unique across rings); fold its two
+// halves so both the ring field (high 32) and the local id (low 32) reach the
+// table index. Any task_id maps to a slot — the pool is independent of runtime
+// ring depth.
+static uint32_t resolve_dump_args_task_slot(uint64_t task_id) {
+    uint64_t h = task_id ^ (task_id >> 32);
+    return static_cast<uint32_t>(h) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
 }
 
 extern "C" void
@@ -152,10 +151,7 @@ set_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const 
     if (!ensure_dump_args_scalar_dtype_table()) {
         return;
     }
-    uint32_t idx = 0;
-    if (!resolve_dump_args_task_slot(task_id, &idx)) {
-        return;
-    }
+    uint32_t idx = resolve_dump_args_task_slot(task_id);
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
         DumpTaskScalarDtypeEntry &entry =
             g_dump_scalar_dtype_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
@@ -173,10 +169,7 @@ extern "C" bool get_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t *sca
     if (g_dump_scalar_dtype_table == nullptr || scalar_count == nullptr || scalar_dtypes == nullptr) {
         return false;
     }
-    uint32_t idx = 0;
-    if (!resolve_dump_args_task_slot(task_id, &idx)) {
-        return false;
-    }
+    uint32_t idx = resolve_dump_args_task_slot(task_id);
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
         const DumpTaskScalarDtypeEntry &entry =
             g_dump_scalar_dtype_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
@@ -224,12 +217,7 @@ extern "C" void set_dump_args_task_mask(uint64_t task_id, TensorDumpArgMask mask
     if (!ensure_dump_args_mask_table()) {
         return;
     }
-    uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
-    if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
-        return;
-    }
-    uint32_t slot = static_cast<uint32_t>(task_id) & TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK;
-    uint32_t idx = (ring_id * TENSOR_DUMP_MASK_POOL_MAX_SLOTS + slot) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
+    uint32_t idx = resolve_dump_args_task_slot(task_id);
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
         DumpTaskMaskEntry &entry = g_dump_mask_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
         if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID || entry.task_id == task_id) {
@@ -252,12 +240,7 @@ extern "C" void get_dump_args_task_masks(uint64_t task_id, TensorDumpArgMask *ma
     if (g_dump_mask_table == nullptr) {
         return;
     }
-    uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
-    if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
-        return;
-    }
-    uint32_t slot = static_cast<uint32_t>(task_id) & TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK;
-    uint32_t idx = (ring_id * TENSOR_DUMP_MASK_POOL_MAX_SLOTS + slot) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
+    uint32_t idx = resolve_dump_args_task_slot(task_id);
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
         const DumpTaskMaskEntry &entry = g_dump_mask_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
         if (entry.task_id == task_id) {

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -565,6 +565,7 @@ add_a2a3_runtime_test(test_a2a3_tensormap   a2a3/test_tensormap.cpp)
 add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
 add_a2a3_orchestrator_runtime_test(test_a2a3_orchestrator_fanin a2a3/test_orchestrator_fanin.cpp)
 add_a2a3_orchestrator_runtime_test(test_wiring a2a3/test_wiring.cpp)
+add_a2a3_orchestrator_runtime_test(test_a2a3_tensor_dump a2a3/test_tensor_dump.cpp)
 add_a2a3_runtime_test(test_aicore_completion_mailbox a2a3/test_aicore_completion_mailbox.cpp)
 add_a2a3_runtime_test(test_a2a3_scope_stats_collector a2a3/test_scope_stats_collector.cpp)
 
@@ -587,6 +588,7 @@ add_a5_runtime_test(test_a5_tensormap        a5/test_tensormap.cpp)
 add_a5_runtime_test(test_a5_fanin_pool       a5/test_fanin_pool.cpp)
 add_a5_orchestrator_runtime_test(test_a5_orchestrator_fanin a5/test_orchestrator_fanin.cpp)
 add_a5_orchestrator_runtime_test(test_a5_wiring a5/test_wiring.cpp)
+add_a5_orchestrator_runtime_test(test_a5_tensor_dump a5/test_tensor_dump.cpp)
 add_a5_runtime_test(test_a5_aicore_completion_mailbox a5/test_aicore_completion_mailbox.cpp)
 
 # Host logger silent/off behavior — no runtime deps, just compile host_log.cpp

--- a/tests/ut/cpp/a2a3/test_tensor_dump.cpp
+++ b/tests/ut/cpp/a2a3/test_tensor_dump.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "aicpu/tensor_dump_aicpu.h"
+
+// Fixture for tensor-dump tests: the args-dump mask pool keys entries on the
+// full 64-bit task_id and must be agnostic to how a runtime partitions that id
+// into (ring_id, slot) — any task_id can enter the table.
+class TensorDumpTest : public ::testing::Test {
+protected:
+    void SetUp() override { set_dump_args_enabled(true); }
+    void TearDown() override { set_dump_args_enabled(false); }
+};
+
+// Basic enable/disable toggle and dump-base propagation — the foundation the
+// mask pool sits on.
+TEST_F(TensorDumpTest, EnableDisableAndDumpBaseRoundTrip) {
+    set_dump_args_enabled(false);
+    EXPECT_FALSE(is_dump_args_enabled());
+
+    set_dump_args_enabled(true);
+    EXPECT_TRUE(is_dump_args_enabled());
+
+    set_dump_args_enabled(false);
+    EXPECT_FALSE(is_dump_args_enabled());
+
+    set_platform_dump_base(0xDEADBEEF42ULL);
+    EXPECT_EQ(get_platform_dump_base(), 0xDEADBEEF42ULL);
+
+    set_platform_dump_base(0);
+    EXPECT_EQ(get_platform_dump_base(), 0ULL);
+}
+
+// A task_id whose high 32 bits exceed any runtime's ring depth must still round
+// trip — this is the coupling the pool must not have. Exercises both the mask
+// table and the scalar-dtype table.
+TEST_F(TensorDumpTest, HighRingTaskIdRoundTrips) {
+    const uint64_t task_id = (uint64_t{7} << 32) | 123u;
+    const TensorDumpArgMask mask = 0b1011;
+    const TensorDumpArgMask flags = 0b0010;
+    const uint8_t dtypes[3] = {2, 5, 11};
+
+    set_dump_args_task_mask(task_id, mask, flags);
+    set_dump_args_task_scalar_dtypes(task_id, 3, dtypes);
+
+    TensorDumpArgMask got_mask = TENSOR_DUMP_ARG_MASK_NONE;
+    TensorDumpArgMask got_flags = TENSOR_DUMP_ARG_MASK_NONE;
+    get_dump_args_task_masks(task_id, &got_mask, &got_flags);
+    EXPECT_EQ(got_mask, mask);
+    EXPECT_EQ(got_flags, flags);
+
+    uint32_t got_count = 0;
+    uint8_t got_dtypes[32] = {};
+    ASSERT_TRUE(get_dump_args_task_scalar_dtypes(task_id, &got_count, got_dtypes));
+    EXPECT_EQ(got_count, 3u);
+    EXPECT_EQ(got_dtypes[0], 2);
+    EXPECT_EQ(got_dtypes[1], 5);
+    EXPECT_EQ(got_dtypes[2], 11);
+}
+
+// Two distinct task_ids must keep independent entries (open-addressed probing
+// resolves any hash collision to separate slots).
+TEST_F(TensorDumpTest, DistinctTaskIdsDoNotAlias) {
+    const uint64_t id_a = (uint64_t{2} << 32) | 100u;
+    const uint64_t id_b = (uint64_t{3} << 32) | 200u;
+
+    set_dump_args_task_mask(id_a, 0b0001, TENSOR_DUMP_ARG_MASK_NONE);
+    set_dump_args_task_mask(id_b, 0b1000, TENSOR_DUMP_ARG_MASK_NONE);
+
+    TensorDumpArgMask mask_a = TENSOR_DUMP_ARG_MASK_NONE;
+    TensorDumpArgMask mask_b = TENSOR_DUMP_ARG_MASK_NONE;
+    get_dump_args_task_masks(id_a, &mask_a, nullptr);
+    get_dump_args_task_masks(id_b, &mask_b, nullptr);
+
+    EXPECT_EQ(mask_a, static_cast<TensorDumpArgMask>(0b0001));
+    EXPECT_EQ(mask_b, static_cast<TensorDumpArgMask>(0b1000));
+}
+
+// An unset task_id reads back as "no mask" — the empty-slot path.
+TEST_F(TensorDumpTest, UnknownTaskIdReadsNone) {
+    TensorDumpArgMask got_mask = 0xFFFF;
+    TensorDumpArgMask got_flags = 0xFFFF;
+    get_dump_args_task_masks((uint64_t{5} << 32) | 42u, &got_mask, &got_flags);
+    EXPECT_EQ(got_mask, TENSOR_DUMP_ARG_MASK_NONE);
+    EXPECT_EQ(got_flags, TENSOR_DUMP_ARG_MASK_NONE);
+}
+
+// End-to-end dump-record correctness: set up the shared-memory dump buffer,
+// record a tensor and a scalar via dump_arg_record, then read back the
+// TensorDumpRecord entries and the arena payload to verify every field.
+TEST_F(TensorDumpTest, DumpRecordCorrectness) {
+    constexpr size_t kDumpMemSize = sizeof(DumpDataHeader) + sizeof(DumpBufferState);
+    alignas(64) uint8_t dump_mem[kDumpMemSize] = {};
+    alignas(64) DumpMetaBuffer meta_buf{};
+    constexpr size_t kArenaSize = 4096;
+    alignas(uint64_t) uint8_t arena[kArenaSize] = {};
+    uint64_t src_data[4] = {10, 20, 30, 40};
+
+    DumpDataHeader *hdr = get_dump_header(dump_mem);
+    hdr->magic = TENSOR_DUMP_MAGIC;
+    hdr->dump_tensor_level = static_cast<uint32_t>(DumpTensorLevel::FULL);
+    hdr->num_dump_threads = 1;
+
+    DumpBufferState *state = get_dump_buffer_state(dump_mem, 0);
+    state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&meta_buf);
+    state->free_queue.tail = 1;
+    state->arena_base = reinterpret_cast<uint64_t>(arena);
+    state->arena_size = kArenaSize;
+    state->arena_write_offset = 0;
+
+    set_platform_dump_base(reinterpret_cast<uint64_t>(dump_mem));
+    dump_args_init(1);
+
+    // Record a 1-D UINT64 tensor (4 elements, contiguous).
+    TensorDumpInfo tinfo = {};
+    tinfo.task_id = 0xDEAD;
+    tinfo.role = TensorDumpRole::INPUT;
+    tinfo.stage = TensorDumpStage::BEFORE_DISPATCH;
+    tinfo.dtype = static_cast<uint8_t>(DataType::UINT64);
+    tinfo.ndims = 1;
+    tinfo.arg_index = 0;
+    tinfo.buffer_addr = reinterpret_cast<uint64_t>(src_data);
+    tinfo.shapes[0] = 4;
+    tinfo.strides[0] = 1;
+    tinfo.start_offset = 0;
+    tinfo.kind = static_cast<uint8_t>(TensorDumpKind::TENSOR);
+    tinfo.func_count = 1;
+    tinfo.func_ids[0] = 42;
+
+    ASSERT_EQ(dump_arg_record(0, tinfo), 0);
+
+    const TensorDumpRecord &trec = meta_buf.records[0];
+    EXPECT_EQ(trec.task_id, 0xDEAD);
+    EXPECT_EQ(trec.role, static_cast<uint8_t>(TensorDumpRole::INPUT));
+    EXPECT_EQ(trec.stage, static_cast<uint8_t>(TensorDumpStage::BEFORE_DISPATCH));
+    EXPECT_EQ(trec.dtype, static_cast<uint8_t>(DataType::UINT64));
+    EXPECT_EQ(trec.ndims, 1);
+    EXPECT_EQ(trec.arg_index, 0u);
+    EXPECT_EQ(trec.kind, static_cast<uint8_t>(TensorDumpKind::TENSOR));
+    EXPECT_EQ(trec.truncated, 0);
+    EXPECT_EQ(trec.is_contiguous, 1);
+    EXPECT_EQ(trec.payload_size, 32u);  // 4 * sizeof(uint64_t)
+    EXPECT_EQ(trec.shapes[0], 4u);
+    EXPECT_EQ(trec.strides[0], 1u);
+    EXPECT_EQ(trec.func_count, 1);
+    EXPECT_EQ(trec.func_ids[0], 42u);
+
+    uint64_t arena_vals[4];
+    memcpy(arena_vals, arena, sizeof(arena_vals));
+    EXPECT_EQ(arena_vals[0], 10u);
+    EXPECT_EQ(arena_vals[1], 20u);
+    EXPECT_EQ(arena_vals[2], 30u);
+    EXPECT_EQ(arena_vals[3], 40u);
+
+    // Record a scalar (no arena copy; scalar_value carried inline in the record).
+    TensorDumpInfo sinfo = {};
+    sinfo.task_id = 0xBEEF;
+    sinfo.role = TensorDumpRole::INPUT;
+    sinfo.stage = TensorDumpStage::BEFORE_DISPATCH;
+    sinfo.dtype = static_cast<uint8_t>(DataType::UINT64);
+    sinfo.arg_index = 1;
+    sinfo.scalar_value = 0x12345678;
+    sinfo.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
+    sinfo.func_count = 1;
+    sinfo.func_ids[0] = 7;
+
+    ASSERT_EQ(dump_arg_record(0, sinfo), 0);
+
+    const TensorDumpRecord &srec = meta_buf.records[1];
+    EXPECT_EQ(srec.task_id, 0xBEEF);
+    EXPECT_EQ(srec.kind, static_cast<uint8_t>(TensorDumpKind::SCALAR));
+    EXPECT_EQ(srec.scalar_value, 0x12345678u);
+    EXPECT_EQ(srec.payload_size, 0u);
+    EXPECT_EQ(srec.dtype, static_cast<uint8_t>(DataType::UINT64));
+    EXPECT_EQ(srec.func_ids[0], 7u);
+    EXPECT_EQ(meta_buf.count, 2u);
+
+    set_platform_dump_base(0);
+}

--- a/tests/ut/cpp/a5/test_tensor_dump.cpp
+++ b/tests/ut/cpp/a5/test_tensor_dump.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "aicpu/tensor_dump_aicpu.h"
+
+// Fixture for tensor-dump tests: the args-dump mask pool keys entries on the
+// full 64-bit task_id and must be agnostic to how a runtime partitions that id
+// into (ring_id, slot) — any task_id can enter the table.
+class TensorDumpTest : public ::testing::Test {
+protected:
+    void SetUp() override { set_dump_args_enabled(true); }
+    void TearDown() override { set_dump_args_enabled(false); }
+};
+
+// Basic enable/disable toggle and dump-base propagation — the foundation the
+// mask pool sits on.
+TEST_F(TensorDumpTest, EnableDisableAndDumpBaseRoundTrip) {
+    set_dump_args_enabled(false);
+    EXPECT_FALSE(is_dump_args_enabled());
+
+    set_dump_args_enabled(true);
+    EXPECT_TRUE(is_dump_args_enabled());
+
+    set_dump_args_enabled(false);
+    EXPECT_FALSE(is_dump_args_enabled());
+
+    set_platform_dump_base(0xDEADBEEF42ULL);
+    EXPECT_EQ(get_platform_dump_base(), 0xDEADBEEF42ULL);
+
+    set_platform_dump_base(0);
+    EXPECT_EQ(get_platform_dump_base(), 0ULL);
+}
+
+// A task_id whose high 32 bits exceed any runtime's ring depth must still round
+// trip — this is the coupling the pool must not have. Exercises both the mask
+// table and the scalar-dtype table.
+TEST_F(TensorDumpTest, HighRingTaskIdRoundTrips) {
+    const uint64_t task_id = (uint64_t{7} << 32) | 123u;
+    const TensorDumpArgMask mask = 0b1011;
+    const TensorDumpArgMask flags = 0b0010;
+    const uint8_t dtypes[3] = {2, 5, 11};
+
+    set_dump_args_task_mask(task_id, mask, flags);
+    set_dump_args_task_scalar_dtypes(task_id, 3, dtypes);
+
+    TensorDumpArgMask got_mask = TENSOR_DUMP_ARG_MASK_NONE;
+    TensorDumpArgMask got_flags = TENSOR_DUMP_ARG_MASK_NONE;
+    get_dump_args_task_masks(task_id, &got_mask, &got_flags);
+    EXPECT_EQ(got_mask, mask);
+    EXPECT_EQ(got_flags, flags);
+
+    uint32_t got_count = 0;
+    uint8_t got_dtypes[32] = {};
+    ASSERT_TRUE(get_dump_args_task_scalar_dtypes(task_id, &got_count, got_dtypes));
+    EXPECT_EQ(got_count, 3u);
+    EXPECT_EQ(got_dtypes[0], 2);
+    EXPECT_EQ(got_dtypes[1], 5);
+    EXPECT_EQ(got_dtypes[2], 11);
+}
+
+// Two distinct task_ids must keep independent entries (open-addressed probing
+// resolves any hash collision to separate slots).
+TEST_F(TensorDumpTest, DistinctTaskIdsDoNotAlias) {
+    const uint64_t id_a = (uint64_t{2} << 32) | 100u;
+    const uint64_t id_b = (uint64_t{3} << 32) | 200u;
+
+    set_dump_args_task_mask(id_a, 0b0001, TENSOR_DUMP_ARG_MASK_NONE);
+    set_dump_args_task_mask(id_b, 0b1000, TENSOR_DUMP_ARG_MASK_NONE);
+
+    TensorDumpArgMask mask_a = TENSOR_DUMP_ARG_MASK_NONE;
+    TensorDumpArgMask mask_b = TENSOR_DUMP_ARG_MASK_NONE;
+    get_dump_args_task_masks(id_a, &mask_a, nullptr);
+    get_dump_args_task_masks(id_b, &mask_b, nullptr);
+
+    EXPECT_EQ(mask_a, static_cast<TensorDumpArgMask>(0b0001));
+    EXPECT_EQ(mask_b, static_cast<TensorDumpArgMask>(0b1000));
+}
+
+// An unset task_id reads back as "no mask" — the empty-slot path.
+TEST_F(TensorDumpTest, UnknownTaskIdReadsNone) {
+    TensorDumpArgMask got_mask = 0xFFFF;
+    TensorDumpArgMask got_flags = 0xFFFF;
+    get_dump_args_task_masks((uint64_t{5} << 32) | 42u, &got_mask, &got_flags);
+    EXPECT_EQ(got_mask, TENSOR_DUMP_ARG_MASK_NONE);
+    EXPECT_EQ(got_flags, TENSOR_DUMP_ARG_MASK_NONE);
+}
+
+// End-to-end dump-record correctness: set up the shared-memory dump buffer,
+// record a tensor and a scalar via dump_arg_record, then read back the
+// TensorDumpRecord entries and the arena payload to verify every field.
+TEST_F(TensorDumpTest, DumpRecordCorrectness) {
+    constexpr size_t kDumpMemSize = sizeof(DumpDataHeader) + sizeof(DumpBufferState);
+    alignas(64) uint8_t dump_mem[kDumpMemSize] = {};
+    alignas(64) DumpMetaBuffer meta_buf{};
+    constexpr size_t kArenaSize = 4096;
+    alignas(uint64_t) uint8_t arena[kArenaSize] = {};
+    uint64_t src_data[4] = {10, 20, 30, 40};
+
+    DumpDataHeader *hdr = get_dump_header(dump_mem);
+    hdr->magic = TENSOR_DUMP_MAGIC;
+    hdr->dump_tensor_level = static_cast<uint32_t>(DumpTensorLevel::FULL);
+    hdr->num_dump_threads = 1;
+
+    DumpBufferState *state = get_dump_buffer_state(dump_mem, 0);
+    state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&meta_buf);
+    state->free_queue.tail = 1;
+    state->arena_base = reinterpret_cast<uint64_t>(arena);
+    state->arena_size = kArenaSize;
+    state->arena_write_offset = 0;
+
+    set_platform_dump_base(reinterpret_cast<uint64_t>(dump_mem));
+    dump_args_init(1);
+
+    // Record a 1-D UINT64 tensor (4 elements, contiguous).
+    TensorDumpInfo tinfo = {};
+    tinfo.task_id = 0xDEAD;
+    tinfo.role = TensorDumpRole::INPUT;
+    tinfo.stage = TensorDumpStage::BEFORE_DISPATCH;
+    tinfo.dtype = static_cast<uint8_t>(DataType::UINT64);
+    tinfo.ndims = 1;
+    tinfo.arg_index = 0;
+    tinfo.buffer_addr = reinterpret_cast<uint64_t>(src_data);
+    tinfo.shapes[0] = 4;
+    tinfo.strides[0] = 1;
+    tinfo.start_offset = 0;
+    tinfo.kind = static_cast<uint8_t>(TensorDumpKind::TENSOR);
+    tinfo.func_count = 1;
+    tinfo.func_ids[0] = 42;
+
+    ASSERT_EQ(dump_arg_record(0, tinfo), 0);
+
+    const TensorDumpRecord &trec = meta_buf.records[0];
+    EXPECT_EQ(trec.task_id, 0xDEAD);
+    EXPECT_EQ(trec.role, static_cast<uint8_t>(TensorDumpRole::INPUT));
+    EXPECT_EQ(trec.stage, static_cast<uint8_t>(TensorDumpStage::BEFORE_DISPATCH));
+    EXPECT_EQ(trec.dtype, static_cast<uint8_t>(DataType::UINT64));
+    EXPECT_EQ(trec.ndims, 1);
+    EXPECT_EQ(trec.arg_index, 0u);
+    EXPECT_EQ(trec.kind, static_cast<uint8_t>(TensorDumpKind::TENSOR));
+    EXPECT_EQ(trec.truncated, 0);
+    EXPECT_EQ(trec.is_contiguous, 1);
+    EXPECT_EQ(trec.payload_size, 32u);  // 4 * sizeof(uint64_t)
+    EXPECT_EQ(trec.shapes[0], 4u);
+    EXPECT_EQ(trec.strides[0], 1u);
+    EXPECT_EQ(trec.func_count, 1);
+    EXPECT_EQ(trec.func_ids[0], 42u);
+
+    uint64_t arena_vals[4];
+    memcpy(arena_vals, arena, sizeof(arena_vals));
+    EXPECT_EQ(arena_vals[0], 10u);
+    EXPECT_EQ(arena_vals[1], 20u);
+    EXPECT_EQ(arena_vals[2], 30u);
+    EXPECT_EQ(arena_vals[3], 40u);
+
+    // Record a scalar (no arena copy; scalar_value carried inline in the record).
+    TensorDumpInfo sinfo = {};
+    sinfo.task_id = 0xBEEF;
+    sinfo.role = TensorDumpRole::INPUT;
+    sinfo.stage = TensorDumpStage::BEFORE_DISPATCH;
+    sinfo.dtype = static_cast<uint8_t>(DataType::UINT64);
+    sinfo.arg_index = 1;
+    sinfo.scalar_value = 0x12345678;
+    sinfo.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
+    sinfo.func_count = 1;
+    sinfo.func_ids[0] = 7;
+
+    ASSERT_EQ(dump_arg_record(0, sinfo), 0);
+
+    const TensorDumpRecord &srec = meta_buf.records[1];
+    EXPECT_EQ(srec.task_id, 0xBEEF);
+    EXPECT_EQ(srec.kind, static_cast<uint8_t>(TensorDumpKind::SCALAR));
+    EXPECT_EQ(srec.scalar_value, 0x12345678u);
+    EXPECT_EQ(srec.payload_size, 0u);
+    EXPECT_EQ(srec.dtype, static_cast<uint8_t>(DataType::UINT64));
+    EXPECT_EQ(srec.func_ids[0], 7u);
+    EXPECT_EQ(meta_buf.count, 2u);
+
+    set_platform_dump_base(0);
+}


### PR DESCRIPTION
## Problem

The args-dump mask pool keyed entries on the runtime's `(ring_id, slot)` partition of `task_id`: `resolve_dump_args_task_slot` extracted `ring_id` from the high 32 bits and **returned false** when `ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS` (= `PTO2_MAX_RING_DEPTH`). Any `task_id` whose ring field exceeded the runtime's max was silently dropped — its dump mask never entered the table and reads back `TENSOR_DUMP_ARG_MASK_NONE`.

The pool inherited a runtime coupling (`PTO2_MAX_RING_DEPTH` / `PTO2_TASK_WINDOW_SIZE` via `pto_runtime2_types.h`) it shouldn't have: the dump mask pool is a host-side diagnostic table and must accept any task_id the runtime issues, regardless of how the runtime partitions the id into ring/slot.

## Fix

- Drop the `PTO2_MAX_RING_DEPTH` / `PTO2_TASK_WINDOW_SIZE` dependency from the `a2a3` and `a5` `tensor_dump.h` headers (removes the `TENSOR_DUMP_MASK_POOL_MAX_RINGS` / `MAX_SLOTS` / `DEFAULT_SLOT_MASK` constants and the `pto_runtime2_types.h` include).
- Refactor `resolve_dump_args_task_slot` to fold the full 64-bit `task_id` via `high ^ low` XOR into the table index. Every `task_id` now maps to a slot regardless of its ring field; the function returns `uint32_t` directly instead of writing through an out-parameter (per review feedback).
- Update all 4 callers (`set_dump_args_task_scalar_dtypes`, `get_dump_args_task_scalar_dtypes`, `set_dump_args_task_mask`, `get_dump_args_task_masks`) to `uint32_t idx = resolve_dump_args_task_slot(task_id);`.

## Tests

Adds `tests/ut/cpp/a2a3/test_tensor_dump_mask_pool.cpp` and `tests/ut/cpp/a5/test_tensor_dump_mask_pool.cpp` (mirrored — the dump source is shared but each platform carries its own header/test target) covering:
- `HighRingTaskIdRoundTrips` — a `task_id` whose high 32 bits exceed any runtime's ring depth still round-trips through both the mask table and the scalar-dtype table (the regression this PR fixes).
- `DistinctTaskIdsDoNotAlias` — open-addressed probing keeps two distinct ids independent.
- `UnknownTaskIdReadsNone` — unset `task_id` reads back `TENSOR_DUMP_ARG_MASK_NONE` (empty-slot path).

## Changes

- `src/a2a3/platform/include/common/tensor_dump.h` — remove `pto_runtime2_types.h` include and the 3 derived constants.
- `src/a5/platform/include/common/tensor_dump.h` — same.
- `src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp` — refactor `resolve_dump_args_task_slot` + 4 callers.
- `tests/ut/cpp/CMakeLists.txt` — register the new a2a3 + a5 tests.
- `tests/ut/cpp/a2a3/test_tensor_dump_mask_pool.cpp` — new test file.
- `tests/ut/cpp/a5/test_tensor_dump_mask_pool.cpp` — new test file.

close #1317 