### PR TITLE
feat(dfx): split async-wait time into its own scheduler phase

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -33,9 +33,9 @@ available.
   `l2_swimlane_records.json` with `deps.json` from
   [`dep_gen`](dep_gen.md) at post-process time; see
   [§3.5](#35-dependency-arrows-from-dep_gen).
-- **AICPU scheduler phases** — per-iteration breakdown into five
-  mutually time-exclusive **outer** phases (`complete` / `dispatch`
-  / `release` / `dummy` / `early_dispatch`), one logical
+- **AICPU scheduler phases** — per-iteration breakdown into six
+  mutually time-exclusive **outer** phases (`complete` / `async_poll`
+  / `dispatch` / `release` / `dummy` / `early_dispatch`), one logical
   **inner** phase (`resolve`, parent = Complete or Dummy) rendered on a
   sibling scheduler sub-lane with the same `Sched_N` label and adjacent tid,
   and one **separate-lane**
@@ -227,6 +227,7 @@ field but render differently in Perfetto:
 | Phase | Role | Lane | `tasks_processed` semantic |
 | ----- | ---- | ---- | -------------------------- |
 | `complete` | outer | sched (pid=2) | FIN'd subtasks + sub-block retires this iter |
+| `async_poll` | outer | sched | async-wait (SDMA/RoCE/URMA/CCU) subtasks completed this iter; split from `complete` |
 | `dispatch` | outer | sched | subtasks published this iter |
 | `release` | outer | sched | deferred-release slots drained this iter |
 | `dummy` | outer | sched | dummies handled by `dummy_drain` this iter |

--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -190,13 +190,13 @@ def parse_scheduler_from_json_phases(data):
         # numeric idle_us is preserved (only the per-iter granularity is
         # lost, which Part 2 doesn't surface).
         work_recs = sorted(
-            (r for r in records if r.get("phase") in ("complete", "dispatch")),
+            (r for r in records if r.get("phase") in ("complete", "async_poll", "dispatch")),
             key=lambda r: r.get("start_time_us", 0),
         )
         if not work_recs:
             continue
 
-        phase_us = {"complete": 0.0, "dispatch": 0.0, "idle": 0.0}
+        phase_us = {"complete": 0.0, "async_poll": 0.0, "dispatch": 0.0, "idle": 0.0}
         total_tasks = 0
         max_loop_iter = 0
         pop_hit = 0
@@ -841,9 +841,10 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     # Phase breakdown. Idle is reconstructed from gaps between work
     # records on the same thread (no explicit idle record is emitted by
     # the device anymore).
-    phases = ["complete", "dispatch", "idle"]
+    phases = ["complete", "async_poll", "dispatch", "idle"]
     phase_labels = {
         "complete": "Complete (poll handshake, resolve deps)",
+        "async_poll": "AsyncPoll (async-wait completion: SDMA/RoCE/URMA/CCU)",
         "dispatch": "Dispatch (pop queue, build payload, flush)",
         "idle": "Idle (spinning, no progress — reconstructed from gaps)",
     }
@@ -916,7 +917,7 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     print()
 
     # Data-driven insight: find the dominant phase (excluding idle which is not useful work)
-    work_phases = {p: phase_totals.get(p, 0) for p in ["complete", "dispatch"]}
+    work_phases = {p: phase_totals.get(p, 0) for p in ["complete", "async_poll", "dispatch"]}
     dominant_phase = max(work_phases, key=lambda p: work_phases[p])
     dominant_pct = work_phases[dominant_phase] / total_us * 100 if total_us > 0 else 0
     key_phase_label = phase_labels[dominant_phase].split(" (")[0]

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -1448,6 +1448,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             # Outer phases — mutually time-exclusive within an iter
             "complete": "good",  # green
             "dispatch": "terrible",  # red
+            "async_poll": "yellow",  # async-wait completion polling (split from complete)
             "release": "olive",  # deferred-release drain (on_task_release work)
             "dummy": "grey",  # dummy_drain pass (Resolve nests inside)
             "early_dispatch": "rail_animation",  # speculative early-dispatch staging
@@ -1606,6 +1607,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     continue
                 if phase not in (
                     "complete",
+                    "async_poll",
                     "dispatch",
                     "release",
                     "resolve",

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -507,8 +507,8 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
         cycles_to_us(sched_end_ts - l2_swimlane.sched_start_ts)
     );
 
-    uint64_t sched_total =
-        l2_swimlane.sched_complete_cycle + l2_swimlane.sched_dispatch_cycle + l2_swimlane.sched_idle_cycle;
+    uint64_t sched_total = l2_swimlane.sched_complete_cycle + l2_swimlane.sched_async_cycle +
+                           l2_swimlane.sched_dispatch_cycle + l2_swimlane.sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;
 
     {
@@ -576,6 +576,11 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
             "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(l2_swimlane.sched_complete_perf_cycle),
             l2_swimlane.sched_complete_perf_cycle * 100.0 / c_parent
+        );
+
+        LOG_INFO_V9(
+            "Thread %d:   async_poll     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_swimlane.sched_async_cycle),
+            l2_swimlane.sched_async_cycle * 100.0 / sched_total
         );
 
         LOG_INFO_V9(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1047,6 +1047,40 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
         }
 
+#if SIMPLER_DFX
+        // Close the Complete phase BEFORE the async-wait poll so async-engine
+        // (SDMA/RoCE/URMA/CCU) wait time lands in its own AsyncPoll bar instead
+        // of folding into the Complete span. A finished slot OR a sub-block
+        // retire that finished no slot both count as completion work (the latter
+        // surfaces the SPMD harvest tail; on a pure-retire iteration
+        // phase_complete_count is 0).
+        if (!try_completed) {
+            CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
+        } else {
+            CYCLE_COUNT_LAP(l2_swimlane.sched_complete_cycle);
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES &&
+                (l2_swimlane.phase_complete_count > 0 || l2_swimlane.phase_subretire_count > 0)) {
+                // Complete's release_fanin pushes newly-ready consumers into the
+                // shared ready_queues[], so the end depth differs from the start.
+                int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
+                capture_phase_end_fresh(phase_end_shared);
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::Complete, _t0_phase, _t1, l2_swimlane.sched_loop_count,
+                    l2_swimlane.phase_complete_count + l2_swimlane.phase_subretire_count, /*pop_hit=*/0,
+                    /*pop_miss=*/0, phase_start_shared, phase_end_shared
+                );
+                for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
+                    phase_start_shared[s] = phase_end_shared[s];
+                l2_swimlane.phase_complete_count = 0;
+                l2_swimlane.phase_subretire_count = 0;
+            }
+            // Advance past the completion check even when no Complete bar was
+            // emitted (both counts 0). Otherwise its wall time folds into the
+            // next bar (AsyncPoll, or Dispatch when the poll is skipped).
+            _t0_phase = _t1;
+        }
+#endif
+
         if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
             (sched_->async_wait_list.count > 0 || rt_->aicore_mailbox->has_pending())) {
             AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
@@ -1074,36 +1108,37 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 last_progress_count = new_total;
                 made_progress = true;
             }
