### PR TITLE
Fix: correct L2 swimlane statistics and SPMD flow anchors

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -476,24 +476,29 @@ dependency / `hb_violation` flows connect via **anchor pairing** on
 the Worker View and Scheduler View task lanes — there is no dedicated
 `SPMD (block-level)` track.
 
-SPMD tasks use the earliest-start subtask row for each
-`(func_id, task_id)` group as the dependency anchor. This keeps one
-representative endpoint per logical function within a task in each view
-and makes the task-dependency arrows share the same anchor records
-as the `complete` flow. The anchor decision includes both the function
-identity and the logical `task_id` (ring/local id), so MIX tasks that
-share a `task_id` across AIC/AIV functions keep separate anchors. The
-converter does not draw one arrow per subtask instance.
+Each view independently selects one SPMD anchor for every
+`(func_id, task_id)` group. The Worker View chooses the earliest visible
+kernel slice: `receive_time_us` when present, including the valid value `0`,
+or `start_time_us` for archived records without a receive timestamp. The
+Scheduler View independently chooses the earliest visible AICPU slice by
+`dispatch_time_us`. Equal start times are resolved by the smaller `core_id`.
+The two views can therefore select different physical subtask records. Within
+each view, dependency and `complete` arrows use that view's selected anchor.
+
+The grouping includes both the function identity and the logical `task_id`
+(ring/local id), so MIX tasks that share a `task_id` across AIC/AIV functions
+keep separate anchors. The converter does not draw one arrow per subtask
+instance.
 
 **`complete` arrows.** Like the dependency mirror, the per-task
 `complete` flow (task → the pid=2 `complete` phase that observed its
-last subtask FIN) is drawn from **both** task views on the same anchor
-rows: the Worker View source anchors on the kernel slice (`end_time_us`),
-the Scheduler View source anchors on the AICPU `finish_time_us`. Both
-mirrors land on the identical pid=2 endpoint (thread + timestamp), so
-clicking the task in either view surfaces the arrow without changing
-completion attribution. The Scheduler View mirror is skipped for an
-anchor with no AICPU finish (its pid=3 bar does not exist).
+last subtask FIN) is drawn from **both** task views using their independently
+selected anchor rows. The Worker View source anchors on the kernel slice
+(`end_time_us`), and the Scheduler View source anchors on the AICPU
+`finish_time_us`. Both arrows land on the identical pid=2 endpoint (thread +
+timestamp), so clicking the task in either view surfaces the arrow without
+changing completion attribution. The Scheduler View arrow is skipped when
+there is no visible AICPU bar.
 
 Non-SPMD tasks (including MIX multi-slot kernels with `block_num == 1`)
 keep every subtask row as an endpoint (N×N pairing unchanged).
