### PR TITLE
ci(a2a3): run pytest/ctest directly on X64 runners, task-submit on ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,10 @@ jobs:
       SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
       SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
       SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
+      # X64 a2a3 runners carry no task-submit (their cards are exclusive to the
+      # runner); ARM64 runners share the host and must lock devices. Steps branch
+      # on this to run pytest/ctest directly on X64 and via task-submit on ARM64.
+      RUNNER_ARCH: ${{ runner.arch }}
 
     steps:
       - name: Checkout repository
@@ -485,7 +489,12 @@ jobs:
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v"
+          CMD="python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            $CMD
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$CMD"
+          fi
 
       - name: Build and run C++ hardware unit tests
         run: |
@@ -502,7 +511,11 @@ jobs:
                     open('tests/ut/cpp/build/resources.json', 'w'))
           "
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
+          fi
 
       - name: Build cann-examples/query (CANN host-API smoke)
         run: |
@@ -544,6 +557,7 @@ jobs:
       SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
       SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
       SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
+      RUNNER_ARCH: ${{ runner.arch }}
 
     steps:
       - name: Checkout repository
@@ -571,7 +585,11 @@ jobs:
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           PYTEST="python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 600"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            $PYTEST --pto-session-timeout 600
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 600"
+          fi
 
       # DFX per-feature smokes — hardware mirror of the st-sim-a2a3 set. The
       # race window in dep_gen only fires on real timing, so this row is
@@ -585,7 +603,11 @@ jobs:
           PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-dep-gen"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            $PYTEST
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          fi
 
       - name: l2_swimlane smoke
         run: |
@@ -595,7 +617,11 @@ jobs:
           PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/ \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-l2-swimlane --enable-dep-gen"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            $PYTEST
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          fi
 
       - name: PMU smoke
         run: |
@@ -605,7 +631,11 @@ jobs:
           PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-pmu 2"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            $PYTEST
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          fi
 
       - name: args_dump smoke
         run: |
@@ -615,7 +645,11 @@ jobs:
           PYTEST="python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --dump-args"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          if [ "$RUNNER_ARCH" = "X64" ]; then
+            $PYTEST
+          else
+            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+          fi
 
 
   # ---------- Detect platform-specific changes (runs on GitHub server) ----------

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -141,13 +141,21 @@ Three hardware tiers, applied to all test categories. See [testing.md](testing.m
 | Platform-specific (a2a3) | `[self-hosted, a2a3]` | `ut-a2a3`, `st-onboard-a2a3` |
 | Platform-specific (a5) | `[self-hosted, a5]` | `ut-a5`, `st-onboard-a5` |
 
-Every step on a self-hosted runner that touches an NPU — pytest and ctest
-alike, on both arches — runs through
-`task-submit --device <list> --run "..."`. The runners are shared with
-interactive users, so the device lock is what keeps a CI job from colliding
-with someone's local run (and vice versa). Steps that only build (cmake,
-`RuntimeBuilder`, the `cann-examples` smokes) take no lock. The same rule
-applies to local onboard work — see
+On a self-hosted runner, every step that touches an NPU — pytest and ctest
+alike — must hold its devices exclusively while it runs. There are two a2a3
+runner pools, branched at run time on `runner.arch`:
+
+- **ARM64 a2a3 runners** share the host with interactive users, so the step
+  runs through `task-submit --device <list> --run "..."`, whose per-device
+  lock keeps a CI job from colliding with someone's local run (and vice
+  versa).
+- **X64 a2a3 runners** carry no `task-submit` — their cards are exclusive to
+  the runner — so the step runs pytest/ctest directly with
+  `--device ${DEVICE_RANGE}`.
+
+a5 runners are ARM64-only and always use `task-submit`. Steps that only build
+(cmake, `RuntimeBuilder`, the `cann-examples` smokes) take no lock on either
+arch. The same device-lock rule applies to local onboard work — see
 [.claude/rules/running-onboard.md](../.claude/rules/running-onboard.md).
 
 ## Test Sources


### PR DESCRIPTION
## Why

The `a2a3` self-hosted pool now spans two runner kinds:

| Runner | Arch | `task-submit`? | Cards |
| --- | --- | --- | --- |
| `runner-dev4-7`, `runner-dev8-11` | ARM64 | yes | shared host |
| `infra-gpu-npu-021`, `infra-gpu-npu-021-2` | **X64** | **no** | exclusive to the runner |

A single `runs-on: [self-hosted, a2a3]` job can land on either pool, so the per-device lock can no longer be unconditional — `task-submit` is not installed on the X64 runners and their cards are already exclusive to the runner.

## What

- Add `RUNNER_ARCH: ${{ runner.arch }}` to `ut-a2a3` and `st-onboard-a2a3`.
- Branch every a2a3 NPU-touching step (7 total: UT py + C++, scene tests + 4 DFX smokes) on `runner.arch`:
  - **X64** → run `pytest`/`ctest` directly with `--device ${DEVICE_RANGE}`
  - **ARM64** → keep the `task-submit --device <list> --run "..."` wrapper (shared host)
- a5 is ARM64-only and unchanged.
- `docs/ci.md` "Hardware Classification" paragraph updated: the old "every step runs through task-submit" claim no longer holds for X64.

No `runs-on` change — both pools stay eligible, which is the point (X64 adds capacity, ARM64 keeps working).

## Notes

Build-only steps (cmake, `RuntimeBuilder`, the `cann-examples` smokes) already take no lock and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)