### PR TITLE
Update: deps_viewer HTML uses conventional scroll/zoom gestures

### DIFF
--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -954,7 +954,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   <span class="stat">{n_edges} edges</span>
   <span class="divider"></span>
   <kbd>drag</kbd><span>pan</span>
-  <kbd>wheel</kbd><span>zoom</span>
+  <kbd>scroll</kbd><span>pan</span>
+  <kbd>ctrl+scroll</kbd><span>zoom</span>
   <kbd>f</kbd><span>fit</span>
   <kbd>r</kbd><span>reset</span>
 </div>
@@ -1045,13 +1046,20 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
 
   stage.addEventListener('wheel', (e) => {{
     e.preventDefault();
-    const rect = stage.getBoundingClientRect();
-    const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
-    const factor = Math.exp(-e.deltaY * 0.001);
-    const newScale = Math.min(20, Math.max(0.02, scale * factor));
-    tx = cx - (cx - tx) * (newScale / scale);
-    ty = cy - (cy - ty) * (newScale / scale);
-    scale = newScale;
+    // ctrlKey is set by a real Ctrl+wheel and by trackpad pinch-to-zoom;
+    // a bare wheel / two-finger swipe pans.
+    if (e.ctrlKey) {{
+      const rect = stage.getBoundingClientRect();
+      const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
+      const factor = Math.exp(-e.deltaY * 0.012);
+      const newScale = Math.min(20, Math.max(0.02, scale * factor));
+      tx = cx - (cx - tx) * (newScale / scale);
+      ty = cy - (cy - ty) * (newScale / scale);
+      scale = newScale;
+    }} else {{
+      tx -= e.deltaX;
+      ty -= e.deltaY;
+    }}
     apply();
   }}, {{ passive: false }});
 


### PR DESCRIPTION
## Summary
- The `deps_viewer --format html` pan/zoom page bound a bare mouse wheel
  to zoom, which fights the normal web / trackpad convention.
- Route the `wheel` handler on `e.ctrlKey`:
  - bare wheel / two-finger swipe **pans** (`deltaX`/`deltaY`), matching
    normal page scrolling
  - Ctrl+wheel and trackpad **pinch** (browsers report pinch as a
    `ctrlKey` wheel) **zoom** around the cursor
- Bump the zoom factor `0.001 → 0.012` so Ctrl+wheel / pinch zooms at a
  usable speed, and update the HUD hints (`scroll pan`, `ctrl+scroll zoom`).

## Testing
- [x] Regenerated an HTML viewer from a real `deps.json` and verified the
      new handler and HUD render into the output; pan/zoom gestures behave
      as described.
- [ ] Simulation tests pass (no runtime/kernel code touched — HTML/JS
      template only)