### PR TITLE
Update: rebalance returned profiling buffers across shards

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -491,9 +491,10 @@ space so the host can read device buffers directly.
 drain/refill shards poll SPSC ready queues and refill free queues from
 shard-local recycled lanes **while kernels are still executing**. Collector
 shards drain the host hand-off queues into `on_buffer_collected`, then the
-replenish thread folds done buffers back into recycled lanes and, for
-modules that declare a recycled watermark, tops those lanes up by batched
-allocation without writing device free queues.
+replenish thread routes done buffers to same-kind lanes below their recycled
+watermarks. Modules that declare no watermark keep origin-shard routing. Any
+remaining watermark deficit is batch-allocated without writing device free
+queues.
 
 Each collector appends metadata to its own vector, so collectors do not
 serialize on the manifest accumulator. Payloads still share one `args.bin`:

--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -681,8 +681,8 @@ space so the host can read device buffers directly.
 drain/refill shards poll SPSC ready queues and refill free queues from
 shard-local recycled lanes **while kernels are still executing**. Collector
 shards drain the host hand-off queues into `on_buffer_collected`, then the
-replenish thread folds done buffers back into recycled lanes and tops up
-optional recycled watermarks.
+replenish thread routes done buffers to same-kind lanes below their recycled
+watermarks before allocating any remaining top-up.
 
 `L2SwimlaneModule` declares four buffer kinds going through one ready
 queue per AICPU thread:

--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -220,11 +220,11 @@ directly into a `PmuRecord` on every task FIN. Buffers rotate through
 an SPSC free queue per core; full buffers flow through a per-thread
 ready queue to host drain/refill shards. Drain refills free queues from
 shard-local recycled lanes; collector shards stream records to CSV during
