### PR TITLE
feat(dfx): scale host drain/collector threads with aicpu_thread_num

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -767,8 +767,10 @@ framework reference.
 a5's `L2SwimlaneCollector` derives from
 `ProfilerBase<L2SwimlaneCollector, L2SwimlaneModule>` and uses the same
 framework abstractions as a2a3, including the same split mgmt +
-collector shard shape (`kMgmtDrainThreadCount` = `kCollectorThreadCount`
-= `PLATFORM_MAX_AICPU_THREADS`, i.e. 7 on a5 vs 4 on a2a3). The
+collector shard shape (`kMaxCollectorThreads` =
+`PLATFORM_MAX_AICPU_THREADS`, i.e. 7 on a5 vs 4 on a2a3, capping the
+shard arrays; the live drain/collector count is
+`min(aicpu_thread_num, kMaxCollectorThreads)`). The
 behavioral deviation from §5.2 is the **transport channel**: a5 has no
 `halHostRegister`, so each device buffer is paired with a
 host-shadow `malloc()` and the mgmt loop synchronizes the two via

--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -326,8 +326,9 @@ a2a3). At shutdown, AICPU flushes any partially-filled buffers via
 a5's `PmuCollector` derives from
 `ProfilerBase<PmuCollector, PmuModule>` and uses the same framework
 abstractions as a2a3, including the same split mgmt + collector shard
-shape (`kMgmtDrainThreadCount` = `kCollectorThreadCount` =
-`PLATFORM_MAX_AICPU_THREADS`, i.e. 7 on a5 vs 4 on a2a3). The
+shape (`kMaxCollectorThreads` = `PLATFORM_MAX_AICPU_THREADS`, i.e. 7 on
+a5 vs 4 on a2a3, capping the shard arrays; the live drain/collector
+count is `min(aicpu_thread_num, kMaxCollectorThreads)`). The
 behavioral deviation from §5.2 is the **transport channel**: a5 has no
 `halHostRegister`, so
 each device buffer is paired with a host-shadow `malloc()` and the

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -162,9 +162,10 @@ Provides:
   before advancing `queue_heads`. On an empty scan, split drain does a short
   busy-poll window before falling back to the 10 us sleep, so micro-bursts
   are less likely to miss AICPU's bounded wait window.
-- Optional collector sharding (`Module::kCollectorThreadCount`) — each
-  collector drains one host ready shard and returns finished buffers through
-  the matching done shard.
+- Optional collector sharding (`Module::kMaxCollectorThreads` caps the shard
+  arrays; the live shard count is the runtime `min(aicpu_thread_num,
+  kMaxCollectorThreads)`) — each collector drains one host ready shard and
+  returns finished buffers through the matching done shard.
 - `poll_and_collect_loop` — per-shard `wait_pop_ready` with a 100 ms cv
   tick, dispatches to `Derived::on_buffer_collected`, then calls
   `manager_.notify_copy_done(...)` itself; idle-timeout hang detector.
@@ -215,10 +216,9 @@ the required members are:
 | `kHostPoolQueueSize` | Optional host done ring depth |
 | `kHostRecycledQueueSize` | Optional per-kind, per-shard recycled ring depth; defaults to `kHostPoolQueueSize` |
 | `kSubsystemName` | Tag used in framework log lines |
-| `kMgmtDrainThreadCount` | Optional; number of mgmt drain shards (defaults to 1) |
-| `kCollectorThreadCount` | Optional number of collector / host ready-queue shards |
+| `kMaxCollectorThreads` | Optional compile-time CAPACITY of the drain / collector shard arrays (defaults to 1); live shard count is the runtime `min(aicpu_thread_num, kMaxCollectorThreads)` set via `set_aicpu_thread_num()` |
 | `refresh_replenish_metadata(mgr, header)` | Optional hook to refresh cached queue metadata before a replenish pass |
