### PR TITLE
[WIP] fix(a2a3/a5): surplus-gate PENDING prefetch

### DIFF
--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -339,6 +339,26 @@ class RuntimeBuilder:
         build_pto_isa_commit = self._resolve_build_pto_isa_commit()
         cache_stamp = self._build_cache_stamp(build_pto_isa_commit)
 
+        def _scheduler_cmake_defines() -> dict[str, str]:
+            # 修改理由：把环境变量 SIMPLER_SCHED_FANOUT_DIRECT_AIC 传入 aicpu cmake，
+            # 便于不改源码即可开关 fanout 直挂做 A/B 与回退（默认由头文件宏开启）。
+            defines: dict[str, str] = {}
+            if os.environ.get("SIMPLER_SCHED_FANOUT_DIRECT_AIC", "").upper() in {
+                "0",
+                "OFF",
+                "FALSE",
+                "NO",
+            }:
+                defines["SIMPLER_SCHED_FANOUT_DIRECT_AIC"] = "0"
+            elif os.environ.get("SIMPLER_SCHED_FANOUT_DIRECT_AIC", "").upper() in {
+                "1",
+                "ON",
+                "TRUE",
+                "YES",
+            }:
+                defines["SIMPLER_SCHED_FANOUT_DIRECT_AIC"] = "1"
+            return defines
+
         def _compile_target(target: str) -> Path:
             include_dirs, source_dirs = self._resolve_target_dirs(config_dir, build_config, target)
             cmake_defines = None
@@ -357,6 +377,10 @@ class RuntimeBuilder:
                 }:
                     defines["SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"] = "ON"
                 cmake_defines = defines or None
+            elif target == "aicpu":
+                # 修改理由：仅 aicpu 目标注入 fanout 宏；host/aicore 不需要该调度路径。
+                sched_defines = _scheduler_cmake_defines()
+                cmake_defines = sched_defines or None
             # compile() adds a {target}/ subdirectory inside build_dir
             cache_dir = self._CACHE_DIR / arch / variant / name
             cache_dir.mkdir(parents=True, exist_ok=True)

--- a/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
@@ -84,6 +84,12 @@ target_compile_options(aicpu_kernel
         $<$<COMPILE_LANGUAGE:C>:-std=gnu11>
 )
 