-execution, and the replenish thread folds done buffers back into recycled
-lanes and tops up optional recycled watermarks without writing device free
-queues. PMU has no init-seeded recycled surplus by default, so the runtime
-watermark is only a minimal reserve batch rather than a core-count-scaled
-extra allocation target.
+execution, and the replenish thread routes done buffers to lanes below their
+recycled watermarks before allocating any remaining top-up. It never writes
+device free queues. PMU has no init-seeded recycled surplus by default, so the
+runtime watermark is only a minimal reserve batch rather than a
+core-count-scaled extra allocation target.
 
 ```text
         HOST                                         DEVICE

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -34,8 +34,9 @@ Each profiling subsystem needs the same plumbing on the host:
   refills device free queues from shard-local recycled lanes, and recycles
   collector-returned buffers while kernels are still running. A module may
   opt into split drain/refill threads plus a replenish thread. Runtime
-  allocation, when enabled, is confined to the replenish thread and publishes
-  only to host-side recycled lanes.
+  allocation, when enabled, is confined to the replenish thread. Before it
+  allocates, that thread routes newly returned buffers to compatible recycled
+  lanes below their watermarks.
 - Collector thread shards that drain host-side hand-off queues and copy
   records out of each ready buffer.
 - A pool of pre-registered device buffers (allocated up-front, refilled on
@@ -122,8 +123,8 @@ Owns:
   fixed-capacity SPSC ring. The producer is the collector shard; the single
   consumer is the replenish thread.
 - `recycled_[shard][kind]` — shard-local SPSC lanes of free device buffers;
-  runtime drain reads the owning shard while replenish writes returned buffers
-  and optional watermark allocations.
+  runtime drain reads the owning shard while replenish writes compatible
+  returned buffers and optional watermark allocations.
 - `retired_[shard][kind]` — mutex-protected exceptional holding pools for
   buffers that were removed from a queue but could not be published to the
   next queue. They are drained only during teardown.
@@ -152,10 +153,11 @@ Provides:
 - Split mgmt threads — `mgmt_drain_loop` drains ready queues and refills the
   originating free queue from the current drain shard's local recycled pool
   (`ProfilerAlgorithms<Module>::process_entry` per popped entry), while
-  `mgmt_replenish_loop` drains done buffers into shard-local recycled pools
-  and keeps optional recycled watermarks topped up by batched allocation. The
-  replenish thread never writes device free queues, so the drain hot path
-  stays allocation-free and remains the only runtime writer to free queues.
+  `mgmt_replenish_loop` routes done buffers to compatible shard-local pools
+  below their recycled watermarks, then tops up remaining deficits by batched
+  allocation. The replenish thread never writes device free queues, so the
+  drain hot path stays allocation-free and remains the only runtime writer to
+  free queues.
   A one-shot `proactive_replenish` seeds every free queue before the threads
   start. Split drain threads do not bulk-mirror the whole
   shared-memory region; they refresh only their queue indices / entries
@@ -218,7 +220,7 @@ the required members are:
 | `kSubsystemName` | Tag used in framework log lines |
 | `kMaxCollectorThreads` | Optional compile-time CAPACITY of the drain / collector shard arrays (defaults to 1); live shard count is the runtime `min(aicpu_thread_num, kMaxCollectorThreads)` set via `set_aicpu_thread_num()` |
 | `refresh_replenish_metadata(mgr, header)` | Optional hook to refresh cached queue metadata before a replenish pass |
-| `recycled_warm_target(kind[, shard_count]) → int` | Optional startup/runtime low-water mark for shard-local recycled lanes; the two-arg form scales the mark with the live shard count |
+| `recycled_warm_target(kind[, shard_count]) → int` | Optional low-water mark used first for same-kind done-buffer routing, then for startup/runtime allocation; the two-arg form scales the mark with the live shard count |
 | `header_from_shm(void*) → DataHeader*` | Cast shared-memory base to header |
 | `batch_size(int kind) → int` | Per-kind batch-alloc count |
 | `resolve_entry(shm, header, q, entry) → optional<EntrySite>` | Map a popped ready entry to (kind, free_queue, buffer_size, partial info); return `nullopt` to drop |
@@ -327,18 +329,20 @@ Current users:
                                           ▲
                                           │
                             replenish thread:
-                            done shard q → recycled[q]
+                            done shard q → recycled[largest same-kind deficit]
+                                           or recycled[q] if none
 ```
 
 The queue shards plus the shard-local recycled pools and the dev↔host map all
 live in the single `BufferPoolManager` instance owned by `ProfilerBase`.
 Each ready shard has one collector consumer; each done shard is written by
-its matching collector and drained by the replenish thread into the same
-recycled shard. Split drain refills the originating free queue on the hot
-path from `recycled[q]`; replenish does not write free queues at runtime.
-Backpressure fallbacks that cannot publish a buffer to ready/free/recycled
-place it in `retired_[q][kind]`, which is outside the hot SPSC path and is
-released at teardown.
+its matching collector and drained by the replenish thread. A completed
+buffer first fills the largest same-kind recycled deficit; when no shard is
+below its target, it returns to its origin shard. Split drain refills the
+originating free queue on the hot path from `recycled[q]`; replenish does not
+write free queues at runtime. Backpressure fallbacks that cannot publish a
+buffer to ready/free/recycled place it in `retired_[q][kind]`, which is outside
+the hot SPSC path and is released at teardown.
 
 ## 5. Lifecycle
 
@@ -402,7 +406,9 @@ mid-run by the framework.
 Two things follow:
 
 - `dev_to_host_` has a narrow mapping lock; ready/done/recycled hand-off is
-  SPSC by shard, so the hot drain/refill path stays on the owning lane.
+  SPSC by shard. Cross-shard return routing does not change ownership:
+  replenish remains the only recycled-lane producer, and each drain shard
+  remains its lane's only consumer.
 - Device-side queue backpressure is bounded for the profiling writers that
   use this protocol. If the host does not make ready-queue space or
   free-queue entries visible within the short wait budget, AICPU records a

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -181,6 +181,27 @@ struct ProfilerModuleHostRecycledQueueCapacity<Module, std::void_t<decltype(Modu
     static constexpr size_t value = Module::kHostRecycledQueueSize > 0 ? Module::kHostRecycledQueueSize : 1;
 };
 
