### PR TITLE
Refactor: get_sys_cnt rescales by the clock's own frequency (arm/x86)

### DIFF
--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -21,10 +21,10 @@
 #define PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
 
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <dlfcn.h>
 
+#include "aicpu/device_time.h"
 #include "common/platform_config.h"
 
 // AICore function attribute - no-op in simulation
@@ -122,19 +122,7 @@ typedef int mem_dsb_t;
  *
  * @return Simulated counter value (ticks)
  */
-inline uint64_t get_sys_cnt_aicore() {
-    auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-    // Convert nanoseconds to counter ticks
-    constexpr uint64_t kNsPerSec = std::nano::den;
-    uint64_t seconds = elapsed_ns / kNsPerSec;
-    uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
-
-    return ticks;
-}
+inline uint64_t get_sys_cnt_aicore() { return sys_cnt_now_ticks(); }
 
 // =============================================================================
 // Register Access Simulation

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -21,10 +21,10 @@
 #define PLATFORM_A5SIM_AICORE_INNER_KERNEL_H_
 
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <dlfcn.h>
 
+#include "aicpu/device_time.h"
 #include "common/platform_config.h"
 
 // AICore function attribute - no-op in simulation
@@ -140,19 +140,7 @@ inline int64_t ld_dev(int32_t *src, int16_t offset) {
  *
  * @return Simulated counter value (ticks)
  */
-inline uint64_t get_sys_cnt_aicore() {
-    auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-
-    // Convert nanoseconds to counter ticks
-    constexpr uint64_t kNsPerSec = std::nano::den;
-    uint64_t seconds = elapsed_ns / kNsPerSec;
-    uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
-
-    return ticks;
-}
+inline uint64_t get_sys_cnt_aicore() { return sys_cnt_now_ticks(); }
 
 // =============================================================================
 // Register Access Simulation

--- a/src/common/platform/include/aicpu/device_time.h
+++ b/src/common/platform/include/aicpu/device_time.h
@@ -65,6 +65,20 @@ inline uint64_t device_time_frequency_hz() {
 
 inline uint64_t get_sys_cnt_aicpu_frequency_hz() { return PLATFORM_PROF_SYS_CNT_FREQ; }
 
+// device_time_now_ticks() expressed in the PLATFORM_PROF_SYS_CNT_FREQ unit that
+// get_sys_cnt_aicpu()/get_sys_cnt_aicore() report in. Rescaling by the clock's
+// own frequency makes it correct without knowing whether this is the device or
+// a host: on the device cntfrq == PROF (identity); on an aarch64 host cntvct
+// runs at that host's cntfrq; on x86 the clock is nanoseconds (1 GHz). The
+// __uint128_t intermediate keeps ticks * PROF from overflowing.
+inline uint64_t sys_cnt_now_ticks() {
+    const uint64_t freq = device_time_frequency_hz();
+    if (freq == 0) {  // cntfrq_el0 unset on a misconfigured/virtualized host — avoid SIGFPE
+        return 0;
+    }
+    return static_cast<uint64_t>(static_cast<__uint128_t>(device_time_now_ticks()) * PLATFORM_PROF_SYS_CNT_FREQ / freq);
+}
+
 inline uint64_t sys_cnt_ticks_to_ns(uint64_t ticks, uint64_t frequency_hz) {
     if (frequency_hz == 0) {
         return UINT64_MAX;

--- a/src/common/platform/onboard/aicpu/device_time.cpp
+++ b/src/common/platform/onboard/aicpu/device_time.cpp
@@ -10,23 +10,4 @@
  */
 #include "aicpu/device_time.h"
 
-#if !defined(__aarch64__)
-#include <chrono>
-#endif
-
-uint64_t get_sys_cnt_aicpu() {
-#if defined(__aarch64__)
-    return device_time_now_ticks();
-#else
-    // host_build_graph orchestrates on the host CPU, where the device generic
-    // timer is unreachable. device_time_now_ticks() is a monotonic steady_clock
-    // nanosecond count off aarch64; rescale it to the PLATFORM_PROF_SYS_CNT_FREQ
-    // tick unit get_sys_cnt_aicpu() reports in, so the orchestrator's cycle-based
-    // timeouts (get_sys_cnt_aicpu() - t0 > ..._CYCLES) and DFX decode stay valid.
-    uint64_t elapsed_ns = device_time_now_ticks();
-    constexpr uint64_t kNsPerSec = std::nano::den;
-    uint64_t seconds = elapsed_ns / kNsPerSec;
-    uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-    return seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
-#endif
-}
+uint64_t get_sys_cnt_aicpu() { return sys_cnt_now_ticks(); }

--- a/src/common/platform/sim/aicpu/device_time.cpp
+++ b/src/common/platform/sim/aicpu/device_time.cpp
@@ -10,15 +10,4 @@
  */
 #include "aicpu/device_time.h"
 
-#include <chrono>
-
-uint64_t get_sys_cnt_aicpu() {
-    // device_time_now_ticks() is a monotonic steady_clock nanosecond count on
-    // the host; rescale to the PLATFORM_PROF_SYS_CNT_FREQ tick unit
-    // get_sys_cnt_aicpu() reports in.
-    uint64_t elapsed_ns = device_time_now_ticks();
-    constexpr uint64_t kNsPerSec = std::nano::den;
-    uint64_t seconds = elapsed_ns / kNsPerSec;
-    uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-    return seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
-}
+uint64_t get_sys_cnt_aicpu() { return sys_cnt_now_ticks(); }


### PR DESCRIPTION
## Why

`get_sys_cnt_aicpu()` / `get_sys_cnt_aicore()` must report ticks in the
device `PLATFORM_PROF_SYS_CNT_FREQ` unit (50 MHz a2a3 / 1 GHz a5) — the
unit the timeout thresholds and DFX decode assume. The prior code
returned **raw cntvct on any aarch64 target**, silently assuming
`cntfrq == PROF`. That holds on the device, but not on an aarch64 host:

- **host_build_graph's orchestrator runs on the host CPU.** On an ARM64
  runner it read that host's cntvct at the host cntfrq (**100 MHz
  measured on a Kunpeng runner**), still decoded as PROF → mis-scaled
  orchestrator timeouts and swimlane timestamps.
- **sim on an aarch64 host (macOS runner)** hit the same aarch64 branch
  of `device_time_now_ticks()` and treated cntvct as if it were
  nanoseconds.

Separately, the two sim **aicore** paths used the non-monotonic
`high_resolution_clock` (can jump backward under NTP → unsigned-delta
underflow → false timeout), and the host rescale was **duplicated in
four places**.

## What

Add `device_time.h::sys_cnt_now_ticks()`:

```cpp
device_time_now_ticks() * PLATFORM_PROF_SYS_CNT_FREQ / device_time_frequency_hz()
```

Dividing by the clock's **own** frequency makes it correct without
distinguishing device from host: device `cntfrq == PROF` (identity), an
aarch64 host uses that host's cntfrq, x86 is nanoseconds at 1 GHz. The
arm-vs-x86 split stays inside `device_time_now_ticks()` /
`device_time_frequency_hz()`, so the four callers carry no `#if`.

All four sys-cnt sites (onboard/sim aicpu, a2a3/a5 sim aicore) route
through it. `cache_ops` keeps its own `__aarch64__` split (x86 has no
`dc` instruction). No orchestration source-selection change is needed.

## Behaviour change per scenario

| scenario | before | after |
| --- | --- | --- |
| device AICPU | raw cntvct | `cntvct*PROF/cntfrq` — **same value**, + one divide |
| hbg orch @x86 host | ns → PROF | same value |
| **hbg orch @arm host** | raw host cntvct (wrong) | **corrected** via host cntfrq |
| sim aicpu @x86 host | ns → PROF | same value |
| **sim aicpu @aarch64 host** | cntvct-as-ns (wrong) | **corrected** |
| **sim aicore** | high_resolution_clock (non-monotonic) | **monotonic** via device_time_now_ticks |
| device AICore | `get_sys_cnt()` intrinsic | unchanged |

## Cost

`get_sys_cnt_aicpu()` on the device now does a cntfrq read + a 128-bit
divide per call instead of a bare `cntvct` read (~30 extra cycles on the
scheduler timing path). The returned value is unchanged.

## Verification

- Native aarch64: `onboard/aicpu/device_time.cpp` compiles; objdump
  confirms it reads cntvct + cntfrq. Value check on a 100 MHz-cntfrq host
  with PROF=50 MHz yields `cntvct/2` exactly (ratio 0.500).
- pre-commit green.
- End-to-end onboard/sim validation via CI (`st-onboard-*`, `st-sim-*`
  l2_swimlane smoke assert `Avg scheduler loop iteration > 0`).

## Note

The separate `st-onboard-a5` red seen earlier
(`/tmp/pytest-of-simpler_a5ci not owned by the current user`) is an
a5-runner environment issue, unrelated to this change.
