### PR TITLE
feat(allreduce): TPUT_ASYNC for IBing forward phase + NeighborBarrier for ring kernels

### DIFF
--- a/tests/st/worker/collectives/_helpers.py
+++ b/tests/st/worker/collectives/_helpers.py
@@ -30,6 +30,7 @@ from simpler_setup.torch_interop import make_tensor_arg
 ALLREDUCE_COUNT = 256
 ALLREDUCE_DTYPE_NBYTES = 4  # float32
 ALLREDUCE_MAX_RANKS = 16
+SDMA_WORKSPACE_SIZE = 16 * 1024  # 16 KiB for SDMA control structures (async modes)
 
 # Other collectives: 64 floats per rank, float32
 COUNT_PER_RANK = 64
@@ -70,7 +71,9 @@ def _allreduce_scratch_params(mode: str, nranks: int) -> tuple[int, int, int]:
         chunk_elems = ALLREDUCE_COUNT // nranks
         float_elems = (nranks + 2) * chunk_elems
         scratch_nbytes = (
-            float_elems * ALLREDUCE_DTYPE_NBYTES + (2 * (nranks - 1) + 1) * ALLREDUCE_MAX_RANKS * ALLREDUCE_DTYPE_NBYTES
+            float_elems * ALLREDUCE_DTYPE_NBYTES
+            + (2 * (nranks - 1) + 1) * ALLREDUCE_MAX_RANKS * ALLREDUCE_DTYPE_NBYTES
+            + SDMA_WORKSPACE_SIZE  # extra tail for SDMA control structures
         )
     else:
         raise ValueError(f"Unsupported allreduce mode: {mode!r}")

--- a/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_bidirectional_ring_kernel.cpp
@@ -10,7 +10,7 @@
  */
 /**
  * Bidirectional Ring AllReduce — two parallel unidirectional rings on
- * disjoint halves of the data, sharing RoundBarrier per step.
+ * disjoint halves of the data, sharing a NeighborBarrier per step.
  *
  * Ring 0 (clockwise, →right neighbour): first half of each chunk's elements.
  *   Uses standard unidirectional RS+AG formulas.
@@ -55,21 +55,34 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPt
     return (__gm__ T *)(ctx->windowsIn[pe] + offset);
 }
 
-AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
-    for (int peer = 0; peer < nranks; ++peer) {
-        if (peer == my_rank) {
-            continue;
+// Per-round neighbor barrier for bidirectional ring topology.
+// Ring0 (CW): r pushes to (r+1), receives from (r-1).
+// Ring1 (CCW): r pushes to (r-1), receives from (r+1).
+// Both rings share one barrier round, so every rank synchronizes with
+// both left and right neighbors.  O(1) per round regardless of P.
+// When P=2, left == right — notify/wait once to avoid redundant ops.
+// Signal rows used exactly once (AtomicAdd 0→1, TWAIT GE 1).
+AICORE inline void
+NeighborBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int left, int right) {
+    // Notify neighbors.
+    {
+        __gm__ int32_t *remote_r = CommRemotePtr(ctx, signal_row + my_rank, right);
+        pto::comm::Signal sig_r(remote_r);
+        pto::comm::TNOTIFY(sig_r, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+        if (left != right) {
+            __gm__ int32_t *remote_l = CommRemotePtr(ctx, signal_row + my_rank, left);
+            pto::comm::Signal sig_l(remote_l);
+            pto::comm::TNOTIFY(sig_l, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
         }
-        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_row + my_rank, peer);
-        pto::comm::Signal sig(remote_signal);
-        pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
     }
-    for (int peer = 0; peer < nranks; ++peer) {
-        if (peer == my_rank) {
-            continue;
+    // Wait on neighbors.
+    {
+        pto::comm::Signal sig_l(signal_row + left);
+        pto::comm::TWAIT(sig_l, (int32_t)1, pto::comm::WaitCmp::GE);
+        if (left != right) {
+            pto::comm::Signal sig_r(signal_row + right);
+            pto::comm::TWAIT(sig_r, (int32_t)1, pto::comm::WaitCmp::GE);
         }
-        pto::comm::Signal sig(signal_row + peer);
-        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
     }
     pipe_barrier(PIPE_ALL);
 }
@@ -162,7 +175,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     //   Pushes ring1[send_idx] to left neighbour at same index.
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
-        RoundBarrier(commCtx, signal_base + (step - 1) * kMaxSupportedRanks, my_rank, nranks);
+        NeighborBarrier(commCtx, signal_base + (step - 1) * kMaxSupportedRanks, my_rank, left, right);
 
         // Ring0: push ring0[(r - step + P) % P] → right's ring0[same index].
         {
@@ -195,7 +208,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
         const int rs_rounds = nranks - 1;
-        RoundBarrier(commCtx, signal_base + (rs_rounds + step - 1) * kMaxSupportedRanks, my_rank, nranks);
+        NeighborBarrier(commCtx, signal_base + (rs_rounds + step - 1) * kMaxSupportedRanks, my_rank, left, right);
 
         // Ring0 AG.
         {
@@ -225,7 +238,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // stage-out reads from ring0/ring1.  Without this, remote writes from
     // other ranks may not have propagated to shared memory yet.
     if (nranks > 1) {
-        RoundBarrier(commCtx, signal_base + (2 * (nranks - 1)) * kMaxSupportedRanks, my_rank, nranks);
+        NeighborBarrier(commCtx, signal_base + (2 * (nranks - 1)) * kMaxSupportedRanks, my_rank, left, right);
     }
 
     // ------------------------------------------------------------------

--- a/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -21,19 +21,25 @@
  * The double-barrier scheme ensures (a) prior writes are globally visible,
  * (b) all snapshots complete, before any push reads the exchange buffers.
  *
- * **Async allgather (forward) phase**: steps ⌊P/2⌋+1..P−1 use TPUT_ASYNC
- * instead of synchronous TPUT<AtomicNone>.  Both CW and CCW pushes are
- * issued to the SDMA engine back-to-back per round, then drained with a
- * single WaitAll().  Reduce-scatter steps (1..⌊P/2⌋) still use synchronous
- * TPUT<AtomicAdd> because TPUT_ASYNC does not support atomic operations.
+ * **Forward (allgather) phase**:
+ *   - CPUSIM (`__CPU_SIM`): TPUT_ASYNC for both CW+CCW AtomicNone pushes,
+ *     drained with WaitAll().  Exercises the async completion API; on sim
+ *     TPUT_ASYNC is a synchronous copy (handle=0).
+ *   - NPU: keep synchronous TPUT<AtomicNone>.  Pulling SDMA async helpers /
+ *     BuildAsyncSession into the AIV .o currently produces unresolved .text
+ *     relocations that simpler's AICore loader rejects (issue #900).  Real
+ *     NPU TPUT_ASYNC needs host SdmaWorkspaceManager + loader support.
+ *
+ * Reduce-scatter steps still use synchronous TPUT<AtomicAdd> on all
+ * platforms (TPUT_ASYNC does not support atomic operations).
  *
  * Scratch layout (per rank, in HCCL window):
  *   [0 .. P*chunk_elems)                   P working chunks
  *   [P*chunk .. (P+1)*chunk)               exchange_right snapshot buffer
  *   [(P+1)*chunk .. (P+2)*chunk)          exchange_left  snapshot buffer
  *   tail                   (2*(P-1)+1) * kMaxSupportedRanks int32 signals
- *   tail + ...                             kSdmaWorkspaceSize bytes for SDMA
- *                                          control structures
+ *   tail + ...                             reserved SDMA workspace bytes
+ *                                          (sim / future NPU async path)
  *
  * Divisibility: requires ALLREDUCE_COUNT % nranks == 0.
  */
