### PR TITLE
fix(dfx): report the drained slot count on the Release bar

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -1338,6 +1338,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             uint64_t rel_t0 = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && deferred_release_count > 0) ?
                                   get_sys_cnt_aicpu() :
                                   0;
+            // Snapshot the slot count before the drain loop decrements it to 0,
+            // so the Release bar can report how many slots it drained.
+            uint32_t released_count = static_cast<uint32_t>(deferred_release_count);
 #endif
             while (deferred_release_count > 0) {
 #if SIMPLER_SCHED_PROFILING
@@ -1354,7 +1357,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             if (rel_t0 != 0) {
                 l2_swimlane_aicpu_record_sched_phase(
                     thread_idx, L2SwimlaneSchedPhaseKind::Release, rel_t0, get_sys_cnt_aicpu(),
-                    l2_swimlane.sched_loop_count, /*tasks_processed=*/0
+                    l2_swimlane.sched_loop_count, released_count
                 );
             }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1340,6 +1340,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             uint64_t rel_t0 = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && deferred_release_count > 0) ?
                                   get_sys_cnt_aicpu() :
                                   0;
+            // Snapshot the slot count before the drain loop decrements it to 0,
+            // so the Release bar can report how many slots it drained.
+            uint32_t released_count = static_cast<uint32_t>(deferred_release_count);
 #endif
             while (deferred_release_count > 0) {
 #if SIMPLER_SCHED_PROFILING
@@ -1356,7 +1359,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             if (rel_t0 != 0) {
                 l2_swimlane_aicpu_record_sched_phase(
                     thread_idx, L2SwimlaneSchedPhaseKind::Release, rel_t0, get_sys_cnt_aicpu(),
-                    l2_swimlane.sched_loop_count, /*tasks_processed=*/0
+                    l2_swimlane.sched_loop_count, released_count
                 );
             }
 #endif


### PR DESCRIPTION
## What

Make the `release(n)` scheduler-phase bar (L2 swimlane, AICPU Scheduler
view) report the number of deferred-release slots actually drained,
instead of always showing `0`.

## Why

`tasks_processed` was hardcoded `0` at the emit site, and the
deferred-release drain loop had already decremented
`deferred_release_count` to `0` before the emit — so the bar carried no
count at all.

## Fix

Snapshot the slot count before the drain loop and pass it to the Release
record, matching the `complete(x)` / `dispatch(x)` convention.

## Cost

One stack-local assignment on the idle (`!made_progress`) path, guarded
by `#if SIMPLER_DFX`; zero cost on the default production build. No new
data structures, GM access, or atomics.

## Test

a2a3 `tensormap_and_ringbuffer` rebuilds clean; l2_swimlane sim tests
pass.