-| `recycled_warm_target(kind[, shard]) → int` | Optional startup/runtime low-water mark for shard-local recycled lanes |
+| `recycled_warm_target(kind[, shard_count]) → int` | Optional startup/runtime low-water mark for shard-local recycled lanes; the two-arg form scales the mark with the live shard count |
 | `header_from_shm(void*) → DataHeader*` | Cast shared-memory base to header |
 | `batch_size(int kind) → int` | Per-kind batch-alloc count |
 | `resolve_entry(shm, header, q, entry) → optional<EntrySite>` | Map a popped ready entry to (kind, free_queue, buffer_size, partial info); return `nullopt` to drop |

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -97,13 +97,11 @@ struct PmuModule {
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
     static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
-    static constexpr uint32_t kMaxCoresPerCollectorShard =
-        (PLATFORM_MAX_CORES + PLATFORM_MAX_AICPU_THREADS - 1) / PLATFORM_MAX_AICPU_THREADS;
     static constexpr uint32_t kHostRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
     static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "PmuModule";
-    static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
-    static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
+    // Producers are the scheduler threads that own each core, one per AICPU thread.
+    static constexpr int kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS;
 
     /**
      * Buffers grown by proactive_replenish are batch-allocated up to the
@@ -115,15 +113,16 @@ struct PmuModule {
         return kBatch < 1 ? 1 : kBatch;
     }
 
-    static constexpr int recycled_warm_target(int /*kind*/) {
-        // Keep half of the init-seeded surplus per shard as the steady-state
-        // low-water mark. PMU normally has no init surplus, so retain one
-        // minimal reserve batch instead of scaling by core count.
+    // Each live collector shard owns ceil(cores / shard_count) cores, so the
+    // watermark grows as the shard count shrinks.
+    static constexpr int recycled_warm_target(int /*kind*/, int shard_count) {
         constexpr int kSurplusPerCore = (PLATFORM_PMU_BUFFERS_PER_CORE > PLATFORM_PMU_SLOT_COUNT) ?
                                             (PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT) :
                                             0;
-        constexpr int kInitialSurplus = kSurplusPerCore * static_cast<int>(kMaxCoresPerCollectorShard);
-        return kInitialSurplus > 0 ? (kInitialSurplus + 1) / 2 : 1;
+        int cores_per_shard =
+            shard_count > 0 ? (PLATFORM_MAX_CORES + shard_count - 1) / shard_count : PLATFORM_MAX_CORES;
+        int initial_surplus = kSurplusPerCore * cores_per_shard;
+        return initial_surplus > 0 ? (initial_surplus + 1) / 2 : 1;
     }
 
     static DataHeader *header_from_shm(void *shm) { return get_pmu_header(shm); }

--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -82,6 +82,10 @@ int PmuCollector::init(
         return -1;
     }
 
+    // Must precede the recycled-lane seeding below: push_recycled() folds its
+    // shard argument modulo the manager's shard count.
+    set_aicpu_thread_num(num_threads);
+
     num_cores_ = num_cores;
     num_threads_ = num_threads;
     event_type_ = event_type;

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -103,13 +103,11 @@ struct PmuModule {
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
     static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
-    static constexpr uint32_t kMaxCoresPerCollectorShard =
-        (PLATFORM_MAX_CORES + PLATFORM_MAX_AICPU_THREADS - 1) / PLATFORM_MAX_AICPU_THREADS;
     static constexpr uint32_t kHostRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
     static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "PmuModule";
-    static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
-    static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
+    // Producers are the scheduler threads that own each core, one per AICPU thread.
+    static constexpr int kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS;
 
     /**
      * Buffers grown by proactive_replenish are batch-allocated up to the
@@ -121,15 +119,16 @@ struct PmuModule {
         return kBatch < 1 ? 1 : kBatch;
     }
 
-    static constexpr int recycled_warm_target(int /*kind*/) {
-        // Keep half of the init-seeded surplus per shard as the steady-state
-        // low-water mark. PMU normally has no init surplus, so retain one
-        // minimal reserve batch instead of scaling by core count.
+    // Each live collector shard owns ceil(cores / shard_count) cores, so the
+    // watermark grows as the shard count shrinks.
+    static constexpr int recycled_warm_target(int /*kind*/, int shard_count) {
         constexpr int kSurplusPerCore = (PLATFORM_PMU_BUFFERS_PER_CORE > PLATFORM_PMU_SLOT_COUNT) ?
                                             (PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT) :
                                             0;
-        constexpr int kInitialSurplus = kSurplusPerCore * static_cast<int>(kMaxCoresPerCollectorShard);
-        return kInitialSurplus > 0 ? (kInitialSurplus + 1) / 2 : 1;
+        int cores_per_shard =
+            shard_count > 0 ? (PLATFORM_MAX_CORES + shard_count - 1) / shard_count : PLATFORM_MAX_CORES;
+        int initial_surplus = kSurplusPerCore * cores_per_shard;
+        return initial_surplus > 0 ? (initial_surplus + 1) / 2 : 1;
     }
 
     static DataHeader *header_from_shm(void *shm) { return get_pmu_header(shm); }

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -92,6 +92,10 @@ int PmuCollector::init(
         return -1;
     }
 
+    // Must precede the recycled-lane seeding below: push_recycled() folds its
+    // shard argument modulo the manager's shard count.
+    set_aicpu_thread_num(num_threads);
+
     num_cores_ = num_cores;
     num_threads_ = num_threads;
     event_type_ = event_type;

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -88,8 +88,8 @@ struct DumpModule {
     static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_AICPU_THREADS * PLATFORM_DUMP_BUFFERS_PER_THREAD;
     static constexpr uint32_t kSlotCount = PLATFORM_DUMP_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "DumpModule";
-    static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
-    static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
+    // Producers are the scheduler threads, one per AICPU thread.
+    static constexpr int kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS;
 
     /**
      * Args-dump bursts can be very large; this is the startup-only batch

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -142,13 +142,13 @@ struct DoneInfo {
 };
 
 template <typename Module, typename = void>
-struct ProfilerModuleCollectorThreadCount {
+struct ProfilerModuleMaxCollectorThreads {
     static constexpr int value = 1;
 };
 
 template <typename Module>
-struct ProfilerModuleCollectorThreadCount<Module, std::void_t<decltype(Module::kCollectorThreadCount)>> {
-    static constexpr int value = Module::kCollectorThreadCount;
+struct ProfilerModuleMaxCollectorThreads<Module, std::void_t<decltype(Module::kMaxCollectorThreads)>> {
+    static constexpr int value = Module::kMaxCollectorThreads;
 };
 
 template <typename Module, typename = void>
@@ -284,8 +284,10 @@ class BufferPoolManager {
 
 public:
     using ReadyBufferInfo = typename Module::ReadyBufferInfo;
-    static constexpr int kCollectorShardCount = ProfilerModuleCollectorThreadCount<Module>::value;
-    static_assert(kCollectorShardCount >= 1, "Module::kCollectorThreadCount must be >= 1");
+    // Compile-time CAPACITY of the shard arrays. The number of shards actually
+    // in use is the runtime `shard_count_` (<= this), set via set_shard_count().
+    static constexpr int kMaxCollectorShards = ProfilerModuleMaxCollectorThreads<Module>::value;
+    static_assert(kMaxCollectorShards >= 1, "Module::kMaxCollectorThreads must be >= 1");
     static constexpr size_t kReadyQueueCapacity = ProfilerModuleHostQueueCapacity<Module>::value;
     static constexpr size_t kPoolQueueCapacity = ProfilerModuleHostPoolQueueCapacity<Module>::value;
     static constexpr size_t kRecycledQueueCapacity = ProfilerModuleHostRecycledQueueCapacity<Module>::value;
@@ -318,6 +320,22 @@ public:
         shm_size_ = shm_size;
         device_id_ = device_id;
     }
+
+    /**
+     * Set how many of the kMaxCollectorShards shards are live for this run.
+     * Every shard-indexed method folds its argument modulo this value, so it
+     * must be set before the first push_recycled() — collectors seed their
+     * recycled lanes during init(), ahead of ProfilerBase::start().
+     */
+    void set_shard_count(int n) {
+        if (n < 1 || n > kMaxCollectorShards) {
+            LOG_ERROR("BufferPoolManager: shard_count %d out of range [1, %d]; clamping", n, kMaxCollectorShards);
+            n = n < 1 ? 1 : kMaxCollectorShards;
+        }
+        shard_count_ = n;
+    }
+
+    int shard_count() const { return shard_count_; }
 
     /**
      * Release every device buffer the framework currently owns: recycled
@@ -784,8 +802,8 @@ public:
     }
 
     void *pop_recycled_for_startup(int kind) {
-        for (size_t shard = 0; shard < recycled_.size(); shard++) {
-            if (void *p = pop_recycled(kind, static_cast<int>(shard)); p != nullptr) return p;
+        for (int shard = 0; shard < shard_count_; shard++) {
+            if (void *p = pop_recycled(kind, shard); p != nullptr) return p;
         }
         return nullptr;
     }
@@ -821,16 +839,16 @@ public:
 
     size_t recycled_count(int kind) const {
         size_t total = 0;
-        for (size_t shard = 0; shard < recycled_.size(); shard++) {
-            total += recycled_[shard][kind].size();
+        for (int shard = 0; shard < shard_count_; shard++) {
+            total += recycled_[static_cast<size_t>(shard)][kind].size();
         }
         return total;
     }
 
     bool recycled_empty() const {
-        for (size_t shard = 0; shard < recycled_.size(); shard++) {
+        for (int shard = 0; shard < shard_count_; shard++) {
             for (int kind = 0; kind < Module::kBufferKinds; kind++) {
-                if (!recycled_[shard][kind].empty()) return false;
+                if (!recycled_[static_cast<size_t>(shard)][kind].empty()) return false;
             }
         }
         return true;
@@ -856,8 +874,8 @@ public:
 
     size_t drain_done_into_recycled() {
         size_t drained = 0;
-        for (size_t shard = 0; shard < done_shards_.size(); shard++) {
-            drained += drain_done_into_recycled(static_cast<int>(shard));
+        for (int shard = 0; shard < shard_count_; shard++) {
+            drained += drain_done_into_recycled(shard);
         }
         return drained;
     }
@@ -919,9 +937,9 @@ private:
         DoneRing queue;
     };
 
-    static size_t normalize_shard(int shard_index) {
+    size_t normalize_shard(int shard_index) const {
         if (shard_index < 0) return 0;
-        return static_cast<size_t>(shard_index) % static_cast<size_t>(kCollectorShardCount);
+        return static_cast<size_t>(shard_index) % static_cast<size_t>(shard_count_);
     }
 
     static size_t align_up(size_t value, size_t alignment) {
@@ -973,11 +991,18 @@ private:
     int device_id_{-1};
     MemoryOps ops_;
 
+    // Live shard count for this run; <= kMaxCollectorShards. Written once by
+    // set_shard_count() during the collector's init(), read by the drain,
+    // replenish and collector threads that start() spawns afterwards — the
+    // std::thread constructor is the synchronization point, so a plain int
+    // needs no atomic.
+    int shard_count_{kMaxCollectorShards};
+
     // mgmt → collector
-    std::array<ReadyQueueShard, kCollectorShardCount> ready_shards_;
+    std::array<ReadyQueueShard, kMaxCollectorShards> ready_shards_;
 
     // collector → mgmt
-    std::array<DoneQueueShard, kCollectorShardCount> done_shards_;
+    std::array<DoneQueueShard, kMaxCollectorShards> done_shards_;
 
     // Host-side pointer mappings are shared across all collector shards.
     mutable std::mutex mapping_mutex_;
@@ -994,11 +1019,11 @@ private:
     std::unordered_set<void *> malloc_shadows_;
 
     // Local recycled buffer pools indexed by collector shard, then Module-defined kind id.
-    std::array<std::array<RecycledRing, Module::kBufferKinds>, kCollectorShardCount> recycled_;
+    std::array<std::array<RecycledRing, Module::kBufferKinds>, kMaxCollectorShards> recycled_;
 
     // Error-path holding pools for buffers removed from recycled_ or popped
     // from device ready queues but not published to a collector/free_queue.
-    std::array<std::array<RetiredPool, Module::kBufferKinds>, kCollectorShardCount> retired_;
+    std::array<std::array<RetiredPool, Module::kBufferKinds>, kMaxCollectorShards> retired_;
 };
 
 }  // namespace profiling_common

--- a/src/common/platform/include/host/dep_gen_collector.h
+++ b/src/common/platform/include/host/dep_gen_collector.h
@@ -88,8 +88,10 @@ struct DepGenModule {
     static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_AICPU_THREADS * PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE;
     static constexpr uint32_t kSlotCount = PLATFORM_DEP_GEN_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "DepGenModule";
-    static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
-    static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
+    // The orchestrator is the sole device-side producer (dep_gen_collector_aicpu
+    // enqueues into queues[s_orch_thread_idx]), so one drain thread scanning
+    // every AICPU ready queue covers it; further shards would only ever be empty.
+    static constexpr int kMaxCollectorThreads = 1;
 
     /**
      * Startup-only batch allocation size for proactive_replenish when the

--- a/src/common/platform/include/host/l2_swimlane_collector.h
+++ b/src/common/platform/include/host/l2_swimlane_collector.h
@@ -88,8 +88,6 @@ struct L2SwimlaneModule {
         PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE +
         PLATFORM_MAX_AICPU_THREADS * (PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD + PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD) +
         PLATFORM_MAX_CORES * PLATFORM_AICORE_BUFFERS_PER_CORE;
-    static constexpr uint32_t kMaxCoresPerCollectorShard =
-        (PLATFORM_MAX_CORES + PLATFORM_MAX_AICPU_THREADS - 1) / PLATFORM_MAX_AICPU_THREADS;
     static constexpr uint32_t kAicpuTaskRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE;
     static constexpr uint32_t kAicoreTaskRecycledQueueSize = PLATFORM_MAX_CORES * PLATFORM_AICORE_BUFFERS_PER_CORE;
     static constexpr uint32_t kPhaseRecycledQueueSize =
@@ -105,8 +103,9 @@ struct L2SwimlaneModule {
                                                                        kPhaseRecycledQueueSize));
     static constexpr uint32_t kSlotCount = PLATFORM_PROF_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "L2SwimlaneModule";
-    static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
-    static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
+    // Producers are the scheduler threads (task / sched-phase records) plus the
+    // orchestrator (orch-phase records) — one per AICPU thread.
+    static constexpr int kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS;
 
     /**
      * Startup-only batch allocation size for proactive_replenish. Sched and
@@ -139,23 +138,28 @@ struct L2SwimlaneModule {
     // The recycled watermark is a steady-state low-water mark, not an
     // additional startup preallocation target. Keep half of the init-seeded
     // surplus per shard; kinds with no surplus keep a minimal reserve.
-    static constexpr int half_initial_surplus_warm_target(int buffers_per_core) {
+    // Cores are spread across the live collector shards, so each shard owns
+    // ceil(cores / shard_count) of them. The watermark must therefore grow as
+    // the shard count shrinks — sizing it against the platform's max thread
+    // count instead would under-provision a run with fewer AICPU threads.
+    static constexpr int cores_per_shard(int shard_count) {
+        return shard_count > 0 ? (PLATFORM_MAX_CORES + shard_count - 1) / shard_count : PLATFORM_MAX_CORES;
+    }
+
+    static constexpr int half_initial_surplus_warm_target(int buffers_per_core, int shard_count) {
         int surplus_per_core = buffers_per_core > static_cast<int>(PLATFORM_PROF_SLOT_COUNT) ?
                                    buffers_per_core - static_cast<int>(PLATFORM_PROF_SLOT_COUNT) :
                                    0;
-        int initial_surplus = surplus_per_core * static_cast<int>(kMaxCoresPerCollectorShard);
+        int initial_surplus = surplus_per_core * cores_per_shard(shard_count);
         return initial_surplus > 0 ? (initial_surplus + 1) / 2 : 1;
     }
 
-    static constexpr int recycled_warm_target(int kind) {
-        constexpr int kAicpuTaskWarmTarget = half_initial_surplus_warm_target(PLATFORM_PROF_BUFFERS_PER_CORE);
-        constexpr int kAicoreTaskWarmTarget = half_initial_surplus_warm_target(PLATFORM_AICORE_BUFFERS_PER_CORE);
-
+    static constexpr int recycled_warm_target(int kind, int shard_count) {
         switch (static_cast<L2SwimlaneBufferKind>(kind)) {
         case L2SwimlaneBufferKind::AicpuTask:
-            return kAicpuTaskWarmTarget;
+            return half_initial_surplus_warm_target(PLATFORM_PROF_BUFFERS_PER_CORE, shard_count);
         case L2SwimlaneBufferKind::AicoreTask:
-            return kAicoreTaskWarmTarget;
+            return half_initial_surplus_warm_target(PLATFORM_AICORE_BUFFERS_PER_CORE, shard_count);
         case L2SwimlaneBufferKind::AicpuSchedPhase:
         case L2SwimlaneBufferKind::AicpuOrchPhase:
             return 0;

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -45,10 +45,15 @@
  *   static constexpr uint32_t kHostRecycledQueueSize;
  *   static constexpr uint32_t kSlotCount;      // FreeQueue::buffer_ptrs[] length.
  *   static constexpr const char* kSubsystemName; // "PMU" / "L2Swimlane" / "Dump".
- *   // Optional: number of mgmt drain shards (defaults to 1).
- *   static constexpr int      kMgmtDrainThreadCount;
- *   // Optional: number of collector threads / host ready-queue shards.
- *   static constexpr int      kCollectorThreadCount;
+ *   // Optional: CAPACITY of the drain / collector shard arrays (defaults to
+ *   // 1). Bounds the shard arrays at compile time; the number of threads
+ *   // actually started is the runtime min(aicpu_thread_num,
+ *   // kMaxCollectorThreads), latched by ProfilerBase::set_aicpu_thread_num().
+ *   // Subsystems whose only device-side producer is the orchestrator (DepGen,
+ *   // ScopeStats) set this to 1: one drain thread scans every AICPU ready
+ *   // queue and finds the single producer's, so extra shards would only ever
+ *   // be empty.
+ *   static constexpr int      kMaxCollectorThreads;
  *   // Optional: refresh cached queue metadata before a replenish pass.
  *   template <typename Mgr>
  *   static void refresh_replenish_metadata(Mgr&, DataHeader*);
@@ -58,6 +63,15 @@
  *
  *   // Per-kind alloc batch size for proactive_replenish's free-queue fallback.
  *   static int batch_size(int kind);
+ *
+ *   // Optional: steady-state low-water mark for a shard-local recycled lane.
+ *   // Two forms; the two-arg one wins if both are present:
+ *   //   static int recycled_warm_target(int kind);
+ *   //   static int recycled_warm_target(int kind, int shard_count);
+ *   // Take the two-arg form when the target depends on how many shards share
+ *   // the device's cores — with `shard_count` live shards each one owns
+ *   // ceil(cores / shard_count) cores, so the target must grow as shards
+ *   // shrink. Omitting both means no watermark (0).
  *
  *   // Required only when kBufferKinds > 1: discriminate which recycled bin
  *   // a finished buffer belongs to. Single-kind modules omit this method;
@@ -191,16 +205,6 @@
 #include "host/profiling_copy.h"
 
 namespace profiling_common {
-
-template <typename Module, typename = void>
-struct ProfilerModuleDrainThreadCount {
-    static constexpr int value = 1;
-};
-
-template <typename Module>
-struct ProfilerModuleDrainThreadCount<Module, std::void_t<decltype(Module::kMgmtDrainThreadCount)>> {
-    static constexpr int value = Module::kMgmtDrainThreadCount;
-};
 
 template <typename Derived, typename ReadyBufferInfo, typename = void>
 struct ProfilerDerivedShardAwareCollector {
@@ -468,11 +472,12 @@ struct ProfilerAlgorithms {
             }
         });
 
+        const int shard_count = mgr.shard_count();
         uint64_t pushed = 0;
         for (int kind = 0; kind < Module::kBufferKinds; kind++) {
             if (buffer_sizes[static_cast<size_t>(kind)] == 0) continue;
-            for (int shard = 0; shard < static_cast<int>(Mgr::kCollectorShardCount); shard++) {
-                size_t target = clamped_recycled_warm_target<Mgr>(kind, shard);
+            for (int shard = 0; shard < shard_count; shard++) {
+                size_t target = clamped_recycled_warm_target<Mgr>(kind, shard, shard_count);
                 if (target == 0) continue;
                 size_t current = mgr.recycled_count(kind, shard);
                 if (current >= target) continue;
@@ -488,11 +493,17 @@ struct ProfilerAlgorithms {
     }
 
 private:
-    static int recycled_warm_target(int kind, int shard) { return recycled_warm_target_impl(kind, shard, 0); }
+    // Modules that scale their watermark with the number of live shards (the
+    // per-shard core load is ceil(cores / shard_count)) implement the two-arg
+    // form; shard-count-independent modules implement the one-arg form.
+    static int recycled_warm_target(int kind, int shard_count) {
+        return recycled_warm_target_impl(kind, shard_count, 0);
+    }
 
     template <typename M = Module>
-    static auto recycled_warm_target_impl(int kind, int shard, int) -> decltype(M::recycled_warm_target(kind, shard)) {
-        return M::recycled_warm_target(kind, shard);
+    static auto recycled_warm_target_impl(int kind, int shard_count, int)
+        -> decltype(M::recycled_warm_target(kind, shard_count)) {
+        return M::recycled_warm_target(kind, shard_count);
     }
 
     template <typename M = Module>
@@ -503,8 +514,8 @@ private:
     static int recycled_warm_target_impl(int, int, ...) { return 0; }
 
     template <typename Mgr>
-    static size_t clamped_recycled_warm_target(int kind, int shard) {
-        int target = recycled_warm_target(kind, shard);
+    static size_t clamped_recycled_warm_target(int kind, int shard, int shard_count) {
+        int target = recycled_warm_target(kind, shard_count);
         if (target <= 0) return 0;
         size_t requested = static_cast<size_t>(target);
         if (requested > Mgr::kRecycledQueueCapacity) {
@@ -631,6 +642,34 @@ private:
 
 public:
     /**
+     * Latch the runtime AICPU thread count. Must be the FIRST thing
+     * Derived::init() does after validating its thread-count argument —
+     * collectors seed their recycled lanes later in init() (via
+     * manager_.push_recycled), and those calls already fold their shard
+     * argument modulo the manager's shard count.
+     *
+     * Two distinct quantities come out of this:
+     *
+     *   queue_count_ — how many DEVICE ready queues exist, i.e. how many AICPU
+     *                  threads can produce. Always `aicpu_thread_num`.
+     *   shard_count_ — how many drain/collector threads (== host shards) to
+     *                  run. Capped by Module::kMaxCollectorThreads, which is 1
+     *                  for the orchestrator-only subsystems (DepGen,
+     *                  ScopeStats): they have a single device-side producer, so
+     *                  one drain thread scanning all `queue_count_` queues is
+     *                  the whole job.
+     *
+     * The two are equal for the subsystems whose producers are the scheduler
+     * threads (L2Swimlane, ArgsDump, PMU).
+     */
+    void set_aicpu_thread_num(int aicpu_thread_num) {
+        queue_count_ = aicpu_thread_num;
+        shard_count_ = std::min(aicpu_thread_num, Manager::kMaxCollectorShards);
+        manager_.set_shard_count(shard_count_);
+        thread_num_set_ = true;
+    }
+
+    /**
      * Stash the memory context produced by Derived::init(). Must be called
      * on the init() success path; if init aborts before this, start(tf) is
      * a no-op.
@@ -697,6 +736,21 @@ public:
     void start(const ThreadFactory &thread_factory) {
         if (shm_host_ == nullptr) return;
 
+        if (!thread_num_set_) {
+            LOG_WARN(
+                "%s: set_aicpu_thread_num() never called; falling back to %d shards", Derived::kSubsystemName,
+                shard_count_
+            );
+        }
+        if (shard_count_ < 1 || shard_count_ > Manager::kMaxCollectorShards || queue_count_ < 1 ||
+            queue_count_ > PLATFORM_MAX_AICPU_THREADS) {
+            LOG_ERROR(
+                "%s: invalid thread counts (shards=%d max=%d, queues=%d max=%d); not starting", Derived::kSubsystemName,
+                shard_count_, Manager::kMaxCollectorShards, queue_count_, PLATFORM_MAX_AICPU_THREADS
+            );
+            return;
+        }
+
         MemoryOps ops;
         ops.alloc = alloc_cb_;
         ops.free_ = free_cb_;
@@ -745,64 +799,38 @@ public:
             (void)ProfilerAlgorithms<Module>::proactive_replenish(manager_, header);
         }
 
-        constexpr int kDrainThreads = ProfilerModuleDrainThreadCount<Module>::value;
-        constexpr int kCollectorThreads = ProfilerModuleCollectorThreadCount<Module>::value;
-        static_assert(kDrainThreads >= 1, "kMgmtDrainThreadCount must be >= 1");
-        static_assert(kCollectorThreads >= 1, "kCollectorThreadCount must be >= 1");
-        static_assert(
-            kCollectorThreads % kDrainThreads == 0,
-            "SPSC host queues require each collector shard to be fed by one drain thread"
-        );
+        // Drain and collector counts are the same value, so every ready shard
+        // has exactly one drain-thread producer — the SPSC invariant the host
+        // queues rely on.
+        const int n = shard_count_;
 
         mgmt_running_.store(true, std::memory_order_release);
-        {
-            if constexpr (kDrainThreads == 1) {
-                if (thread_factory) {
-                    mgmt_thread_ = thread_factory([this]() {
-                        mgmt_drain_loop(0, 1);
-                    });
-                } else {
-                    mgmt_thread_ = std::thread(&ProfilerBase::mgmt_drain_loop, this, 0, 1);
-                }
-            } else {
-                mgmt_drain_threads_.reserve(kDrainThreads);
-                for (int i = 0; i < kDrainThreads; i++) {
-                    if (thread_factory) {
-                        mgmt_drain_threads_.push_back(thread_factory([this, i]() {
-                            mgmt_drain_loop(i, kDrainThreads);
-                        }));
-                    } else {
-                        mgmt_drain_threads_.emplace_back(&ProfilerBase::mgmt_drain_loop, this, i, kDrainThreads);
-                    }
-                }
-            }
+        mgmt_drain_threads_.reserve(n);
+        for (int i = 0; i < n; i++) {
             if (thread_factory) {
-                mgmt_replenish_thread_ = thread_factory([this]() {
-                    mgmt_replenish_loop();
-                });
+                mgmt_drain_threads_.push_back(thread_factory([this, i, n]() {
+                    mgmt_drain_loop(i, n);
+                }));
             } else {
-                mgmt_replenish_thread_ = std::thread(&ProfilerBase::mgmt_replenish_loop, this);
+                mgmt_drain_threads_.emplace_back(&ProfilerBase::mgmt_drain_loop, this, i, n);
             }
         }
-
-        if constexpr (kCollectorThreads == 1) {
-            if (thread_factory) {
-                collector_thread_ = thread_factory([this]() {
-                    poll_and_collect_loop(0, 1);
-                });
-            } else {
-                collector_thread_ = std::thread(&ProfilerBase::poll_and_collect_loop, this, 0, 1);
-            }
+        if (thread_factory) {
+            mgmt_replenish_thread_ = thread_factory([this]() {
+                mgmt_replenish_loop();
+            });
         } else {
-            collector_threads_.reserve(kCollectorThreads);
-            for (int i = 0; i < kCollectorThreads; i++) {
-                if (thread_factory) {
-                    collector_threads_.push_back(thread_factory([this, i]() {
-                        poll_and_collect_loop(i, kCollectorThreads);
-                    }));
-                } else {
-                    collector_threads_.emplace_back(&ProfilerBase::poll_and_collect_loop, this, i, kCollectorThreads);
-                }
+            mgmt_replenish_thread_ = std::thread(&ProfilerBase::mgmt_replenish_loop, this);
+        }
+
+        collector_threads_.reserve(n);
+        for (int i = 0; i < n; i++) {
+            if (thread_factory) {
+                collector_threads_.push_back(thread_factory([this, i]() {
+                    poll_and_collect_loop(i);
+                }));
+            } else {
+                collector_threads_.emplace_back(&ProfilerBase::poll_and_collect_loop, this, i);
             }
         }
     }
@@ -821,9 +849,6 @@ public:
      */
     void stop() {
         mgmt_running_.store(false, std::memory_order_release);
-        if (mgmt_thread_.joinable()) {
-            mgmt_thread_.join();
-        }
         for (auto &thread : mgmt_drain_threads_) {
             if (thread.joinable()) {
                 thread.join();
@@ -834,9 +859,6 @@ public:
             mgmt_replenish_thread_.join();
         }
         execution_complete_.store(true, std::memory_order_release);
-        if (collector_thread_.joinable()) {
-            collector_thread_.join();
-        }
         for (auto &thread : collector_threads_) {
             if (thread.joinable()) {
                 thread.join();
@@ -851,8 +873,14 @@ public:
 protected:
     Manager manager_;
     std::atomic<bool> execution_complete_{false};
-    std::thread collector_thread_;
     std::vector<std::thread> collector_threads_;
+
+    // Latched by set_aicpu_thread_num() during Derived::init(); read by the
+    // threads start() spawns. The std::thread constructor is the
+    // synchronization point, so plain ints need no atomic.
+    int queue_count_{PLATFORM_MAX_AICPU_THREADS};
+    int shard_count_{Manager::kMaxCollectorShards};
+    bool thread_num_set_{false};
 
     // Memory context stashed by Derived::init() via set_memory_context().
     // Derived may read these from finalize() / alloc helpers via the
@@ -970,7 +998,7 @@ private:
 
         while (mgmt_running_.load(std::memory_order_relaxed)) {
             bool found_any = false;
-            for (int q = queue_start; q < PLATFORM_MAX_AICPU_THREADS; q += queue_stride) {
+            for (int q = queue_start; q < queue_count_; q += queue_stride) {
                 ReadyEntry entry;
                 while (Alg::try_pop_aicpu_entry(manager_, header, q, entry, true)) {
                     Alg::process_entry(manager_, header, q, entry);
@@ -990,7 +1018,7 @@ private:
             }
         }
 
-        for (int q = queue_start; q < PLATFORM_MAX_AICPU_THREADS; q += queue_stride) {
+        for (int q = queue_start; q < queue_count_; q += queue_stride) {
             ReadyEntry entry;
             while (Alg::try_pop_aicpu_entry(manager_, header, q, entry, true)) {
                 Alg::process_entry(manager_, header, q, entry);
@@ -1024,7 +1052,7 @@ private:
      *      collectors arm this only after a shard has seen traffic, because
      *      an empty shard can be a valid run shape.
      */
-    void poll_and_collect_loop(int shard_index, int shard_count) {
+    void poll_and_collect_loop(int shard_index) {
         const auto wait_tick = std::chrono::milliseconds(100);
         const auto idle_timeout = std::chrono::seconds(Derived::kIdleTimeoutSec);
         std::optional<std::chrono::steady_clock::time_point> idle_start;
@@ -1045,7 +1073,12 @@ private:
                 }
                 break;
             }
-            if (shard_count > 1 && !has_seen_buffer) {
+            // A shard that has never seen a buffer is a valid run shape at any
+            // shard count — a subsystem can legitimately emit nothing for a
+            // whole run. execution_complete_ above is the exit path for that
+            // case; the idle timeout below only guards a shard that saw traffic
+            // and then stalled.
+            if (!has_seen_buffer) {
                 continue;
             }
             if (!idle_start.has_value()) {
@@ -1074,7 +1107,6 @@ private:
         }
     }
 
-    std::thread mgmt_thread_;
     std::vector<std::thread> mgmt_drain_threads_;
     std::thread mgmt_replenish_thread_;
     std::atomic<bool> mgmt_running_{false};

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -92,8 +92,10 @@ struct ScopeStatsModule {
         PLATFORM_MAX_AICPU_THREADS * PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE;
     static constexpr uint32_t kSlotCount = PLATFORM_SCOPE_STATS_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "ScopeStatsModule";
-    static constexpr int kMgmtDrainThreadCount = PLATFORM_MAX_AICPU_THREADS;
-    static constexpr int kCollectorThreadCount = PLATFORM_MAX_AICPU_THREADS;
+    // The orchestrator is the sole device-side producer (scope_stats_collector_aicpu
+    // enqueues into queues[s_orch_thread_idx]), so one drain thread scanning
+    // every AICPU ready queue covers it; further shards would only ever be empty.
+    static constexpr int kMaxCollectorThreads = 1;
 
     static constexpr int batch_size(int /*kind*/) {
         constexpr int kBatch = PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE - PLATFORM_SCOPE_STATS_SLOT_COUNT;

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -55,6 +55,17 @@ int ArgsDumpCollector::initialize(
         LOG_ERROR("ArgsDumpCollector already initialized");
         return -1;
     }
+    if (num_dump_threads <= 0 || num_dump_threads > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "ArgsDumpCollector::initialize: invalid num_dump_threads=%d (valid range: 1-%d)", num_dump_threads,
+            PLATFORM_MAX_AICPU_THREADS
+        );
+        return -1;
+    }
+
+    // Must precede the recycled-lane seeding below: push_recycled() folds its
+    // shard argument modulo the manager's shard count.
+    set_aicpu_thread_num(num_dump_threads);
 
     num_dump_threads_ = num_dump_threads;
     output_prefix_ = output_prefix;

--- a/src/common/platform/shared/host/dep_gen_collector.cpp
+++ b/src/common/platform/shared/host/dep_gen_collector.cpp
@@ -49,10 +49,17 @@ int DepGenCollector::init(
         LOG_ERROR("DepGenCollector already initialized");
         return -1;
     }
-    if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
-        LOG_ERROR("DepGenCollector::init: invalid arguments");
+    if (num_threads <= 0 || num_threads > PLATFORM_MAX_AICPU_THREADS || alloc_cb == nullptr || free_cb == nullptr) {
+        LOG_ERROR(
+            "DepGenCollector::init: invalid arguments (num_threads=%d, valid range: 1-%d)", num_threads,
+            PLATFORM_MAX_AICPU_THREADS
+        );
         return -1;
     }
+
+    // Must precede the recycled-lane seeding below: push_recycled() folds its
+    // shard argument modulo the manager's shard count.
+    set_aicpu_thread_num(num_threads);
 
     num_threads_ = num_threads;
     total_collected_ = 0;

--- a/src/common/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/l2_swimlane_collector.cpp
@@ -112,6 +112,10 @@ int L2SwimlaneCollector::initialize(
         return -1;
     }
 
+    // Must precede the recycled-lane seeding below: push_recycled() folds its
+    // shard argument modulo the manager's shard count.
+    set_aicpu_thread_num(aicpu_thread_num);
+
     num_aicore_ = num_aicore;
     aicpu_thread_num_ = aicpu_thread_num;
     l2_swimlane_level_ = l2_swimlane_level;
@@ -387,12 +391,16 @@ int L2SwimlaneCollector::initialize(
         return 0;
     };
 
-    // Sched: actual scheduler-thread count is unknown at host-alloc time, so
-    // size buffers to the platform max. Orch: a single instance (pool 0), so
-    // allocate buffers for just one pool while still zeroing all MAX states.
+    // The shm layout spans PLATFORM_MAX_AICPU_THREADS pool states (state_count)
+    // because AICPU's pool-array offsets are fixed at that stride, but only the
+    // first `aicpu_thread_num` of them ever get a producer — so buffers are
+    // allocated for those alone. Seeding a pool at t >= aicpu_thread_num would
+    // also push its surplus into recycled lane `t`, which no drain thread owns.
+    // Orch: a single instance (pool 0), so allocate buffers for just one pool
+    // while still zeroing all MAX states.
     if (init_phase_pools(
             static_cast<L2SwimlaneAicpuSchedPhaseBuffer *>(nullptr), get_sched_phase_buffer_state,
-            /*state_count=*/num_phase_threads, /*buffer_count=*/num_phase_threads,
+            /*state_count=*/num_phase_threads, /*buffer_count=*/aicpu_thread_num,
             /*buffers_per_thread=*/PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD, ProfBufferType::AICPU_SCHED_PHASE, "sched"
         ) != 0) {
         return -1;
@@ -465,7 +473,7 @@ size_t L2SwimlaneCollector::normalize_collector_shard(int collector_shard) const
 }
 
 void L2SwimlaneCollector::reset_collector_shards() {
-    const size_t shard_count = static_cast<size_t>(L2SwimlaneModule::kCollectorThreadCount);
+    const size_t shard_count = static_cast<size_t>(manager_.shard_count());
 
     collected_perf_records_.assign(num_aicore_, {});
     collected_aicore_records_.assign(num_aicore_, {});

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -51,14 +51,21 @@ int ScopeStatsCollector::init(
     int num_threads, const ScopeStatsAllocCallback &alloc_cb, ScopeStatsRegisterCallback register_cb,
     const ScopeStatsFreeCallback &free_cb, int device_id
 ) {
-    if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
-        LOG_ERROR("ScopeStatsCollector::init: invalid arguments");
+    if (num_threads <= 0 || num_threads > PLATFORM_MAX_AICPU_THREADS || alloc_cb == nullptr || free_cb == nullptr) {
+        LOG_ERROR(
+            "ScopeStatsCollector::init: invalid arguments (num_threads=%d, valid range: 1-%d)", num_threads,
+            PLATFORM_MAX_AICPU_THREADS
+        );
         return -1;
     }
     if (initialized_) {
         LOG_ERROR("ScopeStatsCollector already initialized");
         return -1;
     }
+
+    // Must precede the recycled-lane seeding below: push_recycled() folds its
+    // shard argument modulo the manager's shard count.
+    set_aicpu_thread_num(num_threads);
 
     total_collected_ = 0;
     records_.clear();

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -68,11 +68,21 @@ class TestL2Swimlane(SceneTestCase):
         ],
     }
 
+    # The host's drain/collector thread count follows aicpu_thread_num, so the
+    # low-thread cases exercise a shard layout the 4-thread default never
+    # reaches. The task-count assertions below are exact, so a record lost to a
+    # mis-sharded buffer fails the run rather than degrading it silently.
     CASES = [
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+        {
+            "name": "aicpu_threads_2",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 3},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -79,11 +79,22 @@ class TestScopeStats(SceneTestCase):
         ],
     }
 
+    # The host runs one drain/collector thread per live shard, and the shard
+    # count follows aicpu_thread_num. Fewer threads means each surviving
+    # recycled lane serves more cores, so the low-thread cases are the ones
+    # that catch an under-provisioned watermark — which surfaces here as a
+    # non-zero `dropped` in the run's scope_stats.jsonl.
     CASES = [
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+        {
+            "name": "aicpu_threads_2",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 3},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -68,11 +68,21 @@ class TestL2Swimlane(SceneTestCase):
         ],
     }
 
+    # The host's drain/collector thread count follows aicpu_thread_num, so the
+    # low-thread cases exercise a shard layout the 4-thread default never
+    # reaches. The task-count assertions below are exact, so a record lost to a
+    # mis-sharded buffer fails the run rather than degrading it silently.
     CASES = [
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
             "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+        {
+            "name": "aicpu_threads_2",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 3},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -79,11 +79,22 @@ class TestScopeStats(SceneTestCase):
         ],
     }
 
+    # The host runs one drain/collector thread per live shard, and the shard
+    # count follows aicpu_thread_num. Fewer threads means each surviving
+    # recycled lane serves more cores, so the low-thread cases are the ones
+    # that catch an under-provisioned watermark — which surfaces here as a
+    # non-zero `dropped` in the run's scope_stats.jsonl.
     CASES = [
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
             "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+        {
+            "name": "aicpu_threads_2",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 3},
             "params": {},
         },
     ]

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -388,6 +388,17 @@ target_include_directories(test_buffer_pool_manager PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/log
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
 )
+add_common_utils_test(test_profiler_base common/test_profiler_base.cpp)
+target_sources(test_profiler_base PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/unified_log_host.cpp
+)
+target_include_directories(test_profiler_base PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+)
+
 add_common_utils_test(test_l3_l2_orch_comm common/test_l3_l2_orch_comm.cpp)
 
 add_executable(test_trb_runtime_temp_buffer

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -39,7 +39,7 @@ struct TestModule {
     using ReadyBufferInfo = TestReadyBufferInfo;
 
     static constexpr int kBufferKinds = 2;
-    static constexpr int kCollectorThreadCount = 4;
+    static constexpr int kMaxCollectorThreads = 4;
     static constexpr uint32_t kReadyQueueSize = 4;
 };
 
@@ -49,7 +49,7 @@ struct SplitCapacityModule {
     using ReadyBufferInfo = TestReadyBufferInfo;
 
     static constexpr int kBufferKinds = 1;
-    static constexpr int kCollectorThreadCount = 1;
+    static constexpr int kMaxCollectorThreads = 1;
     static constexpr uint32_t kReadyQueueSize = 2;
     static constexpr uint32_t kHostPoolQueueSize = 5;
 };
@@ -60,7 +60,7 @@ struct SplitDoneRecycledCapacityModule {
     using ReadyBufferInfo = TestReadyBufferInfo;
 
     static constexpr int kBufferKinds = 1;
-    static constexpr int kCollectorThreadCount = 1;
+    static constexpr int kMaxCollectorThreads = 1;
     static constexpr uint32_t kReadyQueueSize = 2;
     static constexpr uint32_t kHostPoolQueueSize = 5;
     static constexpr uint32_t kHostRecycledQueueSize = 3;
@@ -92,7 +92,7 @@ struct AlgorithmModule {
     using FreeQueue = AlgorithmFreeQueue;
 
     static constexpr int kBufferKinds = 1;
-    static constexpr int kCollectorThreadCount = 1;
+    static constexpr int kMaxCollectorThreads = 1;
     static constexpr uint32_t kReadyQueueSize = 1;
     static constexpr uint32_t kHostPoolQueueSize = 4;
     static constexpr uint32_t kSlotCount = 1;
@@ -125,7 +125,7 @@ struct WarmRecycledModule {
     using FreeQueue = AlgorithmFreeQueue;
 
     static constexpr int kBufferKinds = 1;
-    static constexpr int kCollectorThreadCount = 2;
+    static constexpr int kMaxCollectorThreads = 2;
     static constexpr uint32_t kReadyQueueSize = 1;
     static constexpr uint32_t kHostPoolQueueSize = 8;
     static constexpr uint32_t kHostRecycledQueueSize = 3;
@@ -136,7 +136,9 @@ struct WarmRecycledModule {
 
     static int batch_size(int /*kind*/) { return 1; }
 
-    static int recycled_warm_target(int /*kind*/, int shard) { return shard + 1; }
+    // Two-arg form: the watermark scales with the number of live shards, the
+    // way L2Swimlane/PMU size theirs against ceil(cores / shard_count).
+    static int recycled_warm_target(int /*kind*/, int shard_count) { return shard_count; }
 
     static std::optional<profiling_common::EntrySite<WarmRecycledModule>>
     resolve_entry(void * /*shm_host*/, DataHeader *header, int /*q*/, const ReadyEntry &entry) {
@@ -161,7 +163,7 @@ struct WarmBatchModule {
     using FreeQueue = AlgorithmFreeQueue;
 
     static constexpr int kBufferKinds = 1;
-    static constexpr int kCollectorThreadCount = 1;
+    static constexpr int kMaxCollectorThreads = 1;
     static constexpr uint32_t kReadyQueueSize = 1;
     static constexpr uint32_t kHostPoolQueueSize = 16;
     static constexpr uint32_t kHostRecycledQueueSize = 16;
@@ -226,7 +228,7 @@ TEST(SpscRingTest, ConcurrentProducerConsumerPreservesFifo) {
 
 TEST(BufferPoolManagerShardingTest, ReadyShardsAreIndependent) {
     using Manager = profiling_common::BufferPoolManager<TestModule>;
-    static_assert(Manager::kCollectorShardCount == 4);
+    static_assert(Manager::kMaxCollectorShards == 4);
 
     Manager manager;
     ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000), 0}, 0));
@@ -398,10 +400,52 @@ TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsAllocatesToRuntimeWate
     };
     manager.set_memory_context(std::move(ops), nullptr, &header, sizeof(header), 0);
 
-    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmRecycledModule>::replenish_recycled_pools(manager, &header), 3u);
-    EXPECT_EQ(manager.recycled_count(0, 0), 1u);
+    // Default shard count is the compile-time max (2), so the module's
+    // shard_count-derived target is 2 and both lanes fill to it.
+    EXPECT_EQ(manager.shard_count(), 2);
+    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmRecycledModule>::replenish_recycled_pools(manager, &header), 4u);
+    EXPECT_EQ(manager.recycled_count(0, 0), 2u);
     EXPECT_EQ(manager.recycled_count(0, 1), 2u);
     EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmRecycledModule>::replenish_recycled_pools(manager, &header), 0u);
+
+    manager.release_owned_buffers([](void *p) {
+        std::free(p);
+    });
+    manager.clear_mappings();
+}
+
+// Shrinking the shard count must (a) leave the unused lanes untouched and
+// (b) raise the per-lane watermark, since the surviving lane now serves the
+// work the retired ones used to. Getting (b) wrong starves the drain thread's
+// recycled lane and silently drops device records.
+TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsFollowsRuntimeShardCount) {
+    using Manager = profiling_common::BufferPoolManager<WarmRecycledModule>;
+
+    Manager manager;
+    AlgorithmHeader header{};
+    profiling_common::MemoryOps ops;
+    ops.alloc = [](size_t size) {
+        return std::malloc(size);
+    };
+    ops.reg = [](void *dev_ptr, size_t /*size*/, int /*device_id*/, void **host_ptr_out) {
+        *host_ptr_out = dev_ptr;
+        return 0;
+    };
+    ops.free_ = [](void *dev_ptr) {
+        std::free(dev_ptr);
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, &header, sizeof(header), 0);
+
+    manager.set_shard_count(1);
+    EXPECT_EQ(manager.shard_count(), 1);
+
+    // One live lane, and the module's target is now 1 (== shard_count). The
+    // summing overload only walks the live lanes, so it equals lane 0 exactly —
+    // nothing was allocated into the lane the shrink retired.
+    EXPECT_EQ(profiling_common::ProfilerAlgorithms<WarmRecycledModule>::replenish_recycled_pools(manager, &header), 1u);
+    EXPECT_EQ(manager.recycled_count(0, 0), 1u);
+    EXPECT_EQ(manager.recycled_count(0), 1u);
 
     manager.release_owned_buffers([](void *p) {
         std::free(p);

--- a/tests/ut/cpp/common/test_profiler_base.cpp
+++ b/tests/ut/cpp/common/test_profiler_base.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * ProfilerBase start/stop and thread-fanout tests.
+ *
+ * The framework runs `min(aicpu_thread_num, Module::kMaxCollectorThreads)`
+ * drain+collector threads while scanning `aicpu_thread_num` device ready
+ * queues. Those two counts are equal for the scheduler-fed subsystems
+ * (L2Swimlane / TensorDump / PMU) but differ for the orchestrator-only ones
+ * (DepGen / ScopeStats), whose single producer writes the LAST queue while
+ * only one shard exists. Both shapes are covered here.
+ */
+
+#include "host/profiler_base.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kReadyQueueSize = 8;
+constexpr uint32_t kSlotCount = 4;
+
+struct TestFreeQueue {
+    volatile uint32_t head{0};
+    volatile uint32_t tail{0};
+    volatile uint64_t buffer_ptrs[kSlotCount]{};
+};
+
+struct TestReadyEntry {
+    uint64_t buffer_ptr{0};
+    uint32_t buffer_seq{0};
+};
+
+// Mirrors the real subsystems: the ready-queue array is dimensioned by the
+// PLATFORM max (the device shm layout stride is fixed there), while only the
+// first `aicpu_thread_num` rows ever get a producer.
+struct TestHeader {
+    TestReadyEntry queues[PLATFORM_MAX_AICPU_THREADS][kReadyQueueSize];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];
+    TestFreeQueue free_queue;
+};
+
+struct TestReadyBufferInfo {
+    void *dev_buffer_ptr{nullptr};
+    void *host_buffer_ptr{nullptr};
+    uint32_t producer_queue{0};
+};
+
+// Base traits; the two Module flavours below differ only in their shard cap.
+template <int kMaxThreads>
+struct TestModuleBase {
+    using DataHeader = TestHeader;
+    using ReadyEntry = TestReadyEntry;
+    using ReadyBufferInfo = TestReadyBufferInfo;
+    using FreeQueue = TestFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr uint32_t kReadyQueueSize = ::kReadyQueueSize;
+    static constexpr uint32_t kHostPoolQueueSize = 64;
+    static constexpr uint32_t kSlotCount = ::kSlotCount;
+    static constexpr const char *kSubsystemName = "TestModule";
+    static constexpr int kMaxCollectorThreads = kMaxThreads;
+
+    static DataHeader *header_from_shm(void *shm) { return static_cast<DataHeader *>(shm); }
+
+    static int batch_size(int /*kind*/) { return 1; }
+
+    static std::optional<profiling_common::EntrySite<TestModuleBase>>
+    resolve_entry(void * /*shm*/, DataHeader *header, int q, const ReadyEntry &entry) {
+        return profiling_common::EntrySite<TestModuleBase>{
+            0,
+            &header->free_queue,
+            sizeof(uint64_t),
+            TestReadyBufferInfo{reinterpret_cast<void *>(entry.buffer_ptr), nullptr, static_cast<uint32_t>(q)},
+        };
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void * /*shm*/, DataHeader *header, Cb &&cb) {
+        cb(0, &header->free_queue, sizeof(uint64_t));
+    }
+};
+
+// Scheduler-fed shape: one shard per AICPU thread.
+using PerThreadModule = TestModuleBase<PLATFORM_MAX_AICPU_THREADS>;
+// Orchestrator-only shape (DepGen / ScopeStats): a single shard no matter how
+// many AICPU threads run.
+using SingleShardModule = TestModuleBase<1>;
+
+template <typename Module>
+class TestCollector : public profiling_common::ProfilerBase<TestCollector<Module>, Module> {
+public:
+    using Base = profiling_common::ProfilerBase<TestCollector<Module>, Module>;
+    using ReadyBufferInfo = typename Module::ReadyBufferInfo;
+
+    // Deliberately short: a false-positive idle timeout must fail the test fast
+    // rather than stall it.
+    static constexpr int kIdleTimeoutSec = 2;
+    static constexpr const char *kSubsystemName = "TestCollector";
+
+    void on_buffer_collected(const ReadyBufferInfo &info, int collector_shard) {
+        collected_.fetch_add(1, std::memory_order_relaxed);
+        last_producer_queue_.store(info.producer_queue, std::memory_order_relaxed);
+        last_shard_.store(collector_shard, std::memory_order_relaxed);
+    }
+
+    int collected() const { return collected_.load(std::memory_order_relaxed); }
+    uint32_t last_producer_queue() const { return last_producer_queue_.load(std::memory_order_relaxed); }
+    int last_shard() const { return last_shard_.load(std::memory_order_relaxed); }
+
+    // Stand-in for a real Derived::init(): latch the thread count and hand the
+    // base an identity-mapped (SVM-style) memory context.
+    void init(int aicpu_thread_num, void *shm) {
+        this->set_aicpu_thread_num(aicpu_thread_num);
+        this->set_memory_context(
+            [](size_t size) {
+                return std::malloc(size);
+            },
+            /*register_cb=*/nullptr, /*free_cb=*/nullptr, /*copy_to_device=*/nullptr, /*copy_from_device=*/nullptr, shm,
+            shm, sizeof(TestHeader), /*device_id=*/0
+        );
+    }
+
+private:
+    std::atomic<int> collected_{0};
+    std::atomic<uint32_t> last_producer_queue_{0};
+    std::atomic<int> last_shard_{-1};
+};
+
+// Publish one buffer on device queue `q`, exactly as DeviceProfilerEngine's
+// enqueue_ready does: write the entry, then advance the tail. The buffer must
+// already be known to the manager — process_entry drops any entry whose device
+// pointer has no host mapping.
+template <typename Collector>
+void publish(Collector &collector, TestHeader &header, int q, uint64_t *buffer) {
+    collector.manager().register_mapping(buffer, buffer);  // SVM-style identity map
+    uint32_t tail = header.queue_tails[q];
+    header.queues[q][tail].buffer_ptr = reinterpret_cast<uint64_t>(buffer);
+    header.queues[q][tail].buffer_seq = 0;
+    header.queue_tails[q] = (tail + 1) % kReadyQueueSize;
+}
+
+template <typename Collector>
+bool wait_for_collected(const Collector &c, int expected, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (c.collected() >= expected) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return c.collected() >= expected;
+}
+
+}  // namespace
+
+// One drain+collector pair per AICPU thread when the module allows it.
+TEST(ProfilerBaseTest, ShardCountFollowsAicpuThreadNum) {
+    TestHeader header{};
+    TestCollector<PerThreadModule> collector;
+    collector.init(2, &header);
+
+    EXPECT_EQ(collector.manager().shard_count(), 2);
+}
+
+// A module capped at one shard keeps one, however many AICPU threads run.
+TEST(ProfilerBaseTest, ShardCountIsCappedByModuleMax) {
+    TestHeader header{};
+    TestCollector<SingleShardModule> collector;
+    collector.init(PLATFORM_MAX_AICPU_THREADS, &header);
+
+    EXPECT_EQ(collector.manager().shard_count(), 1);
+}
+
+// The DepGen / ScopeStats shape: the sole producer is the orchestrator, which
+// writes the LAST queue (index aicpu_thread_num - 1), while only shard 0
+// exists. The single drain thread must still scan every live queue to find it —
+// bounding the scan by the shard count instead of the queue count would miss
+// the producer entirely and silently collect nothing.
+TEST(ProfilerBaseTest, SingleDrainThreadScansEveryLiveQueue) {
+    constexpr int kThreads = 3;
+    constexpr int kOrchQueue = kThreads - 1;
+
+    TestHeader header{};
+    uint64_t buffer = 0;
+
+    TestCollector<SingleShardModule> collector;
+    collector.init(kThreads, &header);
+    ASSERT_EQ(collector.manager().shard_count(), 1);
+
+    collector.start(nullptr);
+    publish(collector, header, kOrchQueue, &buffer);
+
+    EXPECT_TRUE(wait_for_collected(collector, 1, std::chrono::seconds(5)));
+    collector.stop();
+
+    EXPECT_EQ(collector.collected(), 1);
+    EXPECT_EQ(collector.last_producer_queue(), static_cast<uint32_t>(kOrchQueue));
+    EXPECT_EQ(collector.last_shard(), 0);  // folded onto the only shard
+}
+
+// Every live queue's buffers reach a collector when shards and queues are 1:1.
+TEST(ProfilerBaseTest, EveryLiveQueueIsDrained) {
+    constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS;
+
+    TestHeader header{};
+    uint64_t buffers[kThreads]{};
+
+    TestCollector<PerThreadModule> collector;
+    collector.init(kThreads, &header);
+    collector.start(nullptr);
+
+    for (int q = 0; q < kThreads; q++) {
+        publish(collector, header, q, &buffers[q]);
+    }
+
+    EXPECT_TRUE(wait_for_collected(collector, kThreads, std::chrono::seconds(5)));
+    collector.stop();
+    EXPECT_EQ(collector.collected(), kThreads);
+}
+
+// A subsystem that emits nothing for a whole run is a valid shape: stop() must
+// bring the collector down via execution_complete_, NOT via the idle-timeout
+// hang detector. The guard that used to skip arming the timeout only applied
+// when shard_count > 1, so a single-shard subsystem (DepGen / ScopeStats) would
+// trip it. kIdleTimeoutSec is 2s here and stop() is called well after that, so
+// a regression shows up as a hang or an early-abandoned shard, not a flake.
+TEST(ProfilerBaseTest, SilentRunDoesNotTripIdleTimeout) {
+    TestHeader header{};
+    TestCollector<SingleShardModule> collector;
+    collector.init(2, &header);
+
+    collector.start(nullptr);
+    std::this_thread::sleep_for(std::chrono::seconds(3));  // > kIdleTimeoutSec
+
+    // The collector must still be alive and able to take a late buffer.
+    uint64_t buffer = 0;
+    publish(collector, header, 1, &buffer);
+    EXPECT_TRUE(wait_for_collected(collector, 1, std::chrono::seconds(5)));
+
+    collector.stop();
+    EXPECT_EQ(collector.collected(), 1);
+}


### PR DESCRIPTION
Every enabled DFX subsystem started N drain + 1 replenish + N collector threads with N fixed at compile time to PLATFORM_MAX_AICPU_THREADS (a2a3=4, a5=7), regardless of how many AICPU threads the run launched. The host shard arrays and the proactively-replenished device buffers were sized the same way, so a 2-thread run spun drain/collector threads on queues that provably never get a producer and preallocated device buffers into recycled lanes no drain thread owns.

Split the constant's two roles: the std::array capacity stays compile time (no dynamic allocation, no layout change), while the number of threads/shards in use becomes a runtime value latched in Derived::init() via ProfilerBase::set_aicpu_thread_num(). Three quantities, no longer equal:
  queue_count_ = aicpu_thread_num                     device queues to scan
  shard_count_ = min(n, Module::kMaxCollectorThreads) drain/collector threads
  kMaxCollectorThreads                                std::array capacity

Per-DFX thread construction. kMaxCollectorThreads is set per subsystem by who the sole device-side producer is:
  - L2Swimlane  kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS. Producers are the scheduler threads (task / sched-phase records) plus the orchestrator (orch-phase records), one queue per AICPU thread. shard_count_ == queue_count_ == aicpu_thread_num: drain i owns queue i and feeds collector shard i, 1:1.
  - ArgsDump    kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS. Producers are the scheduler threads, one per AICPU thread. Same 1:1 drain<->queue<->collector shape as L2Swimlane.
  - PMU         kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS. Producers are the scheduler threads that own each core, one per AICPU thread. Same 1:1 shape.
  - DepGen      kMaxCollectorThreads = 1. The orchestrator is the sole device-side producer (enqueues into queues[s_orch_thread_idx]). One drain thread scans all queue_count_ queues to find the single producer, so here queue_count_ > shard_count_ == 1; extra shards would only be empty.
  - ScopeStats  kMaxCollectorThreads = 1. Same orchestrator-only shape as DepGen: one drain thread, one collector shard, scanning every live queue.

SPSC still holds everywhere: drain count == collector count == shard_count_, so each ready shard has exactly one drain-thread producer.

The count is injected through a dedicated setter rather than set_memory_context() because PMU seeds its recycled lanes *before* its set_memory_context() call, and every shard index folds modulo the manager's shard count; set_aicpu_thread_num() must precede the first push_recycled().

Two latent defects fixed alongside, same root cause:
- L2Swimlane/PMU derived their recycled watermark from ceil(MAX_CORES / PLATFORM_MAX_AICPU_THREADS). With fewer live shards each owns more cores, so the watermark was under-provisioned by up to 4x (a2a3) / 7x (a5): the recycled pool runs dry, drain cannot refill the device free_queue, and records are dropped. Now computed from the runtime shard count via the two-arg recycled_warm_target(kind, shard_count); aggregate memory is unchanged.
- L2Swimlane allocated sched-phase buffers for all PLATFORM_MAX_AICPU_THREADS pools, pushing the surplus of pools t >= aicpu_thread_num into recycled lane t, which no drain thread owns. Buffers now follow aicpu_thread_num while the shm layout keeps its fixed PLATFORM_MAX_AICPU_THREADS stride (AICPU's pool offsets depend on it).

Also fixes a failure mode the scaling itself introduces: the collector's idle-timeout guard only exempted never-used shards when shard_count > 1, so a single-shard subsystem (DepGen/ScopeStats) that legitimately emits nothing for a whole run would log "collector idle timeout" and abandon its shard. An empty shard is a valid run shape at any shard count; execution_complete_ is the exit path.

Device shm layout is untouched — this is a host-side change only.

Docs: docs/dfx/dynamic-dfx-thread-scaling.md documents the three-quantity model and the per-subsystem shard shapes; profiling-framework.md, pmu-profiling.md and l2-swimlane-profiling.md describe kMaxCollectorThreads as the array capacity with the live count = min(aicpu_thread_num, cap).

Tests: new tests/ut/cpp/common/test_profiler_base.cpp covers the thread fanout, the queue_count_ > shard_count_ shape, and the idle-timeout regression. The DFX scene tests only ran at aicpu_thread_num=4, which on a2a3 is exactly the degenerate shard_count == max case, so scope_stats and l2_swimlane gain an aicpu_thread_num=2 case. (1 is not a valid config: sched_thread_num = n - 1, so it would leave zero schedulers.)