### PR TITLE
Fix: render drain/drain_prepare/drain_publish swimlane phases

### DIFF
--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -1451,6 +1451,11 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             "release": "olive",  # deferred-release drain (on_task_release work)
             "dummy": "grey",  # dummy_drain pass (Resolve nests inside)
             "early_dispatch": "rail_animation",  # speculative early-dispatch staging
+            # sync_start stop-the-world drain: outer bar time-contains the two
+            # inner staging passes, so Perfetto nests them by depth on the track.
+            "drain": "cq_build_running",  # handle_drain_mode outer
+            "drain_prepare": "cq_build_attempt_runnable",  # inner: cluster scan + build_payload
+            "drain_publish": "cq_build_attempt_passed",  # inner: MMIO write_reg per subtask (the cohort launch)
             # Inner phase — nests inside Complete or Dummy via time containment
             "resolve": "vsync_highlight_color",  # on_task_complete: walk consumer list
             # Separate-lane (Worker View AICPU_N) — fallback color if it ever lands on Sched
@@ -1599,7 +1604,17 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         }
                     )
                     continue
-                if phase not in ("complete", "dispatch", "release", "resolve", "early_dispatch", "dummy"):
+                if phase not in (
+                    "complete",
+                    "dispatch",
+                    "release",
+                    "resolve",
+                    "early_dispatch",
+                    "dummy",
+                    "drain",
+                    "drain_prepare",
+                    "drain_publish",
+                ):
                     continue
                 start_us = record["start_time_us"]
                 end_us = record["end_time_us"]


### PR DESCRIPTION
## Summary

`#1304` added the sync_start stop-the-world drain phase kinds — `Drain`,
`DrainPrepare`, `DrainPublish` — to both the device emit
(`l2_swimlane_profiling.h`) and the host serializer
(`l2_swimlane_collector.cpp`, which maps them to `"drain"` /
`"drain_prepare"` / `"drain_publish"`), but never taught the Python
renderer about them.

`swimlane_converter.py` drops any phase outside its sched-lane whitelist.
A sync_start SPMD cohort launches through `handle_drain_mode` →
`drain_stage_cores`, so its actual launch is emitted as `drain_publish`,
**not** `dispatch`. Result: the drain records were produced on-device and
written to `l2_swimlane_records.json`, but silently filtered out at
render time — the scheduler dispatch work for every sync_start cohort
vanished from the Perfetto trace.

This wires the three phases into the renderer:

- Add `drain` / `drain_prepare` / `drain_publish` to `phase_colors`
  (cq_build color family; the outer `drain` bar time-contains the two
  inner staging passes, so Perfetto nests them by depth on the track).
- Add the three phases to the sched-lane render whitelist.

## Testing

Verified on a2a3 silicon at `l2_swimlane_level=4` — for each workload the
rendered scheduler-lane phase histogram now matches the raw record kinds:

| workload | drain | drain_prepare | drain_publish |
| -------- | ----- | ------------- | ------------- |
| `spmd_sync_start`                | 3  | 2  | 2  |
| `spmd_sync_start_early_dispatch` | 3  | 3  | 3  |
| `spmd_sync_start_stress`         | 36 | 24 | 24 |

`qwen3_14b_decode` (no sync_start) is unaffected — `dispatch`/`complete`
render as before.

- [x] Hardware tests pass (a2a3, level-4 swimlane, four workloads)
- [ ] Simulation tests (renderer-only Python change; not arch-specific)