@@ -537,7 +542,7 @@ What the swimlane shows:
   so Perfetto draws arrows between predecessor and successor tasks
   — see [§3.5](#35-dependency-arrows-from-dep_gen). Without
   `deps.json` the trace is correct but unarrowed. For SPMD tasks,
-  dependency arrows use the earliest-start subtask row per
+  dependency arrows independently use each view's earliest visible slice per
   `(func_id, task_id)` group as the anchor.
 - **Scheduler-loop time decomposition.** Per-iteration AICPU
   phase records show how long the scheduler spent in each of

--- a/docs/profiling-name-map.md
+++ b/docs/profiling-name-map.md
@@ -144,8 +144,10 @@ so without `deps.json` tasks cannot be told apart by function — see
 
 ## Tool Usage
 
-The `--func-names` flag is available on both visualization tools.  It
-takes precedence over `-k` (kernel_config.py):
+The `--func-names` flag is available on both visualization tools. It takes
+precedence over `-k` (kernel_config.py). When neither option is specified,
+`swimlane_converter` automatically loads a unique sibling `name_map*.json`;
+multiple sibling candidates require an explicit `--func-names` selection.
 
 ```bash
 # Automatic (via SceneTest profiling)

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -39,6 +39,11 @@ python -m simpler_setup.tools.swimlane_converter
 # Specify an input file
 python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json
 
+# A unique sibling name_map*.json is loaded automatically.
+# Override it explicitly when needed:
+python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json \
+    --func-names outputs/<case>_<ts>/name_map_<case>.json
+
 # Specify an output file
 python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json -o custom_output.json
 
@@ -61,6 +66,11 @@ python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane
 > `--enable-l2-swimlane` runs that consume it. If no `deps.json` is found
 > alongside the perf JSON (and `--deps-json` isn't passed), the trace
 > still renders but has no arrows; the converter prints a warning.
+
+When neither `--func-names` nor `--kernel-config` is specified, the converter
+loads a unique `name_map*.json` next to the input file. If that directory
+contains multiple matching files, it prints a warning and uses default function
+labels until one is selected explicitly with `--func-names`.
 
 ### SPMD dependency visualization
 
@@ -90,7 +100,7 @@ SPMD tasks are present.
 | `input` | | Input JSON file (l2_swimlane_records_*.json). If omitted, the latest file in outputs/ is used |
 | `--output` | `-o` | Output JSON file (default: outputs/merged_swimlane_`<timestamp>`.json) |
 | `--kernel-config` | `-k` | Path to kernel_config.py, used for function name mapping |
-| `--func-names` | | Path to func_id_names_*.json (SceneTest format) for function name mapping |
+| `--func-names` | | Path to name_map*.json (SceneTest format) for function name mapping |
 | `--deps-json` | | Path to a dep_gen `deps.json` (defaults to sibling of input). Without one, no dependency arrows are drawn. |
 | `--overhead` | | Add the 8-line Overhead Analysis counter group (needs `deps.json`). See [sched-overhead-model](../../docs/dfx/sched-overhead-model.md). |
 | `--verbose` | `-v` | Enable verbose output |
@@ -114,6 +124,13 @@ A statistics summary grouped by function (printed to the console), including Exe
 - **Latency**: end-to-end latency from the AICPU perspective (finish_time - dispatch_time, including head OH + Exec + tail OH)
 - **Head/Tail OH**: scheduling head/tail overhead
 - **Exec_%**: Exec / Latency percentage (kernel utilization)
+
+The table prints the source `l2_swimlane_level` recorded in
+`l2_swimlane_records.json`. At level 1, only AICore timing is captured, so
+Latency, Exec%, Head/Tail OH, and Propagation render as `-`, including total
+latency in the TOTAL row. Count, Exec, and Local Setup remain available. The
+`Total Test Time` line is omitted and replaced by an `AICore Observed Span`
+summary. Level 2 and above retain the full latency summary.
 
 #### 3. Scheduler Overhead Deep-Dive
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -20,8 +20,9 @@ Usage:
     python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json -k kernel_config.py
     python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json -v
 
-SPMD (block_num>1): dependency flows use min core_id anchors per core_type
-on physical lanes; see docs/dfx/l2-swimlane-profiling.md §3.5.
+SPMD (block_num>1): dependency flows use the earliest visible task slice
+per (func_id, task_id) independently in each view; see
+docs/dfx/l2-swimlane-profiling.md §3.5.
 """
 
 import argparse
@@ -525,12 +526,27 @@ def _identify_spmd_task_ids(task_map, deps_block_map=None):
     return spmd_ids
 
 
-def _dependency_flow_anchor_rows(task_id, task_map, spmd_task_ids):
-    """Dependency anchor rows.
+def _task_slice_start_us(task):
+    """Start of the task slice emitted in Worker View."""
+    receive_time_us = task.get("receive_time_us")
+    return receive_time_us if receive_time_us is not None else task["start_time_us"]
+
+
+def _scheduler_slice_start_us(task):
+    """Start of the task slice emitted in Scheduler View."""
+    dispatch_time_us = task.get("dispatch_time_us")
+    finish_time_us = task.get("finish_time_us")
+    if dispatch_time_us is None or dispatch_time_us < 0 or finish_time_us is None or finish_time_us <= 0:
+        return float("inf")
+    return dispatch_time_us
+
+
+def _flow_anchor_rows(task_id, task_map, spmd_task_ids, slice_start):
+    """Flow anchor rows selected by one view's visible slice start.
 
     Non-SPMD keeps every subtask row. SPMD collapses rows by
-    ``(func_id, task_id)`` and keeps the earliest-start row in each group, so
-    MIX tasks with shared task_id but distinct AIC/AIV func_id values remain
+    ``(func_id, task_id)`` and keeps the earliest visible slice in each group,
+    so MIX tasks with shared task_id but distinct AIC/AIV func_id values remain
     visible as separate dependency endpoints.
     """
     recs = task_map.get(task_id, [])
@@ -542,18 +558,28 @@ def _dependency_flow_anchor_rows(task_id, task_map, spmd_task_ids):
     for row in recs:
         func_id = row.get("func_id", -1)
         prev = by_func.get(func_id)
-        if prev is None or (row.get("start_time_us", float("inf")), row.get("core_id", 0)) < (
-            prev.get("start_time_us", float("inf")),
+        if prev is None or (slice_start(row), row.get("core_id", 0)) < (
+            slice_start(prev),
             prev.get("core_id", 0),
         ):
             by_func[func_id] = row
     return list(by_func.values())
 
 
-def _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids):
-    """(pred_row, succ_row) pairs for one logical dependency edge."""
-    pred_rows = _dependency_flow_anchor_rows(pred_id, task_map, spmd_task_ids)
-    succ_rows = _dependency_flow_anchor_rows(succ_id, task_map, spmd_task_ids)
+def _worker_flow_anchor_rows(task_id, task_map, spmd_task_ids):
+    """Worker View flow anchors."""
+    return _flow_anchor_rows(task_id, task_map, spmd_task_ids, _task_slice_start_us)
+
+
+def _scheduler_flow_anchor_rows(task_id, task_map, spmd_task_ids):
+    """Scheduler View flow anchors."""
+    return _flow_anchor_rows(task_id, task_map, spmd_task_ids, _scheduler_slice_start_us)
+
+
+def _flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids, anchor_rows):
+    """(pred_row, succ_row) pairs for one logical dependency edge in one view."""
+    pred_rows = anchor_rows(pred_id, task_map, spmd_task_ids)
+    succ_rows = anchor_rows(succ_id, task_map, spmd_task_ids)
     if not pred_rows or not succ_rows:
         return []
     return [(pred_row, succ_row) for pred_row in pred_rows for succ_row in succ_rows]
@@ -714,7 +740,7 @@ def load_func_names_json(json_path):
     return data.get("callable_id_to_name", {}), data.get("orchestrator_name")
 
 
-def print_task_statistics(tasks, func_id_to_name=None):
+def print_task_statistics(tasks, func_id_to_name=None, l2_swimlane_level=None):
     """Print task statistics grouped by func_id.
 
     Exec = kernel execution time (end_time_us - start_time_us) on AICore.
@@ -726,7 +752,11 @@ def print_task_statistics(tasks, func_id_to_name=None):
     Args:
         tasks: List of task dicts
         func_id_to_name: Optional dict mapping func_id to function name
+        l2_swimlane_level: Source collection level. Level 1 has no AICPU
+            dispatch/finish timestamps, so latency-derived metrics are unavailable.
     """
+    has_aicpu_timing = l2_swimlane_level is None or l2_swimlane_level >= 2
+
     # Group tasks by func_id with extended metrics
     func_stats: defaultdict[Any, dict[str, Any]] = defaultdict(
         lambda: {
@@ -744,18 +774,27 @@ def print_task_statistics(tasks, func_id_to_name=None):
     # Track global min dispatch and max finish times
     min_dispatch_time = float("inf")
     max_finish_time = float("-inf")
+    min_aicore_time = float("inf")
+    max_aicore_time = float("-inf")
 
     for task in tasks:
         func_id = task["func_id"]
         duration = task["duration_us"]
         func_stats[func_id]["durations"].append(duration)
 
+        start_time = task["start_time_us"]
+        end_time = task["end_time_us"]
+        receive_time = task.get("receive_time_us")
+        min_aicore_time = min(min_aicore_time, receive_time if receive_time is not None else start_time)
+        max_aicore_time = max(max_aicore_time, end_time)
+
+        if "local_setup_us" in task:
+            func_stats[func_id]["local_setups"].append(task["local_setup_us"])
+
         # Calculate new metrics if dispatch_time_us and finish_time_us are available
-        if "dispatch_time_us" in task and "finish_time_us" in task:
+        if has_aicpu_timing and "dispatch_time_us" in task and "finish_time_us" in task:
             dispatch_time = task["dispatch_time_us"]
             finish_time = task["finish_time_us"]
-            start_time = task["start_time_us"]
-            end_time = task["end_time_us"]
 
             # Head overhead: start_time_us - dispatch_time_us
             head_overhead = start_time - dispatch_time
@@ -769,8 +808,6 @@ def print_task_statistics(tasks, func_id_to_name=None):
             # AICore record came from a pre-receive_time build).
             if "propagation_us" in task:
                 func_stats[func_id]["propagations"].append(task["propagation_us"])
-            if "local_setup_us" in task:
-                func_stats[func_id]["local_setups"].append(task["local_setup_us"])
 
             # Latency: finish_time_us - dispatch_time_us
             latency = finish_time - dispatch_time
@@ -787,6 +824,19 @@ def print_task_statistics(tasks, func_id_to_name=None):
     # Print statistics
     print("\n" + "=" * 140)
     print("Task Statistics by Function")
+    level_descriptions = {
+        1: "AICore timing only",
+        2: "AICore + AICPU timing",
+        3: "AICore + AICPU timing + scheduler phases",
+        4: "full collection with orchestrator phases",
+    }
+    if l2_swimlane_level is None:
+        level_description = "unknown"
+        level_value = "unknown"
+    else:
+        level_description = level_descriptions.get(l2_swimlane_level, "unknown")
+        level_value = l2_swimlane_level
+    print(f"  Source l2_swimlane_level: {level_value} ({level_description}; recorded in l2_swimlane_records.json)")
     print("  Exec = kernel time on AICore; Latency = dispatch->finish (incl. head OH + Exec + tail OH)")
     print("  Head OH split (v3): Prop = NoC propagation (dispatch_ts→AICore receive); Local = dcci+ack (receive→start)")
     print("=" * 140)
@@ -835,11 +885,15 @@ def print_task_statistics(tasks, func_id_to_name=None):
         # Calculate execution ratio: total_exec_time / total_latency
         exec_ratio = (stats["total_exec_time"] / stats["total_latency"] * 100) if stats["total_latency"] > 0 else 0
 
+        latency_str = f"{avg_latency:.2f}" if has_aicpu_timing else "-"
+        exec_ratio_str = f"{exec_ratio:.1f}%" if has_aicpu_timing else "-"
+        head_str = f"{avg_head_overhead:.2f}" if has_aicpu_timing else "-"
+        tail_str = f"{avg_tail_overhead:.2f}" if has_aicpu_timing else "-"
         prop_str = f"{avg_propagation:>12.2f}" if avg_propagation is not None else f"{'-':>12}"
         local_str = f"{avg_local_setup:>13.2f}" if avg_local_setup is not None else f"{'-':>13}"
         print(
-            f"{func_id:<8} {func_name:<12} {count:>5}   {avg_duration:>12.2f}  {avg_latency:>15.2f}  "
-            f"{exec_ratio:>5.1f}%   {avg_head_overhead:>15.2f}  {avg_tail_overhead:>15.2f}  "
+            f"{func_id:<8} {func_name:<12} {count:>5}   {avg_duration:>12.2f}  {latency_str:>15}  "
+            f"{exec_ratio_str:>6}   {head_str:>15}  {tail_str:>15}  "
             f"{prop_str}  {local_str}"
         )
 
@@ -848,15 +902,21 @@ def print_task_statistics(tasks, func_id_to_name=None):
 
     # Calculate total latency (sum of all latencies)
     total_latency_sum = sum(stats["total_latency"] for stats in func_stats.values())
-    print(f"{'TOTAL':<21} {total_count:>5}   {total_duration:>12.2f}  {total_latency_sum:>15.2f}")
+    total_latency_str = f"{total_latency_sum:.2f}" if has_aicpu_timing else "-"
+    print(f"{'TOTAL':<21} {total_count:>5}   {total_duration:>12.2f}  {total_latency_str:>15}")
 
     # Print total test execution time
-    if min_dispatch_time != float("inf") and max_finish_time != float("-inf"):
+    if has_aicpu_timing and min_dispatch_time != float("inf") and max_finish_time != float("-inf"):
         total_test_time = max_finish_time - min_dispatch_time
         print(f"\nTotal Test Time: {total_test_time:.2f} us (from earliest dispatch to latest finish)")
+    elif l2_swimlane_level == 1 and min_aicore_time != float("inf") and max_aicore_time != float("-inf"):
+        aicore_observed_span = max_aicore_time - min_aicore_time
+        print(
+            f"\nAICore Observed Span: {aicore_observed_span:.2f} us (from earliest AICore receive to latest AICore end)"
+        )
 
     # Task execution vs Scheduler overhead summary
-    if total_count > 0 and total_latency_sum > 0:
+    if has_aicpu_timing and total_count > 0 and total_latency_sum > 0:
         avg_exec_us = total_duration / total_count
         avg_latency_us = total_latency_sum / total_count
         exec_latency_ratio_pct = total_duration / total_latency_sum * 100
@@ -1141,8 +1201,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     for task in tasks:
         tid = core_to_tid[task["core_id"]]
         local_setup_us = task.get("local_setup_us", 0.0) or 0.0
-        receive_time_us = task.get("receive_time_us")
-        ts = receive_time_us if receive_time_us is not None else task["start_time_us"]
+        ts = _task_slice_start_us(task)
         dur = task["end_time_us"] - ts
 
         # func_id is already resolved (level=1 records recovered from
@@ -1294,8 +1353,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # Flow events (Flow events "s" and "f" for dependencies). Edges come from
     # deps.json (dep_gen replay); without one we emit no flow events at all,
     # since the device hot path no longer carries fanout (PR #863).
-    # SPMD logical tasks anchor dependency arrows on the min-core_id subtask
-    # row per core_type (AIC and AIV separately when both are present).
+    # SPMD logical tasks independently anchor dependency arrows on each view's
+    # earliest visible slice per (func_id, task_id).
     flow_id = 0
     hb_violation_count = 0
     deps_flow_count = 0
@@ -1315,7 +1374,13 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     )
                 continue
 
-            row_pairs = _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids)
+            row_pairs = _flow_row_pairs(
+                pred_id,
+                succ_id,
+                task_map,
+                spmd_task_ids,
+                _worker_flow_anchor_rows,
+            )
             if not row_pairs:
                 continue
 
@@ -1323,7 +1388,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
             for pred_row, succ_row in row_pairs:
                 src_ts_end = pred_row["end_time_us"] - flow_epsilon
-                dst_ts_start = succ_row.get("receive_time_us") or succ_row["start_time_us"]
+                dst_ts_start = _task_slice_start_us(succ_row)
                 hb_violated = (src_ts_end + flow_epsilon) > dst_ts_start
                 flow_name = "hb_violation" if hb_violated else "dependency"
                 if hb_violated:
@@ -1352,7 +1417,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if spmd_task_ids:
                 print(
                     f"  SPMD tasks: {len(spmd_task_ids)} logical task(s); "
-                    "dependency arrows anchor on min core_id subtask per core_type"
+                    "dependency arrows independently anchor on each view's earliest visible slice per function"
                 )
         else:
             print("  Flow events: 0 (no deps.json — re-run dep_gen and pass --deps-json to add arrows)")
@@ -1790,7 +1855,13 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 if succ_id not in task_map:
                     continue
 
-                row_pairs = _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids)
+                row_pairs = _flow_row_pairs(
+                    pred_id,
+                    succ_id,
+                    task_map,
+                    spmd_task_ids,
+                    _scheduler_flow_anchor_rows,
+                )
                 if not row_pairs:
                     continue
 
@@ -1841,12 +1912,11 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # completed_subtasks counter inside whatever complete phase happened to
     # poll them; only the LAST subtask's finish actually completes the
     # task. So per task: take max(finish_time_us) across its subtasks and
-    # find the complete phase that CONTAINS that time. The visual arrow starts
-    # on the same earliest-start Worker View subtask slice used by SPMD
-    # dependency arrows, then lands at the last subtask's AICPU finish
-    # timestamp inside the complete phase. This keeps the related SPMD flow
-    # arrows anchored on one visible record without changing completion
-    # attribution semantics.
+    # find the complete phase that CONTAINS that time. Each task view starts
+    # its visual arrow on the same independently selected anchor it uses for
+    # SPMD dependency arrows, then lands at the last subtask's AICPU finish
+    # timestamp inside the complete phase. This keeps related SPMD flows
+    # consistent within each view without changing completion attribution.
     #
     # Outbound: per-consumer, gated on full fanin. Each consumer in
     # deps.json has multiple producer fanin edges; refcount += 1 fires
@@ -1875,21 +1945,22 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         # For each task: completion = LAST subtask's finish observation.
         # The owning thread is determined by core_to_thread of that last
         # subtask's core — typical case is the same thread observed
-        # earlier subtasks too, but we don't assume. The flow starts on the
-        # earliest-start Worker View subtask slice and ends at the LAST
-        # subtask's AICPU finish timestamp, preserving completion attribution
-        # while keeping related SPMD arrows on the same record.
+        # earlier subtasks too, but we don't assume. Each task view selects its
+        # own earliest visible subtask slice; both flows end at the LAST
+        # subtask's AICPU finish timestamp, preserving completion attribution.
         task_to_complete: dict[int, dict] = {}
         task_last_subtask: dict[int, tuple[float, float, int]] = {}  # tid -> (last_end_us, last_finish_us, core_id)
-        task_anchor_subtasks: dict[int, list[dict]] = {}
+        task_worker_anchors: dict[int, list[dict]] = {}
+        task_scheduler_anchors: dict[int, list[dict]] = {}
         for tid, recs in tasks_by_id.items():
             valid_finishes = [
                 (r.get("finish_time_us"), r.get("end_time_us"), r["core_id"])
                 for r in recs
                 if r.get("finish_time_us") is not None and r["finish_time_us"] >= 0 and r.get("end_time_us") is not None
             ]
-            anchor_rows = _dependency_flow_anchor_rows(tid, task_map, spmd_task_ids)
-            if not valid_finishes or not anchor_rows:
+            worker_anchors = _worker_flow_anchor_rows(tid, task_map, spmd_task_ids)
+            scheduler_anchors = _scheduler_flow_anchor_rows(tid, task_map, spmd_task_ids)
+            if not valid_finishes or not worker_anchors:
                 continue
             last_finish_us, last_end_us, last_cid = max(valid_finishes, key=lambda x: x[0])
             if last_cid >= len(core_to_thread):
@@ -1898,7 +1969,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if owning_thread < 0 or owning_thread >= len(complete_phases_by_thread):
                 continue
             task_last_subtask[tid] = (last_end_us, last_finish_us, last_cid)
-            task_anchor_subtasks[tid] = anchor_rows
+            task_worker_anchors[tid] = worker_anchors
+            task_scheduler_anchors[tid] = scheduler_anchors
             # Find the complete phase that CONTAINS this last_finish_us.
             # Fall back to the next-starting complete if none contains
             # (rare: AICore reported the finish but the scheduler hadn't
@@ -1917,15 +1989,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if chosen is not None:
                 task_to_complete[tid] = chosen
 
-        # ---- Inbound: one arrow per anchor, mirrored on Worker View and Scheduler View ----
+        # ---- Inbound: one arrow per independently selected view anchor ----
         # Source ts = <bar end> - epsilon so it lands INSIDE the task X event
-        # selected by _dependency_flow_anchor_rows(). Without this anchoring
-        # Perfetto can't bind the flow to a slice and the arrow is invisible
-        # when you click the task. Same convention as the `dependency` arrows,
-        # and — like the Scheduler View dependency mirror — the complete flow
-        # is drawn in both task views so clicking the task in either lands the
-        # arrow. The pid=2 endpoint (thread + ts) is identical for both mirrors,
-        # so completion attribution is unchanged; only the source view differs.
+        # selected for that view. Without this anchoring Perfetto can't bind the
+        # flow to a slice and the arrow is invisible when you click the task.
+        # The pid=2 endpoint (thread + ts) is identical for both views, so
+        # completion attribution is unchanged; only the visual source differs.
         FLOW_EPSILON_US = 0.01
         for tid, comp in task_to_complete.items():
             _last_end_us, last_finish_us, last_cid = task_last_subtask[tid]
@@ -1934,7 +2003,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             dst_ts = comp["start_time_us"]
             if comp["start_time_us"] <= last_finish_us <= comp["end_time_us"]:
                 dst_ts = last_finish_us
-            for anchor in task_anchor_subtasks[tid]:
+            for anchor in task_worker_anchors[tid]:
                 # Worker View (pid=4): anchor on the kernel slice (end_time_us).
                 src_tid = core_to_tid[anchor["core_id"]]
                 src_event_id = task_to_event_id.get((tid, anchor["core_id"]))
@@ -1964,8 +2033,9 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 )
                 flow_id += 1
 
-                # Scheduler View (pid=3): mirror on the AICPU dispatch→finish
-                # bar (source ts = finish_time_us). Skip when this anchor has
+            for anchor in task_scheduler_anchors[tid]:
+                # Scheduler View (pid=3): anchor on the AICPU dispatch→finish
+                # bar (source ts = finish_time_us). Skip when the anchor has
                 # no AICPU finish — its pid=3 bar doesn't exist to bind to.
                 anchor_finish_us = anchor.get("finish_time_us")
                 if anchor_finish_us is None or anchor_finish_us <= 0:
@@ -2322,7 +2392,10 @@ Examples:
     )
     parser.add_argument(
         "--func-names",
-        help="Path to func_id_names_*.json (SceneTest format) for func_id to function name mapping",
+        help=(
+            "Path to name_map*.json for func_id to function name mapping. "
+            "Defaults to a unique sibling name_map*.json next to the input."
+        ),
     )
     parser.add_argument(
         "--deps-json",
@@ -2408,16 +2481,36 @@ def _print_verbose_data_info(data, verbose):
         print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
 
 
-def _load_func_names(args):
-    """Load func_id→name mapping from --func-names JSON or -k kernel_config.py.
+def _find_sibling_name_map(input_path):
+    """Return the unique sibling ``name_map*.json``, if one exists."""
+    candidates = sorted(path for path in Path(input_path).parent.glob("name_map*.json") if path.is_file())
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        candidate_names = ", ".join(path.name for path in candidates)
+        print(
+            f"Warning: multiple sibling name maps found next to {input_path}: {candidate_names}; "
+            "pass --func-names explicitly.",
+            file=sys.stderr,
+        )
+    return None
+
+
+def _load_func_names(args, input_path):
+    """Load func_id→name mapping from an explicit or sibling source.
 
     Returns:
         tuple: (func_id_to_name dict, orchestrator_name str or None)
     """
-    if args.func_names:
+    func_names_path = Path(args.func_names) if args.func_names else None
+    if func_names_path is None and not args.kernel_config:
+        func_names_path = _find_sibling_name_map(input_path)
+
+    if func_names_path is not None:
         if args.verbose:
-            print(f"Loading func names from: {args.func_names}")
-        func_names, orchestrator_name = load_func_names_json(args.func_names)
+            source = "Auto-discovered" if not args.func_names else "Loading"
+            print(f"{source} func names from: {func_names_path}")
+        func_names, orchestrator_name = load_func_names_json(func_names_path)
         if args.verbose:
             print(f"  Loaded {len(func_names)} function name mappings:")
             for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
@@ -2454,7 +2547,7 @@ def main():
         data = read_perf_data(input_path)
         _print_verbose_data_info(data, args.verbose)
 
-        func_names, orchestrator_name = _load_func_names(args)
+        func_names, orchestrator_name = _load_func_names(args, input_path)
 
         output_path = _resolve_output_path(args, input_path)
 
@@ -2504,7 +2597,7 @@ def main():
         print(f"  Output: {output_path}")
         print(f"\nTo visualize: Open https://ui.perfetto.dev/ and drag in {output_path}")
 
-        print_task_statistics(data["tasks"], func_names)
+        print_task_statistics(data["tasks"], func_names, l2_swimlane_level=data["l2_swimlane_level"])
 
         # Scheduler-overhead deep-dive is a SEPARATE manual tool now: it needs
         # the task DAG (deps.json) captured in its own --enable-dep-gen run

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -108,7 +108,62 @@ def _generate_trace(tasks, deps_edges, deps_block_map, tmp_path):
     return out
 
 
-def test_spmd_pred_routes_dependency_to_min_core_subtask(tmp_path):
+def test_task_statistics_level_one_hides_aicpu_metrics(capsys):
+    tasks = [
+        {
+            "task_id": 1,
+            "func_id": 0,
+            "core_id": 0,
+            "core_type": "aic",
+            "start_time_us": 1.0,
+            "end_time_us": 6.0,
+            "duration_us": 5.0,
+            "dispatch_time_us": 0.0,
+            "finish_time_us": 0.0,
+            "receive_time_us": 0.5,
+            "local_setup_us": 0.5,
+        }
+    ]
+
+    sc.print_task_statistics(tasks, {"0": "kernel"}, l2_swimlane_level=1)
+
+    output = capsys.readouterr().out
+    row = next(line for line in output.splitlines() if line.startswith("0        kernel"))
+    total = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+    assert "Source l2_swimlane_level: 1 (AICore timing only; recorded in l2_swimlane_records.json)" in output
+    assert row.split() == ["0", "kernel", "1", "5.00", "-", "-", "-", "-", "-", "0.50"]
+    assert total.split() == ["TOTAL", "1", "5.00", "-"]
+    assert "AICore Observed Span: 5.50 us (from earliest AICore receive to latest AICore end)" in output
+    assert "Total Test Time" not in output
+
+
+def test_load_func_names_auto_discovery_and_explicit_precedence(tmp_path):
+    input_path = tmp_path / "l2_swimlane_records.json"
+    name_map_path = tmp_path / "name_map_case.json"
+    name_map_path.write_text(
+        json.dumps(
+            {
+                "callable_id_to_name": {"0": "kernel"},
+                "orchestrator_name": "orchestrator",
+            }
+        )
+    )
+    args = sc._build_parser().parse_args([str(input_path)])
+
+    func_names, orchestrator_name = sc._load_func_names(args, input_path)
+
+    assert func_names == {"0": "kernel"}
+    assert orchestrator_name == "orchestrator"
+
+    explicit_path = tmp_path / "explicit.json"
+    explicit_path.write_text(json.dumps({"callable_id_to_name": {"0": "explicit"}}))
+    explicit_args = sc._build_parser().parse_args([str(input_path), "--func-names", str(explicit_path)])
+    func_names, _ = sc._load_func_names(explicit_args, input_path)
+
+    assert func_names == {"0": "explicit"}
+
+
+def test_spmd_pred_routes_dependency_to_earliest_slice(tmp_path):
     pred_id = 100
     succ_id = 200
     tasks = [
@@ -134,29 +189,31 @@ def test_spmd_pred_routes_dependency_to_min_core_subtask(tmp_path):
     assert sched_flow[1]["ts"] == tasks[4]["dispatch_time_us"]
 
 
-def test_spmd_succ_routes_dependency_to_min_core_subtask(tmp_path):
+def test_spmd_succ_routes_dependency_to_earliest_slice(tmp_path):
     pred_id = 100
     succ_id = 200
-    tasks = [_task_row(pred_id, 0)]
-    tasks.extend(
-        _task_row(
-            succ_id, core_id, dispatch=20.0 + core_id, start=21.0 + core_id, end=30.0 + core_id, receive=20.5 + core_id
-        )
-        for core_id in range(4)
-    )
+    tasks = [
+        _task_row(pred_id, 0, dispatch=0.0, start=-0.5, end=-0.1, receive=-0.6),
+        _task_row(succ_id, 26, func_id=1, dispatch=0.2, start=1.44, end=3.02, receive=0.0),
+        _task_row(succ_id, 33, func_id=1, dispatch=0.1, start=1.14, end=2.92, receive=0.06),
+    ]
     deps_edges = {pred_id: [succ_id]}
-    deps_block_map = {pred_id: 1, succ_id: 4}
+    deps_block_map = {pred_id: 1, succ_id: 2}
 
     out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
     assert _count_dependency_flow_starts(out, pid=4) == 1
-    flow = _first_worker_dependency_flow(out)
-    assert flow[0]["output_task_count"] == 1
-    assert flow[0]["input_task_count"] == 4
-    assert flow[1]["tid"] == _core_tid(0)
-    assert flow[1]["ts"] == tasks[1]["receive_time_us"]
+    assert _count_dependency_flow_starts(out, pid=3) == 1
+    worker_flow = _first_worker_dependency_flow(out)
+    scheduler_flow = _first_scheduler_dependency_flow(out)
+    assert worker_flow[0]["output_task_count"] == 1
+    assert worker_flow[0]["input_task_count"] == 2
+    assert worker_flow[1]["tid"] == _core_tid(26)
+    assert worker_flow[1]["ts"] == 0.0
+    assert scheduler_flow[1]["tid"] == _aicpu_tid(33)
+    assert scheduler_flow[1]["ts"] == 0.1
 
 
-def test_spmd_to_spmd_one_edge_on_min_core_subtask(tmp_path):
+def test_spmd_to_spmd_one_edge_on_earliest_slice(tmp_path):
     pred_id = 100
     succ_id = 200
     tasks = [_task_row(pred_id, core_id, dispatch=10.0 + core_id) for core_id in range(4)]
@@ -252,19 +309,19 @@ def test_spmd_fallback_without_block_map(tmp_path):
     assert flow[0]["tid"] == _core_tid(0)
 
 
-def test_dependency_flow_anchor_rows_picks_earliest_start_per_func_id():
+def test_worker_flow_anchor_rows_picks_earliest_visible_slice_per_func_id():
     task_map = {
         1: [
-            _task_row(1, 5, "aiv", func_id=2, start=15.0),
-            _task_row(1, 0, "aiv", func_id=2, start=12.0),
-            _task_row(1, 2, "aic", func_id=1, start=13.0),
-            _task_row(1, 7, "aic", func_id=1, start=17.0),
+            _task_row(1, 5, "aiv", func_id=2, start=12.0, receive=10.0),
+            _task_row(1, 0, "aiv", func_id=2, start=11.0, receive=10.0),
+            _task_row(1, 2, "aic", func_id=1, start=13.0, receive=12.0),
+            _task_row(1, 7, "aic", func_id=1, start=12.0, receive=11.0),
         ]
     }
-    rows = sc._dependency_flow_anchor_rows(1, task_map, {1})
+    rows = sc._worker_flow_anchor_rows(1, task_map, {1})
     assert len(rows) == 2
     by_func = {r["func_id"]: r["core_id"] for r in rows}
-    assert by_func == {1: 2, 2: 0}
+    assert by_func == {1: 7, 2: 0}
 
 
 def test_identify_spmd_task_ids_respects_authoritative_block_num_one():
@@ -308,19 +365,16 @@ def _aicpu_tid(core_id):
     return 10000 + core_id * 10
 
 
-def test_complete_flow_mirrored_on_scheduler_view(tmp_path):
-    # One SPMD task across 4 cores, all on scheduler thread 0. A single
-    # complete phase (thread 0) contains every subtask finish.
+def test_complete_flow_uses_independent_view_anchors(tmp_path):
     task_id = 100
     tasks = [
-        _task_row(task_id, core_id, dispatch=10.0 + core_id, start=11.0 + core_id, end=20.0 + core_id)
-        for core_id in range(4)
+        _task_row(task_id, 26, dispatch=0.2, start=1.44, end=3.02, receive=0.0),
+        _task_row(task_id, 33, dispatch=0.1, start=1.14, end=2.92, receive=0.06),
     ]
     deps_edges = {}
-    deps_block_map = {task_id: 4}
-    # finish_time_us = end + 1.0, so subtask finishes span 21.0 .. 24.0.
-    scheduler_phases = [[{"phase": "complete", "start_time_us": 20.0, "end_time_us": 25.0}]]
-    core_to_thread = [0, 0, 0, 0]
+    deps_block_map = {task_id: 2}
+    scheduler_phases = [[{"phase": "complete", "start_time_us": 3.5, "end_time_us": 4.5}]]
+    core_to_thread = [0] * 34
 
     out = tmp_path / "trace.json"
     sc.generate_chrome_trace_json(
@@ -335,28 +389,19 @@ def test_complete_flow_mirrored_on_scheduler_view(tmp_path):
     flows = _complete_flows(out)
     starts_p4 = [e for e in flows if e.get("ph") == "s" and e.get("pid") == 4]
     starts_p3 = [e for e in flows if e.get("ph") == "s" and e.get("pid") == 3]
-    # SPMD single-func anchor collapses the 4 subtasks to one anchor row;
-    # complete is mirrored on both task views for that anchor.
     assert len(starts_p4) == 1
     assert len(starts_p3) == 1
 
     p4 = starts_p4[0]
     p3 = starts_p3[0]
-    anchor_core = 0  # earliest-start subtask
-    anchor = next(t for t in tasks if t["core_id"] == anchor_core)
-    # Worker View source anchors on the kernel slice end; Scheduler View source
-    # anchors on the AICPU finish. Both minus one epsilon (0.01).
-    assert p4["tid"] == _core_tid(anchor_core)
-    assert p4["ts"] == anchor["end_time_us"] - 0.01
-    assert p3["tid"] == _aicpu_tid(anchor_core)
-    assert p3["ts"] == anchor["finish_time_us"] - 0.01
+    assert p4["tid"] == _core_tid(26)
+    assert p4["ts"] == tasks[0]["end_time_us"] - 0.01
+    assert p3["tid"] == _aicpu_tid(33)
+    assert p3["ts"] == tasks[1]["finish_time_us"] - 0.01
 
-    # Both mirrors land on the same pid=2 complete-phase endpoint.
     finishes = [e for e in flows if e.get("ph") == "f"]
     assert len(finishes) == 2
-    assert all(e["pid"] == 2 for e in finishes)
-    assert len({e["tid"] for e in finishes}) == 1
-    assert len({e["ts"] for e in finishes}) == 1
+    assert len({(e["pid"], e["tid"], e["ts"]) for e in finishes}) == 1
 
 
 def test_complete_flow_worker_view_only_without_scheduler_phases(tmp_path):


### PR DESCRIPTION
- report task statistics according to the source l2_swimlane_level and avoid invalid AICPU-derived metrics for level 1 captures
- auto-discover a unique sibling name_map JSON when --func-names is omitted
- select the earliest visible SPMD dependency and complete-flow anchor independently in Worker and Scheduler views, preserving receive_time_us == 0
- update converter documentation and focused unit tests