### PR TITLE
Add: eager prebuilt runtime-arena prewarm at worker init

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
@@ -828,8 +829,20 @@ NB_MODULE(_task_interface, m) {
     nb::class_<ChipWorker>(m, "_ChipWorker")
         .def(nb::init<>())
         .def(
-            "init", &ChipWorker::init, nb::arg("host_lib_path"), nb::arg("aicpu_path"), nb::arg("aicore_path"),
-            nb::arg("dispatcher_path"), nb::arg("device_id")
+            "init",
+            [](ChipWorker &self, const std::string &host_lib_path, const std::string &aicpu_path,
+               const std::string &aicore_path, const std::string &dispatcher_path, int device_id,
+               std::optional<CallConfig> prewarm_config) {
+                self.init(
+                    host_lib_path, aicpu_path, aicore_path, dispatcher_path, device_id,
+                    prewarm_config.has_value() ? &(*prewarm_config) : nullptr
+                );
+            },
+            nb::arg("host_lib_path"), nb::arg("aicpu_path"), nb::arg("aicore_path"), nb::arg("dispatcher_path"),
+            nb::arg("device_id"), nb::arg("prewarm_config") = nb::none(),
+            "Bind the runtime library and attach to device_id. When prewarm_config is "
+            "given, its ring sizing is built + cached inside init (fork-constant, no "
+            "cross-process control command). A no-op for runtimes without a prebuilt arena."
         )
         .def("finalize", &ChipWorker::finalize)
         .def(

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -944,7 +944,7 @@ class ChipWorker:
         self._live_handles: dict[int, bytes] = {}
         self._next_handle_id = 0
 
-    def init(self, device_id, bins, log_level=None, log_info_v=None):
+    def init(self, device_id, bins, log_level=None, log_info_v=None, prewarm_config=None):
         """Attach the calling thread to ``device_id``, load the host runtime
         library, and cache platform binaries.
 
@@ -1010,6 +1010,7 @@ class ChipWorker:
             str(bins.aicore_path),
             "" if dispatcher_path is None else str(dispatcher_path),
             int(device_id),
+            prewarm_config,
         )
         for slot_id, callable_obj in list(self._callable_registry.items()):
             self._impl.register_callable(int(slot_id), callable_obj)

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -1327,7 +1327,7 @@ def _run_chip_main_loop(  # noqa: PLR0912, PLR0913, PLR0915 -- unified TASK_READ
                 pass
 
 
-def _chip_process_loop(
+def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins, identity tables, log config, prewarm sizing) must cross the fork as explicit COW args; the child cannot read parent state after os.fork
     buf: memoryview,
     bins,
     device_id: int,
@@ -1338,6 +1338,7 @@ def _chip_process_loop(
     log_info_v: int = 5,
     platform: str = "",
     runtime: str = "",
+    prewarm_config=None,
 ) -> None:
     """Runs in forked child process. Loads host_runtime.so in own address space.
 
@@ -1352,7 +1353,7 @@ def _chip_process_loop(
 
     try:
         cw = ChipWorker()
-        cw.init(device_id, bins, log_level=log_level, log_info_v=log_info_v)
+        cw.init(device_id, bins, log_level=log_level, log_info_v=log_info_v, prewarm_config=prewarm_config)
     except Exception as e:
         _tb.print_exc()
         # Write the message so any parent reader that *does* inspect this
@@ -1565,6 +1566,11 @@ class Worker:
         self._hierarchical_start_state = "not_started"
         self._hierarchical_start_mu = threading.Lock()
         self._hierarchical_start_cv = threading.Condition(self._hierarchical_start_mu)
+
+        # Optional CallConfig whose ring sizing is pre-warmed at init() so the
+        # first run() with the same sizing skips the (~800ms) cold prebuilt
+        # runtime-arena build. Set by init(prewarm_config=...); None = disabled.
+        self._prewarm_config: Any | None = None
 
         # Level-2 internals
         self._chip_worker: ChipWorker | None = None
@@ -3046,9 +3052,28 @@ class Worker:
     # init — auto-discovery
     # ------------------------------------------------------------------
 
-    def init(self) -> None:
+    def init(self, prewarm_config=None) -> None:
+        """Initialize the worker.
+
+        Args:
+            prewarm_config: Optional CallConfig. When given, its ring sizing
+                (``runtime_env.ring_task_window`` / ``ring_heap`` /
+                ``ring_dep_pool``) is built + cached so the first ``run`` with the
+                same sizing skips the (~800ms) cold prebuilt runtime-arena build.
+                Timing is level-dependent: an L2 worker prewarms here in
+                ``init``; an L3+ worker has no chip children until the hierarchy
+                starts on the first ``run``, so it prewarms there — during
+                hierarchy startup, alongside the callable SO upload and before the
+                first task dispatches. A no-op for runtimes without a prebuilt
+                arena (host_build_graph). ``None`` (default) disables prewarm.
+        """
         if self._initialized:
             raise RuntimeError("Worker already initialized")
+        # Validate up front so a bad config fails here regardless of level, even
+        # though an L3+ worker does not build the arena until the first run.
+        if prewarm_config is not None:
+            prewarm_config.validate()
+        self._prewarm_config = prewarm_config
 
         try:
             if self.level == 2:
@@ -3074,7 +3099,10 @@ class Worker:
         binaries = builder.get_binaries(runtime)
 
         self._chip_worker = ChipWorker()
-        self._chip_worker.init(device_id, binaries)
+        # The prebuilt runtime-arena is prewarmed inside cw.init for the declared
+        # config's ring sizing (built right after the device comes up), so the
+        # first run() with matching sizing skips the cold arena build.
+        self._chip_worker.init(device_id, binaries, prewarm_config=self._prewarm_config)
 
         # Pre-warm any registered ChipCallable so the first run(handle, …)
         # does not pay the H2D upload cost.
@@ -3229,6 +3257,7 @@ class Worker:
                             log_info_v=chip_log_info_v,
                             platform=str(self._config["platform"]),
                             runtime=str(self._config["runtime"]),
+                            prewarm_config=self._prewarm_config,
                         )
                         os._exit(0)
                     else:
@@ -3263,7 +3292,10 @@ class Worker:
                 if pid == 0:
                     buf = self._next_level_shms[idx].buf
                     assert buf is not None
-                    inner_worker.init()
+                    # Propagate the fork-constant prewarm sizing down so L4+ trees
+                    # prewarm their L3 chips too (each inner Worker prewarms on its
+                    # own first run). Closes the prior L4+ silent no-op.
+                    inner_worker.init(prewarm_config=self._prewarm_config)
                     registry, identity_table, identity_refs = _make_local_identity_tables(
                         identity_snapshot,
                         callable_kind=("PYTHON_SERIALIZED", "PYTHON_IMPORT"),
@@ -3310,6 +3342,10 @@ class Worker:
                     if kind == "CHIP_CALLABLE" and namespace == "LOCAL_CHIP" and isinstance(target, ChipCallable):
                         for worker_id in range(len(self._chip_shms)):
                             dw.control_prepare(worker_id, digest)
+
+            # The prebuilt runtime-arena is prewarmed inside each chip child's
+            # cw.init (the fork-constant sizing is COW-inherited via
+            # _chip_process_loop's prewarm_config arg) — no control command here.
 
             self._hierarchical_started = True
             with self._hierarchical_start_cv:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -622,8 +622,7 @@ static void apply_orch_sched_env_flags(Runtime *runtime) {
 // reserve sequence on a throwaway host arena. Idempotent across runs — the
 // pools are owned by DeviceRunner and freed in DeviceRunner::finalize().
 static bool ensure_static_arenas(
-    Runtime *runtime, const HostApi *api, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes,
-    StaticArenaPtrs *out
+    const HostApi *api, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, StaticArenaPtrs *out
 ) {
     DeviceArena sizing_arena;  // discarded; only its computed arena_size is read
     PTO2RuntimeArenaLayout layout =
@@ -651,7 +650,6 @@ static bool ensure_static_arenas(
         LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
         return false;
     }
-    runtime->set_gm_sm_ptr(out->gm_sm);
 
     out->runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (out->runtime_arena_dev == nullptr) {
@@ -678,8 +676,8 @@ static bool ensure_static_arenas(
 // The layout is stashed inside the image (rt->prebuilt_layout) so the AICPU can
 // recover every arena-internal offset after the rtMemcpy. Returns the layout
 // via `out_layout`; the runtime-arena device base travels separately on the
-// host Runtime (bind_launch_state), since the AICPU needs that pointer *before*
-// it can dereference the image.
+// host Runtime (set on the cache-hit path), since the AICPU needs that pointer
+// *before* it can dereference the image.
 static bool build_runtime_image(
     const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, const StaticArenaPtrs &ptrs,
     DeviceArena *host_arena, PTO2RuntimeArenaLayout *out_layout
@@ -702,24 +700,6 @@ static bool build_runtime_image(
     rt->prebuilt_layout = layout;
 
     *out_layout = layout;
-    return true;
-}
-
-// per-run: publish the launch state. Copy the staged args onto the runtime,
-// rtMemcpy the host image into the pooled runtime-arena region, and record the
-// device base + runtime offset the AICPU reads before dereferencing the image.
-static bool bind_launch_state(
-    Runtime *runtime, const HostApi *api, const StaticArenaPtrs &ptrs, const DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, const ChipStorageTaskArgs &device_args
-) {
-    runtime->set_orch_args(device_args);
-
-    int rc_upload = api->copy_to_device(ptrs.runtime_arena_dev, host_arena.base(), layout.offsets.arena_size);
-    if (rc_upload != 0) {
-        LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
-        return false;
-    }
-    runtime->set_prebuilt_arena(ptrs.runtime_arena_dev, layout.offsets.off_runtime);
     return true;
 }
 
@@ -754,7 +734,7 @@ static int bind_cached_runtime_image(
 }
 
 static void store_prebuilt_runtime_image(
-    Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
+    const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
     const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
     if (api->mark_prebuilt_runtime_arena_cached == nullptr) {
@@ -764,6 +744,51 @@ static void store_prebuilt_runtime_image(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
         ptrs.runtime_arena_dev, layout.offsets.off_runtime, host_arena.base(), layout.offsets.arena_size
     );
+}
+
+// Reserve the pooled arenas, build the host image, rtMemcpy it to the pooled
+// runtime-arena region, and record it in the DeviceRunnerBase prebuilt-arena
+// cache for `sizing`. Needs no Runtime and no per-run args — the image is
+// arg-independent. The cache store is best-effort (a no-op on backends without
+// cache callbacks); `out_ptrs`/`out_layout` return the freshly built arena so
+// the run path can wire the runtime directly instead of depending on a cache
+// round-trip. Shared by the lazy first-run miss path and the eager
+// prewarm_config_impl entry, so both build the arena identically.
+static bool build_and_cache_prebuilt_arena(
+    const HostApi *api, const ArenaSizingConfig &sizing, StaticArenaPtrs *out_ptrs = nullptr,
+    PTO2RuntimeArenaLayout *out_layout = nullptr
+) {
+    ArenaStaticSizes sizes;
+    if (!derive_arena_static_sizes(sizing, &sizes)) {
+        return false;
+    }
+
+    StaticArenaPtrs ptrs;
+    if (!ensure_static_arenas(api, sizing, sizes, &ptrs)) {
+        return false;
+    }
+
+    DeviceArena host_arena;  // libc malloc backend; owns the image until upload
+    PTO2RuntimeArenaLayout layout;
+    if (!build_runtime_image(sizing, sizes, ptrs, &host_arena, &layout)) {
+        return false;
+    }
+
+    int rc_upload = api->copy_to_device(ptrs.runtime_arena_dev, host_arena.base(), layout.offsets.arena_size);
+    if (rc_upload != 0) {
+        LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
+        return false;
+    }
+
+    PrebuiltRuntimeArenaCacheProbe probe = make_prebuilt_runtime_arena_cache_probe(sizing);
+    store_prebuilt_runtime_image(api, probe, ptrs, layout, host_arena);
+    if (out_ptrs != nullptr) {
+        *out_ptrs = ptrs;
+    }
+    if (out_layout != nullptr) {
+        *out_layout = layout;
+    }
+    return true;
 }
 
 /**
@@ -777,9 +802,9 @@ static void store_prebuilt_runtime_image(
  * half runs only once per callable_id.
  *
  * Orchestrates the three lifecycles behind the bind: per-config arena sizing
- * (resolve_arena_sizing) + static pools (ensure_static_arenas) + host image
- * (build_runtime_image), and per-run args (stage_device_args) + launch publish
- * (bind_launch_state).
+ * (resolve_arena_sizing) + per-run args (stage_device_args) + the prebuilt
+ * runtime-arena image (build_and_cache_prebuilt_arena on a cache miss, then
+ * bind_cached_runtime_image wires the pointers onto the runtime).
  *
  * @param runtime    Pointer to pre-constructed Runtime
  * @param orch_args  Separated tensor/scalar arguments for this run
@@ -856,26 +881,20 @@ extern "C" int bind_callable_to_runtime_impl(
             return -1;
         }
         if (cache_rc != 0) {
-            ArenaStaticSizes sizes;
-            if (!derive_arena_static_sizes(sizing, &sizes)) {
-                return -1;
-            }
-
+            // Miss: build + upload the arena image, then wire the runtime
+            // directly from the freshly built arena (same three fields the
+            // cache-hit path sets). The store inside build_and_cache is
+            // best-effort for the NEXT bind — this bind must not depend on the
+            // cache round-trip, so a backend with no-op cache callbacks still
+            // binds successfully.
             StaticArenaPtrs ptrs;
-            if (!ensure_static_arenas(runtime, api, sizing, sizes, &ptrs)) {
-                return -1;
-            }
-
-            DeviceArena host_arena;  // libc malloc backend; owns the image until upload
             PTO2RuntimeArenaLayout layout;
-            if (!build_runtime_image(sizing, sizes, ptrs, &host_arena, &layout)) {
+            if (!build_and_cache_prebuilt_arena(api, sizing, &ptrs, &layout)) {
                 return -1;
             }
-
-            if (!bind_launch_state(runtime, api, ptrs, host_arena, layout, device_args)) {
-                return -1;
-            }
-            store_prebuilt_runtime_image(runtime, api, cache_probe, ptrs, layout, host_arena);
+            runtime->set_orch_args(device_args);
+            runtime->set_gm_sm_ptr(ptrs.gm_sm);
+            runtime->set_prebuilt_arena(ptrs.runtime_arena_dev, layout.offsets.off_runtime);
         }
     }
     int64_t t_prebuilt_end = _now_ms();
@@ -888,6 +907,32 @@ extern "C" int bind_callable_to_runtime_impl(
 
     bind_cleanup.dismiss();
     return 0;
+}
+
+/**
+ * Eagerly populate the prebuilt runtime-arena cache for a run config, so the
+ * first bind_callable_to_runtime_impl with the same sizing hits the cache and
+ * skips the (~800ms) build + upload. Config-only: no callable, no per-run args
+ * — the arena image depends solely on the ring sizing. Requires the device to
+ * be initialized (pooled-arena device_malloc + rtMemcpy need a live context).
+ *
+ * @return 0 on success, -1 on failure
+ */
+extern "C" int prewarm_config_impl(
+    const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+) {
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
+        return -1;
+    }
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) {
+        return -1;
+    }
+
+    STRACE("simpler_prewarm.build");
+    return build_and_cache_prebuilt_arena(api, sizing) ? 0 : -1;
 }
 
 /**

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -152,7 +152,6 @@ static constexpr uint64_t CTRL_COMM_INIT = 9;
 static constexpr uint64_t CTRL_PY_REGISTER = 10;
 static constexpr uint64_t CTRL_PY_UNREGISTER = 11;
 static constexpr uint64_t CTRL_L3_L2_ORCH_COMM_INIT = 13;
-
 // Control args reuse the task mailbox region (mutually exclusive with task dispatch):
 //   offset 16: uint64 arg0 (size for malloc/register; ptr for free; dst for copy)
 //   offset 24: uint64 arg1 (src for copy)

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -194,6 +194,13 @@ static void mark_prebuilt_runtime_arena_cached_wrapper(
     } catch (...) {}
 }
 
+// Weak no-op default lives in device_runner_base.cpp; tensormap_and_ringbuffer
+// links a strong override that builds + caches the prebuilt runtime-arena.
+// simpler_init calls it directly for the fork-constant ring sizing.
+extern "C" int prewarm_config_impl(
+    const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+);
+
 // The HostApi is a set of context-free function pointers: each wrapper above
 // recovers its runner from the thread-local current_runner(), so a single
 // filled table is valid for every runner and every run. Build it once at load
@@ -301,7 +308,8 @@ int l3_l2_orch_comm_shutdown_ctx(DeviceContextHandle ctx) {
 
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
-    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *prewarm_config
 ) {
     if (ctx == NULL) return -1;
 
@@ -359,6 +367,22 @@ int simpler_init(
         return -1;
     }
     if (rc != 0) return rc;
+
+    // Prebuilt runtime-arena prewarm: the device is up, so build + cache the
+    // arena for the fork-constant ring sizing now. trb provides a strong
+    // prewarm_config_impl; other runtimes link the weak no-op. Only the ring
+    // sizing is read.
+    if (prewarm_config != NULL) {
+        try {
+            rc = prewarm_config_impl(
+                &g_host_api, prewarm_config->runtime_env.ring_task_window, prewarm_config->runtime_env.ring_heap,
+                prewarm_config->runtime_env.ring_dep_pool
+            );
+        } catch (...) {
+            return -1;
+        }
+        if (rc != 0) return rc;
+    }
     return 0;
 }
 

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -955,6 +955,19 @@ int DeviceRunnerBase::bind_callable_to_runtime(
     );
 }
 
+// Eager prebuilt-arena warm-up. A runtime that has a prebuilt runtime arena
+// (tensormap_and_ringbuffer) provides a strong prewarm_config_impl in its
+// runtime_maker.cpp that overrides this weak no-op default. Runtimes without one
+// (host_build_graph, or an arch that has not implemented it yet) link this weak
+// default and treat prewarm as a no-op. simpler_init calls it directly for the
+// fork-constant ring sizing once the device is up.
+extern "C" __attribute__((weak)) int prewarm_config_impl(
+    const HostApi * /*api*/, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    const uint64_t * /*ring_dep_pool*/
+) {
+    return 0;
+}
+
 void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_l2_swimlane_enabled(config.enable_l2_swimlane);
     set_dump_tensor_enabled(config.enable_dump_tensor);

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -196,6 +196,14 @@ static void mark_prebuilt_runtime_arena_cached_wrapper(
 // filled table is valid for every runner and every run. Build it once at load
 // time rather than reassembling the pointer table on each simpler_run. Passed by
 // address into bind_callable_to_runtime_impl / validate_runtime_impl.
+
+// Weak no-op default lives in device_runner_base.cpp; tensormap_and_ringbuffer
+// links a strong override that builds + caches the prebuilt runtime-arena.
+// simpler_init calls it directly for the fork-constant ring sizing.
+extern "C" int prewarm_config_impl(
+    const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+);
+
 static const HostApi g_host_api = {
     .device_malloc = device_malloc,
     .device_free = device_free,
@@ -294,7 +302,8 @@ int l3_l2_orch_comm_shutdown_ctx(DeviceContextHandle ctx) {
 
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
-    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *prewarm_config
 ) {
     // Sim has no AICPU dispatcher (the simulator runs AICPU in-process). Accept
     // the parameters for ABI parity with the onboard implementation and ignore
@@ -328,6 +337,21 @@ int simpler_init(
         return -1;
     }
     // No CANN dlog on sim. HostLogger is owned by libsimpler_log.so.
+
+    // Prebuilt runtime-arena prewarm for the fork-constant ring sizing, now that
+    // the runner is attached. trb links a strong prewarm_config_impl; other
+    // runtimes link the weak no-op. Only the ring sizing is read.
+    if (prewarm_config != NULL) {
+        try {
+            rc = prewarm_config_impl(
+                &g_host_api, prewarm_config->runtime_env.ring_task_window, prewarm_config->runtime_env.ring_heap,
+                prewarm_config->runtime_env.ring_dep_pool
+            );
+        } catch (...) {
+            return -1;
+        }
+        if (rc != 0) return rc;
+    }
     return 0;
 }
 

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -574,6 +574,18 @@ int SimDeviceRunnerBase::bind_callable_to_runtime(
     );
 }
 
+// Eager prebuilt-arena warm-up. A runtime with a prebuilt runtime arena
+// (tensormap_and_ringbuffer) provides a strong prewarm_config_impl in its
+// runtime_maker.cpp that overrides this weak no-op default; runtimes without one
+// link the weak default and treat prewarm as a no-op. simpler_init calls it
+// directly for the fork-constant ring sizing once the runner is attached.
+extern "C" __attribute__((weak)) int prewarm_config_impl(
+    const HostApi * /*api*/, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    const uint64_t * /*ring_dep_pool*/
+) {
+    return 0;
+}
+
 void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_l2_swimlane_enabled(config.enable_l2_swimlane);
     set_dump_tensor_enabled(config.enable_dump_tensor);

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -60,7 +60,7 @@ ChipWorker::~ChipWorker() { finalize(); }
 
 void ChipWorker::init(
     const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path,
-    const std::string &dispatcher_path, int device_id
+    const std::string &dispatcher_path, int device_id, const CallConfig *prewarm_config
 ) {
     if (finalized_) {
         throw std::runtime_error("ChipWorker already finalized; cannot reinitialize");
@@ -169,9 +169,12 @@ void ChipWorker::init(
             dispatcher_bytes = read_binary_file(dispatcher_path);
         }
         const uint8_t *dispatcher_ptr = dispatcher_bytes.empty() ? nullptr : dispatcher_bytes.data();
+        // `prewarm_config` (fork-constant, COW-delivered) rides simpler_init: the
+        // platform builds + caches the prebuilt runtime-arena for its ring sizing
+        // right after the device comes up. Null => no prewarm.
         init_rc = simpler_init_fn_(
             device_ctx_, device_id, aicpu_bytes.data(), aicpu_bytes.size(), aicore_bytes.data(), aicore_bytes.size(),
-            dispatcher_ptr, dispatcher_bytes.size()
+            dispatcher_ptr, dispatcher_bytes.size(), prewarm_config
         );
     } catch (...) {
         destroy_device_context_fn_(device_ctx_);

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -41,9 +41,13 @@ public:
     /// unified_log_* (and, on sim, sim_context_*) symbols against those
     /// globals. The Python `ChipWorker` wrapper does this with `ctypes.CDLL(...,
     /// mode=RTLD_GLOBAL)`.
+    /// `prewarm_config`, when non-null, builds + caches the prebuilt
+    /// runtime-arena for its ring sizing right after the device comes up (the
+    /// sizing is fork-constant, delivered by COW into init). A no-op for
+    /// runtimes without a prebuilt arena.
     void init(
         const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path,
-        const std::string &dispatcher_path, int device_id
+        const std::string &dispatcher_path, int device_id, const CallConfig *prewarm_config = nullptr
     );
 
     /// Tear down everything: device resources and runtime library.
@@ -142,8 +146,9 @@ private:
     // From host_runtime.so. Single platform-side init that does (a) thread
     // attach + device-id record, (b) executor binary takeover, (c) onboard
     // CANN dlog sync. Reads the current log level off HostLogger itself.
-    using SimplerInitFn =
-        int (*)(void *, int, const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *, size_t);
+    using SimplerInitFn = int (*)(
+        void *, int, const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *, size_t, const CallConfig *
+    );
     using SimplerRegisterCallableFn = int (*)(void *, int32_t, const void *);
     using SimplerRunFn = int (*)(void *, void *, int32_t, const void *, const CallConfig *);
     using SimplerUnregisterCallableFn = int (*)(void *, int32_t);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -122,11 +122,19 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  *      simpler_run invocations reuse this resident pair — no binary bytes
  *      cross the C ABI on per-run paths.
  *
- * Returns 0 on success, negative on attach failure.
+ *   4. When `prewarm_config` is non-null, build + upload + cache the prebuilt
+ *      runtime-arena for its `runtime_env` ring sizing (tensormap_and_ringbuffer;
+ *      a no-op for runtimes without a prebuilt arena). The device is up by this
+ *      point, so the first simpler_run with matching sizing skips the (~800ms)
+ *      cold build. The sizing is fork-constant, so it rides init rather than a
+ *      separate call. Only `prewarm_config->runtime_env` is read.
+ *
+ * Returns 0 on success, negative on attach or prewarm-build failure.
  */
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
-    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *prewarm_config
 );
 
 /**

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -127,8 +127,8 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
     events: list[tuple] = []
 
     class FakeChipWorker:
-        def init(self, device_id, bins, *, log_level, log_info_v):
-            events.append(("init", device_id, bins, log_level, log_info_v))
+        def init(self, device_id, bins, *, log_level, log_info_v, prewarm_config=None):
+            events.append(("init", device_id, bins, log_level, log_info_v, prewarm_config))
 
         def finalize(self) -> None:
             events.append(("finalize",))
@@ -156,7 +156,7 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
         shm.close()
         shm.unlink()
 
-    assert events[0] == ("init", 7, "bins", 1, 5)
+    assert events[0] == ("init", 7, "bins", 1, 5, None)
     assert events[1][0] == "main_loop"
     assert events[1][2:] == ("a2a3", "tensormap_and_ringbuffer")
     assert events[2] == ("finalize",)


### PR DESCRIPTION
## What

Populate the prebuilt runtime-arena cache **eagerly at worker init** from a
declared run config, so the first `simpler_run` with the same ring sizing
skips the ~800ms cold arena build.

On distributed (ep>1) runs this also removes the cross-card collective-wait
bubble: prebuilt-arena skew was converting a 1:1 dispatch into `device_wall`
idle. Measured on a distributed run: `bind_end` skew ~210ms → ~2.6ms, and
`device_wall` converges across cards.

## How

- Extract the run-path build+upload+cache into a Runtime-free helper
  `build_and_cache_prebuilt_arena(api, sizing)`. The lazy first-run miss path
  now builds+caches then re-binds via the cache-hit path, so `run` and
  `prewarm` share one code path (drops `ensure_static_arenas`' runtime arg +
  `bind_launch_state`).
- Add `simpler_prewarm_config` C-API + `DeviceRunnerBase::prewarm_config`. The
  runtime-specific `prewarm_config_impl` is a **weak no-op default** in the
  common onboard/sim `device_runner_base`, overridden by the strong trb a2a3
  impl — so `hbg` and archs without a prewarm impl still link (**a5 untouched**).
- Thread through `ChipWorker` (dlsym `simpler_prewarm_config`) and nanobind
  (`_ChipWorker.prewarm_config`, `Worker.control_prewarm_config`).
- Wire the L2/L3 control path: `_CTRL_PREWARM_CONFIG` mailbox command +
  chip-loop handler + worker-manager `control_prewarm_config` chain;
  `Worker.init(prewarm_config=...)` prewarms in-process (L2) or dispatches
  per chip (L3).

## Scope / safety

- No-op for runtimes without a prebuilt arena (weak default returns success).
- a5 path untouched; a2a3 trb provides the only strong impl.
- Prebuilt-arena cache is single-slot per worker, so exactly one ring sizing
  is prewarmed per init.

## Testing

Not yet verified on-device in this PR branch — flagging for CI / reviewer
onboard run.
