### PR TITLE
feat(dfx): capture early-dispatch flag in dep_gen, badge it in deps_viewer

### DIFF
--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -449,18 +449,19 @@ def _load_task_meta(deps_path, func_names=None):
     return meta
 
 
-def _label(task_id, meta, task_table, fmt_task):
+def _label(task_id, meta, task_table, fmt_task, marker=""):
     base = fmt_task(task_id)
+    pfx = f"{marker} " if marker else ""
     normalized_task_id = _normalize_task_id(task_id)
     kind = _task_kind(normalized_task_id, meta, task_table)
     if kind == "alloc":
-        return f"{base} · alloc"
+        return f"{pfx}{base} · alloc"
     if kind == "dummy":
-        return f"{base} · dummy"
+        return f"{pfx}{base} · dummy"
     func_name = (meta.get(normalized_task_id) or {}).get("func_name")
     if func_name:
-        return f"{base} · {func_name}"
-    return base
+        return f"{pfx}{base} · {func_name}"
+    return f"{pfx}{base}"
 
 
 _CORE_STYLE = {
@@ -569,12 +570,13 @@ def _arg_row_html(arg, tensor_table, side):
     return f'<TR><TD ALIGN="LEFT" PORT="{port}" BGCOLOR="{bg}">{body}</TD></TR>'
 
 
-def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task):
+def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task, marker=""):
     """Build a Graphviz HTML-like label for a task node showing:
         - input rows (top)     INPUT + INOUT slots
-        - identity header      "(ring, local)"
+        - identity header      "<marker> (ring, local) · <func_name>"
         - output rows (bottom) INOUT + OUTPUT_EXISTING + OUTPUT slots
     INOUT slots appear in BOTH compartments (read-then-write semantics).
+    ``marker`` is the 🔥 / ⭐ early-dispatch badge (empty for most tasks).
     """
     args = task_entry.get("args") if task_entry else None
     if not isinstance(args, list):
@@ -585,10 +587,17 @@ def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task):
     header_bg = _CORE_HEADER_COLOR.get(core_type if isinstance(core_type, str) else "", _HEADER_FALLBACK)
     border_attrs = f'BORDER="1" COLOR="{_SPMD_COLOR}"' if _task_block_num(task_entry) > 1 else 'BORDER="0"'
 
+    ident = fmt_task(task_id)
+    func_name = meta_entry.get("func_name") if meta_entry else None
+    if func_name:
+        ident = f"{ident} · {func_name}"
+    if marker:
+        ident = f"{marker} {ident}"
+
     rows = []
     for a in inputs:
         rows.append(_arg_row_html(a, tensor_table, "in"))
-    rows.append(f'<TR><TD ALIGN="CENTER" BGCOLOR="{header_bg}"><B>{_html_escape(fmt_task(task_id))}</B></TD></TR>')
+    rows.append(f'<TR><TD ALIGN="CENTER" BGCOLOR="{header_bg}"><B>{_html_escape(ident)}</B></TD></TR>')
     for a in outputs:
         rows.append(_arg_row_html(a, tensor_table, "out"))
 
@@ -654,7 +663,7 @@ def _task_blocks_text(task_entry):
     return f"SPMD block num = {block_num}"
 
 
-def _plain_node_attrs(task_id, meta, task_table, fmt_task):
+def _plain_node_attrs(task_id, meta, task_table, fmt_task, marker=""):
     meta_entry = meta.get(task_id)
     kind = _task_kind(task_id, meta, task_table)
     if kind == "submit" and meta_entry:
@@ -665,7 +674,7 @@ def _plain_node_attrs(task_id, meta, task_table, fmt_task):
         style = _DEFAULT_STYLE
 
     task_entry = task_table.get(task_id)
-    label = _dot_escape_label(_label(task_id, meta, task_table, fmt_task))
+    label = _dot_escape_label(_label(task_id, meta, task_table, fmt_task, marker=marker))
     label_attr = f'label="{label}"'
     style_attr = style["style"]
     if _task_block_num(task_entry) > 1:
@@ -741,6 +750,32 @@ def emit_text(edges, nodes, meta, deps_path, annotations=None, tensor_table=None
     return "\n".join(lines) + "\n"
 
 
+def _task_markers(nodes, edges, task_table):
+    """Map task_id -> marker string for the node label.
+
+    🔥 (fire): the task itself is a flagged early-dispatch producer
+        (deps.json ``early_dispatch`` — the submit had allow_early_resolve).
+    ⭐ (star): every one of the task's predecessors is 🔥 (and it has at
+        least one), so the task is fully fed by flagged producers.
+    A task can carry both.
+    """
+    pred_map: dict[int, set] = {}
+    for pred, succ in edges:
+        pred_map.setdefault(succ, set()).add(pred)
+
+    def _flagged(tid):
+        return bool((task_table.get(tid) or {}).get("early_dispatch"))
+
+    markers = {}
+    for tid in nodes:
+        fire = "🔥" if _flagged(tid) else ""
+        preds = pred_map.get(tid, set())
+        star = "⭐" if preds and all(_flagged(p) for p in preds) else ""
+        if fire or star:
+            markers[tid] = fire + star
+    return markers
+
+
 def emit_dot(
     edges,
     nodes,
@@ -772,6 +807,7 @@ def emit_dot(
     task_table = task_table or {}
     hidden_edges = set(hidden_edges or ())
     show_tensor = bool(task_table) if show_tensor_info is None else bool(show_tensor_info and task_table)
+    markers = _task_markers(nodes, edges, task_table)
     lines = [
         "digraph deps {",
         f"  rankdir={direction};",
@@ -781,11 +817,12 @@ def emit_dot(
     ]
     for n in nodes:
         m = meta.get(n)
+        marker = markers.get(n, "")
         if show_tensor and n in task_table:
-            html = _task_node_html(n, task_table.get(n), m, tensor_table, fmt_task)
+            html = _task_node_html(n, task_table.get(n), m, tensor_table, fmt_task, marker=marker)
             lines.append(f"  {_node_id(n)} [shape=none, margin=0, label=<{html}>];")
             continue
-        lines.append(f"  {_node_id(n)} [{_plain_node_attrs(n, meta, task_table, fmt_task)}];")
+        lines.append(f"  {_node_id(n)} [{_plain_node_attrs(n, meta, task_table, fmt_task, marker=marker)}];")
 
     def edge_attr_str(edge_attrs):
         return (" [" + ", ".join(edge_attrs) + "]") if edge_attrs else ""

--- a/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -112,7 +112,7 @@ void dep_gen_aicpu_init();
  *                            hot path writing identity fields itself.
  */
 void dep_gen_aicpu_record_submit(
-    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    uint64_t task_id_raw, bool in_manual_scope, bool early_dispatch, int tensor_count, const void *const *tensor_ptrs,
     const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
     const int32_t kernel_ids[3]
 );

--- a/src/a2a3/platform/include/common/dep_gen.h
+++ b/src/a2a3/platform/include/common/dep_gen.h
@@ -82,6 +82,7 @@ constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 64;
  */
 enum DepGenRecordFlags : uint32_t {
     DEP_GEN_FLAG_IN_MANUAL_SCOPE = 1u << 0,  // submit happened inside a manual scope
+    DEP_GEN_FLAG_EARLY_DISPATCH = 1u << 4,   // submit had allow_early_resolve set (flagged producer)
     DEP_GEN_FLAG_HAS_OVERFLOW = 1u << 1,     // base record: at least one overflow record follows
     DEP_GEN_FLAG_OVERFLOW = 1u << 2,         // this slot is a DepGenOverflowRecord, not a DepGenRecord
     DEP_GEN_FLAG_LAST_OVERFLOW = 1u << 3,    // overflow record: end of chain (no further overflow follows)

--- a/src/a2a3/runtime/host_build_graph/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/dep_gen_replay.cpp
@@ -201,6 +201,7 @@ struct TaskArgEntry {
 struct TaskTableEntry {
     uint64_t task_id;
     bool in_manual_scope;
+    bool early_dispatch;
     int32_t kernel_id[3];  // per-subslot {AIC, AIV0, AIV1}, -1 = inactive
     uint32_t block_num;
     std::vector<TaskArgEntry> args;
@@ -324,6 +325,7 @@ bool write_deps_json(
         // pass these through int(...) and don't care which form they receive.
         out << "{\"task_id\":\"" << t.task_id << '"';
         out << ",\"scope\":\"" << (t.in_manual_scope ? "manual" : "auto") << '"';
+        out << ",\"early_dispatch\":" << (t.early_dispatch ? "true" : "false");
         // Per-subslot kernel ids {AIC, AIV0, AIV1}; INVALID_KERNEL_ID = -1 for
         // inactive subslots. Emitted as a plain int triple — downstream viewers
         // (and the swimlane host post-processor) use it to resolve task_id →
@@ -641,6 +643,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         TaskTableEntry task_entry;
         task_entry.task_id = rec.task_id;
         task_entry.in_manual_scope = in_manual_scope;
+        task_entry.early_dispatch = (rec.flags & DEP_GEN_FLAG_EARLY_DISPATCH) != 0;
         task_entry.kernel_id[0] = rec.kernel_id[0];
         task_entry.kernel_id[1] = rec.kernel_id[1];
         task_entry.kernel_id[2] = rec.kernel_id[2];

--- a/src/a2a3/runtime/host_build_graph/host/dep_gen_replay.h
+++ b/src/a2a3/runtime/host_build_graph/host/dep_gen_replay.h
@@ -31,7 +31,7 @@
  *
  * Output format (deps.json, strided tensor representation):
  *
- *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual",
+ *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual", "early_dispatch":<bool>,
  *                 "args":[{"idx":<i32>, "type":"<arg_type>",
  *                          "tensor_id":<u64>, "dtype":"...", "shape":[...],
  *                          "start_offset":<u64>, "strides":[...]}, ...]}, ...],

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -60,7 +60,7 @@ static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot
 // (same pattern as get_sys_cnt_aicpu / l2_swimlane_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
+    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
 ) {}
 
 // Scope_stats enable gate, queried via the same predicate idiom as
@@ -836,7 +836,7 @@ static TaskOutputTensors submit_task_common(
         }
         const int32_t kernel_ids_capture[3] = {aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id};
         dep_gen_aicpu_record_submit(
-            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
+            task_id.raw, orch->in_manual_scope(), args.allow_early_resolve(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
             args.launch_spec.block_num(), kernel_ids_capture
         );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -201,6 +201,7 @@ struct TaskArgEntry {
 struct TaskTableEntry {
     uint64_t task_id;
     bool in_manual_scope;
+    bool early_dispatch;
     int32_t kernel_id[3];  // per-subslot {AIC, AIV0, AIV1}, -1 = inactive
     uint32_t block_num;
     std::vector<TaskArgEntry> args;
@@ -324,6 +325,7 @@ bool write_deps_json(
         // pass these through int(...) and don't care which form they receive.
         out << "{\"task_id\":\"" << t.task_id << '"';
         out << ",\"scope\":\"" << (t.in_manual_scope ? "manual" : "auto") << '"';
+        out << ",\"early_dispatch\":" << (t.early_dispatch ? "true" : "false");
         // Per-subslot kernel ids {AIC, AIV0, AIV1}; INVALID_KERNEL_ID = -1 for
         // inactive subslots. Emitted as a plain int triple — downstream viewers
         // (and the swimlane host post-processor) use it to resolve task_id →
@@ -641,6 +643,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         TaskTableEntry task_entry;
         task_entry.task_id = rec.task_id;
         task_entry.in_manual_scope = in_manual_scope;
+        task_entry.early_dispatch = (rec.flags & DEP_GEN_FLAG_EARLY_DISPATCH) != 0;
         task_entry.kernel_id[0] = rec.kernel_id[0];
         task_entry.kernel_id[1] = rec.kernel_id[1];
         task_entry.kernel_id[2] = rec.kernel_id[2];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -31,7 +31,7 @@
  *
  * Output format (deps.json, strided tensor representation):
  *
- *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual",
+ *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual", "early_dispatch":<bool>,
  *                 "args":[{"idx":<i32>, "type":"<arg_type>",
  *                          "tensor_id":<u64>, "dtype":"...", "shape":[...],
  *                          "start_offset":<u64>, "strides":[...]}, ...]}, ...],

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -58,7 +58,7 @@ static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot
 // (same pattern as get_sys_cnt_aicpu / l2_swimlane_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
+    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
 ) {}
 
 // Scope_stats enable gate, queried via the same predicate idiom as
@@ -832,7 +832,7 @@ static TaskOutputTensors submit_task_common(
         }
         const int32_t kernel_ids_capture[3] = {aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id};
         dep_gen_aicpu_record_submit(
-            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
+            task_id.raw, orch->in_manual_scope(), args.allow_early_resolve(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
             args.launch_spec.block_num(), kernel_ids_capture
         );

--- a/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -112,7 +112,7 @@ void dep_gen_aicpu_init();
  *                            hot path writing identity fields itself.
  */
 void dep_gen_aicpu_record_submit(
-    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    uint64_t task_id_raw, bool in_manual_scope, bool early_dispatch, int tensor_count, const void *const *tensor_ptrs,
     const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
     const int32_t kernel_ids[3]
 );

--- a/src/a5/platform/include/common/dep_gen.h
+++ b/src/a5/platform/include/common/dep_gen.h
@@ -82,6 +82,7 @@ constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 64;
  */
 enum DepGenRecordFlags : uint32_t {
     DEP_GEN_FLAG_IN_MANUAL_SCOPE = 1u << 0,  // submit happened inside a manual scope
+    DEP_GEN_FLAG_EARLY_DISPATCH = 1u << 4,   // submit had allow_early_resolve set (flagged producer)
     DEP_GEN_FLAG_HAS_OVERFLOW = 1u << 1,     // base record: at least one overflow record follows
     DEP_GEN_FLAG_OVERFLOW = 1u << 2,         // this slot is a DepGenOverflowRecord, not a DepGenRecord
     DEP_GEN_FLAG_LAST_OVERFLOW = 1u << 3,    // overflow record: end of chain (no further overflow follows)

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -201,6 +201,7 @@ struct TaskArgEntry {
 struct TaskTableEntry {
     uint64_t task_id;
     bool in_manual_scope;
+    bool early_dispatch;
     int32_t kernel_id[3];  // per-subslot {AIC, AIV0, AIV1}, -1 = inactive
     uint32_t block_num;
     std::vector<TaskArgEntry> args;
@@ -324,6 +325,7 @@ bool write_deps_json(
         // pass these through int(...) and don't care which form they receive.
         out << "{\"task_id\":\"" << t.task_id << '"';
         out << ",\"scope\":\"" << (t.in_manual_scope ? "manual" : "auto") << '"';
+        out << ",\"early_dispatch\":" << (t.early_dispatch ? "true" : "false");
         // Per-subslot kernel ids {AIC, AIV0, AIV1}; INVALID_KERNEL_ID = -1 for
         // inactive subslots. Emitted as a plain int triple — downstream viewers
         // (and the swimlane host post-processor) use it to resolve task_id →
@@ -641,6 +643,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         TaskTableEntry task_entry;
         task_entry.task_id = rec.task_id;
         task_entry.in_manual_scope = in_manual_scope;
+        task_entry.early_dispatch = (rec.flags & DEP_GEN_FLAG_EARLY_DISPATCH) != 0;
         task_entry.kernel_id[0] = rec.kernel_id[0];
         task_entry.kernel_id[1] = rec.kernel_id[1];
         task_entry.kernel_id[2] = rec.kernel_id[2];

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -31,7 +31,7 @@
  *
  * Output format (deps.json, strided tensor representation):
  *
- *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual",
+ *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual", "early_dispatch":<bool>,
  *                 "args":[{"idx":<i32>, "type":"<arg_type>",
  *                          "tensor_id":<u64>, "dtype":"...", "shape":[...],
  *                          "start_offset":<u64>, "strides":[...]}, ...]}, ...],

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -57,7 +57,7 @@ static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot
 // (same pattern as get_sys_cnt_aicpu / l2_perf_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
+    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
 ) {}
 
 #if SIMPLER_DFX
@@ -816,7 +816,7 @@ static TaskOutputTensors submit_task_common(
         }
         const int32_t kernel_ids_capture[3] = {aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id};
         dep_gen_aicpu_record_submit(
-            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
+            task_id.raw, orch->in_manual_scope(), /*early_dispatch=*/false, tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
             args.launch_spec.core_num(), kernel_ids_capture
         );

--- a/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -152,7 +152,7 @@ void dep_gen_aicpu_init() {
 }
 
 void dep_gen_aicpu_record_submit(
-    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    uint64_t task_id_raw, bool in_manual_scope, bool early_dispatch, int tensor_count, const void *const *tensor_ptrs,
     const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
     const int32_t kernel_ids[3]
 ) {
@@ -252,6 +252,9 @@ void dep_gen_aicpu_record_submit(
     // Cast the enum to uint32_t before the ternary so Linux GCC's -Wextra
     // does not warn about "enumerated and non-enumerated type in conditional".
     uint32_t base_flags = in_manual_scope ? static_cast<uint32_t>(DEP_GEN_FLAG_IN_MANUAL_SCOPE) : 0u;
+    if (early_dispatch) {
+        base_flags |= static_cast<uint32_t>(DEP_GEN_FLAG_EARLY_DISPATCH);
+    }
     if (needed > 1) {
         base_flags |= static_cast<uint32_t>(DEP_GEN_FLAG_HAS_OVERFLOW);
     }


### PR DESCRIPTION
## What

Makes the early-dispatch attribute of tasks visible in the dependency graph. dep_gen never recorded whether a submit was a **flagged early-dispatch producer** (`allow_early_resolve`), so `deps_viewer` couldn't show which tasks drive early dispatch — the key scheduling signal behind the a2a3 `sync_start` cohorts.

## Capture path (runtime)

- `DepGenRecordFlags` gains `DEP_GEN_FLAG_EARLY_DISPATCH` (a2a3 + a5).
- `dep_gen_aicpu_record_submit` takes an `early_dispatch` arg and sets the flag; the orchestrator passes `args.allow_early_resolve()` (a2a3 tmr + host_build_graph). **a5 tmr has no early-dispatch, so it passes `false`.**
- `dep_gen_replay` reads the flag and emits `"early_dispatch":<bool>` per task in `deps.json` (a2a3 + a5, tmr + hbg).

## Visualization (`deps_viewer.py`)

- **🔥** — the task itself is a flagged early-dispatch producer.
- **⭐** — every predecessor of the task is flagged (and it has ≥1), so it is fully fed by flagged producers.
- A task can carry both (**🔥⭐**). Badges prefix the node label in both the plain and rich (HTML-table) DOT node renderers, on top of the kernel name (#1339).

## Testing

Verified onboard: a 2-layer qwen3-14B decode `deps.json` flags **188/646** tasks; the HTML graph shows 🔥 on flagged producers (e.g. `🔥 (3, 3) · q_proj`), ⭐ on fully-flagged-fed consumers, and 🔥⭐ where both hold. simpler rebuilt clean (a2a3 + a5); pre-commit (clang-format/tidy/cpplint/ruff/pyright) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)