### PR TITLE
feat(tools): add L2-swimlane critical-path analysis

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -7,6 +7,42 @@ End-user profiling / debug CLIs live in
 [`simpler_setup/tools/`](../simpler_setup/tools/) and ship with the wheel —
 invoke them via `python -m simpler_setup.tools.<name>`.
 
+## critical_path.py
+
+Post-processing analysis over an L2-swimlane run. Given a directory produced by
+a `--enable-l2-swimlane` run, it reconstructs the critical path of the device
+execution and writes a per-task compute/stall report.
+
+It recursively discovers every directory under the given path that holds the
+full triple — a records file (`l2_swimlane_records.json`, or `l2_perf_records.json`
+for older runtimes) plus `deps.json` and `name_map.json` — so it is not
+restricted to a `dfx_outputs/rank*/d*` layout. For each such rank/device it
+builds a happens-before DAG from the dependency graph oriented by observed
+timestamps, then computes two critical paths:
+
+- **Static CPM** — the longest duration-weighted path, i.e. the
+  dependency-limited latency floor (unlimited cores).
+- **Observed** — the as-executed backward "blame" walk from the last-finishing
+  task; each task's compute plus the scheduling stall before it (`data-wait` =
+  waiting on a producer, `core-wait` = waiting for a core to free) tiles the
+  makespan exactly.
+
+It writes `critical_path_report.md` into the given directory: an overview
+(makespan, CPM floor, compute vs. stall split), a per-kernel-family table, and a
+full per-task listing. Pure post-processing — no C++, no device; O(N log N).
+
+```bash
+# Analyze a case run produced with --enable-l2-swimlane
+python tools/critical_path.py <run-dir>
+
+# Options: report filename, kernel-family rows, tick tolerance, echo summary
+python tools/critical_path.py <run-dir> \
+    --report critical_path_report.md --top 25 --stdout
+```
+
+It auto-discovers all ranks, so you can equally point it at a single
+`dfx_outputs/rank0/d0` directory or at the whole run tree.
+
 ## benchmark_rounds.sh
 
 Batch-run a predefined set of ST examples on hardware, parse `orch_start` /

