### PR TITLE
Fix: map dummy and alloc tasks to correct AICPU worker lanes

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -39,8 +39,11 @@ available.
   **inner** phase (`resolve`, parent = Complete or Dummy) rendered on a
   sibling scheduler sub-lane with the same `Sched_N` label and adjacent tid,
   and one **separate-lane**
-  phase (`dummy_task`, rendered on Worker View AICPU_N rather than on the
-  sched lane). Idle iterations no longer emit a record on a2a3; the
+  phase (`dummy_task`, sampled immediately before `on_task_complete()` begins
+  dependency resolution and rendered as a synthetic 0.02 us marker on Worker
+  View AICPU_N rather than on the sched lane). It is emitted by both a2a3
+  runtimes and by a5 `tensormap_and_ringbuffer`; a5 `host_build_graph` has no
+  dummy-task phase path. Idle iterations no longer emit a record on a2a3; the
   host tooling reconstructs idle spans from the gap between
   consecutive work records on the same thread. See §3.2 for the
   full per-phase table. Legacy captures may carry `scan` / `poll` /
@@ -218,8 +221,14 @@ Phase records (per scheduler thread, level >= 3 for
 | `start_time_us` / `end_time_us` | Phase start / end timestamps in microseconds (reader-side cycle→µs conversion) |
 | `phase` | Lowercase phase name. Scheduler: see the table below. Orchestrator: `orch_submit` — one record per `submit_task()` / `alloc_tensors()` call spanning its full `[start, end]` window. Legacy per-sub-step strings (`orch_sync` / `orch_alloc` / `orch_params` / `orch_lookup` / `orch_insert` / `orch_fanin`) may appear in old captures. |
 | `loop_iter` (scheduler) / `submit_idx` (orchestrator) | Iteration / submit-call counter for the producing thread |
-| `tasks_processed` (scheduler) / `task_id` (orchestrator) | Phase-specific union field (see per-phase table) |
+| `tasks_processed` (scheduler) | Number of tasks or blocks handled by the phase; `dummy_task` records one task |
+| `task_id` | Full runtime task id on orchestrator records and scheduler `dummy_task` records |
 | `pop_hit` / `pop_miss` (dispatch only) | Ready-queue pop deltas since the previous dispatch emit |
+
+The raw scheduler record has a phase-tagged union: `dispatch` stores
+`pop_hit` / `pop_miss`, while `dummy_task` stores the 32-bit `local_id` and
+`ring_id` components of its full task id. The Host collector reconstructs the
+`task_id` JSON field.
 
 Scheduler phase taxonomy — three role classes share one `phase`
 field but render differently in Perfetto:
@@ -232,7 +241,7 @@ field but render differently in Perfetto:
 | `dummy` | outer | sched | dummies handled by `dummy_drain` this iter |
 | `early_dispatch` | outer | sched | blocks staged by speculative early-dispatch this pass |
 | `resolve` | inner | sched sub-lane, same `Sched_N` label as its outer lane | consumers visited in `on_task_complete` |
-| `dummy_task` | separate-lane | Worker View AICPU_N (pid=4) | dummy `task_id` low 32 bits (deps.json flow target) |
+| `dummy_task` | separate-lane | Worker View AICPU_N (pid=4) | one dummy entering `on_task_complete()`; full identity is in `task_id` |
 
 Fanin/fanout wiring is not a scheduler phase: it runs on the
 orchestrator submit path, so it has no swimlane lane. Read its cost
@@ -300,11 +309,17 @@ in. The trace contains:
   - `AIC_N` — matrix cores (receive → kernel end from level >= 1)
   - `AIV_N` — vector cores (receive → kernel end from level >= 1)
   - `AICPU_N` — AICPU acting as worker; carries `dummy_task`
-    zero-width markers (one per dummy drained by the sched
-    thread on AICPU N) and `alloc` bars (from `alloc_tensors()`
-    calls that the orchestrator on AICPU 0 inline-completed).
+    0.02 us pre-resolve markers (one per dummy entering
+    `on_task_complete()` on AICPU N) and `alloc` bars (from `alloc_tensors()`
+    calls inline-completed by the dedicated orchestrator on the last
+    AICPU runtime thread).
     Both are activities the AICPU performs as a worker, so they
-    share the same lane tier as AIC/AIV.
+    share the same lane tier as AIC/AIV. When `deps.json` is joined,
+    dependency arrows involving dummy/alloc DAG nodes anchor on these
+    AICPU worker slices. The converter identifies dummy nodes from
+    `deps.json` before consulting runtime timing records. If a dummy's
+    scheduler record is missing, it warns and omits that Worker View bar
+    instead of rendering it as `alloc`.
   AIC/AIV hover args keep both `kernel-duration-us` and
   `local_setup_us`; the old standalone setup preview bar is folded
   into the task bar.
@@ -321,7 +336,7 @@ whether a `deps.json` is present** (see
 
 - **With `deps.json`** — each task shows `func_name(rXtY)` (or
   `func_<id>(rXtY)` when no name map), and dependency arrows are
-  drawn in the AICore View.
+  drawn in the task views.
 - **Without `deps.json`** — the host never records `func_id` (it's
   `-1` on disk), so the converter cannot tell tasks apart by
   function. Every task in **both** views is labeled `task(rXtY)` —
@@ -506,6 +521,8 @@ keep every subtask row as an endpoint (N×N pairing unchanged).
 For each logical `(pred, succ)` edge from `deps.json`, the converter
 emits flows between the Cartesian product of pred/succ anchor rows
 (`|pred_anchors| × |succ_anchors|`), not a per-subtask crossbar.
+Kernel tasks anchor on AIC/AIV task rows; dummy and alloc DAG nodes
+anchor on the AICPU worker slices that represent those activities.
 
 **SPMD lane labels.** Logical SPMD tasks append `_spmd` before the
 `(rXtY)` suffix unless the function name already contains `spmd`
@@ -1025,13 +1042,12 @@ active L2 swimlane buffer at run end. Check the AICPU flush path runs
 for every thread that produced records.
 
 **Phase records empty.** Either the runtime did not emit phase
-data (only `tensormap_and_ringbuffer` does, and only when phase init
-ran — on a2a3 gated on
+data or phase initialization did not run. Both a2a3 runtimes and a5
+`tensormap_and_ringbuffer` provide the dummy-task path; a5
+`host_build_graph` does not. On both architectures collection is gated on
 `L2SwimlaneDataHeader::num_sched_phase_threads > 0` (sched) or
-`num_orch_phase_threads > 0` (orch); on a5 gated on
-`L2SwimlaneAicpuPhaseHeader::magic`), or the host did not pre-zero
-those fields. Verify the runtime calls `l2_swimlane_aicpu_init_phase()`
-in its scheduler init path; check the host's
+`num_orch_phase_threads > 0` (orch). Verify the runtime calls
+`l2_swimlane_aicpu_init_phase()` in its scheduler init path; check the host's
 `L2SwimlaneCollector::initialize` zero-inits the relevant metadata
 fields.
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -541,7 +541,7 @@ def _scheduler_slice_start_us(task):
     return dispatch_time_us
 
 
-def _flow_anchor_rows(task_id, task_map, spmd_task_ids, slice_start):
+def _flow_anchor_rows(task_id, task_map, spmd_task_ids, slice_start, aicpu_worker_anchor_map=None):
     """Flow anchor rows selected by one view's visible slice start.
 
     Non-SPMD keeps every subtask row. SPMD collapses rows by
@@ -550,6 +550,8 @@ def _flow_anchor_rows(task_id, task_map, spmd_task_ids, slice_start):
     visible as separate dependency endpoints.
     """
     recs = task_map.get(task_id, [])
+    if not recs and aicpu_worker_anchor_map:
+        return aicpu_worker_anchor_map.get(task_id, [])
     if not recs:
         return []
     if task_id not in spmd_task_ids:
@@ -566,20 +568,20 @@ def _flow_anchor_rows(task_id, task_map, spmd_task_ids, slice_start):
     return list(by_func.values())
 
 
-def _worker_flow_anchor_rows(task_id, task_map, spmd_task_ids):
+def _worker_flow_anchor_rows(task_id, task_map, spmd_task_ids, aicpu_worker_anchor_map=None):
     """Worker View flow anchors."""
-    return _flow_anchor_rows(task_id, task_map, spmd_task_ids, _task_slice_start_us)
+    return _flow_anchor_rows(task_id, task_map, spmd_task_ids, _task_slice_start_us, aicpu_worker_anchor_map)
 
 
-def _scheduler_flow_anchor_rows(task_id, task_map, spmd_task_ids):
+def _scheduler_flow_anchor_rows(task_id, task_map, spmd_task_ids, aicpu_worker_anchor_map=None):
     """Scheduler View flow anchors."""
-    return _flow_anchor_rows(task_id, task_map, spmd_task_ids, _scheduler_slice_start_us)
+    return _flow_anchor_rows(task_id, task_map, spmd_task_ids, _scheduler_slice_start_us, aicpu_worker_anchor_map)
 
 
-def _flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids, anchor_rows):
+def _flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids, anchor_rows, aicpu_worker_anchor_map=None):
     """(pred_row, succ_row) pairs for one logical dependency edge in one view."""