+template <typename Module>
+auto profiler_module_recycled_warm_target_impl(int kind, int shard_count, int)
+    -> decltype(Module::recycled_warm_target(kind, shard_count)) {
+    return Module::recycled_warm_target(kind, shard_count);
+}
+
+template <typename Module>
+auto profiler_module_recycled_warm_target_impl(int kind, int, long) -> decltype(Module::recycled_warm_target(kind)) {
+    return Module::recycled_warm_target(kind);
+}
+
+template <typename Module>
+int profiler_module_recycled_warm_target_impl(int, int, ...) {
+    return 0;
+}
+
+template <typename Module>
+int profiler_module_recycled_warm_target(int kind, int shard_count) {
+    return profiler_module_recycled_warm_target_impl<Module>(kind, shard_count, 0);
+}
+
 template <typename T, size_t Capacity>
 class SpscRing {
     static_assert(Capacity > 0, "SpscRing capacity must be > 0");
@@ -441,14 +462,18 @@ public:
             shard.queue.clear();
         }
         std::unordered_set<void *> release_ptrs;
+        std::vector<void *> release_order;
         for (const auto &kv : dev_to_host_) {
             if (kv.first != nullptr) {
                 if (void *release_ptr = allocation_base_for_locked(kv.first); release_ptr != nullptr) {
-                    release_ptrs.insert(release_ptr);
+                    if (release_ptrs.insert(release_ptr).second) {
+                        release_order.push_back(release_ptr);
+                    }
                 }
             }
         }
