### PR TITLE
Fix: validate early-dispatch queue generations

### DIFF
--- a/.claude/lib/onboard-detection.md
+++ b/.claude/lib/onboard-detection.md
@@ -31,12 +31,14 @@ bugs. Both detecting the platform and refusing a mismatch are handled by the
    .claude/skills/onboard-arch-precheck/check.sh "$ARCH" || exit 1
    ```
 
-3. The gate caches the *detected* arch at `/tmp/onboard-arch-precheck.cache`
+3. The gate caches the *detected* arch at
+   `${TMPDIR:-/tmp}/onboard-arch-precheck-<uid>.cache`
    (`arch|soc|short_soc`). Use that as the authoritative platform instead of
    re-parsing `npu-smi`:
 
    ```bash
-   PLATFORM=$(cut -d'|' -f1 /tmp/onboard-arch-precheck.cache)
+   CACHE="${TMPDIR:-/tmp}/onboard-arch-precheck-$(id -u).cache"
+   PLATFORM=$(cut -d'|' -f1 "$CACHE")
    ```
 
 ## B. Platform (simulation)

--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -54,8 +54,8 @@ styles**. They measure different things; don't confuse them:
   `examples/model/qwen3_14b/npu_generate.py`, flags `--model-dir --prompt
   --max-seq-len --max-new-tokens --num-layers-override --profile[-verbose]`.
   Measures **end-to-end prefill/decode TPOT** for the whole model; read via
-  the `--profile` report + `device_log_timing` (§2–§5). Use it to reproduce
-  a serving perf number or chase a serving `507018`.
+  the `--profile` report + `strace_timing --rounds-table` (§2–§5). Use it
+  to reproduce a serving perf number or chase a serving `507018`.
 - **Path B — `decode_layer` kernel (pypto-lib).** A single JIT case for one
   decode layer, not the engine. Entry
   `models/qwen3/14b/decode_layer.py`, flags `-p <platform> -d <device>`,
@@ -117,7 +117,8 @@ task-submit --timeout 2400 --max-time 2400 --device auto --device-num 1 --run "\
 
 - `--num-layers-override 40` = full model; `--profile[-verbose]` prints the
   timing report (`api.run_decode` per-step = end-to-end TPOT, `kernel.decode_layer`
-  host wall, per-step layer breakdown).
+  host wall, per-step layer breakdown) plus `strace_timing --rounds-table`
+  (§2–§5).
 - Decode dispatches through the **L3 `DistributedWorker`**, which forks a
   **chip-child (L2)** that runs `run_prepared`. The per-step timing lives at
   **L2**: `run_prepared` computes both host (`host_wall`) and device
@@ -196,14 +197,14 @@ Redirect the CANN device log out of the shared default, then parse it:
 export ASCEND_PROCESS_LOG_PATH="$PWD/build/pypto-serving/build_output/ascend"
 mkdir -p "$ASCEND_PROCESS_LOG_PATH"
 # after the run (local, no device):
-$PY -m simpler_setup.tools.device_log_timing \
-    --device-log "$ASCEND_PROCESS_LOG_PATH/device-*/device-*.log"
+$PY -m simpler_setup.tools.strace_timing \
+    "$ASCEND_PROCESS_LOG_PATH/device-*/device-*.log" --rounds-table
 ```
 