-    pred_rows = anchor_rows(pred_id, task_map, spmd_task_ids)
-    succ_rows = anchor_rows(succ_id, task_map, spmd_task_ids)
+    pred_rows = anchor_rows(pred_id, task_map, spmd_task_ids, aicpu_worker_anchor_map)
+    succ_rows = anchor_rows(succ_id, task_map, spmd_task_ids, aicpu_worker_anchor_map)
     if not pred_rows or not succ_rows:
         return []
     return [(pred_row, succ_row) for pred_row in pred_rows for succ_row in succ_rows]
@@ -1188,7 +1190,40 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     task_to_event_id: dict[tuple[int, int], int] = {}
     task_to_aicpu_event_id: dict[tuple[int, int], int] = {}
     task_to_aicpu_tid: dict[tuple[int, int], int] = {}
+    aicpu_worker_anchor_map: dict[int, list[dict]] = defaultdict(list)
     event_id = 0
+
+    AICPU_TID_BASE = 19000  # noqa: N806
+    scheduler_thread_indices = {int(thread_idx) for thread_idx in (core_to_thread or []) if int(thread_idx) >= 0}
+    scheduler_thread_indices.update(
+        thread_idx for thread_idx, thread_records in enumerate(scheduler_phases or []) if thread_records
+    )
+    scheduler_thread_count = (
+        max(scheduler_thread_indices) + 1 if scheduler_thread_indices else len(scheduler_phases or [])
+    )
+    orchestrator_thread_base = scheduler_thread_count
+    aicpu_worker_thread_count = scheduler_thread_count + len(orchestrator_phases or [])
+
+    # core_to_thread and non-empty phase pools carry runtime scheduler indices;
+    # phase arrays may also contain trailing empty capacity slots. Orchestrator
+    # pools are ordinal-only and occupy the dedicated threads after schedulers.
+    for thread_idx in range(aicpu_worker_thread_count):
+        events.append(
+            {
+                "args": {"name": f"AICPU_{thread_idx}"},
+                "cat": "__metadata",
+                "name": "thread_name",
+                "ph": "M",
+                "pid": 4,
+                "tid": AICPU_TID_BASE + thread_idx,
+            }
+        )
+
+    def worker_flow_endpoint(row):
+        event_id_key = row.get("event_id")
+        if "trace_tid" in row:
+            return row["trace_tid"], event_id_key
+        return core_to_tid[row["core_id"]], task_to_event_id.get((row["task_id"], row["core_id"]))
 
     # Invert deps (pred -> [succ]) into a fanin map (succ -> [pred]) so each task
     # bar can show both its consumers (fanout) and producers (fanin) with counts.
