### PR TITLE
Fix: host_build_graph ring/heap overflow errors cleanly instead of hanging

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -25,9 +25,11 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "aicpu/dep_gen_collector_aicpu.h"
 #include "common/dep_gen.h"
+#include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "pto_dep_compute.h"
 #include "pto_runtime2_types.h"
@@ -100,7 +102,18 @@ __attribute__((weak, visibility("hidden"))) volatile uint32_t *get_reg_ptr(uint6
 // With hidden visibility, the HOST .so does not export this symbol globally,
 // so the AICPU .so's PLT resolves to its own strong definition from
 // device_time.cpp.
-__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
+    // Host fallback: monotonic wall-clock in AICPU cycle units so the host-orch
+    // deadlock/timeout backstops fire at their intended wall-clock (see the
+    // detailed rationale on the same fallback in pto_runtime2.cpp).
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    // Scale sec and nsec separately (divisor is the constant 1e9): avoids a
+    // div-by-zero when PLATFORM_PROF_SYS_CNT_FREQ >= 1 GHz and the truncation
+    // error a `1e9 / FREQ` divisor would introduce for non-dividing frequencies.
+    return static_cast<uint64_t>(ts.tv_sec) * PLATFORM_PROF_SYS_CNT_FREQ +
+           static_cast<uint64_t>(ts.tv_nsec) * PLATFORM_PROF_SYS_CNT_FREQ / 1000000000ull;
+}
 // Weak fallback for builds that don't link l2_swimlane_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
@@ -150,7 +163,18 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #elif SIMPLER_DFX
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
-__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
+    // Host fallback: monotonic wall-clock in AICPU cycle units so the host-orch
+    // deadlock/timeout backstops fire at their intended wall-clock (see the
+    // detailed rationale on the same fallback in pto_runtime2.cpp).
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    // Scale sec and nsec separately (divisor is the constant 1e9): avoids a
+    // div-by-zero when PLATFORM_PROF_SYS_CNT_FREQ >= 1 GHz and the truncation
+    // error a `1e9 / FREQ` divisor would introduce for non-dividing frequencies.
+    return static_cast<uint64_t>(ts.tv_sec) * PLATFORM_PROF_SYS_CNT_FREQ +
+           static_cast<uint64_t>(ts.tv_nsec) * PLATFORM_PROF_SYS_CNT_FREQ / 1000000000ull;
+}
 __attribute__((weak, visibility("hidden"))) void
 l2_swimlane_aicpu_record_orch_phase(uint64_t, uint64_t, uint64_t, uint32_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -23,19 +23,37 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <algorithm>
 
 #include "aicpu/device_time.h"
+#include "common/platform_config.h"
 #include "common/unified_log.h"
 #if SIMPLER_DFX
 #include "aicpu/scope_stats_collector_aicpu.h"
 #endif
 
-// Weak fallback for HOST .so builds (never called, but satisfies linker).
-// The AICPU build links the strong symbol from platform/.../device_time.cpp.
-// Hidden visibility prevents HOST .so from polluting global symbol table.
-__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
+// Host fallback for the host-orchestration path. The AICPU cycle counter is a
+// device register unavailable on the host, so return a monotonic wall-clock
+// scaled to that counter's cycle units (PLATFORM_PROF_SYS_CNT_FREQ). The
+// cycle-denominated deadlock/timeout backstops that run during host orchestration
+// (PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES in the ring/heap/fanin allocators,
+// PTO2_TENSOR_DATA_TIMEOUT_CYCLES in wait_for_tensor_ready) then fire at their
+// intended wall-clock. A constant 0 made those backstops no-ops, so a
+// ring/heap/fanin-pool overflow spun forever instead of failing cleanly (host-orch
+// holds the whole graph and cannot reclaim mid-build). The AICPU build links the
+// strong device counter from device_time.cpp; hidden visibility keeps this off
+// the global dynamic symbol table.
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    // Scale sec and nsec separately (divisor is the constant 1e9): avoids a
+    // div-by-zero when PLATFORM_PROF_SYS_CNT_FREQ >= 1 GHz and the truncation
+    // error a `1e9 / FREQ` divisor would introduce for non-dividing frequencies.
+    return static_cast<uint64_t>(ts.tv_sec) * PLATFORM_PROF_SYS_CNT_FREQ +
+           static_cast<uint64_t>(ts.tv_nsec) * PLATFORM_PROF_SYS_CNT_FREQ / 1000000000ull;
+}
 
 // =============================================================================
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)


### PR DESCRIPTION
## Problem

Under host-orchestration the whole task graph is built on the host before the device schedules, so the ring/heap/fanin pools can't reclaim mid-build and **overflow** when a graph exceeds them (e.g. paged_attention batch=256). The back-pressure allocators (`PTO2FaninPool::ensure_space`, the task/heap allocator, `wait_for_tensor_ready`) use an absolute-time deadlock backstop keyed on `get_sys_cnt_aicpu()` — but the **host weak fallback returned a constant `0`**, so `now - t0` was always 0, the backstop **never fired**, and an overflow **spun forever, holding the NPU until killed**.

(`dep_pool` overflow already fails cleanly via a spin-count limit; the wiring-queue spin is gone since fanout is wired inline.)

## Fix

The host `get_sys_cnt_aicpu` fallback now returns a monotonic wall-clock (`CLOCK_MONOTONIC`) scaled to the AICPU counter's cycle units (`PLATFORM_PROF_SYS_CNT_FREQ`), so every cycle-denominated backstop on the host-orch path fires at its intended wall-clock. This also makes the `get_tensor_data`/`set_tensor_data` spin-wait timeout effective on the host. All three weak host fallbacks are updated consistently so no build variant links a return-0 definition.

## Repro (before: hangs forever; after: fails in ~500 ms)
```
PTO2_RING_HEAP=1024 pytest tests/st/a2a3/host_build_graph/matmul --platform a2a3sim
```
→ `FATAL: Task Allocator Deadlock - Heap Exhausted! No reclaim progress for ~500 ms (25000000 cycles wall clock)` + `RuntimeError: run failed`, instead of spinning.

## Testing
- [x] a2a3sim + a2a3 build `-Werror`
- [x] a2a3sim `host_build_graph` scene suite 10/10 (no regression from the real-time counter)
- [x] tiny-heap overflow repro terminates cleanly (exit 1, not a timeout)
- Device-orch (tensormap) and a5 untouched.
