### PR TITLE
feat(dfx): print what an error code means in the host log, not just the number

### DIFF
--- a/.claude/rules/running-onboard.md
+++ b/.claude/rules/running-onboard.md
@@ -164,6 +164,12 @@ Then read it directly (`$LOGDIR/device-*/device-*.log`) — no more `grep`-ing
 "deadlock" or "OOM" from the host error alone — **read the device log and grep
 for the signature that actually fired:**
 
+> The host log now names the code and the device-side error class it masks — grep
+> for `error detail:` / `orch_error_code=` / `sched_error_code=` / `sub_class=`
+> before opening the device log at all. The full code reference and the per-code
+> debugging notes are in
+> [docs/troubleshooting/device-error-codes.md](../../docs/troubleshooting/device-error-codes.md).
+
 | device-log signature | mechanism | note |
 | -------------------- | --------- | ---- |
 | `FATAL: Task Allocator Deadlock` / `Provable head-of-line` | ring/heap or dep-pool **deadlock** (alloc can't reclaim) | AICPU detector: 500ms backstop (`PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES`) or immediate structural `head_blocked_on_scope_end`. Real capacity/scope deadlock. |

--- a/conftest.py
+++ b/conftest.py
@@ -1069,12 +1069,15 @@ def pytest_runtest_makereport(item, call):
 # (every non-zero rc is wrapped that way), turning a normal failing test into a
 # spurious worker rebuild and, downstream, a misleading runtime-wide skip. So
 # we extract the trailing <N> and match only the known poison codes:
-#   207001 AICore launch failure (the CI cascade trigger)
+#   207001 ACL_ERROR_RT_MEMORY_ALLOCATION  (the CI cascade trigger)
 #   507000 ACL_ERROR_RT_INTERNAL_ERROR  (a5 op-timeout at AICPU stream sync)
 #   507018 ACL_ERROR_RT_AICPU_EXCEPTION
 #   507046 ACL_ERROR_RT_STREAM_SYNC_TIMEOUT
 #   507899 sticky-error rtMalloc / rtStreamCreate on the poisoned context
 #       -1 a5 DeviceRunner fail-fast sentinel ("marked unusable; refusing to run")
+# The names above are CANN's own (acl/error_codes/rt_error_codes.h); what each one
+# means and how to chase it is in docs/troubleshooting/device-error-codes.md, and the
+# host log now prints that meaning next to the code.
 # Worker surfaces these as "run_prepared/prepare_callable/simpler_init failed
 # with code <N>" — never as an AssertionError, so golden mismatches are already
 # excluded.

--- a/docs/troubleshooting/device-error-codes.md
+++ b/docs/troubleshooting/device-error-codes.md
@@ -1,0 +1,269 @@
+# Device Error Codes
+
+What a failing run's error code means, and what is known about chasing each one
+down. The host log now names the code it prints, so this page is the long form of
+what the `error detail:` / `ACL error detail:` lines already tell you.
+
+## How an error reaches you
+
+The `tensormap_and_ringbuffer` runtime runs orchestration and scheduling on the
+AICPU. On a fatal condition the runtime **latches** a code into the shared-memory
+header; the host reads it back in `validate_runtime_impl` and prints:
+
+```text
+[ERROR] PTO2 runtime failed: orch_error_code=1 sched_error_code=0 runtime_status=-1
+[ERROR] error detail: orch_error_code=1 SCOPE_DEADLOCK - tasks submitted in one scope ...
+[ERROR] error hint: raise ring_task_window (PTO2_RING_TASK_WINDOW) or split the scope ...
+```
+
+At most one of `orch_error_code` (1-11) and `sched_error_code` (100+) is ever
+non-zero. `runtime_status` is just the latched code negated.
+
+The exception you see (`RuntimeError: run failed with code <rc>`) is **not** always
+the same number:
+
+| Environment | `<rc>` |
+| ----------- | ------ |
+| **sim** (`a5sim` / `a2a3sim`) | `-N`, where `N` is the latched code. `-1` is SCOPE_DEADLOCK, `-100` is SCHEDULER_TIMEOUT. |
+| **onboard** | Usually a CANN watchdog fires first and masks the code as a generic `507018`. **Do not read `<rc>` as the error code here.** |
+
+So on hardware the exception code is the *least* informative thing on screen. The
+failure lines above are printed either way — start there.
+
+**First move, always:**
+
+```bash
+grep -E "orch_error_code=|sched_error_code=|sub_class=|error detail:" <run log>
+```
+
+## 1. Code reference
+
+### Orchestration errors (1-11)
+
+| Code | Name | Meaning | Whose bug, usually |
+| ---- | ---- | ------- | ------------------ |
+| 1 | SCOPE_DEADLOCK | Tasks in one scope hit the ring task-window cap; slots are not reclaimed until `scope_end` | orchestration |
+| 2 | HEAP_RING_DEADLOCK | Ring task slots *and* heap bytes both exhausted | orchestration / config |
+| 3 | FLOW_CONTROL_DEADLOCK | Task window blocked while heap is not full (classically: nesting on one ring) | orchestration |
+| 4 | DEP_POOL_OVERFLOW | A task's fanin edges overflowed the ring's dependency spill pool | orchestration / config |
+| 5 | INVALID_ARGS | An orchestration API rejected its arguments | orchestration |
+| 6 | *(retired)* | Was per-task fanin overflow; now reported as 4 | — |
+| 7 | REQUIRE_SYNC_START_INVALID | `require_sync_start()` asked for more blocks than the core type physically has | orchestration |
+| 8 | TENSOR_WAIT_TIMEOUT | Waiting for tensor data timed out | kernel / orchestration |
+| 9 | EXPLICIT_ORCH_FATAL | Orchestration called `rt_report_fatal()` itself | orchestration (deliberate) |
+| 10 | SCOPE_TASKS_OVERFLOW | Scope task-record buffer saturated | runtime-internal |
+| 11 | TENSORMAP_OVERFLOW | Tensormap entry pool wedged | runtime-internal / extreme scale |
+
+### Scheduler errors (100+)
+
+| Code | Name | Meaning | Whose bug, usually |
+| ---- | ---- | ------- | ------------------ |
+| 100 | SCHEDULER_TIMEOUT | No forward progress within the timeout. See the sub-class below | depends on sub-class |
+| 101 | ASYNC_COMPLETION_INVALID | Malformed async completion condition | kernel (async) |
+| 102 | ASYNC_WAIT_OVERFLOW | Async wait list full (in-flight completions over the 64 cap) | kernel (async) |
+| 103 | ASYNC_REGISTRATION_FAILED | Illegal async completion message kind | runtime-internal |
+
+### SCHEDULER_TIMEOUT sub-classes
+
+Code 100 is a funnel. The runtime sub-classifies it on device and prints the
+verdict plus locators, so you rarely need the device log:
+
+```text
+[ERROR] PTO2 scheduler timeout sub_class=S1:running-stalled (detail=1) completed=0/1 \
+        running=1 ready=0 waiting=0 orch_done=1 stuck_task_id=42 stuck_core=5
+```
+
+| Sub-class | Meaning | Cause |
+| --------- | ------- | ----- |
+| **S1** running-stalled | A task is on a core and never completes | AICore kernel hang, or a kernel that is merely very slow |
+| **S3** ready-but-all-idle | Cores idle, a fanin-satisfied task exists, nothing dispatched | dispatch loop / sync-start gate |
+| **S4** dependency-deadlock | Only WAIT tasks remain, fanin never resolves | dependency wiring |
+| **S5** orchestrator-starvation | Submitted tasks all done, orchestration not finished | orchestration stuck upstream |
+| **unknown** | Bookkeeping invariant violated | runtime bug / memory corruption |
+
+The counters *are* the decision: priority is `running > ready > waiting > orch not
+done`. `running=1` is always S1; `running=0, ready>0` is S3.
+
+**Only S1 and S3 are reproducible in practice.** S4, S5 and unknown are defensive
+labels — see [4. Codes with no end-to-end test](#4-codes-with-no-end-to-end-test).
+
+### Host-side CANN codes
+
+These come from the driver, not from the runtime. Names are CANN's own
+(`acl/error_codes/rt_error_codes.h`).
+
+| Code | Name | Meaning |
+| ---- | ---- | ------- |
+| 107022 | ACL_ERROR_RT_DEVICE_TASK_ABORT | Task aborted, usually collateral damage from an earlier fault |
+| 207001 | ACL_ERROR_RT_MEMORY_ALLOCATION | Device out of memory |
+| 507000 | ACL_ERROR_RT_INTERNAL_ERROR | Runtime internal error; on a5 this is how an AICPU op timeout surfaces |
+| 507014 | ACL_ERROR_RT_AICORE_TIMEOUT | AICore task exceeded its execution timeout |
+| 507015 | ACL_ERROR_RT_AICORE_EXCEPTION | AICore task faulted |
+| 507017 | ACL_ERROR_RT_AICPU_TIMEOUT | AICPU task exceeded its execution timeout |
+| 507018 | ACL_ERROR_RT_AICPU_EXCEPTION | AICPU task faulted — **the generic one** |
+| 507046 | ACL_ERROR_RT_STREAM_SYNC_TIMEOUT | Host timed out on a stream sync |
+| 507899 | ACL_ERROR_RT_DRV_INTERNAL_ERROR | Driver internal error; typically a *sticky* error on an already-poisoned context |
+| -1 | SIMPLER_DEVICE_UNUSABLE | Our own sentinel: the DeviceRunner had already marked the device unusable |
+
+`507018` is a **generic host-side code**: several unrelated device mechanisms all
+surface as it. Never conclude "deadlock" or "OOM" from it alone. `507899` and
+`107022` are almost always *fallout* — scroll up for the first failure on that
+device. For classifying `507018` against the device log, see the triage table in
+[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md).
+
+## 2. Chasing down a capacity code (1, 2, 4)
+
+These three all say the same thing — "some resource ran out" — without saying
+*which* resource or *which* scope. Do not guess at the ring sizes. Turn on
+`scope_stats`, which records the high-water mark of all four resources (task-window
+slots, heap bytes, dep-pool entries, tensormap entries) per `PTO2_SCOPE`:
+
+```python
+cfg = CallConfig()
+cfg.enable_scope_stats = True
+cfg.output_prefix = "outputs/my_run"
+worker.run(callable, args, cfg)
+```
+
+It works on a **failing** run: the metadata line is marked `"fatal": true` and
+everything written before the fatal is kept. So point it straight at the workload
+that trips the code.
+
+| Bottleneck resource | Code | Fix |
+| ------------------- | ---- | --- |
+| task window | 1 | raise `ring_task_window` (`PTO2_RING_TASK_WINDOW`), or split the scope |
+| heap | 2 | raise `ring_heap` (`PTO2_RING_HEAP`), or shrink per-task args / intermediate tensors |
+| dep pool | 4 | raise `ring_dep_pool` (`PTO2_RING_DEP_POOL`), or cut the fanin count |
+
+Report fields, the `Top Peaks` table and the plotting tool are documented in
+[`../dfx/scope-stats.md`](../dfx/scope-stats.md).
+
+### Minimal reproductions
+
+Each code has a live, minimal trigger in `tests/st/runtime_fatal_codes/`. These are
+the fastest way to see what a code looks like, and the shape to copy when you
+suspect one:
+
+| Code | How the ST provokes it | Fixture |
+| ---- | ---------------------- | ------- |
+| 1 | 8 tasks in one scope with `ring_task_window=4` | `kernels/orchestration/scope_deadlock_orch.cpp` |
+| 2 | One task with a 32 KiB output against `ring_heap=1024` | `heap_ring_deadlock_orch.cpp` |
+| 3 | 8 nested scopes, 3 tasks each — depth ≥3 all land on ring 3 and fill it | `flow_control_deadlock_orch.cpp` |
+| 4 | 128 producers into one consumer against `ring_dep_pool=4` | `dep_pool_overflow_orch.cpp` |
+| 5 | `set_dependencies(nullptr, 4)` — null pointer, non-zero count | `invalid_args_orch.cpp` |
+| 7 | SPMD AIV task asking for 1000 blocks | `require_sync_start_orch.cpp` |
+| 8 | `get_tensor_data()` on the output of a `while(true)` kernel | `tensor_wait_timeout_orch.cpp` |
+| 9 | `rt_report_fatal(...)` plus post-fatal API calls, to prove they no-op | `explicit_fatal_orch.cpp` |
+| 100/S1 | An AIC kernel that spins forever | `aicore_hang_orch.cpp` + `kernels/aic/kernel_hang.cpp` |
+| 101 | Kernel defers `PTO2_ERROR_ASYNC_COMPLETION_INVALID` into the slab directly | `kernels/aiv/kernel_async_completion_invalid.cpp` |
+| 102 | Kernel registers `MAX_COMPLETIONS_PER_TASK + 1` conditions | `kernels/aiv/kernel_async_wait_overflow.cpp` |
+
+## 3. Chasing down a stall (100, and code 8)
+
+### The timeout race decides what you see
+
+Three watchdogs compete, and whichever fires first determines whether you get a
+clean `-100` with a `sub_class`, or a masked `507018`:
+
+- the scheduler no-progress timeout (`PTO2_SCHEDULER_TIMEOUT_MS`),
+- the STARS op-execute timeout (`PTO2_OP_EXECUTE_TIMEOUT_US`, ~45 s, kills `aicpu-sd`),
+- the host stream-sync timeout (`PTO2_STREAM_SYNC_TIMEOUT_MS`).
+
+**A 45 s op-execute kill is not proof of a deadlock** — the kernel may simply be
+slow. To find out which, order the race deliberately. The STs do exactly this, and
+the technique transfers:
+
+- To make the **scheduler** win (get a `sub_class`), squeeze it below the others:
+  `SCHEDULER=2000ms < OP_EXECUTE=3s < STREAM_SYNC=4000ms` (`aicore_hang` case).
+- To let a **slow-but-alive** path finish, push the others out of the way:
+  `SCHEDULER=30000ms`, `OP_EXECUTE=30s`, `STREAM_SYNC=40000ms` — this is how the
+  `tensor_wait_timeout` case lets the 15 s tensor-data wait land code 8 instead of
+  being reaped first.
+
+**These three are read once, at `Worker.init()`.** Changing them between `run()`
+calls on the same Worker does nothing — you must rebuild the Worker (or use a
+separate process) per value. Defaults and the rationale are in
+[`local-timeout-defaults.md`](local-timeout-defaults.md).
+
+### S1: find the stuck kernel
+
+The `sub_class=` line gives you `stuck_task_id` and `stuck_core`. Map the task id
+back to your orchestration and look at that kernel for an infinite loop, a wait on
+a signal that never arrives, or simply too much work.
+
+When the task id is not enough, raise the log level to **V0** and the device log
+prints a task snapshot at the moment of the stall:
+
+```text
+[STALL thread=0 idle_iterations=...] TASK ring=1 task_id=42 state=RUNNING \
+    fanin_refcount=0/2 kernels=[aic:3 aiv0:7 aiv1:-1] \
+    running_on=[owner_thread=0 cores=[core=5(AIC) core=6(AIV0)]]
+```
+
+`kernels=[...]` are the kernel ids in the task's three sub-core slots and
+`cores=[...]` the physical cores running it — that maps "stuck task" to "which
+kernel, on which core".
+
+Setting the level:
+
+- **Worker directly**: `logging.getLogger("simpler").setLevel("V0")` **before**
+  `worker.init()` — the level is snapshotted at init and pushed to the device, so
+  setting it between `run()` calls has no effect.
+- **pytest / scene test**: `--log-level v0`.
+
+V0 is the most verbose level (V0 verbose … V9 terse, default V5). Device logs land
+in the shared `~/ascend/log/debug/device-<id>/` by default, where several processes
+interleave; redirect them per-run with `ASCEND_PROCESS_LOG_PATH` (the directory must
+exist) before reading. See the "Device logs" section of
+[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md).
+
+### Code 8, specifically
+
+The tensor-data wait defaults to 15 s (`PTO2_TENSOR_DATA_TIMEOUT_MS`,
+frequency-scaled). It means either the producer never completed, or a consumer never
+released its fanout reference. Check for a hung producer first (that is S1 above),
+then verify the consumer really declares the dependency and exits. If the kernel is
+merely slow, raising the timeout will prove it.
+
+## 4. Codes with no end-to-end test
+
+Three codes and three stall sub-classes have no ST — not from neglect, but because
+they cannot be provoked. Recording why, so the next person does not re-derive it
+(the argument lives in `tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py`):
+
+- **103 ASYNC_REGISTRATION_FAILED** is structurally pre-empted. The AICore side caps
+  at `MAX_COMPLETIONS_PER_TASK` (64) and latches **102** on the 65th condition, so
+  the scheduler-side "more than 64" check that would raise 103 never sees enough
+  messages. 103 is reachable only by corrupting the slab (UB) or a malformed message.
+- **10 SCOPE_TASKS_OVERFLOW** cannot be reached either. `scope_tasks_cap` is the sum
+  of the per-ring windows, but each ring physically holds only `window - 1` tasks, so
+  all rings together top out at `cap - PTO2_MAX_RING_DEPTH` — strictly below the cap.
+  The rings always fill first and latch 1 or 3. Shrinking the window shrinks both, so
+  the gap holds.
+- **11 TENSORMAP_OVERFLOW** needs the 65536-entry pool (`PTO2_TENSORMAP_POOL_SIZE`,
+  compile-time, not tunable via `runtime_env`) flooded *and* a stalled producer
+  holding entries.
+- **S4 / S5 / unknown**: not expressible through the public API. `set_dependencies()`
+  can only name already-submitted tasks, so a dependency cycle cannot be written; a
+  stuck producer is RUNNING (→ S1), never pure WAIT (S4). `total_tasks_` counts
+  *submitted* tasks, so once they retire `completed == total` and the S5 watchdog
+  never fires. They are kept as defensive labels: if a future bug produces the state,
+  it gets named instead of mislabelled.
+
+The name tables are held complete for these anyway
+(`tests/ut/cpp/common/test_error_code_names.cpp`) — an unreachable code is exactly
+the one that would otherwise print as a bare number on the day it finally fires.
+
+If you do hit 10, 11, 103, S4, S5 or unknown, it is a runtime bug. Keep the device
+log and report it.
+
+## References
+
+- Code definitions: `src/{arch}/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h`
+- Name/hint tables: `src/common/runtime_status/error_names.h`, `src/common/platform/include/host/acl_error_names.h`
+- Host print site: `.../host/runtime_maker.cpp` (`validate_runtime_impl`)
+- Sub-class logic: `.../runtime/scheduler/scheduler_cold_path.cpp` (`classify_stall_reason`)
+- End-to-end negative tests: `tests/st/runtime_fatal_codes/`
+- Onboard `507018` mechanism triage + device logs: [`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md)
+- Timeout defaults: [`local-timeout-defaults.md`](local-timeout-defaults.md)
+- Capacity DFX: [`../dfx/scope-stats.md`](../dfx/scope-stats.md)

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 #include "acl/acl.h"
+#include "host/acl_error_log.h"
 
 // Include HAL constants from CANN (header only, library loaded dynamically)
 #include "ascend_hal.h"
@@ -133,6 +134,7 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
     aclError aRet = aclInit(nullptr);
     if (aRet != ACL_SUCCESS && static_cast<int>(aRet) != ACL_ERROR_REPEAT_INITIALIZE) {
         LOG_ERROR("aclInit failed: %d", static_cast<int>(aRet));
+        ACL_LOG_ERROR_DETAIL(aRet);
         return static_cast<int>(aRet);
     }
 
@@ -140,6 +142,7 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
     aRet = aclrtSetDevice(device_id);
     if (aRet != ACL_SUCCESS) {
         LOG_ERROR("aclrtSetDevice(%d) failed: %d", device_id, static_cast<int>(aRet));
+        ACL_LOG_ERROR_DETAIL(aRet);
         return static_cast<int>(aRet);
     }
 
@@ -154,6 +157,7 @@ void *DeviceRunner::create_comm_stream() {
     aclError aRet = aclrtCreateStream(&stream);
     if (aRet != ACL_SUCCESS) {
         LOG_ERROR("aclrtCreateStream failed: %d", static_cast<int>(aRet));
+        ACL_LOG_ERROR_DETAIL(aRet);
         return nullptr;
     }
     return stream;

--- a/src/a2a3/platform/onboard/host/memory_allocator.cpp
+++ b/src/a2a3/platform/onboard/host/memory_allocator.cpp
@@ -19,6 +19,7 @@
 
 #include <runtime/rt.h>
 
+#include "host/acl_error_log.h"
 #include "common/unified_log.h"
 
 MemoryAllocator::~MemoryAllocator() { finalize(); }
@@ -28,6 +29,7 @@ void *MemoryAllocator::alloc(size_t size) {
     int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
     if (rc != 0) {
         LOG_ERROR("rtMalloc failed: %d (size=%zu)", rc, size);
+        ACL_LOG_ERROR_DETAIL(rc);
         return nullptr;
     }
 
@@ -50,6 +52,7 @@ int MemoryAllocator::free(void *ptr) {
     int rc = rtFree(ptr);
     if (rc != 0) {
         LOG_ERROR("rtFree failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -54,6 +54,7 @@
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/pto_types.h"
 #include "../runtime/runtime.h"
+#include "../../../../common/runtime_status/error_log.h"
 #include "../../../../common/task_interface/call_config.h"
 #include "callable.h"
 #include "common/platform_config.h"
@@ -980,10 +981,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
-        LOG_ERROR(
-            "PTO2 runtime failed: orch_error_code=%d sched_error_code=%d runtime_status=%d", orch_error_code,
-            sched_error_code, runtime_status
-        );
+        LOG_RUNTIME_FAILURE(orch_error_code, sched_error_code, runtime_status);
         skip_tensor_copy_back = true;
     } else {
         graph_out_ptr = host_header.graph_output_ptr;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -45,6 +45,7 @@
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/runtime.h"
+#include "../../../../common/runtime_status/error_log.h"
 #include "../../../../common/task_interface/call_config.h"
 #include "callable.h"
 #include "common/platform_config.h"
@@ -975,10 +976,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
-        LOG_ERROR(
-            "PTO2 runtime failed: orch_error_code=%d sched_error_code=%d runtime_status=%d", orch_error_code,
-            sched_error_code, runtime_status
-        );
+        LOG_RUNTIME_FAILURE(orch_error_code, sched_error_code, runtime_status);
         // A scheduler no-progress timeout (code 100) carries a device-classified
         // sub-reason + locators so the failure line is self-diagnosing without a
         // device-log dive. The full stall snapshot stays in the device log / plog.

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -18,6 +18,7 @@
 #include "device_runner.h"
 
 #include "acl/acl.h"
+#include "host/acl_error_log.h"
 #include "host_log.h"
 
 #include <dlfcn.h>
@@ -95,6 +96,7 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
     aclError aRet = aclInit(nullptr);
     if (aRet != ACL_SUCCESS && static_cast<int>(aRet) != kAclRepeatInit) {
         LOG_ERROR("aclInit failed: %d", static_cast<int>(aRet));
+        ACL_LOG_ERROR_DETAIL(aRet);
         return static_cast<int>(aRet);
     }
 
@@ -102,6 +104,7 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
     aRet = aclrtSetDevice(device_id);
     if (aRet != ACL_SUCCESS) {
         LOG_ERROR("aclrtSetDevice(%d) failed: %d", device_id, static_cast<int>(aRet));
+        ACL_LOG_ERROR_DETAIL(aRet);
         return static_cast<int>(aRet);
     }
 
@@ -116,6 +119,7 @@ void *DeviceRunner::create_comm_stream() {
     aclError aRet = aclrtCreateStream(&stream);
     if (aRet != ACL_SUCCESS) {
         LOG_ERROR("aclrtCreateStream failed: %d", static_cast<int>(aRet));
+        ACL_LOG_ERROR_DETAIL(aRet);
         return nullptr;
     }
     return stream;

--- a/src/a5/platform/onboard/host/memory_allocator.cpp
+++ b/src/a5/platform/onboard/host/memory_allocator.cpp
@@ -19,6 +19,7 @@
 
 #include <runtime/rt.h>
 
+#include "host/acl_error_log.h"
 #include "common/unified_log.h"
 
 MemoryAllocator::~MemoryAllocator() { finalize(); }
@@ -28,6 +29,7 @@ void *MemoryAllocator::alloc(size_t size) {
     int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
     if (rc != 0) {
         LOG_ERROR("rtMalloc failed: %d (size=%zu)", rc, size);
+        ACL_LOG_ERROR_DETAIL(rc);
         return nullptr;
     }
 
@@ -50,6 +52,7 @@ int MemoryAllocator::free(void *ptr) {
     int rc = rtFree(ptr);
     if (rc != 0) {
         LOG_ERROR("rtFree failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -45,6 +45,7 @@
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/runtime.h"
+#include "../../../../common/runtime_status/error_log.h"
 #include "../../../../common/task_interface/call_config.h"
 #include "callable.h"
 #include "common/platform_config.h"
@@ -930,10 +931,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
-        LOG_ERROR(
-            "PTO2 runtime failed: orch_error_code=%d sched_error_code=%d runtime_status=%d", orch_error_code,
-            sched_error_code, runtime_status
-        );
+        LOG_RUNTIME_FAILURE(orch_error_code, sched_error_code, runtime_status);
         // A scheduler no-progress timeout (code 100) carries a device-classified
         // sub-reason + locators so the failure line is self-diagnosing without a
         // device-log dive. The full stall snapshot stays in the device log / plog.

--- a/src/common/platform/include/host/acl_error_log.h
+++ b/src/common/platform/include/host/acl_error_log.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * ACL / RT Error-Code Annotation (host failure line)
+ *
+ * Emits the human-readable half of a CANN failure: what the return code means, what to do
+ * next, and CANN's own last error message.
+ *
+ * A macro rather than a function on purpose. LOG_ERROR bakes in __FUNCTION__, __FILENAME__
+ * and __LINE__ at its expansion point, so a function would stamp all of these lines with this
+ * header instead of the call that failed. There are a dozen expansion sites (rtSetDevice,
+ * rtMalloc, rtStreamCreate, the stream syncs, the kernel launches, ...) and *which* one failed
+ * is the first thing a reader needs, so the annotation has to inherit the caller's provenance.
+ *
+ * The annotation goes on its own lines, after the call site's existing "<call> failed: <rc>"
+ * line. That line -- and the "<op> failed with code <rc>" exception text it eventually turns
+ * into -- is parsed by conftest to detect a poisoned device, so it is left untouched.
+ */
+
+#ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_ACL_ERROR_LOG_H_
+#define SRC_COMMON_PLATFORM_INCLUDE_HOST_ACL_ERROR_LOG_H_
+
+#include <acl/acl.h>
+
+#include <cstdint>
+
+#include "acl_error_names.h"
+#include "common/unified_log.h"
+
+// Annotates a non-zero CANN return code. An uncharacterised code is left alone rather than
+// labelled with a guess; CANN's own message is still printed in that case, since it is the
+// driver's account of what went wrong and beats any static table we could write.
+#define ACL_LOG_ERROR_DETAIL(rc)                                                                                \
+    do {                                                                                                        \
+        const int32_t acl_rc_ = static_cast<int32_t>(rc);                                                       \
+        if (acl_rc_ != 0) {                                                                                     \
+            const char *acl_name_ = acl_error_name(acl_rc_);                                                    \
+            if (acl_name_ != nullptr) {                                                                         \
+                LOG_ERROR("ACL error detail: %d %s - %s", acl_rc_, acl_name_, acl_error_desc(acl_rc_));         \
+                const char *acl_hint_ = acl_error_hint(acl_rc_);                                                \
+                if (acl_hint_ != nullptr) {                                                                     \
+                    LOG_ERROR("ACL error hint: %s. See docs/troubleshooting/device-error-codes.md", acl_hint_); \
+                }                                                                                               \
+            }                                                                                                   \
+            const char *acl_recent_ = aclGetRecentErrMsg();                                                     \
+            if (acl_recent_ != nullptr && acl_recent_[0] != '\0') {                                             \
+                LOG_ERROR("ACL recent error message: %s", acl_recent_);                                         \
+            }                                                                                                   \
+        }                                                                                                       \
+    } while (0)
+
+#endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_ACL_ERROR_LOG_H_

--- a/src/common/platform/include/host/acl_error_names.h
+++ b/src/common/platform/include/host/acl_error_names.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * ACL / RT Error-Code Names and Triage Hints (host)
+ *
+ * Names the CANN return codes this project actually hits, so a host failure line carries
+ * more than a bare integer. Only the codes we have seen and can say something useful about
+ * are listed; anything else is reported as unknown rather than guessed at.
+ *
+ * Values mirror CANN's acl/error_codes/rt_error_codes.h. They are spelled as literals here
+ * so this header stays free of any CANN include and can be unit-tested on a host without a
+ * toolkit installed.
+ *
+ * Full triage steps: docs/troubleshooting/device-error-codes.md
+ */
+
+#ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_ACL_ERROR_NAMES_H_
+#define SRC_COMMON_PLATFORM_INCLUDE_HOST_ACL_ERROR_NAMES_H_
+
+#include <cstdint>
+
+// a5 DeviceRunner fail-fast sentinel: the device was marked unusable and the runner refused
+// to run. Not a CANN code -- it never leaves this project.
+#define SIMPLER_DEVICE_UNUSABLE (-1)
+
+// Symbolic name of a CANN return code, or nullptr when the code is not one we have
+// characterised. Callers use nullptr to suppress the annotation instead of guessing.
+static inline const char *acl_error_name(int32_t rc) {
+    switch (rc) {
+    case SIMPLER_DEVICE_UNUSABLE:
+        return "SIMPLER_DEVICE_UNUSABLE";
+    case 107022:
+        return "ACL_ERROR_RT_DEVICE_TASK_ABORT";
+    case 207001:
+        return "ACL_ERROR_RT_MEMORY_ALLOCATION";
+    case 507000:
+        return "ACL_ERROR_RT_INTERNAL_ERROR";
+    case 507014:
+        return "ACL_ERROR_RT_AICORE_TIMEOUT";
+    case 507015:
+        return "ACL_ERROR_RT_AICORE_EXCEPTION";
+    case 507017:
+        return "ACL_ERROR_RT_AICPU_TIMEOUT";
+    case 507018:
+        return "ACL_ERROR_RT_AICPU_EXCEPTION";
+    case 507046:
+        return "ACL_ERROR_RT_STREAM_SYNC_TIMEOUT";
+    case 507899:
+        return "ACL_ERROR_RT_DRV_INTERNAL_ERROR";
+    default:
+        return nullptr;
+    }
+}
+
+// One-sentence meaning of a CANN return code, in terms of what it means *for this project*.
+static inline const char *acl_error_desc(int32_t rc) {
+    switch (rc) {
+    case SIMPLER_DEVICE_UNUSABLE:
+        return "the DeviceRunner had already marked this device unusable and refused to run";
+    case 107022:
+        return "the device task was aborted, usually as collateral damage after another task on the "
+               "same device faulted";
+    case 207001:
+        return "device memory allocation failed (out of memory)";
+    case 507000:
+        return "runtime internal error -- on a5 this is what an AICPU op timeout surfaces as at "
+               "stream sync";
+    case 507014:
+        return "an AICore task exceeded its execution timeout";
+    case 507015:
+        return "an AICore task raised an exception";
+    case 507017:
+        return "an AICPU task exceeded its execution timeout";
+    case 507018:
+        return "an AICPU task raised an exception; several distinct on-device mechanisms all surface "
+               "as this one generic code";
+    case 507046:
+        return "the host timed out waiting on a stream sync; the device never reported completion";
+    case 507899:
+        return "driver internal error -- typically a sticky error returned by every later call on an "
+               "already-poisoned context, so it is a symptom of an earlier failure, not the cause";
+    default:
+        return nullptr;
+    }
+}
+
+// What to do next about a CANN return code. nullptr when we have nothing specific to say.
+static inline const char *acl_error_hint(int32_t rc) {
+    switch (rc) {
+    case SIMPLER_DEVICE_UNUSABLE:
+        return "look for the earlier failure that marked the device unusable; this line is a "
+               "consequence of it";
+    case 107022:
+    case 507899:
+        return "look further up the log for the first failure on this device -- this code is fallout, "
+               "not the root cause";
+    case 207001:
+        return "reduce the workload's device memory footprint, or check whether another process is "
+               "holding memory on this device";
+    case 507000:
+    case 507014:
+    case 507017:
+    case 507018:
+    case 507046:
+        return "do NOT read this as 'deadlock' or 'OOM' on its own -- it is a generic host-side code. "
+               "Grep the host log for 'orch_error_code=' / 'sched_error_code=' / 'sub_class=' to get "
+               "the device-classified reason, and read the device log for the detector that fired";
+    case 507015:
+        return "find the faulting AICore kernel in the device log; this is a kernel-side fault, not a "
+               "capacity or scheduling problem";
+    default:
+        return nullptr;
+    }
+}
+
+#endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_ACL_ERROR_NAMES_H_

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -43,6 +43,7 @@
 #include "common/host_api.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "host/acl_error_log.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
 #include "pto_runtime_c_api.h"
@@ -321,6 +322,7 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
     int rc = rtSetDevice(device_id);
     if (rc != 0) {
         LOG_ERROR("rtSetDevice(%d) failed: %d", device_id, rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
 
@@ -365,6 +367,7 @@ int DeviceRunnerBase::ensure_device_initialized() {
         rc = rtStreamCreate(&stream_aicpu_, 0);
         if (rc != 0) {
             LOG_ERROR("rtStreamCreate (AICPU) failed: %d", rc);
+            ACL_LOG_ERROR_DETAIL(rc);
             return rc;
         }
         aicpu_created_here = true;
@@ -373,6 +376,7 @@ int DeviceRunnerBase::ensure_device_initialized() {
         rc = rtStreamCreate(&stream_aicore_, 0);
         if (rc != 0) {
             LOG_ERROR("rtStreamCreate (AICore) failed: %d", rc);
+            ACL_LOG_ERROR_DETAIL(rc);
             // Roll back only the AICPU stream we just created, not a
             // pre-existing persistent one.
             if (aicpu_created_here) {
@@ -608,6 +612,7 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
     int rc = rtMemcpy(gm_addr, layout.total_size, scratch.data(), layout.total_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         LOG_ERROR("rtMemcpy chip callable H2D failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         mem_alloc_.free(gm_addr);
         return 0;
     }
@@ -733,6 +738,7 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
     }
     if (rc != 0) {
         LOG_ERROR("launch_device_register: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
 
@@ -1068,6 +1074,7 @@ int DeviceRunnerBase::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args
         int rc = rtRegisterAllKernel(&binary, &aicore_bin_handle_);
         if (rc != RT_ERROR_NONE) {
             LOG_ERROR("rtRegisterAllKernel failed: %d", rc);
+            ACL_LOG_ERROR_DETAIL(rc);
             aicore_bin_handle_ = nullptr;
             return rc;
         }
@@ -1088,6 +1095,7 @@ int DeviceRunnerBase::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args
     int rc = rtKernelLaunchWithHandleV2(aicore_bin_handle_, 0, block_dim_, &rt_args, nullptr, stream, &cfg);
     if (rc != RT_ERROR_NONE) {
         LOG_ERROR("rtKernelLaunchWithHandleV2 failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
 
@@ -1210,10 +1218,12 @@ int DeviceRunnerBase::sync_run_streams() {
             "Stream sync timeout: stream=AICPU timeout_ms=%d device_id=%d block_dim=%d",
             timeout_config_.stream_sync_timeout_ms, device_id_, block_dim_
         );
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
     if (rc != 0) {
         LOG_ERROR("aclrtSynchronizeStreamWithTimeout (AICPU) failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
 
@@ -1224,10 +1234,12 @@ int DeviceRunnerBase::sync_run_streams() {
             "Stream sync timeout: stream=AICore timeout_ms=%d device_id=%d block_dim=%d",
             timeout_config_.stream_sync_timeout_ms, device_id_, block_dim_
         );
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
     if (rc != 0) {
         LOG_ERROR("aclrtSynchronizeStreamWithTimeout (AICore) failed: %d", rc);
+        ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
     return 0;

--- a/src/common/runtime_status/error_log.h
+++ b/src/common/runtime_status/error_log.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Runtime Failure Line (host)
+ *
+ * The whole host-side report of a latched runtime failure: the machine-readable line, then
+ * what the code means and what to do about it. One macro, because the two halves are only
+ * correct together -- a caller cannot emit the raw codes and forget the explanation.
+ *
+ * A macro rather than a function on purpose. LOG_ERROR bakes in __FUNCTION__, __FILENAME__
+ * and __LINE__ at its expansion point, so wrapping it in a function would stamp every line
+ * with this header's name instead of the site that actually detected the failure. Expanding
+ * at the call site keeps the log pointing at validate_runtime_impl in the caller's
+ * runtime_maker.cpp, which is the thing a reader needs.
+ *
+ * The first line is parsed by the STs (which match on "orch_error_code=N") and mirrored in
+ * tests/ut/py/test_resource_failure_summary.py, so its text is kept byte-for-byte stable.
+ * The meaning goes on the lines *after* it, never inside it.
+ *
+ * Kept separate from error_names.h so that header stays free of any logging dependency
+ * and can be unit-tested on its own. Include the runtime's pto_runtime_status.h first.
+ */
+
+#ifndef SRC_COMMON_RUNTIME_STATUS_ERROR_LOG_H_
+#define SRC_COMMON_RUNTIME_STATUS_ERROR_LOG_H_
+
+#include <stdint.h>
+
+#include "error_names.h"
+#include "common/unified_log.h"
+
+// Reports a non-zero runtime_status: the codes, then their meaning and triage hint. A code
+// this build does not know about is left un-annotated rather than mislabeled -- a bare number
+// beats a neighbouring code's text.
+#define LOG_RUNTIME_FAILURE(orch_error_code, sched_error_code, runtime_status)                                      \
+    do {                                                                                                            \
+        const int32_t rtf_orch_ = (orch_error_code);                                                                \
+        const int32_t rtf_sched_ = (sched_error_code);                                                              \
+        LOG_ERROR(                                                                                                  \
+            "PTO2 runtime failed: orch_error_code=%d sched_error_code=%d runtime_status=%d", rtf_orch_, rtf_sched_, \
+            (runtime_status)                                                                                        \
+        );                                                                                                          \
+        const int32_t rtf_code_ = latched_error_code(rtf_orch_, rtf_sched_);                                        \
+        if (rtf_code_ != PTO2_ERROR_NONE && error_desc(rtf_code_)[0] != '\0') {                                     \
+            LOG_ERROR(                                                                                              \
+                "error detail: %s=%d %s - %s", latched_error_field(rtf_orch_, rtf_sched_), rtf_code_,               \
+                error_name(rtf_code_), error_desc(rtf_code_)                                                        \
+            );                                                                                                      \
+            if (error_hint(rtf_code_)[0] != '\0') {                                                                 \
+                LOG_ERROR("error hint: %s. See docs/troubleshooting/device-error-codes.md", error_hint(rtf_code_)); \
+            }                                                                                                       \
+        }                                                                                                           \
+    } while (0)
+
+#endif  // SRC_COMMON_RUNTIME_STATUS_ERROR_LOG_H_

--- a/src/common/runtime_status/error_names.h
+++ b/src/common/runtime_status/error_names.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Runtime Error-Code Names and Triage Hints
+ *
+ * Turns a latched PTO2_ERROR_* code into text for the host failure line, so a caller
+ * reading the log does not have to look the number up. Same role for the error code
+ * that stall_detail_name() already plays for the stall sub-class.
+ *
+ * The switches key off the PTO2_ERROR_* macros rather than literals, so the code values
+ * live in exactly one place (the per-runtime pto_runtime_status.h). Include this header
+ * *after* that one; the #error below enforces it.
+ *
+ * Full triage steps per code: docs/troubleshooting/device-error-codes.md
+ */
+
+#ifndef SRC_COMMON_RUNTIME_STATUS_ERROR_NAMES_H_
+#define SRC_COMMON_RUNTIME_STATUS_ERROR_NAMES_H_
+
+#include <stdint.h>
+
+#ifndef PTO2_ERROR_SCOPE_DEADLOCK
+#error "include the runtime's pto_runtime_status.h before error_names.h"
+#endif
+
+// Symbolic name of a latched PTO2_ERROR_* code. "unknown" for a code this table does not
+// cover -- callers use that to suppress the annotation rather than print a misleading one.
+static inline const char *error_name(int32_t code) {
+    switch (code) {
+    case PTO2_ERROR_NONE:
+        return "none";
+    case PTO2_ERROR_SCOPE_DEADLOCK:
+        return "SCOPE_DEADLOCK";
+    case PTO2_ERROR_HEAP_RING_DEADLOCK:
+        return "HEAP_RING_DEADLOCK";
+    case PTO2_ERROR_FLOW_CONTROL_DEADLOCK:
+        return "FLOW_CONTROL_DEADLOCK";
+    case PTO2_ERROR_DEP_POOL_OVERFLOW:
+        return "DEP_POOL_OVERFLOW";
+    case PTO2_ERROR_INVALID_ARGS:
+        return "INVALID_ARGS";
+#ifdef PTO2_ERROR_DEPENDENCY_OVERFLOW
+    case PTO2_ERROR_DEPENDENCY_OVERFLOW:
+        return "DEPENDENCY_OVERFLOW (retired; now reported as DEP_POOL_OVERFLOW)";
+#endif
+    case PTO2_ERROR_REQUIRE_SYNC_START_INVALID:
+        return "REQUIRE_SYNC_START_INVALID";
+    case PTO2_ERROR_TENSOR_WAIT_TIMEOUT:
+        return "TENSOR_WAIT_TIMEOUT";
+    case PTO2_ERROR_EXPLICIT_ORCH_FATAL:
+        return "EXPLICIT_ORCH_FATAL";
+    case PTO2_ERROR_SCOPE_TASKS_OVERFLOW:
+        return "SCOPE_TASKS_OVERFLOW";
+    case PTO2_ERROR_TENSORMAP_OVERFLOW:
+        return "TENSORMAP_OVERFLOW";
+    case PTO2_ERROR_SCHEDULER_TIMEOUT:
+        return "SCHEDULER_TIMEOUT";
+    case PTO2_ERROR_ASYNC_COMPLETION_INVALID:
+        return "ASYNC_COMPLETION_INVALID";
+    case PTO2_ERROR_ASYNC_WAIT_OVERFLOW:
+        return "ASYNC_WAIT_OVERFLOW";
+    case PTO2_ERROR_ASYNC_REGISTRATION_FAILED:
+        return "ASYNC_REGISTRATION_FAILED";
+    default:
+        return "unknown";
+    }
+}
+
+// One-sentence meaning of a latched PTO2_ERROR_* code. Empty string for an uncovered code.
+static inline const char *error_desc(int32_t code) {
+    switch (code) {
+    case PTO2_ERROR_NONE:
+        return "no error";
+    case PTO2_ERROR_SCOPE_DEADLOCK:
+        return "tasks submitted in one scope reached the ring task-window cap; their fanout "
+               "references are only released at scope_end, so no slot can be reclaimed";
+    case PTO2_ERROR_HEAP_RING_DEADLOCK:
+        return "the ring task allocator ran out of both task slots and heap bytes, so no further "
+               "task can be admitted";
+    case PTO2_ERROR_FLOW_CONTROL_DEADLOCK:
+        return "the task window is blocked while the heap is not full -- typically nesting on the "
+               "same ring, where an outer task waits on an inner task that cannot get a slot";
+    case PTO2_ERROR_DEP_POOL_OVERFLOW:
+        return "a task's explicit fanin edges overflowed the ring's dependency spill pool";
+    case PTO2_ERROR_INVALID_ARGS:
+        return "an orchestration API rejected its arguments (bad alloc_tensors info, illegal nested "
+               "scope, unknown task id in set_dependencies, or an L0TaskArgs carrying an error flag)";
+#ifdef PTO2_ERROR_DEPENDENCY_OVERFLOW
+    case PTO2_ERROR_DEPENDENCY_OVERFLOW:
+        return "retired code: per-task fanin overflow is now reported as DEP_POOL_OVERFLOW";
+#endif
+    case PTO2_ERROR_REQUIRE_SYNC_START_INVALID:
+        return "require_sync_start() asked for more blocks than the target core type physically has, "
+               "which can never be satisfied";
+    case PTO2_ERROR_TENSOR_WAIT_TIMEOUT:
+        return "waiting for tensor data timed out: the producing task never completed, or a consumer "
+               "never released its fanout reference";
+    case PTO2_ERROR_EXPLICIT_ORCH_FATAL:
+        return "the orchestration code called rt_report_fatal() itself; every later orchestration API "
+               "call short-circuits to a no-op";
+    case PTO2_ERROR_SCOPE_TASKS_OVERFLOW:
+        return "the scope task-record buffer saturated (runtime-internal; the rings normally fill "
+               "first and latch SCOPE_DEADLOCK or FLOW_CONTROL_DEADLOCK)";
+    case PTO2_ERROR_TENSORMAP_OVERFLOW:
+        return "the tensormap entry pool is wedged and last_task_alive cannot advance "
+               "(runtime-internal, or an extreme-scale workload)";
+    case PTO2_ERROR_SCHEDULER_TIMEOUT:
+        return "the scheduler saw no forward progress within its timeout; the sub_class= line below "
+               "carries the device-classified reason and locators";
+    case PTO2_ERROR_ASYNC_COMPLETION_INVALID:
+        return "an async completion condition is malformed (bad completion_type, null counter address, "
+               "or an invalid SDMA event record)";
+    case PTO2_ERROR_ASYNC_WAIT_OVERFLOW:
+        return "the async wait list filled up: in-flight async completions exceeded the per-task cap";
+    case PTO2_ERROR_ASYNC_REGISTRATION_FAILED:
+        return "the scheduler received an async completion message of an illegal kind (runtime-internal; "
+               "ASYNC_WAIT_OVERFLOW normally intercepts this first)";
+    default:
+        return "";
+    }
+}
+
+// What to do next about a latched PTO2_ERROR_* code. Empty string for an uncovered code.
+static inline const char *error_hint(int32_t code) {
+    switch (code) {
+    case PTO2_ERROR_NONE:
+        return "";
+    case PTO2_ERROR_SCOPE_DEADLOCK:
+        return "raise ring_task_window (PTO2_RING_TASK_WINDOW) or split the scope so slots are "
+               "reclaimed sooner; enable CallConfig.enable_scope_stats to see which scope peaked";
+    case PTO2_ERROR_HEAP_RING_DEADLOCK:
+        return "raise ring_heap (PTO2_RING_HEAP) or shrink per-task args / intermediate tensors; the "
+               "'Ring buffer sizes:' line above reports the configured capacities";
+    case PTO2_ERROR_FLOW_CONTROL_DEADLOCK:
+        return "check for self-dependent or nested submission on one ring; raise ring_task_window "
+               "(PTO2_RING_TASK_WINDOW) or move the nested submission to another ring";
+    case PTO2_ERROR_DEP_POOL_OVERFLOW:
+        return "raise ring_dep_pool (PTO2_RING_DEP_POOL) or cut the fanin count of the offending "
+               "set_dependencies() call; enable CallConfig.enable_scope_stats to locate it";
+    case PTO2_ERROR_INVALID_ARGS:
+        return "an orchestration bug, not a capacity problem -- resizing the rings will not help; "
+               "recheck the arguments of the orchestration API calls listed above";
+#ifdef PTO2_ERROR_DEPENDENCY_OVERFLOW
+    case PTO2_ERROR_DEPENDENCY_OVERFLOW:
+        return "see DEP_POOL_OVERFLOW";
+#endif
+    case PTO2_ERROR_REQUIRE_SYNC_START_INVALID:
+        return "lower the task's block_num to at most the physical core count of the target core type "
+               "(total AIV count, or total cluster count for MIX/AIC), or drop the sync-start request";
+    case PTO2_ERROR_TENSOR_WAIT_TIMEOUT:
+        return "find the producing kernel and check it for a hang (see SCHEDULER_TIMEOUT sub_class S1); "
+               "verify the consumer declares the dependency and exits; raise PTO2_TENSOR_DATA_TIMEOUT_MS "
+               "to tell a slow kernel apart from a stuck one";
+    case PTO2_ERROR_EXPLICIT_ORCH_FATAL:
+        return "self-inflicted -- follow the message passed to the rt_report_fatal() call site";
+    case PTO2_ERROR_SCOPE_TASKS_OVERFLOW:
+    case PTO2_ERROR_TENSORMAP_OVERFLOW:
+    case PTO2_ERROR_ASYNC_REGISTRATION_FAILED:
+        return "not expected in normal operation -- keep the device log and report it to the runtime "
+               "maintainers; tuning the ring capacities will not help";
+    case PTO2_ERROR_SCHEDULER_TIMEOUT:
+        return "read the sub_class= line below first, then follow the S1-S5 table in the doc; raise "
+               "PTO2_SCHEDULER_TIMEOUT_MS to tell a true deadlock apart from a merely slow kernel";
+    case PTO2_ERROR_ASYNC_COMPLETION_INVALID:
+        return "recheck the register_completion_condition() arguments in the kernel, in particular the "
+               "completion type and the counter address";
+    case PTO2_ERROR_ASYNC_WAIT_OVERFLOW:
+        return "cut the number of in-flight async completions per task, and confirm the consumer side "
+               "actually polls and retires them";
+    default:
+        return "";
+    }
+}
+
+// At most one of the two codes is ever non-zero (orchestrator and scheduler each latch
+// their own, first-writer-wins). These two pick the latched one and name the field it
+// came from, so every failure site annotates the same way without repeating the choice.
+static inline int32_t latched_error_code(int32_t orch_error_code, int32_t sched_error_code) {
+    return orch_error_code != PTO2_ERROR_NONE ? orch_error_code : sched_error_code;
+}
+
+static inline const char *latched_error_field(int32_t orch_error_code, int32_t sched_error_code) {
+    return orch_error_code != PTO2_ERROR_NONE ? "orch_error_code" : "sched_error_code";
+}
+
+#endif  // SRC_COMMON_RUNTIME_STATUS_ERROR_NAMES_H_

--- a/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
+++ b/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
@@ -44,13 +44,17 @@ RUNTIME = "tensormap_and_ringbuffer"
 KERNELS = os.path.join(HERE, "kernels")
 ORCH_DIR = os.path.join(KERNELS, "orchestration")
 
-# case -> dict(orch, code, runtime_env, kernel, marker)
+# case -> dict(orch, code, runtime_env, kernel, marker, explain)
 #   code       : runtime status the host reports in sim (orch_error_code or sched_error_code)
 #   runtime_env: CallConfig.runtime_env overrides that pin the offending resource small
 #   kernel     : AIV kernel (rel to kernels/) for the async cases, else None
 #   marker     : substring of the validate_runtime_impl host-log line proving the
 #                device error class reached the host (the assertion that holds on
 #                both sim and onboard, even when onboard masks the code as 507xxx)
+#   explain    : PTO2_ERROR_* name the "error detail:" annotation line must carry, so
+#                the log says what the code *means* and not just what it is. Every reachable
+#                code is checked here; the unreachable ones (10/11/103) are covered by the
+#                cpput over the name table itself.
 CASES = {
     "scope_deadlock": dict(
         orch="scope_deadlock_orch.cpp",
@@ -58,6 +62,7 @@ CASES = {
         runtime_env={"ring_task_window": 4},
         kernel=None,
         marker="orch_error_code=1",
+        explain="SCOPE_DEADLOCK",
     ),
     "heap_ring_deadlock": dict(
         orch="heap_ring_deadlock_orch.cpp",
@@ -65,6 +70,7 @@ CASES = {
         runtime_env={"ring_heap": 1024},
         kernel=None,
         marker="orch_error_code=2",
+        explain="HEAP_RING_DEADLOCK",
     ),
     "flow_control_deadlock": dict(
         orch="flow_control_deadlock_orch.cpp",
@@ -72,6 +78,7 @@ CASES = {
         runtime_env={"ring_task_window": 4},
         kernel=None,
         marker="orch_error_code=3",
+        explain="FLOW_CONTROL_DEADLOCK",
     ),
     "dep_pool_overflow": dict(
         orch="dep_pool_overflow_orch.cpp",
@@ -79,6 +86,7 @@ CASES = {
         runtime_env={"ring_dep_pool": 4},
         kernel=None,
         marker="orch_error_code=4",
+        explain="DEP_POOL_OVERFLOW",
     ),
     "invalid_args": dict(
         orch="invalid_args_orch.cpp",
@@ -86,6 +94,7 @@ CASES = {
         runtime_env={},
         kernel=None,
         marker="orch_error_code=5",
+        explain="INVALID_ARGS",
     ),
     "require_sync_start_invalid": dict(
         orch="require_sync_start_orch.cpp",
@@ -93,6 +102,7 @@ CASES = {
         runtime_env={},
         kernel="aiv/kernel_noop.cpp",
         marker="orch_error_code=7",
+        explain="REQUIRE_SYNC_START_INVALID",
     ),
     "aicore_hang": dict(
         orch="aicore_hang_orch.cpp",
@@ -109,6 +119,7 @@ CASES = {
             "SIMPLER_STREAM_SYNC_TIMEOUT_MS": 4000,
         },
         marker="sub_class=S1",
+        explain="SCHEDULER_TIMEOUT",
     ),
     "tensor_wait_timeout": dict(
         orch="tensor_wait_timeout_orch.cpp",
@@ -128,6 +139,7 @@ CASES = {
             "SIMPLER_STREAM_SYNC_TIMEOUT_MS": 40000,
         },
         marker="orch_error_code=8",
+        explain="TENSOR_WAIT_TIMEOUT",
     ),
     "async_completion_invalid": dict(
         orch="async_error_orch.cpp",
@@ -135,6 +147,7 @@ CASES = {
         runtime_env={},
         kernel="aiv/kernel_async_completion_invalid.cpp",
         marker="sched_error_code=101",
+        explain="ASYNC_COMPLETION_INVALID",
     ),
     "async_wait_overflow": dict(
         orch="async_error_orch.cpp",
@@ -142,6 +155,7 @@ CASES = {
         runtime_env={},
         kernel="aiv/kernel_async_wait_overflow.cpp",
         marker="sched_error_code=102",
+        explain="ASYNC_WAIT_OVERFLOW",
     ),
     "explicit_fatal": dict(
         orch="explicit_fatal_orch.cpp",
@@ -149,6 +163,7 @@ CASES = {
         runtime_env={},
         kernel=None,
         marker="orch_error_code=9",
+        explain="EXPLICIT_ORCH_FATAL",
     ),
     # Error codes still without an e2e case, and why. Device-side cpput keeps the
     # structural ones covered; the sub-classes have unit coverage of the classifier.
@@ -202,6 +217,19 @@ CASES = {
     # TENSOR_WAIT_TIMEOUT (8) IS covered (onboard, both arches) — see the
     # tensor_wait_timeout case.
 }
+
+
+def _assert_annotated(log: str, case: dict) -> None:
+    """The failure line must be followed by what the code *means*, not just the number.
+
+    The machine-readable "PTO2 runtime failed: ..." line is deliberately left alone -- it is
+    what ``marker`` matches and what conftest's device-poison regex reads -- so the meaning is
+    carried on its own "error detail:" line, emitted by the LOG_RUNTIME_FAILURE macro
+    (src/common/runtime_status/error_log.h).
+    """
+    assert "error detail:" in log, "host log carries the raw code but no explanation of it"
+    assert case["explain"] in log, f"annotation does not name the code as '{case['explain']}'"
+    assert "error hint:" in log, "annotation names the code but says nothing about what to do"
 
 
 def _build_chip_callable(platform: str, case: dict) -> ChipCallable:
@@ -273,7 +301,9 @@ def test_fatal_code_surfaces_on_sim(st_platform, st_device_ids, case_name, monke
         with pytest.raises(RuntimeError, match=rf"(run_runtime|run) failed with code -{case['code']}\b"):
             worker.run(handle, ChipStorageTaskArgs(), config)
         captured = capfd.readouterr()
-        assert case["marker"] in captured.err + captured.out, f"missing '{case['marker']}' in host log"
+        log = captured.err + captured.out
+        assert case["marker"] in log, f"missing '{case['marker']}' in host log"
+        _assert_annotated(log, case)
     finally:
         worker.close()
 
@@ -295,6 +325,8 @@ def test_device_error_class_reaches_host_log(st_platform, st_device_ids, case_na
         with pytest.raises(RuntimeError):
             worker.run(handle, ChipStorageTaskArgs(), config)
         captured = capfd.readouterr()
-        assert case["marker"] in captured.err + captured.out, f"device error class '{case['marker']}' not in host log"
+        log = captured.err + captured.out
+        assert case["marker"] in log, f"device error class '{case['marker']}' not in host log"
+        _assert_annotated(log, case)
     finally:
         worker.close()

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -472,6 +472,13 @@ target_include_directories(test_runtime_timeout_config_a5 PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/a5/platform/include
 )
 
+# The PTO2_ERROR_* codes the name table switches on live in the runtime's status header;
+# a2a3's and a5's copies are identical, so compiling against one covers both.
+add_common_utils_test(test_error_code_names common/test_error_code_names.cpp)
+target_include_directories(test_error_code_names PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/common
+)
+
 add_executable(test_scope_stats_collector
     common/test_scope_stats_collector.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/scope_stats_collector.cpp

--- a/tests/ut/cpp/common/test_error_code_names.cpp
+++ b/tests/ut/cpp/common/test_error_code_names.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Error-code name tables: every code an operator can see must translate to text.
+ *
+ * The e2e coverage in tests/st/runtime_fatal_codes only reaches the codes a workload can
+ * actually provoke. Codes 10, 11 and 103 are argued unreachable there and so have no ST --
+ * but an unreachable code is exactly the one that shows up as a bare number on the day it
+ * finally fires. These tests hold the tables complete regardless of reachability.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "pto_runtime_status.h"
+
+#include "runtime_status/error_names.h"
+
+#include "host/acl_error_names.h"
+
+namespace {
+
+bool is_blank(const char *s) { return s == nullptr || s[0] == '\0'; }
+
+// Every PTO2 error code, including the ones no ST can provoke. 6 is retired and absent from
+// the tensormap_and_ringbuffer header this test compiles against.
+constexpr int32_t kAllRuntimeCodes[] = {
+    PTO2_ERROR_SCOPE_DEADLOCK,        PTO2_ERROR_HEAP_RING_DEADLOCK,
+    PTO2_ERROR_FLOW_CONTROL_DEADLOCK, PTO2_ERROR_DEP_POOL_OVERFLOW,
+    PTO2_ERROR_INVALID_ARGS,          PTO2_ERROR_REQUIRE_SYNC_START_INVALID,
+    PTO2_ERROR_TENSOR_WAIT_TIMEOUT,   PTO2_ERROR_EXPLICIT_ORCH_FATAL,
+    PTO2_ERROR_SCOPE_TASKS_OVERFLOW,  PTO2_ERROR_TENSORMAP_OVERFLOW,
+    PTO2_ERROR_SCHEDULER_TIMEOUT,     PTO2_ERROR_ASYNC_COMPLETION_INVALID,
+    PTO2_ERROR_ASYNC_WAIT_OVERFLOW,   PTO2_ERROR_ASYNC_REGISTRATION_FAILED,
+};
+
+TEST(RuntimeErrorNames, EveryCodeHasNameDescAndHint) {
+    for (int32_t code : kAllRuntimeCodes) {
+        EXPECT_STRNE(error_name(code), "unknown") << "code " << code << " is missing from the name table";
+        EXPECT_FALSE(is_blank(error_desc(code))) << "code " << code << " has no description";
+        EXPECT_FALSE(is_blank(error_hint(code))) << "code " << code << " has no triage hint";
+    }
+}
+
+TEST(RuntimeErrorNames, NamesAreDistinct) {
+    for (size_t i = 0; i < std::size(kAllRuntimeCodes); ++i) {
+        for (size_t j = i + 1; j < std::size(kAllRuntimeCodes); ++j) {
+            EXPECT_STRNE(error_name(kAllRuntimeCodes[i]), error_name(kAllRuntimeCodes[j]))
+                << "codes " << kAllRuntimeCodes[i] << " and " << kAllRuntimeCodes[j] << " share a name";
+        }
+    }
+}
+
+TEST(RuntimeErrorNames, NoErrorIsNotAnError) {
+    EXPECT_STREQ(error_name(PTO2_ERROR_NONE), "none");
+    EXPECT_TRUE(is_blank(error_hint(PTO2_ERROR_NONE)));
+}
+
+// An unrecognised code must be reported as such. Annotating it with a neighbouring code's
+// text would be worse than printing the bare number.
+TEST(RuntimeErrorNames, UnknownCodeFallsBack) {
+    for (int32_t code : {6, 12, 42, 99, 104, 9999, -1}) {
+        EXPECT_STREQ(error_name(code), "unknown") << "code " << code;
+        EXPECT_TRUE(is_blank(error_desc(code))) << "code " << code;
+        EXPECT_TRUE(is_blank(error_hint(code))) << "code " << code;
+    }
+}
+
+// The orchestrator and the scheduler each latch into their own field, and at most one is
+// ever non-zero. The annotation has to name the field the code actually came from.
+TEST(RuntimeErrorNames, LatchedCodePicksTheNonZeroField) {
+    EXPECT_EQ(latched_error_code(PTO2_ERROR_SCOPE_DEADLOCK, PTO2_ERROR_NONE), PTO2_ERROR_SCOPE_DEADLOCK);
+    EXPECT_STREQ(latched_error_field(PTO2_ERROR_SCOPE_DEADLOCK, PTO2_ERROR_NONE), "orch_error_code");
+
+    EXPECT_EQ(latched_error_code(PTO2_ERROR_NONE, PTO2_ERROR_SCHEDULER_TIMEOUT), PTO2_ERROR_SCHEDULER_TIMEOUT);
+    EXPECT_STREQ(latched_error_field(PTO2_ERROR_NONE, PTO2_ERROR_SCHEDULER_TIMEOUT), "sched_error_code");
+
+    EXPECT_EQ(latched_error_code(PTO2_ERROR_NONE, PTO2_ERROR_NONE), PTO2_ERROR_NONE);
+}
+
+// The stall sub-class already had a name table; keep it and the error table consistent so a
+// SCHEDULER_TIMEOUT annotation and its sub_class= line cannot disagree.
+TEST(RuntimeErrorNames, StallDetailStillNamed) {
+    EXPECT_STREQ(stall_detail_name(PTO2_STALL_DETAIL_RUNNING_STALLED), "S1:running-stalled");
+    EXPECT_STREQ(stall_detail_name(PTO2_STALL_DETAIL_UNKNOWN), "unknown:accounting/corruption");
+}
+
+// ---------------------------------------------------------------------------
+// ACL / RT codes (host side)
+// ---------------------------------------------------------------------------
+
+// The codes conftest treats as device-poisoning, plus the ones the onboard rules doc triages.
+// If a code is worth branching on, it is worth naming in the log.
+constexpr int32_t kKnownAclCodes[] = {
+    SIMPLER_DEVICE_UNUSABLE, 107022, 207001, 507000, 507014, 507015, 507017, 507018, 507046, 507899,
+};
+
+TEST(AclErrorNames, KnownCodesHaveNameDescAndHint) {
+    for (int32_t rc : kKnownAclCodes) {
+        ASSERT_NE(acl_error_name(rc), nullptr) << "rc " << rc << " is missing from the name table";
+        EXPECT_FALSE(is_blank(acl_error_desc(rc))) << "rc " << rc << " has no description";
+        EXPECT_FALSE(is_blank(acl_error_hint(rc))) << "rc " << rc << " has no triage hint";
+    }
+}
+
+// 207001 is ACL_ERROR_RT_MEMORY_ALLOCATION per CANN's rt_error_codes.h -- not the "AICore
+// launch failure" that this repo's comments long claimed. Pin the authoritative names so the
+// log cannot re-inherit the folklore.
+TEST(AclErrorNames, NamesMatchCann) {
+    EXPECT_STREQ(acl_error_name(207001), "ACL_ERROR_RT_MEMORY_ALLOCATION");
+    EXPECT_STREQ(acl_error_name(507000), "ACL_ERROR_RT_INTERNAL_ERROR");
+    EXPECT_STREQ(acl_error_name(507018), "ACL_ERROR_RT_AICPU_EXCEPTION");
+    EXPECT_STREQ(acl_error_name(507046), "ACL_ERROR_RT_STREAM_SYNC_TIMEOUT");
+    EXPECT_STREQ(acl_error_name(507899), "ACL_ERROR_RT_DRV_INTERNAL_ERROR");
+}
+
+TEST(AclErrorNames, UnknownCodeIsNotGuessedAt) {
+    for (int32_t rc : {0, 1, 507019, 600000}) {
+        EXPECT_EQ(acl_error_name(rc), nullptr) << "rc " << rc;
+        EXPECT_EQ(acl_error_desc(rc), nullptr) << "rc " << rc;
+        EXPECT_EQ(acl_error_hint(rc), nullptr) << "rc " << rc;
+    }
+}
+
+}  // namespace


### PR DESCRIPTION
Closes #1350.

## Problem

A failing run showed the caller a bare integer and nothing about what it meant:

```text
[ERROR] PTO2 runtime failed: orch_error_code=1 sched_error_code=0 runtime_status=-1
[ERROR] aclrtSynchronizeStreamWithTimeout (AICPU) failed: 507018
RuntimeError: run failed with code 507018
```

The meanings *existed* in the repo — in `conftest.py`'s comments, in the `507018` triage table in `.claude/rules/running-onboard.md`, in the reasoning inside `tests/st/runtime_fatal_codes/` — but never reached the log. There was no code→string mapping anywhere: no `switch` over the ACL codes, and `aclGetRecentErrMsg()` was never called (zero hits repo-wide). The one precedent was `stall_detail_name()`, which is why a `SCHEDULER_TIMEOUT` already prints `sub_class=S1:running-stalled` instead of a bare `1`.

## What this does

Names the code where it is printed. The machine-readable failure lines are left **byte-for-byte alone** — the STs match on them and `conftest`'s device-poison detection parses them — so the meaning goes on its own lines after them:

```text
[ERROR] PTO2 runtime failed: orch_error_code=1 sched_error_code=0 runtime_status=-1
[ERROR] error detail: orch_error_code=1 SCOPE_DEADLOCK - tasks submitted in one scope
        reached the ring task-window cap; their fanout references are only released at scope_end
[ERROR] error hint: raise ring_task_window (PTO2_RING_TASK_WINDOW) or split the scope;
        set CallConfig.enable_scope_stats to confirm which resource peaked.
        See docs/troubleshooting/device-error-codes.md
```

Two tables, each with a pure names header (no logging/CANN dependency, so it unit-tests standalone) and a thin emitter beside it:

- `src/common/runtime_status/error_names.h` (emitter `error_log.h`, macro `LOG_RUNTIME_FAILURE`) — PTO2 codes 1–11 / 100–103. The `switch` keys off the **`PTO2_ERROR_*` macros, not literals**, so the code values still live only in the runtime's `pto_runtime_status.h` and one table serves all three print sites (a2a3-trb, a5-trb, a2a3-host_build_graph). A `#error` enforces the include order. Retired code 6 is handled behind an `#ifdef`, since only the `host_build_graph` copy still declares it.
- `src/common/platform/include/host/acl_error_names.h` — the CANN codes we actually hit, wired into the onboard host failure sites. The emitter additionally appends **`aclGetRecentErrMsg()`**, which is the driver's own account and beats any static text we could write.

An uncharacterised code is left **un-annotated rather than mislabeled** — printing a neighbouring code's text would be worse than printing the bare number.

## Corrects a piece of folklore

`207001` is **`ACL_ERROR_RT_MEMORY_ALLOCATION`** per CANN's `rt_error_codes.h` — not the "AICore launch failure" that `conftest.py`'s comment has claimed. The comment is fixed and a cpput pins the authoritative names so the log cannot re-inherit the wrong one.

## Tests

- **ST**: every case in `tests/st/runtime_fatal_codes/` now also asserts the annotation names its code. No new trigger fixtures were needed — the suite already covers every *reachable* code (1, 2, 3, 4, 5, 7, 8, 9, 100/S1, 101, 102).
- **cpput** (`tests/ut/cpp/common/test_error_code_names.cpp`, new): holds both tables complete *independently of reachability*. Codes 10, 11 and 103 have no ST because they are argued structurally unreachable — which makes them exactly the ones that would print as a bare number on the day they finally fire. Also pins the unknown-code fallback and the CANN names.

## Docs

`docs/troubleshooting/device-error-codes.md` (new) — the repo had **no** documentation of the PTO2 codes at all. Chapter 1 is a scannable code reference; the rest is the accumulated debugging experience per code: the minimal reproduction each code has in the ST suite, how to order the three competing watchdogs so the scheduler wins the race (and why a 45 s op-execute kill is *not* proof of a deadlock), and why 10 / 11 / 103 / S4 / S5 cannot be provoked. Ring tuning, timeout defaults and device-log triage are linked, not restated. `.claude/rules/running-onboard.md` now points at it from the `507018` section.

## Verification

- `test_error_code_names` — 9/9 pass.
- `pytest tests/st/runtime_fatal_codes --platform a5sim` — 9 pass, 2 `onboard_only` skipped.
- `pytest tests/ut/py/test_resource_failure_summary.py` — passes; its fixture hard-codes the `PTO2 runtime failed:` text, so it is the machine proof that line is unchanged.
- `pre-commit` clean on all touched files.

**Not run:** the onboard suite (`--platform a2a3`), which is the only path that exercises the ACL `507xxx` annotation — it needs a locked device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