@@ -41,12 +47,12 @@
 #include <pto/pto-inst.hpp>
 #include "pto/comm/comm_types.hpp"
 #include "pto/comm/pto_comm_inst.hpp"
-#include "pto/comm/async_common/async_types.hpp"
-#ifndef __CPU_SIM
-#include "pto/comm/async_common/async_event_impl.hpp"
-#endif
 #include "platform_comm/comm_context.h"
 #include "tensor.h"
+
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
+#include "pto/comm/async_common/async_types.hpp"
+#endif
 
 #ifndef __gm__
 #define __gm__
@@ -59,7 +65,9 @@
 static constexpr size_t ALLREDUCE_COUNT = 256;
 static constexpr int kMaxSupportedRanks = 16;
 static constexpr size_t kSdmaWorkspaceSize = 16 * 1024;
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
 static constexpr int kMaxAsyncEvents = 8;
+#endif
 
 template <typename T>
 AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPtr, int pe) {
@@ -83,38 +91,20 @@ AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_
     pipe_barrier(PIPE_ALL);
 }
 
-// ---------------------------------------------------------------------------
-// Async session wrapper (self-contained; inline for homogeneity with all
-// other AIV kernel files in this directory).
-// ---------------------------------------------------------------------------
-
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
+// Sim-only async session wrapper.  Intentionally not compiled for NPU AIV
+// payloads — SDMA async helpers currently trip AICore loader issue #900.
 struct AivAsyncSession {
     pto::comm::AsyncSession session{};
     pto::comm::AsyncEvent events[kMaxAsyncEvents];
     int numPending = 0;
 
-#if defined(__CPU_SIM) || defined(__COSTMODEL)
     AICORE bool Init(__gm__ uint8_t *workspace, const pto::comm::sdma::SdmaBaseConfig & = {}) {
         (void)workspace;
         session = {};
         numPending = 0;
         return true;
     }
-#else
-    template <int kRows = 1, int kCols = 256>
-    AICORE bool Init(
-        __gm__ uint8_t *workspace,
-        const pto::comm::sdma::SdmaBaseConfig &baseConfig = {pto::comm::sdma::kDefaultSdmaBlockBytes, 0, 1}
-    ) {
-        using ScratchTile = pto::Tile<pto::TileType::Vec, uint8_t, kRows, kCols, pto::BLayout::RowMajor, -1, -1>;
-        ScratchTile scratchTile(kRows, kCols);
-        TASSIGN(scratchTile, static_cast<uint8_t>(0));
-        bool ok = pto::comm::BuildAsyncSession(scratchTile, workspace, session, 0, baseConfig);
-        if (!ok) return false;
-        numPending = 0;
-        return true;
-    }
-#endif
 
     AICORE void Reset() { numPending = 0; }
 
@@ -131,10 +121,7 @@ struct AivAsyncSession {
         return true;
     }
 };