-        }
-
 #if SIMPLER_DFX
-        if (!try_completed) {
-            CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
-        } else {
-            CYCLE_COUNT_LAP(l2_swimlane.sched_complete_cycle);
-            // Emit on any completion work this iteration — a finished slot OR
-            // sub-block retires that did not finish a slot. The latter makes the
-            // SPMD harvest tail visible (count field = blocks processed this
-            // iteration; on a pure-retire iteration phase_complete_count is 0).
-            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES &&
-                (l2_swimlane.phase_complete_count > 0 || l2_swimlane.phase_subretire_count > 0)) {
-                // Complete's release_fanin pushes newly-ready consumers into the
-                // shared ready_queues[], so the end depth differs from the start.
+            // AsyncPoll phase: the async-wait completion poll, split out of
+            // Complete. Recorded here inside the poll branch, so "did the poll
+            // run" needs no separate flag. sched_async_cycle accrues only on
+            // iterations that actually poll. The bar is emitted even on a
+            // zero-completion poll so its polling cost stays visible rather than
+            // folding into the next bar. tasks_processed = async subtasks
+            // completed this iter.
+            CYCLE_COUNT_LAP(l2_swimlane.sched_async_cycle);
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
+                // A completing poll runs on_task_complete, which pushes
+                // newly-ready consumers into the shared ready_queues[] — so the
+                // end depth then differs from the start; a zero-completion poll
+                // leaves the queues untouched and the cached start sample holds.
                 int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
-                capture_phase_end_fresh(phase_end_shared);
+                if (poll_result.completed > 0) {
+                    capture_phase_end_fresh(phase_end_shared);
+                } else {
+                    capture_phase_end(phase_end_shared);
+                }
                 l2_swimlane_aicpu_record_sched_phase(
-                    thread_idx, L2SwimlaneSchedPhaseKind::Complete, _t0_phase, _t1, l2_swimlane.sched_loop_count,
-                    l2_swimlane.phase_complete_count + l2_swimlane.phase_subretire_count, /*pop_hit=*/0,
-                    /*pop_miss=*/0, phase_start_shared, phase_end_shared
+                    thread_idx, L2SwimlaneSchedPhaseKind::AsyncPoll, _t0_phase, _t1, l2_swimlane.sched_loop_count,
+                    static_cast<uint32_t>(poll_result.completed), /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared,
+                    phase_end_shared
                 );
                 for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
                     phase_start_shared[s] = phase_end_shared[s];
                 _t0_phase = _t1;
-                l2_swimlane.phase_complete_count = 0;
-                l2_swimlane.phase_subretire_count = 0;
             }
