### PR TITLE
ci: pin ut-a2a3 to the x86 (X64) self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,11 @@ jobs:
   # ---------- Unit tests (a2a3 hardware, Python + C++) ----------
   ut-a2a3:
     needs: pre-commit
-    runs-on: [self-hosted, a2a3]
+    # The a2a3 pool mixes x86 8P hosts (infra-gpu-npu-021[-2]) and arm64 4P
+    # hosts (runner-dev*) under the same `a2a3` label. ut-a2a3 assumes the
+    # 8-NPU x86 host (DEVICE_RANGE 0-7/8-15; local pto-isa mirror lives here),
+    # so pin to the X64 label instead of matching the 4-NPU arm64 runners.
+    runs-on: [self-hosted, a2a3, X64]
     timeout-minutes: 30
     env:
       SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"


### PR DESCRIPTION
## What
Pin `ut-a2a3` to the x86 (`X64`) self-hosted runner.

## Why
The `a2a3` runner pool is mixed-arch:
- **x86 8P**: `infra-gpu-npu-021[-2]` (label `X64`)
- **arm64 4P**: `runner-dev4-7` / `runner-dev8-11` (label `ARM64`)

`runs-on: [self-hosted, a2a3]` can land `ut-a2a3` on a 4-NPU arm64 box, but the job assumes the 8-NPU x86 host — `DEVICE_RANGE` is `0-7`/`8-15`, and the local pto-isa mirror (which makes the build's `pto-isa` clone reliable behind the pod proxy) only exists there. Adding the `X64` label targets it deterministically.

This PR is also the validation run for that pto-isa local-mirror setup — the `Set up environment` step (the `pto-isa` clone) should now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)