-
-// ---------------------------------------------------------------------------
-// Kernel entry point
-// ---------------------------------------------------------------------------
+#endif
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
@@ -165,19 +152,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     __gm__ float *exchange_left = exchange_right + static_cast<size_t>(chunk_elems);
     __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(exchange_left + static_cast<size_t>(chunk_elems));
 
-    // SDMA workspace: carved from the end of the scratch buffer, after the
-    // signal rows.  On CPUSIM, TPUT_ASYNC always completes immediately
-    // (handle=0), so the workspace content is irrelevant.
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
+    // Reserved SDMA workspace tail (content unused on sim — TPUT_ASYNC is sync).
     __gm__ uint8_t *workspace = reinterpret_cast<__gm__ uint8_t *>(
         signal_base + (static_cast<size_t>(2 * (nranks - 1) + 1) * kMaxSupportedRanks)
     );
-
-    // Build the async session (one per kernel invocation).
     AivAsyncSession asyncS;
     if (!asyncS.Init(workspace)) {
         pipe_barrier(PIPE_ALL);
         return;
     }
+#else
+    (void)kSdmaWorkspaceSize;
+#endif
 
     ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
     StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
@@ -211,12 +198,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // Phase 2: IBing interleaved RS+AG — P−1 rounds.
     //
     // Steps 1..⌊P/2⌋:     reduce  — AtomicAdd pushes from exchange buffers.
-    // Steps ⌊P/2⌋+1..P−1: forward — TPUT_ASYNC AtomicNone pushes.
-    //
-    // Double-barrier + exchange-buffer snapshot scheme replicates MPI
-    // ISend/IRecv semantics (plan 44).  Forward steps issue both CW and CCW
-    // pushes to the SDMA engine via TPUT_ASYNC and drain with a single
-    // WaitAll() instead of pipe_barrier(PIPE_ALL).
+    // Steps ⌊P/2⌋+1..P−1: forward — AtomicNone (async on sim, sync on NPU).
     // ------------------------------------------------------------------
     const int left = (my_rank - 1 + nranks) % nranks;
     const int right = (my_rank + 1) % nranks;
@@ -268,10 +250,10 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         RoundBarrier(commCtx, signal_base + (2 * (step - 1) + 1) * kMaxSupportedRanks, my_rank, nranks);
 
         if (fwd) {
-            // Forward step (allgather): TPUT_ASYNC for both CW and CCW pushes.
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
+            // Forward step: TPUT_ASYNC for both CW and CCW pushes (sim API path).
             asyncS.Reset();
 
-            // Right-bound async push.
             {
                 __gm__ float *src = exchange_right;
                 __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
@@ -281,7 +263,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                 asyncS.Issue(ev);
             }
 
-            // Left-bound async push.
             {
                 __gm__ float *src = exchange_left;
                 __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
@@ -291,12 +272,27 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                 asyncS.Issue(ev);
             }
 
-            // Wait for both SDMA transfers to complete.
             asyncS.WaitAll();
+#else
+            // NPU: synchronous AtomicNone (SDMA async not yet loader-safe).
+            {
+                __gm__ float *src = exchange_right;
+                __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
+                GT srcG(src, chunkShape, chunkStride);
+                GT dstG(dst, chunkShape, chunkStride);
+                pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
+            }
+            {
+                __gm__ float *src = exchange_left;
+                __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
+                GT srcG(src, chunkShape, chunkStride);
+                GT dstG(dst, chunkShape, chunkStride);
+                pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
+            }
+            pipe_barrier(PIPE_ALL);
+#endif
         } else {
-            // Reduce step: synchronous TPUT<AtomicAdd> (async does not
-            // support atomic operations).
-            // Right-bound reduce push.
+            // Reduce step: synchronous TPUT<AtomicAdd>.
             {
                 __gm__ float *src = exchange_right;
                 __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
@@ -304,8 +300,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                 GT dstG(dst, chunkShape, chunkStride);
                 pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
             }
-
-            // Left-bound reduce push.
             {
                 __gm__ float *src = exchange_left;
                 __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
@@ -313,7 +307,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                 GT dstG(dst, chunkShape, chunkStride);
                 pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
             }
-
             pipe_barrier(PIPE_ALL);
         }
     }

