### PR TITLE
fix(dfx): deps_viewer HTML/DOT node label shows the kernel name

### DIFF
--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -361,8 +361,20 @@ def _merge_task_meta_with_kernel_ids(meta, task_table, func_names=None):
             entry["func_labels"] = [
                 func_names.get(str(slot)) or func_names.get(slot) or f"f{slot}" if slot >= 0 else "-1" for slot in slots
             ]
-            if not entry.get("func_name") and entry["func_labels"]:
-                entry["func_name"] = entry["func_labels"][0]
+            # func_name = the ACTIVE slots' names, order-preserving-deduped.
+            # kernel_ids is [aic, aiv0, aiv1]: an AIC-only task shows the AIC
+            # name, an AIV-only task the AIV name (never the inactive slot's
+            # "-1"), and a MIX task both (e.g. "paged_attention_cce_aic +
+            # paged_attention_cce_aiv"). aiv0/aiv1 usually carry the same
+            # func_id (one AIV kernel on two cores), so the dedup collapses
+            # them to one name.
+            if not entry.get("func_name"):
+                active_names = []
+                for fid in valid_ids:
+                    nm = func_names.get(str(fid)) or func_names.get(fid) or f"f{fid}"
+                    if nm not in active_names:
+                        active_names.append(nm)
+                entry["func_name"] = " + ".join(active_names)
         elif any(s >= 0 for s in slots):
             entry["func_labels"] = [f"f{slot}" if slot >= 0 else "-1" for slot in slots]
         if not entry.get("core_type"):
@@ -445,6 +457,9 @@ def _label(task_id, meta, task_table, fmt_task):
         return f"{base} · alloc"
     if kind == "dummy":
         return f"{base} · dummy"
+    func_name = (meta.get(normalized_task_id) or {}).get("func_name")
+    if func_name:
+        return f"{base} · {func_name}"
     return base
 
 


### PR DESCRIPTION
## Problem

`deps_viewer --format html` (and DOT) left compute nodes unreadable — three gaps:

1. **Node label never showed the kernel name.** `_label` rendered `(ring, task_id)` with only an `· alloc` / `· dummy` suffix, even with `--func-names`. `_merge_task_meta_with_kernel_ids` already resolves each task's func name into `meta`, but `_label` never read it.

2. **AIV-only SPMD tasks showed `· -1`.** The name came from `func_labels[0]` — the AIC slot. `kernel_ids` is `[aic, aiv0, aiv1]`, so an AIV-only task (`[-1, aiv0, -1]`) has an inactive slot 0.

3. **MIX tasks showed only one name.** A MIX task (AIC + AIV, e.g. `[12, 13, 13]`) resolved to just the AIC kernel.

## Fix

1. `_label` appends `· <name>` when resolved.
2/3. Build `func_name` from **every active slot**, order-preserving-deduped:
   - **AIC-only** → the AIC name (`q_proj`)
   - **AIV-only** → the AIV name (`silu`, `rope_qkv`)
   - **MIX (C+V)** → both (`paged_attention_cce_aic + paged_attention_cce_aiv`)

   `aiv0`/`aiv1` usually share a func_id (one AIV kernel on two cores), so the dedup collapses them to one name.

Node labels on a 2-layer qwen3 decode deps.json:
```
(3, 8)  · paged_attention_cce_aic + paged_attention_cce_aiv    (MIX)
(3, 2)  · q_proj                                                (AIC-only)
(3, 213) · silu                                                 (AIV-only, was · -1)
(1, 3)  · lm_head
```
Zero `· -1` nodes after the fix.

alloc/dummy suffixes and text mode (separate `func_id=[...]` path) are unchanged.

## Testing

- `deps_viewer --format html --func-names <name_map.json>` on a qwen3 decode deps.json: AIC / AIV / MIX nodes all carry the correct name(s); MIX shows both; 0 `-1` labels.
- alloc/dummy and text-mode output unchanged.
- pre-commit (ruff/pyright) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)