### PR TITLE
Fix: add aarch64 guards for ARM64 inline assembly in AICPU files

### DIFF
--- a/src/common/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/common/platform/onboard/aicpu/cache_ops.cpp
@@ -15,6 +15,7 @@
 
 namespace aicpu_cache_maintenance {
 
+#if defined(__aarch64__)
 void invalidate_range_impl(const void *addr, size_t size) {
     if (size == 0) {
         return;
@@ -42,5 +43,9 @@ void flush_range_impl(const void *addr, size_t size) {
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");
 }
+#else
+void invalidate_range_impl(const void *, size_t) {}
+void flush_range_impl(const void *, size_t) {}
+#endif
 
 }  // namespace aicpu_cache_maintenance

--- a/src/common/platform/onboard/aicpu/device_time.cpp
+++ b/src/common/platform/onboard/aicpu/device_time.cpp
@@ -17,5 +17,5 @@ uint64_t get_sys_cnt_aicpu() {
     return ticks;
 }
 #else
-uint64_t get_sys_cnt_aicpu() { return 0; }
+uint64_t get_sys_cnt_aicpu() { return device_time_now_ticks(); }
 #endif

--- a/src/common/platform/onboard/aicpu/device_time.cpp
+++ b/src/common/platform/onboard/aicpu/device_time.cpp
@@ -10,8 +10,12 @@
  */
 #include "aicpu/device_time.h"
 
+#if defined(__aarch64__)
 uint64_t get_sys_cnt_aicpu() {
     uint64_t ticks;
     asm volatile("mrs %0, cntvct_el0" : "=r"(ticks));
     return ticks;
 }
+#else
+uint64_t get_sys_cnt_aicpu() { return 0; }
+#endif


### PR DESCRIPTION
## Problem

CI fails on x86_64 runners when compiling a2a3 hostbuild because files in `src/common/platform/onboard/aicpu/` contain ARM64-specific inline assembly instructions that cannot be compiled on x86_64:

```
Error: no such instruction: `dc civac,%rax\'
Error: no such instruction: `mrs %rax,cntvct_el0`
```

## Solution

Add `#if defined(__aarch64__)` guards around ARM64 inline assembly:

- **cache_ops.cpp**: Wrap ARM64 cache instructions (`dc civac`, `dc cvac`, `dsb`, `isb`)
- **device_time.cpp**: Wrap ARM64 `mrs cntvct_el0` instruction
- Provide empty stub implementations for x86_64 (these are onboard-only files, so the x86 path is unreachable at runtime)

## Notes

- PR #1361 (`cddf2b6c`) worked around this issue by CI configuration (x86 runners skip compilation of ARM64 code), but that only fixes CI, not the code itself
- This fix makes the code compilable on any architecture, following cross-platform best practices
- The x86 stubs are unreachable at runtime since these files are only used in onboard builds