@@ -1350,79 +1385,11 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             task_to_aicpu_event_id[(task["task_id"], task["core_id"])] = event_id
             event_id += 1
 
-    # Flow events (Flow events "s" and "f" for dependencies). Edges come from
-    # deps.json (dep_gen replay); without one we emit no flow events at all,
-    # since the device hot path no longer carries fanout (PR #863).
-    # SPMD logical tasks independently anchor dependency arrows on each view's
-    # earliest visible slice per (func_id, task_id).
     flow_id = 0
     hb_violation_count = 0
     deps_flow_count = 0
     edges_by_pred = deps_edges or {}
     flow_epsilon = 0.01
-
-    for pred_id, succ_ids in edges_by_pred.items():
-        if pred_id not in task_map:
-            continue
-
-        for succ_id in succ_ids:
-            if succ_id not in task_map:
-                if verbose:
-                    print(
-                        f"Warning: Task {format_task_display(pred_id)} (raw {pred_id}) "
-                        f"references non-existent successor {format_task_display(succ_id)} (raw {succ_id})"
-                    )
-                continue
-
-            row_pairs = _flow_row_pairs(
-                pred_id,
-                succ_id,
-                task_map,
-                spmd_task_ids,
-                _worker_flow_anchor_rows,
-            )
-            if not row_pairs:
-                continue
-
-            output_task_count = _dependency_task_fan_count(pred_id, spmd_task_ids, task_map, deps_block_map)
-            input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
-            for pred_row, succ_row in row_pairs:
-                src_ts_end = pred_row["end_time_us"] - flow_epsilon
-                dst_ts_start = _task_slice_start_us(succ_row)
-                hb_violated = (src_ts_end + flow_epsilon) > dst_ts_start
-                flow_name = "hb_violation" if hb_violated else "dependency"
-                if hb_violated:
-                    hb_violation_count += 1
-                _append_dependency_flow_pair(
-                    events,
-                    flow_id,
-                    flow_name,
-                    4,
-                    core_to_tid[pred_row["core_id"]],
-                    src_ts_end,
-                    task_to_event_id.get((pred_id, pred_row["core_id"])),
-                    4,
-                    core_to_tid[succ_row["core_id"]],
-                    dst_ts_start,
-                    task_to_event_id.get((succ_id, succ_row["core_id"])),
-                    input_task_count=input_task_count,
-                    output_task_count=output_task_count,
-                )
-                flow_id += 1
-                deps_flow_count += 1
-
-    if verbose:
-        if deps_edges is not None:
-            print(f"  Dependency flow events: {deps_flow_count} edges (source: deps.json)")
-            if spmd_task_ids:
-                print(
-                    f"  SPMD tasks: {len(spmd_task_ids)} logical task(s); "
-                    "dependency arrows independently anchor on each view's earliest visible slice per function"
-                )
-        else:
-            print("  Flow events: 0 (no deps.json — re-run dep_gen and pass --deps-json to add arrows)")
-        if hb_violation_count > 0:
-            print(f"  Happens-before violations: {hb_violation_count} edge(s) flagged as 'hb_violation'")
 
     # AICPU Scheduler phase events (l2_swimlane_level >= 3)
     if scheduler_phases:
@@ -1513,30 +1480,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     continue
                 finishes_per_complete[id(t_comp)] += 1
 
-        # Worker View (pid=4) AICPU lanes: AICPU_N treated as a worker tier
-        # alongside AIC_N (matrix) and AIV_N (vector). DummyTask phases (per
-        # dummy DAG-node identity markers from the scheduler thread that
-        # drained them) and Alloc phases (per `alloc_tensors()` call from the
-        # orchestrator) both render on these lanes — they are the activities
-        # that an AICPU performs when it acts as a worker. The lane index is
-        # the AICPU id; with the current 1:1 sched-thread-to-AICPU mapping,
-        # `thread_idx` IS the AICPU id, and the single orch is on AICPU 0.
-        # Tids 19000+aicpu_id keep them visually grouped after the physical
-        # AIC/AIV lanes (which sit at 10000+core_id*10).
-        AICPU_TID_BASE = 19000  # noqa: N806
-        num_aicpu_lanes = max(len(scheduler_phases), len(orchestrator_phases or []))
-        for aicpu_id in range(num_aicpu_lanes):
-            events.append(
-                {
-                    "args": {"name": f"AICPU_{aicpu_id}"},
-                    "cat": "__metadata",
-                    "name": "thread_name",
-                    "ph": "M",
-                    "pid": 4,
-                    "tid": AICPU_TID_BASE + aicpu_id,
-                }
-            )
-
         # Dummy task X event width — start/end on the device coincide
         # (identification is a single MSR read); render as a 0.02 µs sliver
         # so Perfetto picks it up instead of collapsing it to a hairline.
@@ -1584,18 +1527,20 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     start_us = record["start_time_us"]
                     end_us = record["end_time_us"]
                     dur = max(end_us - start_us, DUMMY_BAR_MIN_DUR_US)
-                    task_id_low32 = record.get("tasks_processed", 0)
+                    task_id = normalize_pto2_task_id_int(record.get("task_id"))
+                    task_label = format_task_display(task_id) if task_id is not None else "unknown"
                     events.append(
                         {
                             "args": {
                                 "phase": "dummy_task",
                                 "loop_iter": record.get("loop_iter", 0),
-                                "dummy_task_id_low32": task_id_low32,
-                                "event-hint": f"dummy(t{task_id_low32})",
+                                "task_id": task_id,
+                                "event-hint": f"dummy({task_label})",
                             },
                             "cat": "event",
                             "cname": "grey",
-                            "name": f"dummy(t{task_id_low32})",
+                            "id": event_id,
+                            "name": f"dummy({task_label})",
                             "ph": "X",
                             "pid": 4,
                             "tid": AICPU_TID_BASE + thread_idx,
@@ -1603,6 +1548,18 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                             "dur": dur,
                         }
                     )