+if(DEFINED SIMPLER_SCHED_FANOUT_DIRECT_AIC)
+    # 修改理由：允许 runtime_builder / 手动 cmake -D 覆盖默认宏，开关 fanout 直挂 AIC。
+    target_compile_definitions(aicpu_kernel PRIVATE
+        SIMPLER_SCHED_FANOUT_DIRECT_AIC=${SIMPLER_SCHED_FANOUT_DIRECT_AIC})
+endif()
+
 target_include_directories(aicpu_kernel
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/a2a3/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicpu/CMakeLists.txt
@@ -90,6 +90,12 @@ target_compile_options(aicpu_kernel
         $<$<COMPILE_LANGUAGE:C>:-std=gnu11>
 )
 
+if(DEFINED SIMPLER_SCHED_FANOUT_DIRECT_AIC)
+    # 修改理由：允许 runtime_builder / 手动 cmake -D 覆盖默认宏，开关 fanout 直挂 AIC。
+    target_compile_definitions(aicpu_kernel PRIVATE
+        SIMPLER_SCHED_FANOUT_DIRECT_AIC=${SIMPLER_SCHED_FANOUT_DIRECT_AIC})
+endif()
+
 # Include directories
 target_include_directories(aicpu_kernel
     PRIVATE

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -31,6 +31,11 @@
 
 #include <atomic>
 
+#ifndef SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：默认开启 fanout 直挂 AIC；可用 cmake/环境变量关掉，便于 A/B 与回退。
+#define SIMPLER_SCHED_FANOUT_DIRECT_AIC 1
+#endif
+
 #include "common/core_type.h"
 #include "common/memory_barrier.h"
 #include "utils/device_arena.h"
@@ -41,6 +46,10 @@
 #include "pto_shared_memory.h"
 
 #include "aicpu/device_time.h"  // get_sys_cnt_aicpu (weak; used by early-dispatch doorbell timing too)
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：route_ready_once 在 header 内联，需前向声明 enqueue，实现放在 dispatch.cpp。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
 #if SIMPLER_SCHED_PROFILING
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
 #define PTO2_SCHED_CYCLE_LAP(acc)   \
@@ -91,6 +100,8 @@ struct alignas(64) PTO2ReadyQueue {
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         return (e >= d) ? (e - d) : 0;
     }
+
+    void reset_for_reuse() {}
 
     bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
 
@@ -419,9 +430,9 @@ struct PTO2SchedulerLayout {
     size_t off_dummy_ready_queue_slots;
     size_t off_early_dispatch_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_early_sync_start_queue_slots;
-    size_t off_dep_pool_entries;
+    size_t off_dep_pool_entries[PTO2_MAX_RING_DEPTH];
     uint64_t ready_queue_capacity;
-    int32_t dep_pool_capacity;
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
 };
 
 /**
@@ -455,8 +466,11 @@ struct PTO2SchedulerState {
         // by SchedulerState::wire_arena_pointers). The `ring` field stores
         // the device address of the SM ring header — computed via offset
         // arithmetic, no SM dereference.
-        bool init_data_from_layout(void *sm_dev_base);
+        bool init_data_from_layout(void *sm_dev_base, int32_t ring_id);
+        void reset_for_reuse(void *sm_dev_base, int32_t ring_id, std::atomic<int32_t> *orch_err);
         void destroy();
+
+        void sync_to_sm() { ring->fc.last_task_alive.store(last_task_alive, std::memory_order_release); }
 
 #if SIMPLER_DFX
         void publish_dep_pool_snapshot() {
@@ -470,7 +484,31 @@ struct PTO2SchedulerState {
             if (tail > top) tail = top;
         }
 #endif
-    } ring_sched_state;
+
+        void advance_ring_pointers() {
+            int32_t current_task_index = ring->fc.current_task_index.load(std::memory_order_acquire);
+            int32_t old_last_task_alive = last_task_alive;
+
+            while (last_task_alive < current_task_index) {
+                PTO2TaskSlotState &slot_state = ring->get_slot_state_by_task_id(last_task_alive);
+                if (slot_state.task_state.load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
+                    break;
+                }
+                last_task_alive++;
+            }
+
+            // Eager reset: prepare reclaimed slots for reuse while still hot in cache.
+            // Safe because last_task_alive has advanced past these slots but
+            // sync_to_sm has not yet published — the orchestrator cannot reuse
+            // them until the release store below.
+            // Skips payload, task, ring_id — immutable after RingSchedState::init().
+            for (int32_t id = old_last_task_alive; id < last_task_alive; id++) {
+                ring->get_slot_state_by_task_id(id).reset_for_reuse();
+            }
+
+            sync_to_sm();
+        }
+    } ring_sched_states[PTO2_MAX_RING_DEPTH];
 
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
@@ -486,6 +524,16 @@ struct PTO2SchedulerState {
     // the dispatch loop and completed inline -- never goes to AICore.
     PTO2ReadyQueue dummy_ready_queue;
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：仅在 on_task_complete 的 fanout 游走期间有效；把 SchedulerContext
+    // 与本线程 idx 传给 route_ready_once，以便把新就绪的 AIC 记入本线程 defer，
+    // 而不是立刻 push 进共享 ready_queues（缩短 ready 往返）。
+    int32_t fanout_direct_aic_thread_idx_{-1};
+    void *fanout_direct_aic_sched_ctx_{nullptr};
+    bool *fanout_direct_aic_made_progress_{nullptr};
+    bool *fanout_direct_aic_try_pushed_{nullptr};
+#endif
+
     alignas(64) AsyncWaitList async_wait_list;
 
     // Statistics (cold path, isolated from hot-path fields)
@@ -497,12 +545,15 @@ struct PTO2SchedulerState {
     // Inline hot-path methods
     // =========================================================================
 
-    // Route a ready slot to the right global queue. Dummy tasks (empty active_mask)
-    // live in dummy_ready_queue; a ready sync_start cohort goes to the per-shape
-    // ready_sync_queues[] (drained as Tier-0); everything else to ready_queues[].
+    // Route a ready slot to the right global queue. Dep-only tasks — DUMMY-shaped
+    // (empty active_mask) or a task whose dispatch predicate fails — live in
+    // dummy_ready_queue and are retired inline; a ready sync_start cohort goes to
+    // the per-shape ready_sync_queues[] (drained as Tier-0); everything else to
+    // ready_queues[].
     void push_ready_routed(PTO2TaskSlotState *slot_state) {
         PTO2ResourceShape shape = slot_state->active_mask.to_shape();
-        if (shape == PTO2ResourceShape::DUMMY) {
+        if (shape == PTO2ResourceShape::DUMMY ||
+            (slot_state->active_mask.has_predicate() && !slot_state->payload->predicate.pass())) {
             dummy_ready_queue.push(slot_state);
         } else if (slot_state->active_mask.requires_sync_start()) {
             ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
@@ -524,18 +575,89 @@ struct PTO2SchedulerState {
         }
     }
 
-    // host_build_graph host-orch: the COMPLETED->CONSUMED flip existed only to
-    // gate execution-time reclaim (now removed) and to serialize against the
-    // orchestrator's concurrent producer claim — which cannot happen here, since
-    // the orchestrator runs to completion on the host before the device
-    // scheduler starts. Nothing reads CONSUMED during device execution
-    // (completion uses completed_tasks_; wait_for_tensor_ready's consumer wait
-    // keys on fanout_refcount), so the flip is gone. fanout_refcount is still
-    // bumped by release_producer / release_producer_scope so the host-side
-    // wait_for_consumers sees consumers retire.
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
+        // Read fanout_refcount/fanout_count and flip COMPLETED->CONSUMED under
+        // fanout_lock. The orchestrator claims producers (fanout_count++) under the
+        // same lock, so the consume decision is serialized against a concurrent
+        // claim: either the ++ lands first (count then exceeds refcount, so we do
+        // not consume and the producer stays pinned until released) or the consume
+        // lands first (the orchestrator then observes CONSUMED and skips the
+        // claim). Without this lock a claim racing the consume desyncs the slot's
+        // refcount and wedges in-order reclaim.
+        bool became_consumed = false;
+        slot_state.lock_fanout();
+        if (slot_state.fanout_refcount.load(std::memory_order_acquire) == slot_state.fanout_count) {
+            PTO2TaskState expected = PTO2_TASK_COMPLETED;
+            became_consumed = slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+        }
+        slot_state.unlock_fanout();
+        if (!became_consumed) return;
+
+#if SIMPLER_SCHED_PROFILING
+        tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+#endif
+
+        int32_t ring_id = slot_state.ring_id;
+        // advance_ring_pointers (and the reset_for_reuse it triggers) MUST run
+        // outside fanout_lock: reset_for_reuse stores fanout_lock=0 and would
+        // clobber a held lock. Safe here — the slot is CONSUMED and quiescent.
+        // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
+        int32_t expected_lock = 0;
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
+            ring_sched_states[ring_id].advance_ring_pointers();
+            ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
+        }
+    }
+
+#if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+        // See the non-profiling overload for why the read + COMPLETED->CONSUMED
+        // flip is serialized against the orchestrator's claim under fanout_lock.
+        bool became_consumed = false;
+        slot_state.lock_fanout();
+        atomic_count += 1;  // lock CAS
+        uint32_t fc = slot_state.fanout_count;
+        uint32_t rc = slot_state.fanout_refcount.load(std::memory_order_acquire);
+        atomic_count += 1;  // fanout_refcount.load (fanout_count is a plain read under lock)
+        if (rc == fc) {
+            PTO2TaskState expected = PTO2_TASK_COMPLETED;
+            became_consumed = slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+            atomic_count += 1;  // CAS
+        }
+        slot_state.unlock_fanout();
+        atomic_count += 1;  // unlock store
+        if (!became_consumed) return;
+
+#if SIMPLER_SCHED_PROFILING
+        tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+#endif
+
+        int32_t ring_id = slot_state.ring_id;
+        // advance_ring_pointers + reset_for_reuse run outside fanout_lock (reset
+        // stores fanout_lock=0). Safe — the slot is CONSUMED and quiescent.
+        // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
+        int32_t expected_lock = 0;
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
+            ring_sched_states[ring_id].advance_ring_pointers();
+            ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
+            atomic_count += 2;  // try-lock CAS + unlock store
+        } else {
+            atomic_count += 1;  // failed try-lock CAS
+        }
+    }
+#endif
 
     void release_producer(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
+        check_and_handle_consumed(slot_state);
     }
 
     // Scope-end release: sets bit31 (PTO2_FANOUT_SCOPE_BIT) instead of bumping a
@@ -545,17 +667,20 @@ struct PTO2SchedulerState {
     // "waiting on a consumer".
     void release_producer_scope(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
+        check_and_handle_consumed(slot_state);
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
     void release_producer(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
+        check_and_handle_consumed(slot_state, atomic_count);
     }
 
     void release_producer_scope(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
+        check_and_handle_consumed(slot_state, atomic_count);
     }
 #endif
 
@@ -793,6 +918,7 @@ struct PTO2SchedulerState {
         p.unlock_fanout();
         for (; edge != nullptr; edge = edge->next) {
             PTO2TaskSlotState *c = edge->slot_state;
+            if (c->active_mask.has_predicate()) continue;  // predicated consumers never early-dispatch
             // Compare to fanin_actual_count (the real producer-edge count), NOT
             // fanin_count: fanin_count = fanin_actual_count + 1 (a self/wiring +1 that
             // ready_fanin gets but dispatch_fanin does not). dispatch_fanin starts at
@@ -841,6 +967,8 @@ struct PTO2SchedulerState {
     };
 
     inline bool try_early_dispatch_release(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+        // A predicated task is evaluated at the ready point, never early-dispatched.
+        if (slot_state.active_mask.has_predicate()) return false;
         // Never staged => CAS NONE->DISPATCHED wins => dispatch normally.
         uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
         if (slot_state.payload->early_dispatch_state.compare_exchange_strong(
@@ -899,6 +1027,22 @@ struct PTO2SchedulerState {
     }
 
     bool route_ready_once(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+        // 修改理由：shape 提前取出，供 fanout 钩子与后续入队共用，避免重复 to_shape()。
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：complete 扇出解锁的单块 AIC，若本线程有空闲核则走 defer 直挂，
+        // 跳过 readyQ；失败则回落原 claim+入队路径。勿抢 early-dispatch STAGING
+        // 消费者（由 enqueue 内 ED 检查保证），否则门铃不响会 S1。
+        if (shape == PTO2ResourceShape::AIC && slot_state.logical_block_num == 1 &&
+            fanout_direct_aic_sched_ctx_ != nullptr && fanout_direct_aic_thread_idx_ >= 0) {
+            if (pto2_try_fanout_direct_aic_enqueue(
+                    fanout_direct_aic_sched_ctx_, fanout_direct_aic_thread_idx_, slot_state
+                )) {
+                return true;
+            }
+        }
+#endif
+
         if (!try_claim_ready_once(slot_state)) return false;
 
         // Early-dispatch: pre-staged tasks are released by doorbell
@@ -911,8 +1055,8 @@ struct PTO2SchedulerState {
             return true;
         }
 
-        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-        if (shape == PTO2ResourceShape::DUMMY) {
+        if (shape == PTO2ResourceShape::DUMMY ||
+            (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
             dummy_ready_queue.push(&slot_state);
         } else if (slot_state.active_mask.requires_sync_start()) {
             ready_sync_queues[static_cast<int32_t>(shape)].push(&slot_state);
@@ -927,6 +1071,20 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
         EarlyDispatchReleaseSink *sink = nullptr
     ) {
+        // 修改理由：与非 profiling 重载一致——先取 shape，再尝试 fanout 直挂钩子。
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：SCHED_PROFILING 重载同样需要钩子，否则开 profiling 时路径不一致。
+        if (shape == PTO2ResourceShape::AIC && slot_state.logical_block_num == 1 &&
+            fanout_direct_aic_sched_ctx_ != nullptr && fanout_direct_aic_thread_idx_ >= 0) {
+            if (pto2_try_fanout_direct_aic_enqueue(
+                    fanout_direct_aic_sched_ctx_, fanout_direct_aic_thread_idx_, slot_state
+                )) {
+                return true;
+            }
+        }
+#endif
+
         uint8_t state = slot_state.ready_state.load(std::memory_order_acquire);
         atomic_count += 1;  // ready_state load
         for (;;) {
@@ -951,8 +1109,8 @@ struct PTO2SchedulerState {
             return true;
         }
 
-        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-        if (shape == PTO2ResourceShape::DUMMY) {
+        if (shape == PTO2ResourceShape::DUMMY ||
+            (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
             dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
         } else if (slot_state.active_mask.requires_sync_start()) {
             ready_sync_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
@@ -1142,6 +1300,8 @@ struct PTO2SchedulerState {
     int32_t on_task_release(PTO2TaskSlotState &slot_state, int32_t thread_idx) {
         PTO2_SCHED_CYCLE_START();
         extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
+        extern uint64_t g_sched_self_atomic_count[];
+        extern uint64_t g_sched_self_consumed_cycle[];
         extern uint64_t g_sched_complete_count[];
         uint64_t fanin_atomics = 0;
 #else
@@ -1160,11 +1320,15 @@ struct PTO2SchedulerState {
         PTO2_SCHED_CYCLE_LAP(g_sched_fanin_cycle[thread_idx]);
 #endif
 
-        // host-orch: no self CONSUMED flip — see release_producer. The task's
-        // own fanout_refcount is already complete via the consumer/scope
-        // releases above; nothing reads CONSUMED during device execution.
+        // Self consumed check
 #if SIMPLER_SCHED_PROFILING
+        uint64_t self_atomics = 0;
+        check_and_handle_consumed(slot_state, self_atomics);
+        g_sched_self_atomic_count[thread_idx] += self_atomics;
+        PTO2_SCHED_CYCLE_LAP(g_sched_self_consumed_cycle[thread_idx]);
         g_sched_complete_count[thread_idx]++;
+#else
+        check_and_handle_consumed(slot_state);
 #endif
         return payload->fanin_actual_count;
     }
@@ -1176,6 +1340,12 @@ struct PTO2SchedulerState {
     // Capacities are baked into the returned layout; init_data_from_layout uses
     // the same values.
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    static PTO2SchedulerLayout
+    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
+    static PTO2SchedulerLayout reserve_layout(
+        DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH],
+        const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never
@@ -1185,6 +1355,7 @@ struct PTO2SchedulerState {
     // scheduler only needs the SM header / ring header base addresses,
     // both window-size-independent.)
     bool init_data_from_layout(const PTO2SchedulerLayout &layout, DeviceArena &arena, void *sm_dev_base);
+    void reset_for_reuse(const PTO2SchedulerLayout &layout, void *sm_dev_base);
 
     // Phase 3b: write the arena-internal pointer fields
     // (ready_queues[].slots, dummy_ready_queue.slots, dep_pool.base for each

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -15,6 +15,7 @@
 
 #include "common/unified_log.h"
 #include "aicpu/dep_gen_collector_aicpu.h"
+#include "aicpu/device_phase_aicpu.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
@@ -32,18 +33,23 @@
 // Cold-path helpers for the main dispatch loop (noinline to reduce hot-loop icache)
 // =============================================================================
 
-static void latch_scheduler_error(PTO2SharedMemoryHeader *header, int32_t thread_idx, int32_t error_code) {
+// Returns true iff this call won the first-writer CAS for sched_error_code — the
+// caller may then write companion fields (e.g. the stall detail) knowing they
+// describe the same observation that owns the latched code.
+static bool latch_scheduler_error(PTO2SharedMemoryHeader *header, int32_t thread_idx, int32_t error_code) {
     if (header == nullptr || error_code == PTO2_ERROR_NONE) {
-        return;
+        return false;
     }
     // The first error code/thread pair wins; the bitmap cumulatively records all reporting threads.
     int32_t expected = PTO2_ERROR_NONE;
-    if (header->sched_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
+    bool won = header->sched_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel);
+    if (won) {
         header->sched_error_thread.store(thread_idx, std::memory_order_release);
     }
     if (thread_idx >= 0 && thread_idx < 32) {
         header->sched_error_bitmap.fetch_or(1U << static_cast<uint32_t>(thread_idx), std::memory_order_acq_rel);
     }
+    return won;
 }
 
 LoopAction SchedulerContext::handle_orchestrator_exit(
@@ -72,6 +78,9 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
         }
         return LoopAction::BREAK_LOOP;
     }
+
+    bool orch_done = orchestrator_done_.load(std::memory_order_acquire);
+    if (!orch_done) return LoopAction::NONE;
 
     task_count = total_tasks_;
     if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
@@ -227,10 +236,14 @@ void SchedulerContext::log_stall_diagnostics(
     if (thread_idx == 0) {
         int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_state.ring;
+            PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
             int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
             submitted_in_ring += ring_task_count;
-            for (int32_t si = 0; si < ring_task_count; si++) {
+            // Scan only live task_ids [last_task_alive, current_task_index): slots
+            // wrap (slot = task_id % window), so starting at 0 re-reads each live
+            // slot once per earlier task_id and inflates the scan_* counts.
+            int32_t ring_task_start = ring.fc.last_task_alive.load(std::memory_order_relaxed);
+            for (int32_t si = ring_task_start; si < ring_task_count; si++) {
                 PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
                 PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
                 int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
@@ -353,6 +366,80 @@ void SchedulerContext::log_shutdown_stall_snapshot(
     }
 }
 
+SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() const {
+    StallClassification cls{};
+    cls.stuck_task_id = -1;
+    cls.stuck_core = -1;
+    int32_t cnt_running = 0, cnt_ready = 0, cnt_waiting = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
+        int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
+        // Active task_ids live in [last_task_alive, current_task_index); slots wrap
+        // (slot = task_id % window), so scanning from 0 re-reads each live slot once
+        // per earlier task_id that mapped to it -- inflating the counts to O(history).
+        // Start at the tail so each live slot is visited exactly once (O(window)).
+        int32_t ring_task_start = ring.fc.last_task_alive.load(std::memory_order_relaxed);
+        for (int32_t si = ring_task_start; si < ring_task_count; si++) {
+            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+            if (st >= PTO2_TASK_COMPLETED) continue;
+            // Same ground truth as log_stall_diagnostics: task_state stays PENDING
+            // until COMPLETED, so RUNNING is read from core ownership, not the slot.
+            int32_t run_core = -1;
+            for (int32_t cid = 0; cid < cores_total_num_; cid++) {
+                if (core_exec_states_[cid].running_slot_state == &slot_state) {
+                    run_core = cid;
+                    break;
+                }
+            }
+            if (run_core >= 0) {
+                if (cnt_running == 0) {
+                    // Snapshot the non-atomic task pointer once: it can be null on a
+                    // torn slot, and a concurrent writer may flip it mid-read.
+                    PTO2TaskDescriptor *task_ptr = slot_state.task;
+                    cls.stuck_task_id = (task_ptr != nullptr) ? static_cast<int64_t>(task_ptr->task_id.raw) : -1;
+                    cls.stuck_core = run_core;
+                }
+                cnt_running++;
+                continue;
+            }
+            // 修改理由：仅挂在 pending_slot_state 上的任务不得计为 READY——否则“有
+            // pending、核全空闲”会被误判成 S3:ready-but-all-idle，掩盖真实挂起。
+            int32_t pend_core = -1;
+            for (int32_t cid = 0; cid < cores_total_num_; cid++) {
+                if (core_exec_states_[cid].pending_slot_state == &slot_state) {
+                    pend_core = cid;
+                    break;
+                }
+            }
+            if (pend_core >= 0) {
+                if (cnt_running == 0) {
+                    PTO2TaskDescriptor *task_ptr = slot_state.task;
+                    cls.stuck_task_id = (task_ptr != nullptr) ? static_cast<int64_t>(task_ptr->task_id.raw) : -1;
+                    cls.stuck_core = pend_core;
+                }
+                cnt_running++;
+                continue;
+            }
+            int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
+            int32_t fi = slot_state.fanin_count;
+            if (rc >= fi) {
+                cnt_ready++;
+                continue;
+            }
+            cnt_waiting++;
+        }
+    }
+    cls.cnt_running = cnt_running;
+    cls.cnt_ready = cnt_ready;
+    cls.cnt_waiting = cnt_waiting;
+    cls.completed = completed_tasks_.load(std::memory_order_relaxed);
+    cls.total = total_tasks_;
+    cls.orch_done = orchestrator_done_ ? 1 : 0;
+    cls.detail = classify_stall_detail(cnt_running, cnt_ready, cnt_waiting, cls.orch_done);
+    return cls;
+}
+
 int32_t SchedulerContext::handle_timeout_exit(
     int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations,
     int32_t last_progress_count
@@ -361,11 +448,28 @@ int32_t SchedulerContext::handle_timeout_exit(
     uint64_t sched_start_ts
 #endif
 ) {
+    StallClassification cls = classify_stall_reason();
     LOG_ERROR(
-        "[STALL thread=%d idle_iterations=%d] TIMEOUT_EXIT after_idle_iterations=%d", thread_idx, idle_iterations,
-        idle_iterations
+        "[STALL thread=%d idle_iterations=%d] TIMEOUT_EXIT after_idle_iterations=%d sub_class=%s "
+        "completed=%d/%d running=%d ready=%d waiting=%d orch_done=%d stuck_task_id=%" PRId64 " stuck_core=%d",
+        thread_idx, idle_iterations, idle_iterations, stall_detail_name(cls.detail), cls.completed, cls.total,
+        cls.cnt_running, cls.cnt_ready, cls.cnt_waiting, cls.orch_done, cls.stuck_task_id, cls.stuck_core
     );
-    latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
+    // Only the thread that wins the code-100 latch publishes the detail/locators,
+    // keeping the host-visible sub-class consistent with the latched code.
+    if (latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT) && header != nullptr) {
+        header->sched_stall_completed.store(cls.completed, std::memory_order_relaxed);
+        header->sched_stall_total.store(cls.total, std::memory_order_relaxed);
+        header->sched_stall_cnt_running.store(cls.cnt_running, std::memory_order_relaxed);
+        header->sched_stall_cnt_ready.store(cls.cnt_ready, std::memory_order_relaxed);
+        header->sched_stall_cnt_waiting.store(cls.cnt_waiting, std::memory_order_relaxed);
+        header->sched_stall_orch_done.store(cls.orch_done, std::memory_order_relaxed);
+        header->sched_stall_task_id.store(cls.stuck_task_id, std::memory_order_relaxed);
+        header->sched_stall_core.store(cls.stuck_core, std::memory_order_relaxed);
+        // detail published last (release) so a host reading a non-NONE detail
+        // sees the locators above already settled.
+        header->sched_stall_detail.store(cls.detail, std::memory_order_release);
+    }
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
         log_shutdown_stall_snapshot(thread_idx, idle_iterations, last_progress_count);
 #if SIMPLER_DFX
@@ -390,19 +494,31 @@ int32_t SchedulerContext::handle_timeout_exit(
     }
 #if SIMPLER_DFX
     uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
+    aicpu_phase_set_window(
+        AicpuPhase::SchedWindow, static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts)
+    );
+#if SIMPLER_SCHED_PROFILING
     LOG_INFO_V9(
         "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
         static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
         cycles_to_us(sched_timeout_ts - sched_start_ts)
     );
 #endif
+#endif
     return -PTO2_ERROR_SCHEDULER_TIMEOUT;
 }
 
 #if SIMPLER_DFX
-void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, int32_t cur_thread_completed) {
+void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unused]] int32_t cur_thread_completed) {
     auto &l2_swimlane = sched_l2_swimlane_[thread_idx];
     uint64_t sched_end_ts = get_sys_cnt_aicpu();
+    // Ride the sched window home to the host phase buffer (the host reduces
+    // across sched threads → the `Sched` [STRACE] marker). The verbose
+    // per-thread device-log line below is now opt-in deep-dive.
+    aicpu_phase_set_window(
+        AicpuPhase::SchedWindow, static_cast<uint64_t>(l2_swimlane.sched_start_ts), static_cast<uint64_t>(sched_end_ts)
+    );
+#if SIMPLER_SCHED_PROFILING
     LOG_INFO_V9(
         "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
         static_cast<uint64_t>(l2_swimlane.sched_start_ts), static_cast<uint64_t>(sched_end_ts),
@@ -413,7 +529,6 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, int32_t cur_t
         l2_swimlane.sched_complete_cycle + l2_swimlane.sched_dispatch_cycle + l2_swimlane.sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;
 
-#if SIMPLER_SCHED_PROFILING
     {
         PTO2SchedProfilingData sp = scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
@@ -515,11 +630,11 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, int32_t cur_t
             );
         }
     }
-#endif
     LOG_INFO_V9(
         "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
         cycles_to_us(sched_total), static_cast<uint64_t>(l2_swimlane.sched_loop_count), cur_thread_completed
     );
+#endif
 }
 #endif
 
@@ -571,7 +686,7 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 // landed, so the shared aic_count_/aiv_count_ are written by one thread only.
 // =============================================================================
 void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads) {
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
     const int32_t total = cores_total_num_;
     const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(tidx) * total) / nthreads);
     const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(tidx + 1) * total) / nthreads);
@@ -799,7 +914,7 @@ int32_t SchedulerContext::pre_handshake_init(
     // hs_setup_done_, so it happens-before every thread's handshake_partition
     // (and therefore before any aicpu_ready=1 write).
     if (is_l2_swimlane_enabled()) {
-        l2_swimlane_aicpu_init(runtime->worker_count);
+        l2_swimlane_aicpu_init(runtime->dev.worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
             // Sched-phase pool count must match the dump_args_init thread count
@@ -813,7 +928,7 @@ int32_t SchedulerContext::pre_handshake_init(
             // Orchestration is always single-threaded, so orch-phase is one pool
             // (ordinal 0) — see record_orch_phase.
             const int orch_phase_threads = 1;
-            l2_swimlane_aicpu_init_phase(runtime->worker_count, sched_phase_threads, orch_phase_threads);
+            l2_swimlane_aicpu_init_phase(runtime->dev.worker_count, sched_phase_threads, orch_phase_threads);
         }
     } else {
         l2_swimlane_level_ = L2SwimlaneLevel::DISABLED;
@@ -821,7 +936,7 @@ int32_t SchedulerContext::pre_handshake_init(
 #endif
 
     // Core count is needed by every thread to compute its handshake slice.
-    cores_total_num_ = runtime->worker_count;
+    cores_total_num_ = runtime->dev.worker_count;
     if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
         LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
         return -1;
@@ -902,7 +1017,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         // count) while valid counts still add up, with no signed overflow.
         int64_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
+            int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
             if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count += ring_tasks;
         }
         total_tasks_ = static_cast<int32_t>(pto2_count);
@@ -910,6 +1025,9 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         total_tasks_ = 0;
     }
     completed_tasks_.store(0, std::memory_order_release);
+
+    // Device orchestration: the orchestrator thread flips this when the graph is built.
+    orchestrator_done_.store(false, std::memory_order_release);
 
     // prepare_subtask_to_core fully writes a per-core payload / deferred-slab slot
     // before the AICore is told to read it: build_payload sets
@@ -962,7 +1080,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         }
     }
 
-    func_id_to_addr_ = runtime->func_id_to_addr_;
+    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
 
     return 0;
 }
@@ -1002,6 +1120,7 @@ void SchedulerContext::deinit() {
     // Reset task counters and orchestrator state
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
+    orchestrator_done_.store(false, std::memory_order_release);
     completed_.store(false, std::memory_order_release);
 
     // Reset core discovery and assignment state
@@ -1026,13 +1145,20 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
     sched_ = &rt->scheduler;
 }
 
+void SchedulerContext::wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx) {
+    while (!orchestration_done() && !completed_.load(std::memory_order_acquire)) {
+        if (sched_ != nullptr && sched_->sm_header != nullptr &&
+            check_idle_fatal_error(thread_idx, sched_->sm_header, runtime) == LoopAction::BREAK_LOOP) {
+            break;
+        }
+        SPIN_WAIT_HINT();
+    }
+}
+
 // =============================================================================
-// Post-orchestration bookkeeping. Runs once on the boot leader after the
-// host-built image is attached; latches total_tasks_ and folds inline-completed
-// tasks (or shuts down on a fatal orchestration error). The caller publishes
-// runtime_init_ready_ (release) after this returns — that store is what makes
-// total_tasks_ visible to the scheduler threads, which acquire it before
-// dispatching.
+// Post-orchestration bookkeeping. Runs on the orchestrator thread once the
+// build phase finishes; folds inline-completed tasks, flips orchestrator_done_,
+// and drives the orchestrator → scheduler core transition (or fatal shutdown).
 // =============================================================================
 void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
@@ -1056,6 +1182,7 @@ void SchedulerContext::on_orchestration_done(
         rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
 #endif
     }
+    orchestrator_done_.store(true, std::memory_order_release);
 
     // Check for fatal error from orchestration; if so, shut down immediately.
     int32_t orch_err = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -199,6 +199,14 @@ void SchedulerContext::complete_slot_task(
         // profiling-flags-smoke build path where SIMPLER_DFX is OFF and
         // the Resolve emit below is excluded.
         [[maybe_unused]] uint32_t consumers_resolved = 0;
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：仅在 on_task_complete 扇出窗口内启用 route_ready_once 的直挂钩子；
+        // 传入本线程 idx 与 SchedulerContext，把新就绪 AIC 写入本线程 defer。
+        sched_->fanout_direct_aic_thread_idx_ = thread_idx;
+        sched_->fanout_direct_aic_sched_ctx_ = this;
+        sched_->fanout_direct_aic_made_progress_ = nullptr;
+        sched_->fanout_direct_aic_try_pushed_ = nullptr;
+#endif
 #if SIMPLER_SCHED_PROFILING
         // SCHED_PROFILING variant takes thread_idx for its per-thread atomic
         // counter side-effects (g_sched_*_atomic_count[thread_idx], consumed
@@ -207,6 +215,13 @@ void SchedulerContext::complete_slot_task(
         consumers_resolved = sched_->on_task_complete(slot_state, thread_idx).fanout_edges;
 #else
         consumers_resolved = sched_->on_task_complete(slot_state);
+#endif
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：扇出结束必须清 scope，避免后续非 fanout 的 route_ready_once 误走直挂。
+        sched_->fanout_direct_aic_thread_idx_ = -1;
+        sched_->fanout_direct_aic_sched_ctx_ = nullptr;
+        sched_->fanout_direct_aic_made_progress_ = nullptr;
+        sched_->fanout_direct_aic_try_pushed_ = nullptr;
 #endif
 #if SIMPLER_DFX
         if (resolve_t0 != 0) {
@@ -370,6 +385,16 @@ void SchedulerContext::check_running_cores_for_completion(
             reg_task_id, reg_state, core.running_reg_task_id, core.pending_reg_task_id, pending_gated
         );
         if (!t.matched) continue;
+
+#if SIMPLER_DFX
+        // Release an ACK-gated AICore swimlane buffer if this matched ACK/FIN is
+        // the one a rotation is waiting on: it proves the core advanced past the
+        // just-rotated buffer's tail record (FIN precedes the record write on
+        // this runtime, so rotation could not release the buffer itself).
+        if (l2_swimlane_level_ != L2SwimlaneLevel::DISABLED) {
+            l2_swimlane_aicpu_on_aicore_ack(core_id, thread_idx, static_cast<uint32_t>(reg_task_id));
+        }
+#endif
 
 #if SIMPLER_SCHED_PROFILING
         if (l2_swimlane.l2_swimlane_enabled && (t.running_done || t.pending_done)) {

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -94,13 +94,24 @@ public:
     //  - publishes core assignments to the perf collector (SIMPLER_DFX)
     //  - latches submitted task count from PTO2 shared memory
     //  - folds inline_completed_tasks into completed_tasks_
+    //  - flips orchestrator_done_ and triggers core transition
     //    (skipped on fatal error — emergency_shutdown runs instead)
     // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
     void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
 
-    // Bind the PTO2Runtime scheduler pointer.
+    // Bind the PTO2Runtime scheduler pointer. Required in device-orchestration
+    // mode where rt is created by the orchestrator thread after init().
     void bind_runtime(PTO2Runtime *rt);
+
+    // Serial orch->sched mode pre-dispatch wait. No AICore dispatch happens
+    // before orchestrator_done_.
+    void wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx);
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：header 内联的 route_ready_once 经 C 钩子调私有 enqueue，需 friend。
+    friend bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
 
     // =========================================================================
     // State queries / external synchronization points
@@ -110,6 +121,7 @@ public:
     int32_t aiv_count() const { return aiv_count_; }
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+    bool orchestration_done() const { return orchestrator_done_.load(std::memory_order_relaxed); }
 
 private:
     // =========================================================================
@@ -139,6 +151,14 @@ private:
     // sync_start drain coordination
     SyncStartDrainState drain_state_;
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：每调度线程一份线程本地 defer 缓冲——complete 扇出时写入、
+    // dispatch_ready_tasks 在 sync_start 层之后 drain；避免 claim 后只停在 defer 里导致 S3。
+    static constexpr int32_t kFanoutDirectAicPendingCap = 512;
+    PTO2TaskSlotState *fanout_direct_aic_pending_[MAX_AICPU_THREADS][kFanoutDirectAicPendingCap];
+    int32_t fanout_direct_aic_pending_n_[MAX_AICPU_THREADS]{0};
+#endif
+
 #if SIMPLER_DFX
     SchedL2SwimlaneCounters sched_l2_swimlane_[MAX_AICPU_THREADS];
     // Cached once at init() from get_l2_swimlane_level(), AFTER
@@ -149,6 +169,8 @@ private:
     // --- Task-execution tracking ---
     std::atomic<int32_t> completed_tasks_{0};
     int32_t total_tasks_{0};
+    // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
+    std::atomic<bool> orchestrator_done_{false};
     std::atomic<bool> completed_{false};
     uint64_t *func_id_to_addr_{nullptr};
 
@@ -343,6 +365,26 @@ private:
         int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
     );
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：fanout 直挂 AIC 的核心 API——enqueue 做资格/admit/claim+CAS；
+    // drain 在 sync_start 层之后清空 defer（entered_drain 时 flush_to_ready_only，
+    // 保证 claim 后必上核或进 readyQ）；stage 目前仅 idle（pending 另开，勿与 idle 相加）。
+    bool enqueue_fanout_direct_aic(int32_t thread_idx, PTO2TaskSlotState &slot_state);
+    void drain_fanout_direct_aic_pending(
+        int32_t thread_idx, bool &made_progress, bool &try_pushed, bool flush_to_ready_only = false,
+        bool pmu_active = false
+    );
+    bool try_fanout_direct_dispatch_aic(
+        int32_t thread_idx, PTO2TaskSlotState &slot_state, bool *made_progress, bool *try_pushed,
+        bool pmu_active = false
+    );
+    // 修改理由：对齐 run_staging_order 的 AIC-PENDING 门控（无残留 MIX、无对端空闲 AIC、
+    // 且存在安全本地 pending 核）；供后续启用 pending 挂核时复用，避免 Case-3.1。
+    bool fanout_aic_pending_gate_ok(int32_t thread_idx) const;
+    // 修改理由：筛掉已有 pending_slot_state 或 ED 门控中的 running 核，防止错误挂 pending。
+    CoreTracker::BitStates fanout_aic_safe_pending_cores(int32_t thread_idx) const;
+#endif
+
     // Shared staging order for both dispatch sources (normal ready + speculative early):
     // MIX strict priority, IDLE stage before PENDING stage, cross-thread idle gating
     // (MIX-IDLE ▶ c/v-IDLE ▶ MIX-PEND ▶ c/v-PEND). `stage(shape, phase)` stages that
@@ -457,6 +499,27 @@ private:
     // pre-dispatch / WAIT-only deadlock (e.g. dependency cycle) and the
     // ownerless idle threads are the only observers — let one of them latch.
     bool no_thread_owns_running_task() const;
+
+    // One-glance classification of a no-progress timeout, derived from state the
+    // scheduler already holds at the stall. Reduces the multi-state snapshot to a
+    // dominant PTO2_STALL_DETAIL_* sub-class plus a few locator fields, which
+    // handle_timeout_exit propagates to host alongside the unchanged code 100.
+    struct StallClassification {
+        int32_t detail;         // PTO2_STALL_DETAIL_*
+        int32_t cnt_running;    // tasks observed RUNNING (on a core)
+        int32_t cnt_ready;      // fanin-satisfied but not dispatched
+        int32_t cnt_waiting;    // still waiting on fanin
+        int32_t completed;      // completed_tasks_ snapshot
+        int32_t total;          // total_tasks_ snapshot
+        int32_t orch_done;      // orchestrator_done flag (0/1)
+        int64_t stuck_task_id;  // S1: first RUNNING task's id (-1 if none)
+        int32_t stuck_core;     // S1: core hosting it (-1 if none)
+    };
+
+    // Scan the rings once (same ground truth as log_stall_diagnostics: a slot is
+    // RUNNING iff a core holds it as running_slot_state) and reduce to a
+    // StallClassification. Pure reads — safe to call from any scheduler thread.
+    __attribute__((noinline, cold)) StallClassification classify_stall_reason() const;
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
         int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations,

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cstdio>
 #include <limits>
 
 #include "common.h"  // debug_assert
@@ -213,10 +214,11 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 
     // AICore buffer rotation lives on the dispatch path: count this dispatch
     // and rotate before write_reg when we're about to cross a BUFFER_SIZE
-    // boundary. The completion-before-dispatch invariant makes this race-free
-    // (all prior tasks on this core have FIN'd, so AICore has dcci'd their
-    // records out of the old buffer). Gated on the same enable bit as flush
-    // so level=1 (AICORE_TIMING-only) participates without needing complete_task.
+    // boundary. The just-filled buffer is not handed to the host here — it is
+    // released once AICore ACKs this boundary dispatch (see the ACK hook in
+    // check_running_cores_for_completion), because FIN precedes the swimlane
+    // record on this runtime. `reg_task_id` is passed as that ACK gate. Gated on
+    // the same enable bit as flush so level=1 (AICORE_TIMING-only) participates.
 #if SIMPLER_DFX
     if (l2_swimlane_level_ != L2SwimlaneLevel::DISABLED) {
         l2_swimlane_aicpu_on_aicore_dispatch(core_id, thread_idx, reg_task_id);
@@ -555,6 +557,233 @@ void SchedulerContext::run_staging_order(
     }
 }
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+
+// 修改理由：C 钩子转调 SchedulerContext，供 pto_scheduler.h 内联的 route_ready_once 使用。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state) {
+    return static_cast<SchedulerContext *>(sched_ctx)->enqueue_fanout_direct_aic(thread_idx, slot_state);
+}
+
+CoreTracker::BitStates SchedulerContext::fanout_aic_safe_pending_cores(int32_t thread_idx) const {
+    // 修改理由：挂正常 pending 时排除已有 pending 的核，以及 ED=STAGING /
+    // sync_start+DISPATCHED 的 running 核，否则易 Case-3.1 死锁。
+    CoreTracker::BitStates safe(0ULL);
+    CoreTracker::BitStates cand =
+        core_trackers_[thread_idx].get_pending_core_offset_states(PTO2ResourceShape::AIC);
+    while (cand.has_value()) {
+        const int32_t core_offset = cand.pop_first();
+        const int32_t core_id = core_trackers_[thread_idx].get_core_id_by_offset(core_offset);
+        const CoreExecState &core = core_exec_states_[core_id];
+        if (core.pending_slot_state != nullptr) {
+            continue;
+        }
+        const PTO2TaskSlotState *rs = core.running_slot_state;
+        if (rs != nullptr && rs->payload != nullptr) {
+            const uint8_t ed = rs->payload->early_dispatch_state.load(std::memory_order_relaxed);
+            if (ed == PTO2_EARLY_DISPATCH_STAGING) {
+                continue;
+            }
+            if (ed == PTO2_EARLY_DISPATCH_DISPATCHED && rs->active_mask.requires_sync_start()) {
+                continue;
+            }
+        }
+        safe |= CoreTracker::BitStates(1ULL << core_offset);
+    }
+    return safe;
+}
+
+bool SchedulerContext::fanout_aic_pending_gate_ok(int32_t thread_idx) const {
+    // 修改理由：与 run_staging_order AIC-PENDING 同门控——有 MIX 残留则让路；
+    // 对端有空闲则本线程不挂 pending；且本地须有安全 pending 核。
+    if (has_residual_mix()) {
+        return false;
+    }
+    if (has_idle_in_other_threads(thread_idx, PTO2ResourceShape::AIC)) {
+        return false;
+    }
+    return fanout_aic_safe_pending_cores(thread_idx).has_value();
+}
+
+bool SchedulerContext::enqueue_fanout_direct_aic(int32_t thread_idx, PTO2TaskSlotState &slot_state) {
+#if defined(SIMPLER_PMU) && SIMPLER_PMU
+    // 修改理由：PMU 路径下不走直挂，与正常 PENDING 抑制一致。
+    if (is_pmu_enabled()) {
+        return false;
+    }
+#endif
+    // 修改理由：资格——仅 AIC + 单逻辑块 + 非 sync_start + 谓词通过；
+    // AIV / MIX / SPMD(block_num!=1) 永不进入，避免打乱既有调度语义。
+    if (slot_state.active_mask.to_shape() != PTO2ResourceShape::AIC) {
+        return false;
+    }
+    if (slot_state.logical_block_num != 1) {
+        return false;
+    }
+    if (slot_state.active_mask.requires_sync_start()) {
+        return false;
+    }
+    if (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass()) {
+        return false;
+    }
+    // 修改理由：不得抢 early-dispatch 消费者——否则会跳过 try_early_dispatch_release，
+    // 门铃不响导致 gated 核 S1。
+    if (slot_state.payload->early_dispatch_state.load(std::memory_order_acquire) !=
+        PTO2_EARLY_DISPATCH_NONE) {
+        return false;
+    }
+
+    // 修改理由：对齐 run_staging_order——有 MIX 残留时本轮不直挂 AIC，回落 readyQ，
+    // 保持 MIX 严格优先。
+    if (has_residual_mix()) {
+        return false;
+    }
+
+    // 修改理由：admit 仅本线程空闲 AIC（A/B 基线）；勿把 idle+pending 相加，
+    // 否则过 defer 易 orphan 致 S3。pending 挂核另开。
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    const int32_t admit_cap = tracker.get_idle_core_offset_states(PTO2ResourceShape::AIC).count();
+    if (admit_cap <= 0) {
+        return false;
+    }
+
+    int32_t &n = fanout_direct_aic_pending_n_[thread_idx];
+    if (n >= admit_cap || n >= kFanoutDirectAicPendingCap) {
+        return false;
+    }
+
+    // 修改理由：defer 窗口内用 CAS 把 ED NONE→DISPATCHED，占住槽位，防止并发 early-dispatch
+    // 再标 STAGING 与直挂冲突。
+    uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
+    if (!slot_state.payload->early_dispatch_state.compare_exchange_strong(
+            expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        )) {
+        return false;
+    }
+
+    // 修改理由：与 route_ready_once 同样先 claim；若对端已 claim，返回 true 表示已处理，
+    // 避免回落第二次 claim 失败导致就绪丢失。
+    if (!sched_->try_claim_ready_once(slot_state)) {
+        return true;
+    }
+
+    fanout_direct_aic_pending_[thread_idx][n++] = &slot_state;
+    return true;
+}
+
+void SchedulerContext::drain_fanout_direct_aic_pending(
+    int32_t thread_idx, bool &made_progress, bool &try_pushed, bool flush_to_ready_only, bool pmu_active
+) {
+    int32_t &n = fanout_direct_aic_pending_n_[thread_idx];
+    auto push_ready = [&](PTO2TaskSlotState *slot) {
+        // 修改理由：不变量——每个已 claim 的 fanout 槽最终必须上核或进 ready_queues。
+        sched_->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].push(slot);
+    };
+
+    // 修改理由：sync_start stop-the-world 占用核时禁止在此 stage，只把已 claim 槽推进
+    // readyQ，保证 drain 后仍可达。有 MIX 残留时同 skip_aic_aiv，不抢 AIC。
+    const bool force_ready = flush_to_ready_only || has_residual_mix();
+
+    for (int32_t i = 0; i < n; i++) {
+        PTO2TaskSlotState *slot = fanout_direct_aic_pending_[thread_idx][i];
+        if (force_ready) {
+            push_ready(slot);
+            continue;
+        }
+        if (!try_fanout_direct_dispatch_aic(thread_idx, *slot, &made_progress, &try_pushed, pmu_active)) {
+            push_ready(slot);
+        }
+    }
+    n = 0;
+}
+
+bool SchedulerContext::try_fanout_direct_dispatch_aic(
+    int32_t thread_idx, PTO2TaskSlotState &slot_state, bool *made_progress, bool *try_pushed, bool pmu_active
+) {
+#if defined(SIMPLER_PMU) && SIMPLER_PMU
+    if (is_pmu_enabled()) {
+        return false;
+    }
+#endif
+    if (slot_state.active_mask.to_shape() != PTO2ResourceShape::AIC) {
+        return false;
+    }
+    if (slot_state.logical_block_num != 1) {
+        return false;
+    }
+    if (slot_state.active_mask.requires_sync_start()) {
+        return false;
+    }
+    if (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass()) {
+        return false;
+    }
+    // 修改理由：enqueue 已 CAS 为 DISPATCHED；若仍见 STAGING 则拒绝 stage，防协议破坏。
+    const uint8_t ed = slot_state.payload->early_dispatch_state.load(std::memory_order_acquire);
+    if (ed == PTO2_EARLY_DISPATCH_STAGING) {
+        return false;
+    }
+    // 修改理由：stage 时再查 MIX 残留（enqueue 后可能出现），与正常 staging 一致。
+    if (has_residual_mix()) {
+        return false;
+    }
+
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    CoreTracker::BitStates cores(0ULL);
+    bool to_pending = false;
+
+    // 修改理由：当前仅 idle stage（A/B 基线）；pending 挂核路径单独启用前不上核。
+    cores = tracker.get_idle_core_offset_states(PTO2ResourceShape::AIC);
+    if (!cores.has_value()) {
+        (void)pmu_active;
+        return false;
+    }
+
+    const int32_t available = cores.count();
+    int32_t start = 0;
+    const int32_t claim = slot_state.claim_block_range(slot_state.logical_block_num, available, start);
+    if (claim == 0) {
+        return false;
+    }
+
+    // 修改理由：单块任务 claim!=0 即整任务；无余块需再 push。
+
+    PublishHandle handles[CoreTracker::MAX_CLUSTERS];
+    int handle_count = 0;
+    for (int32_t b = 0; b < claim; b++) {
+        const int32_t core_offset = cores.pop_first();
+        handle_count += prepare_block_for_dispatch(
+            thread_idx, core_offset, slot_state, PTO2ResourceShape::AIC, to_pending, start + b,
+            &handles[handle_count]
+        );
+    }
+    // 修改理由：AIC prepare 每块恒返回 1；claim_block_range 已推进 next_block_idx 后
+    // 不可再 return false（readyQ 回落会见 claim==0 而丢任务）。
+    debug_assert(handle_count > 0);
+
+    wmb();
+    uint64_t dispatch_ts = 0;
+#if SIMPLER_DFX
+    if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
+        dispatch_ts = get_sys_cnt_aicpu();
+    }
+#endif
+    for (int i = 0; i < handle_count; i++) {
+        publish_subtask_to_core(handles[i], dispatch_ts);
+    }
+
+    sched_->record_published_blocks(slot_state, claim);
+    sched_->propagate_dispatch_fanin(slot_state);
+
+    if (made_progress != nullptr) {
+        *made_progress = true;
+    }
+    if (try_pushed != nullptr) {
+        *try_pushed = true;
+    }
+    return true;
+}
+
+#endif  // SIMPLER_SCHED_FANOUT_DIRECT_AIC
+
 void SchedulerContext::dispatch_ready_tasks(
     int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
 ) {
@@ -578,6 +807,15 @@ void SchedulerContext::dispatch_ready_tasks(
             return has_residual_sync_mix();
         }
     );
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：任何提前 return（含 entered_drain）前必须清空 fanout defer——
+    // 已 claim 槽只能上核或进 readyQ，不能只留在线程本地缓冲；否则会 S3。
+    // sync_start drain 占用机器时 flush_to_ready_only=true。
+    drain_fanout_direct_aic_pending(
+        thread_idx, made_progress, try_pushed, /*flush_to_ready_only=*/entered_drain, pmu_active
+    );
+#endif
     if (entered_drain) return;
 
     // Tier 1: regular ready work.
@@ -870,14 +1108,14 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
     LOG_INFO_V0(
         "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
-        static_cast<uint64_t>(header->ring.task_descriptors_offset),
-        static_cast<uint64_t>(header->ring.task_window_size)
+        static_cast<uint64_t>(header->rings[0].task_descriptors_offset),
+        static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
-    Handshake *hank = static_cast<Handshake *>(runtime->workers);
+    Handshake *hank = static_cast<Handshake *>(runtime->dev.workers);
     LOG_INFO_V0(
         "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
-        static_cast<uint64_t>(header->ring.task_window_size)
+        static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
     LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
@@ -985,8 +1223,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     const int32_t scheduler_timeout_ms_override = get_scheduler_timeout_ms();
     if (scheduler_timeout_ms_override > 0) {
         scheduler_timeout_cycles =
-            static_cast<uint64_t>(scheduler_timeout_ms_override) * PLATFORM_PROF_SYS_CNT_FREQ / 1000;
+            static_cast<uint64_t>(scheduler_timeout_ms_override) * (PLATFORM_PROF_SYS_CNT_FREQ / 1000);
     }
+
     while (true) {
         if (completed_.load(std::memory_order_acquire)) {
             break;
@@ -1422,8 +1661,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
 #if SIMPLER_DFX
     // Final-drain: emit any pop_hit / pop_miss accrued since the last
-    // dispatch emit (typically the trailing idle loops while waiting for the
-    // last in-flight tasks to complete) as a zero-duration synthetic dispatch record so
+    // dispatch emit (typically the trailing idle loops while waiting for
+    // orchestrator_done_) as a zero-duration synthetic dispatch record so
     // sum(record.pop_*) reconciles with the run-cumulative counter.
     // Gate on SCHED_PHASES — at lower levels the phase buffer is never
     // flushed (see below), so writing this record would be wasted work.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -19,17 +19,6 @@
 #include "pto_runtime2_types.h"
 #include "spin_hint.h"
 
-// host_build_graph host-orch build: PTO2Runtime embeds PTO2SchedulerState by
-// value, so this header is compiled into the host libhost_runtime.so. The AICPU
-// spin_hint.h that defines PLATFORM_SCHEDULER_TIMEOUT_MS is not on the host
-// include path; supply it here. The value only sizes an on-device scheduler
-// timeout and is never consumed host-side (the scheduler does not run on the
-// host). host_runtime_EXPORTS is CMake's auto-define for the host shared-lib
-// target, so the AICPU/AICore builds keep the real platform constant.
-#ifdef host_runtime_EXPORTS
-constexpr int32_t PLATFORM_SCHEDULER_TIMEOUT_MS = 2000;
-#endif
-
 // =============================================================================
 // Profiling macros (compile-time gated)
 // =============================================================================
@@ -124,7 +113,7 @@ struct alignas(64) CoreExecState {
     uint64_t pending_dispatch_timestamp;  // offset 56: AICPU dispatch timestamp for pending task
 #else
     // --- Cold fields (init/diagnostics only, never in hot path) ---
-    int32_t worker_id;          // offset 48: index in runtime.workers[]
+    int32_t worker_id;          // offset 48: index in runtime.dev.workers[]
     uint32_t physical_core_id;  // offset 52: hardware physical core ID
     CoreType core_type;         // offset 56: AIC or AIV (enum class : int32_t)
     uint8_t pad2_[4];           // offset 60: pad to 64 bytes
@@ -487,6 +476,18 @@ struct SlotTransition {
     bool pending_freed = false;  // pending_occupied can be cleared
     bool matched = false;        // some case was hit (otherwise skip apply)
 };
+
+#ifndef SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：编译开关默认开启 fanout 直挂 AIC；关闭后行为与 main 一致。
+#define SIMPLER_SCHED_FANOUT_DIRECT_AIC 1
+#endif
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：对外钩子声明——仅单块 AIC（logical_block_num==1、!sync_start、谓词通过、
+// ED==NONE）可在 complete 扇出时 defer，跳过 ready_queues；AIV/MIX/SPMD/已 early-stage
+// 的任务永不进入。实现见 SchedulerContext::enqueue_fanout_direct_aic。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
 
 // =============================================================================
 // Profiling counters (compile-time gated)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -31,6 +31,11 @@
 
 #include <atomic>
 
+#ifndef SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：默认开启 fanout 直挂 AIC；可用 cmake/环境变量关掉，便于 A/B 与回退。
+#define SIMPLER_SCHED_FANOUT_DIRECT_AIC 1
+#endif
+
 #include "common/core_type.h"
 #include "common/memory_barrier.h"
 #include "utils/device_arena.h"
@@ -41,6 +46,10 @@
 #include "pto_shared_memory.h"
 
 #include "aicpu/device_time.h"  // get_sys_cnt_aicpu (weak; used by early-dispatch doorbell timing too)
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：route_ready_once 在 header 内联，需前向声明 enqueue，实现放在 dispatch.cpp。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
 #if SIMPLER_SCHED_PROFILING
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
 #define PTO2_SCHED_CYCLE_LAP(acc)   \
@@ -514,6 +523,16 @@ struct PTO2SchedulerState {
     // Dependency-only tasks (active_mask is empty, shape == DUMMY). Drained by
     // the dispatch loop and completed inline -- never goes to AICore.
     PTO2ReadyQueue dummy_ready_queue;
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：仅在 on_task_complete 的 fanout 游走期间有效；把 SchedulerContext
+    // 与本线程 idx 传给 route_ready_once，以便把新就绪的 AIC 记入本线程 defer，
+    // 而不是立刻 push 进共享 ready_queues（缩短 ready 往返）。
+    int32_t fanout_direct_aic_thread_idx_{-1};
+    void *fanout_direct_aic_sched_ctx_{nullptr};
+    bool *fanout_direct_aic_made_progress_{nullptr};
+    bool *fanout_direct_aic_try_pushed_{nullptr};
+#endif
 
     alignas(64) AsyncWaitList async_wait_list;
 
@@ -1008,6 +1027,22 @@ struct PTO2SchedulerState {
     }
 
     bool route_ready_once(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+        // 修改理由：shape 提前取出，供 fanout 钩子与后续入队共用，避免重复 to_shape()。
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：complete 扇出解锁的单块 AIC，若本线程有空闲核则走 defer 直挂，
+        // 跳过 readyQ；失败则回落原 claim+入队路径。勿抢 early-dispatch STAGING
+        // 消费者（由 enqueue 内 ED 检查保证），否则门铃不响会 S1。
+        if (shape == PTO2ResourceShape::AIC && slot_state.logical_block_num == 1 &&
+            fanout_direct_aic_sched_ctx_ != nullptr && fanout_direct_aic_thread_idx_ >= 0) {
+            if (pto2_try_fanout_direct_aic_enqueue(
+                    fanout_direct_aic_sched_ctx_, fanout_direct_aic_thread_idx_, slot_state
+                )) {
+                return true;
+            }
+        }
+#endif
+
         if (!try_claim_ready_once(slot_state)) return false;
 
         // Early-dispatch: pre-staged tasks are released by doorbell
@@ -1020,7 +1055,6 @@ struct PTO2SchedulerState {
             return true;
         }
 
-        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
             dummy_ready_queue.push(&slot_state);
@@ -1037,6 +1071,20 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
         EarlyDispatchReleaseSink *sink = nullptr
     ) {
+        // 修改理由：与非 profiling 重载一致——先取 shape，再尝试 fanout 直挂钩子。
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：SCHED_PROFILING 重载同样需要钩子，否则开 profiling 时路径不一致。
+        if (shape == PTO2ResourceShape::AIC && slot_state.logical_block_num == 1 &&
+            fanout_direct_aic_sched_ctx_ != nullptr && fanout_direct_aic_thread_idx_ >= 0) {
+            if (pto2_try_fanout_direct_aic_enqueue(
+                    fanout_direct_aic_sched_ctx_, fanout_direct_aic_thread_idx_, slot_state
+                )) {
+                return true;
+            }
+        }
+#endif
+
         uint8_t state = slot_state.ready_state.load(std::memory_order_acquire);
         atomic_count += 1;  // ready_state load
         for (;;) {
@@ -1061,7 +1109,6 @@ struct PTO2SchedulerState {
             return true;
         }
 
-        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
             dummy_ready_queue.push(&slot_state, atomic_count, push_wait);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -403,6 +403,24 @@ SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() 
                 cnt_running++;
                 continue;
             }
+            // 修改理由：仅挂在 pending_slot_state 上的任务不得计为 READY——否则“有
+            // pending、核全空闲”会被误判成 S3:ready-but-all-idle，掩盖真实挂起。
+            int32_t pend_core = -1;
+            for (int32_t cid = 0; cid < cores_total_num_; cid++) {
+                if (core_exec_states_[cid].pending_slot_state == &slot_state) {
+                    pend_core = cid;
+                    break;
+                }
+            }
+            if (pend_core >= 0) {
+                if (cnt_running == 0) {
+                    PTO2TaskDescriptor *task_ptr = slot_state.task;
+                    cls.stuck_task_id = (task_ptr != nullptr) ? static_cast<int64_t>(task_ptr->task_id.raw) : -1;
+                    cls.stuck_core = pend_core;
+                }
+                cnt_running++;
+                continue;
+            }
             int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
             int32_t fi = slot_state.fanin_count;
             if (rc >= fi) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -199,6 +199,14 @@ void SchedulerContext::complete_slot_task(
         // profiling-flags-smoke build path where SIMPLER_DFX is OFF and
         // the Resolve emit below is excluded.
         [[maybe_unused]] uint32_t consumers_resolved = 0;
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：仅在 on_task_complete 扇出窗口内启用 route_ready_once 的直挂钩子；
+        // 传入本线程 idx 与 SchedulerContext，把新就绪 AIC 写入本线程 defer。
+        sched_->fanout_direct_aic_thread_idx_ = thread_idx;
+        sched_->fanout_direct_aic_sched_ctx_ = this;
+        sched_->fanout_direct_aic_made_progress_ = nullptr;
+        sched_->fanout_direct_aic_try_pushed_ = nullptr;
+#endif
 #if SIMPLER_SCHED_PROFILING
         // SCHED_PROFILING variant takes thread_idx for its per-thread atomic
         // counter side-effects (g_sched_*_atomic_count[thread_idx], consumed
@@ -207,6 +215,13 @@ void SchedulerContext::complete_slot_task(
         consumers_resolved = sched_->on_task_complete(slot_state, thread_idx).fanout_edges;
 #else
         consumers_resolved = sched_->on_task_complete(slot_state);
+#endif
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：扇出结束必须清 scope，避免后续非 fanout 的 route_ready_once 误走直挂。
+        sched_->fanout_direct_aic_thread_idx_ = -1;
+        sched_->fanout_direct_aic_sched_ctx_ = nullptr;
+        sched_->fanout_direct_aic_made_progress_ = nullptr;
+        sched_->fanout_direct_aic_try_pushed_ = nullptr;
 #endif
 #if SIMPLER_DFX
         if (resolve_t0 != 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -108,6 +108,11 @@ public:
     // before orchestrator_done_.
     void wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx);
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：header 内联的 route_ready_once 经 C 钩子调私有 enqueue，需 friend。
+    friend bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
+
     // =========================================================================
     // State queries / external synchronization points
     // =========================================================================
@@ -145,6 +150,14 @@ private:
 
     // sync_start drain coordination
     SyncStartDrainState drain_state_;
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：每调度线程一份线程本地 defer 缓冲——complete 扇出时写入、
+    // dispatch_ready_tasks 在 sync_start 层之后 drain；避免 claim 后只停在 defer 里导致 S3。
+    static constexpr int32_t kFanoutDirectAicPendingCap = 512;
+    PTO2TaskSlotState *fanout_direct_aic_pending_[MAX_AICPU_THREADS][kFanoutDirectAicPendingCap];
+    int32_t fanout_direct_aic_pending_n_[MAX_AICPU_THREADS]{0};
+#endif
 
 #if SIMPLER_DFX
     SchedL2SwimlaneCounters sched_l2_swimlane_[MAX_AICPU_THREADS];
@@ -351,6 +364,26 @@ private:
     void dispatch_ready_tasks(
         int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
     );
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：fanout 直挂 AIC 的核心 API——enqueue 做资格/admit/claim+CAS；
+    // drain 在 sync_start 层之后清空 defer（entered_drain 时 flush_to_ready_only，
+    // 保证 claim 后必上核或进 readyQ）；stage 目前仅 idle（pending 另开，勿与 idle 相加）。
+    bool enqueue_fanout_direct_aic(int32_t thread_idx, PTO2TaskSlotState &slot_state);
+    void drain_fanout_direct_aic_pending(
+        int32_t thread_idx, bool &made_progress, bool &try_pushed, bool flush_to_ready_only = false,
+        bool pmu_active = false
+    );
+    bool try_fanout_direct_dispatch_aic(
+        int32_t thread_idx, PTO2TaskSlotState &slot_state, bool *made_progress, bool *try_pushed,
+        bool pmu_active = false
+    );
+    // 修改理由：对齐 run_staging_order 的 AIC-PENDING 门控（无残留 MIX、无对端空闲 AIC、
+    // 且存在安全本地 pending 核）；供后续启用 pending 挂核时复用，避免 Case-3.1。
+    bool fanout_aic_pending_gate_ok(int32_t thread_idx) const;
+    // 修改理由：筛掉已有 pending_slot_state 或 ED 门控中的 running 核，防止错误挂 pending。
+    CoreTracker::BitStates fanout_aic_safe_pending_cores(int32_t thread_idx) const;
+#endif
 
     // Shared staging order for both dispatch sources (normal ready + speculative early):
     // MIX strict priority, IDLE stage before PENDING stage, cross-thread idle gating

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cstdio>
 #include <limits>
 
 #include "common.h"  // debug_assert
@@ -556,6 +557,233 @@ void SchedulerContext::run_staging_order(
     }
 }
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+
+// 修改理由：C 钩子转调 SchedulerContext，供 pto_scheduler.h 内联的 route_ready_once 使用。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state) {
+    return static_cast<SchedulerContext *>(sched_ctx)->enqueue_fanout_direct_aic(thread_idx, slot_state);
+}
+
+CoreTracker::BitStates SchedulerContext::fanout_aic_safe_pending_cores(int32_t thread_idx) const {
+    // 修改理由：挂正常 pending 时排除已有 pending 的核，以及 ED=STAGING /
+    // sync_start+DISPATCHED 的 running 核，否则易 Case-3.1 死锁。
+    CoreTracker::BitStates safe(0ULL);
+    CoreTracker::BitStates cand =
+        core_trackers_[thread_idx].get_pending_core_offset_states(PTO2ResourceShape::AIC);
+    while (cand.has_value()) {
+        const int32_t core_offset = cand.pop_first();
+        const int32_t core_id = core_trackers_[thread_idx].get_core_id_by_offset(core_offset);
+        const CoreExecState &core = core_exec_states_[core_id];
+        if (core.pending_slot_state != nullptr) {
+            continue;
+        }
+        const PTO2TaskSlotState *rs = core.running_slot_state;
+        if (rs != nullptr && rs->payload != nullptr) {
+            const uint8_t ed = rs->payload->early_dispatch_state.load(std::memory_order_relaxed);
+            if (ed == PTO2_EARLY_DISPATCH_STAGING) {
+                continue;
+            }
+            if (ed == PTO2_EARLY_DISPATCH_DISPATCHED && rs->active_mask.requires_sync_start()) {
+                continue;
+            }
+        }
+        safe |= CoreTracker::BitStates(1ULL << core_offset);
+    }
+    return safe;
+}
+
+bool SchedulerContext::fanout_aic_pending_gate_ok(int32_t thread_idx) const {
+    // 修改理由：与 run_staging_order AIC-PENDING 同门控——有 MIX 残留则让路；
+    // 对端有空闲则本线程不挂 pending；且本地须有安全 pending 核。
+    if (has_residual_mix()) {
+        return false;
+    }
+    if (has_idle_in_other_threads(thread_idx, PTO2ResourceShape::AIC)) {
+        return false;
+    }
+    return fanout_aic_safe_pending_cores(thread_idx).has_value();
+}
+
+bool SchedulerContext::enqueue_fanout_direct_aic(int32_t thread_idx, PTO2TaskSlotState &slot_state) {
+#if defined(SIMPLER_PMU) && SIMPLER_PMU
+    // 修改理由：PMU 路径下不走直挂，与正常 PENDING 抑制一致。
+    if (is_pmu_enabled()) {
+        return false;
+    }
+#endif
+    // 修改理由：资格——仅 AIC + 单逻辑块 + 非 sync_start + 谓词通过；
+    // AIV / MIX / SPMD(block_num!=1) 永不进入，避免打乱既有调度语义。
+    if (slot_state.active_mask.to_shape() != PTO2ResourceShape::AIC) {
+        return false;
+    }
+    if (slot_state.logical_block_num != 1) {
+        return false;
+    }
+    if (slot_state.active_mask.requires_sync_start()) {
+        return false;
+    }
+    if (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass()) {
+        return false;
+    }
+    // 修改理由：不得抢 early-dispatch 消费者——否则会跳过 try_early_dispatch_release，
+    // 门铃不响导致 gated 核 S1。
+    if (slot_state.payload->early_dispatch_state.load(std::memory_order_acquire) !=
+        PTO2_EARLY_DISPATCH_NONE) {
+        return false;
+    }
+
+    // 修改理由：对齐 run_staging_order——有 MIX 残留时本轮不直挂 AIC，回落 readyQ，
+    // 保持 MIX 严格优先。
+    if (has_residual_mix()) {
+        return false;
+    }
+
+    // 修改理由：admit 仅本线程空闲 AIC（A/B 基线）；勿把 idle+pending 相加，
+    // 否则过 defer 易 orphan 致 S3。pending 挂核另开。
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    const int32_t admit_cap = tracker.get_idle_core_offset_states(PTO2ResourceShape::AIC).count();
+    if (admit_cap <= 0) {
+        return false;
+    }
+
+    int32_t &n = fanout_direct_aic_pending_n_[thread_idx];
+    if (n >= admit_cap || n >= kFanoutDirectAicPendingCap) {
+        return false;
+    }
+
+    // 修改理由：defer 窗口内用 CAS 把 ED NONE→DISPATCHED，占住槽位，防止并发 early-dispatch
+    // 再标 STAGING 与直挂冲突。
+    uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
+    if (!slot_state.payload->early_dispatch_state.compare_exchange_strong(
+            expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        )) {
+        return false;
+    }
+
+    // 修改理由：与 route_ready_once 同样先 claim；若对端已 claim，返回 true 表示已处理，
+    // 避免回落第二次 claim 失败导致就绪丢失。
+    if (!sched_->try_claim_ready_once(slot_state)) {
+        return true;
+    }
+
+    fanout_direct_aic_pending_[thread_idx][n++] = &slot_state;
+    return true;
+}
+
+void SchedulerContext::drain_fanout_direct_aic_pending(
+    int32_t thread_idx, bool &made_progress, bool &try_pushed, bool flush_to_ready_only, bool pmu_active
+) {
+    int32_t &n = fanout_direct_aic_pending_n_[thread_idx];
+    auto push_ready = [&](PTO2TaskSlotState *slot) {
+        // 修改理由：不变量——每个已 claim 的 fanout 槽最终必须上核或进 ready_queues。
+        sched_->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].push(slot);
+    };
+
+    // 修改理由：sync_start stop-the-world 占用核时禁止在此 stage，只把已 claim 槽推进
+    // readyQ，保证 drain 后仍可达。有 MIX 残留时同 skip_aic_aiv，不抢 AIC。
+    const bool force_ready = flush_to_ready_only || has_residual_mix();
+
+    for (int32_t i = 0; i < n; i++) {
+        PTO2TaskSlotState *slot = fanout_direct_aic_pending_[thread_idx][i];
+        if (force_ready) {
+            push_ready(slot);
+            continue;
+        }
+        if (!try_fanout_direct_dispatch_aic(thread_idx, *slot, &made_progress, &try_pushed, pmu_active)) {
+            push_ready(slot);
+        }
+    }
+    n = 0;
+}
+
+bool SchedulerContext::try_fanout_direct_dispatch_aic(
+    int32_t thread_idx, PTO2TaskSlotState &slot_state, bool *made_progress, bool *try_pushed, bool pmu_active
+) {
+#if defined(SIMPLER_PMU) && SIMPLER_PMU
+    if (is_pmu_enabled()) {
+        return false;
+    }
+#endif
+    if (slot_state.active_mask.to_shape() != PTO2ResourceShape::AIC) {
+        return false;
+    }
+    if (slot_state.logical_block_num != 1) {
+        return false;
+    }
+    if (slot_state.active_mask.requires_sync_start()) {
+        return false;
+    }
+    if (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass()) {
+        return false;
+    }
+    // 修改理由：enqueue 已 CAS 为 DISPATCHED；若仍见 STAGING 则拒绝 stage，防协议破坏。
+    const uint8_t ed = slot_state.payload->early_dispatch_state.load(std::memory_order_acquire);
+    if (ed == PTO2_EARLY_DISPATCH_STAGING) {
+        return false;
+    }
+    // 修改理由：stage 时再查 MIX 残留（enqueue 后可能出现），与正常 staging 一致。
+    if (has_residual_mix()) {
+        return false;
+    }
+
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    CoreTracker::BitStates cores(0ULL);
+    bool to_pending = false;
+
+    // 修改理由：当前仅 idle stage（A/B 基线）；pending 挂核路径单独启用前不上核。
+    cores = tracker.get_idle_core_offset_states(PTO2ResourceShape::AIC);
+    if (!cores.has_value()) {
+        (void)pmu_active;
+        return false;
+    }
+
+    const int32_t available = cores.count();
+    int32_t start = 0;
+    const int32_t claim = slot_state.claim_block_range(slot_state.logical_block_num, available, start);
+    if (claim == 0) {
+        return false;
+    }
+
+    // 修改理由：单块任务 claim!=0 即整任务；无余块需再 push。
+
+    PublishHandle handles[CoreTracker::MAX_CLUSTERS];
+    int handle_count = 0;
+    for (int32_t b = 0; b < claim; b++) {
+        const int32_t core_offset = cores.pop_first();
+        handle_count += prepare_block_for_dispatch(
+            thread_idx, core_offset, slot_state, PTO2ResourceShape::AIC, to_pending, start + b,
+            &handles[handle_count]
+        );
+    }
+    // 修改理由：AIC prepare 每块恒返回 1；claim_block_range 已推进 next_block_idx 后
+    // 不可再 return false（readyQ 回落会见 claim==0 而丢任务）。
+    debug_assert(handle_count > 0);
+
+    wmb();
+    uint64_t dispatch_ts = 0;
+#if SIMPLER_DFX
+    if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
+        dispatch_ts = get_sys_cnt_aicpu();
+    }
+#endif
+    for (int i = 0; i < handle_count; i++) {
+        publish_subtask_to_core(handles[i], dispatch_ts);
+    }
+
+    sched_->record_published_blocks(slot_state, claim);
+    sched_->propagate_dispatch_fanin(slot_state);
+
+    if (made_progress != nullptr) {
+        *made_progress = true;
+    }
+    if (try_pushed != nullptr) {
+        *try_pushed = true;
+    }
+    return true;
+}
+
+#endif  // SIMPLER_SCHED_FANOUT_DIRECT_AIC
+
 void SchedulerContext::dispatch_ready_tasks(
     int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
 ) {
@@ -579,6 +807,15 @@ void SchedulerContext::dispatch_ready_tasks(
             return has_residual_sync_mix();
         }
     );
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：任何提前 return（含 entered_drain）前必须清空 fanout defer——
+    // 已 claim 槽只能上核或进 readyQ，不能只留在线程本地缓冲；否则会 S3。
+    // sync_start drain 占用机器时 flush_to_ready_only=true。
+    drain_fanout_direct_aic_pending(
+        thread_idx, made_progress, try_pushed, /*flush_to_ready_only=*/entered_drain, pmu_active
+    );
+#endif
     if (entered_drain) return;
 
     // Tier 1: regular ready work.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -477,6 +477,18 @@ struct SlotTransition {
     bool matched = false;        // some case was hit (otherwise skip apply)
 };
 
+#ifndef SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：编译开关默认开启 fanout 直挂 AIC；关闭后行为与 main 一致。
+#define SIMPLER_SCHED_FANOUT_DIRECT_AIC 1
+#endif
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：对外钩子声明——仅单块 AIC（logical_block_num==1、!sync_start、谓词通过、
+// ED==NONE）可在 complete 扇出时 defer，跳过 ready_queues；AIV/MIX/SPMD/已 early-stage
+// 的任务永不进入。实现见 SchedulerContext::enqueue_fanout_direct_aic。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
+
 // =============================================================================
 // Profiling counters (compile-time gated)
 // =============================================================================

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -84,6 +84,12 @@ target_compile_options(aicpu_kernel
         $<$<COMPILE_LANGUAGE:C>:-std=gnu11>
 )
 
+if(DEFINED SIMPLER_SCHED_FANOUT_DIRECT_AIC)
+    # 修改理由：允许 runtime_builder / 手动 cmake -D 覆盖默认宏，开关 fanout 直挂 AIC。
+    target_compile_definitions(aicpu_kernel PRIVATE
+        SIMPLER_SCHED_FANOUT_DIRECT_AIC=${SIMPLER_SCHED_FANOUT_DIRECT_AIC})
+endif()
+
 target_include_directories(aicpu_kernel
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/a5/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a5/platform/sim/aicpu/CMakeLists.txt
@@ -88,6 +88,12 @@ target_compile_options(aicpu_kernel
         $<$<COMPILE_LANGUAGE:C>:-std=gnu11>
 )
 
+if(DEFINED SIMPLER_SCHED_FANOUT_DIRECT_AIC)
+    # 修改理由：允许 runtime_builder / 手动 cmake -D 覆盖默认宏，开关 fanout 直挂 AIC。
+    target_compile_definitions(aicpu_kernel PRIVATE
+        SIMPLER_SCHED_FANOUT_DIRECT_AIC=${SIMPLER_SCHED_FANOUT_DIRECT_AIC})
+endif()
+
 # Include directories
 target_include_directories(aicpu_kernel
     PRIVATE

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -31,15 +31,26 @@
 
 #include <atomic>
 
+#ifndef SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：默认开启 fanout 直挂 AIC；可用 cmake/环境变量关掉，便于 A/B 与回退。
+#define SIMPLER_SCHED_FANOUT_DIRECT_AIC 1
+#endif
+
 #include "common/core_type.h"
+#include "common/memory_barrier.h"
 #include "utils/device_arena.h"
+#include "aicpu/platform_regs.h"  // get_reg_ptr / RegId for the early-dispatch doorbell
 #include "pto_async_wait.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 
+#include "aicpu/device_time.h"  // get_sys_cnt_aicpu (weak; used by early-dispatch doorbell timing too)
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：route_ready_once 在 header 内联，需前向声明 enqueue，实现放在 dispatch.cpp。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
 #if SIMPLER_SCHED_PROFILING
-#include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
 #define PTO2_SCHED_CYCLE_LAP(acc)   \
     do {                            \
@@ -59,6 +70,7 @@
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
     PTO2TaskSlotState *slot_state;
+    uint64_t task_id_snapshot;
 };
 
 /**
@@ -91,7 +103,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     void reset_for_reuse() {}
 
-    bool push(PTO2TaskSlotState *slot_state) {
+    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+
+    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -111,13 +125,16 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
+        slot->task_id_snapshot = task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) {
+    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+
+    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return;
 
         uint64_t pos;
@@ -146,6 +163,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
+            slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
     }
@@ -190,7 +208,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() {
+    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+
+    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -216,6 +236,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState *result = slot->slot_state;
+        if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -271,7 +292,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+
+    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -303,6 +326,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
+            if (task_id_snapshots != nullptr) task_id_snapshots[i] = slot->task_id_snapshot;
             slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
         }
         return count;
@@ -402,7 +426,10 @@ struct CompletionStats {
  */
 struct PTO2SchedulerLayout {
     size_t off_ready_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
+    size_t off_ready_sync_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_dummy_ready_queue_slots;
+    size_t off_early_dispatch_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
+    size_t off_early_sync_start_queue_slots;
     size_t off_dep_pool_entries[PTO2_MAX_RING_DEPTH];
     uint64_t ready_queue_capacity;
     int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
@@ -486,9 +513,26 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
+    // Ready sync_start queues, one per shape. A ready sync_start cohort parks here
+    // instead of ready_queues[] so the dispatch loop can drain it as a strict Tier-0
+    // (sync_start > MIX > C/V) before any regular ready task takes a core, while
+    // reusing the same per-shape dispatch_shape machinery (fits-local inline vs
+    // stop-the-world drain, per-core MIX placement, head-start spacing).
+    PTO2ReadyQueue ready_sync_queues[PTO2_NUM_RESOURCE_SHAPES];
+
     // Dependency-only tasks (active_mask is empty, shape == DUMMY). Drained by
     // the dispatch loop and completed inline -- never goes to AICore.
     PTO2ReadyQueue dummy_ready_queue;
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：仅在 on_task_complete 的 fanout 游走期间有效；把 SchedulerContext
+    // 与本线程 idx 传给 route_ready_once，以便把新就绪的 AIC 记入本线程 defer，
+    // 而不是立刻 push 进共享 ready_queues（缩短 ready 往返）。
+    int32_t fanout_direct_aic_thread_idx_{-1};
+    void *fanout_direct_aic_sched_ctx_{nullptr};
+    bool *fanout_direct_aic_made_progress_{nullptr};
+    bool *fanout_direct_aic_try_pushed_{nullptr};
+#endif
 
     alignas(64) AsyncWaitList async_wait_list;
 
@@ -501,16 +545,33 @@ struct PTO2SchedulerState {
     // Inline hot-path methods
     // =========================================================================
 
-    // Route a ready slot to the right global queue. Dummy tasks (empty
-    // active_mask) live in dummy_ready_queue; everything else goes to the
-    // per-shape ready_queues[].
+    // Route a ready slot to the right global queue. Dep-only tasks — DUMMY-shaped
+    // (empty active_mask) or a task whose dispatch predicate fails — live in
+    // dummy_ready_queue and are retired inline; a ready sync_start cohort goes to
+    // the per-shape ready_sync_queues[] (drained as Tier-0); everything else to
+    // ready_queues[].
     void push_ready_routed(PTO2TaskSlotState *slot_state) {
         PTO2ResourceShape shape = slot_state->active_mask.to_shape();
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state->active_mask.has_predicate() && !slot_state->payload->predicate.pass())) {
             dummy_ready_queue.push(slot_state);
+        } else if (slot_state->active_mask.requires_sync_start()) {
+            ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
         } else {
             ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+        }
+    }
+
+    bool try_claim_ready_once(PTO2TaskSlotState &slot_state) {
+        uint8_t state = slot_state.ready_state.load(std::memory_order_acquire);
+        for (;;) {
+            if ((state & PTO2_READY_CLAIMED) != 0) return false;
+            uint8_t desired = state | PTO2_READY_CLAIMED;
+            if (slot_state.ready_state.compare_exchange_weak(
+                    state, desired, std::memory_order_acq_rel, std::memory_order_acquire
+                )) {
+                return true;
+            }
         }
     }
 
@@ -601,9 +662,9 @@ struct PTO2SchedulerState {
 
     // Scope-end release: sets bit31 (PTO2_FANOUT_SCOPE_BIT) instead of bumping a
     // consumer ref. Called exactly once per task from on_scope_end. Keeping it a
-    // distinct add lets a consumer release leave the scope bit unset, so "all
-    // consumers done but scope still open" stays distinguishable from "fully
-    // consumed".
+    // distinct add lets the deadlock detector tell "waiting only on scope_end"
+    // (head COMPLETED, refcount == fanout_count & ~SCOPE_BIT) apart from
+    // "waiting on a consumer".
     void release_producer_scope(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
@@ -623,50 +684,480 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state) {
+    // Early-dispatch release. If the now-ready task was pre-staged
+    // (gated on a core), ring its DATA_MAIN_BASE high-32 doorbell RIGHT HERE in
+    // the completion path — the moment its last producer's FIN satisfies fanin —
+    // instead of routing it through the ready queue and waiting for the dispatch
+    // pass to pop it. Returns true if the task is fully handled (caller must NOT
+    // push to the ready queue). Returns false when the caller must route C
+    // normally: either it was never pre-staged, OR it is a SPMD consumer only
+    // PARTIALLY pre-staged — the gated blocks are released by the doorbells rung
+    // here, and the remaining (next_block_idx .. logical_block_num) blocks
+    // dispatch normally off the ready queue. Lock-free claim shared with Hook 1
+    // (the stager): CAS NONE->DISPATCHED wins => not pre-staged; otherwise flip
+    // STAGING->DISPATCHED and destructively claim the published doorbell bits.
+
+    // Per-core early-dispatch doorbell table. Hook 1 records each gated core's
+    // (reg_addr, dispatch token) here at stage time; the completion-path release
+    // reads it back for the cores set in the consumer's staged_core_mask. One
+    // global table indexed by core_id (not per-task): gated cores in flight are
+    // bounded by the chip's core count (no two-level pre-dispatch), so this is the
+    // natural capacity and removes the old per-task 3-doorbell cap.
+    struct EarlyDispatchDoorbell {
+        uint64_t addr{0};
+        uint32_t token{0};
+    };
+    EarlyDispatchDoorbell early_dispatch_doorbell_table[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS * 64]{};
+
+    // Cross-thread early-dispatch work queues, one PTO2ReadyQueue MPMC instance per
+    // resource shape (AIC/AIV/MIX) — arena-backed, reserved/wired in pto_runtime2_init
+    // alongside the per-shape ready queues, and indexed the same way. A candidate is
+    // pushed to the queue for its own shape (active_mask.to_shape()) so the drain can
+    // pop per shape and size the pop to that shape's free cores, exactly as normal
+    // dispatch pops ready_queues[shape].
+    //
+    // A consumer's SPMD blocks span cores owned by several AICPU threads, but only a
+    // thread RUNNING the consumer's producer discovers it (via the producer's
+    // fanout). When that producer is thread-local (e.g. a 16-block AIV op filling one
+    // thread's cores), the other threads never see the consumer and its blocks on
+    // their cores can't pre-stage. The first claimer pushes the partially-staged
+    // consumer here; every idle thread's early_dispatch pass pops one, stages a range
+    // onto ITS OWN cores (range-claim via next_block_idx), and re-pushes if blocks
+    // remain — exactly mirroring how a partially-dispatched SPMD task is re-pushed to
+    // the ready queue (scheduler_dispatch: pop -> claim -> re-push). A stale/released
+    // entry fails the STAGING check on pop and is dropped; a push that overflows is
+    // logged and the consumer's blocks fall back to normal dispatch.
+    PTO2ReadyQueue early_dispatch_queues[PTO2_NUM_RESOURCE_SHAPES];
+
+    // sync_start early-dispatch candidates park here instead of early_dispatch_queues[]:
+    // they need an atomic all-or-nothing stage via the drain barrier, not
+    // early_dispatch_shape's per-thread partial range-claim. Shape-agnostic (the
+    // rendezvous counts cores, not blocks), so a single queue serves all shapes; drained
+    // as the highest occupancy tier at the top of try_early_dispatch.
+    //
+    // Deliberately single, vs the normal source's per-shape ready_sync_queues[]: a READY
+    // sync cohort (producer done) can dispatch inline when it fits, so it reuses the
+    // per-shape dispatch_shape; an EARLY sync cohort always carries a non-zero
+    // src_payload gate and therefore always drains. The shape-agnostic rendezvous
+    // makes one queue sufficient. Same drain, two sources.
+    PTO2ReadyQueue early_sync_start_queue;
+
+    static inline void ring_one_doorbell(uint64_t reg_addr, uint32_t token) {
+        volatile uint64_t *dmb = reinterpret_cast<volatile uint64_t *>(get_reg_ptr(reg_addr, RegId::DATA_MAIN_BASE));
+        uint64_t tk = static_cast<uint64_t>(token);
+        *dmb = (tk << 32) | tk;  // 64-bit STR: high=low=token releases the gated AICore
+    }
+
+    inline void ring_staged_doorbell_bits(int word, uint64_t bits) {
+        while (bits != 0) {
+            int core_id = word * 64 + __builtin_ctzll(bits);
+            bits &= bits - 1;
+            ring_one_doorbell(
+                early_dispatch_doorbell_table[core_id].addr, early_dispatch_doorbell_table[core_id].token
+            );
+        }
+    }
+
+    static inline uint64_t claim_all_staged_doorbell_bits(std::atomic<uint64_t> &mask) {
+        return mask.exchange(0, std::memory_order_seq_cst);
+    }
+
+    static inline uint64_t claim_late_staged_doorbell_bits(std::atomic<uint64_t> &mask, uint64_t candidates) {
+        return mask.fetch_and(~candidates, std::memory_order_seq_cst) & candidates;
+    }
+
+    static inline bool should_gate_early_dispatch(bool force_gate, uint8_t early_dispatch_state) {
+        return force_gate || early_dispatch_state == PTO2_EARLY_DISPATCH_STAGING;
+    }
+
+    static inline bool
+    ring_claimed_local_doorbell(uint64_t claimed_word, int core_id, uint64_t reg_addr, uint32_t token) {
+        if ((claimed_word & (1ULL << (core_id & 63))) == 0) return false;
+        ring_one_doorbell(reg_addr, token);
+        return true;
+    }
+
+    static inline bool try_claim_early_dispatch_launch(PTO2TaskPayload &payload) {
+        uint8_t expected = PTO2_EARLY_DISPATCH_LAUNCH_NONE;
+        return payload.early_dispatch_launch_state.compare_exchange_strong(
+            expected, PTO2_EARLY_DISPATCH_LAUNCH_RINGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+        );
+    }
+
+    inline void record_published_blocks(PTO2TaskSlotState &slot_state, int32_t count) {
+        if (count <= 0 || !slot_state.allow_early_resolve) return;
+        slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
+    }
+
+    // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
+    // the NONE->RINGING launch latch and invokes this exactly once after drain
+    // staging completes, while the corresponding per-core table entries are live.
+    inline void ring_all_staged_doorbells(PTO2TaskSlotState &slot_state) {
+        for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+            uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
+            while (bits != 0) {
+                int core_id = w * 64 + __builtin_ctzll(bits);
+                bits &= bits - 1;
+                ring_one_doorbell(
+                    early_dispatch_doorbell_table[core_id].addr, early_dispatch_doorbell_table[core_id].token
+                );
+            }
+        }
+    }
+
+    static inline bool try_claim_early_sync_drain(PTO2TaskPayload &payload) {
+        uint8_t expected = PTO2_EARLY_SYNC_DRAIN_NONE;
+        return payload.early_sync_drain_state.compare_exchange_strong(
+            expected, PTO2_EARLY_SYNC_DRAIN_OWNER, std::memory_order_seq_cst, std::memory_order_seq_cst
+        );
+    }
+
+    static inline bool owns_early_sync_drain(const PTO2TaskPayload &payload) {
+        return (payload.early_sync_drain_state.load(std::memory_order_acquire) & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0;
+    }
+
+    static inline void mark_early_sync_drain_armed(PTO2TaskPayload &payload) {
+        payload.early_sync_drain_state.fetch_or(PTO2_EARLY_SYNC_DRAIN_ARMED, std::memory_order_seq_cst);
+    }
+
+    static inline bool publish_ready_to_early_sync_drain(PTO2TaskPayload &payload) {
+        uint8_t previous =
+            payload.early_sync_drain_state.fetch_or(PTO2_EARLY_SYNC_DRAIN_READY, std::memory_order_seq_cst);
+        return (previous & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0;
+    }
+
+    inline void cancel_early_sync_drain(PTO2TaskSlotState &slot_state) {
+        uint8_t previous =
+            slot_state.payload->early_sync_drain_state.exchange(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
+        if ((previous & PTO2_EARLY_SYNC_DRAIN_OWNER) == 0) return;
+        if ((previous & PTO2_EARLY_SYNC_DRAIN_READY) != 0) {
+            push_ready_routed(&slot_state);
+            return;
+        }
+        if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_STAGING) {
+            early_sync_start_queue.push_tagged(&slot_state, static_cast<uint64_t>(slot_state.task->task_id.raw));
+        }
+    }
+
+    static inline void finish_early_sync_drain(PTO2TaskPayload &payload) {
+        uint8_t state = payload.early_sync_drain_state.load(std::memory_order_seq_cst);
+        while ((state & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0 && (state & PTO2_EARLY_SYNC_DRAIN_COMPLETE) == 0) {
+            uint8_t desired = state | PTO2_EARLY_SYNC_DRAIN_COMPLETE;
+            if (payload.early_sync_drain_state.compare_exchange_weak(
+                    state, desired, std::memory_order_seq_cst, std::memory_order_seq_cst
+                )) {
+                return;
+            }
+        }
+    }
+    // sync_start rendezvous: a sync_start consumer's gated cores launch as an atomic
+    // cohort, so their doorbells are held until BOTH halves hold — every gated core
+    // occupies a running slot (running_slot_count == popcount(staged_core_mask)) AND the
+    // producer released (early_dispatch_state == DISPATCHED). Counting CORES (not blocks) makes
+    // this shape-agnostic: an AIC/AIV block is one core, a MIX block is a cluster whose
+    // cores promote pending->running independently. Called from both halves (the producer
+    // release and each pending->running promotion); whichever observes the second half
+    // wins the launch latch and rings exactly once. Returns true only to that winner,
+    // which may then expose the cohort to its fanout.
+    inline bool maybe_rendezvous_ring(PTO2TaskSlotState &slot_state) {
+        int32_t staged_cores = 0;
+        for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
+            staged_cores +=
+                __builtin_popcountll(slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst));
+        if (staged_cores == 0) return false;
+        if (slot_state.payload->running_slot_count.load(std::memory_order_seq_cst) != staged_cores) return false;
+        if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) != PTO2_EARLY_DISPATCH_DISPATCHED)
+            return false;
+        if (!try_claim_early_dispatch_launch(*slot_state.payload)) return false;
+        ring_all_staged_doorbells(slot_state);
+        wmb();
+        slot_state.payload->early_dispatch_launch_state.store(
+            PTO2_EARLY_DISPATCH_LAUNCH_COMPLETE, std::memory_order_release
+        );
+        return true;
+    }
+
+    inline bool retry_sync_start_rendezvous_after_drain(PTO2TaskSlotState &slot_state) {
+        if (!maybe_rendezvous_ring(slot_state)) return false;
+        propagate_dispatch_fanin(slot_state);
+        return true;
+    }
+
+    // Event-driven candidate detection (the dual of fanin_refcount/ready). Called after a
+    // FLAGGED producer `p` publishes blocks (normal dispatch, early-dispatch release, or the
+    // sync_start drain), but no-ops until every logical block is launch-visible. Only then
+    // does it walk p's fanout and bump each consumer's
+    // dispatch_fanin. A consumer whose dispatch_fanin reaches fanin_actual_count (= every
+    // producer is flagged-and-fully-dispatched, or was already complete when the consumer was
+    // wired) is an early-dispatch candidate: CAS NONE->STAGING (exactly-once) and push to
+    // early_dispatch_queues[shape] (or early_sync_start_queue for a require_sync_start cohort)
+    // for the drain to pre-stage. The full-publication gate is load-bearing: a consumer that
+    // pre-occupies cores off a producer whose later blocks are not yet launch-visible would gate the
+    // very cores those blocks need, starving the producer so it never completes and the
+    // rendezvous never rings — a resource deadlock. published_block_count advances after
+    // every placement path publishes its claimed range. Once-guarded per producer.
+    // Only codegen-flagged producers propagate: a task's successors early-dispatch off its
+    // DIRECT producers' marks, never an inherited chain.
+    void propagate_dispatch_fanin(PTO2TaskSlotState &p) {
+        if (!p.allow_early_resolve) return;  // only codegen-flagged (direct) producers propagate
+        if (p.payload->published_block_count.load(std::memory_order_seq_cst) < p.logical_block_num) return;
+        if (p.payload->early_dispatch_state.load(std::memory_order_acquire) == PTO2_EARLY_DISPATCH_STAGING) return;
+        uint8_t launch_state = p.payload->early_dispatch_launch_state.load(std::memory_order_acquire);
+        if (launch_state == PTO2_EARLY_DISPATCH_LAUNCH_RINGING) return;
+        if (p.active_mask.requires_sync_start()) {
+            bool was_pre_staged = false;
+            for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+                was_pre_staged |= p.payload->staged_core_mask[w].load(std::memory_order_acquire) != 0;
+            }
+            if (was_pre_staged && launch_state != PTO2_EARLY_DISPATCH_LAUNCH_COMPLETE) return;
+        }
+        if (p.payload->dispatch_propagated.exchange(1, std::memory_order_acq_rel) != 0)
+            return;  // already propagated once
+        p.lock_fanout();
+        PTO2DepListEntry *edge = p.fanout_head;  // snapshot head, walk lock-free (fanout stable by dispatch)
+        p.unlock_fanout();
+        for (; edge != nullptr; edge = edge->next) {
+            PTO2TaskSlotState *c = edge->slot_state;
+            if (c->active_mask.has_predicate()) continue;  // predicated consumers never early-dispatch
+            // Compare to fanin_actual_count (the real producer-edge count), NOT
+            // fanin_count: fanin_count = fanin_actual_count + 1 (a self/wiring +1 that
+            // ready_fanin gets but dispatch_fanin does not). dispatch_fanin starts at
+            // the wiring-time flagged-pre-completed seed and is bumped here by flagged
+            // producers; reaching fanin_actual_count means every producer is
+            // flagged-and-fully-published or was pre-completed. An unflagged producer leaves the
+            // seed short and never bumps, so this stays unreachable for that consumer.
+            int32_t nf = c->payload->dispatch_fanin.fetch_add(1, std::memory_order_acq_rel) + 1;
+            if (nf != c->payload->fanin_actual_count) continue;
+            PTO2ResourceShape shape = c->active_mask.to_shape();
+            if (shape != PTO2ResourceShape::AIC && shape != PTO2ResourceShape::AIV && shape != PTO2ResourceShape::MIX)
+                continue;
+            // sync_start blocks launch as an atomic cohort. They ride the early-dispatch path
+            // too, but through a dedicated shape-agnostic queue (early_sync_start_queue),
+            // drained as the highest tier in try_early_dispatch via the gated drain +
+            // running-slot rendezvous (enter_drain_mode pre-stages every block gated — MIX
+            // with per-core split placement — and the rendezvous rings them together once
+            // every gated core occupies a running slot and the producer released). They must
+            // NOT enter early_dispatch_queues[shape]: that path's partial range-claim would
+            // strand gated cohort blocks nobody rings, so the rendezvous never reaches
+            // block_num. The rendezvous counts CORES (a MIX block spans a cluster), so one
+            // shape-agnostic queue suffices.
+            uint8_t expect = PTO2_EARLY_DISPATCH_NONE;  // exactly-once: only the CAS winner enqueues
+            if (!c->payload->early_dispatch_state.compare_exchange_strong(
+                    expect, PTO2_EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+                ))
+                continue;
+            uint64_t task_id = static_cast<uint64_t>(c->task->task_id.raw);
+            if (c->active_mask.requires_sync_start()) early_sync_start_queue.push_tagged(c, task_id);
+            else early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(c, task_id);
+        }
+    }
+
+    // Collects consumers released via the early-dispatch-doorbell path during a
+    // single on_task_complete fanout walk, so their dispatch_fanin
+    // propagation runs AFTER the walk — never between two siblings' doorbells.
+    struct EarlyDispatchReleaseSink {
+        static constexpr int CAP = 32;
+        PTO2TaskSlotState *items[CAP];
+        int n = 0;
+        inline bool push(PTO2TaskSlotState *s) {
+            if (n >= CAP) return false;
+            items[n++] = s;
+            return true;
+        }
+    };
+
+    inline bool try_early_dispatch_release(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+        // A predicated task is evaluated at the ready point, never early-dispatched.
+        if (slot_state.active_mask.has_predicate()) return false;
+        // Never staged => CAS NONE->DISPATCHED wins => dispatch normally.
+        uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
+        if (slot_state.payload->early_dispatch_state.compare_exchange_strong(
+                expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+            )) {
+            return false;
+        }
+        // route_ready_once admits one caller, but keep the helper defensive: a
+        // duplicate that observes or loses an in-progress launch must never
+        // route the same partial task a second time.
+        if (expect != PTO2_EARLY_DISPATCH_STAGING) return true;
+        bool sync_start = slot_state.active_mask.requires_sync_start();
+        if (!sync_start && !try_claim_early_dispatch_launch(*slot_state.payload)) return true;
+        expect = PTO2_EARLY_DISPATCH_STAGING;
+        slot_state.payload->early_dispatch_state.compare_exchange_strong(
+            expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        );
+        // Producer released: ring the gated cores. A non-sync_start consumer launches
+        // each block the instant its doorbell fires. A sync_start consumer instead holds
+        // for the rendezvous — every gated core must occupy a running slot first — so the
+        // flip to DISPATCHED above is only the producer-released half; maybe_rendezvous_ring
+        // rings now iff running_slot_count already reached popcount(staged_core_mask) (all
+        // gated cores took idle running slots), else the last pending->running promotion rings.
+        bool launched = true;
+        if (sync_start) {
+            launched = maybe_rendezvous_ring(slot_state);
+        } else {
+            // Destructively claim every published bit. A stager racing this pass
+            // can claim only bits that land after the exchange, so each gated core
+            // has exactly one doorbell writer.
+            for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+                uint64_t owned = claim_all_staged_doorbell_bits(slot_state.payload->staged_core_mask[w]);
+                ring_staged_doorbell_bits(w, owned);
+            }
+            wmb();
+            slot_state.payload->early_dispatch_launch_state.store(
+                PTO2_EARLY_DISPATCH_LAUNCH_COMPLETE, std::memory_order_seq_cst
+            );
+        }
+        // This pre-staged consumer was just released by its doorbell — it starts
+        // running NOW, so propagate dispatch_fanin to ITS consumers (only if it is
+        // itself codegen-flagged; the gate inside no-ops otherwise). Defer it via the
+        // sink so it runs after the whole fanout walk: doing it inline here would
+        // delay the doorbells of later consumers in the same producer's fanout.
+        // Fallback to inline if no sink / sink full.
+        if (launched) {
+            if (sink == nullptr || !sink->push(&slot_state)) {
+                propagate_dispatch_fanin(slot_state);
+            }
+        }
+        // No explicit removal from the cross-thread queue: a still-queued entry for
+        // this consumer is now DISPATCHED and is dropped when a peer pops it.
+        // Fully pre-staged => skip the ready queue. Partially staged SPMD consumer =>
+        // fall through so the caller pushes C; dispatch resumes from next_block_idx.
+        return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
+    }
+
+    bool route_ready_once(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+        // 修改理由：shape 提前取出，供 fanout 钩子与后续入队共用，避免重复 to_shape()。
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：complete 扇出解锁的单块 AIC，若本线程有空闲核则走 defer 直挂，
+        // 跳过 readyQ；失败则回落原 claim+入队路径。勿抢 early-dispatch STAGING
+        // 消费者（由 enqueue 内 ED 检查保证），否则门铃不响会 S1。
+        if (shape == PTO2ResourceShape::AIC && slot_state.logical_block_num == 1 &&
+            fanout_direct_aic_sched_ctx_ != nullptr && fanout_direct_aic_thread_idx_ >= 0) {
+            if (pto2_try_fanout_direct_aic_enqueue(
+                    fanout_direct_aic_sched_ctx_, fanout_direct_aic_thread_idx_, slot_state
+                )) {
+                return true;
+            }
+        }
+#endif
+
+        if (!try_claim_ready_once(slot_state)) return false;
+
+        // Early-dispatch: pre-staged tasks are released by doorbell
+        // here, skipping the ready-queue round-trip entirely.
+        bool early_handled = try_early_dispatch_release(slot_state, sink);
+        if (slot_state.active_mask.requires_sync_start()) {
+            bool drain_owned = publish_ready_to_early_sync_drain(*slot_state.payload);
+            if (early_handled || drain_owned) return true;
+        } else if (early_handled) {
+            return true;
+        }
+
+        if (shape == PTO2ResourceShape::DUMMY ||
+            (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
+            dummy_ready_queue.push(&slot_state);
+        } else if (slot_state.active_mask.requires_sync_start()) {
+            ready_sync_queues[static_cast<int32_t>(shape)].push(&slot_state);
+        } else {
+            ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
+        }
+        return true;
+    }
+
+#if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
+    bool route_ready_once(
+        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        EarlyDispatchReleaseSink *sink = nullptr
+    ) {
+        // 修改理由：与非 profiling 重载一致——先取 shape，再尝试 fanout 直挂钩子。
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：SCHED_PROFILING 重载同样需要钩子，否则开 profiling 时路径不一致。
+        if (shape == PTO2ResourceShape::AIC && slot_state.logical_block_num == 1 &&
+            fanout_direct_aic_sched_ctx_ != nullptr && fanout_direct_aic_thread_idx_ >= 0) {
+            if (pto2_try_fanout_direct_aic_enqueue(
+                    fanout_direct_aic_sched_ctx_, fanout_direct_aic_thread_idx_, slot_state
+                )) {
+                return true;
+            }
+        }
+#endif
+
+        uint8_t state = slot_state.ready_state.load(std::memory_order_acquire);
+        atomic_count += 1;  // ready_state load
+        for (;;) {
+            if ((state & PTO2_READY_CLAIMED) != 0) return false;
+            uint8_t desired = state | PTO2_READY_CLAIMED;
+            if (slot_state.ready_state.compare_exchange_weak(
+                    state, desired, std::memory_order_acq_rel, std::memory_order_acquire
+                )) {
+                atomic_count += 1;  // ready_state CAS
+                break;
+            }
+            atomic_count += 1;  // failed ready_state CAS
+        }
+
+        // Early-dispatch: pre-staged tasks are released by doorbell
+        // here, skipping the ready-queue round-trip entirely.
+        bool early_handled = try_early_dispatch_release(slot_state, sink);
+        if (slot_state.active_mask.requires_sync_start()) {
+            bool drain_owned = publish_ready_to_early_sync_drain(*slot_state.payload);
+            if (early_handled || drain_owned) return true;
+        } else if (early_handled) {
+            return true;
+        }
+
+        if (shape == PTO2ResourceShape::DUMMY ||
+            (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
+            dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
+        } else if (slot_state.active_mask.requires_sync_start()) {
+            ready_sync_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
+        } else {
+            ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
+        }
+        return true;
+    }
+#endif
+
+    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
 
         if (new_refcount == slot_state.fanin_count) {
-            push_ready_routed(&slot_state);
-            return true;
+            return route_ready_once(slot_state, sink);
         }
         return false;
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait) {
+    bool release_fanin_and_check_ready(
+        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        EarlyDispatchReleaseSink *sink = nullptr
+    ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
-            // Dummy slots go to dummy_ready_queue; everything else to the per-shape
-            // ready_queues[]. Use the profiling-aware push so atomic_count / push_wait
-            // stay consistent with the non-dummy path.
-            PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-            if (shape == PTO2ResourceShape::DUMMY ||
-                (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass())) {
-                dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
-            } else {
-                ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
-            }
-            return true;
+            return route_ready_once(slot_state, atomic_count, push_wait, sink);
         }
         return false;
     }
 #endif
 
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count) {
-        return ready_queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
+    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count) {
+        return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
     }
 
 #if SIMPLER_SCHED_PROFILING
     int get_ready_tasks_batch(
-        PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count,
+        uint64_t &wait_cycle
     ) {
-        return ready_queues[static_cast<int32_t>(shape)].pop_batch(out, max_count, atomic_count, wait_cycle);
+        return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count, atomic_count, wait_cycle);
     }
 #endif
 
@@ -702,14 +1193,20 @@ struct PTO2SchedulerState {
 
     /**
      * Two-stage completion: second stage.
-     * Called exactly once when all subtasks of a mixed task are done
-     * (i.e., on_subtask_complete returned true).
-     * Handles fanout notification, fanin release, and self-consumption check.
+     * Called exactly once when all subtasks of a task are done (i.e.,
+     * on_subtask_complete returned true). Walks the consumer (fanout) list,
+     * decrements each consumer's fanin, pushes newly-ready ones, and rings
+     * doorbells for early-dispatch hits.
+     *
+     * Non-PROFILING returns the consumer-walk count (= edges traversed). The
+     * Resolve swimlane bar reads it to label the bar with how many successors
+     * actually got resolved. PROFILING returns the richer CompletionStats
+     * whose `fanout_edges` carries the same number.
      */
 #if SIMPLER_SCHED_PROFILING
     CompletionStats
 #else
-    void
+    uint32_t
 #endif
     on_task_complete(
         PTO2TaskSlotState &slot_state
@@ -720,6 +1217,8 @@ struct PTO2SchedulerState {
     ) {
 #if SIMPLER_SCHED_PROFILING
         CompletionStats stats = {0, 0, 0, true};
+#else
+        uint32_t consumer_walk_count = 0;
 #endif
 #if SIMPLER_SCHED_PROFILING
         extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
@@ -734,32 +1233,52 @@ struct PTO2SchedulerState {
 #else
         slot_state.lock_fanout();
 #endif
-        slot_state.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
+        slot_state.mark_completed();
         PTO2DepListEntry *current = slot_state.fanout_head;  // Protected by fanout_lock
         slot_state.unlock_fanout();
 
 #if SIMPLER_SCHED_PROFILING
-        lock_atomics += 2;  // state.store + unlock.store
+        lock_atomics += 3;  // task_state.store + ready_state.fetch_or + unlock.store
         g_sched_lock_atomic_count[thread_idx] += lock_atomics;
         g_sched_lock_wait_cycle[thread_idx] += lock_wait;
         PTO2_SCHED_CYCLE_LAP(g_sched_lock_cycle[thread_idx]);
 #endif
 
-        // Fanout: notify consumers
+        // Fanout: notify consumers. A pre-staged consumer that becomes ready has
+        // its doorbell rung INLINE (db = nullptr) the moment its node is reached,
+        // not batched to after the whole walk — so a flagged consumer near the
+        // front of the list starts immediately and overlaps the remaining
+        // release_fanin work for the other consumers, instead of waiting for the
+        // full O(fanout-degree) walk (~5us for a 50-consumer producer).
+        //
+        // Safe on silicon: the producer's slot is already COMPLETED here — every
+        // SPMD block has FIN'd AND dcci-flushed its output to HBM before
+        // on_task_complete runs — so a released consumer never reads stale
+        // producer output. (Batching used to align the released wave, but pushed
+        // every doorbell to the end of the walk, defeating the whole point of
+        // early-dispatch: minimal producer-end -> consumer-start.)
 #if SIMPLER_SCHED_PROFILING
         uint64_t fanout_atomics = 0, push_wait = 0;
 #endif
+        // Doorbells for released pre-staged consumers fire INLINE in the walk
+        // below; their dispatch_fanin propagation is collected here and replayed
+        // after the walk, so no consumer's doorbell waits on a sibling's propagate.
+        EarlyDispatchReleaseSink rel_sink;
         while (current != nullptr) {
             PTO2TaskSlotState &consumer_slot = *current->slot_state;
 #if SIMPLER_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, &rel_sink)) {
                 stats.tasks_enqueued++;
             }
 #else
-            release_fanin_and_check_ready(consumer_slot);
+            consumer_walk_count++;
+            release_fanin_and_check_ready(consumer_slot, &rel_sink);
 #endif
             current = current->next;
+        }
+        for (int i = 0; i < rel_sink.n; i++) {
+            propagate_dispatch_fanin(*rel_sink.items[i]);
         }
 
 #if SIMPLER_SCHED_PROFILING
@@ -767,6 +1286,8 @@ struct PTO2SchedulerState {
         g_sched_push_wait_cycle[thread_idx] += push_wait;
         PTO2_SCHED_CYCLE_LAP(g_sched_fanout_cycle[thread_idx]);
         return stats;
+#else
+        return consumer_walk_count;
 #endif
     }
 
@@ -821,6 +1342,10 @@ struct PTO2SchedulerState {
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
     static PTO2SchedulerLayout
     reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
+    static PTO2SchedulerLayout reserve_layout(
+        DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH],
+        const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never
@@ -846,14 +1371,23 @@ struct PTO2SchedulerState {
 // Scheduler cold-path API is declared as PTO2SchedulerState member functions.
 // See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
-// Short-circuit NotDeferred completions seen during drain so they don't grow
-// entries[]. Mirrors the a2a3 impl; see that mirror for the rationale.
+// try_inline_complete_locked: short-circuit NotDeferred completions seen during
+// drain so they don't grow entries[]. Defined here (not in pto_async_wait.h)
+// because PTO2SchedulerState's on_task_complete signature is only known
+// after its full definition above.
+//
+// When the deferred_release_slot_states[] buffer is full, drain it via
+// on_task_release before appending — mirrors the same overflow-drain idiom
+// that scheduler_completion.cpp's inline NotDeferred path uses, so high task
+// rates don't surface as ASYNC_WAIT_OVERFLOW errors.
 inline bool
 AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+    // Return value (CompletionStats / consumer-walk count) discarded:
+    // async-wait drain path has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING
-    sink.sched->on_task_complete(slot_state, sink.thread_idx);
+    (void)sink.sched->on_task_complete(slot_state, sink.thread_idx);
 #else
-    sink.sched->on_task_complete(slot_state);
+    (void)sink.sched->on_task_complete(slot_state);
 #endif
     if (*sink.deferred_release_count >= sink.deferred_release_capacity) {
         while (*sink.deferred_release_count > 0) {
@@ -903,9 +1437,17 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
 
     for (int32_t i = count - 1; i >= 0; --i) {
         AsyncWaitEntry &entry = entries[i];
+        uintptr_t last_invalidated_counter_line = static_cast<uintptr_t>(-1);
         for (int32_t c = 0; c < entry.condition_count; c++) {
             CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
+            if (cond.completion_type == COMPLETION_TYPE_COUNTER && cond.counter_addr != nullptr) {
+                uintptr_t counter_line = mailbox_cache_line(cond.counter_addr);
+                if (counter_line != last_invalidated_counter_line) {
+                    cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
+                    last_invalidated_counter_line = counter_line;
+                }
+            }
             CompletionPollResult poll = cond.test();
             if (poll.state == CompletionPollState::FAILED) {
                 result.error_code = poll.error_code;
@@ -921,11 +1463,18 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
         }
 
         if (entry.normal_done && entry.waiting_completion_count <= 0) {
+            // Return value (CompletionStats / consumer-walk count) discarded:
+            // deferred-completion drain has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING
-            sched->on_task_complete(*entry.slot_state, thread_idx);
+            (void)sched->on_task_complete(*entry.slot_state, thread_idx);
 #else
-            sched->on_task_complete(*entry.slot_state);
+            (void)sched->on_task_complete(*entry.slot_state);
 #endif
+            // Drain deferred_release in place when the buffer fills — same
+            // overflow-drain idiom used by complete_slot_task's inline path
+            // and by try_inline_complete_locked. Without this, large bursts
+            // of completable wait_list entries in a single poll surfaced as
+            // ASYNC_WAIT_OVERFLOW under the MPSC model.
             if (deferred_release_count >= deferred_release_capacity) {
                 while (deferred_release_count > 0) {
 #if SIMPLER_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -186,8 +186,11 @@ void format_core_status(
         );
     } else {
         snprintf(
-            buf, buf_size, "core%d(busy kernel=%d task=%" PRId64 " cond_reg_state=%s ANOMALY)", core_id, kernel,
-            task_id_raw, cond_reg_state_str
+            buf, buf_size,
+            "core%d(busy kernel=%d task=%" PRId64
+            " cond_reg_state=%s ANOMALY cond_tok=%d running_tok=%d pending_tok=%d)",
+            core_id, kernel, task_id_raw, cond_reg_state_str, EXTRACT_TASK_ID(cond_reg),
+            core_state->running_reg_task_id, core_state->pending_reg_task_id
         );
     }
 }
@@ -323,7 +326,7 @@ void SchedulerContext::log_stall_diagnostics(
         bool aiv0_idle = tracker.is_aiv0_core_idle(offset);
         bool aiv1_idle = tracker.is_aiv1_core_idle(offset);
         int32_t cluster_id = cli * ast + thread_idx;
-        char aic_buf[128], aiv0_buf[128], aiv1_buf[128];
+        char aic_buf[192], aiv0_buf[192], aiv1_buf[192];
         format_core_status(
             aic_buf, sizeof(aic_buf), aic_id, aic_idle, &core_exec_states_[aic_id], core_exec_states_[aic_id].reg_addr
         );
@@ -396,6 +399,24 @@ SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() 
                     PTO2TaskDescriptor *task_ptr = slot_state.task;
                     cls.stuck_task_id = (task_ptr != nullptr) ? static_cast<int64_t>(task_ptr->task_id.raw) : -1;
                     cls.stuck_core = run_core;
+                }
+                cnt_running++;
+                continue;
+            }
+            // 修改理由：仅挂在 pending_slot_state 上的任务不得计为 READY——否则“有
+            // pending、核全空闲”会被误判成 S3:ready-but-all-idle，掩盖真实挂起。
+            int32_t pend_core = -1;
+            for (int32_t cid = 0; cid < cores_total_num_; cid++) {
+                if (core_exec_states_[cid].pending_slot_state == &slot_state) {
+                    pend_core = cid;
+                    break;
+                }
+            }
+            if (pend_core >= 0) {
+                if (cnt_running == 0) {
+                    PTO2TaskDescriptor *task_ptr = slot_state.task;
+                    cls.stuck_task_id = (task_ptr != nullptr) ? static_cast<int64_t>(task_ptr->task_id.raw) : -1;
+                    cls.stuck_core = pend_core;
                 }
                 cnt_running++;
                 continue;
@@ -504,8 +525,8 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
         cycles_to_us(sched_end_ts - l2_swimlane.sched_start_ts)
     );
 
-    uint64_t sched_total = l2_swimlane.sched_complete_cycle + l2_swimlane.sched_scan_cycle +
-                           l2_swimlane.sched_dispatch_cycle + l2_swimlane.sched_idle_cycle;
+    uint64_t sched_total =
+        l2_swimlane.sched_complete_cycle + l2_swimlane.sched_dispatch_cycle + l2_swimlane.sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;
 
     {
@@ -598,11 +619,6 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
         );
 
         LOG_INFO_V9(
-            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_swimlane.sched_scan_cycle),
-            l2_swimlane.sched_scan_cycle * 100.0 / sched_total
-        );
-
-        LOG_INFO_V9(
             "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_swimlane.sched_idle_cycle),
             l2_swimlane.sched_idle_cycle * 100.0 / sched_total
         );
@@ -623,7 +639,7 @@ void SchedulerContext::log_l2_swimlane_summary(int32_t thread_idx, [[maybe_unuse
 #endif
 
 // =============================================================================
-// Shutdown: deinit AICore regs for this thread's cores.
+// Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
 // Orchestrator threads have core_trackers_[thread_idx].core_num() == 0 -> no-op.
 // platform_deinit_aicore_regs is idempotent; safe to call after early completion.
 // =============================================================================
@@ -633,7 +649,6 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
     if (core_num == 0) return 0;
 
 #if SIMPLER_DFX
-    // Restore PMU CTRL registers for this thread's cores before AICore shutdown
     if (is_pmu_enabled()) {
         pmu_aicpu_finalize(cores, core_num);
     }
@@ -891,31 +906,27 @@ int32_t SchedulerContext::pre_handshake_init(
 
 #if SIMPLER_DFX
     // l2_swimlane_aicpu_init promotes g_l2_swimlane_level from the shared-memory
-    // header — must be called BEFORE the orchestrator thread caches the level
-    // via rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level() in
-    // AicpuExecutor::run(). Otherwise the cached value would still be DISABLED
-    // (only the binary enable bit has been seeded by kernel.cpp at this point),
-    // and the CYCLE_COUNT_START() gate in pto_orchestrator.cpp would suppress
-    // all ORCH_PHASES records. Reset the cached level on disabled runs so a
+    // header — must be called BEFORE caching the level, otherwise the cached
+    // value would still be 0 (only the binary enable bit has been seeded by
+    // kernel.cpp at this point). Reset the cached level on disabled runs so a
     // prior enabled launch's level can't leak into the phase-record gates in
-    // scheduler_dispatch (`>= SCHED_PHASES`). This runs on the leader before it
-    // publishes hs_setup_done_, so it happens-before every thread's
-    // handshake_partition (and therefore before any aicpu_ready=1 write).
+    // scheduler_dispatch. This runs on the leader before it publishes
+    // hs_setup_done_, so it happens-before every thread's handshake_partition
+    // (and therefore before any aicpu_ready=1 write).
     if (is_l2_swimlane_enabled()) {
         l2_swimlane_aicpu_init(runtime->dev.worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
-            // Sched phase pool count = number of scheduler threads.
-            // This block runs before assign_cores_to_threads, so the
+            // Sched-phase pool count must match the dump_args_init thread count
+            // below. This block runs before assign_cores_to_threads, so the
             // active_sched_threads_ member isn't set yet — recompute the same
-            // normalization locally: sched_thread_num_ <= 0 is the "use all
-            // AICPU threads as scheduler threads" sentinel (see
-            // assign_cores_to_threads' active_sched_threads_). Without this
-            // normalization here, init_phase would prime zero sched pools
-            // and all sched_phase emits would silently drop.
+            // normalization locally: sched_thread_num_ <= 0 means "use all AICPU
+            // threads as scheduler threads" (see assign_cores_to_threads'
+            // active_sched_threads_). Without it, init_phase would prime zero
+            // sched pools and all sched_phase emits would silently drop.
             const int sched_phase_threads = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
-            // Orch phase is a single instance (PR #971 design), so the orch
-            // pool count is always 1.
+            // Orchestration is always single-threaded, so orch-phase is one pool
+            // (ordinal 0) — see record_orch_phase.
             const int orch_phase_threads = 1;
             l2_swimlane_aicpu_init_phase(runtime->dev.worker_count, sched_phase_threads, orch_phase_threads);
         }
@@ -1004,12 +1015,12 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         // more than the scope cap. This rejects any garbage pattern (negative
         // or positive), so uninitialized rings contribute 0 (the correct boot
         // count) while valid counts still add up, with no signed overflow.
-        int64_t task_count = 0;
+        int64_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-            if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) task_count += ring_tasks;
+            if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count += ring_tasks;
         }
-        total_tasks_ = static_cast<int32_t>(task_count);
+        total_tasks_ = static_cast<int32_t>(pto2_count);
     } else {
         total_tasks_ = 0;
     }
@@ -1040,6 +1051,35 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         }
     }
 
+    // Prefill the per-dispatch AsyncCtx constant fields once. Of AsyncCtx's five
+    // fields, four are constant for a given (core, buf_idx): the three pointers
+    // target the fixed deferred_slab_per_core_[core][buf] members, and capacity is
+    // MAX_COMPLETIONS_PER_TASK. Only task_token varies per dispatch, so build_payload
+    // writes just that; these constants survive across dispatches because the
+    // payload buffer is never zeroed between them.
+    // The two context-pointer args are also per-(core, buf_idx) constants — they
+    // target this buffer's own local_context / global_context — so prefill them
+    // here too and drop them from the per-dispatch build_payload writes. This keeps
+    // the per-dispatch write footprint on the CL0 control block only (args[48]/[49]
+    // live on a later line).
+    for (int32_t core_id = 0; core_id < RUNTIME_MAX_WORKER; core_id++) {
+        for (int32_t buf = 0; buf < 2; buf++) {
+            PTO2DispatchPayload &dp = payload_per_core_[core_id][buf];
+            AsyncCtx &ac = dp.local_context.async_ctx;
+            volatile DeferredCompletionSlab *slab = &deferred_slab_per_core_[core_id][buf];
+            ac.completion_count = &slab->count;
+            ac.completion_error_code = &slab->error_code;
+            ac.completion_entries = &slab->entries[0];
+            ac.completion_capacity = MAX_COMPLETIONS_PER_TASK;
+            // Clear the slab once here; thereafter only the completion path re-clears
+            // count (and only when a deferred task dirtied it), never per dispatch.
+            slab->count = 0;
+            slab->error_code = PTO2_ERROR_NONE;
+            dp.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dp.local_context);
+            dp.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dp.global_context);
+        }
+    }
+
     func_id_to_addr_ = runtime->dev.func_id_to_addr_;
 
     return 0;
@@ -1054,11 +1094,14 @@ void SchedulerContext::deinit() {
     }
 
     // No per-core memset of payload_per_core_ / deferred_slab_per_core_ here
-    // (~300 KB across all cores). Both are fully re-initialized at dispatch
-    // before they can be read: dispatch_task sets deferred_slab->count = 0 /
-    // error_code = NONE and build_payload() overwrites every payload field
-    // (function addr, args[], contexts, not_ready) on the exact [core][buf_idx]
-    // about to run. The consumer side cannot reach a stale slot either: the
+    // (~300 KB across all cores). They are re-initialized before they can be read:
+    // build_payload() overwrites the per-dispatch payload fields (function addr,
+    // args[0..num_args) or src_payload, block_idx/block_num, async_ctx.task_token)
+    // on the exact [core][buf_idx] about to run; the async_ctx slab pointers +
+    // capacity, the two context-pointer args, and the deferred slab (count = 0 /
+    // error_code = NONE) are all cleared once per run in init() — the slab is
+    // thereafter re-cleared only by the completion path after a deferred task.
+    // The consumer side cannot reach a stale slot either: the
     // drain only services a core's running_reg_task_id, and the loop above
     // already reset every core_exec_states_[].running/pending_reg_task_id to
     // AICPU_TASK_INVALID — so no FIN for an undispatched slot is processed, and
@@ -1069,6 +1112,9 @@ void SchedulerContext::deinit() {
     drain_state_.sync_start_pending.store(0, std::memory_order_release);
     drain_state_.drain_worker_elected.store(0, std::memory_order_release);
     drain_state_.drain_ack_mask.store(0, std::memory_order_release);
+    drain_state_.drain_stage_go.store(0, std::memory_order_release);
+    drain_state_.drain_stage_done_mask.store(0, std::memory_order_release);
+    drain_state_.drain_running_staged.store(0, std::memory_order_release);
     drain_state_.pending_task.store(nullptr, std::memory_order_release);
 
     // Reset task counters and orchestrator state
@@ -1119,7 +1165,9 @@ void SchedulerContext::on_orchestration_done(
 ) {
 #if SIMPLER_DFX
     if (l2_swimlane_level_ >= L2SwimlaneLevel::ORCH_PHASES) {
-        // Flush orchestrator's phase record buffer (orch pool, ordinal 0)
+        // Flush the orchestrator's orch-phase buffer (single instance, pool 0).
+        // The orchestrator has no scheduler-phase pool of its own — those belong
+        // to the scheduler threads and are flushed in scheduler_dispatch.
         l2_swimlane_aicpu_flush_orch_phase_buffer(thread_idx);
     }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -10,6 +10,8 @@
  */
 #include "scheduler_context.h"
 
+#include <algorithm>
+
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
@@ -35,7 +37,7 @@ inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
 
 // Pure function: read register result -> SlotTransition (no side effects).
 SlotTransition SchedulerContext::decide_slot_transition(
-    int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id
+    int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id, bool pending_gated
 ) {
     SlotTransition t;
     if (pending_id != AICPU_TASK_INVALID && reg_task_id == pending_id) {
@@ -54,9 +56,22 @@ SlotTransition SchedulerContext::decide_slot_transition(
                 t.matched = true;
                 t.running_done = true;
                 t.running_freed = true;
+            } else if (pending_gated) {
+                // Case 3.3: running FIN, pending is a EARLY-DISPATCH GATED task. The
+                // Case 3.1 "wait for the pending's ack" shortcut assumes the AICore
+                // immediately runs the pending task; a gated task instead spins on
+                // its doorbell and never acks until its producer completes — and
+                // that producer's completion depends on collecting THIS running FIN.
+                // Waiting would deadlock. Complete the running FIN now and promote
+                // the gated task (it then skip-gates until its doorbell). pending is
+                // NOT freed (it promotes, not retires) so the bitmap update keeps the
+                // core off-limits — no second gated block, no doorbell overwrite.
+                t.matched = true;
+                t.running_done = true;
+                t.running_freed = true;
             }
-            // Case 3.1: running FIN, pending exists -> skip (transient state).
-            // Case 1/2 (pending ACK/FIN) will complete running implicitly via running_done=true.
+            // Case 3.1: running FIN, NON-gated pending exists -> skip (transient
+            // state). Case 1/2 (pending ack/FIN) completes running implicitly.
         } else {
             // Case 4: running ACK -- only pending_freed (slot now hardware-latched)
             t.matched = true;
@@ -81,10 +96,14 @@ void SchedulerContext::complete_slot_task(
 #else
     (void)hank;
 #endif
-    // MPSC fast-path: see a2a3 mirror for the full design narrative. The
-    // any_subtask_deferred flag on slot_state discriminates non-deferred
-    // tasks (inline complete in parallel on FIN thread) from deferred ones
-    // (route through the lock-free AICoreCompletionMailbox).
+    // MPSC fast-path is opt-in per task: only tasks with at least one subtask
+    // that registered a deferred condition route through the mailbox. Pure
+    // non-deferred tasks complete inline on this thread (matching pre-MPSC
+    // behavior — keeps the common case parallelized across scheduler threads
+    // instead of serializing through the single consumer). The
+    // deferred-completion flag on slot_state is the discriminator; it's set
+    // (release) before on_subtask_complete and read (acquire) after, so the
+    // last subtask sees flag writes from any earlier subtask of the same task.
     AICoreCompletionMailbox *mailbox = rt_ != nullptr ? rt_->aicore_mailbox : nullptr;
     bool defer_completion_to_consumer = false;
 
@@ -111,7 +130,11 @@ void SchedulerContext::complete_slot_task(
         }
 
         if (cond_count > 0) {
-            slot_state.any_subtask_deferred.store(true, std::memory_order_release);
+            // Publish "this task is deferred" before on_subtask_complete so the
+            // acq_rel fetch_add inside on_subtask_complete makes the flag
+            // visible to whichever subtask sees task_complete=true (which may
+            // be this thread or a later one).
+            slot_state.mark_any_subtask_deferred();
 
             const PTO2TaskId token = slot_state.task->task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
@@ -121,13 +144,27 @@ void SchedulerContext::complete_slot_task(
                     SPIN_WAIT_HINT();
                 }
             }
+            // Re-clear for the next reuse of this (core, buf) slot. Done here — on
+            // the hot cache line we just read — instead of on every dispatch, since
+            // only a deferred task (count > 0) ever dirties it. error_code needs no
+            // reset: a non-NONE code aborted the run above.
+            deferred_slab->count = 0;
         }
     }
 
     bool task_complete = sched_->on_subtask_complete(slot_state);
 
-    if (task_complete && slot_state.payload != nullptr &&
-        slot_state.any_subtask_deferred.load(std::memory_order_acquire)) {
+#if SIMPLER_DFX
+    // Sub-block retire that did not finish the slot: record it so the poll
+    // iteration becomes visible on the scheduler lane (the SPMD harvest tail).
+    if (!task_complete && l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
+        l2_swimlane.phase_subretire_count++;
+    }
+#endif
+
+    if (task_complete && slot_state.payload != nullptr && slot_state.has_any_subtask_deferred()) {
+        // Some subtask of this task registered conditions; finish the
+        // registration by handing the slot_state off to the consumer.
         while (!mailbox->try_push_normal_done(slot_state.task->task_id, reinterpret_cast<uint64_t>(&slot_state))) {
             sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
             SPIN_WAIT_HINT();
@@ -149,15 +186,58 @@ void SchedulerContext::complete_slot_task(
             );
         }
 #endif
+#if SIMPLER_DFX
+        // Time Resolve (walk the consumer list, decrement each consumer's
+        // fanin, push the newly-ready ones, ring doorbells for early-dispatch
+        // hits) so it renders as a child bar nested inside this iteration's
+        // Complete bar. The 1 µs floor below filters out the ~88% of tasks
+        // with 1-2 consumers (~500 ns Resolve) so only the long broadcast /
+        // reduction walks stand out on the lane.
+        uint64_t resolve_t0 = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
+#endif
+        // [[maybe_unused]] silences -Werror=unused-but-set-variable on the
+        // profiling-flags-smoke build path where SIMPLER_DFX is OFF and
+        // the Resolve emit below is excluded.
+        [[maybe_unused]] uint32_t consumers_resolved = 0;
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：仅在 on_task_complete 扇出窗口内启用 route_ready_once 的直挂钩子；
+        // 传入本线程 idx 与 SchedulerContext，把新就绪 AIC 写入本线程 defer。
+        sched_->fanout_direct_aic_thread_idx_ = thread_idx;
+        sched_->fanout_direct_aic_sched_ctx_ = this;
+        sched_->fanout_direct_aic_made_progress_ = nullptr;
+        sched_->fanout_direct_aic_try_pushed_ = nullptr;
+#endif
 #if SIMPLER_SCHED_PROFILING
         // SCHED_PROFILING variant takes thread_idx for its per-thread atomic
         // counter side-effects (g_sched_*_atomic_count[thread_idx], consumed
-        // by the otc_* log lines). Its return value is unused.
-        (void)sched_->on_task_complete(slot_state, thread_idx);
+        // by the otc_* log lines). It returns CompletionStats whose
+        // `fanout_edges` is the consumer-walk count.
+        consumers_resolved = sched_->on_task_complete(slot_state, thread_idx).fanout_edges;
 #else
-        sched_->on_task_complete(slot_state);
+        consumers_resolved = sched_->on_task_complete(slot_state);
+#endif
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+        // 修改理由：扇出结束必须清 scope，避免后续非 fanout 的 route_ready_once 误走直挂。
+        sched_->fanout_direct_aic_thread_idx_ = -1;
+        sched_->fanout_direct_aic_sched_ctx_ = nullptr;
+        sched_->fanout_direct_aic_made_progress_ = nullptr;
+        sched_->fanout_direct_aic_try_pushed_ = nullptr;
 #endif
 #if SIMPLER_DFX
+        if (resolve_t0 != 0) {
+            uint64_t resolve_t1 = get_sys_cnt_aicpu();
+            // Filter: drop Resolve bars under 1 µs so the lane shows only
+            // resolves that did meaningful work (high consumer counts or
+            // doorbells). 50 cycles @ 50 MHz = 1 µs (PLATFORM_PROF_SYS_CNT_FREQ
+            // is the device sys-cnt frequency).
+            constexpr uint64_t RESOLVE_EMIT_MIN_CYCLES = PLATFORM_PROF_SYS_CNT_FREQ / 1'000'000;  // 1 µs
+            if (resolve_t1 - resolve_t0 >= RESOLVE_EMIT_MIN_CYCLES) {
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::Resolve, resolve_t0, resolve_t1, l2_swimlane.sched_loop_count,
+                    consumers_resolved
+                );
+            }
+        }
         l2_swimlane.phase_complete_count++;
 #endif
         if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
@@ -183,7 +263,9 @@ void SchedulerContext::complete_slot_task(
     // {start, end, task_token_raw}, host resolves func_id/core_type from
     // dep_gen / per-core mapping, and AICPU has nothing to write. Only at
     // AICPU_TIMING (level=2) and above does AICPU contribute dispatch/finish
-    // timestamps via complete_task.
+    // timestamps via complete_task. Bypassing here saves the per-completion
+    // hot-path cost (counter inc + ring lookup + record store + wmb + buffer
+    // rotation bookkeeping) for runs that only want AICore timing.
     if (l2_swimlane.l2_swimlane_enabled && l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
 #if SIMPLER_SCHED_PROFILING
         uint64_t t_perf_start = get_sys_cnt_aicpu();
@@ -201,17 +283,10 @@ void SchedulerContext::complete_slot_task(
         l2_swimlane.sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
 #endif
     }
-#endif
 
-#if SIMPLER_DFX
     if (is_pmu_enabled()) {
-        // Slot key must be the 32-bit register token AICore wrote into
-        // dual_issue_slots[task_id & 1].task_id (= DATA_MAIN_BASE value).
-        // task_id.raw is the full PTO2 (ring_id<<32|local_id) encoding —
-        // matching on that would never hit. Pass the PTO2 id separately
-        // for the PmuRecord.
-        pmu_aicpu_complete_record(
-            core_id, thread_idx, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+        pmu_aicpu_record_task(
+            core_id, thread_idx, slot_state.task->task_id.raw,
             slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
         );
     }
@@ -250,6 +325,21 @@ void SchedulerContext::check_running_cores_for_completion(
         int32_t core_id = tracker.get_core_id_by_offset(bit_pos);
         CoreExecState &core = core_exec_states_[core_id];
 
+        // Skip gated early-dispatch cores. A STAGED task is parked on this core
+        // waiting for its doorbell — it physically cannot ACK/FIN yet, so
+        // reading its COND (MMIO, and the core is hot-spinning on its own SPR)
+        // every poll is pure waste that drags out the completion phase. The
+        // doorbell (try_early_dispatch_release) flips early_dispatch_state to DISPATCHED, at
+        // which point the core becomes pollable again and its FIN is caught.
+        // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
+        {
+            PTO2TaskSlotState *rs = core.running_slot_state;
+            if (rs != nullptr && rs->payload != nullptr &&
+                rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) {
+                continue;
+            }
+        }
+
         // --- Judgment phase: read register, derive transition ---
         // Use the precomputed cond_ptr (resolved once in handshake) to skip
         // the reg_offset switch and reg_addr addition on every poll.
@@ -272,9 +362,43 @@ void SchedulerContext::check_running_cores_for_completion(
         }
 #endif
 
-        SlotTransition t =
-            decide_slot_transition(reg_task_id, reg_state, core.running_reg_task_id, core.pending_reg_task_id);
+        // A pending task is "gated" when it is an early-dispatch pre-stage still parked on
+        // its doorbell: it will not ack on the producer's FIN, so the Case 3.1 wait-for-
+        // pending-ack shortcut would deadlock. Detect it so decide_slot_transition completes
+        // the running FIN and PROMOTES it (Case 3.3) instead.
+        //
+        // "Gated" is "not yet launched (rung)", which is NOT the same as
+        // early_dispatch_state. STAGING covers the pre-release window. But a sync_start block
+        // stays gated even AFTER its producer releases (early_dispatch_state STAGING ->
+        // DISPATCHED): the cohort is not rung until the rendezvous has assembled EVERY core
+        // into a running slot, and this pending block (being promoted now) is by definition
+        // not yet counted, so the ring has not fired and it is still gated. Classifying it by
+        // STAGING alone would, once the producer's release beats the last promotion, treat it
+        // as a normal task and wait for an ack that never comes -> deadlock (the
+        // nondeterministic sync_start stall).
+        uint8_t pending_ss =
+            (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr) ?
+                core.pending_slot_state->payload->early_dispatch_state.load(std::memory_order_relaxed) :
+                static_cast<uint8_t>(PTO2_EARLY_DISPATCH_NONE);
+        bool pending_gated =
+            (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr &&
+             (pending_ss == PTO2_EARLY_DISPATCH_STAGING ||
+              (pending_ss == PTO2_EARLY_DISPATCH_DISPATCHED &&
+               core.pending_slot_state->active_mask.requires_sync_start())));
+        SlotTransition t = decide_slot_transition(
+            reg_task_id, reg_state, core.running_reg_task_id, core.pending_reg_task_id, pending_gated
+        );
         if (!t.matched) continue;
+
+#if SIMPLER_DFX
+        // Release an ACK-gated AICore swimlane buffer if this matched ACK/FIN is
+        // the one a rotation is waiting on: it proves the core advanced past the
+        // just-rotated buffer's tail record (FIN precedes the record write on
+        // this runtime, so rotation could not release the buffer itself).
+        if (l2_swimlane_level_ != L2SwimlaneLevel::DISABLED) {
+            l2_swimlane_aicpu_on_aicore_ack(core_id, thread_idx, static_cast<uint32_t>(reg_task_id));
+        }
+#endif
 
 #if SIMPLER_SCHED_PROFILING
         if (l2_swimlane.l2_swimlane_enabled && (t.running_done || t.pending_done)) {
@@ -284,9 +408,11 @@ void SchedulerContext::check_running_cores_for_completion(
 
 #if SIMPLER_DFX
         // Capture finish_ts at the FIN observation point — right after rmb()
-        // pinned cacheable AICore reads downstream of the register load, and
-        // BEFORE any fanin / deferred-release work. Anything later would
-        // charge AICPU completion-processing cost to (end → finish).
+        // above pinned the cacheable AICore reads downstream of the register
+        // load, and BEFORE any fanin / deferred-release work. Anything later
+        // (slot transition apply, complete_slot_task fanin processing) would
+        // charge AICPU completion-processing cost to the (end → finish)
+        // span, masking the actual FIN-delivery latency.
         uint64_t finish_ts = 0;
         if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING && (t.pending_done || t.running_done)) {
             finish_ts = get_sys_cnt_aicpu();
@@ -322,7 +448,19 @@ void SchedulerContext::check_running_cores_for_completion(
         // 2. Update slot data
         if (t.running_freed) {
             if (core.pending_slot_state != nullptr && !t.pending_done) {
+                // A gated sync_start block promoting into the running slot advances the
+                // rendezvous. Capture that BEFORE promote nulls the pending fields; after
+                // it lands, bump running_slot_count and ring iff this was the block that
+                // completed the cohort (and the producer already released).
+                PTO2TaskSlotState *promoted = core.pending_slot_state;
+                bool sync_start_promote = pending_gated && promoted->active_mask.requires_sync_start();
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
+                if (sync_start_promote) {
+                    promoted->payload->running_slot_count.fetch_add(1, std::memory_order_seq_cst);
+                    if (sched_->maybe_rendezvous_ring(*promoted)) {
+                        sched_->propagate_dispatch_fanin(*promoted);
+                    }
+                }
             } else {
                 clear_running_slot(core);  // Case 1 or Case 3 (no pending)
                 if (t.pending_done) {
@@ -372,10 +510,14 @@ bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t b
         )) {
         return false;  // Another thread already holds the drain slot.
     }
-    // We own the drain slot.  Store the task and reset election flag before making it visible.
+    // We own the drain slot.  Store the task and reset the coordination flags before making
+    // it visible.
     drain_state_.pending_task.store(slot_state, std::memory_order_release);
     drain_state_.drain_ack_mask.store(0, std::memory_order_relaxed);
     drain_state_.drain_worker_elected.store(0, std::memory_order_relaxed);
+    drain_state_.drain_stage_go.store(0, std::memory_order_relaxed);
+    drain_state_.drain_stage_done_mask.store(0, std::memory_order_relaxed);
+    drain_state_.drain_running_staged.store(0, std::memory_order_relaxed);
     // Release store: all stores above are now visible to any thread that
     // acquire-loads sync_start_pending and sees block_num > 0.
     drain_state_.sync_start_pending.store(block_num, std::memory_order_release);
@@ -383,63 +525,170 @@ bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t b
 }
 
 // Count total available resources across all scheduler threads for a given shape.
-int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_t core_mask) {
+// include_pending adds each thread's pending-capable cores/clusters — used by the
+// gated (early) sync_start drain, which pre-stages onto idle running slots AND onto
+// busy cores' pending slots. The ready drain (include_pending=false) counts idle only.
+int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending) {
     int32_t total = 0;
     for (int32_t t = 0; t < active_sched_threads_; t++) {
         if (shape == PTO2ResourceShape::MIX) {
-            total += core_trackers_[t].count_mix_running_clusters(core_mask);
+            // Gated MIX uses split placement (each core to running-if-idle / pending-if-busy),
+            // so a cluster is available iff every used core has some free slot. The ready
+            // path (include_pending=false) still needs whole-cluster idle placement.
+            total += include_pending ? core_trackers_[t].count_mix_split_clusters(core_mask) :
+                                       core_trackers_[t].count_mix_running_clusters(core_mask);
         } else {
             total += core_trackers_[t].get_idle_core_offset_states(shape).count();
+            if (include_pending) {
+                total += core_trackers_[t].get_pending_core_offset_states(shape).count();
+            }
         }
     }
     return total;
 }
 
-// Drain worker: dispatch all blocks in one pass across all threads' trackers.
-// Called only when global resources >= block_num, so one pass always suffices.
-// All other threads are spinning -- the drain worker has exclusive tracker access.
-void SchedulerContext::drain_worker_dispatch(Runtime *runtime, int32_t block_num) {
-    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
-    if (!slot_state) {
-        drain_state_.sync_start_pending.store(0, std::memory_order_release);
-        return;
-    }
+// One thread's share of the drain staging: CAS-claim block indices and publish them onto
+// THIS thread's own cores, concurrently with peers. Returns the number of cores placed on a
+// RUNNING slot (the rendezvous seed contribution). Each thread touches only its own tracker
+// and its own cores' doorbell-table entries; the CAS on next_block_idx and the fetch_or into
+// staged_core_mask are the only cross-thread points.
+//
+// A gated (early) sync_start drain pre-stages every block behind its doorbell
+// (prepare_block_for_dispatch is force-gated for the claimed drain range) and defers the launch
+// to the rendezvous: idle cores take a gated RUNNING slot; busy cores take a gated PENDING
+// slot (promoted by Case 3.3 as those cores' running tasks FIN). A non-gated (ready) drain
+// leaves early_dispatch_state==NONE, so every block launches immediately on an idle running slot and
+// the pending pass is skipped. For MIX, a gated block uses SPLIT placement (each core
+// independently: idle->running, busy->pending) — safe only because gated.
+int32_t
+SchedulerContext::drain_stage_cores(PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated) {
+    CoreTracker &tracker = core_trackers_[thread_idx];
     PTO2ResourceShape shape = slot_state->active_mask.to_shape();
     uint8_t core_mask = slot_state->active_mask.core_mask();
+    bool mix_split = gated && shape == PTO2ResourceShape::MIX;
+    int32_t running_staged = 0;
 
-    for (int32_t t = 0; t < active_sched_threads_ && slot_state->next_block_idx < block_num; t++) {
-        auto valid = (shape == PTO2ResourceShape::MIX) ?
-                         core_trackers_[t].get_mix_running_cluster_offset_states(core_mask) :
-                         core_trackers_[t].get_idle_core_offset_states(shape);
-        while (valid.has_value() && slot_state->next_block_idx < block_num) {
-            dispatch_block(runtime, t, valid.pop_first(), *slot_state, shape, false, slot_state->next_block_idx);
-            slot_state->next_block_idx++;
+    // Stage from this thread's `valid` cores/clusters: CAS-claim a block-index range sized to
+    // what this thread can place (against peers claiming concurrently), then publish those
+    // blocks onto valid cores. prepare_block_for_dispatch decides each MIX core's slot per-core
+    // (idle -> running, busy -> pending when to_pending); a MIX cluster's idle cores are the
+    // running-slot cores, counted BEFORE staging mutates the tracker (rendezvous seed).
+    auto stage = [&](CoreTracker::BitStates valid, bool to_pending) {
+        while (valid.has_value()) {
+            int32_t avail = valid.count();
+            int32_t start = 0;
+            int32_t claim = slot_state->claim_block_range(block_num, avail, start);
+            if (claim == 0) return;
+#if SIMPLER_DFX
+            bool sub_prof = l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES;
+            uint64_t prep_t0 = sub_prof ? get_sys_cnt_aicpu() : 0;
+#endif
+            PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
+            int handle_count = 0;
+            int32_t claimed[CoreTracker::MAX_CLUSTERS * 3];
+            for (int32_t b = 0; b < claim; b++)
+                claimed[b] = valid.pop_first();
+            bool is_mix = (shape == PTO2ResourceShape::MIX);
+            if (claim > 0) prefetch_block_dst(thread_idx, claimed[0], is_mix);
+            for (int32_t b = 0; b < claim; b++) {
+                if (b + 1 < claim) prefetch_block_dst(thread_idx, claimed[b + 1], is_mix);
+                auto core_offset = claimed[b];
+                if (shape == PTO2ResourceShape::MIX) {
+                    running_staged += tracker.mix_cluster_idle_core_count(core_offset, core_mask);
+                }
+                handle_count += prepare_block_for_dispatch(
+                    thread_idx, core_offset, *slot_state, shape, to_pending, start + b, &handles[handle_count], gated
+                );
+            }
+            wmb();
+            uint64_t dispatch_ts = 0;
+#if SIMPLER_DFX
+            uint64_t pub_t0 = 0;
+            if (sub_prof) {
+                pub_t0 = get_sys_cnt_aicpu();
+                // DrainPrepare bar: cluster scan happened before this lambda, so this covers the
+                // build_payload work for `claim` blocks (handle_count subtasks).
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::DrainPrepare, prep_t0, pub_t0,
+                    sched_l2_swimlane_[thread_idx].sched_loop_count, static_cast<uint32_t>(handle_count)
+                );
+            }
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
+                dispatch_ts = pub_t0 != 0 ? pub_t0 : get_sys_cnt_aicpu();
+            }
+#endif
+            // Accumulate this batch's gated cores into a LOCAL mask and OR it into the shared
+            // staged_core_mask ONCE below, instead of a seq_cst fetch_or per subtask — that
+            // per-write atomic contends across all drain threads on the same 2 words and was
+            // ~half the publish cost. The doorbell-table writes stay per-core (unique cid, no
+            // contention).
+            uint64_t my_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
+            for (int i = 0; i < handle_count; i++) {
+                publish_subtask_to_core(handles[i], dispatch_ts);
+                if (gated) {
+                    int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
+                    sched_->early_dispatch_doorbell_table[cid].addr = handles[i].reg_addr;
+                    sched_->early_dispatch_doorbell_table[cid].token = handles[i].reg_task_id;
+                    my_mask[cid >> 6] |= 1ULL << (cid & 63);
+                }
+            }
+            if (gated) {
+                for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+                    if (my_mask[w] != 0) {
+                        slot_state->payload->staged_core_mask[w].fetch_or(my_mask[w], std::memory_order_seq_cst);
+                    }
+                }
+            }
+#if SIMPLER_DFX
+            if (sub_prof) {
+                // DrainPublish bar: the MMIO write_reg per subtask (+ gated doorbell/mask record).
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::DrainPublish, pub_t0, get_sys_cnt_aicpu(),
+                    sched_l2_swimlane_[thread_idx].sched_loop_count, static_cast<uint32_t>(handle_count)
+                );
+            }
+#endif
+            sched_->record_published_blocks(*slot_state, claim);
+            // AIC/AIV running placement (whole block on idle cores); MIX running cores are
+            // counted per-cluster above (mix_cluster_idle_core_count).
+            if (gated && shape != PTO2ResourceShape::MIX && !to_pending) running_staged += handle_count;
+        }
+    };
+
+    if (mix_split) {
+        // Gated MIX: to_pending=true opts every BUSY used core into its pending slot while idle
+        // used cores take running slots (prepare_block_for_dispatch: to_pending && !is_core_idle).
+        stage(tracker.get_mix_split_cluster_offset_states(core_mask), /*to_pending=*/true);
+    } else {
+        auto idle = (shape == PTO2ResourceShape::MIX) ? tracker.get_mix_running_cluster_offset_states(core_mask) :
+                                                        tracker.get_idle_core_offset_states(shape);
+        stage(idle, /*to_pending=*/false);  // idle -> running (ready launch + gated pre-stage)
+        if (gated) {
+            stage(tracker.get_pending_core_offset_states(shape), /*to_pending=*/true);
         }
     }
-
-    // All blocks dispatched -- clear drain state.
-    // Release fence ensures tracker mutations are visible to threads that
-    // acquire-load sync_start_pending == 0 and resume normal operation.
-    std::atomic_thread_fence(std::memory_order_release);
-    drain_state_.pending_task.store(nullptr, std::memory_order_release);
-    drain_state_.drain_ack_mask.store(0, std::memory_order_relaxed);
-    drain_state_.drain_worker_elected.store(0, std::memory_order_relaxed);
-    drain_state_.sync_start_pending.store(0, std::memory_order_release);
+    return running_staged;
 }
 
 // Called by each scheduler thread when drain_state_.sync_start_pending != 0.
 //
-// Protocol (single-stage ack barrier):
-//   1. Ack barrier: all threads signal they've stopped dispatch, then spin
-//      until all ack bits are set.
-//      If this thread's bit gets cleared while waiting, a reset occurred -- return.
-//   2. Election: one thread wins the CAS and becomes the drain worker.
-//      If resources are insufficient, reset ack/election fields and return --
-//      all threads resume completion polling to free running cores, then retry.
-//   3. Dispatch: elected thread dispatches all blocks (one pass, resources guaranteed).
-//      Non-elected threads spin-wait until sync_start_pending == 0.
-//      During dispatch the elected thread has exclusive tracker access.
-void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
+// Protocol:
+//   1. Ack barrier: all threads signal they've stopped dispatch, spin until all acked.
+//      If this thread's ack bit gets cleared while waiting, a reset occurred -- return.
+//   2. Election + availability: one thread wins the CAS. It checks global resources; if
+//      insufficient it resets ack/election so all threads resume completion polling to free
+//      cores, then retry. If sufficient it releases parallel staging (stage_go).
+//   3. Parallel stage: EVERY thread stages its OWN cores concurrently (CAS-claimed block
+//      indices), accumulates its running-slot cores, and marks its stage_done bit.
+//   4. Finalize: the elected thread waits for all stage_done bits, seeds the rendezvous
+//      (running_slot_count) for a gated drain, and reopens the gate
+//      (a release-store the non-elected threads acquire, so the seed is visible before any
+//      completion promotes a pending block). Non-elected threads spin until the gate reopens.
+void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] uint64_t *out_stage_wall_cycles) {
+#if SIMPLER_DFX
+    bool drain_prof = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && out_stage_wall_cycles != nullptr);
+    uint64_t drain_acked_ts = 0;  // set at ack-barrier end; used to measure the stage wall
+#endif
     // Every spin in this function honors is_completed(): once the run latches
     // completed_ (all tasks done, or a fatal error raised elsewhere), peers leave
     // the dispatch loop and stop participating in the drain. A thread parked in a
@@ -472,15 +721,74 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
         if ((ack & (1u << thread_idx)) == 0) return;
         SPIN_WAIT_HINT();
     }
-
     // Election -- exactly one thread wins the CAS.
     int32_t expected = 0;
     drain_state_.drain_worker_elected.compare_exchange_strong(
         expected, thread_idx + 1, std::memory_order_acquire, std::memory_order_relaxed
     );
+    bool elected = drain_state_.drain_worker_elected.load(std::memory_order_relaxed) == thread_idx + 1;
 
-    if (drain_state_.drain_worker_elected.load(std::memory_order_relaxed) != thread_idx + 1) {
-        // Non-elected: spin-wait for drain completion or resource-insufficient reset.
+    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    // OWNER is acquired before the drain is published and persists through
+    // completion, so every staging thread makes the same gate decision even if
+    // producer release changes early_dispatch_state during the barrier.
+    bool gated = slot_state != nullptr && slot_state->payload != nullptr &&
+                 PTO2SchedulerState::owns_early_sync_drain(*slot_state->payload);
+
+    if (elected) {
+        if (slot_state == nullptr) {
+            // pending_task observed null only when a concurrent drain completion already cleared
+            // it. Stale-elected: release the election lock and return. Do NOT clear drain_ack_mask
+            // / sync_start_pending -- a *new* drain run may already be accumulating acks.
+            drain_state_.drain_worker_elected.store(0, std::memory_order_release);
+            return;
+        }
+        PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+        // A gated drain may pre-stage onto pending slots too (idle+pending); the ready drain
+        // needs block_num idle cores/clusters.
+        int32_t available =
+            count_global_available(shape, slot_state->active_mask.core_mask(), /*include_pending=*/gated);
+        if (available < block_num) {
+            // Insufficient -- reset so all threads resume completion polling to free cores, then retry.
+            drain_state_.drain_ack_mask.store(0, std::memory_order_release);
+            drain_state_.drain_worker_elected.store(0, std::memory_order_release);
+            return;
+        }
+        // Release parallel staging: every thread (this one included) now stages its own cores.
+        drain_state_.drain_running_staged.store(0, std::memory_order_relaxed);
+        drain_state_.drain_stage_done_mask.store(0, std::memory_order_relaxed);
+        drain_state_.drain_stage_go.store(1, std::memory_order_release);
+    } else {
+        // Non-elected: wait for the go signal, or bail if the elected thread reset (stale /
+        // insufficient resources).
+        while (drain_state_.drain_stage_go.load(std::memory_order_acquire) == 0) {
+            if (is_completed()) return;
+            if (drain_state_.drain_worker_elected.load(std::memory_order_acquire) == 0) return;
+            SPIN_WAIT_HINT();
+        }
+        slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+        if (slot_state == nullptr) return;
+        gated = slot_state->payload != nullptr && PTO2SchedulerState::owns_early_sync_drain(*slot_state->payload);
+    }
+
+    // Parallel stage this thread's own cores (CAS-claimed block indices), then mark done.
+#if SIMPLER_DFX
+    if (drain_prof) drain_acked_ts = get_sys_cnt_aicpu();  // pre-stage
+#endif
+    int32_t my_running = drain_stage_cores(slot_state, block_num, thread_idx, gated);
+#if SIMPLER_DFX
+    // out param carries the PURE drain_stage_cores wall (build_payload + MMIO publish of
+    // this thread's cores), isolating it from availability + stage_go handshake.
+    if (drain_prof && drain_acked_ts != 0) *out_stage_wall_cycles = get_sys_cnt_aicpu() - drain_acked_ts;
+#endif
+    drain_state_.drain_running_staged.fetch_add(my_running, std::memory_order_acq_rel);
+    drain_state_.drain_stage_done_mask.fetch_or(1u << thread_idx, std::memory_order_release);
+
+    if (!elected) {
+        // Non-elected: staging done; wait for the elected thread to reopen the gate. Exiting via
+        // sync_start_pending==0 (release/acquire) or drain_worker_elected==0 both synchronize
+        // with the elected's finalize (its release fence sequences the seed before both stores),
+        // so the running_slot_count seed is visible before this thread resumes completions.
         while (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
             if (is_completed()) return;
             if (drain_state_.drain_worker_elected.load(std::memory_order_acquire) == 0) return;
@@ -489,29 +797,40 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
         return;
     }
 
-    // Elected: check if global resources are sufficient.
-    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
-    if (slot_state == nullptr) {
-        // pending_task is observed null only when a concurrent drain completion
-        // already cleared it (drain_worker_dispatch nulls it before reopening the
-        // gate). That drain is done and this is a stale-elected thread, so just
-        // release the election lock and return. Do NOT clear drain_ack_mask or
-        // sync_start_pending: a *new* drain run may already be active and
-        // accumulating acks, and zeroing them would corrupt it into a hang.
-        drain_state_.drain_worker_elected.store(0, std::memory_order_release);
-        return;
+    // Elected: wait for all threads to finish staging, then seed the rendezvous and reopen.
+    while ((drain_state_.drain_stage_done_mask.load(std::memory_order_acquire) & all_acked) != all_acked) {
+        if (is_completed()) return;
+        SPIN_WAIT_HINT();
     }
-    PTO2ResourceShape shape = slot_state->active_mask.to_shape();
-    int32_t available = count_global_available(shape, slot_state->active_mask.core_mask());
-
-    if (available < block_num) {
-        // Insufficient resources -- reset drain fields so threads can resume
-        // completion polling to free running cores, then retry.
-        drain_state_.drain_ack_mask.store(0, std::memory_order_release);
-        drain_state_.drain_worker_elected.store(0, std::memory_order_release);
-        return;
+    if (gated) {
+        // Seed the rendezvous with the running-slot cores staged across all threads; pending
+        // cores advance it as they promote. maybe_rendezvous_ring (producer release) rings iff
+        // this already equals popcount(staged_core_mask) — i.e. no pending spill.
+        slot_state->payload->running_slot_count.store(
+            static_cast<int16_t>(drain_state_.drain_running_staged.load(std::memory_order_acquire)),
+            std::memory_order_seq_cst
+        );
     }
+    // Clear drain state and reopen the gate FIRST, so the other threads resume immediately.
+    // Release fence sequences the seed + tracker mutations before every clear, so any thread
+    // that acquire-observes one of them (sync_start_pending==0 / drain_worker_elected==0) sees
+    // the seed. `slot_state` is a local holding the fa_fused slot (not drain_state_), so it stays
+    // valid for the propagate below even if a new drain reuses pending_task after reopen.
+    std::atomic_thread_fence(std::memory_order_release);
+    drain_state_.pending_task.store(nullptr, std::memory_order_release);
+    drain_state_.drain_stage_go.store(0, std::memory_order_relaxed);
+    drain_state_.drain_stage_done_mask.store(0, std::memory_order_relaxed);
+    drain_state_.drain_ack_mask.store(0, std::memory_order_relaxed);
+    drain_state_.drain_worker_elected.store(0, std::memory_order_relaxed);
+    drain_state_.sync_start_pending.store(0, std::memory_order_release);
 
-    // Dispatch -- all other threads are spinning, elected thread has exclusive tracker access.
-    drain_worker_dispatch(runtime, block_num);
+    // Recheck after publishing the drain seed. The producer-side rendezvous check can race
+    // ahead of drain completion and fail while running_slot_count is still incomplete. When
+    // every block landed directly in a running slot, no pending promotion remains to retry it.
+    if (gated) {
+        sched_->retry_sync_start_rendezvous_after_drain(*slot_state);
+    } else {
+        sched_->propagate_dispatch_fanin(*slot_state);
+    }
+    PTO2SchedulerState::finish_early_sync_drain(*slot_state->payload);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -11,6 +11,7 @@
 #ifndef SCHEDULER_CONTEXT_H
 #define SCHEDULER_CONTEXT_H
 
+#include "aicpu/platform_regs.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/unified_log.h"
 #include "scheduler_types.h"
@@ -18,12 +19,13 @@
 #include "scheduler/pto_scheduler.h"
 
 #include "aicore_completion_mailbox.h"
+#include "pto2_dispatch_payload.h"
 
 // These macros are defined in runtime.h, but we cannot include it here
 // (it pulls in Handshake which we only forward-declare).  Mirror the
 // authoritative values so the class layout compiles standalone.
 #ifndef RUNTIME_MAX_WORKER
-#define RUNTIME_MAX_WORKER 108
+#define RUNTIME_MAX_WORKER 72
 #endif
 #ifndef RUNTIME_MAX_FUNC_ID
 #define RUNTIME_MAX_FUNC_ID 1024
@@ -106,6 +108,11 @@ public:
     // before orchestrator_done_.
     void wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx);
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：header 内联的 route_ready_once 经 C 钩子调私有 enqueue，需 friend。
+    friend bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
+
     // =========================================================================
     // State queries / external synchronization points
     // =========================================================================
@@ -144,6 +151,14 @@ private:
     // sync_start drain coordination
     SyncStartDrainState drain_state_;
 
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：每调度线程一份线程本地 defer 缓冲——complete 扇出时写入、
+    // dispatch_ready_tasks 在 sync_start 层之后 drain；避免 claim 后只停在 defer 里导致 S3。
+    static constexpr int32_t kFanoutDirectAicPendingCap = 512;
+    PTO2TaskSlotState *fanout_direct_aic_pending_[MAX_AICPU_THREADS][kFanoutDirectAicPendingCap];
+    int32_t fanout_direct_aic_pending_n_[MAX_AICPU_THREADS]{0};
+#endif
+
 #if SIMPLER_DFX
     SchedL2SwimlaneCounters sched_l2_swimlane_[MAX_AICPU_THREADS];
     // Cached once at init() from get_l2_swimlane_level(), AFTER
@@ -181,17 +196,15 @@ private:
     // handshake_partition; checked by the leader in post_handshake_init.
     std::atomic<bool> handshake_failed_{false};
 
-#if SIMPLER_DFX
-    // Physical core ids keyed by logical worker id. Populated by
-    // handshake_all_cores() and handed to pmu_aicpu_init() so the platform
-    // can resolve per-core PMU MMIO bases. Only needed when SIMPLER_DFX=1
-    // — without it, PMU is compiled out and core_exec_states_ already
-    // carries the field.
-    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER]{};
-#endif
-
     // Platform AICore-register base array (set by AicpuExecutor before init()).
     uint64_t regs_{0};
+
+#if SIMPLER_DFX
+    // PMU profiling: physical core IDs for PMU MMIO base resolution.
+    // Separate storage because CoreExecState's 64-byte budget has no room for
+    // physical_core_id when SIMPLER_DFX=1.
+    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER]{};
+#endif
 
     // =========================================================================
     // Core management (scheduler_cold_path.cpp)
@@ -225,32 +238,116 @@ private:
         return "?";
     }
 
-    int pop_ready_tasks_batch(PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count);
+    int pop_ready_tasks_batch(
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+    );
 
     void build_payload(
         PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
-        const AsyncCtx &async_ctx, int32_t block_idx
+        int32_t block_idx, bool force_gate
     );
 
-    void dispatch_subtask_to_core(
-        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
-        PTO2SubtaskSlot subslot, bool to_pending, int32_t block_idx
+    // Batched-dispatch primitives. prepare_* builds the payload and per-core
+    // state; publish_* issues the MMIO register write. Callers must wmb()
+    // between the prepare batch and the publish batch, then sample
+    // get_sys_cnt_aicpu() once and pass it to publish_* for every handle.
+    //
+    // dispatch_timestamp_slot points to the CoreExecState slot
+    // (pending_dispatch_timestamp / running_dispatch_timestamp) selected at
+    // prepare time, or nullptr when L2 swimlane is below AICPU_TIMING and no
+    // dispatch timestamp is being recorded.
+    struct PublishHandle {
+        uint64_t reg_addr;
+        uint32_t reg_task_id;
+        int32_t core_offset;
+        uint64_t *dispatch_timestamp_slot;
+    };
+
+    PublishHandle prepare_subtask_to_core(
+        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        bool to_pending, int32_t block_idx, bool force_gate
     );
 
-    void dispatch_mix_block_to_cluster(
-        Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending,
-        int32_t block_idx
-    );
+    inline void publish_subtask_to_core(const PublishHandle &h, uint64_t dispatch_ts) {
+        if (h.dispatch_timestamp_slot != nullptr) {
+            *h.dispatch_timestamp_slot = dispatch_ts;
+        }
+        write_reg(h.reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(h.reg_task_id));
+    }
 
-    void dispatch_block(
-        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
-        PTO2ResourceShape shape, bool to_pending, int32_t block_idx
+    // Prefetch the cold per-core structures the next block's prepare touches.
+    // Ordering is load-bearing: issue the STALLING LOAD first — CoreExecState,
+    // read by dispatch_seq++ whose value feeds reg_task_id -> buf_idx -> the whole
+    // dispatch — for every core of the block, BEFORE the store-target prefetches.
+    // MSHRs saturate (a MIX block warms 3 cores); issuing the read prefetches
+    // first keeps them from being the ones dropped. The dispatch-buffer writes
+    // still get prefetched (measured to help ~30% on this shallow-store-buffer
+    // control core), just after the reads. rw=1 on CoreExecState (read AND
+    // written) gives Exclusive, serving both without a Shared->Exclusive upgrade.
+    inline void prefetch_block_dst(int32_t thread_idx, int32_t core_offset, bool is_mix) {
+        CoreTracker &tracker = core_trackers_[thread_idx];
+        int32_t cids[3] = {};
+        int32_t nc = 0;
+        if (is_mix) {
+            cids[nc++] = tracker.get_core_id_by_offset(tracker.get_aic_core_offset(core_offset));
+            cids[nc++] = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(core_offset));
+            cids[nc++] = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(core_offset));
+        } else {
+            cids[nc++] = tracker.get_core_id_by_offset(core_offset);
+        }
+        // Stalling loads first.
+        for (int32_t i = 0; i < nc; i++)
+            __builtin_prefetch(&core_exec_states_[cids[i]], 1, 3);
+        // Store targets after (dispatch buffer CL0 control + CL1 args, both bufs).
+        for (int32_t i = 0; i < nc; i++) {
+            for (int32_t buf = 0; buf < 2; buf++) {
+                const char *dp = reinterpret_cast<const char *>(&payload_per_core_[cids[i]][buf]);
+                __builtin_prefetch(dp, 1, 3);
+                __builtin_prefetch(dp + 64, 1, 3);
+            }
+        }
+    }
+
+    // Fan out one block's subtasks (1 for AIC/AIV, 1-3 for MIX) into the
+    // caller-supplied handles buffer. Returns the number of handles written.
+    int prepare_block_for_dispatch(
+        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape,
+        bool to_pending, int32_t block_idx, PublishHandle *out_handles, bool force_gate = false
     );
 
     void dispatch_shape(
-        Runtime *runtime, int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
+        int32_t thread_idx, PTO2ReadyQueue *disp_queues, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
         CoreTracker &tracker, bool &entered_drain, bool &made_progress, bool &try_pushed
     );
+
+    // Early-dispatch (Hook 1). Mirrors dispatch_ready_tasks: owns its
+    // own gating (off-PMU, this thread has a spare slot, and no normal ready work
+    // is queued) and sets made_progress / try_pushed when it stages, so the caller
+    // is a single unconditional call like normal dispatch. After normal dispatch
+    // leaves idle cores spare, pre-stage the consumers of any RUNNING flagged
+    // producer onto those cores with a non-zero src_payload (gated). Touches no dependency
+    // state — the task is released by the doorbell at its normal ready-pop (Hook 2).
+    int32_t try_early_dispatch(
+        int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+    );
+
+    // Stage the already-claimed range [start, start+count) of consumer `c` onto
+    // thread_idx's idle (RUNNING slot) then pending (gated-pending, promote-on-FIN)
+    // cores from the provided free-core sets. The caller claims next_block_idx and
+    // re-pushes `c` BEFORE calling, so this expensive prepare+publish runs
+    // concurrently with peers (mirrors the normal SPMD dispatch path). Returns the
+    // number of blocks staged.
+    int32_t stage_consumer_blocks(
+        int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+        CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
+    );
+
+    // Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
+    // pre-stage claimed block ranges onto this thread's free cores of `shape` for the
+    // given phase (IDLE -> onto idle cores in the RUNNING slot; PENDING -> onto a
+    // running core's gated pending slot). Pop is sized to the shape's capacity exactly
+    // as dispatch_shape sizes normal dispatch. Returns the number of blocks staged.
+    int32_t early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase);
 
     // One pass of "Phase 4" in the resolve_and_dispatch loop: IDLE-stage dispatch
     // for MIX then (if no mix residual) AIC/AIV; then PENDING-stage dispatch with
@@ -265,9 +362,38 @@ private:
     // not unbounded — once mix completes on at least one cluster, the next
     // pass either drains the residual or admits AIC/AIV.
     void dispatch_ready_tasks(
-        Runtime *runtime, int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress,
-        bool &try_pushed
+        int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
     );
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：fanout 直挂 AIC 的核心 API——enqueue 做资格/admit/claim+CAS；
+    // drain 在 sync_start 层之后清空 defer（entered_drain 时 flush_to_ready_only，
+    // 保证 claim 后必上核或进 readyQ）；stage 目前仅 idle（pending 另开，勿与 idle 相加）。
+    bool enqueue_fanout_direct_aic(int32_t thread_idx, PTO2TaskSlotState &slot_state);
+    void drain_fanout_direct_aic_pending(
+        int32_t thread_idx, bool &made_progress, bool &try_pushed, bool flush_to_ready_only = false,
+        bool pmu_active = false
+    );
+    bool try_fanout_direct_dispatch_aic(
+        int32_t thread_idx, PTO2TaskSlotState &slot_state, bool *made_progress, bool *try_pushed,
+        bool pmu_active = false
+    );
+    // 修改理由：对齐 run_staging_order 的 AIC-PENDING 门控（无残留 MIX、无对端空闲 AIC、
+    // 且存在安全本地 pending 核）；供后续启用 pending 挂核时复用，避免 Case-3.1。
+    bool fanout_aic_pending_gate_ok(int32_t thread_idx) const;
+    // 修改理由：筛掉已有 pending_slot_state 或 ED 门控中的 running 核，防止错误挂 pending。
+    CoreTracker::BitStates fanout_aic_safe_pending_cores(int32_t thread_idx) const;
+#endif
+
+    // Shared staging order for both dispatch sources (normal ready + speculative early):
+    // MIX strict priority, IDLE stage before PENDING stage, cross-thread idle gating
+    // (MIX-IDLE ▶ c/v-IDLE ▶ MIX-PEND ▶ c/v-PEND). `stage(shape, phase)` stages that
+    // shape+phase bucket for the source and returns true to STOP the pass (normal returns
+    // true when it enters drain mode; early always returns false). `residual_mix()` reports
+    // whether MIX work remains queued for the source (normal reads ready_queues[MIX], early
+    // reads early_dispatch_queues[MIX]). IDLE runs under PMU; PENDING is withheld under PMU.
+    template <typename StageFn, typename ResidualMixFn>
+    void run_staging_order(int32_t thread_idx, bool pmu_active, StageFn &&stage, ResidualMixFn &&residual_mix);
 
     // Returns true if any *other* scheduler thread currently has an idle core
     // matching `shape`. Used as a scheduling hint on the PENDING dispatch path
@@ -284,12 +410,29 @@ private:
         return sched_->ready_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size() > 0;
     }
 
+    // Tier-0 analog of has_residual_mix for the ready sync_start lane: true if MIX
+    // sync_start cohorts remain queued, so the Tier-0 pass keeps MIX strict priority
+    // over its own AIC/AIV sync work. Same relaxed-size snapshot caveat.
+    bool has_residual_sync_mix() const {
+        return sched_->ready_sync_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size() > 0;
+    }
+
+    // Early-dispatch analog of has_residual_mix: true if MIX early-dispatch candidates
+    // remain queued. has_residual_mix reads the normal MIX ready queue, which is empty
+    // whenever the Phase-4b early pass runs (it is gated on all ready_queues being
+    // empty), so early-dispatch MIX priority needs its own residual check against
+    // early_dispatch_queues[MIX]. Same relaxed-size snapshot caveat as has_residual_mix.
+    bool has_residual_early_mix() const {
+        return sched_->early_dispatch_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size() > 0;
+    }
+
     // =========================================================================
     // Completion & drain (scheduler_completion.cpp)
     // =========================================================================
 
-    static SlotTransition
-    decide_slot_transition(int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id);
+    static SlotTransition decide_slot_transition(
+        int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id, bool pending_gated = false
+    );
 
     void complete_slot_task(
         PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
@@ -310,9 +453,15 @@ private:
     );
 
     bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
-    int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask);
-    void drain_worker_dispatch(Runtime *runtime, int32_t block_num);
-    void handle_drain_mode(Runtime *runtime, int32_t thread_idx);
+    int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending = false);
+    // One thread's share of the drain: CAS-claim block indices and stage them onto THIS
+    // thread's own cores (parallel with peers), returning the number of running-slot cores
+    // staged (the rendezvous seed contribution).
+    int32_t drain_stage_cores(PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated);
+    // out_stage_wall_cycles (profiling only): cycles this thread spent in drain_stage_cores
+    // (prepare + publish), set ONLY on threads that actually staged. Lets the caller isolate
+    // the pure stage wall from the ack-barrier + finalize spans in the Drain bar.
+    void handle_drain_mode(int32_t thread_idx, uint64_t *out_stage_wall_cycles = nullptr);
 
     // =========================================================================
     // Cold path: exit checks, stall diagnostics, profiling (scheduler_cold_path.cpp)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,9 +12,11 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cstdio>
 #include <limits>
 
 #include "common.h"  // debug_assert
+
 #include "common/unified_log.h"
 #include "aicpu/aicpu_device_config.h"
 #include "aicpu/device_time.h"
@@ -32,6 +34,19 @@
 #include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/args_dump_aicpu.h"
 
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+
+// AICore materializes args[] from src_payload on the gated path using the
+// byte offsets in pto2_dispatch_payload.h (the AICore .o cannot see PTO2TaskPayload).
+// Pin those constants to the real layout here, where the struct is fully visible.
+static_assert(offsetof(PTO2TaskPayload, tensor_count) == PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, scalar_count) == PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, tensors) == PTO2_TASKPAYLOAD_TENSORS_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, scalars) == PTO2_TASKPAYLOAD_SCALARS_OFFSET);
+static_assert(sizeof(Tensor) == PTO2_TASKPAYLOAD_TENSOR_STRIDE);
+
 // =============================================================================
 // Dispatch helpers
 // =============================================================================
@@ -39,6 +54,13 @@
 namespace {
 inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
 }
+
+// The early-dispatch core bitmask (PTO2_EARLY_DISPATCH_CORE_MASK_WORDS * 64 bits) must cover
+// every global core_id, and the per-core doorbell table is sized to match.
+static_assert(
+    RUNTIME_MAX_WORKER <= PTO2_EARLY_DISPATCH_CORE_MASK_WORDS * 64,
+    "staged_core_mask too small for RUNTIME_MAX_WORKER cores"
+);
 
 const char *SchedulerContext::shape_name(PTO2ResourceShape shape) {
     switch (shape) {
@@ -73,7 +95,7 @@ bool SchedulerContext::has_idle_in_other_threads(int32_t self_thread_idx, PTO2Re
 }
 
 int SchedulerContext::pop_ready_tasks_batch(
-    PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
 ) {
 #if SIMPLER_DFX
     auto &l2_swimlane = sched_l2_swimlane_[thread_idx];
@@ -81,11 +103,11 @@ int SchedulerContext::pop_ready_tasks_batch(
     extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
     uint64_t t_pop_start = get_sys_cnt_aicpu();
     int count = sched_->get_ready_tasks_batch(
-        shape, out, max_count, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]
+        queues, shape, out, max_count, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]
     );
     l2_swimlane.sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
 #else
-    int count = sched_->get_ready_tasks_batch(shape, out, max_count);
+    int count = sched_->get_ready_tasks_batch(queues, shape, out, max_count);
 #endif
     if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
         if (count > 0) {
@@ -96,42 +118,60 @@ int SchedulerContext::pop_ready_tasks_batch(
     }
 #else
     (void)thread_idx;
-    int count = sched_->get_ready_tasks_batch(shape, out, max_count);
+    int count = sched_->get_ready_tasks_batch(queues, shape, out, max_count);
 #endif
     return count;
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
-    const AsyncCtx &async_ctx, int32_t block_idx
+    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
+    bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
     uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
     const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
     dispatch_payload.function_bin_addr = callable->resolved_addr();
     auto &payload = *slot_state.payload;
-    int n = 0;
-    for (int32_t i = 0; i < payload.tensor_count; i++) {
-        dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
+    // A claimed early-stage range stays gated even if producer completion flips
+    // the shared state before this payload is built. All other dispatches run on
+    // pickup.
+    if (PTO2SchedulerState::should_gate_early_dispatch(
+            force_gate, payload.early_dispatch_state.load(std::memory_order_relaxed)
+        )) {
+        // Gated task: hand the idle AICore the source payload (non-zero = gate) and
+        // let it fill args[0..num_args) itself during its doorbell wait, instead of
+        // paying the arg-vector write on this scheduler thread.
+        dispatch_payload.src_payload = reinterpret_cast<uint64_t>(&payload);
+    } else {
+        // Ready task: fill args here; src_payload = 0 signals AICore to run on pickup.
+        dispatch_payload.src_payload = 0;
+        int n = 0;
+        for (int32_t i = 0; i < payload.tensor_count; i++) {
+            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
+        }
+        for (int32_t i = 0; i < payload.scalar_count; i++) {
+            dispatch_payload.args[n++] = payload.scalars[i];
+        }
     }
-    for (int32_t i = 0; i < payload.scalar_count; i++) {
-        dispatch_payload.args[n++] = payload.scalars[i];
-    }
-    dispatch_payload.local_context.s_block_idx = block_idx;
-    dispatch_payload.local_context.s_block_num = slot_state.logical_block_num;
-    dispatch_payload.local_context.async_ctx = async_ctx;
-    dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
-    dispatch_payload.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
+    dispatch_payload.local_context.block_idx = block_idx;
+    dispatch_payload.local_context.block_num = slot_state.logical_block_num;
+    // AsyncCtx's slab pointers + capacity are prefilled once per (core, buf_idx)
+    // in init(); only task_token varies per dispatch. deferred_slab is never null
+    // on this path, so task_token is always the live task id (matches the old
+    // AsyncCtx::make(non-null) result). args[PAYLOAD_LOCAL_CONTEXT_INDEX] /
+    // [PAYLOAD_GLOBAL_CONTEXT_INDEX] are per-(core, buf_idx) constants, also
+    // prefilled in init().
+    dispatch_payload.local_context.async_ctx.task_token = slot_state.task->task_id;
 }
 
-void SchedulerContext::dispatch_subtask_to_core(
-    Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
-    bool to_pending, int32_t block_idx
+SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
+    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
+    int32_t block_idx, bool force_gate
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
     auto core_id = tracker.get_core_id_by_offset(core_offset);
-    (void)runtime;
     CoreExecState &core_exec_state = core_exec_states_[core_id];
+
     core_exec_state.dispatch_seq++;
     uint32_t reg_task_id = core_exec_state.dispatch_seq & TASK_ID_MASK;
     static_assert(
@@ -144,11 +184,12 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][buf_idx];
-    deferred_slab->count = 0;
-    deferred_slab->error_code = PTO2_ERROR_NONE;
-    AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
-    build_payload(payload, slot_state, subslot, async_ctx, block_idx);
+    // The deferred_slab is NOT reset here: it is init-cleared once and the
+    // completion path re-clears count only after a task actually recorded a
+    // deferred completion (count > 0), which is rare. A non-deferred task never
+    // touches count/error_code, so the slab stays clean without a per-dispatch
+    // write — keeping this cold per-core line off the dispatch path.
+    build_payload(payload, slot_state, subslot, block_idx, force_gate);
 
     if (to_pending) {
         core_exec_state.pending_subslot = subslot;
@@ -160,6 +201,7 @@ void SchedulerContext::dispatch_subtask_to_core(
         core_exec_state.running_reg_task_id = static_cast<int32_t>(reg_task_id);
         tracker.change_core_state(core_offset);
     }
+    tracker.set_pending_occupied(core_offset);
 
     LOG_DEBUG(
         "Thread %d: Dispatched %s %s task %" PRId64 " kernel_id=[%d,%d,%d] block_idx=%d/total_blocks=%d to"
@@ -172,70 +214,31 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     // AICore buffer rotation lives on the dispatch path: count this dispatch
     // and rotate before write_reg when we're about to cross a BUFFER_SIZE
-    // boundary. The just-filled buffer is stashed for ACK-gated release; a5 does
-    // not wire the ACK hook, so it drains via the next-rotation / run-end
-    // backstop. `reg_task_id` is passed as the gate token.
+    // boundary. The just-filled buffer is not handed to the host here — it is
+    // released once AICore ACKs this boundary dispatch (see the ACK hook in
+    // check_running_cores_for_completion), because FIN precedes the swimlane
+    // record on this runtime. `reg_task_id` is passed as that ACK gate. Gated on
+    // the same enable bit as flush so level=1 (AICORE_TIMING-only) participates.
 #if SIMPLER_DFX
     if (l2_swimlane_level_ != L2SwimlaneLevel::DISABLED) {
         l2_swimlane_aicpu_on_aicore_dispatch(core_id, thread_idx, reg_task_id);
     }
 #endif
 
-    // Publish task data (slot_state / args writes done above) before AICore
-    // can observe the dispatched task_id. ARM64 needs an explicit store-store
-    // fence across Normal-cacheable -> Device-nGnRnE; the old write_reg()
-    // helper provided this implicitly via __sync_synchronize.
-    wmb();
-
-    // Capture dispatch timestamp at the latest possible moment — after wmb,
-    // immediately before the DATA_MAIN_BASE write.
+    uint64_t *dispatch_timestamp_slot = nullptr;
 #if SIMPLER_DFX
     if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
-        uint64_t dispatch_ts = get_sys_cnt_aicpu();
-        if (to_pending) {
-            core_exec_state.pending_dispatch_timestamp = dispatch_ts;
-        } else {
-            core_exec_state.running_dispatch_timestamp = dispatch_ts;
-        }
+        dispatch_timestamp_slot =
+            to_pending ? &core_exec_state.pending_dispatch_timestamp : &core_exec_state.running_dispatch_timestamp;
     }
 #endif
 
-    write_reg(core_exec_state.reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
-    tracker.set_pending_occupied(core_offset);
+    return PublishHandle{core_exec_state.reg_addr, reg_task_id, core_offset, dispatch_timestamp_slot};
 }
 
-void SchedulerContext::dispatch_mix_block_to_cluster(
-    Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending,
-    int32_t block_idx
-) {
-    CoreTracker &tracker = core_trackers_[thread_idx];
-    uint8_t cmask = slot_state.active_mask.core_mask();
-    if (cmask & PTO2_SUBTASK_MASK_AIC) {
-        bool aic_to_pending = to_pending && !tracker.is_aic_core_idle(cluster_offset);
-        dispatch_subtask_to_core(
-            runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
-            aic_to_pending, block_idx
-        );
-    }
-    if (cmask & PTO2_SUBTASK_MASK_AIV0) {
-        bool aiv0_to_pending = to_pending && !tracker.is_aiv0_core_idle(cluster_offset);
-        dispatch_subtask_to_core(
-            runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
-            aiv0_to_pending, block_idx
-        );
-    }
-    if (cmask & PTO2_SUBTASK_MASK_AIV1) {
-        bool aiv1_to_pending = to_pending && !tracker.is_aiv1_core_idle(cluster_offset);
-        dispatch_subtask_to_core(
-            runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
-            aiv1_to_pending, block_idx
-        );
-    }
-}
-
-void SchedulerContext::dispatch_block(
-    Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape,
-    bool to_pending, int32_t block_idx
+int SchedulerContext::prepare_block_for_dispatch(
+    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
+    int32_t block_idx, PublishHandle *out_handles, bool force_gate
 ) {
 #if SIMPLER_DFX
     if (is_dump_args_enabled()) {
@@ -250,24 +253,61 @@ void SchedulerContext::dispatch_block(
         );
     }
 #endif
+    CoreTracker &tracker = core_trackers_[thread_idx];
     if (shape == PTO2ResourceShape::MIX) {
-        dispatch_mix_block_to_cluster(runtime, thread_idx, core_offset, slot_state, to_pending, block_idx);
-    } else if (shape == PTO2ResourceShape::AIC) {
-        dispatch_subtask_to_core(
-            runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIC, to_pending, block_idx
-        );
-    } else {
-        dispatch_subtask_to_core(
-            runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending, block_idx
-        );
-    }
+        uint8_t cmask = slot_state.active_mask.core_mask();
+        int n = 0;
+        // Per-core slot placement (#1308): an idle used core takes its running slot
+        // (tracked by the completion poller), a busy used core takes its gated pending slot
+        // (promoted on completion). The sync_start drain relies on this — it passes
+        // to_pending=true so every busy core opts into a pending slot; the non-zero
+        // src_payload gate keeps the whole cohort waiting for the rendezvous.
+        if (cmask & PTO2_SUBTASK_MASK_AIC) {
+            bool p = to_pending && !tracker.is_aic_core_idle(core_offset);
+            out_handles[n++] = prepare_subtask_to_core(
+                thread_idx, tracker.get_aic_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIC, p, block_idx,
+                force_gate
+            );
+        }
+        if (cmask & PTO2_SUBTASK_MASK_AIV0) {
+            bool p = to_pending && !tracker.is_aiv0_core_idle(core_offset);
+            out_handles[n++] = prepare_subtask_to_core(
+                thread_idx, tracker.get_aiv0_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV0, p, block_idx,
+                force_gate
+            );
+        }
+        if (cmask & PTO2_SUBTASK_MASK_AIV1) {
+            bool p = to_pending && !tracker.is_aiv1_core_idle(core_offset);
+            out_handles[n++] = prepare_subtask_to_core(
+                thread_idx, tracker.get_aiv1_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV1, p, block_idx,
+                force_gate
+            );
+        }
 #if SIMPLER_DFX
-    sched_l2_swimlane_[thread_idx].phase_dispatch_count += __builtin_popcount(slot_state.active_mask.core_mask());
+        sched_l2_swimlane_[thread_idx].phase_dispatch_count += __builtin_popcount(cmask);
 #endif
+        return n;
+    } else if (shape == PTO2ResourceShape::AIC) {
+        out_handles[0] = prepare_subtask_to_core(
+            thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIC, to_pending, block_idx, force_gate
+        );
+#if SIMPLER_DFX
+        sched_l2_swimlane_[thread_idx].phase_dispatch_count += 1;
+#endif
+        return 1;
+    } else {
+        out_handles[0] = prepare_subtask_to_core(
+            thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending, block_idx, force_gate
+        );
+#if SIMPLER_DFX
+        sched_l2_swimlane_[thread_idx].phase_dispatch_count += 1;
+#endif
+        return 1;
+    }
 }
 
 void SchedulerContext::dispatch_shape(
-    Runtime *runtime, int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
+    int32_t thread_idx, PTO2ReadyQueue *disp_queues, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
     CoreTracker &tracker, bool &entered_drain, bool &made_progress, bool &try_pushed
 ) {
 #if SIMPLER_SCHED_PROFILING
@@ -283,10 +323,72 @@ void SchedulerContext::dispatch_shape(
     while (cores.has_value() && !entered_drain) {
         int want = cores.count();
         PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
-        int got = pop_ready_tasks_batch(shape, thread_idx, batch, want);
+        int got = pop_ready_tasks_batch(disp_queues, shape, thread_idx, batch, want);
         if (got == 0) break;
 
+        // sync_start exclusion gate.
+        //
+        // When the popped batch contains a sync_start task we MUST publish each
+        // prior task with its own wmb so AICore receives them with time
+        // separation. The drain coordinator's `count_global_available()` check
+        // reads the per-thread CoreTracker, and although `prepare_block_for_dispatch`
+        // marks cores occupied synchronously, the head-start between successive
+        // tasks is what lets the surrounding completion loop catch up on FINs in
+        // the retry window when the sync_start task hits insufficient resources.
+        // Bursting all prior tasks at the end of the pop (cross-task batching)
+        // collapses that head-start and causes spmd_sync_start_stress to time
+        // out via 507018 on ~40% of runs — see
+        // docs/investigations/2026-06-cross-task-batched-publish.md.
+        //
+        // When the batch carries no sync_start task, no drain entry can happen
+        // in this pop, so we hoist `handles[]`, `wmb()`, and the publish loop
+        // out of the per-task body. One wmb amortizes across all tasks and one
+        // dispatch_ts is shared, which restores ~60 ns first-to-last AICore
+        // start span for single-block decode kernels (out_proj, q_proj, ...).
+        // Detection is a single mask check per task — cheap relative to even
+        // one register write.
+        bool any_sync_start = false;
+        for (int bi = 0; bi < got; bi++) {
+            if (batch[bi]->active_mask.requires_sync_start()) {
+                any_sync_start = true;
+                break;
+            }
+        }
+
+        // handles[] is sized for the MIX worst case: total claims across the
+        // pop bounded by `cores.count() ≤ MAX_CLUSTERS`, and each block
+        // contributes ≤ 3 subtasks for MIX.
+        PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
+        int handle_count = 0;
         bool dispatched_any = false;
+        // Logical block ranges published by this pop. AIV can pop two entries per
+        // cluster, so this ledger has the same worst-case bound as handles[].
+        PTO2TaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
+        int16_t published_counts[CoreTracker::MAX_CLUSTERS * 3];
+        int published_n = 0;
+#if SIMPLER_SCHED_PROFILING
+        uint64_t t_setup_start = get_sys_cnt_aicpu();
+#endif
+
+        // Flush prepared-but-unpublished handles. Required before
+        // `enter_drain_mode` so the drain coordinator sees cores as occupied,
+        // and at the per-task boundary when `any_sync_start` is true.
+        auto flush_publish = [&]() {
+            if (handle_count == 0) return;
+            wmb();
+            uint64_t dispatch_ts = 0;
+#if SIMPLER_DFX
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
+                dispatch_ts = get_sys_cnt_aicpu();
+            }
+#endif
+            for (int i = 0; i < handle_count; i++) {
+                publish_subtask_to_core(handles[i], dispatch_ts);
+            }
+            handle_count = 0;
+            made_progress = true;
+        };
+
         for (int bi = 0; bi < got; bi++) {
             PTO2TaskSlotState *slot_state = batch[bi];
             CoreTracker::BitStates selected_mix_clusters(0ULL);
@@ -302,23 +404,28 @@ void SchedulerContext::dispatch_shape(
                     }
                 }
                 if (!selected_mix_clusters.has_value()) {
-                    sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+                    disp_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
                 }
             }
 
+            // (Early-dispatch pre-staged tasks never reach this ready-pop: they are
+            // released by their doorbell in release_fanin_and_check_ready the
+            // instant their last producer completes — see try_early_dispatch_release.)
+
             if (slot_state->active_mask.requires_sync_start()) {
                 if (is_pending) {
-                    sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+                    disp_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
                 }
                 int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
                 if (available < slot_state->logical_block_num) {
+                    flush_publish();
                     if (!enter_drain_mode(slot_state, slot_state->logical_block_num)) {
-                        sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+                        disp_queues[static_cast<int32_t>(shape)].push(slot_state);
                     }
                     for (int rem = bi + 1; rem < got; rem++) {
-                        sched_->ready_queues[static_cast<int32_t>(shape)].push(batch[rem]);
+                        disp_queues[static_cast<int32_t>(shape)].push(batch[rem]);
                     }
                     entered_drain = true;
                     break;
@@ -326,30 +433,31 @@ void SchedulerContext::dispatch_shape(
             }
 
             if (!cores.has_value()) {
-                sched_->ready_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                flush_publish();
+                disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
                 break;
             }
 
-            dispatched_any = true;
-            try_pushed = true;
-#if SIMPLER_SCHED_PROFILING
-            uint64_t t_setup_start = get_sys_cnt_aicpu();
-#endif
             // Claim a contiguous range of blocks, hand the slot back to the
             // ready queue immediately, then perform the expensive dispatches.
             // This lets other schedulers concurrently claim and dispatch the
             // remaining blocks of the same SPMD task instead of spinning while
-            // this thread fills all its own cores.  Only local `start + b` is
-            // read after the push -- `next_block_idx` may already be advanced
+            // this thread fills all its own cores. Only local `start + b` is
+            // read after the push — `next_block_idx` may already be advanced
             // by another scheduler that popped the slot.
-            int32_t remaining = slot_state->logical_block_num - slot_state->next_block_idx;
             int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
-            int32_t claim = std::min(available, remaining);
-            int32_t start = slot_state->next_block_idx;
-            slot_state->next_block_idx += claim;
+            int32_t start = 0;
+            int32_t claim = slot_state->claim_block_range(slot_state->logical_block_num, available, start);
+            if (claim == 0) continue;
+            dispatched_any = true;
+            try_pushed = true;
 
-            if (slot_state->next_block_idx < slot_state->logical_block_num) {
-                sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+            published_list[published_n] = slot_state;
+            published_counts[published_n] = static_cast<int16_t>(claim);
+            published_n++;
+
+            if (start + claim < slot_state->logical_block_num) {
+                disp_queues[static_cast<int32_t>(shape)].push(slot_state);
             }
 
             for (int32_t b = 0; b < claim; b++) {
@@ -357,13 +465,28 @@ void SchedulerContext::dispatch_shape(
                 if (is_mix) {
                     cores.clear_bit(core_offset);
                 }
-                dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending, start + b);
+                handle_count += prepare_block_for_dispatch(
+                    thread_idx, core_offset, *slot_state, shape, is_pending, start + b, &handles[handle_count]
+                );
             }
-            made_progress = true;
-#if SIMPLER_SCHED_PROFILING
-            l2_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
-#endif
+
+            // Sync_start exclusion: flush per task so prior tasks have head-
+            // start time before any sync_start drain check. Normal batches
+            // fall through and accumulate for one cross-task flush at the
+            // end of the pop.
+            if (any_sync_start) {
+                flush_publish();
+            }
         }
+
+        flush_publish();
+        for (int i = 0; i < published_n; i++) {
+            sched_->record_published_blocks(*published_list[i], published_counts[i]);
+            sched_->propagate_dispatch_fanin(*published_list[i]);
+        }
+#if SIMPLER_SCHED_PROFILING
+        l2_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
+#endif
 
         if (!dispatched_any) break;
 
@@ -373,8 +496,9 @@ void SchedulerContext::dispatch_shape(
     }
 }
 
-void SchedulerContext::dispatch_ready_tasks(
-    Runtime *runtime, int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+template <typename StageFn, typename ResidualMixFn>
+void SchedulerContext::run_staging_order(
+    int32_t thread_idx, bool pmu_active, StageFn &&stage, ResidualMixFn &&residual_mix
 ) {
     using Phase = CoreTracker::DispatchPhase;
 
@@ -387,24 +511,17 @@ void SchedulerContext::dispatch_ready_tasks(
     };
     const PTO2ResourceShape *aic_aiv = kAicAivOrder[thread_idx & 1];
 
-    bool entered_drain = false;
-
     // ===== IDLE stage =====
-    dispatch_shape(
-        runtime, thread_idx, PTO2ResourceShape::MIX, Phase::IDLE, tracker, entered_drain, made_progress, try_pushed
-    );
-    if (entered_drain) return;
+    if (stage(PTO2ResourceShape::MIX, Phase::IDLE)) return;
 
     // MIX-IDLE residual: AIC/AIV (both IDLE and PENDING) yield for this pass.
     // MIX-PENDING below still runs — that is the core of "mix strict priority":
     // pending slots are spent on mix before AIC/AIV get any chance.
-    bool skip_aic_aiv = has_residual_mix();
+    bool skip_aic_aiv = residual_mix();
 
     if (!skip_aic_aiv) {
         for (int i = 0; i < 2; i++) {
-            PTO2ResourceShape s = aic_aiv[i];
-            dispatch_shape(runtime, thread_idx, s, Phase::IDLE, tracker, entered_drain, made_progress, try_pushed);
-            if (entered_drain) return;
+            if (stage(aic_aiv[i], Phase::IDLE)) return;
         }
     }
 
@@ -420,16 +537,12 @@ void SchedulerContext::dispatch_ready_tasks(
     // The gate is NOT subject to skip_aic_aiv — residual mix continues to drain
     // via pending slots on this thread when no peer is idle.
     if (!has_idle_in_other_threads(thread_idx, PTO2ResourceShape::MIX)) {
-        dispatch_shape(
-            runtime, thread_idx, PTO2ResourceShape::MIX, Phase::PENDING, tracker, entered_drain, made_progress,
-            try_pushed
-        );
-        if (entered_drain) return;
+        if (stage(PTO2ResourceShape::MIX, Phase::PENDING)) return;
     }
 
     // Re-check after MIX-PENDING. If MIX-IDLE already set skip_aic_aiv, leave
     // it set; otherwise, escalate iff PENDING-MIX left residual.
-    if (!skip_aic_aiv && has_residual_mix()) {
+    if (!skip_aic_aiv && residual_mix()) {
         skip_aic_aiv = true;
     }
 
@@ -440,9 +553,543 @@ void SchedulerContext::dispatch_ready_tasks(
     for (int i = 0; i < 2; i++) {
         PTO2ResourceShape s = aic_aiv[i];
         if (has_idle_in_other_threads(thread_idx, s)) continue;
-        dispatch_shape(runtime, thread_idx, s, Phase::PENDING, tracker, entered_drain, made_progress, try_pushed);
-        if (entered_drain) return;
+        if (stage(s, Phase::PENDING)) return;
     }
+}
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+
+// 修改理由：C 钩子转调 SchedulerContext，供 pto_scheduler.h 内联的 route_ready_once 使用。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state) {
+    return static_cast<SchedulerContext *>(sched_ctx)->enqueue_fanout_direct_aic(thread_idx, slot_state);
+}
+
+CoreTracker::BitStates SchedulerContext::fanout_aic_safe_pending_cores(int32_t thread_idx) const {
+    // 修改理由：挂正常 pending 时排除已有 pending 的核，以及 ED=STAGING /
+    // sync_start+DISPATCHED 的 running 核，否则易 Case-3.1 死锁。
+    CoreTracker::BitStates safe(0ULL);
+    CoreTracker::BitStates cand =
+        core_trackers_[thread_idx].get_pending_core_offset_states(PTO2ResourceShape::AIC);
+    while (cand.has_value()) {
+        const int32_t core_offset = cand.pop_first();
+        const int32_t core_id = core_trackers_[thread_idx].get_core_id_by_offset(core_offset);
+        const CoreExecState &core = core_exec_states_[core_id];
+        if (core.pending_slot_state != nullptr) {
+            continue;
+        }
+        const PTO2TaskSlotState *rs = core.running_slot_state;
+        if (rs != nullptr && rs->payload != nullptr) {
+            const uint8_t ed = rs->payload->early_dispatch_state.load(std::memory_order_relaxed);
+            if (ed == PTO2_EARLY_DISPATCH_STAGING) {
+                continue;
+            }
+            if (ed == PTO2_EARLY_DISPATCH_DISPATCHED && rs->active_mask.requires_sync_start()) {
+                continue;
+            }
+        }
+        safe |= CoreTracker::BitStates(1ULL << core_offset);
+    }
+    return safe;
+}
+
+bool SchedulerContext::fanout_aic_pending_gate_ok(int32_t thread_idx) const {
+    // 修改理由：与 run_staging_order AIC-PENDING 同门控——有 MIX 残留则让路；
+    // 对端有空闲则本线程不挂 pending；且本地须有安全 pending 核。
+    if (has_residual_mix()) {
+        return false;
+    }
+    if (has_idle_in_other_threads(thread_idx, PTO2ResourceShape::AIC)) {
+        return false;
+    }
+    return fanout_aic_safe_pending_cores(thread_idx).has_value();
+}
+
+bool SchedulerContext::enqueue_fanout_direct_aic(int32_t thread_idx, PTO2TaskSlotState &slot_state) {
+#if defined(SIMPLER_PMU) && SIMPLER_PMU
+    // 修改理由：PMU 路径下不走直挂，与正常 PENDING 抑制一致。
+    if (is_pmu_enabled()) {
+        return false;
+    }
+#endif
+    // 修改理由：资格——仅 AIC + 单逻辑块 + 非 sync_start + 谓词通过；
+    // AIV / MIX / SPMD(block_num!=1) 永不进入，避免打乱既有调度语义。
+    if (slot_state.active_mask.to_shape() != PTO2ResourceShape::AIC) {
+        return false;
+    }
+    if (slot_state.logical_block_num != 1) {
+        return false;
+    }
+    if (slot_state.active_mask.requires_sync_start()) {
+        return false;
+    }
+    if (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass()) {
+        return false;
+    }
+    // 修改理由：不得抢 early-dispatch 消费者——否则会跳过 try_early_dispatch_release，
+    // 门铃不响导致 gated 核 S1。
+    if (slot_state.payload->early_dispatch_state.load(std::memory_order_acquire) !=
+        PTO2_EARLY_DISPATCH_NONE) {
+        return false;
+    }
+
+    // 修改理由：对齐 run_staging_order——有 MIX 残留时本轮不直挂 AIC，回落 readyQ，
+    // 保持 MIX 严格优先。
+    if (has_residual_mix()) {
+        return false;
+    }
+
+    // 修改理由：admit 仅本线程空闲 AIC（A/B 基线）；勿把 idle+pending 相加，
+    // 否则过 defer 易 orphan 致 S3。pending 挂核另开。
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    const int32_t admit_cap = tracker.get_idle_core_offset_states(PTO2ResourceShape::AIC).count();
+    if (admit_cap <= 0) {
+        return false;
+    }
+
+    int32_t &n = fanout_direct_aic_pending_n_[thread_idx];
+    if (n >= admit_cap || n >= kFanoutDirectAicPendingCap) {
+        return false;
+    }
+
+    // 修改理由：defer 窗口内用 CAS 把 ED NONE→DISPATCHED，占住槽位，防止并发 early-dispatch
+    // 再标 STAGING 与直挂冲突。
+    uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
+    if (!slot_state.payload->early_dispatch_state.compare_exchange_strong(
+            expect, PTO2_EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        )) {
+        return false;
+    }
+
+    // 修改理由：与 route_ready_once 同样先 claim；若对端已 claim，返回 true 表示已处理，
+    // 避免回落第二次 claim 失败导致就绪丢失。
+    if (!sched_->try_claim_ready_once(slot_state)) {
+        return true;
+    }
+
+    fanout_direct_aic_pending_[thread_idx][n++] = &slot_state;
+    return true;
+}
+
+void SchedulerContext::drain_fanout_direct_aic_pending(
+    int32_t thread_idx, bool &made_progress, bool &try_pushed, bool flush_to_ready_only, bool pmu_active
+) {
+    int32_t &n = fanout_direct_aic_pending_n_[thread_idx];
+    auto push_ready = [&](PTO2TaskSlotState *slot) {
+        // 修改理由：不变量——每个已 claim 的 fanout 槽最终必须上核或进 ready_queues。
+        sched_->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].push(slot);
+    };
+
+    // 修改理由：sync_start stop-the-world 占用核时禁止在此 stage，只把已 claim 槽推进
+    // readyQ，保证 drain 后仍可达。有 MIX 残留时同 skip_aic_aiv，不抢 AIC。
+    const bool force_ready = flush_to_ready_only || has_residual_mix();
+
+    for (int32_t i = 0; i < n; i++) {
+        PTO2TaskSlotState *slot = fanout_direct_aic_pending_[thread_idx][i];
+        if (force_ready) {
+            push_ready(slot);
+            continue;
+        }
+        if (!try_fanout_direct_dispatch_aic(thread_idx, *slot, &made_progress, &try_pushed, pmu_active)) {
+            push_ready(slot);
+        }
+    }
+    n = 0;
+}
+
+bool SchedulerContext::try_fanout_direct_dispatch_aic(
+    int32_t thread_idx, PTO2TaskSlotState &slot_state, bool *made_progress, bool *try_pushed, bool pmu_active
+) {
+#if defined(SIMPLER_PMU) && SIMPLER_PMU
+    if (is_pmu_enabled()) {
+        return false;
+    }
+#endif
+    if (slot_state.active_mask.to_shape() != PTO2ResourceShape::AIC) {
+        return false;
+    }
+    if (slot_state.logical_block_num != 1) {
+        return false;
+    }
+    if (slot_state.active_mask.requires_sync_start()) {
+        return false;
+    }
+    if (slot_state.active_mask.has_predicate() && !slot_state.payload->predicate.pass()) {
+        return false;
+    }
+    // 修改理由：enqueue 已 CAS 为 DISPATCHED；若仍见 STAGING 则拒绝 stage，防协议破坏。
+    const uint8_t ed = slot_state.payload->early_dispatch_state.load(std::memory_order_acquire);
+    if (ed == PTO2_EARLY_DISPATCH_STAGING) {
+        return false;
+    }
+    // 修改理由：stage 时再查 MIX 残留（enqueue 后可能出现），与正常 staging 一致。
+    if (has_residual_mix()) {
+        return false;
+    }
+
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    CoreTracker::BitStates cores(0ULL);
+    bool to_pending = false;
+
+    // 修改理由：当前仅 idle stage（A/B 基线）；pending 挂核路径单独启用前不上核。
+    cores = tracker.get_idle_core_offset_states(PTO2ResourceShape::AIC);
+    if (!cores.has_value()) {
+        (void)pmu_active;
+        return false;
+    }
+
+    const int32_t available = cores.count();
+    int32_t start = 0;
+    const int32_t claim = slot_state.claim_block_range(slot_state.logical_block_num, available, start);
+    if (claim == 0) {
+        return false;
+    }
+
+    // 修改理由：单块任务 claim!=0 即整任务；无余块需再 push。
+
+    PublishHandle handles[CoreTracker::MAX_CLUSTERS];
+    int handle_count = 0;
+    for (int32_t b = 0; b < claim; b++) {
+        const int32_t core_offset = cores.pop_first();
+        handle_count += prepare_block_for_dispatch(
+            thread_idx, core_offset, slot_state, PTO2ResourceShape::AIC, to_pending, start + b,
+            &handles[handle_count]
+        );
+    }
+    // 修改理由：AIC prepare 每块恒返回 1；claim_block_range 已推进 next_block_idx 后
+    // 不可再 return false（readyQ 回落会见 claim==0 而丢任务）。
+    debug_assert(handle_count > 0);
+
+    wmb();
+    uint64_t dispatch_ts = 0;
+#if SIMPLER_DFX
+    if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
+        dispatch_ts = get_sys_cnt_aicpu();
+    }
+#endif
+    for (int i = 0; i < handle_count; i++) {
+        publish_subtask_to_core(handles[i], dispatch_ts);
+    }
+
+    sched_->record_published_blocks(slot_state, claim);
+    sched_->propagate_dispatch_fanin(slot_state);
+
+    if (made_progress != nullptr) {
+        *made_progress = true;
+    }
+    if (try_pushed != nullptr) {
+        *try_pushed = true;
+    }
+    return true;
+}
+
+#endif  // SIMPLER_SCHED_FANOUT_DIRECT_AIC
+
+void SchedulerContext::dispatch_ready_tasks(
+    int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+) {
+    // Normal ready dispatch (is_ready): dispatch_shape places each block on pickup and
+    // signals a stop by setting entered_drain when it enters a sync_start drain.
+    bool entered_drain = false;
+
+    // Tier 0: ready sync_start cohorts take cores before any regular ready task
+    // (sync_start > MIX > C/V within the normal source). Same order and machinery,
+    // fed from ready_sync_queues; an oversized cohort arms the stop-the-world drain
+    // (entered_drain), which also short-circuits the regular tier below.
+    run_staging_order(
+        thread_idx, pmu_active,
+        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
+            dispatch_shape(
+                thread_idx, sched_->ready_sync_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
+            );
+            return entered_drain;
+        },
+        [&] {
+            return has_residual_sync_mix();
+        }
+    );
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+    // 修改理由：任何提前 return（含 entered_drain）前必须清空 fanout defer——
+    // 已 claim 槽只能上核或进 readyQ，不能只留在线程本地缓冲；否则会 S3。
+    // sync_start drain 占用机器时 flush_to_ready_only=true。
+    drain_fanout_direct_aic_pending(
+        thread_idx, made_progress, try_pushed, /*flush_to_ready_only=*/entered_drain, pmu_active
+    );
+#endif
+    if (entered_drain) return;
+
+    // Tier 1: regular ready work.
+    run_staging_order(
+        thread_idx, pmu_active,
+        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
+            dispatch_shape(
+                thread_idx, sched_->ready_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
+            );
+            return entered_drain;
+        },
+        [&] {
+            return has_residual_mix();
+        }
+    );
+}
+
+// Stage the ALREADY-CLAIMED range [start, start+count) of consumer `c` onto
+// thread_idx's idle then pending cores. The caller has atomically advanced
+// next_block_idx by `count` AND re-pushed `c` for peers
+// BEFORE calling this — so this, the expensive prepare+publish, runs CONCURRENTLY
+// with peers staging other ranges of the same consumer. This mirrors the normal
+// SPMD dispatch path (claim range -> re-push -> dispatch).
+// `idle`/`pend` are this thread's free-core sets, sized so idle.count+pend.count >=
+// count (the caller clamped the claim to them), so all `count` blocks get a core.
+//
+// Rule 1: idle cores -> gated task in the RUNNING slot. Rule 2: PENDING slot of
+// cores running a real task -> promoted in when that task FINs (gated-pending Case
+// 3.3 in decide_slot_transition completes the running FIN + promotes instead of
+// waiting for an ack the gated task never sends). Each staged core stays
+// pending_occupied while gated, so no second gated block stacks on it.
+//
+// Doorbell ownership: release flips STAGING->DISPATCHED and exchanges the shared
+// mask to claim its bits. A late stager ORs its bits, then fetch-and-clears only
+// those release did not take and rings them from its immutable local handles.
+// The seq_cst order guarantees every gated core has exactly one writer.
+int32_t SchedulerContext::stage_consumer_blocks(
+    int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+    CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
+) {
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    // Stamp the real pre-stage time (NOT 0) so the swimlane shows these blocks
+    // dispatched during the producer's run, not at trace start.
+    uint64_t early_dispatch_ts = get_sys_cnt_aicpu();
+    uint64_t my_cores[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};  // cores gated by this staging pass
+    int32_t staged = 0;
+    int32_t block = start;
+    // Mirror the normal flush_publish (scheduler_dispatch.cpp wmb()+publish loop):
+    // prepare ALL claimed blocks' payloads (idle bucket -> running slot, pend bucket
+    // -> gated pending), then ONE wmb(), then publish. The wmb guarantees the
+    // src_payload gate + source args are globally visible before any DATA_MAIN_BASE token —
+    // without it a gated core can pick up the token and dcci a stale payload. The
+    // shared `count` budget bounds total blocks <= free clusters/cores, so both
+    // buckets fit one handles[] buffer.
+    PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
+    int n = 0;
+    auto prepare_from = [&](CoreTracker::BitStates &avail, bool to_pending) {
+        while (count > 0 && avail.has_value()) {
+            int32_t core_offset = avail.pop_first();
+            n += prepare_block_for_dispatch(
+                thread_idx, core_offset, *c, shape, to_pending, block, &handles[n], /*force_gate=*/true
+            );
+            block++;
+            count--;
+            staged++;
+        }
+    };
+    if (idle.has_value()) prepare_from(idle, /*to_pending=*/false);
+    if (pend.has_value()) prepare_from(pend, /*to_pending=*/true);
+    if (n > 0) {
+        wmb();
+        for (int i = 0; i < n; i++) {
+            publish_subtask_to_core(handles[i], early_dispatch_ts);
+            int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
+            sched_->early_dispatch_doorbell_table[cid].addr = handles[i].reg_addr;
+            sched_->early_dispatch_doorbell_table[cid].token = handles[i].reg_task_id;
+            my_cores[cid >> 6] |= (1ULL << (cid & 63));
+        }
+    }
+    // Publish all this thread's gated cores into the shared mask in one OR per word
+    // (vs one per subtask) so release sees them; seq_cst keeps the self-ring order.
+    for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
+        if (my_cores[w] != 0) c->payload->staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
+
+    // Full publication and release are independent events. The seq_cst
+    // state/launch/count operations form a two-sided handshake. A released
+    // block must ring before contributing to the publication count.
+    bool released = staged > 0 &&
+                    c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_DISPATCHED;
+
+    // Claim only bits the release path did not take. Local handles remain valid
+    // even if the shared per-core table is reused before this thread resumes.
+    if (released) {
+        uint64_t owned[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
+        for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+            if (my_cores[w] != 0) {
+                owned[w] =
+                    PTO2SchedulerState::claim_late_staged_doorbell_bits(c->payload->staged_core_mask[w], my_cores[w]);
+            }
+        }
+        for (int i = 0; i < n; i++) {
+            int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
+            PTO2SchedulerState::ring_claimed_local_doorbell(
+                owned[cid >> 6], cid, handles[i].reg_addr, handles[i].reg_task_id
+            );
+        }
+        wmb();
+    }
+    sched_->record_published_blocks(*c, staged);
+    // Retry unconditionally after publication. The guards are cheap, and a
+    // pre-ring state read can become stale if release completes before this
+    // count update.
+    sched_->propagate_dispatch_fanin(*c);
+    return staged;
+}
+
+// Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
+// pre-stage claimed block ranges onto this thread's `shape` cores for `phase`. IDLE
+// stages onto idle cores (RUNNING slot, gated); PENDING stages onto a running core's
+// gated pending slot. Candidates are pushed to the shape's queue EVENT-DRIVEN by
+// propagate_dispatch_fanin, so the shape is the queue index (no per-consumer
+// to_shape()). Returns the number of blocks staged.
+int32_t
+SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
+    CoreTracker &tracker = core_trackers_[thread_idx];
+    int32_t s = static_cast<int32_t>(shape);
+    bool is_mix = (shape == PTO2ResourceShape::MIX);
+    bool is_idle = (phase == CoreTracker::DispatchPhase::IDLE);
+
+    // Size the pop exactly as dispatch_shape does: MIX to the cluster count, else the
+    // phase's dispatchable-core count. Skip the queue entirely when no core is free
+    // for this shape+phase (avoids a pointless pop + immediate push-back).
+    CoreTracker::BitStates cores =
+        is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
+    if (!cores.has_value()) return 0;
+
+    int32_t total_staged = 0;
+    PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
+    // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
+    // bounded by the shape's capacity so the stack buffer always holds it. Then for
+    // each consumer: CLAIM a range sized to THIS thread's free cores by advancing
+    // next_block_idx with a CAS (atomic — next_block_idx is shared with normal
+    // dispatch, which also claims it if release routes the consumer to the ready
+    // queue, so a plain store could double-dispatch), RE-PUSH it for peers, THEN do
+    // the expensive prepare+publish. Re-pushing before staging lets peers claim the
+    // next range and stage CONCURRENTLY — a wide consumer (online_softmax, 48 blocks)
+    // is filled by all idle threads in parallel. When cores run out mid-batch the
+    // unprocessed remainder is pushed back for peers (mirrors normal's push_batch of
+    // the unconsumed tail).
+    int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
+    for (int bi = 0; bi < got; bi++) {
+        PTO2TaskSlotState *c = batch[bi];
+        if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
+        if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
+            continue;  // released
+
+        // The single free-core bucket for this phase. For MIX, an active-mask-aware
+        // whole-cluster scan keeps only the clusters whose placement matches the phase
+        // (RUNNING placement for IDLE, PENDING placement for PENDING), matching normal
+        // dispatch's classify_mix_cluster — unused cores in the cluster are ignored, so
+        // a MIX whose unused AIV is busy is not stranded. For AIC/AIV it is just the
+        // phase's dispatchable cores.
+        CoreTracker::BitStates bucket;
+        if (is_mix) {
+            auto wanted = is_idle ? CoreTracker::MixPlacement::RUNNING : CoreTracker::MixPlacement::PENDING;
+            uint8_t cmask = c->active_mask.core_mask();
+            CoreTracker::BitStates candidates = tracker.get_cluster_offset_states();
+            while (candidates.has_value()) {
+                int32_t cluster_offset = candidates.pop_first();
+                if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
+                    bucket |= CoreTracker::BitStates(1ULL << cluster_offset);
+                }
+            }
+        } else {
+            bucket = tracker.get_dispatchable_cores(shape, phase);
+        }
+        int32_t freecores = bucket.has_value() ? bucket.count() : 0;
+        if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
+            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
+            break;
+        }
+        int32_t start = 0;
+        int32_t claim = c->claim_block_range(c->logical_block_num, freecores, start);
+        if (claim == 0) continue;  // nothing left to claim -> drop (no re-push)
+        // Re-push for concurrent peers BEFORE the expensive staging.
+        if (start + claim < c->logical_block_num) {
+            if (!sched_->early_dispatch_queues[s].push_tagged(c, task_id_snapshots[bi]))
+                LOG_INFO_V9(
+                    "[EARLY_DISPATCH] queue full on re-push, consumer=%" PRId64,
+                    static_cast<int64_t>(c->task->task_id.raw)
+                );
+        }
+        // stage_consumer_blocks fills the idle bucket (RUNNING slot) then the pend
+        // bucket (gated pending); pass this phase's bucket in the matching slot and an
+        // empty other so only the phase's cores are staged.
+        CoreTracker::BitStates empty(0ULL);
+        total_staged += is_idle ? stage_consumer_blocks(thread_idx, c, shape, start, claim, bucket, empty) :
+                                  stage_consumer_blocks(thread_idx, c, shape, start, claim, empty, bucket);
+    }
+    return total_staged;
+}
+
+// Early-dispatch drain (idle pass) — the EARLY source's analog of dispatch_ready_tasks.
+// Both sources share run_staging_order for the shape order (MIX strict priority, IDLE
+// before PENDING, cross-thread idle gating: MIX-IDLE ▶ c/v-IDLE ▶ MIX-PEND ▶ c/v-PEND) and
+// both drain their sync_start cohort FIRST as the highest occupancy tier (Tier 0), via the
+// same all-or-nothing drain barrier. This one owns its own gating and progress flags.
+// Returns the number of blocks staged this pass (for the EarlyDispatch swimlane bar).
+int32_t SchedulerContext::try_early_dispatch(
+    int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+) {
+    // Gate, owned here rather than by the caller (mirrors dispatch_ready_tasks
+    // withholding PENDING under PMU internally):
+    //   - pmu_active: staging gated work perturbs the single-issue PMU windows the
+    //     same way dual-issue PENDING dispatch does, so early dispatch is off.
+    //   - has_any_free_slot: this thread has no spare capacity to stage onto (a
+    //     purely local read; a fully-occupied thread bails before touching shared
+    //     queues).
+    //   - ready queues empty: normal dispatch (both the ready sync_start lane and the
+    //     regular ready_queues) strictly precedes early — there is no real ready task
+    //     to delay only when every normal queue is drained.
+    if (pmu_active || !tracker.has_any_free_slot()) return 0;
+    for (int s = 0; s < PTO2_NUM_RESOURCE_SHAPES; s++) {
+        if (sched_->ready_sync_queues[s].size() > 0 || sched_->ready_queues[s].size() > 0) return 0;
+    }
+
+    // ===== Tier 0: sync_start cohorts (highest occupancy tier, all-or-nothing) =====
+    // sync_start candidates park in their own shape-agnostic queue. They cannot ride
+    // early_dispatch_shape's per-thread partial range-claim (a partial claim strands gated
+    // cohort blocks nobody rings, so the rendezvous never reaches block_num). Instead arm the
+    // drain barrier: it takes exclusive tracker access and only stages when global
+    // idle+pending >= block_num, guaranteeing all-or-nothing. Win => the dispatch loop runs
+    // the gated drain next iteration; lose (a drain is already armed, or capacity <
+    // block_num) => cancel the owner and re-push or transfer its final ready route. A
+    // non-STAGING pop was already released and is dropped. Staging happens inside the drain,
+    // so this arms at most one drain and adds no blocks to total_staged here.
+    uint64_t sync_task_id_snapshot = 0;
+    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+        bool current_sync_task = static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot &&
+                                 c->active_mask.requires_sync_start();
+        if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
+            if (c->payload->early_dispatch_state.load(std::memory_order_seq_cst) != PTO2_EARLY_DISPATCH_STAGING) {
+                sched_->cancel_early_sync_drain(*c);
+            } else if (enter_drain_mode(c, c->logical_block_num)) {
+                PTO2SchedulerState::mark_early_sync_drain_armed(*c->payload);
+            } else {
+                sched_->cancel_early_sync_drain(*c);
+            }
+        }
+    }
+
+    // Regular early staging (NOT is_ready): same MIX/idle/pending order as normal dispatch,
+    // via the shared skeleton. early_dispatch_shape stages a gated block range and never
+    // enters drain, so the stage callback always reports "no stop".
+    int32_t total_staged = 0;
+    run_staging_order(
+        thread_idx, pmu_active,
+        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
+            total_staged += early_dispatch_shape(thread_idx, shape, phase);
+            return false;
+        },
+        [&] {
+            return has_residual_early_mix();
+        }
+    );
+
+    // Staging is dispatch work: reset the idle/stall clock and route this iter's tail
+    // cycles to the dispatch accumulator, exactly as normal dispatch does.
+    if (total_staged > 0) {
+        made_progress = true;
+        try_pushed = true;
+    }
+    return total_staged;
 }
 
 // =============================================================================
@@ -450,6 +1097,7 @@ void SchedulerContext::dispatch_ready_tasks(
 // =============================================================================
 
 int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
+    always_assert(sched_ != nullptr);
     CoreTracker &tracker = core_trackers_[thread_idx];
     LOG_INFO_V0("Thread %d: resolve_and_dispatch entry", thread_idx);
 
@@ -470,7 +1118,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
-    LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, tracker.core_num());
+    LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
     int32_t cur_thread_completed = 0;
     // Non-zero once a scheduler-hang timeout latches; returned in place of the
     // completed count so the caller still sees the negative error rc while the
@@ -488,10 +1136,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     int32_t deferred_release_count = 0;
 
     // PMU runs require single-issue dispatch — overlapping in-flight tasks
-    // pollute per-task PMU counters. Cached at function scope (parity with
-    // a2a3): is_pmu_enabled() is extern "C" and the compiler cannot hoist it
-    // across the dispatch loop on its own, and the value is loop-invariant
-    // (PMU is latched once at kernel entry).
+    // pollute per-task PMU counters, so skip the PENDING pre-load phase.
+    // Cached at function scope: is_pmu_enabled() is extern "C" and the
+    // compiler cannot hoist it across the dispatch loop on its own.
 #if SIMPLER_DFX
     const bool pmu_active = is_pmu_enabled();
 #else
@@ -535,7 +1182,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             // and silently corrupt the snapshot.
             constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
             for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++) {
-                const size_t qsize = sched_->ready_queues[s].size();
+                // Total normal-source ready depth of shape `s` = regular ready lane + the
+                // sync_start Tier-0 lane; both feed dispatch_ready_tasks for this shape.
+                const size_t qsize = sched_->ready_queues[s].size() + sched_->ready_sync_queues[s].size();
                 iter_shared_snapshot[s] = static_cast<int16_t>(std::min(qsize, kMax));
             }
             iter_shared_sampled = true;
@@ -586,6 +1235,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         CYCLE_COUNT_START();
         l2_swimlane.sched_loop_count++;
         uint64_t _t0_phase = _t0;
+        // Release is the only "no Complete/Dispatch bar" attribution we keep —
+        // emitted with its own span in the idle branch below. Iterations that
+        // only scan/poll show as blank gaps; the per-loop Poll/Scan bars (PR
+        // #1079 debug overlay) were removed since "scheduler is polling when
+        // there's nothing to do" carries no actionable signal.
         // Per-iter lazy shared-queue snapshot: first phase emit in this iter
         // pays the atomic-load cost, subsequent emits in the same iter reuse
         // the cached value. Reset here so we re-sample exactly once per iter
@@ -664,20 +1318,26 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
         } else {
             CYCLE_COUNT_LAP(l2_swimlane.sched_complete_cycle);
-            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && l2_swimlane.phase_complete_count > 0) {
+            // Emit on any completion work this iteration — a finished slot OR
+            // sub-block retires that did not finish a slot. The latter makes the
+            // SPMD harvest tail visible (count field = blocks processed this
+            // iteration; on a pure-retire iteration phase_complete_count is 0).
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES &&
+                (l2_swimlane.phase_complete_count > 0 || l2_swimlane.phase_subretire_count > 0)) {
                 // Complete's release_fanin pushes newly-ready consumers into the
                 // shared ready_queues[], so the end depth differs from the start.
                 int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
                 capture_phase_end_fresh(phase_end_shared);
                 l2_swimlane_aicpu_record_sched_phase(
                     thread_idx, L2SwimlaneSchedPhaseKind::Complete, _t0_phase, _t1, l2_swimlane.sched_loop_count,
-                    l2_swimlane.phase_complete_count, /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared,
-                    phase_end_shared
+                    l2_swimlane.phase_complete_count + l2_swimlane.phase_subretire_count, /*pop_hit=*/0,
+                    /*pop_miss=*/0, phase_start_shared, phase_end_shared
                 );
                 for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
                     phase_start_shared[s] = phase_end_shared[s];
                 _t0_phase = _t1;
                 l2_swimlane.phase_complete_count = 0;
+                l2_swimlane.phase_subretire_count = 0;
             }
         }
 #endif
@@ -686,38 +1346,79 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Phase 2 drain check
         if (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
-            handle_drain_mode(runtime, thread_idx);
+#if SIMPLER_DFX
+            // The drain is otherwise a swimlane blind spot: the `continue` below skips
+            // every phase record, and handle_drain_mode is uninstrumented. Time it here so
+            // the sync_start stop-the-world window shows on the scheduler lane (one bar per
+            // iteration that enters the drain; retries appear as multiple bars).
+            uint64_t drain_t0 = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
+            uint64_t drain_stage_wall = 0;  // set by handle_drain_mode ONLY if this thread staged
+            handle_drain_mode(thread_idx, &drain_stage_wall);
+            // Record a Drain bar only when this thread actually did drain work (reached
+            // drain_stage_cores). The many no-op entries — ack + availability-insufficient
+            // reset, stale-elected, non-elected bail before stage_go — never stage, so they
+            // would otherwise clutter the lane with zero-work drain(0) bars.
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && drain_stage_wall != 0) {
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::Drain, drain_t0, get_sys_cnt_aicpu(),
+                    l2_swimlane.sched_loop_count, static_cast<uint32_t>(drain_stage_wall)
+                );
+            }
+#else
+            handle_drain_mode(thread_idx);
+#endif
             continue;
         }
 
-        // Phase 3: Drain dummy ready queue (thread 0 only).
+        // Phase 3: Drain dummy ready queue (S0/S1/S2).
         //
         // Dependency-only tasks bypass AICore dispatch: they go through the
         // scheduler so fanin/fanout edges stay consistent, but completion is
-        // signalled inline here. Pinned to thread 0 to avoid cross-thread races.
-        if (thread_idx == 0) {
-            constexpr int DUMMY_DRAIN_BATCH = 16;
+        // signalled inline here. The ready queue is MPMC, and the fanout path
+        // uses per-slot locks/atomics, so multiple scheduler threads can share
+        // the dependency-only resolve work.
+        if (thread_idx < 3) {
+            constexpr int DUMMY_DRAIN_BATCH = 8;
             PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
 #if SIMPLER_DFX
             // Dummy outer phase: covers handling of all dummies popped this
-            // iter. tasks_processed = dummy_got.
+            // iter. Per-dummy DummyTask markers are emitted to a SEPARATE lane
+            // (Worker View AICPU_N) by the converter, so they do not nest
+            // under this bar. Resolve emits below DO land on the sched lane
+            // and nest under this Dummy outer by time containment.
             uint64_t dummy_outer_t0 =
                 (dummy_got > 0 && l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
 #endif
             for (int di = 0; di < dummy_got; di++) {
                 PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
+
+                // ----- Resolve work: walk this dummy's consumer list. ------
+                // Same 1 µs filter as the main-path Resolve emit suppresses
+                // dummies whose consumer release runs sub-microsecond.
 #if SIMPLER_DFX
                 uint64_t dummy_resolve_t0 =
                     (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
 #endif
+                // [[maybe_unused]] silences -Werror=unused-but-set-variable on
+                // the profiling-flags-smoke build path where SIMPLER_DFX is
+                // OFF and the Resolve emit below is excluded.
+                [[maybe_unused]] uint32_t dummy_consumers = 0;
 #if SIMPLER_SCHED_PROFILING
-                sched_->on_task_complete(dummy_slot, thread_idx);
+                dummy_consumers = sched_->on_task_complete(dummy_slot, thread_idx).fanout_edges;
 #else
-                sched_->on_task_complete(dummy_slot);
+                dummy_consumers = sched_->on_task_complete(dummy_slot);
 #endif
 #if SIMPLER_DFX
                 if (dummy_resolve_t0 != 0) {
+                    uint64_t dummy_resolve_t1 = get_sys_cnt_aicpu();
+                    constexpr uint64_t RESOLVE_EMIT_MIN_CYCLES = PLATFORM_PROF_SYS_CNT_FREQ / 1'000'000;  // 1 µs
+                    if (dummy_resolve_t1 - dummy_resolve_t0 >= RESOLVE_EMIT_MIN_CYCLES) {
+                        l2_swimlane_aicpu_record_sched_phase(
+                            thread_idx, L2SwimlaneSchedPhaseKind::Resolve, dummy_resolve_t0, dummy_resolve_t1,
+                            sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_consumers
+                        );
+                    }
                     l2_swimlane_aicpu_record_dummy_task(
                         thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
                         dummy_slot.task->task_id.raw
@@ -747,6 +1448,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 made_progress = true;
             }
 #if SIMPLER_DFX
+            // Emit Dummy outer over the whole dummy_drain pass. Span starts at
+            // dummy_outer_t0 (captured after pop_batch) and ends at "now".
+            // tasks_processed = dummy_got. Advancing _t0_phase here makes the
+            // following Dispatch / EarlyDispatch / second-Complete bars start
+            // at this end.
             if (dummy_outer_t0 != 0) {
                 uint64_t dummy_outer_t1 = get_sys_cnt_aicpu();
                 int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
@@ -759,45 +1465,88 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
                     phase_start_shared[s] = phase_end_shared[s];
                 _t0_phase = dummy_outer_t1;
+                // We do NOT re-sync _t0/_t1 — the dummy span will be absorbed
+                // into the next CYCLE_COUNT_LAP accumulator. The phase-model
+                // anchor (_t0_phase) is the authoritative source for bar spans
+                // on the swimlane; the cycle accumulators are coarse aggregates.
             }
 #endif
         }
 
         // Phase 4: MIX-strict-priority dispatch with phase-split and
         // cross-thread idle gating. See dispatch_ready_tasks for the policy.
-        // pmu_active is cached at function scope above (loop-invariant).
-        dispatch_ready_tasks(runtime, thread_idx, tracker, pmu_active, made_progress, try_pushed);
+#if SIMPLER_DFX
+        uint64_t dispatch_t0 = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
+#endif
+        dispatch_ready_tasks(thread_idx, tracker, pmu_active, made_progress, try_pushed);
+#if SIMPLER_DFX
+        // Emit Dispatch IMMEDIATELY after dispatch_ready_tasks so its span
+        // covers the actual publish work — not the trailing second-poll /
+        // early-dispatch time. (Pre-redesign the Dispatch emit lived at iter
+        // end with span extending past the second poll, which made finish_time
+        // events from the second poll fall under the Dispatch bar rather than
+        // a Complete bar of their own — confusing for trace consumers.)
+        if (dispatch_t0 != 0 && l2_swimlane.phase_dispatch_count > 0) {
+            uint64_t dispatch_t1 = get_sys_cnt_aicpu();
+            uint64_t pop_hit_delta = l2_swimlane.pop_hit - l2_swimlane.pop_hit_at_last_emit;
+            uint64_t pop_miss_delta = l2_swimlane.pop_miss - l2_swimlane.pop_miss_at_last_emit;
+            debug_assert(pop_hit_delta < (1ULL << 32));
+            debug_assert(pop_miss_delta < (1ULL << 32));
+            int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
+            capture_phase_end(phase_end_shared);
+            l2_swimlane_aicpu_record_sched_phase(
+                thread_idx, L2SwimlaneSchedPhaseKind::Dispatch, _t0_phase, dispatch_t1, l2_swimlane.sched_loop_count,
+                l2_swimlane.phase_dispatch_count, static_cast<uint32_t>(pop_hit_delta),
+                static_cast<uint32_t>(pop_miss_delta), phase_start_shared, phase_end_shared
+            );
+            for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++) {
+                phase_start_shared[s] = phase_end_shared[s];
+            }
+            _t0_phase = dispatch_t1;
+            l2_swimlane.phase_dispatch_count = 0;
+            l2_swimlane.pop_hit_at_last_emit = l2_swimlane.pop_hit;
+            l2_swimlane.pop_miss_at_last_emit = l2_swimlane.pop_miss;
+        }
+#endif
+
+        // Phase 4b: early-dispatch onto spare cores, mirroring the Phase 4 call
+        // shape. try_early_dispatch owns its own gating (off-PMU, this
+        // thread has a spare slot, no normal ready work queued) and updates
+        // made_progress / try_pushed, so this is a single unconditional call — it
+        // returns 0 without staging when gated out.
+#if SIMPLER_DFX
+        bool early_dispatch_record = l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES;
+        uint64_t early_dispatch_t0 = early_dispatch_record ? get_sys_cnt_aicpu() : 0;
+#endif
+        [[maybe_unused]] int32_t staged_count =
+            try_early_dispatch(thread_idx, tracker, pmu_active, made_progress, try_pushed);
+#if SIMPLER_DFX
+        // Emit an EarlyDispatch bar so a staging-dominated iteration is attributed
+        // to early-dispatch rather than disappearing into a blank gap.
+        if (early_dispatch_record && staged_count > 0) {
+            uint64_t early_dispatch_t1 = get_sys_cnt_aicpu();
+            l2_swimlane_aicpu_record_sched_phase(
+                thread_idx, L2SwimlaneSchedPhaseKind::EarlyDispatch, early_dispatch_t0, early_dispatch_t1,
+                sched_l2_swimlane_[thread_idx].sched_loop_count, static_cast<uint32_t>(staged_count)
+            );
+            // prepare_block_for_dispatch bumped phase_dispatch_count while staging;
+            // those blocks belong to this EarlyDispatch bar, so clear the counter
+            // before it leaks into the next Dispatch bar.
+            sched_l2_swimlane_[thread_idx].phase_dispatch_count = 0;
+            // Advance _t0_phase so the next phase bar starts at the EarlyDispatch
+            // end, not before it (otherwise their spans overlap and the
+            // outer-phase mutual-exclusion breaks).
+            _t0_phase = early_dispatch_t1;
+        }
+#endif
 
 #if SIMPLER_DFX
+        // Cycle-counter LAP for the iter tail. Dispatch's emit moved earlier
+        // (see Phase 4 above) so this branch only routes the time accumulator.
         if (!try_pushed) {
             CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
         } else {
             CYCLE_COUNT_LAP(l2_swimlane.sched_dispatch_cycle);
-            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && l2_swimlane.phase_dispatch_count > 0) {
-                // Final-drain at loop end emits the trailing-idle tail so
-                // sum-of-deltas == run-cumulative.
-                uint64_t pop_hit_delta = l2_swimlane.pop_hit - l2_swimlane.pop_hit_at_last_emit;
-                uint64_t pop_miss_delta = l2_swimlane.pop_miss - l2_swimlane.pop_miss_at_last_emit;
-                // L2SwimlaneAicpuSchedPhaseRecord's dispatch counters are uint32 — an overflow means
-                // an emit was missed for ~4 billion pops, which is well outside any
-                // realistic dispatch cadence and silently truncates without this guard.
-                debug_assert(pop_hit_delta < (1ULL << 32));
-                debug_assert(pop_miss_delta < (1ULL << 32));
-                int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
-                capture_phase_end(phase_end_shared);
-                l2_swimlane_aicpu_record_sched_phase(
-                    thread_idx, L2SwimlaneSchedPhaseKind::Dispatch, _t0_phase, _t1, l2_swimlane.sched_loop_count,
-                    l2_swimlane.phase_dispatch_count, static_cast<uint32_t>(pop_hit_delta),
-                    static_cast<uint32_t>(pop_miss_delta), phase_start_shared, phase_end_shared
-                );
-                for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++) {
-                    phase_start_shared[s] = phase_end_shared[s];
-                }
-                _t0_phase = _t1;
-                l2_swimlane.phase_dispatch_count = 0;
-                l2_swimlane.pop_hit_at_last_emit = l2_swimlane.pop_hit;
-                l2_swimlane.pop_miss_at_last_emit = l2_swimlane.pop_miss;
-            }
         }
 #endif
 
@@ -810,6 +1559,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             idle_iterations = 0;
             last_progress_ts = get_sys_cnt_aicpu();
         } else {
+#if SIMPLER_DFX
+            uint64_t rel_t0 = (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && deferred_release_count > 0) ?
+                                  get_sys_cnt_aicpu() :
+                                  0;
+#endif
             while (deferred_release_count > 0) {
 #if SIMPLER_SCHED_PROFILING
                 (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
@@ -817,6 +1571,18 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
             }
+#if SIMPLER_DFX
+            // Release is a distinct operation from the poll scan — emit it with
+            // its own span (Perfetto nests it inside the surrounding poll/idle
+            // run by time-containment) rather than competing with poll for one
+            // per-iteration label.
+            if (rel_t0 != 0) {
+                l2_swimlane_aicpu_record_sched_phase(
+                    thread_idx, L2SwimlaneSchedPhaseKind::Release, rel_t0, get_sys_cnt_aicpu(),
+                    l2_swimlane.sched_loop_count, /*tasks_processed=*/0
+                );
+            }
+#endif
             idle_iterations++;
 
             if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
@@ -869,9 +1635,13 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             SPIN_WAIT_HINT();
 #if SIMPLER_DFX
             CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
-            // a2a3 design has Complete + Dispatch sched phases only; idle gaps
-            // are reconstructed at post-process time from sched record spacing.
-            (void)_t0_phase;
+            // _t0_phase advances through idle laps so the next emitted
+            // COMPLETE/DISPATCH bar starts at the iter it actually ran in, not
+            // at the start of the preceding idle stretch. The idle/poll time
+            // itself is attributed by the activity-fill below — no blanks.
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
+                _t0_phase = _t1;
+            }
 #endif
         }
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -16,7 +16,6 @@
 
 #include "common/core_type.h"
 #include "common/platform_config.h"
-#include "pto2_dispatch_payload.h"
 #include "pto_runtime2_types.h"
 #include "spin_hint.h"
 
@@ -209,6 +208,25 @@ public:
 
     bool has_any_running_cores() const { return ((~core_states_) & (aic_mask_ | aiv_mask_)).has_value(); }
 
+    // True if any core on this thread still has a free slot to stage onto — an
+    // idle core (running slot) or a running core with a free pending slot. A
+    // core is unavailable only when running AND its pending slot is occupied;
+    // idle cores keep pending_occupied_ clear by invariant, so
+    // ~pending_occupied_ over all cores is exactly "has a free slot". Purely
+    // local (no shared/atomic access) — used to skip early dispatch, and its
+    // shared-queue pop, when this thread has no capacity at all.
+    // BitStates of every core on this thread with a free slot to stage onto: a
+    // core is unavailable only when running AND its pending slot is occupied.
+    // Idle cores keep pending_occupied_ clear by invariant, so ~pending_occupied_
+    // over aic|aiv is exactly "has a free slot". Spans AIC+AIV, so its .count() is
+    // an upper bound on the early-dispatch drain's per-shape pop (never exceeds the
+    // thread's total free cores), and .has_value() is the has_any_free_slot()
+    // predicate that gates the Phase-4b early-dispatch pass. Purely local (no
+    // shared/atomic access).
+    BitStates get_free_slot_states() const { return (~pending_occupied_) & (aic_mask_ | aiv_mask_); }
+
+    bool has_any_free_slot() const { return get_free_slot_states().has_value(); }
+
     template <CoreType CT>
     int32_t get_running_count() const {
         if constexpr (CT == CoreType::AIC) {
@@ -336,6 +354,53 @@ public:
         return MixPlacement::PENDING;
     }
 
+    // --- Gated MIX split placement ---
+    // A gated MIX block can place each of its cores INDEPENDENTLY (idle core -> gated
+    // running slot; busy core with a free pending slot -> gated pending slot), because
+    // every core waits on the doorbell and nothing executes until the rendezvous rings.
+    // This is unsafe for immediate (non-gated) dispatch — hence separate from
+    // classify_mix_cluster, which forces a single placement for the whole cluster.
+
+    // Cores of `cluster_offset` named by core_mask.
+    BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
+        BitStates used(0ULL);
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates(1ULL << cluster_offset);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates(1ULL << (cluster_offset + 1));
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates(1ULL << (cluster_offset + 2));
+        return used;
+    }
+
+    // Every used core has SOME free slot: a core lacks one only when it is running AND
+    // its pending slot is occupied (both slots taken).
+    bool mix_cluster_all_slots(int32_t cluster_offset, uint8_t core_mask) const {
+        BitStates used = mix_used_cores(cluster_offset, core_mask);
+        if (!used.has_value()) return false;
+        BitStates no_slot = (~core_states_) & pending_occupied_;  // running AND pending taken
+        return !(used & no_slot).has_value();
+    }
+
+    // Used cores that are idle -> will take a running slot (rendezvous seed count).
+    int32_t mix_cluster_idle_core_count(int32_t cluster_offset, uint8_t core_mask) const {
+        return (mix_used_cores(cluster_offset, core_mask) & core_states_).count();
+    }
+
+    // Clusters where every used core has a free slot (gated MIX split gate/iteration).
+    BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
+        BitStates result(0ULL);
+        BitStates candidates = get_cluster_offset_states();
+        while (candidates.has_value()) {
+            int32_t off = candidates.pop_first();
+            if (mix_cluster_all_slots(off, core_mask)) {
+                result |= BitStates(1ULL << off);
+            }
+        }
+        return result;
+    }
+
+    int32_t count_mix_split_clusters(uint8_t core_mask) const {
+        return get_mix_split_cluster_offset_states(core_mask).count();
+    }
+
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
         BitStates result(0ULL);
         BitStates candidates = get_cluster_offset_states();
@@ -412,6 +477,18 @@ struct SlotTransition {
     bool matched = false;        // some case was hit (otherwise skip apply)
 };
 
+#ifndef SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：编译开关默认开启 fanout 直挂 AIC；关闭后行为与 main 一致。
+#define SIMPLER_SCHED_FANOUT_DIRECT_AIC 1
+#endif
+
+#if SIMPLER_SCHED_FANOUT_DIRECT_AIC
+// 修改理由：对外钩子声明——仅单块 AIC（logical_block_num==1、!sync_start、谓词通过、
+// ED==NONE）可在 complete 扇出时 defer，跳过 ready_queues；AIV/MIX/SPMD/已 early-stage
+// 的任务永不进入。实现见 SchedulerContext::enqueue_fanout_direct_aic。
+bool pto2_try_fanout_direct_aic_enqueue(void *sched_ctx, int32_t thread_idx, PTO2TaskSlotState &slot_state);
+#endif
+
 // =============================================================================
 // Profiling counters (compile-time gated)
 // =============================================================================
@@ -420,12 +497,17 @@ struct SlotTransition {
 struct alignas(64) SchedL2SwimlaneCounters {
     bool l2_swimlane_enabled{false};
     uint64_t sched_start_ts{0};
-    uint64_t sched_scan_cycle{0};
     uint64_t sched_complete_cycle{0};
     uint64_t sched_dispatch_cycle{0};
     uint64_t sched_idle_cycle{0};
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
+    // Sub-block retires that did NOT finish a slot (SPMD blocks of a multi-block
+    // task retiring one at a time). Counted separately so the Complete-phase
+    // emit can fire on poll iterations that only retired sub-blocks — otherwise
+    // the serial-harvest tail of an SPMD slot is invisible (no slot completes
+    // until the last block, leaving the scheduler lane blank for that window).
+    uint32_t phase_subretire_count{0};
     uint32_t phase_dispatch_count{0};
     // Per-emit delta is (current - *_at_last_emit). Accumulated only when
     // l2_swimlane_level_ >= SCHED_PHASES.
@@ -455,7 +537,15 @@ struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> drain_worker_elected{0};  // 0=none; >0: elected thread's (thread_idx+1)
     std::atomic<uint32_t> drain_ack_mask{0};       // bit per thread; all-set = all threads reached ack barrier
     std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
-    int32_t _pad[10];
+    // Parallel staging: after the elected thread confirms global availability it sets
+    // stage_go, releasing every thread to stage its OWN cores concurrently (vs the old
+    // single-thread serial fill). Each thread ORs its bit into stage_done_mask when it
+    // finishes and accumulates its running-slot cores into running_staged; the elected
+    // thread waits for all bits, seeds the rendezvous, and reopens the gate.
+    std::atomic<int32_t> drain_stage_go{0};          // 0=hold; 1=elected released parallel staging
+    std::atomic<uint32_t> drain_stage_done_mask{0};  // bit per thread; all-set = all threads done staging
+    std::atomic<int32_t> drain_running_staged{0};    // sum of running-slot cores staged (rendezvous seed)
+    int32_t _pad[7];
 };
 static_assert(sizeof(SyncStartDrainState) == 64);
 


### PR DESCRIPTION
## Summary

WIP. Surplus-gate PENDING prefetch on **a2a3** (tensormap_and_ringbuffer + host_build_graph) and the same policy on **a5** (tensormap_and_ringbuffer), kept in sync. Default mode is **Min4** with `kPendingGateMinCap = 4`.

Related: #1341.

## Gate policies: Base / Full / Min4

Compile-time switch `kPendingGateMode` in `scheduler_dispatch.cpp` (same logic on a2a3 TMR/HBG and a5 TMR). Only the PENDING stage is gated; IDLE/running fill is unchanged. For Full/Min4, `dispatch_shape` / early-dispatch also cap the PENDING pop with `want_cap = pending_surplus(...)`.

### Base

Legacy behavior (no surplus / no `want_cap`):

- Enter MIX-PENDING only if `!has_idle_in_other_threads(self, MIX)`.
- Enter AIC/AIV-PENDING only if `!has_idle_in_other_threads(self, shape)` (skip that shape when a peer reports idle).
- `pending_want_cap = -1` (uncapped pending pop sized to local pending slots).
- Peer idle for AIC/AIV prefers published per-thread idle atomics; MIX still scans peer trackers.

### Full

Issue-style strict surplus (prefetch only on genuine surplus over **all** idle running capacity):

```text
reserved = Σ idle_running(shape)     # all scheduler threads
allow PENDING iff ready_depth(shape) > reserved
want_cap  = depth - reserved         # when allowed
```

- Replaces the Base peer-idle boolean skip on the PENDING stage.
- Encodes “an idle core anywhere beats a pending slot here,” but can suppress prefetch when the idle snapshot is large relative to a shallow ready wave.

### Min4 (default)

Capped surplus — compromise between Base and Full:

```text
reserved = min(Σ idle_running(shape), kPendingGateMinCap)   # default cap = 4
allow PENDING iff ready_depth(shape) > reserved
want_cap  = depth - reserved
```

- `kPendingGateMinCap` is a compile-time parameter (default **4**).
- Idle sum uses `count_idle_running_capped`: scan **self first**, stop once the running total reaches the cap so remaining peer idle atomics are not loaded.
- Same gate applies to normal ready and (on a2a3) early-dispatch sources; depth is taken from the source queue being staged.

## Results

Workload: `qwen3_14b_decode` / `StressBatch16Seq3500` on a2a3 TMR, L2 swimlane + `deps.json`, analyzed with `simpler_setup.tools.sched_overhead_analysis` (n=5 each mode, same machine / task-submit).

### Column meanings

Metrics below come from that tool. Where a cell is `mean ± stdev`, it is over the five runs.

| Column | Meaning |
|--------|---------|
| **mode** | Compile-time PENDING gate under test: Base / Full / Min4. |
| **makespan (µs)** | Wall-clock window of the profiled AICore work: time from the **first task start** to the **last task end** on the swimlane (`window` in the tool). Lower is better. |
| **has_overhead** | Fraction of that window during which **every engine that still has undispatched ready work** is in a scheduling-overhead state (engines with no ready work are ignored). Reported as `% of makespan`. High values mean ready work is present but cores/engines that should absorb it are stalled on the scheduler path — the symptom #1341 amplifies under imbalance. |
| **AIC pending switches** (`pend_sw`) | Count of AIC **pending-style pickups**: on the same AIC core, a task whose `dispatch_time < previous task end` (work was pre-parked in the pending slot and starts as soon as the prior FIN completes). Higher count means more pending prefetches actually fired; it is not by itself good or bad — useful mainly to see whether a gate still allows prefetch vs starving it. |
| **Tail P50 (µs)** | Median **Tail OH** over tasks: `finish_time − end_time` on each task (AICPU/reap-side lag after the AICore reports end), clamped at ≥ 0. P50 is the 50th percentile of that per-task distribution. Larger Tail P50 usually tracks slower completion/reap feedback into the next dispatch cycle. |
| **crit sched %** | On the DAG **critical path** (makespan-determining chain of dependent tasks): share of that path’s span attributed to **scheduler-injected** latency (`Scheduler injected` in Part 6), as opposed to pure AICore compute on the path. Higher means more of end-to-end latency is spent in scheduler gaps along the critical chain. |
| **run** | Individual repetition index (1…5) for the per-run table. |
| **has_oh** | Same as **has_overhead** (short name in the per-run table). |
| **pend_sw** | Same as **AIC pending switches**. |

### Mode sweep (means ± stdev)

| mode | makespan (µs) | has_overhead | AIC pending switches | Tail P50 (µs) | crit sched % |
|------|---------------|--------------|----------------------|---------------|--------------|
| Base | 2237.7 ± 116.6 | 24.1 ± 7.6% | 575 ± 67 | 2.94 ± 1.19 | 45.3 ± 2.9 |
| Full | 2205.1 ± 99.4 | 23.0 ± 8.1% | 594 ± 44 | 2.61 ± 1.25 | 45.5 ± 3.1 |
| Min4 | 2160.7 ± 14.3 | 19.5 ± 0.8% | 613 ± 12 | 2.08 ± 0.02 | 44.2 ± 2.1 |

Min4 cut Base’s bad-tail outliers (Base makespan range ~2148–2414 µs) while keeping the good-path cluster flat.

### Min4 + early-exit (cap=4, current default)

| run | makespan | has_oh | pend_sw | Tail P50 | crit sched % |
|-----|----------|--------|---------|----------|--------------|
| 1 | 2162.1 | 19.1% | 620 | 2.06 | 43.1 |
| 2 | 2150.3 | 18.4% | 622 | 2.12 | 42.3 |
| 3 | 2149.8 | 19.1% | 620 | 2.08 | 42.8 |
| 4 | 2155.6 | 19.1% | 615 | 2.24 | 45.6 |
| 5 | 2160.5 | 19.2% | 618 | 2.14 | 45.4 |
| **mean** | **2155.7 ± 5.7** | **19.0 ± 0.3%** | **619 ± 3** | **2.13 ± 0.07** | **43.8 ± 1.5** |

vs Base median (~2163 µs / 19.7% oh): essentially flat on the good path, much tighter variance.

### Cap sensitivity (Min4 early-exit, cap=8)

mean makespan **2179.2 ± 17.1**, has_oh **19.3 ± 0.8%** — slightly worse / noisier than cap=4; default remains **4**.