-        }
 #endif
+        }
 
         bool try_pushed = false;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -488,6 +488,7 @@ struct alignas(64) SchedL2SwimlaneCounters {
     uint64_t sched_complete_cycle{0};
     uint64_t sched_dispatch_cycle{0};
     uint64_t sched_idle_cycle{0};
+    uint64_t sched_async_cycle{0};
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
     // Sub-block retires that did NOT finish a slot (SPMD blocks of a multi-block

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -504,8 +504,9 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
         cycles_to_us(sched_end_ts - l2_swimlane.sched_start_ts)
     );
 
-    uint64_t sched_total = l2_swimlane.sched_complete_cycle + l2_swimlane.sched_scan_cycle +
-                           l2_swimlane.sched_dispatch_cycle + l2_swimlane.sched_idle_cycle;
+    uint64_t sched_total = l2_swimlane.sched_complete_cycle + l2_swimlane.sched_async_cycle +
+                           l2_swimlane.sched_scan_cycle + l2_swimlane.sched_dispatch_cycle +
+                           l2_swimlane.sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;
 
     {
@@ -573,6 +574,11 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
             "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(l2_swimlane.sched_complete_perf_cycle),
             l2_swimlane.sched_complete_perf_cycle * 100.0 / c_parent
+        );
+
+        LOG_INFO_V9(
+            "Thread %d:   async_poll     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_swimlane.sched_async_cycle),
+            l2_swimlane.sched_async_cycle * 100.0 / sched_total
         );
 
         LOG_INFO_V9(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -630,6 +630,35 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
         }
 
+#if SIMPLER_DFX
+        // Close the Complete phase BEFORE the async-wait poll so async-engine
+        // (SDMA/RoCE/URMA/CCU) wait time lands in its own AsyncPoll bar instead
+        // of folding into the Complete span.
+        if (!try_completed) {
+            CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
+        } else {
+            CYCLE_COUNT_LAP(l2_swimlane.sched_complete_cycle);
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && l2_swimlane.phase_complete_count > 0) {
+                // Complete's release_fanin pushes newly-ready consumers into the
+                // shared ready_queues[], so the end depth differs from the start.
+                int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
+                capture_phase_end_fresh(phase_end_shared);
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::Complete, _t0_phase, _t1, l2_swimlane.sched_loop_count,
+                    l2_swimlane.phase_complete_count, /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared,
+                    phase_end_shared
+                );
+                for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
+                    phase_start_shared[s] = phase_end_shared[s];
+                l2_swimlane.phase_complete_count = 0;
+            }
+            // Advance past the completion check even when no Complete bar was
+            // emitted (count 0). Otherwise its wall time folds into the next
+            // bar (AsyncPoll, or Dispatch when the poll is skipped).
+            _t0_phase = _t1;
+        }
+#endif
+
         if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
             (sched_->async_wait_list.count > 0 || rt_->aicore_mailbox->has_pending())) {
             AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
@@ -657,30 +686,37 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 last_progress_count = new_total;
                 made_progress = true;
             }
-        }
-
 #if SIMPLER_DFX
