### PR TITLE
fix(dfx): restore the collector shard count that #1343 left undefined (main does not compile)

### DIFF
--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -270,7 +270,7 @@ void PmuCollector::reset_collector_shards() {
     (void)close_csv_shards();
     cleanup_csv_shards();
 
-    const size_t shard_count = static_cast<size_t>(PmuModule::kCollectorThreadCount);
+    const size_t shard_count = static_cast<size_t>(manager_.shard_count());
     csv_shard_paths_.clear();
     csv_shard_paths_.reserve(shard_count);
     for (size_t shard = 0; shard < shard_count; shard++) {

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -308,7 +308,7 @@ void PmuCollector::reset_collector_shards() {
     (void)close_csv_shards();
     cleanup_csv_shards();
 
-    const size_t shard_count = static_cast<size_t>(PmuModule::kCollectorThreadCount);
+    const size_t shard_count = static_cast<size_t>(manager_.shard_count());
     csv_shard_paths_.clear();
     csv_shard_paths_.reserve(shard_count);
     for (size_t shard = 0; shard < shard_count; shard++) {

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -63,7 +63,7 @@ size_t ArgsDumpCollector::normalize_collector_shard(int collector_shard) const {
 }
 
 void ArgsDumpCollector::reset_collector_shards() {
-    const size_t shard_count = static_cast<size_t>(DumpModule::kCollectorThreadCount);
+    const size_t shard_count = static_cast<size_t>(manager_.shard_count());
     collected_.clear();
     collected_by_collector_.assign(shard_count, {});
     collector_counters_.assign(shard_count, {});

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -41,10 +41,13 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     ASSERT_TRUE(std::filesystem::create_directories(test_dir));
 
     constexpr int kRecordsPerShard = 32;
-    constexpr int kShardCount = DumpModule::kCollectorThreadCount;
+    constexpr int kShardCount = DumpModule::kMaxCollectorThreads;
     ArgsDumpCollector collector;
     ASSERT_EQ(
-        collector.initialize(1, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL_JSON_ONLY), 0
+        collector.initialize(
+            kShardCount, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL_JSON_ONLY
+        ),
+        0
     );
 
     std::vector<DumpMetaBuffer> buffers(kShardCount);

--- a/tests/ut/cpp/common/test_pmu_collector.cpp
+++ b/tests/ut/cpp/common/test_pmu_collector.cpp
@@ -74,7 +74,7 @@ TEST(PmuCollectorTest, MergesConcurrentShardWritesIntoFinalCsv) {
     ASSERT_TRUE(std::filesystem::create_directories(test_dir));
 
     constexpr int kRecordsPerShard = 64;
-    constexpr int kShardCount = PmuModule::kCollectorThreadCount;
+    constexpr int kShardCount = PmuModule::kMaxCollectorThreads;
     PmuCollector collector;
     ASSERT_EQ(
         collector.init(


### PR DESCRIPTION
## main does not compile

`main` (`8efe1127`) references `Module::kCollectorThreadCount` in three source files and two unit tests. That member no longer exists anywhere in the tree:

```text
src/a2a3/platform/shared/host/pmu_collector.cpp:273:63: error:
    'kCollectorThreadCount' is not a member of 'PmuModule'
src/common/platform/shared/host/args_dump_collector.cpp:66:64: error:
    'kCollectorThreadCount' is not a member of 'DumpModule'
src/a5/platform/shared/host/pmu_collector.cpp:311:63: error:
    'kCollectorThreadCount' is not a member of 'PmuModule'
```

Any branch cut from `main` fails in these three files before it ever reaches its own changes, so this is currently blocking unrelated work.

## Cause

#1343 deliberately split the constant's two roles:

- `Module::kMaxCollectorThreads` — the compile-time `std::array` capacity;
- `manager_.shard_count()` — the runtime shard count, derived from `aicpu_thread_num`.

The rename landed in the headers and in `l2_swimlane_collector.cpp`, which was updated to

```cpp
const size_t shard_count = static_cast<size_t>(manager_.shard_count());
```

The identical statement in the other three `reset_collector_shards()` implementations was not.

## Fix

The three runtime sites take the same replacement `l2_swimlane_collector.cpp` already got — the **live** `manager_.shard_count()`, not the capacity. Sizing the shard bookkeeping to the capacity would reinstate exactly the pre-#1343 behaviour the split exists to remove.

The two unit tests use the symbol in a `constexpr` context, where the compile-time capacity is what they mean, so they take `kMaxCollectorThreads`.

## One real test bug fell out of this

`test_args_dump_collector` declared **one** dump thread and then drove `kShardCount` shards. That was harmless while `reset_collector_shards()` always allocated the shard array at capacity regardless of the declared thread count — but that is precisely the behaviour #1343 removed. With the shard count now following `aicpu_thread_num`, `normalize_collector_shard()` correctly asserts `collector_shard out of range`.

The test now declares the threads it actually uses, matching what `test_pmu_collector` already did. This is the test being made honest, not the assert being worked around.

## Verification

- `pip install --no-build-isolation -e .` — builds; `main` does not.
- `ctest -LE requires_hardware` — **59/59 pass** (the 6 collector/profiler/buffer-pool tests among them).
- `pytest tests/st -k "dfx or dump or pmu or swimlane" --platform a5sim` — 5 passed.
- `pre-commit` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