--- a/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -12,13 +12,6 @@
  * IBing Interleaved Bidirectional Ring AllReduce — faithful implementation
  * of the algorithm by Zong et al., ACM TACO 2025.
  *
- * Unlike the two-ring bidirectional_ring variant (which runs separate RS
- * and AG phases, 2(P-1)+1 barriers), this kernel implements the true
- * IBing interleaved schedule: P-1 bidirectional rounds, each round
- * pushing one chunk clockwise and one counter-clockwise, with the
- * first ⌊P/2⌋ steps using AtomicAdd (reduce-scatter) and the remaining
- * steps using AtomicNone (allgather-forward).
- *
  * Right-bound:  r pushes chunks[(r - s + P) % P]         → rank r+1
  * Left-bound:   r pushes chunks[(r + s + 1 + P) % P]    → rank r-1
  *
@@ -28,11 +21,19 @@
  * The double-barrier scheme ensures (a) prior writes are globally visible,
  * (b) all snapshots complete, before any push reads the exchange buffers.
  *
+ * **Async allgather (forward) phase**: steps ⌊P/2⌋+1..P−1 use TPUT_ASYNC
+ * instead of synchronous TPUT<AtomicNone>.  Both CW and CCW pushes are
+ * issued to the SDMA engine back-to-back per round, then drained with a
+ * single WaitAll().  Reduce-scatter steps (1..⌊P/2⌋) still use synchronous
+ * TPUT<AtomicAdd> because TPUT_ASYNC does not support atomic operations.
+ *
  * Scratch layout (per rank, in HCCL window):
  *   [0 .. P*chunk_elems)                   P working chunks
- *   [P*chunk .. (P+1)*chunk)               exchange_right (snapshot buffer)
- *   [(P+1)*chunk .. (P+2)*chunk)          exchange_left  (snapshot buffer)
+ *   [P*chunk .. (P+1)*chunk)               exchange_right snapshot buffer
+ *   [(P+1)*chunk .. (P+2)*chunk)          exchange_left  snapshot buffer
  *   tail                   (2*(P-1)+1) * kMaxSupportedRanks int32 signals
+ *   tail + ...                             kSdmaWorkspaceSize bytes for SDMA
+ *                                          control structures
  *
  * Divisibility: requires ALLREDUCE_COUNT % nranks == 0.
  */
@@ -40,6 +41,10 @@
 #include <pto/pto-inst.hpp>
 #include "pto/comm/comm_types.hpp"
 #include "pto/comm/pto_comm_inst.hpp"
+#include "pto/comm/async_common/async_types.hpp"
+#ifndef __CPU_SIM
+#include "pto/comm/async_common/async_event_impl.hpp"
+#endif
 #include "platform_comm/comm_context.h"
 #include "tensor.h"
 
@@ -53,6 +58,8 @@
 
 static constexpr size_t ALLREDUCE_COUNT = 256;
 static constexpr int kMaxSupportedRanks = 16;
+static constexpr size_t kSdmaWorkspaceSize = 16 * 1024;
+static constexpr int kMaxAsyncEvents = 8;
 
 template <typename T>
 AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPtr, int pe) {
@@ -75,6 +82,62 @@ AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_
     }
     pipe_barrier(PIPE_ALL);
 }
