### PR TITLE
perf: skip device staging for pure-output tensors

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
@@ -24,7 +24,11 @@ class TestBenchmarkBgemm(SceneTestCase):
         "orchestration": {
             "source": "kernels/orchestration/bgemm_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
-            "signature": [D.IN, D.IN, D.OUT, D.IN],
+            # C is a zero-initialized accumulator: the AIV add kernel reads C
+            # from GM, adds the matmul result, and stores it back across grid_k
+            # iterations. Its host-provided zeros must be staged H2D, so C is
+            # INOUT (read-before-write), not a pure OUT.
+            "signature": [D.IN, D.IN, D.INOUT, D.IN],
         },
         "incores": [
             {

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py
@@ -32,7 +32,11 @@ class TestBgemm(SceneTestCase):
         "orchestration": {
             "source": "kernels/orchestration/bgemm_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
-            "signature": [D.IN, D.IN, D.OUT],
+            # C is a zero-initialized accumulator: the AIV tile kernel reads C
+            # from GM (TLOAD), adds the matmul result, and stores it back across
+            # GRID_K iterations. Its host-provided zeros must be staged H2D, so
+            # C is INOUT (read-before-write), not a pure OUT.
+            "signature": [D.IN, D.IN, D.INOUT],
         },
         "incores": [
             {

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -743,23 +743,18 @@ extern "C" int bind_callable_to_runtime_impl(
             return -1;
         }
 
-        // Pure write-only OUTPUT buffers carry no meaningful host content, so
-        // the H2D copy-in is wasted. Zero them on-device instead (cheap HBM
-        // memset, no PCIe) so any region the kernel leaves unwritten reads as 0
-        // rather than pooled-allocator garbage. INOUT (read-before-write)
-        // and IN keep the H2D copy. Falls back to copy_to_device if a backend
-        // did not wire device_memset.
+        // Pure write-only OUTPUT buffers are never read by the kernel and hold
+        // no meaningful host content, so they need no device staging — the
+        // kernel defines what it writes and any unwritten bytes are undefined.
+        // IN / INOUT (read-before-write) are staged H2D.
         bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
-        int rc;
-        if (is_pure_output && api->device_memset != nullptr) {
-            rc = api->device_memset(dev_ptr, 0, size);
-        } else {
-            rc = api->copy_to_device(dev_ptr, host_ptr, size);
-        }
-        if (rc != 0) {
-            LOG_ERROR("Failed to stage tensor %d to device", i);
-            api->device_free(dev_ptr);
-            return -1;
+        if (!is_pure_output) {
+            int rc = api->copy_to_device(dev_ptr, host_ptr, size);
+            if (rc != 0) {
+                LOG_ERROR("Failed to stage tensor %d to device", i);
+                api->device_free(dev_ptr);
+                return -1;
+            }
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
         // no point copying them back D2H at the end. Index the signature

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -562,25 +562,20 @@ static bool stage_device_args(
             return false;
         }
 
-        // Pure write-only OUTPUT buffers carry no meaningful host content, so
-        // the H2D copy-in is wasted. Zero them on-device instead (cheap HBM
-        // memset, no PCIe) so any region the kernel leaves unwritten reads as 0
-        // rather than pooled-allocator garbage. INOUT (read-before-write)
-        // and IN keep the H2D copy. Falls back to copy_to_device if a backend
-        // did not wire device_memset.
+        // Pure write-only OUTPUT buffers are never read by the kernel and hold
+        // no meaningful host content, so they need no device staging — the
+        // kernel defines what it writes and any unwritten bytes are undefined.
+        // IN / INOUT (read-before-write) are staged H2D.
         bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
-        int rc;
-        if (is_pure_output && api->device_memset != nullptr) {
-            rc = api->device_memset(dev_ptr, 0, size);
-        } else {
-            rc = api->copy_to_device(dev_ptr, host_ptr, size);
-        }
-        if (rc != 0) {
-            LOG_ERROR("Failed to stage tensor %d to device", i);
-            if (release_kind == TensorReleaseKind::Free) {
-                api->device_free(dev_ptr);
+        if (!is_pure_output) {
+            int rc = api->copy_to_device(dev_ptr, host_ptr, size);
+            if (rc != 0) {
+                LOG_ERROR("Failed to stage tensor %d to device", i);
+                if (release_kind == TensorReleaseKind::Free) {
+                    api->device_free(dev_ptr);
+                }
+                return false;
             }
-            return false;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
         // no point copying them back D2H at the end. Index the signature

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -562,25 +562,20 @@ static bool stage_device_args(
             return false;
         }
 
-        // Pure write-only OUTPUT buffers carry no meaningful host content, so
-        // the H2D copy-in is wasted. Zero them on-device instead (cheap HBM
-        // memset, no PCIe) so any region the kernel leaves unwritten reads as 0
-        // rather than pooled-allocator garbage. INOUT (read-before-write)
-        // and IN keep the H2D copy. Falls back to copy_to_device if a backend
-        // did not wire device_memset.
+        // Pure write-only OUTPUT buffers are never read by the kernel and hold
+        // no meaningful host content, so they need no device staging — the
+        // kernel defines what it writes and any unwritten bytes are undefined.
+        // IN / INOUT (read-before-write) are staged H2D.
         bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
-        int rc;
-        if (is_pure_output && api->device_memset != nullptr) {
-            rc = api->device_memset(dev_ptr, 0, size);
-        } else {
-            rc = api->copy_to_device(dev_ptr, host_ptr, size);
-        }
-        if (rc != 0) {
-            LOG_ERROR("Failed to stage tensor %d to device", i);
-            if (release_kind == TensorReleaseKind::Free) {
-                api->device_free(dev_ptr);
+        if (!is_pure_output) {
+            int rc = api->copy_to_device(dev_ptr, host_ptr, size);
+            if (rc != 0) {
+                LOG_ERROR("Failed to stage tensor %d to device", i);
+                if (release_kind == TensorReleaseKind::Free) {
+                    api->device_free(dev_ptr);
+                }
+                return false;
             }
-            return false;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
         // no point copying them back D2H at the end. Index the signature

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -253,7 +253,7 @@ TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
     ASSERT_EQ(bind_runtime(malloc_runtime, malloc_api_, args, signature, 2), 0);
     EXPECT_EQ(fake_.device_malloc_count, 2);
     EXPECT_EQ(fake_.copy_to_count, 2);
-    EXPECT_EQ(fake_.device_memset_count, 1);
+    EXPECT_EQ(fake_.device_memset_count, 0);
     ASSERT_EQ(validate_runtime_impl(&malloc_runtime, &malloc_api_), 0);
     EXPECT_EQ(fake_.device_free_count, 2);
     EXPECT_EQ(fake_.copy_from_count, 2);
@@ -266,7 +266,7 @@ TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
     EXPECT_EQ(fake_.device_malloc_count, 1);
     EXPECT_EQ(fake_.retained_size, align_up(64, kAlign) * 2);
     EXPECT_EQ(fake_.copy_to_count, 2);
-    EXPECT_EQ(fake_.device_memset_count, 1);
+    EXPECT_EQ(fake_.device_memset_count, 0);
     ASSERT_EQ(validate_runtime_impl(&buffer_runtime, &api_), 0);
     // Retained buffer is NOT freed at end of run — it lives on the slot.
     EXPECT_EQ(fake_.device_free_count, 0);
@@ -330,7 +330,7 @@ TEST_F(TrbRuntimeTempBufferTest, LargerRunGrowsSmallerRunKeepsBuffer) {
     EXPECT_EQ(fake_.retained_size, align_up(4096, kAlign) * 2);
 }
 
-TEST_F(TrbRuntimeTempBufferTest, ChildMemoryIsPassThroughAndPureOutStillMemsets) {
+TEST_F(TrbRuntimeTempBufferTest, ChildMemoryIsPassThroughAndPureOutSkipsStaging) {
     fake_.reset();
     Runtime runtime = make_runtime();
     std::vector<uint8_t> child(64, 3);
@@ -341,15 +341,16 @@ TEST_F(TrbRuntimeTempBufferTest, ChildMemoryIsPassThroughAndPureOutStillMemsets)
     ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
 
     ASSERT_EQ(bind_runtime(runtime, api_, args, signature, 2), 0);
-    // Only the non-child output tensor is staged: one retained buffer sized to
-    // a single 1024-aligned slice, no per-tensor malloc, child passed through.
+    // The pure-OUT tensor still gets a retained slice (one 1024-aligned slot,
+    // no per-tensor malloc), but its buffer is handed to the kernel with no
+    // staging; the child is passed through.
     EXPECT_EQ(fake_.device_malloc_count, 1);
     EXPECT_EQ(fake_.retained_size, align_up(64, kAlign));
-    // The pure-OUT tensor is memset (not copied) and the child is passed
-    // through, so no tensor copy-in — the single copy_to is the runtime arena
-    // image upload that every bind performs.
+    // The pure-OUT tensor is neither copied nor memset and the child is passed
+    // through, so no tensor copy-in and no memset — the single copy_to is the
+    // runtime arena image upload that every bind performs.
     EXPECT_EQ(fake_.copy_to_count, 1);
-    EXPECT_EQ(fake_.device_memset_count, 1);
+    EXPECT_EQ(fake_.device_memset_count, 0);
     ASSERT_EQ(validate_runtime_impl(&runtime, &api_), 0);
     EXPECT_EQ(fake_.device_free_count, 0);
 }


### PR DESCRIPTION
## Summary

- Pure write-only OUTPUT tensors were zero-filled on-device (`device_memset`) during per-run arg staging so any bytes the kernel left unwritten read as `0` instead of pooled-allocator garbage.
- That full-buffer HBM memset is a **measurable per-run cost for large outputs**, and it is not required for correctness: an `OUT` tensor is write-only, so the kernel never reads the buffer's initial content, and any region it does not write is undefined by contract.
- **Change:** skip staging entirely for pure `OUT` tensors — `device_malloc`, then hand the buffer to the kernel with no memset and no H2D copy. `IN` / `INOUT` (read-before-write) still copy H2D; D2H copy-back of outputs is unchanged.
- Applied consistently to all three staging paths:
  - `a2a3` tensormap_and_ringbuffer
  - `a2a3` host_build_graph
  - `a5` tensormap_and_ringbuffer

## Behavior note

If a kernel leaves part of a pure-`OUT` buffer unwritten and a golden compares the full buffer, it will now surface (previously masked by the zero-fill). This is intended — such cases should compare only the written region, or be flagged as a kernel that under-writes its output. The `device_memset` platform plumbing (`HostApi`, `DeviceRunnerBase`) is intentionally left in place as an unused capability.

## Testing

- [ ] Simulation CI passes
- [ ] Hardware CI passes