### PR TITLE
Sync: host_build_graph tmr parity catch-up (per-device timeout, tensor-timeout ms, scope_tasks_cap)

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -46,7 +46,9 @@ One extra step versus get_tensor_data: wait for all consumers to finish (`fanout
 ### 3.3 Timeout
 
 - Uses cycle counter (`get_sys_cnt_aicpu()`), checked every 1024 spins
-- Threshold: `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` (~10 s at 1.5 GHz)
+- Threshold: `PTO2_TENSOR_DATA_TIMEOUT_MS` (15 s), scaled to
+  `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` via `PLATFORM_PROF_SYS_CNT_FREQ` so it reaps
+  at the same wall-clock on every arch
 - On timeout: sets `orch.fatal = true`, preventing further task submission
 
 ## 4. add_output with Initial Value

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -584,10 +584,10 @@ static bool prepare_task(
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         // scope_tasks lives in the per-Worker arena (single backing allocation),
-        // so realloc is not legal. Capacity == PTO2_SCOPE_TASKS_CAP ==
-        // PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH, the total in-flight slot
-        // budget — hitting it means every ring is saturated, so no further push
-        // could succeed regardless of buffer growth.
+        // so realloc is not legal. Capacity is the total in-flight slot budget
+        // (the runtime task window; see reserve_layout) — hitting it means the
+        // ring is saturated, so no further push could succeed regardless of
+        // buffer growth.
         orch->report_fatal(
             PTO2_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
             "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -55,6 +55,13 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
            static_cast<uint64_t>(ts.tv_nsec) * PLATFORM_PROF_SYS_CNT_FREQ / 1000000000ull;
 }
 
+// Derived here, not in pto_runtime2_types.h: that header is included by orchestrations
+// that define PLATFORM_PROF_SYS_CNT_FREQ locally, so pulling the platform header into
+// it caused a redefinition conflict (#1189). Scaling MS by the counter frequency (like
+// SCHEDULER_TIMEOUT_CYCLES) keeps the data-wait wall-clock identical across arches.
+static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
+    (PTO2_TENSOR_DATA_TIMEOUT_MS * PLATFORM_PROF_SYS_CNT_FREQ) / 1000;
+
 // =============================================================================
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -113,9 +113,15 @@
 #define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
 #define PTO2_DEP_POOL_CLEANUP_INTERVAL 64   // Cleanup every N retired tasks
 
-// get_tensor_data/set_tensor_data spin wait timeout in cycles.
-// ~10s on hardware (1.5 GHz counter), ~10s on simulation (chrono-based).
-constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
+// get_tensor_data/set_tensor_data spin-wait timeout, expressed in time. The cycle
+// count (PTO2_TENSOR_DATA_TIMEOUT_CYCLES) is derived from this in pto_runtime2.cpp
+// — its only user — by scaling with the platform counter frequency, like
+// SCHEDULER_TIMEOUT_CYCLES, so it reaps at the same wall-clock on every arch (a
+// fixed raw cycle count would be 15 s on a5 at 1 GHz but 300 s on a2a3 at 50 MHz).
+// PLATFORM_PROF_SYS_CNT_FREQ is deliberately NOT pulled into this header: it is
+// included by orchestrations that define that constant locally, so doing so caused
+// a redefinition conflict. See issue #1189.
+constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
 
 // =============================================================================
 // Task States

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -17,6 +17,7 @@
 #include "common.h"  // debug_assert
 
 #include "common/unified_log.h"
+#include "aicpu/aicpu_device_config.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
 #include "callable.h"
@@ -977,6 +978,15 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     // "now" so the first budget cycle starts when this thread does, not at
     // an undefined value.
     uint64_t last_progress_ts = get_sys_cnt_aicpu();
+    // Per-device override latched once at worker init by simpler_aicpu_init
+    // (InitArgs.scheduler_timeout_ms -> resident-SO global). 0 means no
+    // override; fall back to the compile-time SCHEDULER_TIMEOUT_CYCLES.
+    uint64_t scheduler_timeout_cycles = SCHEDULER_TIMEOUT_CYCLES;
+    const int32_t scheduler_timeout_ms_override = get_scheduler_timeout_ms();
+    if (scheduler_timeout_ms_override > 0) {
+        scheduler_timeout_cycles =
+            static_cast<uint64_t>(scheduler_timeout_ms_override) * PLATFORM_PROF_SYS_CNT_FREQ / 1000;
+    }
     while (true) {
         if (completed_.load(std::memory_order_acquire)) {
             break;
@@ -1374,7 +1384,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             // case) — refresh last_progress_ts and keep spinning. The
             // STALL diagnostic above still fires periodically so
             // observability is preserved.
-            if (get_sys_cnt_aicpu() - last_progress_ts > SCHEDULER_TIMEOUT_CYCLES) {
+            if (get_sys_cnt_aicpu() - last_progress_ts > scheduler_timeout_cycles) {
                 bool self_owns = self_owns_running_task(thread_idx);
                 bool global_stuck = !self_owns && total_tasks_ > 0 &&
                                     completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -228,7 +228,13 @@ void PTO2SchedulerState::destroy() {
 PTO2OrchestratorLayout
 PTO2OrchestratorState::reserve_layout(DeviceArena &arena, int32_t task_window_size, int32_t dep_pool_capacity) {
     PTO2OrchestratorLayout layout{};
-    layout.scope_tasks_cap = PTO2_SCOPE_TASKS_CAP;
+    // scope_tasks holds every task in the open scope, so its cap is the real
+    // in-flight budget = the (runtime) task window. Using the compile-time
+    // PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when ring_task_window
+    // was enlarged past the default (premature SCOPE_TASKS_OVERFLOW) and
+    // over-allocated it when shrunk. See issue #1188.
+    always_assert(task_window_size > 0);
+    layout.scope_tasks_cap = task_window_size;
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     layout.dep_pool_capacity = dep_pool_capacity;
 


### PR DESCRIPTION
## Summary

Low-priority parity sync of three tmr changes into `host_build_graph`, keeping its scheduler/orchestrator aligned with `tensormap_and_ringbuffer` for cheaper future syncs. Preserves hbg's host-orch invariants.

- **Per-device scheduler timeout** — the no-progress hang gate now honors a per-run override (`get_scheduler_timeout_ms`, latched at worker init), falling back to compile-time `SCHEDULER_TIMEOUT_CYCLES`. Tunable per run without a rebuild.
- **`PTO2_TENSOR_DATA_TIMEOUT` ms-vs-cycles (#1189)** — the `get_tensor_data`/`set_tensor_data` spin-wait timeout is now `PTO2_TENSOR_DATA_TIMEOUT_MS = 15000`, derived to cycles via `PLATFORM_PROF_SYS_CNT_FREQ` → same **15 s** wall-clock on every arch (was raw 15e9 cycles = ~300 s on a2a3's 50 MHz). Effective on the host path too (host clock landed in the overflow-timeout fix #1337).
- **Runtime `scope_tasks_cap` (#1188)** — scope-tasks capacity is now the runtime `task_window_size` instead of compile-time `PTO2_SCOPE_TASKS_CAP`, so a resized `PTO2_RING_TASK_WINDOW` is sized correctly (single-ring reduction of tmr's per-ring sum).

**Not included:** #1336 (early-dispatch queue generations) already reached hbg's copy when it landed — no port needed. #1182 (stall sub-classification) **intentionally skipped** — diagnostics-only, would need `sched_stall_*` SM-header fields + adapting its removed `orchestrator_done_` reference; not worth the risk here.

## Preserved host-orch divergences
Single ring (no `rings[]`/`ring_id`), no execution-time reclaim, flat `runtime->workers`/`runtime->func_id_to_addr_`, no ACK-gate, no `orchestrator_done_`.

## Testing
- [x] All 8 runtime targets build `-Werror`
- [x] a2a3sim `host_build_graph` scene suite 10/10
- [x] a2a3 **onboard** `host_build_graph` suite 10 passed / 1 skipped
- `tensormap_and_ringbuffer` and a5 untouched.
