### PR TITLE
Fix: exclude alloc-only fanin from star markers

### DIFF
--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -758,9 +758,9 @@ def _task_markers(nodes, edges, meta, task_table):
         (deps.json ``early_dispatch`` — the submit had allow_early_resolve)
         or an alloc task. Alloc tasks are immediate graph sources, so they
         are treated as fire-marked producers by default.
-    ⭐ (star): every one of the task's predecessors is 🔥 (and it has at
-        least one), so the task is fully fed by flagged producers or alloc
-        sources.
+    ⭐ (star): every one of the task's predecessors is 🔥, and at least
+        one predecessor is not an alloc task. An alloc-only fanin does not
+        qualify.
     A task can carry both.
     """
     pred_map: dict[int, set] = {}
@@ -774,7 +774,13 @@ def _task_markers(nodes, edges, meta, task_table):
     for tid in nodes:
         fire = "🔥" if _fire_marked(tid) else ""
         preds = pred_map.get(tid, set())
-        star = "⭐" if preds and all(_fire_marked(p) for p in preds) else ""
+        star = (
+            "⭐"
+            if preds
+            and all(_fire_marked(p) for p in preds)
+            and any(_task_kind(p, meta, task_table) != "alloc" for p in preds)
+            else ""
+        )
         if fire or star:
             markers[tid] = fire + star
     return markers

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -243,17 +243,51 @@ def test_emit_dot_handles_missing_task_table():
     assert 'label="🔥 1 · alloc"' in dot
 
 
-def test_emit_dot_treats_alloc_as_a_fire_marked_source():
+def test_emit_dot_does_not_mark_alloc_only_successor_with_star():
     dot = deps_viewer.emit_dot(
-        edges=[(1, 2)],
-        nodes=[1, 2],
+        edges=[(1, 3), (2, 3)],
+        nodes=[1, 2, 3],
         meta={},
-        task_table={2: {"task_id": 2, "kernel_ids": [-1, 7, -1]}},
+        task_table={3: {"task_id": 3, "kernel_ids": [-1, 7, -1]}},
         show_tensor_info=False,
     )
 
     assert 'label="🔥 1 · alloc"' in dot
-    assert 'label="⭐ 2"' in dot
+    assert 'label="🔥 2 · alloc"' in dot
+    assert 'label="3"' in dot
+
+
+def test_emit_dot_marks_star_with_alloc_and_early_dispatch_predecessors():
+    dot = deps_viewer.emit_dot(
+        edges=[(1, 3), (2, 3)],
+        nodes=[1, 2, 3],
+        meta={},
+        task_table={
+            2: {"task_id": 2, "kernel_ids": [-1, 6, -1], "early_dispatch": True},
+            3: {"task_id": 3, "kernel_ids": [-1, 7, -1]},
+        },
+        show_tensor_info=False,
+    )
+
+    assert 'label="🔥 1 · alloc"' in dot
+    assert 'label="🔥 2"' in dot
+    assert 'label="⭐ 3"' in dot
+
+
+def test_emit_dot_does_not_mark_star_when_any_predecessor_lacks_fire():
+    dot = deps_viewer.emit_dot(
+        edges=[(1, 4), (2, 4), (3, 4)],
+        nodes=[1, 2, 3, 4],
+        meta={},
+        task_table={
+            2: {"task_id": 2, "kernel_ids": [-1, 6, -1], "early_dispatch": True},
+            3: {"task_id": 3, "kernel_ids": [-1, 7, -1]},
+            4: {"task_id": 4, "kernel_ids": [-1, 8, -1]},
+        },
+        show_tensor_info=False,
+    )
+
+    assert 'label="4"' in dot
 
 
 def test_emit_dot_hides_selected_edges_with_background_color():


### PR DESCRIPTION
## Summary

- require at least one non-alloc predecessor before adding a ⭐ marker
- preserve alloc tasks as 🔥 sources when mixed with early-dispatch tasks
- cover alloc-only, mixed, and missing-🔥 predecessor cases

## Testing

- [x] `.venv/bin/python -m pytest tests/ut -q` (594 passed, 2 skipped)
- [x] `.venv/bin/python -m pytest tests/ut/py/test_deps_viewer.py -q` (28 passed after rebase)
- [x] `ruff check` and `ruff format --check` on changed files