+                    if task_id is not None:
+                        aicpu_worker_anchor_map[task_id].append(
+                            {
+                                "task_id": task_id,
+                                "start_time_us": start_us,
+                                "end_time_us": start_us + dur,
+                                "receive_time_us": start_us,
+                                "trace_tid": AICPU_TID_BASE + thread_idx,
+                                "event_id": event_id,
+                            }
+                        )
+                    event_id += 1
                     continue
                 if phase not in (
                     "complete",
@@ -1766,41 +1723,28 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             "orch_fanin": "rail_animation",
         }
 
-        # Build the regular-task and dummy-task id sets so the orch-phase loop
-        # below can identify which orch_submit envelopes belong to
-        # `alloc_tensors()` calls (no AICore record, no DummyTask phase — purely
-        # inline-completed by the orchestrator on host CPU). Those get a
-        # parallel ALLOC bar on Worker View pid=4 so the DAG node is visible.
+        # Build the runtime task-id sets so the orch-phase loop can distinguish
+        # alloc_tensors() calls from submitted tasks. deps.json remains the
+        # identity source when a runtime timing record is missing.
         regular_task_ids = {int(t.get("task_id", -1)) for t in tasks}
-        dummy_low32 = set()
+        dummy_task_ids = set()
         if scheduler_phases:
             for thread_records in scheduler_phases:
                 for rec in thread_records:
                     if rec.get("phase") == "dummy_task":
-                        dummy_low32.add(rec.get("tasks_processed", 0))
-
-        # Alloc bars land on the same AICPU_N lane that hosts the orchestrator
-        # (one AICPU lane per AICPU; the orch is on AICPU 0 in the single-orch
-        # case). The AICPU lane metadata is emitted by the scheduler_phases
-        # block above (via AICPU_TID_BASE). If there are orch records but no
-        # sched records (level=4 with no SCHED_PHASES data), emit them here so
-        # the alloc bars below have valid lane metadata.
-        AICPU_TID_BASE = 19000  # noqa: N806
-        if not scheduler_phases:
-            for orch_idx in range(len(orchestrator_phases)):
-                events.append(
-                    {
-                        "args": {"name": f"AICPU_{orch_idx}"},
-                        "cat": "__metadata",
-                        "name": "thread_name",
-                        "ph": "M",
-                        "pid": 4,
-                        "tid": AICPU_TID_BASE + orch_idx,
-                    }
-                )
+                        task_id = normalize_pto2_task_id_int(rec.get("task_id"))
+                        if task_id is not None:
+                            dummy_task_ids.add(task_id)
+        deps_dummy_task_ids = {
+            task_id
+            for task_id, kernel_ids in (deps_kernel_map or {}).items()
+            if all(kernel_id < 0 for kernel_id in kernel_ids)
+        }
+        missing_dummy_record_warnings = set()
 
         for orch_idx, thread_records in enumerate(orchestrator_phases):
             tid = 4000 + orch_idx
+            orch_worker_thread_idx = orchestrator_thread_base + orch_idx
             for record in thread_records:
                 phase = record.get("phase", "unknown")
                 start_us = record["start_time_us"]
@@ -1831,16 +1775,23 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 }
                 events.append(event)
 
-                # Classification: orch_submit envelopes whose task_id is NOT in
-                # the AICore record set AND NOT in DummyTask phases are
-                # alloc_tensors() calls. Render a parallel "alloc(...)" bar on
-                # the Worker View AICPU_{orch_idx} lane so the DAG node is
-                # visible (matches the dummy treatment — both are AICPU acting
-                # as worker).
+                # deps.json identifies submitted tasks independently of the
+                # timing buffers. Runtime records provide the fallback for
+                # captures without task metadata.
                 if phase == "orch_submit" and task_id >= 0:
-                    is_regular = task_id in regular_task_ids
-                    task_low32 = task_id & 0xFFFFFFFF
-                    is_dummy = task_low32 in dummy_low32
+                    if deps_kernel_map is not None and task_id in deps_kernel_map:
+                        is_dummy = task_id in deps_dummy_task_ids
+                        is_regular = not is_dummy
+                        if is_dummy and task_id not in dummy_task_ids and task_id not in missing_dummy_record_warnings:
+                            print(
+                                f"Warning: dummy({format_task_display(task_id)}) has no dummy_task scheduler record; "
+                                "its Worker View bar cannot be rendered.",
+                                file=sys.stderr,
+                            )
+                            missing_dummy_record_warnings.add(task_id)
+                    else:
+                        is_regular = task_id in regular_task_ids
+                        is_dummy = task_id in dummy_task_ids
                     if not is_regular and not is_dummy:
                         events.append(
                             {
@@ -1851,14 +1802,98 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                                 },
                                 "cat": "event",
                                 "cname": "olive",
+                                "id": event_id,
                                 "name": f"alloc({format_task_display(task_id)})",
                                 "ph": "X",
                                 "pid": 4,
-                                "tid": AICPU_TID_BASE + orch_idx,
+                                "tid": AICPU_TID_BASE + orch_worker_thread_idx,
                                 "ts": start_us,
                                 "dur": max(dur, 0.02),
                             }
                         )