--- a/tools/critical_path.py
+++ b/tools/critical_path.py
@@ -1,0 +1,487 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Critical-path analysis over an L2-swimlane build_output.
+
+Given a ``build_output/<case>`` directory produced by a ``--enable-l2-swimlane``
+run, this reconstructs the critical path of the device execution and writes a
+report describing, for every task on that path, its wall-clock duration, the
+compute time it contributes, and the runtime-scheduling stall (wait) before it,
+each as a fraction of the global makespan.
+
+Inputs consumed per rank (auto-discovered under the given directory, next to the
+``merged_swimlane_*.json`` files):
+  - ``l2_swimlane_records.json`` : per (task, core-block) execution slices
+  - ``deps.json``                : task dependency DAG (producer -> consumer)
+  - ``name_map.json``            : callable_id -> kernel name
+
+Two critical paths are computed:
+  A) Static CPM  : longest duration-weighted path in the happens-before DAG,
+                   i.e. the dependency-limited latency floor (unlimited cores).
+  B) Observed    : the as-executed "blame" path, walked backward from the last
+                   finishing task through whichever predecessor (data dependency
+                   or same-core resource) most tightly gated each task's start.
+                   Its compute + stall segments tile the makespan exactly.
+
+Usage:
+    python tools/critical_path.py build_output/_jit_l3_decode_fwd_<ts>
+    python tools/critical_path.py build_output/<case> --top 60 --stdout
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+INF = float("inf")
+
+# Structured per-task L2 records file. Current runs emit ``l2_swimlane_records.json``;
+# ``l2_perf_records.json`` is the name used in some docs / older runtimes. The first
+# name that exists in a rank dir is used.
+SWIMLANE_RECORD_NAMES = ("l2_swimlane_records.json", "l2_perf_records.json")
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _find_records(d: Path) -> Path | None:
+    """Return the structured swimlane-records file in *d*, or None."""
+    for name in SWIMLANE_RECORD_NAMES:
+        if (d / name).exists():
+            return d / name
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Data loading and per-task graph construction                                #
+# --------------------------------------------------------------------------- #
+@dataclass
+class RankGraph:
+    """Per-task timing + happens-before / resource predecessors for one rank."""
+
+    freq: int
+    start: dict[str, int]
+    end: dict[str, int]
+    dur: dict[str, int]
+    name: dict[str, str]
+    nblock: dict[str, int]
+    hb_pred: dict[str, list[str]]  # data-dependency predecessors (time-forward)
+    core_prev: dict[str, tuple[str, int]]  # same-core resource predecessor (task, end)
+    t0: int
+    t1: int
+    kept_edges: int
+    label: str
+
+
+def discover_rank_dirs(root: Path) -> list[Path]:
+    """Return every directory under *root* that holds a full swimlane triple."""
+    if root.is_file():
+        root = root.parent
+    dirs: set[Path] = set()
+    for name in SWIMLANE_RECORD_NAMES:
+        for rec in root.rglob(name):
+            d = rec.parent
+            if (d / "deps.json").exists() and (d / "name_map.json").exists():
+                dirs.add(d)
+    return sorted(dirs)
+
+
+def build_graph(rank_dir: Path, root: Path, tol: int) -> RankGraph:
+    rec_file = _find_records(rank_dir)
+    if rec_file is None:
+        raise FileNotFoundError(f"no swimlane records ({' / '.join(SWIMLANE_RECORD_NAMES)}) in {rank_dir}")
+    sw = _read_json(rec_file)
+    deps = _read_json(rank_dir / "deps.json")
+    name_map = _read_json(rank_dir / "name_map.json").get("callable_id_to_name", {})
+
+    freq = int(sw["metadata"]["clock_freq_hz"])
+    # aicore_tasks rows are [core_id, task_token, reg_task_id, start_tick, end_tick,
+    # receive_to_start_cycles] (see L2SwimlaneCollector::export_swimlane_json). Kernel
+    # names come from deps.json's kernel_ids, not from these rows.
+    recs = sw["aicore_tasks"]
+    if not recs:
+        raise RuntimeError(f"no aicore_tasks records in {rec_file} (empty/failed profiling run?)")
+
+    start: dict[str, int] = {}
+    end: dict[str, int] = {}
+    nblock: collections.Counter = collections.Counter()
+    core_slices: dict[int, list[tuple[int, int, str]]] = collections.defaultdict(list)
+    for core, tid, _seq, st, en, _recv in recs:
+        t = str(tid)
+        start[t] = min(start.get(t, INF), st)
+        end[t] = max(end.get(t, -INF), en)
+        nblock[t] += 1
+        core_slices[core].append((st, en, t))
+
+    dur = {t: end[t] - start[t] for t in start}
+    # task_id / edge endpoints are strings in deps.json but ints in the swimlane
+    # records; normalise everything to str so the joins never silently miss.
+    tinfo = {str(t["task_id"]): t for t in deps["tasks"]}
+
+    def name_of(t: str) -> str:
+        ks = tinfo.get(t, {}).get("kernel_ids") or []
+        cid = next((k for k in ks if k is not None and k >= 0), None)
+        if cid is None:
+            return "unknown"
+        return name_map.get(str(cid), f"cid{cid}")
+
+    name = {t: name_of(t) for t in start}
+
+    # Happens-before DAG: keep a data-dep edge p->s only when p is timed, finished
+    # by the time s started (+tol), AND started strictly earlier.  The deps graph
+    # is already an acyclic producer->consumer DAG; the strict-start condition makes
+    # edge retention antisymmetric, so the retained graph is provably acyclic even
+    # under tick-level ties, and every edge is time-forward for the DP / backward walk.
+    hb_pred: dict[str, list[str]] = collections.defaultdict(list)
+    kept = 0
+    seen: set[tuple[str, str]] = set()
+    for e in deps["edges"]:
+        p, s = str(e["pred"]), str(e["succ"])
+        if p == s or p not in start or s not in start or (p, s) in seen:
+            continue
+        seen.add((p, s))
+        if end[p] <= start[s] + tol and start[p] < start[s]:
+            hb_pred[s].append(p)
+            kept += 1
+
+    # Same-core resource predecessor: the moment the core a task first lands on was
+    # freed = max end over all earlier slices on that core (running-max handles any
+    # pipelined/overlapping slices correctly, not just the immediately-prior one).
+    core_prev: dict[str, tuple[str, int]] = {}
+    for _core, sl in core_slices.items():
+        sl.sort()
+        best_end, best_task = -INF, None
+        for st, en, t in sl:
+            if best_task is not None and best_task != t and best_end <= st + tol and st == start[t]:
+                cur = core_prev.get(t)
+                if cur is None or best_end > cur[1]:
+                    # best_end is a real tick here (set alongside best_task); the
+                    # -INF float only survives while best_task is still None.
+                    core_prev[t] = (best_task, int(best_end))
+            if en > best_end:
+                best_end, best_task = en, t
+
+    label = str(rank_dir.relative_to(root)) if rank_dir != root else rank_dir.name
+    return RankGraph(
+        freq=freq,
+        start=start,
+        end=end,
+        dur=dur,
+        name=name,
+        nblock=dict(nblock),
+        hb_pred=hb_pred,
+        core_prev=core_prev,
+        t0=min(start.values()),
+        t1=max(end.values()),
+        kept_edges=kept,
+        label=label,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Critical-path algorithms                                                    #
+# --------------------------------------------------------------------------- #
+def topo_order(g: RankGraph) -> list[str]:
+    indeg = {t: 0 for t in g.start}
+    succ: dict[str, list[str]] = collections.defaultdict(list)
+    for s, preds in g.hb_pred.items():
+        for p in preds:
+            succ[p].append(s)
+            indeg[s] += 1
+    q = collections.deque(t for t in g.start if indeg[t] == 0)
+    order: list[str] = []
+    while q:
+        u = q.popleft()
+        order.append(u)
+        for v in succ[u]:
+            indeg[v] -= 1
+            if indeg[v] == 0:
+                q.append(v)
+    if len(order) != len(g.start):
+        raise RuntimeError(f"happens-before graph is cyclic ({len(order)}/{len(g.start)})")
+    return order
+
+
+def static_cpm(g: RankGraph, order: list[str]) -> tuple[list[str], int]:
+    """Longest duration-weighted path in the happens-before DAG."""
+    finish: dict[str, int] = {}
+    choice: dict[str, str | None] = {}
+    for v in order:
+        best_p, best_f = None, 0
+        for p in g.hb_pred.get(v, ()):
+            if finish[p] > best_f:
+                best_f, best_p = finish[p], p
+        finish[v] = best_f + g.dur[v]
+        choice[v] = best_p
+    sink = max(finish, key=lambda t: finish[t])
+    path: list[str] = []
+    v: str | None = sink
+    while v is not None:
+        path.append(v)
+        v = choice[v]
+    path.reverse()
+    return path, finish[sink]
+
+
+@dataclass
+class Segment:
+    task: str
+    name: str
+    dur: int  # task wall-clock span (ticks)
+    compute: int  # non-overlapped compute contributed on the path (ticks)
+    stall: int  # gap before this task on the path (ticks)
+    kind: str  # blame class for the gap: data-wait / core-wait / front-gap
+
+
+@dataclass
+class RankResult:
+    label: str
+    freq: int
+    makespan: int
+    cpm_len: int
+    cpm_ntasks: int
+    cpm_head: list[str]
+    segments: list[Segment] = field(default_factory=list)
+    compute_total: int = 0
+    stall_total: int = 0
+    stall_by_kind: dict[str, int] = field(default_factory=dict)
+    ntasks: int = 0
+    kept_edges: int = 0
+
+
+def observed_path(g: RankGraph, tol: int) -> list[tuple[str, str]]:
+    """Backward blame walk -> list of (task, gap_kind), sink-first then reversed."""
+    sink = max(g.end, key=lambda t: g.end[t])
+    walk: list[tuple[str, str]] = []
+    v: str | None = sink
+    seen: set[str] = set()
+    while v is not None and v not in seen:
+        seen.add(v)
+        cand: list[tuple[int, str, str]] = []
+        for p in g.hb_pred.get(v, ()):
+            if g.end[p] <= g.start[v] + tol and g.start[p] < g.start[v]:
+                cand.append((g.end[p], p, "data-wait"))
+        cp = g.core_prev.get(v)
+        if cp is not None and cp[1] <= g.start[v] + tol and g.start.get(cp[0], INF) < g.start[v]:
+            cand.append((cp[1], cp[0], "core-wait"))
+        if not cand:
+            walk.append((v, "front-gap"))
+            break
+        cand.sort()
+        _bind_end, bp, kind = cand[-1]
+        walk.append((v, kind))
+        v = bp
+    walk.reverse()
+    return walk
+
+
+def analyze_rank(g: RankGraph, tol: int) -> RankResult:
+    order = topo_order(g)
+    cpm_path, cpm_len = static_cpm(g, order)
+    walk = observed_path(g, tol)
+
+    # Frontier sweep -> exact tiling of [t0, end[sink]] into compute + stall.
+    segments: list[Segment] = []
+    stall_by_kind: collections.Counter = collections.Counter()
+    compute_total = stall_total = 0
+    frontier = g.t0
+    for t, kind in walk:
+        s, e = g.start[t], g.end[t]
+        gap = max(0, s - frontier)
+        eff = max(0, e - max(s, frontier))
+        segments.append(Segment(task=t, name=g.name[t], dur=g.dur[t], compute=eff, stall=gap, kind=kind))
+        stall_by_kind[kind] += gap
+        compute_total += eff
+        stall_total += gap
+        frontier = max(frontier, e)
+
+    return RankResult(
+        label=g.label,
+        freq=g.freq,
+        makespan=g.t1 - g.t0,
+        cpm_len=cpm_len,
+        cpm_ntasks=len(cpm_path),
+        cpm_head=[g.name[t] for t in cpm_path[:10]],
+        segments=segments,
+        compute_total=compute_total,
+        stall_total=stall_total,
+        stall_by_kind=dict(stall_by_kind),
+        ntasks=len(g.start),
+        kept_edges=g.kept_edges,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reporting                                                                   #
+# --------------------------------------------------------------------------- #
+def _us(ticks: int, freq: int) -> float:
+    return ticks / freq * 1e6
+
+
+def _pct(part: int, whole: int) -> float:
+    return part / whole * 100 if whole else 0.0
+
+
+def render_report(results: list[RankResult], top: int) -> str:
+    out: list[str] = []
+    w = out.append
+    w("# Critical-path report (L2 swimlane)\n")
+    w("Generated by `tools/critical_path.py`. Times are device wall-clock; percentages are of each rank's makespan.\n")
+    w("- **Static CPM path**: dependency-limited latency floor (unlimited cores).")
+    w(
+        "- **Observed path**: the as-executed critical path; its per-task compute + "
+        "the runtime-scheduling stall before each task tile the makespan exactly."
+    )
+    w(
+        "- **stall kinds**: `data-wait` = waiting on an upstream producer; "
+        "`core-wait` = waiting for the assigned core to be freed (resource "
+        "serialization); `front-gap` = launch/dispatch delay before the first task.\n"
+    )
+
+    for r in results:
+        ms = r.makespan
+        w(f"\n## Rank `{r.label}`\n")
+        w(f"- tasks: {r.ntasks} | happens-before edges: {r.kept_edges}")
+        w(f"- **makespan**: {_us(ms, r.freq) / 1e3:.3f} ms")
+        w(
+            f"- **static CPM path**: {_us(r.cpm_len, r.freq) / 1e3:.3f} ms "
+            f"({_pct(r.cpm_len, ms):.1f}% of makespan) over {r.cpm_ntasks} tasks"
+        )
+        w(f"- **observed critical path**: {len(r.segments)} tasks")
+        w(f"  - compute: {_us(r.compute_total, r.freq) / 1e3:.3f} ms ({_pct(r.compute_total, ms):.1f}%)")
+        w(f"  - stall (runtime scheduling): {_us(r.stall_total, r.freq) / 1e3:.3f} ms ({_pct(r.stall_total, ms):.1f}%)")
+        for kind, val in sorted(r.stall_by_kind.items(), key=lambda kv: -kv[1]):
+            if val:
+                w(f"    - {kind}: {_us(val, r.freq) / 1e3:.3f} ms ({_pct(val, ms):.1f}%)")
+        check = r.compute_total + r.stall_total
+        w(
+            f"  - tiling check: compute+stall = {check} ticks vs makespan {ms} ticks "
+            f"({'exact' if check == ms else f'diff {check - ms}'})"
+        )
+
+        # Time by kernel family on the observed path.
+        fam_c: collections.Counter = collections.Counter()
+        fam_s: collections.Counter = collections.Counter()
+        fam_n: collections.Counter = collections.Counter()
+        for seg in r.segments:
+            fam = _family(seg.name)
+            fam_c[fam] += seg.compute
+            fam_s[fam] += seg.stall
+            fam_n[fam] += 1
+        w("\n### Time on the observed critical path, by kernel family\n")
+        w("| kernel family | compute ms | % makespan | stall ms | # on path |")
+        w("|---|---:|---:|---:|---:|")
+        for fam, cval in fam_c.most_common(top):
+            w(
+                f"| {fam} | {_us(cval, r.freq) / 1e3:.3f} | {_pct(cval, ms):.1f}% | "
+                f"{_us(fam_s[fam], r.freq) / 1e3:.3f} | {fam_n[fam]} |"
+            )
+
+        # Full per-task listing of the observed critical path.
+        w(f"\n### Observed critical path — all {len(r.segments)} tasks\n")
+        w("| # | kernel | task µs | compute µs (%mk) | stall µs (%mk) | stall kind |")
+        w("|---:|---|---:|---:|---:|---|")
+        for i, seg in enumerate(r.segments):
+            w(
+                f"| {i} | {seg.name} | {_us(seg.dur, r.freq):.1f} | "
+                f"{_us(seg.compute, r.freq):.1f} ({_pct(seg.compute, ms):.2f}%) | "
+                f"{_us(seg.stall, r.freq):.1f} ({_pct(seg.stall, ms):.2f}%) | "
+                f"{seg.kind if seg.stall else ''} |"
+            )
+    w("")
+    return "\n".join(out)
+
+
+def _family(name: str) -> str:
+    # Strip an optional trailing block index and/or an aic/aiv suffix in a single
+    # pass, so 'gate_0_aic', 'hc_pre_fused_3_aic' and 'exp_up_mm_2' all fold to
+    # their family ('gate', 'hc_pre_fused', 'exp_up_mm').
+    return re.sub(r"(_\d+)?(_(?:aic|aiv))?$", "", name)
+
+
+def render_summary(results: list[RankResult]) -> str:
+    lines: list[str] = []
+    for r in results:
+        ms = r.makespan
+        by_kind = sorted(r.stall_by_kind.items(), key=lambda kv: -kv[1])
+        detail = ", ".join(f"{k} {_pct(v, ms):.1f}%" for k, v in by_kind if v)
+        lines.append(
+            f"[{r.label}] makespan={_us(ms, r.freq) / 1e3:.3f}ms  "
+            f"CPM={_us(r.cpm_len, r.freq) / 1e3:.2f}ms({_pct(r.cpm_len, ms):.0f}%)  "
+            f"compute={_pct(r.compute_total, ms):.1f}%  "
+            f"stall={_pct(r.stall_total, ms):.1f}% ({detail})"
+        )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                         #
+# --------------------------------------------------------------------------- #
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Reconstruct the critical path of an L2-swimlane build_output "
+        "and write a per-task compute/stall report.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "build_dir",
+        type=Path,
+        help="build_output/<case> directory (or any dir containing dfx_outputs/rank*/d*/l2_swimlane_records.json)",
+    )
+    p.add_argument("--report", default="critical_path_report.md", help="report filename, written under build_dir")
+    p.add_argument("--top", type=int, default=25, help="rows in the kernel-family table")
+    p.add_argument("--tol", type=int, default=2, help="tick tolerance when deciding 'finished before' (clock ticks)")
+    p.add_argument("--stdout", action="store_true", help="also print a one-line-per-rank summary to stdout")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    root: Path = args.build_dir.expanduser().resolve()
+    if not root.exists():
+        print(f"error: path not found: {root}", file=sys.stderr)
+        return 2
+    # If a file (e.g. a records file) was passed, anchor discovery and the
+    # relative-path labels on its parent directory.
+    if root.is_file():
+        root = root.parent
+    rank_dirs = discover_rank_dirs(root)
+    if not rank_dirs:
+        print(
+            f"error: no l2_swimlane_records.json (+deps.json+name_map.json) found "
+            f"under {root}. Did the run use --enable-l2-swimlane?",
+            file=sys.stderr,
+        )
+        return 2
+
+    results: list[RankResult] = []
+    for d in rank_dirs:
+        g = build_graph(d, root, args.tol)
+        results.append(analyze_rank(g, args.tol))
+
+    report = render_report(results, args.top)
+    out_path = root / args.report
+    out_path.write_text(report, encoding="utf-8")
+
+    print(f"Analyzed {len(results)} rank(s) under {root}")
+    print(render_summary(results))
+    print(f"Report written to: {out_path}")
+    if args.stdout:
+        print("\n" + report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Add `tools/critical_path.py`, a pure post-processing tool that reconstructs the
critical path of an L2-swimlane run and writes a per-task compute/stall report.

This tool consumes the runtime's L2-swimlane dfx artifacts, so it belongs
alongside the runtime rather than in the kernel/model library. It was originally
proposed against `pypto-lib` (hw-native-sys/pypto-lib#757), which is now closed
in favor of this PR so the tool stays co-located with the record formats it
parses and evolves with them.

- Auto-discovers every rank/device under a run directory
  (`dfx_outputs/rank*/d*/`) from `l2_swimlane_records.json` + `deps.json` +
  `name_map.json`.
- Builds a happens-before DAG from the dependency graph oriented by observed
  swimlane timestamps (keep `pred->succ` only when `end[pred] <= start[succ]`),
  then computes two critical paths:
  - **Static CPM** — longest duration-weighted path, i.e. the
    dependency-limited latency floor (unlimited cores).
  - **Observed** — the as-executed backward "blame" walk from the
    last-finishing task; each task's compute plus the runtime-scheduling stall
    before it (`data-wait` = waiting on a producer, `core-wait` = waiting for a
    core to be freed) tiles the makespan exactly.
- Writes `critical_path_report.md` into the run directory: an overview
  (makespan, CPM floor, compute vs. stall split), a per-kernel-family table,
  and a full per-task listing.
- Documents CLI usage in `tools/README.md`.
- Pure post-processing (no C++, no device); complexity is O(N log N); stdlib only.

## Usage

```bash
# Analyze a run produced with --enable-l2-swimlane
python tools/critical_path.py <run-dir>

# Options: report filename, kernel-family rows, tick tolerance, echo summary
python tools/critical_path.py <run-dir> \
    --report critical_path_report.md --top 25 --stdout
```

It auto-discovers all ranks, so you can point it at a single
`dfx_outputs/rank0/d0` directory or at the whole run tree.