+
+// ---------------------------------------------------------------------------
+// Async session wrapper (self-contained; inline for homogeneity with all
+// other AIV kernel files in this directory).
+// ---------------------------------------------------------------------------
+
+struct AivAsyncSession {
+    pto::comm::AsyncSession session{};
+    pto::comm::AsyncEvent events[kMaxAsyncEvents];
+    int numPending = 0;
+
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
+    AICORE bool Init(__gm__ uint8_t *workspace,
+                     const pto::comm::sdma::SdmaBaseConfig& = {}) {
+        (void)workspace;
+        session = {};
+        numPending = 0;
+        return true;
+    }
+#else
+    template <int kRows = 1, int kCols = 256>
+    AICORE bool Init(__gm__ uint8_t *workspace,
+                     const pto::comm::sdma::SdmaBaseConfig& baseConfig =
+                         {pto::comm::sdma::kDefaultSdmaBlockBytes, 0, 1}) {
+        using ScratchTile =
+            pto::Tile<pto::TileType::Vec, uint8_t, kRows, kCols, pto::BLayout::RowMajor, -1, -1>;
+        ScratchTile scratchTile(kRows, kCols);
+        TASSIGN(scratchTile, static_cast<uint8_t>(0));
+        bool ok = pto::comm::BuildAsyncSession(scratchTile, workspace, session, 0, baseConfig);
+        if (!ok) return false;
+        numPending = 0;
+        return true;
+    }
+#endif
+
+    AICORE void Reset() { numPending = 0; }
+
+    AICORE void Issue(const pto::comm::AsyncEvent& ev) {
+        events[numPending++] = ev;
+    }
+
+    AICORE bool WaitAll() {
+        for (int i = 0; i < numPending; ++i) {
+            if (!events[i].Wait(session)) {
+                numPending = 0;
+                return false;
+            }
+        }
+        numPending = 0;
+        return true;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Kernel entry point
+// ---------------------------------------------------------------------------
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
@@ -104,6 +167,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     __gm__ float *exchange_right = scratch + static_cast<size_t>(nranks * chunk_elems);
     __gm__ float *exchange_left = exchange_right + static_cast<size_t>(chunk_elems);
     __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(exchange_left + static_cast<size_t>(chunk_elems));
+
+    // SDMA workspace: carved from the end of the scratch buffer, after the
+    // signal rows.  On CPUSIM, TPUT_ASYNC always completes immediately
+    // (handle=0), so the workspace content is irrelevant.
+    __gm__ uint8_t *workspace =
+        reinterpret_cast<__gm__ uint8_t *>(signal_base + (static_cast<size_t>(2 * (nranks - 1) + 1) * kMaxSupportedRanks));
+
+    // Build the async session (one per kernel invocation).
+    AivAsyncSession asyncS;
+    if (!asyncS.Init(workspace)) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
 
     ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
     StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
@@ -136,22 +212,13 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // ------------------------------------------------------------------
     // Phase 2: IBing interleaved RS+AG — P−1 rounds.
     //
-    // In each step s ∈ [1, P−1]:
-    //   - Push chunk (r - s + P) % P to right neighbour.
-    //   - Push chunk (r + s + 1 + P) % P to left neighbour.
+    // Steps 1..⌊P/2⌋:     reduce  — AtomicAdd pushes from exchange buffers.
+    // Steps ⌊P/2⌋+1..P−1: forward — TPUT_ASYNC AtomicNone pushes.
     //
-    //   Steps 1..⌊P/2⌋:     reduce  — AtomicAdd pushes from exchange buffers.
-    //   Steps ⌊P/2⌋+1..P−1: forward — AtomicNone pushes (allgather).
-    //
-    // CPU sim and NPU both use a double-barrier scheme:
-    //   1. Barrier A: ensure prior writes are globally visible.
-    //   2. Snapshot:  copy src chunks → exchange buffers.
-    //   3. Barrier B: ensure all snapshots complete.
-    //   4. Push:      write exchange buffers → neighbour's chunks[].
-    //
-    // This replicates MPI exchange-buffer semantics.  Without snapshots,
-    // a remote TPUT can modify chunks[idx_l] between the right-bound and
-    // left-bound TLOAD within the same step, double-counting data.
+    // Double-barrier + exchange-buffer snapshot scheme replicates MPI
+    // ISend/IRecv semantics (plan 44).  Forward steps issue both CW and CCW
+    // pushes to the SDMA engine via TPUT_ASYNC and drain with a single
+    // WaitAll() instead of pipe_barrier(PIPE_ALL).
     // ------------------------------------------------------------------
     const int left = (my_rank - 1 + nranks) % nranks;
     const int right = (my_rank + 1) % nranks;
@@ -166,16 +233,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         const bool fwd = (step > reduce_steps);
 
         // Snapshot source chunks into exchange buffers.
-        //
-        // On NPU the snapshot stays on the MTE pipeline (TLOAD → TSTORE)
-        // so that pipe_barrier(PIPE_ALL) in the following RoundBarrier
-        // guarantees the exchange buffers are visible to subsequent MTE
-        // TLOADs inside TPUT.  Scalar-write snapshots are not flushed by
-        // PIPE_ALL and produce stale reads (zero accumulation).
-        //
-        // On CPU sim, scalar pointer writes into POSIX shm are sufficient
-        // because all ranks map the same physical pages and RoundBarrier's
-        // seq_cst atomics provide cross-process ordering.
 #ifdef __CPU_SIM
         for (int i = 0; i < chunk_elems; ++i)
             exchange_right[i] = chunks[static_cast<size_t>(idx_r * chunk_elems) + i];
@@ -212,27 +269,55 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         // Barrier B: all snapshots complete — safe to push.
         RoundBarrier(commCtx, signal_base + (2 * (step - 1) + 1) * kMaxSupportedRanks, my_rank, nranks);
 
-        // Right-bound push.
-        {
-            __gm__ float *src = exchange_right;
-            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
-            GT srcG(src, chunkShape, chunkStride);
-            GT dstG(dst, chunkShape, chunkStride);
-            if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
-            else pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
-        }
+        if (fwd) {
+            // Forward step (allgather): TPUT_ASYNC for both CW and CCW pushes.
+            asyncS.Reset();
 
-        // Left-bound push.
-        {
-            __gm__ float *src = exchange_left;
-            __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
-            GT srcG(src, chunkShape, chunkStride);
-            GT dstG(dst, chunkShape, chunkStride);
-            if (fwd) pto::comm::TPUT<pto::AtomicType::AtomicNone>(dstG, srcG, pushTile);
-            else pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
-        }
+            // Right-bound async push.
+            {
+                __gm__ float *src = exchange_right;
+                __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
+                GT srcG(src, chunkShape, chunkStride);
+                GT dstG(dst, chunkShape, chunkStride);
+                pto::comm::AsyncEvent ev = pto::comm::TPUT_ASYNC(dstG, srcG, asyncS.session);
+                asyncS.Issue(ev);
+            }
 
-        pipe_barrier(PIPE_ALL);
+            // Left-bound async push.
+            {
+                __gm__ float *src = exchange_left;
+                __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
+                GT srcG(src, chunkShape, chunkStride);
+                GT dstG(dst, chunkShape, chunkStride);
+                pto::comm::AsyncEvent ev = pto::comm::TPUT_ASYNC(dstG, srcG, asyncS.session);
+                asyncS.Issue(ev);
+            }
+
+            // Wait for both SDMA transfers to complete.
+            asyncS.WaitAll();
+        } else {
+            // Reduce step: synchronous TPUT<AtomicAdd> (async does not
+            // support atomic operations).
+            // Right-bound reduce push.
+            {
+                __gm__ float *src = exchange_right;
+                __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_r * chunk_elems), right);
+                GT srcG(src, chunkShape, chunkStride);
+                GT dstG(dst, chunkShape, chunkStride);
+                pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
+            }
+
+            // Left-bound reduce push.
+            {
+                __gm__ float *src = exchange_left;
+                __gm__ float *dst = CommRemotePtr(commCtx, chunks + static_cast<size_t>(idx_l * chunk_elems), left);
+                GT srcG(src, chunkShape, chunkStride);
+                GT dstG(dst, chunkShape, chunkStride);
+                pto::comm::TPUT<pto::AtomicType::AtomicAdd>(dstG, srcG, pushTile);
+            }
+
+            pipe_barrier(PIPE_ALL);
+        }
     }
 
     // ------------------------------------------------------------------