+                        aicpu_worker_anchor_map[task_id].append(
+                            {
+                                "task_id": task_id,
+                                "start_time_us": start_us,
+                                "end_time_us": start_us + max(dur, 0.02),
+                                "receive_time_us": start_us,
+                                "trace_tid": AICPU_TID_BASE + orch_worker_thread_idx,
+                                "event_id": event_id,
+                            }
+                        )
+                        event_id += 1
+
+    # Flow events (Flow events "s" and "f" for dependencies). Edges come from
+    # deps.json (dep_gen replay); without one we emit no flow events at all,
+    # since the device hot path no longer carries fanout (PR #863).
+    # SPMD logical tasks anchor Worker View dependency arrows on the earliest
+    # visible kernel slice per (func_id, task_id). Dummy/alloc DAG nodes have no
+    # kernel row, so their arrows anchor on the AICPU worker slice emitted above.
+    for pred_id, succ_ids in edges_by_pred.items():
+        if pred_id not in task_map and pred_id not in aicpu_worker_anchor_map:
+            continue
+
+        for succ_id in succ_ids:
+            if succ_id not in task_map and succ_id not in aicpu_worker_anchor_map:
+                if verbose:
+                    print(
+                        f"Warning: Task {format_task_display(pred_id)} (raw {pred_id}) "
+                        f"references non-existent successor {format_task_display(succ_id)} (raw {succ_id})"
+                    )
+                continue
+
+            row_pairs = _flow_row_pairs(
+                pred_id,
+                succ_id,
+                task_map,
+                spmd_task_ids,
+                _worker_flow_anchor_rows,
+                aicpu_worker_anchor_map,
+            )
+            if not row_pairs:
+                continue
+
+            output_task_count = _dependency_task_fan_count(pred_id, spmd_task_ids, task_map, deps_block_map)
+            input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
+            for pred_row, succ_row in row_pairs:
+                src_ts_end = pred_row["end_time_us"] - flow_epsilon
+                dst_ts_start = _task_slice_start_us(succ_row)
+                hb_violated = (src_ts_end + flow_epsilon) > dst_ts_start
+                flow_name = "hb_violation" if hb_violated else "dependency"
+                if hb_violated:
+                    hb_violation_count += 1
+                src_tid, src_event_id = worker_flow_endpoint(pred_row)
+                dst_tid, dst_event_id = worker_flow_endpoint(succ_row)
+                _append_dependency_flow_pair(
+                    events,
+                    flow_id,
+                    flow_name,
+                    4,
+                    src_tid,
+                    src_ts_end,
+                    src_event_id,
+                    4,
+                    dst_tid,
+                    dst_ts_start,
+                    dst_event_id,
+                    input_task_count=input_task_count,
+                    output_task_count=output_task_count,
+                )
+                flow_id += 1
+                deps_flow_count += 1
+
+    if verbose:
+        if deps_edges is not None:
+            print(f"  Dependency flow events: {deps_flow_count} edges (source: deps.json)")
+            if spmd_task_ids:
+                print(
+                    f"  SPMD tasks: {len(spmd_task_ids)} logical task(s); "
+                    "dependency arrows independently anchor on each view's earliest visible slice per function"
+                )
+        else:
+            print("  Flow events: 0 (no deps.json — re-run dep_gen and pass --deps-json to add arrows)")
+        if hb_violation_count > 0:
+            print(f"  Happens-before violations: {hb_violation_count} edge(s) flagged as 'hb_violation'")
 
     # Scheduler View dependency mirror (AICPU timestamps).
     if has_aicpu_data:

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -1154,24 +1154,6 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             for (int di = 0; di < dummy_got; di++) {
                 PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
 
-                // ----- DummyTask phase: dummy "task" identity marker. --------
-                // The dummy has no AICore presence — start ≈ end (1 cycle
-                // wide, just "we identified it"). Converter renders this on
-                // Worker View's DUMMY_T{thread} lane so the DAG node is
-                // visually present. tasks_processed = task_token low 32 bits
-                // (= local_id within ring) so deps.json flow arrows can land.
-                // The Resolve work that follows is emitted separately below.
-#if SIMPLER_DFX
-                if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
-                    uint64_t dummy_marker_t = get_sys_cnt_aicpu();
-                    uint32_t dummy_id_low32 = static_cast<uint32_t>(dummy_slot.task->task_id.raw & 0xFFFFFFFFu);
-                    l2_swimlane_aicpu_record_sched_phase(
-                        thread_idx, L2SwimlaneSchedPhaseKind::DummyTask, dummy_marker_t, dummy_marker_t,
-                        sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_id_low32
-                    );
-                }
-#endif
-
                 // ----- Resolve work: walk this dummy's consumer list. ------
                 // Same 1 µs filter as the main-path Resolve emit suppresses
                 // dummies whose consumer release runs sub-microsecond.
@@ -1198,6 +1180,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                             sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_consumers
                         );
                     }
+                    l2_swimlane_aicpu_record_dummy_task(
+                        thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                        dummy_slot.task->task_id.raw
+                    );
                 }
 #endif
                 // Dummy tasks have no subtasks to retire and no fanout pre-conditions
@@ -1224,7 +1210,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
 #if SIMPLER_DFX
             // Emit Dummy outer over the whole dummy_drain pass. Span starts at
-            // dummy_outer_t0 (captured before the pop_batch) and ends at "now".
+            // dummy_outer_t0 (captured after pop_batch) and ends at "now".
             // tasks_processed = dummy_got. Advancing _t0_phase here makes the
             // following Dispatch / EarlyDispatch / second-Complete bars start
             // at this end.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1156,24 +1156,6 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             for (int di = 0; di < dummy_got; di++) {
                 PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
 
-                // ----- DummyTask phase: dummy "task" identity marker. --------
-                // The dummy has no AICore presence — start ≈ end (1 cycle
-                // wide, just "we identified it"). Converter renders this on
-                // Worker View's DUMMY_T{thread} lane so the DAG node is
-                // visually present. tasks_processed = task_token low 32 bits
-                // (= local_id within ring) so deps.json flow arrows can land.
-                // The Resolve work that follows is emitted separately below.
-#if SIMPLER_DFX
-                if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
-                    uint64_t dummy_marker_t = get_sys_cnt_aicpu();
-                    uint32_t dummy_id_low32 = static_cast<uint32_t>(dummy_slot.task->task_id.raw & 0xFFFFFFFFu);
-                    l2_swimlane_aicpu_record_sched_phase(
-                        thread_idx, L2SwimlaneSchedPhaseKind::DummyTask, dummy_marker_t, dummy_marker_t,
-                        sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_id_low32
-                    );
-                }
-#endif
-
                 // ----- Resolve work: walk this dummy's consumer list. ------
                 // Same 1 µs filter as the main-path Resolve emit suppresses
                 // dummies whose consumer release runs sub-microsecond.