-        for (void *p : release_ptrs) {
+        std::sort(release_order.begin(), release_order.end(), std::less<void *>{});
+        for (void *p : release_order) {
             release_fn(p);
         }
         for (void *host_ptr : malloc_shadows_) {
@@ -603,8 +628,8 @@ public:
 
     // -------------------------------------------------------------------------
     // done_queue shards: collector threads report buffers they have finished
-    // copying; mgmt folds them back into the same shard's recycled pool of the
-    // right kind.
+    // copying; replenish routes each buffer to a same-kind recycled lane below
+    // its warm target, or back to the origin lane when no deficit exists.
     // -------------------------------------------------------------------------
 
     bool notify_copy_done(void *dev_ptr, int kind, int shard_index = 0) {
@@ -872,10 +897,27 @@ public:
         return drained;
     }
 
+    /**
+     * Drain every done shard, filling the largest same-kind recycled deficit
+     * before returning a buffer to its origin shard. The replenish thread is
+     * the only runtime consumer for all done shards and the only runtime
+     * producer for all recycled lanes.
+     */
     size_t drain_done_into_recycled() {
         size_t drained = 0;
-        for (int shard = 0; shard < shard_count_; shard++) {
-            drained += drain_done_into_recycled(shard);
+        for (int origin_shard = 0; origin_shard < shard_count_; origin_shard++) {
+            auto &done = done_shards_[static_cast<size_t>(origin_shard)];
+            DoneInfo info{};
+            while (done.queue.pop(info)) {
+                size_t target_shard = select_recycled_shard(info.kind, static_cast<size_t>(origin_shard));
+                bool published = push_recycled(info.kind, info.dev_ptr, static_cast<int>(target_shard));
+                if (!published && target_shard != static_cast<size_t>(origin_shard)) {
+                    published = push_recycled(info.kind, info.dev_ptr, origin_shard);
+                }
+                if (published || retire_unqueued_buffer(info.kind, info.dev_ptr, origin_shard)) {
+                    drained++;
+                }
+            }
         }
         return drained;
     }
@@ -948,6 +990,26 @@ private:
         if (rem == 0) return value;
         if (value > std::numeric_limits<size_t>::max() - (alignment - rem)) return 0;
         return value + (alignment - rem);
+    }
+
+    size_t select_recycled_shard(int kind, size_t origin_shard) const {
+        size_t selected = origin_shard;
+        size_t largest_deficit = 0;
+        int configured_target = profiler_module_recycled_warm_target<Module>(kind, shard_count_);
+        if (configured_target <= 0) return selected;
+
+        size_t target = std::min(static_cast<size_t>(configured_target), kRecycledQueueCapacity);
+        size_t live_shards = static_cast<size_t>(shard_count_);
+        for (size_t offset = 1; offset <= live_shards; offset++) {
+            size_t shard = (origin_shard + offset) % live_shards;
+            size_t current = recycled_[shard][kind].size();
+            size_t deficit = current < target ? target - current : 0;
+            if (deficit > largest_deficit) {
+                selected = shard;
+                largest_deficit = deficit;
+            }
+        }
+        return selected;
     }
 
     void *allocation_base_for_locked(void *dev_ptr) const {

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -86,7 +86,9 @@
  *       void* shm_host, DataHeader*, int q, const ReadyEntry&);
  *
  *   // Enumerate every (kind, instance) free_queue and its buffer size for
- *   // proactive_replenish to top up. Callback signature:
+ *   // proactive_replenish to top up. Every instance of one kind has the same
+ *   // buffer size, so completed buffers can move between collector shards.
+ *   // Callback signature:
  *   //   (int kind, FreeQueue* fq, size_t buffer_size).
  *   template <typename Cb>
  *   static void for_each_instance(void* shm_host, DataHeader*, Cb&&);
@@ -101,12 +103,13 @@
  *                          drain/collector threads start. If recycled is dry,
  *                          it allocates one registered block and carves it
  *                          into a batch of buffers.
- *   mgmt_replenish_loop    drains collector-done buffers back into recycled
- *                          lanes and keeps optional per-kind recycled watermarks
- *                          topped up in batches of max(kSlotCount, gap). It
- *                          never writes device free_queues, so
- *                          the drain hot path remains allocation-free and owns
- *                          all runtime free_queue publication.
+ *   mgmt_replenish_loop    routes collector-done buffers to same-kind lanes
+ *                          below their optional recycled watermarks, then tops
+ *                          up remaining deficits in batches of
+ *                          max(kSlotCount, gap). It never writes device
+ *                          free_queues, so the drain hot path remains
+ *                          allocation-free and owns all runtime free_queue
+ *                          publication.
  *
  * The above two algorithms live in ProfilerAlgorithms<Module>; Module only
  * supplies the data-access traits above. Implementors must NOT zero `count`
@@ -493,25 +496,9 @@ struct ProfilerAlgorithms {
     }
 
 private:
-    // Modules that scale their watermark with the number of live shards (the
-    // per-shard core load is ceil(cores / shard_count)) implement the two-arg
-    // form; shard-count-independent modules implement the one-arg form.
     static int recycled_warm_target(int kind, int shard_count) {
-        return recycled_warm_target_impl(kind, shard_count, 0);
+        return profiler_module_recycled_warm_target<Module>(kind, shard_count);
     }
-
-    template <typename M = Module>
-    static auto recycled_warm_target_impl(int kind, int shard_count, int)
-        -> decltype(M::recycled_warm_target(kind, shard_count)) {
-        return M::recycled_warm_target(kind, shard_count);
-    }
-
-    template <typename M = Module>
-    static auto recycled_warm_target_impl(int kind, int, long) -> decltype(M::recycled_warm_target(kind)) {
-        return M::recycled_warm_target(kind);
-    }
-
-    static int recycled_warm_target_impl(int, int, ...) { return 0; }
 
     template <typename Mgr>
     static size_t clamped_recycled_warm_target(int kind, int shard, int shard_count) {

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -153,6 +154,43 @@ struct WarmRecycledModule {
     template <typename Cb>
     static void for_each_instance(void * /*shm_host*/, DataHeader *header, Cb &&cb) {
         cb(0, &header->free_queue, sizeof(uint64_t));
+    }
+};
+
+struct RebalanceComparisonModule {
+    using DataHeader = AlgorithmHeader;
+    using ReadyEntry = AlgorithmReadyEntry;
+    using ReadyBufferInfo = AlgorithmReadyBufferInfo;
+    using FreeQueue = AlgorithmFreeQueue;
+
+    static constexpr int kBufferKinds = 2;
+    static constexpr int kMaxCollectorThreads = 4;
+    static constexpr uint32_t kReadyQueueSize = 1;
+    static constexpr uint32_t kHostPoolQueueSize = 256;
+    static constexpr uint32_t kHostRecycledQueueSize = 256;
+    static constexpr uint32_t kSlotCount = 1;
+    static constexpr const char *kSubsystemName = "RebalanceComparisonModule";
+
+    static DataHeader *header_from_shm(void *shared_mem_host) { return static_cast<DataHeader *>(shared_mem_host); }
+
+    static int batch_size(int /*kind*/) { return 1; }
+
+    static int recycled_warm_target(int kind, int shard_count) { return kind == 0 ? shard_count - 1 : shard_count; }
+
+    static std::optional<profiling_common::EntrySite<RebalanceComparisonModule>>
+    resolve_entry(void * /*shm_host*/, DataHeader *header, int /*q*/, const ReadyEntry &entry) {
+        return profiling_common::EntrySite<RebalanceComparisonModule>{
+            0,
+            &header->free_queue,
+            sizeof(uint64_t),
+            AlgorithmReadyBufferInfo{reinterpret_cast<void *>(entry.buffer_ptr), nullptr},
+        };
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void * /*shm_host*/, DataHeader *header, Cb &&cb) {
+        cb(0, &header->free_queue, sizeof(uint64_t));
+        cb(1, &header->free_queue, sizeof(uint64_t) * 2);
     }
 };
 
@@ -451,6 +489,278 @@ TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsFollowsRuntimeShardCou
         std::free(p);
     });
     manager.clear_mappings();
+}
+
+TEST(BufferPoolManagerShardingTest, CompletedBufferRebalancingAvoidsAllocationsAcrossKindsAndShards) {
+    using Module = RebalanceComparisonModule;
+    using Manager = profiling_common::BufferPoolManager<Module>;
+    static constexpr int kLiveShardCount = 3;
+    using ShardCounts = std::array<size_t, kLiveShardCount>;
+    using ShardInputCounts = std::array<int, kLiveShardCount>;
+    using KindCounts = std::array<ShardCounts, Module::kBufferKinds>;
+    using KindInputCounts = std::array<ShardInputCounts, Module::kBufferKinds>;
+
+    struct ScenarioResult {
+        bool setup_ok{false};
+        size_t drained{0};
+        uint64_t allocated_buffers{0};
+        size_t allocation_calls{0};
+        size_t registration_calls{0};
+        KindCounts recycled_counts{};
+        bool ownership_preserved{false};
+    };
+
+    auto run_scenario = [](bool rebalance, bool balanced) {
+        Manager manager;
+        manager.set_shard_count(kLiveShardCount);
+        AlgorithmHeader header{};
+        size_t allocation_calls = 0;
+        size_t registration_calls = 0;
+        profiling_common::MemoryOps ops;
+        ops.alloc = [&](size_t size) {
+            allocation_calls++;
+            return std::malloc(size);
+        };
+        ops.reg = [&](void *dev_ptr, size_t /*size*/, int /*device_id*/, void **host_ptr_out) {
+            registration_calls++;
+            *host_ptr_out = dev_ptr;
+            return 0;
+        };
+        ops.free_ = [](void *dev_ptr) {
+            std::free(dev_ptr);
+            return 0;
+        };
+        manager.set_memory_context(std::move(ops), nullptr, &header, sizeof(header), 0);
+
+        KindInputCounts completed_by_origin{};
+        if (balanced) {
+            completed_by_origin = {
+                ShardInputCounts{2, 2, 2},
+                ShardInputCounts{3, 3, 3},
+            };
+        } else {
+            completed_by_origin = {
+                ShardInputCounts{6, 0, 0},
+                ShardInputCounts{0, 0, 9},
+            };
+        }
+
+        std::array<std::set<void *>, Module::kBufferKinds> completed_buffers;
+        size_t completed_count = 0;
+        for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+            size_t buffer_size = sizeof(uint64_t) * static_cast<size_t>(kind + 1);
+            for (int shard = 0; shard < kLiveShardCount; shard++) {
+                for (int i = 0; i < completed_by_origin[kind][shard]; i++) {
+                    void *host_ptr = nullptr;
+                    void *dev_ptr = manager.alloc_and_register_block(buffer_size, &host_ptr);
+                    if (dev_ptr == nullptr || !manager.notify_copy_done(dev_ptr, kind, shard)) {
+                        manager.release_all_owned([](void *p) {
+                            std::free(p);
+                        });
+                        return ScenarioResult{};
+                    }
+                    completed_buffers[kind].insert(dev_ptr);
+                    completed_count++;
+                }
+            }
+        }
+        allocation_calls = 0;
+        registration_calls = 0;
+
+        size_t drained = 0;
+        if (rebalance) {
+            drained = manager.drain_done_into_recycled();
+        } else {
+            for (int shard = 0; shard < kLiveShardCount; shard++) {
+                drained += manager.drain_done_into_recycled(shard);
+            }
+        }
+        uint64_t allocated = profiling_common::ProfilerAlgorithms<Module>::replenish_recycled_pools(manager, &header);
+        KindCounts recycled_counts{};
+        for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+            for (int shard = 0; shard < kLiveShardCount; shard++) {
+                recycled_counts[kind][shard] = manager.recycled_count(kind, shard);
+            }
+        }
+
+        std::array<std::set<void *>, Module::kBufferKinds> observed_buffers;
+        bool no_duplicates = true;
+        for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+            for (int shard = 0; shard < kLiveShardCount; shard++) {
+                while (void *dev_ptr = manager.pop_recycled(kind, shard)) {
+                    no_duplicates = observed_buffers[kind].insert(dev_ptr).second && no_duplicates;
+                }
+            }
+        }
+        bool all_completed_present = true;
+        size_t observed_count = 0;
+        for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+            observed_count += observed_buffers[kind].size();
+            for (void *dev_ptr : completed_buffers[kind]) {
+                all_completed_present = observed_buffers[kind].count(dev_ptr) == 1 && all_completed_present;
+            }
+        }
+        bool ownership_preserved =
+            no_duplicates && all_completed_present && observed_count == completed_count + allocated;
+        ScenarioResult result{
+            true, drained, allocated, allocation_calls, registration_calls, recycled_counts, ownership_preserved,
+        };
+        manager.release_all_owned([](void *p) {
+            std::free(p);
+        });
+        return result;
+    };
+
+    ScenarioResult origin_only = run_scenario(false, false);
+    ScenarioResult rebalanced = run_scenario(true, false);
+    ASSERT_TRUE(origin_only.setup_ok);
+    ASSERT_TRUE(rebalanced.setup_ok);
+
+    const KindCounts expected_origin_only = {
+        ShardCounts{6, 2, 2},
+        ShardCounts{3, 3, 9},
+    };
+    EXPECT_EQ(origin_only.drained, 15u);
+    EXPECT_EQ(origin_only.recycled_counts, expected_origin_only);
+    EXPECT_EQ(origin_only.allocated_buffers, 10u);
+    EXPECT_EQ(origin_only.allocation_calls, 4u);
+    EXPECT_EQ(origin_only.registration_calls, 4u);
+    EXPECT_TRUE(origin_only.ownership_preserved);
+
+    const KindCounts expected_rebalanced = {
+        ShardCounts{2, 2, 2},
+        ShardCounts{3, 3, 3},
+    };
+    EXPECT_EQ(rebalanced.drained, 15u);
+    EXPECT_EQ(rebalanced.recycled_counts, expected_rebalanced);
+    EXPECT_EQ(rebalanced.allocated_buffers, 0u);
+    EXPECT_EQ(rebalanced.allocation_calls, 0u);
+    EXPECT_EQ(rebalanced.registration_calls, 0u);
+    EXPECT_TRUE(rebalanced.ownership_preserved);
+
+    EXPECT_LT(rebalanced.allocated_buffers, origin_only.allocated_buffers);
+    EXPECT_LT(rebalanced.allocation_calls, origin_only.allocation_calls);
+    EXPECT_LT(rebalanced.registration_calls, origin_only.registration_calls);
+
+    ScenarioResult balanced_origin = run_scenario(false, true);
+    ScenarioResult balanced_rebalanced = run_scenario(true, true);
+    ASSERT_TRUE(balanced_origin.setup_ok);
+    ASSERT_TRUE(balanced_rebalanced.setup_ok);
+    EXPECT_EQ(balanced_origin.recycled_counts, expected_rebalanced);
+    EXPECT_EQ(balanced_rebalanced.recycled_counts, expected_rebalanced);
+    EXPECT_EQ(balanced_origin.allocated_buffers, 0u);
+    EXPECT_EQ(balanced_rebalanced.allocated_buffers, 0u);
+    EXPECT_EQ(balanced_origin.allocation_calls, 0u);
+    EXPECT_EQ(balanced_rebalanced.allocation_calls, 0u);
+    EXPECT_EQ(balanced_origin.registration_calls, 0u);
+    EXPECT_EQ(balanced_rebalanced.registration_calls, 0u);
+    EXPECT_TRUE(balanced_origin.ownership_preserved);
+    EXPECT_TRUE(balanced_rebalanced.ownership_preserved);
+}
+
+TEST(BufferPoolManagerShardingTest, ConcurrentRebalancingPreservesOwnershipAcrossLiveShards) {
+    using Module = RebalanceComparisonModule;
+    using Manager = profiling_common::BufferPoolManager<Module>;
+    static constexpr int kLiveShardCount = 3;
+    static constexpr int kBuffersPerKindAndShard = 64;
+    static constexpr size_t kExpectedTotal =
+        static_cast<size_t>(kLiveShardCount * Module::kBufferKinds * kBuffersPerKindAndShard);
+
+    Manager manager;
+    manager.set_shard_count(kLiveShardCount);
+    using PerKindBuffers = std::array<std::vector<void *>, Module::kBufferKinds>;
+    std::array<PerKindBuffers, kLiveShardCount> expected;
+    std::array<PerKindBuffers, kLiveShardCount> consumed;
+    for (int shard = 0; shard < kLiveShardCount; shard++) {
+        for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+            for (int i = 0; i < kBuffersPerKindAndShard; i++) {
+                uintptr_t value = 0x1000000u + static_cast<uintptr_t>(kind) * 0x100000u +
+                                  static_cast<uintptr_t>(shard) * 0x10000u + static_cast<uintptr_t>(i + 1);
+                expected[shard][kind].push_back(ptr(value));
+            }
+        }
+    }
+
+    std::atomic<size_t> enqueued{0};
+    std::atomic<int> producers_done{0};
+    std::atomic<int> notify_failures{0};
+    std::atomic<bool> replenish_done{false};
+    size_t drained_total = 0;
+
+    std::array<std::thread, kLiveShardCount> consumers;
+    for (int shard = 0; shard < kLiveShardCount; shard++) {
+        consumers[shard] = std::thread([&, shard]() {
+            while (true) {
+                bool popped = false;
+                for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+                    if (void *dev_ptr = manager.pop_recycled(kind, shard); dev_ptr != nullptr) {
+                        consumed[shard][kind].push_back(dev_ptr);
+                        popped = true;
+                    }
+                }
+                if (popped) continue;
+
+                if (replenish_done.load(std::memory_order_acquire)) {
+                    bool empty = true;
+                    for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+                        empty = manager.recycled_count(kind, shard) == 0 && empty;
+                    }
+                    if (empty) break;
+                }
+                std::this_thread::yield();
+            }
+        });
+    }
+
+    std::thread replenish([&]() {
+        while (producers_done.load(std::memory_order_acquire) < kLiveShardCount ||
+               drained_total < enqueued.load(std::memory_order_acquire)) {
+            size_t drained = manager.drain_done_into_recycled();
+            drained_total += drained;
+            if (drained == 0) std::this_thread::yield();
+        }
+        replenish_done.store(true, std::memory_order_release);
+    });
+
+    std::array<std::thread, kLiveShardCount> producers;
+    for (int shard = 0; shard < kLiveShardCount; shard++) {
+        producers[shard] = std::thread([&, shard]() {
+            for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+                for (void *dev_ptr : expected[shard][kind]) {
+                    if (manager.notify_copy_done(dev_ptr, kind, shard)) {
+                        enqueued.fetch_add(1, std::memory_order_release);
+                    } else {
+                        notify_failures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            }
+            producers_done.fetch_add(1, std::memory_order_release);
+        });
+    }
+
+    for (auto &producer : producers)
+        producer.join();
+    replenish.join();
+    for (auto &consumer : consumers)
+        consumer.join();
+
+    EXPECT_EQ(notify_failures.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(enqueued.load(std::memory_order_acquire), kExpectedTotal);
+    EXPECT_EQ(drained_total, kExpectedTotal);
+    for (int kind = 0; kind < Module::kBufferKinds; kind++) {
+        std::set<void *> expected_kind;
+        std::set<void *> consumed_kind;
+        bool no_duplicates = true;
+        for (int shard = 0; shard < kLiveShardCount; shard++) {
+            expected_kind.insert(expected[shard][kind].begin(), expected[shard][kind].end());
+            for (void *dev_ptr : consumed[shard][kind]) {
+                no_duplicates = consumed_kind.insert(dev_ptr).second && no_duplicates;
+            }
+        }
+        EXPECT_TRUE(no_duplicates);
+        EXPECT_EQ(consumed_kind, expected_kind);
+        EXPECT_EQ(manager.recycled_count(kind), 0u);
+    }
 }
 
 TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsUsesSlotSizedBatchForSmallGap) {


### PR DESCRIPTION
## Summary

- Route newly completed profiling buffers to the largest live, same-kind
  recycled-lane deficit before allocating another registered batch.
- Preserve SPSC ownership: replenish remains each recycled lane's only
  producer, and its drain shard remains the only consumer.
- Keep origin-shard routing for modules without recycled watermarks, and add
  multi-kind, multi-shard A/B and concurrent ownership coverage.
- Update the profiling framework and collector documentation to describe the
  new return path.

## A/B result

- Skewed workload, origin-only baseline: 10 new buffers and 4
  allocation/registration calls.
- Skewed workload, Stage 1 rebalancing: 0 new buffers and 0
  allocation/registration calls.
- Balanced workload: both paths require 0 new allocations or registrations.

## Testing

- [x] Pre-commit hooks pass for all changed files.
- [x] C++ unit suite passes (59/59).
- [x] Concurrent rebalancing ownership test passes across 200 repetitions.
- [x] L2 Swimlane, PMU, and ArgsDump scene tests pass on both a2a3sim and
  a5sim.
- [ ] Onboard hardware tests were not run because the local architecture
  precheck could not identify compatible silicon.

Close #1344
