### PR TITLE
fix(dfx): strace_timing --tree medians all invocations, not the first

### DIFF
--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -121,11 +121,21 @@ task-submit --timeout 2400 --max-time 2400 --device auto --device-num 1 --run "\
 - Decode dispatches through the **L3 `DistributedWorker`**, which forks a
   **chip-child (L2)** that runs `run_prepared`. The per-step timing lives at
   **L2**: `run_prepared` computes both host (`host_wall`) and device
-  (`device_wall` = the fused-decode orchestrator wall, ~33 ms — nonzero) plus
-  the device orch/sched markers. The L3 parent's `Worker.run` returns
-  `RunTiming(python_wall, 0)` — its `device_wall=0` is **expected** (L3 is a
-  dispatcher with no device wall of its own) and is **not** the source you
+  (`device_wall` = the fused-decode orchestrator wall, ~40 ms at 3.5k context —
+  nonzero) plus the device orch/sched markers. The L3 parent's `Worker.run`
+  returns `RunTiming(python_wall, 0)` — its `device_wall=0` is **expected** (L3
+  is a dispatcher with no device wall of its own) and is **not** the source you
   read. Read L2 instead (next section).
+
+  > **Warmup skews single-invocation reads.** The pypto-serving profile warmup
+  > dispatches a tiny-KV decode step (`[warmup] decode dispatch … seq_len≈257`,
+  > `device_wall` ~28 ms) *before* the real 3.5k-context steps (~40 ms). Any
+  > tool that reports one invocation shows the warmup value. Decode is
+  > memory-bound: ~28 ms reads the 28 GB bf16 weights every step, +~12 ms reads
+  > the 3.3k-token KV for attention — the KV read is why warmup (short KV) is
+  > ~12 ms cheaper, not cold start. Trust `kernel.decode_layer avg` from
+  > `--profile` (excludes warmup) or `strace_timing --tree` (medians all
+  > invocations); do not read a single decode step.
 
 ## 3. Run decode (batch-16)
 
@@ -222,9 +232,9 @@ The full per-token decomposition (what each layer means / how to get it):
 
 ②③④ come from the **L2 chip-child** `run_prepared`'s `host_wall` /
 `runner_run` / `device_wall`. `host_wall` and `device_wall` are already