@@ -1200,6 +1182,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                             sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_consumers
                         );
                     }
+                    l2_swimlane_aicpu_record_dummy_task(
+                        thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                        dummy_slot.task->task_id.raw
+                    );
                 }
 #endif
                 // Dummy tasks have no subtasks to retire and no fanout pre-conditions
@@ -1226,7 +1212,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
 #if SIMPLER_DFX
             // Emit Dummy outer over the whole dummy_drain pass. Span starts at
-            // dummy_outer_t0 (captured before the pop_batch) and ends at "now".
+            // dummy_outer_t0 (captured after pop_batch) and ends at "now".
             // tasks_processed = dummy_got. Advancing _t0_phase here makes the
             // following Dispatch / EarlyDispatch / second-Complete bars start
             // at this end.

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -733,7 +733,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // device LOG_INFO_V9 "orch_start=… orch_end=… orch_cost=…" line
             // below carries the same envelope info for debugging, and
             // host-side swimlane derives per-phase timing from the per-event
-            // L2SwimlaneAicpuPhaseRecord[] stream that already covers everything inside
+            // L2SwimlaneAicpuOrchPhaseRecord[] stream that already covers everything inside
             // submit_task().
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -707,10 +707,22 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
             for (int di = 0; di < dummy_got; di++) {
                 PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
+#if SIMPLER_DFX
+                uint64_t dummy_resolve_t0 =
+                    (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
+#endif
 #if SIMPLER_SCHED_PROFILING
                 sched_->on_task_complete(dummy_slot, thread_idx);
 #else
                 sched_->on_task_complete(dummy_slot);
+#endif
+#if SIMPLER_DFX
+                if (dummy_resolve_t0 != 0) {
+                    l2_swimlane_aicpu_record_dummy_task(
+                        thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                        dummy_slot.task->task_id.raw
+                    );
+                }
 #endif
                 // Dummy tasks have no subtasks to retire and no fanout pre-conditions
                 // beyond their own producers; release self-reference so the slot can
@@ -766,7 +778,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 // sum-of-deltas == run-cumulative.
                 uint64_t pop_hit_delta = l2_swimlane.pop_hit - l2_swimlane.pop_hit_at_last_emit;
                 uint64_t pop_miss_delta = l2_swimlane.pop_miss - l2_swimlane.pop_miss_at_last_emit;
-                // L2SwimlaneAicpuPhaseRecord's extras are uint32 — a delta that overflows means
+                // L2SwimlaneAicpuSchedPhaseRecord's dispatch counters are uint32 — an overflow means
                 // an emit was missed for ~4 billion pops, which is well outside any
                 // realistic dispatch cadence and silently truncates without this guard.
                 debug_assert(pop_hit_delta < (1ULL << 32));

--- a/src/common/platform/include/aicpu/l2_swimlane_collector_aicpu.h
+++ b/src/common/platform/include/aicpu/l2_swimlane_collector_aicpu.h
@@ -194,13 +194,15 @@ void l2_swimlane_aicpu_init_phase(int worker_count, int num_sched_phase_threads,
  * record's corresponding slot is zero-filled).
  *
  * @param thread_idx       Scheduler thread index
- * @param kind             Complete or Dispatch
+ * @param kind             Scheduler phase kind; DummyTask uses l2_swimlane_aicpu_record_dummy_task
  * @param start_time       Phase start timestamp
  * @param end_time         Phase end timestamp
  * @param loop_iter        Current scheduler-loop iteration number
  * @param tasks_processed  Tasks processed in this phase batch
- * @param pop_hit          Dispatch delta since last emit (0 for Complete)
- * @param pop_miss         Dispatch delta since last emit (0 for Complete)
+ * @param pop_hit          Ready-queue hit delta since the previous Dispatch emit; ignored for other kinds
+ *                         (Complete, Release, Dummy, EarlyDispatch, Resolve, Drain, DrainPrepare, DrainPublish)
+ * @param pop_miss         Ready-queue miss delta since the previous Dispatch emit; ignored for other kinds
+ *                         (Complete, Release, Dummy, EarlyDispatch, Resolve, Drain, DrainPrepare, DrainPublish)
  * @param shared_at_start  Per-shape sched.ready_queues[shape].size() at phase start (may be nullptr)
  * @param shared_at_end    Per-shape sched.ready_queues[shape].size() at phase end (may be nullptr)
  */
@@ -209,6 +211,16 @@ void l2_swimlane_aicpu_record_sched_phase(
     uint32_t tasks_processed, uint32_t pop_hit = 0, uint32_t pop_miss = 0, const int16_t *shared_at_start = nullptr,
     const int16_t *shared_at_end = nullptr
 );
+
+/**
+ * Record the completion point of one dependency-only dummy task.
+ *
+ * @param thread_idx     Scheduler thread that completed the task
+ * @param complete_time  Timestamp sampled immediately before completion propagation
+ * @param loop_iter      Current scheduler-loop iteration number
+ * @param task_id        Full PTO2 task identity
+ */
+void l2_swimlane_aicpu_record_dummy_task(int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id);
 
 /**
  * Set orchestrator thread index for per-task phase recording

--- a/src/common/platform/include/common/l2_swimlane_profiling.h
+++ b/src/common/platform/include/common/l2_swimlane_profiling.h
@@ -515,9 +515,8 @@ enum class L2SwimlaneSchedPhaseKind : uint32_t {
                   // push newly-ready successors, ring doorbells for
                   // early-dispatch hits. tasks_processed = # consumers visited.
     // Separate-lane (Worker View pid=4 AICPU_N)
-    DummyTask = 7,      // Per-dummy identity marker (zero-width). tasks_processed
-                        // = task_token_raw low 32 bits so deps.json flow arrows
-                        // can land on it.
+    DummyTask = 7,      // Per-dummy identity marker (zero-width). phase_data.dummy_task
+                        // carries the local/ring components of the full PTO2 identity.
     Drain = 8,          // handle_drain_mode outer: the sync_start stop-the-world drain
                         // (ack barrier + availability + parallel stage + finalize).
                         // One bar per dispatch-loop iteration that enters the drain,
@@ -539,9 +538,9 @@ constexpr int L2SWIMLANE_NUM_QUEUE_SHAPES = 3;
  *
  * Position in the per-thread buffer is the identity — no thread_id field.
  *
- * pop_hit / pop_miss carry SCHED_DISPATCH delta counters since the last emit
- * (zero for Complete). Kept named, not "extra1"/"extra2", so the device-side
- * commit and the host-side JSON emit don't drift on which extra means which.
+ * phase_data is tagged by kind: Dispatch uses its ready-queue counters and
+ * DummyTask uses the local/ring components of the full task id. Other kinds
+ * store zero in the Dispatch view.
  *
  * Queue-depth snapshots (shared_depth_*) record the per-shape scheduler ready
  * queue occupancy at phase boundaries. They surface the dep-release-then-
@@ -554,12 +553,28 @@ struct L2SwimlaneAicpuSchedPhaseRecord {
     uint32_t loop_iter;             // Scheduler-loop iteration number on this thread
     L2SwimlaneSchedPhaseKind kind;  // see enum above
     uint32_t tasks_processed;       // Tasks processed in this phase batch
-    uint32_t pop_hit;               // SCHED_DISPATCH delta since last emit (0 for Complete)
-    uint32_t pop_miss;              // SCHED_DISPATCH delta since last emit (0 for Complete)
+    union {
+        struct {
+            uint32_t pop_hit;   // Ready-queue hit delta since the previous Dispatch emit
+            uint32_t pop_miss;  // Ready-queue miss delta since the previous Dispatch emit
+        } dispatch;
+        struct {
+            uint32_t local_id;  // task_id bits [31:0]
+            uint32_t ring_id;   // task_id bits [63:32]
+        } dummy_task;
+    } phase_data;
     int16_t shared_depth_at_start[L2SWIMLANE_NUM_QUEUE_SHAPES];  // sched->ready_queues[shape].size()
     int16_t shared_depth_at_end[L2SWIMLANE_NUM_QUEUE_SHAPES];
     uint32_t _pad[4];  // 64B alignment padding
 };
+static_assert(
+    sizeof(decltype(L2SwimlaneAicpuSchedPhaseRecord::phase_data)) == 8,
+    "L2SwimlaneAicpuSchedPhaseRecord phase data must remain 8 bytes"
+);
+static_assert(
+    offsetof(L2SwimlaneAicpuSchedPhaseRecord, phase_data) == 28,
+    "L2SwimlaneAicpuSchedPhaseRecord phase data offset drift"
+);
 static_assert(sizeof(L2SwimlaneAicpuSchedPhaseRecord) == 64, "L2SwimlaneAicpuSchedPhaseRecord layout drift");
 
 /**

--- a/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
@@ -915,14 +915,10 @@ static Record *acquire_phase_slot(
     return record;
 }
 
-void l2_swimlane_aicpu_record_sched_phase(
-    int thread_idx, L2SwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
-    uint32_t tasks_processed, uint32_t pop_hit, uint32_t pop_miss, const int16_t *shared_at_start,
-    const int16_t *shared_at_end
-) {
-    if (!s_phase_initialized) return;
+static inline L2SwimlaneAicpuSchedPhaseRecord *acquire_sched_phase_record(int thread_idx) {
+    if (!s_phase_initialized) return nullptr;
     auto *state = s_sched_phase_pools[thread_idx];
-    if (state == nullptr) return;
+    if (state == nullptr) return nullptr;
 
     state->head.total_record_count += 1;
 
@@ -932,15 +928,20 @@ void l2_swimlane_aicpu_record_sched_phase(
     );
     if (record == nullptr) {
         state->head.dropped_record_count += 1;
-        return;
+        return nullptr;
     }
+    return record;
+}
+
+static inline void fill_sched_phase_record(
+    L2SwimlaneAicpuSchedPhaseRecord *record, L2SwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time,
+    uint32_t loop_iter, uint32_t tasks_processed, const int16_t *shared_at_start, const int16_t *shared_at_end
+) {
     record->start_time = start_time;
     record->end_time = end_time;
     record->loop_iter = loop_iter;
     record->kind = kind;
     record->tasks_processed = tasks_processed;
-    record->pop_hit = pop_hit;
-    record->pop_miss = pop_miss;
     auto copy_snapshot = [](int16_t dst[L2SWIMLANE_NUM_QUEUE_SHAPES], const int16_t *src) {
         if (src == nullptr) {
             for (int i = 0; i < L2SWIMLANE_NUM_QUEUE_SHAPES; i++)
@@ -952,6 +953,31 @@ void l2_swimlane_aicpu_record_sched_phase(
     };
     copy_snapshot(record->shared_depth_at_start, shared_at_start);
     copy_snapshot(record->shared_depth_at_end, shared_at_end);
+}
+
+void l2_swimlane_aicpu_record_sched_phase(
+    int thread_idx, L2SwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
+    uint32_t tasks_processed, uint32_t pop_hit, uint32_t pop_miss, const int16_t *shared_at_start,
+    const int16_t *shared_at_end
+) {
+    auto *record = acquire_sched_phase_record(thread_idx);
+    if (record == nullptr) return;
+    fill_sched_phase_record(
+        record, kind, start_time, end_time, loop_iter, tasks_processed, shared_at_start, shared_at_end
+    );
+    record->phase_data.dispatch.pop_hit = pop_hit;
+    record->phase_data.dispatch.pop_miss = pop_miss;
+}
+
+void l2_swimlane_aicpu_record_dummy_task(int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id) {
+    auto *record = acquire_sched_phase_record(thread_idx);
+    if (record == nullptr) return;
+    fill_sched_phase_record(
+        record, L2SwimlaneSchedPhaseKind::DummyTask, complete_time, complete_time, loop_iter,
+        /*tasks_processed=*/1, /*shared_at_start=*/nullptr, /*shared_at_end=*/nullptr
+    );
+    record->phase_data.dummy_task.local_id = static_cast<uint32_t>(task_id);
+    record->phase_data.dummy_task.ring_id = static_cast<uint32_t>(task_id >> 32);
 }
 
 void l2_swimlane_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }

