### PR TITLE
CI: serialize a2a3 onboard steps through task-submit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,8 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v"
 
       - name: Build and run C++ hardware unit tests
         run: |
@@ -500,10 +501,8 @@ jobs:
           json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
                     open('tests/ut/cpp/build/resources.json', 'w'))
           "
-          ctest --test-dir tests/ut/cpp/build \
-              -L "^requires_hardware(_a2a3)?$" \
-              --resource-spec-file $PWD/tests/ut/cpp/build/resources.json \
-              -j$(nproc) --output-on-failure
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
 
       - name: Build cann-examples/query (CANN host-API smoke)
         run: |
@@ -570,8 +569,9 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v \
-            --pto-session-timeout 600 --require-pto-isa
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 600"
 
       # DFX per-feature smokes — hardware mirror of the st-sim-a2a3 set. The
       # race window in dep_gen only fires on real timing, so this row is
@@ -581,33 +581,41 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-dep-gen
+            --require-pto-isa --enable-dep-gen"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
 
       - name: l2_swimlane smoke
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/ \
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/ \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-l2-swimlane --enable-dep-gen
+            --require-pto-isa --enable-l2-swimlane --enable-dep-gen"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
 
       - name: PMU smoke
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-pmu 2
+            --require-pto-isa --enable-pmu 2"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
 
       - name: args_dump smoke
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --dump-args
+            --require-pto-isa --dump-args"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
 
 
   # ---------- Detect platform-specific changes (runs on GitHub server) ----------

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -141,6 +141,15 @@ Three hardware tiers, applied to all test categories. See [testing.md](testing.m
 | Platform-specific (a2a3) | `[self-hosted, a2a3]` | `ut-a2a3`, `st-onboard-a2a3` |
 | Platform-specific (a5) | `[self-hosted, a5]` | `ut-a5`, `st-onboard-a5` |
 
+Every step on a self-hosted runner that touches an NPU — pytest and ctest
+alike, on both arches — runs through
+`task-submit --device <list> --run "..."`. The runners are shared with
+interactive users, so the device lock is what keeps a CI job from colliding
+with someone's local run (and vice versa). Steps that only build (cmake,
+`RuntimeBuilder`, the `cann-examples` smokes) take no lock. The same rule
+applies to local onboard work — see
+[.claude/rules/running-onboard.md](../.claude/rules/running-onboard.md).
+
 ## Test Sources
 
 ### `tests/ut/` — Python unit tests (ut-py)


### PR DESCRIPTION
## Summary

The a2a3 self-hosted runner is shared with interactive users, but every device-facing step in `ut-a2a3` and `st-onboard-a2a3` invoked pytest/ctest bare — no device lock. A CI job and someone's local run could land on the same die. The a5 jobs already route through `task-submit`; this brings a2a3 to parity.

- Wraps all seven device-facing steps in `task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "..."`, using the same `DEVICE_LIST` derivation as the a5 jobs:
  - `ut-a2a3`: Python hardware UT, C++ hardware `ctest`
  - `st-onboard-a2a3`: full scene-test run + the dep_gen / l2_swimlane / PMU / args_dump DFX smokes
- Build-only steps (`RuntimeBuilder`, `cmake`, the `cann-examples` smokes) take no lock — they touch no device.
- `docs/ci.md`: documents the device-lock rule for self-hosted runners, and points at `.claude/rules/running-onboard.md` for the equivalent local rule.

The 1800s budget is well clear of observed runtimes: on a recent green run the whole `st-onboard-a2a3` job took 9 min and `ut-a2a3` took 4 min, setup included.

## Testing

- [x] YAML parses; all seven device-facing steps confirmed wrapped, build-only steps confirmed unwrapped
- [x] Shell fragments dry-run against a stub `task-submit` — `\$` in the ctest label regex survives to `$`, `DEVICE_RANGE=0-1` derives `--device 0,1`, multi-line `PYTEST` collapses to one command string
- [x] `pre-commit run --files .github/workflows/ci.yml docs/ci.md` passes
- [x] **The a2a3 CI run on this PR is the real check** — it verifies `task-submit` is actually on the a2a3 runner's PATH. That was never exercised there before (a5 was the only user), so if the binary is missing, `ut-a2a3` / `st-onboard-a2a3` will fail with `command not found` rather than a test failure.