### PR TITLE
Fix: compile host_build_graph orchestration with host g++

### DIFF
--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -419,15 +419,23 @@ class KernelCompiler:
         if orch_includes:
             include_dirs = include_dirs + orch_includes
 
-        # Resolve toolchain: HOST_GXX needs no runtime-specific extras
-        toolchain_type = self._get_toolchain(
-            {
-                "a2a3": ToolchainType.AARCH64_GXX,
-                "a2a3sim": ToolchainType.HOST_GXX,
-                "a5": ToolchainType.AARCH64_GXX,
-                "a5sim": ToolchainType.HOST_GXX,
-            },
-        )
+        # host_build_graph dlopens the orchestration .so on the host, so it
+        # compiles with the host g++ (x86_64) regardless of platform.
+        # tensormap_and_ringbuffer dlopens it on the aarch64 AICPU onboard, so
+        # it cross-compiles there and uses the host g++ only for sim.
+        if runtime_name == "host_build_graph":
+            toolchain_type = ToolchainType.HOST_GXX
+        elif runtime_name == "tensormap_and_ringbuffer":
+            toolchain_type = self._get_toolchain(
+                {
+                    "a2a3": ToolchainType.AARCH64_GXX,
+                    "a2a3sim": ToolchainType.HOST_GXX,
+                    "a5": ToolchainType.AARCH64_GXX,
+                    "a5sim": ToolchainType.HOST_GXX,
+                },
+            )
+        else:
+            raise ValueError(f"Unknown runtime_name: {runtime_name!r}")
         toolchain: Union[GxxToolchain, Aarch64GxxToolchain]
         if toolchain_type == ToolchainType.AARCH64_GXX:
             assert self.aarch64 is not None, "aarch64 toolchain is only available for hardware platforms"
@@ -435,9 +443,7 @@ class KernelCompiler:
         else:
             toolchain = self.host_gxx
 
-        # HOST_GXX: simulation build (host execution)
-        # AARCH64_GXX: cross-compilation for supported runtimes
-        #   Note: orchestration uses ops table via pto_orchestration_api.h (no extra runtime sources needed)
+        # Orchestration uses the ops table via pto_orchestration_api.h (no extra runtime sources needed).
         return self._compile_orchestration_shared_lib(
             source_path,
             toolchain,


### PR DESCRIPTION
## Summary
- `host_build_graph` dlopens the orchestration `.so` on the **x86_64 host**, but `compile_orchestration` routed a2a3/a5 to the aarch64 cross-compiler unconditionally — that routing predates `host_build_graph`. The AArch64 orch `.so` could not be dlopened by the x86_64 host runtime, surfacing as `dlopen failed: ... No such file or directory` and failing **every** `host_build_graph` scene test on a2a3 onboard.
- Route the orch toolchain by **runtime** instead of only by platform: `host_build_graph` → `HOST_GXX` (host-dlopen path, onboard + sim); `tensormap_and_ringbuffer` → `AARCH64_GXX` onboard (AICPU dlopen), `HOST_GXX` for sim.
- The `else` branch is byte-identical to before, so `tensormap_and_ringbuffer` is unchanged.

## Root cause (evidence)
- Before: orch `.so` (a2a3 `host_build_graph`) was `Machine: AArch64`; `libhost_runtime.so` and the host are `X86-64`. `ldd` reported "not a dynamic executable"; glibc's loader emits the misleading `No such file or directory` on an ELF machine mismatch.
- After: orch `.so` is `X86-64`, `ldd` resolves all deps cleanly.

## Testing
Onboard a2a3 (910B2C), device 0 (run unlocked — `task-submit` is not on this box; results are deterministic, not concurrency-related):

| Test | Before | After |
| --- | --- | --- |
| `host_build_graph/vector_example` | ❌ dlopen fail | ✅ PASSED |
| `host_build_graph/paged_attention` (the case #1185 claimed passed) | ❌ dlopen fail | ✅ PASSED |
| `tensormap_and_ringbuffer/alternating_matmul_add` (regression guard) | ✅ | ✅ PASSED |

## Note
a5 `host_build_graph` takes the same code path (also host-dlopen) and is fixed by this change, but I have no a5 silicon here to onboard-verify — please run an a5 `host_build_graph` case on an a5 box / the a5 CI leg.