--- a/src/common/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/l2_swimlane_collector.cpp
@@ -1059,7 +1059,13 @@ int L2SwimlaneCollector::export_swimlane_json() {
                         << ", \"start_cycles\": " << pr.start_time << ", \"end_cycles\": " << pr.end_time
                         << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed;
                 if (pr.kind == L2SwimlaneSchedPhaseKind::Dispatch) {
-                    outfile << ", \"pop_hit\": " << pr.pop_hit << ", \"pop_miss\": " << pr.pop_miss;
+                    outfile << ", \"pop_hit\": " << pr.phase_data.dispatch.pop_hit
+                            << ", \"pop_miss\": " << pr.phase_data.dispatch.pop_miss;
+                }
+                if (pr.kind == L2SwimlaneSchedPhaseKind::DummyTask) {
+                    uint64_t task_id = (static_cast<uint64_t>(pr.phase_data.dummy_task.ring_id) << 32) |
+                                       pr.phase_data.dummy_task.local_id;
+                    outfile << ", \"task_id\": " << task_id;
                 }
                 // Queue-depth snapshots — [AIC, AIV, MIX] per L2SwimlaneAicpuSchedPhaseRecord docstring.
                 emit_depth_array("shared_at_start", pr.shared_depth_at_start);

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -412,3 +412,69 @@ def test_complete_flow_worker_view_only_without_scheduler_phases(tmp_path):
 
     out = _generate_trace(tasks, {}, {task_id: 1}, tmp_path)
     assert _complete_flows(out) == []
+
+
+def test_aicpu_worker_lanes_and_full_dummy_ids_follow_runtime_threads(tmp_path):
+    out = tmp_path / "trace.json"
+    dummy_r1t1 = (1 << 32) | 1
+    dummy_r2t1 = (2 << 32) | 1
+    alloc_r3t1 = (3 << 32) | 1
+    scheduler_phases = [
+        [],
+        [{"phase": "dummy_task", "task_id": dummy_r1t1, "start_time_us": 1.0, "end_time_us": 1.0}],
+        [{"phase": "dummy_task", "task_id": dummy_r2t1, "start_time_us": 2.0, "end_time_us": 2.0}],
+        [],
+    ]
+    orchestrator_phases = [[{"phase": "orch_submit", "task_id": alloc_r3t1, "start_time_us": 3.0, "end_time_us": 4.0}]]
+
+    sc.generate_chrome_trace_json(
+        [],
+        str(out),
+        scheduler_phases=scheduler_phases,
+        orchestrator_phases=orchestrator_phases,
+        core_to_thread=[0, 1, 2],
+        deps_edges={dummy_r1t1: [dummy_r2t1]},
+        deps_kernel_map={dummy_r1t1: [-1, -1, -1], dummy_r2t1: [-1, -1, -1]},
+    )
+
+    with open(out) as f:
+        events = json.load(f)["traceEvents"]
+    aicpu_lanes = {
+        event["tid"]: event["args"]["name"]
+        for event in events
+        if event.get("ph") == "M"
+        and event.get("pid") == 4
+        and event.get("args", {}).get("name", "").startswith("AICPU_")
+    }
+    assert aicpu_lanes == {
+        19000: "AICPU_0",
+        19001: "AICPU_1",
+        19002: "AICPU_2",
+        19003: "AICPU_3",
+    }
+    assert next(event for event in events if event.get("name") == "dummy(r1t1)")["tid"] == 19001
+    assert next(event for event in events if event.get("name") == "dummy(r2t1)")["tid"] == 19002
+    assert next(event for event in events if event.get("name") == "alloc(r3t1)")["tid"] == 19003
+
+    flow = _first_worker_dependency_flow(out)
+    assert [(event["ph"], event["tid"]) for event in flow] == [("s", 19001), ("f", 19002)]
+
+
+def test_deps_dummy_without_runtime_record_is_not_rendered_as_alloc(tmp_path, capsys):
+    out = tmp_path / "trace.json"
+    dummy_task_id = (1 << 32) | 1
+
+    sc.generate_chrome_trace_json(
+        [],
+        str(out),
+        scheduler_phases=[[]],
+        orchestrator_phases=[
+            [{"phase": "orch_submit", "task_id": dummy_task_id, "start_time_us": 2.0, "end_time_us": 3.0}]
+        ],
+        deps_kernel_map={dummy_task_id: [-1, -1, -1]},
+    )
+
+    with open(out) as f:
+        events = json.load(f)["traceEvents"]
+    assert not any(event.get("name") == "alloc(r1t1)" for event in events)
+    assert "dummy(r1t1) has no dummy_task scheduler record" in capsys.readouterr().err


### PR DESCRIPTION
  - Record full dummy task IDs at the pre-resolve timestamp
  - Build AICPU worker lanes from the actual scheduler topology
  - Anchor dummy and alloc dependencies on their Worker View slices
  - Avoid misclassifying dropped dummy records as alloc tasks
  - Add representative converter tests and update L2 documentation