-`device_log_timing` reports per-round **Total / Orch / Sched** from the
-`SIMPLER_DFX` markers (on by default, no swimlane needed). Round 0 is the
-prefill; the rest are decode steps. **Total ≈ on-device kernel makespan** =
-the "kernel run time" layer.
+`strace_timing --rounds-table` reports per-round **Device / Orch / Sched**
+from the `[STRACE]` markers (on by default, no swimlane needed). Round 0 is
+the prefill; the rest are decode steps. **Device ≈ on-device kernel
+makespan** = the "kernel run time" layer.
 
 For layers ②③④ — the host↔device and bind/validate spans — parse the
 `[STRACE]` host-trace markers with `strace_timing.py` (landed in
@@ -224,7 +225,7 @@ The full per-token decomposition (what each layer means / how to get it):
 
 | layer | = | source |
 | ----- | - | ------ |
-| ① kernel run time | makespan | `device_log_timing` Total |
+| ① kernel run time | makespan | `strace_timing --rounds-table` Device |
 | ② device init/finalize | `device_wall − makespan` | `strace_timing` (`[STRACE]` markers) |
 | ③ host↔device handshake | `runner_run − device_wall` | `strace_timing` (`runner_run` span) |
 | ④ attach+bind+validate | `host_wall − runner_run` | `strace_timing` (`bind`/`validate` spans) |

--- a/.claude/skills/onboard-arch-precheck/SKILL.md
+++ b/.claude/skills/onboard-arch-precheck/SKILL.md
@@ -105,7 +105,7 @@ Pipeline:
 
 The skill **never hardcodes "this box is a2a3"** — every check
 re-derives the answer from `npu-smi` + the CANN ini files. The result
-is cached at `/tmp/onboard-arch-precheck.cache` (format
+is cached at `${TMPDIR:-/tmp}/onboard-arch-precheck-<uid>.cache` (format
 `arch|soc|short_soc`) with a 1-hour TTL so repeat invocations stay fast
 (~5 ms). Mismatch errors include the specific SoC + Short_SoC_version
 so you know exactly what silicon was detected (e.g.

--- a/.claude/skills/onboard-arch-precheck/check.sh
+++ b/.claude/skills/onboard-arch-precheck/check.sh
@@ -22,7 +22,7 @@
 set -u
 
 REQUESTED="${1:-}"
-CACHE="/tmp/onboard-arch-precheck.cache"
+CACHE="${TMPDIR:-/tmp}/onboard-arch-precheck-$(id -u).cache"
 TTL=3600   # 1 hour
 
 if [ -z "$REQUESTED" ]; then

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -61,6 +61,7 @@
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
     PTO2TaskSlotState *slot_state;
+    uint64_t task_id_snapshot;
 };
 
 /**
@@ -91,7 +92,9 @@ struct alignas(64) PTO2ReadyQueue {
         return (e >= d) ? (e - d) : 0;
     }
 
-    bool push(PTO2TaskSlotState *slot_state) {
+    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+
+    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -111,13 +114,16 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
+        slot->task_id_snapshot = task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) {
+    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+
+    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return;
 
         uint64_t pos;
@@ -146,6 +152,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
+            slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
     }
@@ -190,7 +197,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() {
+    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+
+    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -216,6 +225,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState *result = slot->slot_state;
+        if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -271,7 +281,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+
+    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -303,6 +315,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
+            if (task_id_snapshots != nullptr) task_id_snapshots[i] = slot->task_id_snapshot;
             slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
         }
         return count;
@@ -697,7 +710,7 @@ struct PTO2SchedulerState {
             return;
         }
         if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_STAGING) {
-            early_sync_start_queue.push(&slot_state);
+            early_sync_start_queue.push_tagged(&slot_state, static_cast<uint64_t>(slot_state.task->task_id.raw));
         }
     }
 
@@ -807,8 +820,9 @@ struct PTO2SchedulerState {
                     expect, PTO2_EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
                 ))
                 continue;
-            if (c->active_mask.requires_sync_start()) early_sync_start_queue.push(c);
-            else early_dispatch_queues[static_cast<int32_t>(shape)].push(c);
+            uint64_t task_id = static_cast<uint64_t>(c->task->task_id.raw);
+            if (c->active_mask.requires_sync_start()) early_sync_start_queue.push_tagged(c, task_id);
+            else early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(c, task_id);
         }
     }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -715,6 +715,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
 
     int32_t total_staged = 0;
     PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
     // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
     // bounded by the shape's capacity so the stack buffer always holds it. Then for
     // each consumer: CLAIM a range sized to THIS thread's free cores by advancing
@@ -726,9 +727,10 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     // is filled by all idle threads in parallel. When cores run out mid-batch the
     // unprocessed remainder is pushed back for peers (mirrors normal's push_batch of
     // the unconsumed tail).
-    int got = sched_->early_dispatch_queues[s].pop_batch(batch, cores.count());
+    int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
         PTO2TaskSlotState *c = batch[bi];
+        if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
         if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
             continue;  // released
 
@@ -754,7 +756,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
-            sched_->early_dispatch_queues[s].push_batch(&batch[bi], got - bi);
+            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
             break;
         }
         int32_t start = 0;
@@ -762,7 +764,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         if (claim == 0) continue;  // nothing left to claim -> drop (no re-push)
         // Re-push for concurrent peers BEFORE the expensive staging.
         if (start + claim < c->logical_block_num) {
-            if (!sched_->early_dispatch_queues[s].push(c))
+            if (!sched_->early_dispatch_queues[s].push_tagged(c, task_id_snapshots[bi]))
                 LOG_INFO_V9(
                     "[EARLY_DISPATCH] queue full on re-push, consumer=%" PRId64,
                     static_cast<int64_t>(c->task->task_id.raw)
@@ -812,8 +814,11 @@ int32_t SchedulerContext::try_early_dispatch(
     // block_num) => cancel the owner and re-push or transfer its final ready route. A
     // non-STAGING pop was already released and is dropped. Staging happens inside the drain,
     // so this arms at most one drain and adds no blocks to total_staged here.
-    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop()) {
-        if (PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
+    uint64_t sync_task_id_snapshot = 0;
+    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+        bool current_sync_task = static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot &&
+                                 c->active_mask.requires_sync_start();
+        if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
             if (c->payload->early_dispatch_state.load(std::memory_order_seq_cst) != PTO2_EARLY_DISPATCH_STAGING) {
                 sched_->cancel_early_sync_drain(*c);
             } else if (enter_drain_mode(c, c->logical_block_num)) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -61,6 +61,7 @@
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
     PTO2TaskSlotState *slot_state;
+    uint64_t task_id_snapshot;
 };
 
 /**
@@ -93,7 +94,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     void reset_for_reuse() {}
 
-    bool push(PTO2TaskSlotState *slot_state) {
+    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+
+    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -113,13 +116,16 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
+        slot->task_id_snapshot = task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) {
+    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+
+    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return;
 
         uint64_t pos;
@@ -148,6 +154,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
+            slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
     }
@@ -192,7 +199,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() {
+    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+
+    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -218,6 +227,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState *result = slot->slot_state;
+        if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -273,7 +283,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+
+    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -305,6 +317,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
+            if (task_id_snapshots != nullptr) task_id_snapshots[i] = slot->task_id_snapshot;
             slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
         }
         return count;
@@ -800,7 +813,7 @@ struct PTO2SchedulerState {
             return;
         }
         if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_STAGING) {
-            early_sync_start_queue.push(&slot_state);
+            early_sync_start_queue.push_tagged(&slot_state, static_cast<uint64_t>(slot_state.task->task_id.raw));
         }
     }
 
@@ -910,8 +923,9 @@ struct PTO2SchedulerState {
                     expect, PTO2_EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
                 ))
                 continue;
-            if (c->active_mask.requires_sync_start()) early_sync_start_queue.push(c);
-            else early_dispatch_queues[static_cast<int32_t>(shape)].push(c);
+            uint64_t task_id = static_cast<uint64_t>(c->task->task_id.raw);
+            if (c->active_mask.requires_sync_start()) early_sync_start_queue.push_tagged(c, task_id);
+            else early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(c, task_id);
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -717,6 +717,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
 
     int32_t total_staged = 0;
     PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
     // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
     // bounded by the shape's capacity so the stack buffer always holds it. Then for
     // each consumer: CLAIM a range sized to THIS thread's free cores by advancing
@@ -728,9 +729,10 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     // is filled by all idle threads in parallel. When cores run out mid-batch the
     // unprocessed remainder is pushed back for peers (mirrors normal's push_batch of
     // the unconsumed tail).
-    int got = sched_->early_dispatch_queues[s].pop_batch(batch, cores.count());
+    int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
         PTO2TaskSlotState *c = batch[bi];
+        if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
         if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
             continue;  // released
 
@@ -756,7 +758,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
-            sched_->early_dispatch_queues[s].push_batch(&batch[bi], got - bi);
+            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
             break;
         }
         int32_t start = 0;
@@ -764,7 +766,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         if (claim == 0) continue;  // nothing left to claim -> drop (no re-push)
         // Re-push for concurrent peers BEFORE the expensive staging.
         if (start + claim < c->logical_block_num) {
-            if (!sched_->early_dispatch_queues[s].push(c))
+            if (!sched_->early_dispatch_queues[s].push_tagged(c, task_id_snapshots[bi]))
                 LOG_INFO_V9(
                     "[EARLY_DISPATCH] queue full on re-push, consumer=%" PRId64,
                     static_cast<int64_t>(c->task->task_id.raw)
@@ -814,8 +816,11 @@ int32_t SchedulerContext::try_early_dispatch(
     // block_num) => cancel the owner and re-push or transfer its final ready route. A
     // non-STAGING pop was already released and is dropped. Staging happens inside the drain,
     // so this arms at most one drain and adds no blocks to total_staged here.
-    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop()) {
-        if (PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
+    uint64_t sync_task_id_snapshot = 0;
+    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+        bool current_sync_task = static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot &&
+                                 c->active_mask.requires_sync_start();
+        if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
             if (c->payload->early_dispatch_state.load(std::memory_order_seq_cst) != PTO2_EARLY_DISPATCH_STAGING) {
                 sched_->cancel_early_sync_drain(*c);
             } else if (enter_drain_mode(c, c->logical_block_num)) {

--- a/tests/ut/cpp/a2a3/test_ready_queue.cpp
+++ b/tests/ut/cpp/a2a3/test_ready_queue.cpp
@@ -181,6 +181,31 @@ TEST_F(ReadyQueueTest, PopBatchPartial) {
     }
 }
 
+TEST_F(ReadyQueueTest, TaggedBatchPopPreservesTaskGeneration) {
+    PTO2TaskSlotState items[2];
+    PTO2TaskSlotState *input[2]{&items[0], &items[1]};
+    constexpr uint64_t queued_task_ids[2]{0x123456789abcdef0ULL, 0x0fedcba987654321ULL};
+    queue.push_batch_tagged(input, queued_task_ids, 2);
+
+    PTO2TaskSlotState *out[2];
+    uint64_t task_id_snapshots[2]{};
+    ASSERT_EQ(queue.pop_batch_tagged(out, task_id_snapshots, 2), 2);
+    EXPECT_EQ(out[0], &items[0]);
+    EXPECT_EQ(out[1], &items[1]);
+    EXPECT_EQ(task_id_snapshots[0], queued_task_ids[0]);
+    EXPECT_EQ(task_id_snapshots[1], queued_task_ids[1]);
+}
+
+TEST_F(ReadyQueueTest, TaggedPopPreservesTaskGeneration) {
+    PTO2TaskSlotState item;
+    constexpr uint64_t queued_task_id = 0xfedcba9876543210ULL;
+    ASSERT_TRUE(queue.push_tagged(&item, queued_task_id));
+
+    uint64_t task_id_snapshot = 0;
+    EXPECT_EQ(queue.pop_tagged(&task_id_snapshot), &item);
+    EXPECT_EQ(task_id_snapshot, queued_task_id);
+}
+
 TEST_F(ReadyQueueTest, PopBatchEmpty) {
     PTO2TaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -54,6 +54,7 @@ protected:
     // payload, and the scheduler's release/propagate paths dereference it.
     static constexpr int kSlotPayloadPoolSize = 16;
     PTO2TaskPayload slot_payload_pool_[kSlotPayloadPoolSize];
+    PTO2TaskDescriptor slot_task_pool_[kSlotPayloadPoolSize];
     int slot_payload_pool_idx_ = 0;
 
     void SetUp() override {
@@ -93,6 +94,9 @@ protected:
         PTO2TaskPayload &slot_pl = slot_payload_pool_[slot_payload_pool_idx_++ % kSlotPayloadPoolSize];
         memset(&slot_pl, 0, sizeof(slot_pl));
         slot.payload = &slot_pl;
+        PTO2TaskDescriptor &slot_task = slot_task_pool_[(slot_payload_pool_idx_ - 1) % kSlotPayloadPoolSize];
+        memset(&slot_task, 0, sizeof(slot_task));
+        slot.task = &slot_task;
     }
 
     void publish_no_fanin(PTO2TaskSlotState &slot) {


### PR DESCRIPTION
## Summary
- tag regular and sync-start early-dispatch queue entries with task IDs
- discard stale generations before reading reused task-slot metadata
- isolate onboard architecture-precheck caches by UID
- replace the removed Qwen `device_log_timing` command with `strace_timing --rounds-table`

## Testing
- [x] editable build of all runtimes
- [x] a2a3 ready-queue C++ tests (22 passed)
- [x] a2a3sim early-sync and stress tests (2 passed)
- [x] a2a3sim host_build_graph vector smoke (1 passed)
- [x] onboard-precheck shell syntax and sim pass-through
- [x] stale documentation reference scan and `git diff --check`