-computed there (and `device_wall` is nonzero, ~33 ms — it is the L2 orchestrator
-wall, *not* the L3 parent's `RunTiming.device_wall=0`); the L3 parent drops
-the child's `RunTiming`, so they never reach a return value.
+computed there (and `device_wall` is nonzero, ~40 ms at 3.5k context — it is the
+L2 orchestrator wall, *not* the L3 parent's `RunTiming.device_wall=0`); the L3
+parent drops the child's `RunTiming`, so they never reach a return value.
 
 Simpler surfaces them instead as **`[STRACE]` host-trace markers** — one
 line per `run_prepared` stage

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -230,6 +230,13 @@ buckets by callable hash `hid`, and reports each callable's mean `simpler_run`
 plus per-stage means. It reads the host-emitted `[STRACE]` lines and shows the
 host stages (`bind`/`runner_run`/`validate`) alongside the AICPU phases.
 
+`--tree` renders one nested span tree per callable; each node's duration is the
+**median across every invocation** of that callable (not one invocation's
+value). This matters for a callable whose invocations differ in cost — e.g.
+qwen3 decode, where the pypto-serving profile warmup dispatches a tiny-KV step
+(seq_len≈257, ~28 ms) before the real 3.5k-context steps (~40 ms); a
+single-invocation tree would report the warmup value.
+
 `--rounds-table` renders one row per invocation of the busiest `hid` —
 **Host** always, plus **Device / Effective / Orch / Sched** when present, in the
 format `tools/benchmark_rounds.sh` parses. `Effective` is the orch∪sched merged

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -146,6 +146,15 @@ def _mean(values):
     return sum(values) / len(values) if values else 0.0
 
 
+def _median(values):
+    if not values:
+        return 0.0
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+
 def print_tpot_table(buckets, label_for_hid=None, stream=sys.stdout):
     """Print a per-callable TPOT table. The most-invoked bucket is decode."""
     if not buckets:
@@ -364,19 +373,38 @@ def to_chrome_trace(invocations, buckets=None):
     return {"traceEvents": events, "displayTimeUnit": "ms"}
 
 
-def _print_inv_tree(inv, stream=sys.stdout):
-    """Print one invocation's spans as a nested tree built from the dotted span
+def _print_agg_tree(invs, stream=sys.stdout):
+    """Print a callable's spans as a nested tree built from the dotted span
     names (so e.g. ``simpler_run.bind.args`` nests under ``simpler_run.bind``),
     NOT from depth+ts — host (steady_clock) and device (``clk=dev``) spans live
     on different clocks, so timestamp containment across domains is meaningless;
-    the dotted name is the unambiguous parent link. Siblings are ordered by
-    ``ts``. Device spans are tagged ``[dev]``; durations are µs."""
-    by_name = {s.name: s for s in inv.spans}
-    # children[parent_name] = [child span...]; a span's parent is its name minus
-    # the last dotted segment (if that prefix is itself a known span).
+    the dotted name is the unambiguous parent link. Device spans are tagged
+    ``[dev]``; durations are µs.
+
+    Each node's duration is the **median across every invocation** of this
+    callable, not one invocation's value. A single-invocation tree would mislead
+    on a callable whose invocations differ in cost — e.g. qwen3 decode, where the
+    pypto-serving profile warmup dispatches a tiny-KV decode step (seq_len≈257)
+    before the real steps: its Effective (~28 ms) is far below the steady-state
+    (~40 ms at 3.5k context). The median is robust to that warmup outlier."""
+    # Per-span-name median duration across all invocations. by_name() rebuilds
+    # its dict per call, so materialize each invocation's map once and reuse it
+    # for both the medians here and the per-inv Effective loop below.
+    by_names = [inv.by_name() for inv in invs]
+    dur_samples: dict = defaultdict(list)
+    for bn in by_names:
+        for name, span in bn.items():
+            dur_samples[name].append(span.dur)
+    med = {name: _median(ds) for name, ds in dur_samples.items()}
+
+    # Structure + ts ordering from the LAST invocation — for qwen decode the
+    # warmup step is inv 0, so the last is a steady-state one; either way the
+    # dotted-name tree shape is identical across invocations.
+    ref = invs[-1]
+    by_name = {s.name: s for s in ref.spans}
     children = {}
     roots = []
-    for s in inv.spans:
+    for s in ref.spans:
         parent = s.name.rsplit(".", 1)[0] if "." in s.name else None
         if parent is not None and parent in by_name:
             children.setdefault(parent, []).append(s)
@@ -386,7 +414,7 @@ def _print_inv_tree(inv, stream=sys.stdout):
     def emit(s, indent):
         tag = " [dev]" if s.is_device else ""
         leaf = s.name.rsplit(".", 1)[-1] if "." in s.name else s.name
-        stream.write(f"{'  ' * indent}{leaf:<22}{tag:>6}  {s.dur / 1000.0:>12.1f} us\n")
+        stream.write(f"{'  ' * indent}{leaf:<22}{tag:>6}  {med[s.name] / 1000.0:>12.1f} us\n")
         kids = sorted(children.get(s.name, []), key=lambda x: x.ts)
         # orch and sched run concurrently (see docs/dfx/device-phases.md): render
         # them on ONE line, left = orch, right = sched, under their merged window
@@ -397,13 +425,23 @@ def _print_inv_tree(inv, stream=sys.stdout):
             cleaf = c.name.rsplit(".", 1)[-1]
             if cleaf == "orch" and has_sched:
                 sched = next(k for k in kids if k.name.rsplit(".", 1)[-1] == "sched")
-                eff = (max(c.ts + c.dur, sched.ts + sched.dur) - min(c.ts, sched.ts)) / 1000.0
+                # Effective is per-invocation (orch ∪ sched depends on both
+                # markers' overlap in that inv), so take the median of the
+                # per-inv Effective values rather than combining the two medians.
+                effs = []
+                for bn in by_names:
+                    o, sc = bn.get(c.name), bn.get(sched.name)
+                    if o is not None and sc is not None:
+                        effs.append(max(o.ts + o.dur, sc.ts + sc.dur) - min(o.ts, sc.ts))
+                eff = _median(effs) / 1000.0
                 base = "  " * (indent + 1)
                 # Effective = the merged orch ∪ sched window, with the two
                 # concurrent children shown side by side on the indented line
                 # below it (see docs/dfx/device-phases.md).
                 stream.write(f"{base}{'Effective':<22} [dev]  {eff:>12.1f} us\n")
-                stream.write(f"{base}  orch {c.dur / 1000.0:.1f}  ∥  sched {sched.dur / 1000.0:.1f}   (concurrent)\n")
+                stream.write(
+                    f"{base}  orch {med[c.name] / 1000.0:.1f}  ∥  sched {med[sched.name] / 1000.0:.1f}   (concurrent)\n"
+                )
             elif cleaf == "sched" and has_orch:
                 continue  # shown beside orch on the Effective line above
             else:
@@ -421,9 +459,10 @@ def print_tree(buckets, stream=sys.stdout):
     ordered = sorted(buckets.items(), key=lambda kv: len(kv[1]), reverse=True)
     for hid, invs in ordered:
         label = _bucket_label(buckets, hid)
-        print(f"callable hid={hid} ({label}) — {len(invs)} invocation(s)", file=stream)
-        # Show the first invocation's tree as representative (they share structure).
-        _print_inv_tree(invs[0], stream=stream)
+        n = len(invs)
+        suffix = f" — median of {n} invocation(s)" if n > 1 else " — 1 invocation"
+        print(f"callable hid={hid} ({label}){suffix}", file=stream)
+        _print_agg_tree(invs, stream=stream)
         print(file=stream)
 
 


### PR DESCRIPTION
## Problem

`strace_timing … --tree` printed **only the first invocation** of each callable as "representative":

```python
# Show the first invocation's tree as representative (they share structure).
_print_inv_tree(invs[0], stream=stream)
```

Invocations share tree *shape* but not *durations*. For a qwen3-14B serving run, the pypto-serving profile **warmup** dispatches a tiny-KV decode step (`[warmup] decode dispatch … seq_len≈257`) before the real steps, and both use the same decode-kernel `hid`. So `--tree` reported the **warmup** step and dropped the 19 real steps.

Measured (3.5k-token prompt), decode `hid` across its 20 invocations:

| invocation | KV | Effective |
| ---------- | -- | --------- |
| warmup decode | 257 | **27.8 ms** ← what `--tree` printed |
| real decode (19 steps) | 3338 | **39.6 ms** (steady) |

The ~12 ms gap is entirely `sched` (identical task graph, `orch` +0.4 ms) — it's the attention KV-cache read (257 vs 3338 tokens), not cold start. Decode is memory-bound: ~28 ms reads the 28 GB bf16 weights every step, +~12 ms reads the 3.3k-token KV.

Net: `--tree` underreported steady-state decode `Effective` by ~12 ms (reported ~28 ms; real ~40 ms).

## Fix

`_print_agg_tree` aggregates each span's duration as the **median across every invocation** of the callable (robust to the warmup outlier). `Effective` is medianed per-invocation (it depends on each inv's orch/sched overlap). Header now reads `— median of N invocation(s)`.

Before → after on the same 3.5k decode log:
```
callable hid=… (decode) — 20 invocation(s)          callable hid=… (decode) — median of 20 invocation(s)
      Effective   [dev]   27840.2 us          →            Effective   [dev]   39578.0 us
```

The default TPOT table (`print_tpot_table`) and `--rounds-table` already aggregated correctly and are unchanged.

## Docs

- `simpler_setup/tools/README.md`: document that `--tree` medians all invocations, with the qwen warmup example.
- `.claude/skills/multi-repo-qwen-setup/SKILL.md`: the skill said decode `device_wall` is "~33 ms" — the same warmup underreport. Corrected to ~40 ms at 3.5k context, added a warmup-skew + memory-bound note.

## Testing

- `--tree` on a 3.5k qwen decode log now shows steady-state 39.6 ms (was 27.8 ms); single-invocation callables (prefill) unchanged.
- Default TPOT table and `--rounds-table` outputs unchanged (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)