### PR TITLE
Add: HostApi register/unregister_device_memory_to_host (SVM host-map)

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -58,7 +58,7 @@ extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_d
 }
 
 // =============================================================================
-// Lazy-loaded HAL (ascend_hal) for profiling host-register only
+// Lazy-loaded HAL (ascend_hal) for halHostRegister / halHostUnregister
 // =============================================================================
 
 namespace {
@@ -697,6 +697,57 @@ int DeviceRunner::force_reset_device() {
         "force_reset_device: aclrtResetDeviceForce(%d) cleared the poisoned card (probe confirmed clean)", device_id_
     );
     return 0;
+}
+
+void *DeviceRunner::register_device_memory_to_host(void *dev_ptr, std::size_t bytes) {
+    if (dev_ptr == nullptr || bytes == 0) {
+        return nullptr;
+    }
+    if (device_id_ < 0) {
+        LOG_ERROR("register_device_memory_to_host: invalid device_id %d", device_id_);
+        return nullptr;
+    }
+    if (load_hal_if_needed() != 0) {
+        LOG_ERROR("register_device_memory_to_host: failed to load ascend_hal: %s", dlerror());
+        return nullptr;
+    }
+    HalHostRegisterFn fn = get_halHostRegister();
+    if (fn == nullptr) {
+        LOG_ERROR("register_device_memory_to_host: halHostRegister symbol not found: %s", dlerror());
+        return nullptr;
+    }
+    void *host_va = nullptr;
+    int rc = fn(dev_ptr, bytes, DEV_SVM_MAP_HOST, device_id_, &host_va);
+    if (rc != 0) {
+        LOG_ERROR("register_device_memory_to_host: halHostRegister failed for dev_ptr %p (rc=%d)", dev_ptr, rc);
+        return nullptr;
+    }
+    return host_va;
+}
+
+void DeviceRunner::unregister_device_memory_from_host(void *dev_ptr) {
+    if (dev_ptr == nullptr) {
+        return;
+    }
+    if (device_id_ < 0) {
+        LOG_ERROR("unregister_device_memory_from_host: invalid device_id %d", device_id_);
+        return;
+    }
+    if (load_hal_if_needed() != 0) {
+        LOG_ERROR("unregister_device_memory_from_host: failed to load ascend_hal: %s", dlerror());
+        return;
+    }
+    // halHostUnregister is keyed by the device pointer; the HAL maps it back to
+    // the host VA internally.
+    HalHostUnregisterFn fn = get_halHostUnregister();
+    if (fn == nullptr) {
+        LOG_ERROR("unregister_device_memory_from_host: halHostUnregister symbol not found: %s", dlerror());
+        return;
+    }
+    int rc = fn(dev_ptr, device_id_);
+    if (rc != 0) {
+        LOG_ERROR("unregister_device_memory_from_host: halHostUnregister failed for dev_ptr %p (rc=%d)", dev_ptr, rc);
+    }
 }
 
 int DeviceRunner::finalize() {

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -114,6 +114,12 @@ public:
      */
     int run(Runtime &runtime, const CallConfig &config) override;
 
+    // Map/unmap a device buffer into host address space via
+    // halHostRegister(DEV_SVM_MAP_HOST) / halHostUnregister. The returned host
+    // VA may differ from dev_ptr — callers must use it for host access.
+    void *register_device_memory_to_host(void *dev_ptr, std::size_t bytes) override;
+    void unregister_device_memory_from_host(void *dev_ptr) override;
+
     /**
      * a2a3-only `dep_gen` enablement setter. The shared
      * `set_l2_swimlane_enabled`, `set_dump_tensor_enabled`,

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -32,6 +32,16 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Map a device buffer into host address space and return a host-readable VA
+    // (nullptr on failure); the paired unregister releases it. The returned VA
+    // may differ from dev_ptr, so callers must use it, not dev_ptr, for host
+    // access, and pair every register with an unregister before free. Used by a
+    // host-side orchestrator (host_build_graph) to read control tensors whose
+    // buffer.addr is a device address. a2a3 onboard wraps
+    // halHostRegister(DEV_SVM_MAP_HOST); sim is identity; a5 onboard and any
+    // backend without a host-map path return nullptr / no-op.
+    void *(*register_device_memory_to_host)(void *dev_ptr, size_t bytes);
+    void (*unregister_device_memory_from_host)(void *dev_ptr);
     // Set a device buffer to a byte value (device-side, no PCIe). Used to
     // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
     // null on backends that don't wire it; callers must fall back to

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -106,6 +106,20 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
+static void *register_device_memory_to_host(void *dev_ptr, size_t bytes) {
+    try {
+        return current_runner()->register_device_memory_to_host(dev_ptr, bytes);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void unregister_device_memory_from_host(void *dev_ptr) {
+    try {
+        current_runner()->unregister_device_memory_from_host(dev_ptr);
+    } catch (...) {}
+}
+
 static int device_memset(void *dev_ptr, int value, size_t size) {
     if (dev_ptr == NULL) return -1;
     try {
@@ -204,6 +218,8 @@ static const HostApi g_host_api = {
     .device_free = device_free,
     .copy_to_device = copy_to_device,
     .copy_from_device = copy_from_device,
+    .register_device_memory_to_host = register_device_memory_to_host,
+    .unregister_device_memory_from_host = unregister_device_memory_from_host,
     .device_memset = device_memset,
     .get_retained_temp_buffer = get_retained_temp_buffer,
     .set_retained_temp_buffer = set_retained_temp_buffer,

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -100,6 +100,23 @@ public:
     int l3_l2_orch_comm_shutdown();
 
     /**
+     * Map a device buffer into the host address space and return a
+     * host-readable VA (or nullptr on failure); the paired unregister releases
+     * it. The returned VA may differ from dev_ptr, so callers must use it, not
+     * dev_ptr, for host access. Register/unregister must be paired (unregister
+     * before free_tensor). On a2a3 onboard this wraps
+     * halHostRegister(DEV_SVM_MAP_HOST); a5 onboard has no host-map path and
+     * uses the base default. Base default: unsupported (returns nullptr /
+     * no-op); a2a3 overrides.
+     */
+    virtual void *register_device_memory_to_host(void *dev_ptr, std::size_t bytes) {
+        (void)dev_ptr;
+        (void)bytes;
+        return nullptr;
+    }
+    virtual void unregister_device_memory_from_host(void *dev_ptr) { (void)dev_ptr; }
+
+    /**
      * Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2
      * shared memory, trb prebuilt runtime arena) as three independent
      * device allocations. Must be called before any `acquire_pooled_*`.

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -103,6 +103,20 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
+static void *register_device_memory_to_host(void *dev_ptr, size_t bytes) {
+    try {
+        return current_runner()->register_device_memory_to_host(dev_ptr, bytes);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void unregister_device_memory_from_host(void *dev_ptr) {
+    try {
+        current_runner()->unregister_device_memory_from_host(dev_ptr);
+    } catch (...) {}
+}
+
 static int device_memset(void *dev_ptr, int value, size_t size) {
     if (dev_ptr == NULL) return -1;
     try {
@@ -201,6 +215,8 @@ static const HostApi g_host_api = {
     .device_free = device_free,
     .copy_to_device = copy_to_device,
     .copy_from_device = copy_from_device,
+    .register_device_memory_to_host = register_device_memory_to_host,
+    .unregister_device_memory_from_host = unregister_device_memory_from_host,
     .device_memset = device_memset,
     .get_retained_temp_buffer = get_retained_temp_buffer,
     .set_retained_temp_buffer = set_retained_temp_buffer,

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -104,6 +104,15 @@ public:
     int l3_l2_orch_comm_init(void *control_block, size_t control_block_size);
     int l3_l2_orch_comm_shutdown();
 
+    // On sim, allocate_tensor returns a plain host pointer, so the "device"
+    // address is already host-readable — register is identity, unregister a
+    // no-op. Mirrors the onboard DeviceRunnerBase API (separate class trees).
+    void *register_device_memory_to_host(void *dev_ptr, size_t bytes) {
+        (void)bytes;
+        return dev_ptr;
+    }
+    void unregister_device_memory_from_host(void *dev_ptr) { (void)dev_ptr; }
+
     int record_device_orch_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
         const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -126,6 +126,10 @@ int fake_copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     return 0;
 }
 
+void *fake_register_device_memory_to_host(void *dev_ptr, size_t /* bytes */) { return dev_ptr; }
+
+void fake_unregister_device_memory_from_host(void * /* dev_ptr */) {}
+
 int fake_device_memset(void *dev_ptr, int value, size_t size) {
     ++g_fake->device_memset_count;
     std::memset(dev_ptr, value, size);
@@ -177,6 +181,8 @@ HostApi make_host_api(bool with_temporary_buffer = true) {
         fake_device_free,
         fake_copy_to_device,
         fake_copy_from_device,
+        fake_register_device_memory_to_host,
+        fake_unregister_device_memory_from_host,
         fake_device_memset,
         with_temporary_buffer ? fake_get_retained_temp_buffer : nullptr,
         with_temporary_buffer ? fake_set_retained_temp_buffer : nullptr,


### PR DESCRIPTION
## Summary

Adds a platform capability for mapping a device buffer into the **host** address space, returning a host-readable VA, exposed through the shared `HostApi` table. This lets a host-side orchestrator dereference control tensors whose `buffer.addr` is a device address.

- `DeviceRunnerBase` (onboard) gains virtual `register_device_memory_to_host` / `unregister_device_memory_from_host` (base default: `nullptr` / no-op).
- **a2a3 onboard** overrides via `halHostRegister(DEV_SVM_MAP_HOST)` / `halHostUnregister`.
- **a5 onboard** uses the base default (no host-map path on a5).
- **sim** implements them as identity / no-op (the sim "device" pointer is already host-readable).
- `HostApi` (`common/host_api.h`) gains the two function pointers; both `c_api_shared.cpp` tables (onboard + sim) wire wrappers forwarding to `current_runner()`.

Contract: the returned host VA may differ from `dev_ptr` — callers must use it (not `dev_ptr`) for host access, and pair every register with an unregister before `free_tensor`.

## Context

This is the platform half of the `host_build_graph` (host-orchestration) runtime: the host orchestrator needs to read control tensors (e.g. paged_attention's `context_lens`) that live in device memory. Landing the capability separately, with the two-function contract named for **intent** (`register_device_memory_to_host`) rather than the a2a3 HAL mechanism, keeps the interface clean and correct across all backends (a2a3 SVM, a5 shadow, sim identity).

**No consumer in this change** — the hbg runtime PR (#1185) consumes it and drops its previous ad-hoc bridge.

## Testing
- [x] All 4 platforms × 2 runtimes build with `-Werror` (a2a3sim, a5sim, a2a3, a5).
- [x] pre-commit (clang-format, check-headers) clean.
- [ ] Onboard behavior exercised by the consumer PR (#1185).