### PR TITLE
Fix: defer early dispatch until producer publication

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -241,7 +241,7 @@ struct PTO2TaskPayload {
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
     // Early-dispatch metadata (AICPU-side only). Ordered by descending
-    // alignment (8B mask, 4B fanin, then 1B flags) so the block packs with no
+    // alignment (8B mask, 4B fanin, then 2B/1B counters and flags) so the block packs with no
     // internal padding. Kept here after the fanin array (not moved up front): on
     // cache line 8 it shares only with the rarely-touched fanin tail, whereas in
     // line 0 the early-dispatch atomics (written during staging) would false-share with
@@ -254,11 +254,17 @@ struct PTO2TaskPayload {
     // PTO2TaskPayload::init before the slot can be staged again.
     std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
     // Early-dispatch CANDIDATE detection (event-driven, dual of fanin_refcount):
-    // seeded at wiring with producers already complete, then a flagged producer's
-    // DISPATCH bumps each consumer's dispatch_fanin. dispatch_fanin ==
-    // fanin_actual_count  <=>  every producer is flagged-and-dispatched or was
+    // seeded at wiring with producers already complete, then a flagged producer
+    // bumps each consumer after all of its logical blocks are published.
+    // dispatch_fanin == fanin_actual_count  <=>  every producer is
+    // flagged-and-fully-published or was
     // pre-completed  =>  this task is an early-dispatch candidate (push early_dispatch_queues[shape]).
-    std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: flagged-dispatched + pre-completed producers
+    std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: fully-published + pre-completed producers
+    // Number of logical blocks whose payloads and MMIO tokens are published.
+    // Claimed-but-unpublished blocks do not make a producer launch-visible. Its
+    // seq_cst updates pair with early_dispatch_state to avoid losing the final
+    // publish vs. release wakeup for a pre-staged producer.
+    std::atomic<int16_t> published_block_count{0};
     // Lock-free claim state shared by the stagers (Hook 1, possibly several AICPU
     // threads concurrently) and the completion-path release: 0=NONE, 1=STAGING,
     // 3=DISPATCHED (2=STAGED is unused now). STAGING is the STABLE gated state —
@@ -344,11 +350,14 @@ struct PTO2TaskPayload {
         // one of ITS producers is flagged (propagate_dispatch_fanin bumps
         // dispatch_fanin and may CAS early_dispatch_state on any consumer, independent of the
         // consumer's own hint). So they MUST be zeroed here unconditionally.
+        // published_block_count and dispatch_propagated are producer-side, but share
+        // this same per-submit lifetime and are reset here too.
         early_dispatch_state.store(PTO2_EARLY_DISPATCH_NONE, std::memory_order_relaxed);
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_core_mask[w].store(0, std::memory_order_relaxed);
         dispatch_fanin.store(0, std::memory_order_relaxed);
         dispatch_propagated.store(0, std::memory_order_relaxed);
+        published_block_count.store(0, std::memory_order_relaxed);
     }
 };
 
@@ -517,7 +526,7 @@ struct alignas(64) PTO2TaskSlotState {
         next_block_idx.store(0, std::memory_order_relaxed);
         ready_state.store(PTO2_READY_UNCLAIMED, std::memory_order_relaxed);
         allow_early_resolve = false;
-        // Note: payload early-dispatch fields (early_dispatch_state / staged_core_mask / dispatch_fanin)
+        // Note: payload early-dispatch fields (state, masks, fanin, publication count)
         // are NOT reset here — this method skips the payload by contract. They are
         // (re)initialized in PTO2TaskPayload::init on every submit, before the slot
         // becomes visible to the scheduler.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -698,10 +698,16 @@ struct PTO2SchedulerState {
         *dmb = (tk << 32) | tk;  // 64-bit STR: high=low=token releases the gated AICore
     }
 
-    // Event-driven candidate detection (the dual of fanin_refcount/ready). Call when a
-    // FLAGGED producer `p` DISPATCHES (starts running): walk its fanout and bump each
+    inline void record_published_blocks(PTO2TaskSlotState &slot_state, int32_t count) {
+        if (count <= 0 || !slot_state.allow_early_resolve) return;
+        slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
+    }
+
+    // Event-driven candidate detection (the dual of fanin_refcount/ready). Call after
+    // publishing a FLAGGED producer's blocks: once every logical block is launch-visible,
+    // walk its fanout and bump each
     // consumer's dispatch_fanin. A consumer whose dispatch_fanin reaches
-    // fanin_actual_count (= every producer is either flagged-and-dispatched, or was
+    // fanin_actual_count (= every producer is either flagged-and-fully-published, or was
     // already complete when the consumer was wired) is an early-dispatch candidate:
     // CAS NONE->STAGING (exactly-once) and push to early_dispatch_queues[shape] for the idle drain to
     // pre-stage. Once-guarded per producer so an SPMD producer's block-by-block
@@ -709,6 +715,7 @@ struct PTO2SchedulerState {
     // successors early-dispatch off its DIRECT producers' marks, never an inherited chain.
     void propagate_dispatch_fanin(PTO2TaskSlotState &p) {
         if (!p.allow_early_resolve) return;  // only codegen-flagged (direct) producers propagate
+        if (p.payload->published_block_count.load(std::memory_order_seq_cst) < p.logical_block_num) return;
         if (p.payload->dispatch_propagated.exchange(1, std::memory_order_acq_rel) != 0)
             return;  // already propagated once
         p.lock_fanout();
@@ -721,7 +728,7 @@ struct PTO2SchedulerState {
             // ready_fanin gets but dispatch_fanin does not). dispatch_fanin starts at
             // the wiring-time flagged-pre-completed seed and is bumped here by flagged
             // producers; reaching fanin_actual_count means every producer is
-            // flagged-dispatched or was pre-completed. An unflagged producer leaves the
+            // flagged-and-fully-published or was pre-completed. An unflagged producer leaves the
             // seed short and never bumps, so this stays unreachable for that consumer.
             int32_t nf = c->payload->dispatch_fanin.fetch_add(1, std::memory_order_acq_rel) + 1;
             if (nf != c->payload->fanin_actual_count) continue;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -521,6 +521,7 @@ void SchedulerContext::drain_worker_dispatch(int32_t block_num) {
         for (int i = 0; i < handle_count; i++) {
             publish_subtask_to_core(handles[i], dispatch_ts);
         }
+        sched_->record_published_blocks(*slot_state, claim);
     }
 
     // The drain path IS this sync_start producer's dispatch, so it must bump its

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -328,14 +328,11 @@ void SchedulerContext::dispatch_shape(
         PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
         int handle_count = 0;
         bool dispatched_any = false;
-        // Slots dispatched this pop whose dispatch_fanin must be propagated to
-        // consumers. Deferred until AFTER publish (below) so a flagged producer's
-        // fanout walk never sits between claiming cores and publishing its own
-        // blocks — doing it inline delays this thread's blocks while peer threads
-        // co-dispatching the same SPMD task publish immediately, misaligning the
-        // task's block starts. Bounded by cores.count() ≤ MAX_CLUSTERS dispatches.
-        PTO2TaskSlotState *prop_list[CoreTracker::MAX_CLUSTERS];
-        int prop_n = 0;
+        // Logical block ranges published by this pop. AIV can pop two entries per
+        // cluster, so this ledger has the same worst-case bound as handles[].
+        PTO2TaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
+        int16_t published_counts[CoreTracker::MAX_CLUSTERS * 3];
+        int published_n = 0;
 #if SIMPLER_SCHED_PROFILING
         uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
@@ -410,12 +407,6 @@ void SchedulerContext::dispatch_shape(
 
             dispatched_any = true;
             try_pushed = true;
-            // Record for deferred dispatch_fanin propagation after this pop's
-            // blocks are published (see after the loop). propagate's own guard
-            // filters non-flagged slots, so recording unconditionally is cheap.
-            if (prop_n < static_cast<int>(sizeof(prop_list) / sizeof(prop_list[0]))) {
-                prop_list[prop_n++] = slot_state;
-            }
             // Claim a contiguous range of blocks, hand the slot back to the
             // ready queue immediately, then perform the expensive dispatches.
             // This lets other schedulers concurrently claim and dispatch the
@@ -428,6 +419,10 @@ void SchedulerContext::dispatch_shape(
             int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
             int32_t claim = std::min(available, remaining);
             slot_state->next_block_idx.store(static_cast<int16_t>(start + claim), std::memory_order_relaxed);
+
+            published_list[published_n] = slot_state;
+            published_counts[published_n] = static_cast<int16_t>(claim);
+            published_n++;
 
             if (start + claim < slot_state->logical_block_num) {
                 disp_queues[static_cast<int32_t>(shape)].push(slot_state);
@@ -453,11 +448,9 @@ void SchedulerContext::dispatch_shape(
         }
 
         flush_publish();
-        // Blocks are published; now propagate dispatch_fanin for any flagged
-        // producers dispatched above (knob A: producer is running). Off the
-        // pre-publish path so it cannot delay or misalign their blocks.
-        for (int i = 0; i < prop_n; i++) {
-            sched_->propagate_dispatch_fanin(*prop_list[i]);
+        for (int i = 0; i < published_n; i++) {
+            sched_->record_published_blocks(*published_list[i], published_counts[i]);
+            sched_->propagate_dispatch_fanin(*published_list[i]);
         }
 #if SIMPLER_SCHED_PROFILING
         l2_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
@@ -637,10 +630,16 @@ int32_t SchedulerContext::stage_consumer_blocks(
     for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
         if (my_cores[w] != 0) c->payload->staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
+    // Full publication and release are independent events. The seq_cst
+    // count/state rechecks form a two-sided handshake: release propagates if
+    // publication won, and the final stager propagates if release won.
+    sched_->record_published_blocks(*c, staged);
+    bool released = staged > 0 &&
+                    c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_DISPATCHED;
+
     // If release already flipped DISPATCHED, it may have read the mask before our
     // bits landed — ring our own cores so none is left gated forever.
-    if (staged > 0 &&
-        c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_DISPATCHED) {
+    if (released) {
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = my_cores[w];
             while (bits != 0) {
@@ -652,6 +651,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
             }
         }
     }
+    if (released) sched_->propagate_dispatch_fanin(*c);
     return staged;
 }
 

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -258,9 +258,10 @@ TEST_F(WiringTest, WireTaskMixedProducerStates) {
 // =============================================================================
 // Early-dispatch seed (direct-only): a consumer becomes an early-dispatch
 // candidate ONLY when every producer is codegen-flagged (allow_early_resolve,
-// now a slot_state field). A single unflagged producer leaves dispatch_fanin
-// short forever. Auto-chain inheritance was removed, so flagged-ness is the
-// producer's own static hint — never propagated down a chain.
+// now a slot_state field) and fully published or pre-completed. A single
+// unflagged producer leaves dispatch_fanin short forever. Auto-chain inheritance
+// was removed, so flagged-ness is the producer's own static hint — never
+// propagated down a chain.
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskAllFlaggedPrecompletedSeedsDispatchFanin) {
@@ -340,10 +341,10 @@ TEST_F(WiringTest, WireTaskOneUnflaggedProducerDisqualifiesSeed) {
     EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // disqualified: seed stays 0
 }
 
-TEST_F(WiringTest, EarlyDispatchReachesCandidateWhenAllFlagged) {
+TEST_F(WiringTest, EarlyDispatchWaitsForAllProducerBlocksPublished) {
     // A flagged, still-pending producer seeds nothing at wiring (not
-    // pre-completed); its DISPATCH propagates and bumps the consumer to
-    // fanin_actual_count, making it an early-dispatch candidate.
+    // pre-completed); only publishing every logical block bumps the consumer
+    // to fanin_actual_count and makes it an early-dispatch candidate.
     alignas(64) PTO2TaskSlotState task_slot;
     alignas(64) PTO2TaskSlotState producer;
     alignas(64) PTO2TaskPayload payload;
@@ -352,6 +353,7 @@ TEST_F(WiringTest, EarlyDispatchReachesCandidateWhenAllFlagged) {
 
     init_slot(producer, PTO2_TASK_PENDING, 1, 1);
     producer.allow_early_resolve = true;
+    producer.logical_block_num = 3;
 
     init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
     payload.fanin_actual_count = 1;
@@ -361,6 +363,16 @@ TEST_F(WiringTest, EarlyDispatchReachesCandidateWhenAllFlagged) {
 
     wire_fanin(task_slot, 1);
     EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // pending -> nothing seeded yet
+
+    sched.record_published_blocks(producer, 2);
+    sched.propagate_dispatch_fanin(producer);
+    EXPECT_EQ(payload.dispatch_fanin.load(), 0);
+    EXPECT_EQ(producer.payload->dispatch_propagated.load(), 0);
+
+    sched.record_published_blocks(producer, 1);
+    sched.propagate_dispatch_fanin(producer);
+    EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);
+    EXPECT_EQ(producer.payload->dispatch_propagated.load(), 1);
 
     sched.propagate_dispatch_fanin(producer);
     EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);
@@ -388,6 +400,7 @@ TEST_F(WiringTest, EarlyDispatchBlockedByUnflaggedProducer) {
     wire_fanin(task_slot, 2);
     EXPECT_EQ(payload.dispatch_fanin.load(), 0);  // q unflagged -> disqualified seed
 
+    sched.record_published_blocks(p_flagged, p_flagged.logical_block_num);
     sched.propagate_dispatch_fanin(p_flagged);    // bumps to 1
     sched.propagate_dispatch_fanin(q_unflagged);  // gate returns, no bump
     EXPECT_EQ(payload.dispatch_fanin.load(), 1);  // never reaches 2 -> not a candidate
@@ -448,6 +461,7 @@ TEST_F(WiringTest, FlaggedPrecompletedCreatorTransparentToEarlyDispatch) {
     wire_fanin(task_slot, 2);
     EXPECT_EQ(payload.dispatch_fanin.load(), 1);  // creator seeded (transparent), not disqualified
 
+    sched.record_published_blocks(compute, compute.logical_block_num);
     sched.propagate_dispatch_fanin(compute);                               // compute dispatches -> bumps to 2
     EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);  // candidate
 }


### PR DESCRIPTION
## Summary
- track logical block publication after payload and MMIO visibility
- cover normal dispatch, early staging, and sync-start drain placement paths
- propagate early-dispatch fanout only after every producer block is published
- preserve the release-vs-final-stager retry handshake

## Testing
- C++ unit tests: 54/54 passed
- pre-commit hooks: passed
- full CI: passed
- with PR #1304 commit `b9564b7e`, the exact Qwen3 PR691-kernel workload
  completes 3/3 at a 2GB ring heap
- without this publication fix, the same PR1304-only build reaches allocator
  deadlock at `current=7789, last_alive=5255`, with the head task at 82/109
  consumers

This is separate from PR #1304 because the partial-publication race is already
present on main. PR #1304 carries the independent sync-start cohort launch fix.