--- a/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp
@@ -94,8 +94,7 @@ struct AivAsyncSession {
     int numPending = 0;
 
 #if defined(__CPU_SIM) || defined(__COSTMODEL)
-    AICORE bool Init(__gm__ uint8_t *workspace,
-                     const pto::comm::sdma::SdmaBaseConfig& = {}) {
+    AICORE bool Init(__gm__ uint8_t *workspace, const pto::comm::sdma::SdmaBaseConfig & = {}) {
         (void)workspace;
         session = {};
         numPending = 0;
@@ -103,11 +102,11 @@ struct AivAsyncSession {
     }
 #else
     template <int kRows = 1, int kCols = 256>
-    AICORE bool Init(__gm__ uint8_t *workspace,
-                     const pto::comm::sdma::SdmaBaseConfig& baseConfig =
-                         {pto::comm::sdma::kDefaultSdmaBlockBytes, 0, 1}) {
-        using ScratchTile =
-            pto::Tile<pto::TileType::Vec, uint8_t, kRows, kCols, pto::BLayout::RowMajor, -1, -1>;
+    AICORE bool Init(
+        __gm__ uint8_t *workspace,
+        const pto::comm::sdma::SdmaBaseConfig &baseConfig = {pto::comm::sdma::kDefaultSdmaBlockBytes, 0, 1}
+    ) {
+        using ScratchTile = pto::Tile<pto::TileType::Vec, uint8_t, kRows, kCols, pto::BLayout::RowMajor, -1, -1>;
         ScratchTile scratchTile(kRows, kCols);
         TASSIGN(scratchTile, static_cast<uint8_t>(0));
         bool ok = pto::comm::BuildAsyncSession(scratchTile, workspace, session, 0, baseConfig);
@@ -119,9 +118,7 @@ struct AivAsyncSession {
 
     AICORE void Reset() { numPending = 0; }
 
-    AICORE void Issue(const pto::comm::AsyncEvent& ev) {
-        events[numPending++] = ev;
-    }
+    AICORE void Issue(const pto::comm::AsyncEvent &ev) { events[numPending++] = ev; }
 
     AICORE bool WaitAll() {
         for (int i = 0; i < numPending; ++i) {
@@ -171,8 +168,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // SDMA workspace: carved from the end of the scratch buffer, after the
     // signal rows.  On CPUSIM, TPUT_ASYNC always completes immediately
     // (handle=0), so the workspace content is irrelevant.
-    __gm__ uint8_t *workspace =
-        reinterpret_cast<__gm__ uint8_t *>(signal_base + (static_cast<size_t>(2 * (nranks - 1) + 1) * kMaxSupportedRanks));
+    __gm__ uint8_t *workspace = reinterpret_cast<__gm__ uint8_t *>(
+        signal_base + (static_cast<size_t>(2 * (nranks - 1) + 1) * kMaxSupportedRanks)
+    );
 
     // Build the async session (one per kernel invocation).
     AivAsyncSession asyncS;

--- a/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ring_kernel.cpp
@@ -25,7 +25,7 @@
  * After each per-round barrier, peers read directly from each other's
  * chunks[] slots via CommRemotePtr — no separate exchange publish buffer.
  * The ``pipe_barrier(PIPE_ALL)`` at the end of each RS/AG step body drains
- * MTE pipes before ``RoundBarrier`` fires ``TNOTIFY`` (hand-written
+ * MTE pipes before ``NeighborBarrier`` fires ``TNOTIFY`` (hand-written
  * equivalent of PTOAS v0.45's automatic ``emitTNotifyMteDrain``).
  *
  * args layout (passed as Tensor arg slots — see allreduce_ring_orch.cpp):
@@ -61,24 +61,22 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPt
     return (__gm__ T *)(ctx->windowsIn[pe] + offset);
 }
 
-// Per-round barrier row: used exactly once (AtomicAdd 0→1, TWAIT GE 1).
-// No explicit reset — matches mesh allreduce_onephase_kernel.cpp; zeroing races peer notify.
-AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
-    for (int peer = 0; peer < nranks; ++peer) {
-        if (peer == my_rank) {
-            continue;
-        }
-        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_row + my_rank, peer);
-        pto::comm::Signal sig(remote_signal);
-        pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
-    }
-    for (int peer = 0; peer < nranks; ++peer) {
-        if (peer == my_rank) {
-            continue;
-        }
-        pto::comm::Signal sig(signal_row + peer);
-        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
-    }
+// Per-round neighbor barrier for ring topology.
+// Rank r TLOADs (reads) from left = (r-1)%P; right = (r+1)%P TLOADs from r.
+// Each rank notifies its right neighbor (who reads from this rank's chunks)
+// and waits on its left neighbor (whose chunks this rank reads from).
+// Signal rows used exactly once (AtomicAdd 0→1, TWAIT GE 1) —
+// matches RoundBarrier zero-init semantics (fresh HCCL window).
+AICORE inline void
+NeighborBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int left, int nranks) {
+    int right = (my_rank + 1) % nranks;
+    // Notify right neighbor: "I'm done with this step, you can TLOAD from my chunks."
+    __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_row + my_rank, right);
+    pto::comm::Signal sig_out(remote_signal);
+    pto::comm::TNOTIFY(sig_out, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    // Wait on left neighbor: "Are you done? I need to TLOAD your chunks."
+    pto::comm::Signal sig_in(signal_row + left);
+    pto::comm::TWAIT(sig_in, (int32_t)1, pto::comm::WaitCmp::GE);
     pipe_barrier(PIPE_ALL);
 }
 
@@ -146,11 +144,11 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
         const int recv_add_idx = (my_rank - step - 1 + nranks) % nranks;
+        const int left = (my_rank - 1 + nranks) % nranks;
 
-        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
+        NeighborBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, left, nranks);
         ++round;
 
-        const int left = (my_rank - 1 + nranks) % nranks;
         const int left_send_idx = (left - step + nranks) % nranks;
         {
             __gm__ float *remote_chunk =
@@ -180,11 +178,11 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
         const int recv_idx = (my_rank - step + nranks) % nranks;
+        const int left = (my_rank - 1 + nranks) % nranks;
 
-        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
+        NeighborBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, left, nranks);
         ++round;
 
-        const int left = (my_rank - 1 + nranks) % nranks;
         const int left_send_idx = (left - step + 1 + nranks) % nranks;
         {
             __gm__ float *remote_chunk =


### PR DESCRIPTION
## Summary

This PR stacks two related allreduce improvements:

1. **Neighbor-only barriers** for `ring` and `bidirectional_ring` (also in [#1378](https://github.com/hw-native-sys/simpler/pull/1378)) — replace full-mesh `RoundBarrier` with `NeighborBarrier` so each round only notifies/waits left/right neighbors (`O(1)` instead of `O(P)` sync traffic).
2. **TPUT_ASYNC for IBing forward/allgather on CPUSIM** — in `allreduce_ibing_kernel.cpp`, forward rounds (`⌊P/2⌋+1 .. P−1`) issue both CW and CCW `AtomicNone` pushes via `TPUT_ASYNC`, then drain with a single `WaitAll()`. On **NPU**, forward stays on synchronous `TPUT<AtomicNone>` (see note below).

## What changes

| File | Change |
|------|--------|
| `allreduce_ring_kernel.cpp` | `RoundBarrier` → `NeighborBarrier` (notify right, wait left) |
| `allreduce_bidirectional_ring_kernel.cpp` | `RoundBarrier` → `NeighborBarrier` (notify/wait left+right; collapse when P=2) |
| `allreduce_ibing_kernel.cpp` | Sim: `TPUT_ASYNC` + `WaitAll` on forward; NPU: sync `TPUT<AtomicNone>`; reduce stays sync `AtomicAdd`; reserve 16 KiB SDMA workspace in scratch |
| `_helpers.py` | Add `SDMA_WORKSPACE_SIZE` to ibing scratch sizing |

## Algorithmic logic (before → after)

This PR does **not** invent new collective schedules. The data-movement algorithms stay the same; what changes is *how* we synchronize and *how* forward transfers complete (sim path).

| Mode | Before | After | Logic change? |
|------|--------|-------|---------------|
| **ring** | RS+AG over `2(P−1)` rounds; each round full-mesh barrier, then one peer transfer | Same RS+AG schedule and same round count | **No** — only who you barrier with (neighbors instead of all ranks) |
| **bidirectional_ring** | Two half-data rings (CW+CCW), `2(P−1)+1` rounds; full-mesh barrier; two sync TPUTs per round | Same dual-ring schedule and round count | **No** — same payload movement; neighbor barrier only |
| **ibing** | Interleaved `P−1` rounds; reduce = sync `AtomicAdd` both dirs; forward = sync `AtomicNone` both dirs | Same indices, exchange buffers, and double-barrier snapshot scheme | **Sim only** — forward uses `TPUT_ASYNC` + `WaitAll`; **NPU** keeps sync `AtomicNone` |

## Expected performance impact

### Sync / barrier cost

Barrier *round counts* are unchanged. What drops is the *cost per round*:

| Mode | Barrier rounds | Per-round sync before | Per-round sync after | Expected win |
|------|----------------|----------------------|----------------------|--------------|
| **ring** | `2(P−1)` | notify/wait **P−1** peers | notify **1** + wait **1** | Sync traffic ~`(P−1)×` → `1×` per round; grows with P |
| **bidirectional_ring** | `2(P−1)+1` | notify/wait **P−1** peers | notify/wait left+right (`2`, or `1` if P=2) | Same idea; still `O(1)` per round |
| **ibing** | still `2×(P−1)` + final (double-barrier scheme) | unchanged | unchanged | **No** barrier-count win; NPU data path unchanged |

### Data-path latency (IBing forward)

| Platform | Before | After | Expected win |
|----------|--------|-------|--------------|
| **CPUSIM** | 2× blocking `TPUT` + `pipe_barrier` | 2× `TPUT_ASYNC` + `WaitAll` | API exercise only — sim `TPUT_ASYNC` is immediate sync copy |
| **NPU** | 2× blocking `TPUT<AtomicNone>` | same (gated) | none until SDMA async is loader-safe |

### Qualitative scaling (neighbor barriers)

- **P=2:** small — neighbor sync ≈ full mesh.
- **P=4:** clear ring/bidirectional barrier saving.
- **P=8+:** ring/bidirectional dominate via `O(P)→O(1)` sync.

### Bottom line

- **ring / bidirectional_ring:** same algorithm, cheaper barriers → lower latency especially at larger P.
- **ibing:** sim wires the `TPUT_ASYNC` completion API; NPU remains sync until host `SdmaWorkspaceManager` + AICore loader support land.
- **Not in this PR:** full IBing paper barrier reduction / real NPU dual-direction SDMA overlap.

## NPU note (a5 onboard / issue #900)

Including SDMA async helpers (`BuildAsyncSession` / `async_event_impl.hpp`) in the AIV `.o` produces **unresolved `.text` relocations** that simpler's AICore loader rejects ([#900](https://github.com/hw-native-sys/simpler/issues/900)). Because all allreduce modes share one `_ALLREDUCE_MODES` CALLABLE list, a broken ibing kernel fails **setup for every mode** (onephase/twophase/ring/bidir/ibing).

**Mitigation in this PR:** compile `TPUT_ASYNC` only under `__CPU_SIM` / `__COSTMODEL`; NPU forward path stays on sync `TPUT<AtomicNone>`. NeighborBarrier changes are unaffected.

CI: `st-sim-a2a3` / `st-sim-a5` were already green; onboard a5 failed for the reason above before this gate.

## Why

- Ring topologies only talk to immediate neighbors — a full-mesh barrier per round is unnecessary.
- IBing’s forward phase pushes two independent `AtomicNone` transfers; `TPUT_ASYNC` is the right completion model once SDMA is safe to load on AIV.
- Reduce steps remain synchronous because `TPUT_ASYNC` does not support `AtomicAdd`.

## Notes / stacking

- Head includes the NeighborBarrier commit from `perf/neighbor-only-barriers-ring-allreduce` (**#1378**). Prefer merging #1378 first so this PR becomes a clean TPUT_ASYNC delta; or merge this PR alone if you want both together.
- Real NPU `TPUT_ASYNC` follow-up: host `SdmaWorkspaceManager` workspace + AICore loader reloc support (#900).

## Test plan

- [x] Sim CI: `st-sim-a2a3` / `st-sim-a5` (passed on prior push)
- [ ] Sim: `tests/st/worker/collectives/allreduce/test_allreduce.py` — ring / bidirectional_ring / ibing
- [ ] Onboard a5: allreduce P2 modes should pass setup again after sim-only async gate
- [ ] NPU spot-check a2a3: ibing P=2, ring P=2/P=4, bidirectional_ring P=2/P=4
- [ ] No regression on onephase / twophase modes
- [ ] (Optional) NPU timing before/after on ring + bidirectional_ring at P=4/P=8 to quantify barrier savings