### PR TITLE
docs(test): fix stale TensorDump comment to ArgsDump

### DIFF
--- a/tests/ut/cpp/common/test_profiler_base.cpp
+++ b/tests/ut/cpp/common/test_profiler_base.cpp
@@ -15,7 +15,7 @@
  * The framework runs `min(aicpu_thread_num, Module::kMaxCollectorThreads)`
  * drain+collector threads while scanning `aicpu_thread_num` device ready
  * queues. Those two counts are equal for the scheduler-fed subsystems
- * (L2Swimlane / TensorDump / PMU) but differ for the orchestrator-only ones
+ * (L2Swimlane / ArgsDump / PMU) but differ for the orchestrator-only ones
  * (DepGen / ScopeStats), whose single producer writes the LAST queue while
  * only one shard exists. Both shapes are covered here.
  */


### PR DESCRIPTION
## What

The dump-tensor DFX subsystem was renamed to **dump-args** in a prior PR — the collector is `ArgsDumpCollector` and its subsystem-name string is `"ArgsDump"` (`src/common/platform/include/host/args_dump_collector.h:196`), the generated manifest is `args_dump/args_dump.json`, and all enums/APIs are `ArgsDump*` / `dump_args_*`.

One test header comment in `tests/ut/cpp/common/test_profiler_base.cpp` still referred to the old `TensorDump` name. This aligns it with the actual subsystem name.

## Why

Purely cosmetic — it was the last remaining `TensorDump` identifier in the tree. No code behavior changes. (The only other `tensor_dump` string left is an intentional negative-assertion guard in `test_args_dump.py` verifying the legacy `tensor_dump.json` is not emitted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)