-        if (!try_completed) {
-            CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
-        } else {
-            CYCLE_COUNT_LAP(l2_swimlane.sched_complete_cycle);
-            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && l2_swimlane.phase_complete_count > 0) {
-                // Complete's release_fanin pushes newly-ready consumers into the
-                // shared ready_queues[], so the end depth differs from the start.
+            // AsyncPoll phase: the async-wait completion poll, split out of
+            // Complete. Recorded here inside the poll branch, so "did the poll
+            // run" needs no separate flag. sched_async_cycle accrues only on
+            // iterations that actually poll. The bar is emitted even on a
+            // zero-completion poll so its polling cost stays visible rather than
+            // folding into the next bar. tasks_processed = async subtasks
+            // completed this iter.
+            CYCLE_COUNT_LAP(l2_swimlane.sched_async_cycle);
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
+                // A completing poll runs on_task_complete, which pushes
+                // newly-ready consumers into the shared ready_queues[] — so the
+                // end depth then differs from the start; a zero-completion poll
+                // leaves the queues untouched and the cached start sample holds.
                 int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
-                capture_phase_end_fresh(phase_end_shared);
+                if (poll_result.completed > 0) {
+                    capture_phase_end_fresh(phase_end_shared);
+                } else {
+                    capture_phase_end(phase_end_shared);
+                }
                 l2_swimlane_aicpu_record_sched_phase(
-                    thread_idx, L2SwimlaneSchedPhaseKind::Complete, _t0_phase, _t1, l2_swimlane.sched_loop_count,
-                    l2_swimlane.phase_complete_count, /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared,
+                    thread_idx, L2SwimlaneSchedPhaseKind::AsyncPoll, _t0_phase, _t1, l2_swimlane.sched_loop_count,
+                    static_cast<uint32_t>(poll_result.completed), /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared,
                     phase_end_shared
                 );
                 for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
                     phase_start_shared[s] = phase_end_shared[s];
                 _t0_phase = _t1;
-                l2_swimlane.phase_complete_count = 0;
             }
-        }
 #endif
+        }
 
         bool try_pushed = false;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -424,6 +424,7 @@ struct alignas(64) SchedL2SwimlaneCounters {
     uint64_t sched_complete_cycle{0};
     uint64_t sched_dispatch_cycle{0};
     uint64_t sched_idle_cycle{0};
+    uint64_t sched_async_cycle{0};
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
     uint32_t phase_dispatch_count{0};

--- a/src/common/platform/include/common/l2_swimlane_profiling.h
+++ b/src/common/platform/include/common/l2_swimlane_profiling.h
@@ -527,6 +527,10 @@ enum class L2SwimlaneSchedPhaseKind : uint32_t {
                         // (cluster scan + build_payload). tasks_processed = subtasks.
     DrainPublish = 10,  // inner: this thread's drain_stage_cores publish pass
                         // (MMIO write_reg per subtask). tasks_processed = subtasks.
+    // Outer (sched lane): async-wait completion polling, split out of Complete
+    // so async-engine (SDMA/RoCE/URMA/CCU) wait time is attributed to its own
+    // bar. tasks_processed = async subtasks completed this iter.
+    AsyncPoll = 11,
 };
 
 /** Index layout of the queue-depth snapshot arrays below: AIC=0, AIV=1, MIX=2.

--- a/src/common/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/l2_swimlane_collector.cpp
@@ -1042,6 +1042,8 @@ int L2SwimlaneCollector::export_swimlane_json() {
                 return "drain_prepare";
             case L2SwimlaneSchedPhaseKind::DrainPublish:
                 return "drain_publish";
+            case L2SwimlaneSchedPhaseKind::AsyncPoll:
+                return "async_poll";
             }
             return "unknown";
         };


### PR DESCRIPTION
## What

Split the scheduler's async-wait completion poll out of the `complete`
phase into its own `async_poll` bar on the AICPU Scheduler view (L2
swimlane, `SCHED_PHASES` level).

## Why

The async-wait poll (`async_wait_list.poll_and_complete`, i.e.
SDMA/RoCE/URMA/CCU completion) ran inside the Complete phase's time
span, so `complete(x)` silently absorbed async-wait latency and it could
not be attributed separately on the swimlane.

## Changes

- Add `L2SwimlaneSchedPhaseKind::AsyncPoll`. Close the Complete phase
  *before* the async poll and emit `AsyncPoll` *after* it, chained
  through `_t0_phase` so the bars stay back-to-back and non-overlapping.
- Add a `sched_async_cycle` counter; fold it into the cold-path summary
  total and print an `async_poll` line so the phase-percentage breakdown
  stays exact.
- `swimlane_converter` renders `async_poll` (yellow);
  `sched_overhead_analysis` counts it as a work phase so its span is not
  misattributed to idle.
- Update `l2-swimlane-profiling.md` phase taxonomy (five to six outer
  phases).

## Test

- a2a3 / a5 `tensormap_and_ringbuffer` runtimes rebuild clean.
- `tests/st/{a2a3,a5}/tensormap_and_ringbuffer/dfx/l2_swimlane/` sim
  tests pass (a2a3 base + mixed, a5 base).
