### PR TITLE
feat(a5): add URMA deferred completion backend for tensormap_and_ringbuffer

### DIFF
--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -346,16 +346,12 @@ class RuntimeBuilder:
                 defines: dict[str, str] = {}
                 if build_pto_isa_commit:
                     defines["SIMPLER_PTO_ISA_BUILD_COMMIT"] = build_pto_isa_commit
-                # Mirror the SIMPLER_ENABLE_PTO_SDMA_WORKSPACE env var into the
-                # CMake option (src/{arch}/platform/onboard/host/CMakeLists.txt)
-                # so the a5 SDMA workspace overlay is built only when opted in.
-                if os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() in {
-                    "1",
-                    "ON",
-                    "TRUE",
-                    "YES",
-                }:
-                    defines["SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"] = "ON"
+                for opt_in_define in (
+                    "SIMPLER_ENABLE_PTO_SDMA_WORKSPACE",
+                    "SIMPLER_ENABLE_PTO_URMA_WORKSPACE",
+                ):
+                    if os.environ.get(opt_in_define, "").upper() in {"1", "ON", "TRUE", "YES"}:
+                        defines[opt_in_define] = "ON"
                 cmake_defines = defines or None
             # compile() adds a {target}/ subdirectory inside build_dir
             cache_dir = self._CACHE_DIR / arch / variant / name

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -23,7 +23,7 @@ from .toolchain import Aarch64GxxToolchain, CCECToolchain, GxxToolchain, Toolcha
 logger = logging.getLogger(__name__)
 
 
-_SDMA_WORKSPACE_TRUTHY = {"1", "ON", "TRUE", "YES"}
+_WORKSPACE_TRUTHY = {"1", "ON", "TRUE", "YES"}
 
 
 def _sdma_workspace_enabled() -> bool:
@@ -33,7 +33,12 @@ def _sdma_workspace_enabled() -> bool:
     src/a5/platform/onboard/host/CMakeLists.txt. Set the env var of the same
     name to a truthy value (1/ON/TRUE/YES) to enable the overlay at build time.
     """
-    return os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() in _SDMA_WORKSPACE_TRUTHY
+    return os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() in _WORKSPACE_TRUTHY
+
+
+def _urma_workspace_enabled() -> bool:
+    """Whether the a5 PTO URMA workspace overlay is opted in."""
+    return os.environ.get("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", "").upper() in _WORKSPACE_TRUTHY
 
 
 class BuildTarget:
@@ -184,14 +189,9 @@ class RuntimeCompiler:
     def _init_a5(self):
         """Initialize toolchains for real a5 hardware."""
         env_manager.ensure("ASCEND_HOME_PATH")
-        # The PTO SDMA workspace overlay (comm_hccl.cpp ensure_sdma_workspace +
-        # libnnopbase link) is opt-in via the SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
-        # env var, mirrored to the CMake option of the same name in
-        # src/a5/platform/onboard/host/CMakeLists.txt. Default OFF because the
-        # available a5 CANN drops lack working aclnnShmemSdmaStarsQuery
-        # primitives — see docs/a5-sdma-overlay.md (#1315). When opted in, the
-        # host build needs pto-isa headers via PTO_ISA_ROOT (same contract as a2a3).
-        if _sdma_workspace_enabled():
+        # A5 PTO async workspace overlays are opt-in until the CI CANN package
+        # exposes the required primitives reliably; see #1315.
+        if _sdma_workspace_enabled() or _urma_workspace_enabled():
             env_manager.ensure("PTO_ISA_ROOT")
 
         # AICore: Bisheng CCE compiler with A5 platform

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -181,15 +181,20 @@ find_library(HCOMM_LIB
         ${ASCEND_ARCH_HOME}/lib64
     NO_DEFAULT_PATH
 )
-if(HCCL_LIB AND HCOMM_LIB)
-    set(HCCL_LINK_TARGETS ${HCCL_LIB} ${HCOMM_LIB})
-    message(STATUS "Using HCCL libraries: ${HCCL_LIB};${HCOMM_LIB}")
+if(HCCL_LIB)
+    if(HCOMM_LIB)
+        set(HCCL_LINK_TARGETS ${HCCL_LIB} ${HCOMM_LIB})
+        message(STATUS "Using HCCL libraries: ${HCCL_LIB};${HCOMM_LIB}")
+    else()
+        set(HCCL_LINK_TARGETS ${HCCL_LIB})
+        message(STATUS "Using HCCL library: ${HCCL_LIB}")
+    endif()
 elseif(HCOMM_LIB)
     set(HCCL_LINK_TARGETS ${HCOMM_LIB})
     message(WARNING "libhccl not found; using HCCL library: ${HCOMM_LIB}")
 else()
     message(FATAL_ERROR
-        "libhcomm not found under ${ASCEND_HOME_PATH}/lib64 or ${ASCEND_ARCH_HOME}/lib64")
+        "Neither libhccl nor libhcomm found under ${ASCEND_HOME_PATH}/lib64 or ${ASCEND_ARCH_HOME}/lib64")
 endif()
 
 # Link against CANN runtime libraries

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -32,13 +32,6 @@ if(DEFINED CUSTOM_INCLUDE_DIRS)
 else()
     message(FATAL_ERROR "MUST set CUSTOM_INCLUDE_DIRS to build Host runtime")
 endif()
-if(NOT DEFINED ENV{PTO_ISA_ROOT})
-    message(FATAL_ERROR
-        "a5 onboard host_runtime requires PTO_ISA_ROOT "
-        "(URMA workspace setup uses pto-isa host headers)")
-endif()
-list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
-
 set(ASCEND_ARCH_HOME "${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux")
 
 # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE: opt-in overlay that wires the PTO-ISA
@@ -52,11 +45,12 @@ set(ASCEND_ARCH_HOME "${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux")
 # Flip ON via -DSIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON (or the env var of the
 # same name, forwarded by simpler_setup/runtime_builder.py).
 option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE "Enable a5 PTO SDMA workspace overlay" OFF)
-if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
+option(SIMPLER_ENABLE_PTO_URMA_WORKSPACE "Enable a5 PTO URMA workspace overlay" OFF)
+if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE OR SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
     if(NOT DEFINED ENV{PTO_ISA_ROOT})
         message(FATAL_ERROR
-            "a5 onboard host_runtime with SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON requires PTO_ISA_ROOT "
-            "(needs pto-isa headers + CANN 9.0+ with a5 SDMA primitives)")
+            "a5 onboard host_runtime PTO async workspace overlays require PTO_ISA_ROOT "
+            "(needs pto-isa host headers)")
     endif()
     list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
 endif()
@@ -127,6 +121,9 @@ target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a5")
 
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)
+endif()
+if(SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
+    target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_URMA_WORKSPACE=1)
 endif()
 
 set(SIMPLER_PTO_ISA_BUILD_COMMIT "" CACHE STRING

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -32,6 +32,14 @@ if(DEFINED CUSTOM_INCLUDE_DIRS)
 else()
     message(FATAL_ERROR "MUST set CUSTOM_INCLUDE_DIRS to build Host runtime")
 endif()
+if(NOT DEFINED ENV{PTO_ISA_ROOT})
+    message(FATAL_ERROR
+        "a5 onboard host_runtime requires PTO_ISA_ROOT "
+        "(URMA workspace setup uses pto-isa host headers)")
+endif()
+list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
+
+set(ASCEND_ARCH_HOME "${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux")
 
 # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE: opt-in overlay that wires the PTO-ISA
 # async-SDMA workspace into comm_alloc_windows. When ON it pulls in pto-isa
@@ -121,6 +129,13 @@ if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)
 endif()
 
+set(SIMPLER_PTO_ISA_BUILD_COMMIT "" CACHE STRING
+    "PTO-ISA commit used for host_runtime cache key")
+if(NOT "${SIMPLER_PTO_ISA_BUILD_COMMIT}" STREQUAL "")
+    target_compile_definitions(host_runtime PRIVATE
+        SIMPLER_PTO_ISA_BUILD_COMMIT="${SIMPLER_PTO_ISA_BUILD_COMMIT}")
+endif()
+
 # Include directories - always include local headers
 target_include_directories(host_runtime
     PRIVATE
@@ -139,18 +154,42 @@ target_include_directories(host_runtime
         # rtsLaunchCpuKernel API used by LoadAicpuOp).
         ${ASCEND_HOME_PATH}/pkg_inc/runtime/runtime
         ${ASCEND_HOME_PATH}/pkg_inc/profiling
+        ${ASCEND_ARCH_HOME}/include
+        ${ASCEND_ARCH_HOME}/pkg_inc
+        ${ASCEND_ARCH_HOME}/pkg_inc/runtime
+        ${ASCEND_ARCH_HOME}/pkg_inc/runtime/runtime
+        ${ASCEND_ARCH_HOME}/pkg_inc/profiling
+        ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/asc/include
+        ${ASCEND_ARCH_HOME}/asc/include
+        ${ASCEND_ARCH_HOME}/include/driver
         ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/include/driver
 )
 
-# CANN 9.x exposes the working non-V2 HCCL entry points through libhcomm.
-# Link it explicitly so comm_hccl.cpp can follow the same initialization path
-# as the pto-isa communication tests.
-find_library(HCOMM_LIB NAMES hcomm PATHS ${ASCEND_HOME_PATH}/lib64 NO_DEFAULT_PATH)
-if(HCOMM_LIB)
+# Prefer libhccl when the CANN package ships it. Newer CANN packages may only
+# ship libhcomm, matching pto-isa's own A5 comm tests, so fall back to hcomm.
+find_library(HCCL_LIB
+    NAMES hccl
+    PATHS
+        ${ASCEND_HOME_PATH}/lib64
+        ${ASCEND_ARCH_HOME}/lib64
+    NO_DEFAULT_PATH
+)
+find_library(HCOMM_LIB
+    NAMES hcomm
+    PATHS
+        ${ASCEND_HOME_PATH}/lib64
+        ${ASCEND_ARCH_HOME}/lib64
+    NO_DEFAULT_PATH
+)
+if(HCCL_LIB AND HCOMM_LIB)
+    set(HCCL_LINK_TARGETS ${HCCL_LIB} ${HCOMM_LIB})
+    message(STATUS "Using HCCL libraries: ${HCCL_LIB};${HCOMM_LIB}")
+elseif(HCOMM_LIB)
     set(HCCL_LINK_TARGETS ${HCOMM_LIB})
-    message(STATUS "Using HCCL library: ${HCOMM_LIB}")
+    message(WARNING "libhccl not found; using HCCL library: ${HCOMM_LIB}")
 else()
-    message(FATAL_ERROR "libhcomm not found under ${ASCEND_HOME_PATH}/lib64")
+    message(FATAL_ERROR
+        "libhcomm not found under ${ASCEND_HOME_PATH}/lib64 or ${ASCEND_ARCH_HOME}/lib64")
 endif()
 
 # Link against CANN runtime libraries
@@ -166,6 +205,8 @@ target_link_libraries(host_runtime
         runtime
         ascendcl
         -Wl,--no-as-needed ${HCCL_LINK_TARGETS} -Wl,--as-needed
+        c_sec
+        nnopbase
         dl
 )
 
@@ -173,6 +214,9 @@ target_link_directories(host_runtime
     PRIVATE
         ${ASCEND_HOME_PATH}/lib64
         ${ASCEND_HOME_PATH}/runtime/lib64
+        ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/lib64
+        ${ASCEND_ARCH_HOME}/lib64
+        ${ASCEND_ARCH_HOME}/runtime/lib64
 )
 
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -46,6 +46,11 @@ set(ASCEND_ARCH_HOME "${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux")
 # same name, forwarded by simpler_setup/runtime_builder.py).
 option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE "Enable a5 PTO SDMA workspace overlay" OFF)
 option(SIMPLER_ENABLE_PTO_URMA_WORKSPACE "Enable a5 PTO URMA workspace overlay" OFF)
+if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE AND SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
+    message(FATAL_ERROR
+        "SIMPLER_ENABLE_PTO_SDMA_WORKSPACE and SIMPLER_ENABLE_PTO_URMA_WORKSPACE are mutually exclusive "
+        "because CommContext exposes a single workSpace/workSpaceSize pair")
+endif()
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE OR SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
     if(NOT DEFINED ENV{PTO_ISA_ROOT})
         message(FATAL_ERROR

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -771,8 +771,7 @@ static uint64_t urma_workspace_bytes(uint32_t rank_count) {
     constexpr uint32_t qp_num = 1;
     return sizeof(UrmaInfo) +
            static_cast<uint64_t>(rank_count) *
-               (2ULL * sizeof(UrmaWQCtx) * qp_num + 2ULL * sizeof(UrmaCqCtx) * qp_num +
-                sizeof(UrmaMemInfo) * qp_num);
+               (2ULL * sizeof(UrmaWQCtx) * qp_num + 2ULL * sizeof(UrmaCqCtx) * qp_num + sizeof(UrmaMemInfo) * qp_num);
 }
 
 static bool rank_ids_are_dense_prefix(const uint32_t *rank_ids, size_t rank_count) {
@@ -1032,9 +1031,7 @@ static int domain_alloc_via_ipc(
         domain_workspace_addr = reinterpret_cast<uint64_t>(out->urma_workspace->GetWorkspaceAddr());
         domain_workspace_size = urma_workspace_bytes(static_cast<uint32_t>(rank_count));
     } else {
-        LOG_WARN(
-            "[comm rank %d] alloc_domain: URMA workspace disabled for non-dense rank mapping", h->rank
-        );
+        LOG_WARN("[comm rank %d] alloc_domain: URMA workspace disabled for non-dense rank mapping", h->rank);
     }
 #endif
 

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -50,6 +50,7 @@
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
 #include "pto/comm/async/sdma/sdma_workspace_manager.hpp"
 #endif
+#include "pto/comm/async/urma/urma_workspace_manager.hpp"
 
 // Thin wrappers around the HCCL public APIs we use. Kept as a translation
 // layer in case we need to swap (e.g., InitConfig variant) later.
@@ -82,6 +83,7 @@ struct DomainAllocation {
     // can cycle repeatedly within one comm handle before any device reset, so
     // these are released explicitly at domain teardown rather than left to reset.
     std::vector<std::pair<void *, aclrtDrvMemHandle>> peer_windows;
+    std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> urma_workspace;
     CommContext *device_ctx = nullptr;  // aclrtMalloc'd CommContext mirror
 };
 
@@ -103,6 +105,7 @@ struct CommHandle_ {
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
     std::unique_ptr<pto::comm::sdma::SdmaWorkspaceManager> sdma_workspace;
 #endif
+    std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> urma_workspace;
 };
 
 // ============================================================================
@@ -756,6 +759,60 @@ static void ensure_sdma_workspace(CommHandle h) {
 #endif
 }
 
+static uint64_t urma_workspace_bytes(uint32_t rank_count) {
+    using namespace pto::comm::urma;
+    constexpr uint32_t qp_num = 1;
+    return sizeof(UrmaInfo) +
+           static_cast<uint64_t>(rank_count) *
+               (2ULL * sizeof(UrmaWQCtx) * qp_num + 2ULL * sizeof(UrmaCqCtx) * qp_num +
+                sizeof(UrmaMemInfo) * qp_num);
+}
+
+static bool rank_ids_are_dense_prefix(const uint32_t *rank_ids, size_t rank_count) {
+    if (rank_ids == nullptr) return false;
+    for (size_t i = 0; i < rank_count; ++i) {
+        if (rank_ids[i] != static_cast<uint32_t>(i)) return false;
+    }
+    return true;
+}
+
+static bool init_urma_workspace(
+    CommHandle h, uint32_t rank_id, uint32_t rank_count, void *symmetric_addr, uint64_t symmetric_size,
+    std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> &workspace
+) {
+    if (workspace) return workspace->GetWorkspaceAddr() != nullptr;
+    if (h == nullptr || h->hccl_comm == nullptr || symmetric_addr == nullptr || symmetric_size == 0 ||
+        rank_id >= rank_count) {
+        return false;
+    }
+
+    auto manager = std::make_unique<pto::comm::urma::UrmaWorkspaceManager>();
+    if (!manager->Init(h->hccl_comm, rank_id, rank_count, symmetric_addr, symmetric_size)) {
+        LOG_WARN(
+            "[comm rank %d] URMA workspace init failed (rank_id=%u rank_count=%u size=%llu)", h->rank, rank_id,
+            rank_count, static_cast<unsigned long long>(symmetric_size)
+        );
+        return false;
+    }
+    workspace = std::move(manager);
+    return true;
+}
+
+static bool ensure_base_urma_workspace(CommHandle h) {
+    if (h == nullptr) return false;
+    if (h->urma_workspace) return h->host_ctx.workSpace != 0 && h->host_ctx.workSpaceSize != 0;
+    void *local_buf = reinterpret_cast<void *>(static_cast<uintptr_t>(h->host_ctx.windowsIn[h->rank]));
+    if (!init_urma_workspace(
+            h, static_cast<uint32_t>(h->rank), static_cast<uint32_t>(h->nranks), local_buf, h->host_ctx.winSize,
+            h->urma_workspace
+        )) {
+        return false;
+    }
+    h->host_ctx.workSpace = reinterpret_cast<uint64_t>(h->urma_workspace->GetWorkspaceAddr());
+    h->host_ctx.workSpaceSize = urma_workspace_bytes(static_cast<uint32_t>(h->nranks));
+    return h->host_ctx.workSpace != 0 && h->host_ctx.workSpaceSize != 0;
+}
+
 // Performs the per-allocation Path-D dance for one subset rank.  rank_ids
 // must list participating BASE-COMM rank ids in domain rank order; this
 // rank's domain_rank must match its base rank for the same invariant
@@ -930,12 +987,31 @@ static int domain_alloc_via_ipc(
     // those kernels early-return on the workSpace guard.
     ensure_sdma_workspace(h);
 
+    uint64_t domain_workspace_addr = h->host_ctx.workSpace;
+    uint64_t domain_workspace_size = h->host_ctx.workSpaceSize;
+    if (rank_ids_are_dense_prefix(rank_ids, rank_count)) {
+        if (!init_urma_workspace(
+                h, domain_rank, static_cast<uint32_t>(rank_count), localBuf, aligned_size, out->urma_workspace
+            )) {
+            out->urma_workspace.reset();
+            release_domain_peer_windows(*out);
+            release_own_vmm_window(localBuf, handle);
+            return -1;
+        }
+        domain_workspace_addr = reinterpret_cast<uint64_t>(out->urma_workspace->GetWorkspaceAddr());
+        domain_workspace_size = urma_workspace_bytes(static_cast<uint32_t>(rank_count));
+    } else {
+        LOG_WARN(
+            "[comm rank %d] alloc_domain: URMA workspace disabled for non-dense rank mapping", h->rank
+        );
+    }
+
     CommContext ctx{};
     ctx.rankId = domain_rank;
     ctx.rankNum = static_cast<uint32_t>(subset_n);
     ctx.winSize = aligned_size;
-    ctx.workSpace = h->host_ctx.workSpace;
-    ctx.workSpaceSize = h->host_ctx.workSpaceSize;
+    ctx.workSpace = domain_workspace_addr;
+    ctx.workSpaceSize = domain_workspace_size;
     ctx.windowsIn[my_dr] = reinterpret_cast<uint64_t>(localBuf);
     // Import each peer's shareable handle onto our device; see the symmetry
     // note in alloc_windows_via_ipc (one win_size, shared chip granularity).
@@ -948,6 +1024,7 @@ static int domain_alloc_via_ipc(
                 "[comm rank %d] alloc_domain: ImportFromShareableHandle(peer_dr=%d) -> %d", h->rank, p,
                 static_cast<int>(aret)
             );
+            out->urma_workspace.reset();
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -960,6 +1037,7 @@ static int domain_alloc_via_ipc(
                 static_cast<int>(aret)
             );
             aclrtFreePhysical(peerHandle);
+            out->urma_workspace.reset();
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -969,6 +1047,7 @@ static int domain_alloc_via_ipc(
             LOG_ERROR("[comm rank %d] alloc_domain: peer MapMem(peer_dr=%d) -> %d", h->rank, p, static_cast<int>(aret));
             aclrtReleaseMemAddress(peerVa);
             aclrtFreePhysical(peerHandle);
+            out->urma_workspace.reset();
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -981,6 +1060,7 @@ static int domain_alloc_via_ipc(
             aclrtUnmapMem(peerVa);
             aclrtReleaseMemAddress(peerVa);
             aclrtFreePhysical(peerHandle);
+            out->urma_workspace.reset();
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -993,6 +1073,7 @@ static int domain_alloc_via_ipc(
     aret = aclrtMalloc(&newDevMem, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ctx aclrtMalloc -> %d", h->rank, static_cast<int>(aret));
+        out->urma_workspace.reset();
         release_own_vmm_window(localBuf, handle);
         return -1;
     }
@@ -1000,6 +1081,7 @@ static int domain_alloc_via_ipc(
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ctx Memcpy H2D -> %d", h->rank, static_cast<int>(aret));
         aclrtFree(newDevMem);
+        out->urma_workspace.reset();
         release_own_vmm_window(localBuf, handle);
         return -1;
     }
@@ -1032,6 +1114,8 @@ extern "C" int comm_alloc_windows(CommHandle h, size_t win_size, uint64_t *devic
     // Optional PTO-ISA async SDMA workspace pre-allocation (overlays the comm
     // backend's output; comm-side flow does not care about workSpace).
     ensure_sdma_workspace(h);
+    if (!ensure_base_urma_workspace(h)) return -1;
+    if (!file_barrier(h->rootinfo_path, h->rank, h->nranks, "base_urma_ready", h->run_token)) return -1;
 
     void *newDevMem = nullptr;
     aclError aRet = aclrtMalloc(&newDevMem, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
@@ -1193,6 +1277,8 @@ extern "C" int comm_alloc_domain_windows(
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
         aclrtFree(alloc->device_ctx);
+        alloc->urma_workspace.reset();
+        release_domain_peer_windows(*alloc);
         release_own_vmm_window(alloc->local_buf, alloc->own_handle);
         return -1;
     }
@@ -1245,6 +1331,7 @@ comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_co
         aclError aret = aclrtFree(alloc->device_ctx);
         if (aret != ACL_SUCCESS && rc == 0) rc = -1;
     }
+    alloc->urma_workspace.reset();
     // local_buf and every peer import are VMM-mapped VAs, not aclrtMalloc
     // pointers: unmap + release the VA reservation, then free the physical
     // handle.
@@ -1290,10 +1377,12 @@ extern "C" int comm_destroy(CommHandle h) try {
     for (auto &kv : h->domain_allocations) {
         auto &alloc = kv.second;
         if (alloc->device_ctx) aclrtFree(alloc->device_ctx);
+        alloc->urma_workspace.reset();
         release_domain_peer_windows(*alloc);
         if (alloc->local_buf) release_own_vmm_window(alloc->local_buf, alloc->own_handle);
     }
     h->domain_allocations.clear();
+    h->urma_workspace.reset();
     if (h->hccl_comm) {
         HcclResult hret = hccl_comm_destroy(h->hccl_comm);
         if (hret != HCCL_SUCCESS) {

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -987,8 +987,14 @@ static int domain_alloc_via_ipc(
     // those kernels early-return on the workSpace guard.
     ensure_sdma_workspace(h);
 
-    uint64_t domain_workspace_addr = h->host_ctx.workSpace;
-    uint64_t domain_workspace_size = h->host_ctx.workSpaceSize;
+    uint64_t domain_workspace_addr = 0;
+    uint64_t domain_workspace_size = 0;
+#ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
+    if (h->sdma_workspace) {
+        domain_workspace_addr = reinterpret_cast<uint64_t>(h->sdma_workspace->GetWorkspaceAddr());
+        domain_workspace_size = 16 * 1024;
+    }
+#endif
     if (rank_ids_are_dense_prefix(rank_ids, rank_count)) {
         if (!init_urma_workspace(
                 h, domain_rank, static_cast<uint32_t>(rank_count), localBuf, aligned_size, out->urma_workspace
@@ -1074,6 +1080,7 @@ static int domain_alloc_via_ipc(
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ctx aclrtMalloc -> %d", h->rank, static_cast<int>(aret));
         out->urma_workspace.reset();
+        release_domain_peer_windows(*out);
         release_own_vmm_window(localBuf, handle);
         return -1;
     }
@@ -1082,6 +1089,7 @@ static int domain_alloc_via_ipc(
         LOG_ERROR("[comm rank %d] alloc_domain: ctx Memcpy H2D -> %d", h->rank, static_cast<int>(aret));
         aclrtFree(newDevMem);
         out->urma_workspace.reset();
+        release_domain_peer_windows(*out);
         release_own_vmm_window(localBuf, handle);
         return -1;
     }

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -50,7 +50,9 @@
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
 #include "pto/comm/async/sdma/sdma_workspace_manager.hpp"
 #endif
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
 #include "pto/comm/async/urma/urma_workspace_manager.hpp"
+#endif
 
 // Thin wrappers around the HCCL public APIs we use. Kept as a translation
 // layer in case we need to swap (e.g., InitConfig variant) later.
@@ -83,7 +85,9 @@ struct DomainAllocation {
     // can cycle repeatedly within one comm handle before any device reset, so
     // these are released explicitly at domain teardown rather than left to reset.
     std::vector<std::pair<void *, aclrtDrvMemHandle>> peer_windows;
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> urma_workspace;
+#endif
     CommContext *device_ctx = nullptr;  // aclrtMalloc'd CommContext mirror
 };
 
@@ -105,7 +109,9 @@ struct CommHandle_ {
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
     std::unique_ptr<pto::comm::sdma::SdmaWorkspaceManager> sdma_workspace;
 #endif
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> urma_workspace;
+#endif
 };
 
 // ============================================================================
@@ -759,6 +765,7 @@ static void ensure_sdma_workspace(CommHandle h) {
 #endif
 }
 
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
 static uint64_t urma_workspace_bytes(uint32_t rank_count) {
     using namespace pto::comm::urma;
     constexpr uint32_t qp_num = 1;
@@ -811,6 +818,23 @@ static bool ensure_base_urma_workspace(CommHandle h) {
     h->host_ctx.workSpace = reinterpret_cast<uint64_t>(h->urma_workspace->GetWorkspaceAddr());
     h->host_ctx.workSpaceSize = urma_workspace_bytes(static_cast<uint32_t>(h->nranks));
     return h->host_ctx.workSpace != 0 && h->host_ctx.workSpaceSize != 0;
+}
+#endif
+
+static void reset_domain_urma_workspace(DomainAllocation &alloc) {
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
+    alloc.urma_workspace.reset();
+#else
+    (void)alloc;
+#endif
+}
+
+static void reset_base_urma_workspace(CommHandle h) {
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
+    h->urma_workspace.reset();
+#else
+    (void)h;
+#endif
 }
 
 // Performs the per-allocation Path-D dance for one subset rank.  rank_ids
@@ -995,11 +1019,12 @@ static int domain_alloc_via_ipc(
         domain_workspace_size = 16 * 1024;
     }
 #endif
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     if (rank_ids_are_dense_prefix(rank_ids, rank_count)) {
         if (!init_urma_workspace(
                 h, domain_rank, static_cast<uint32_t>(rank_count), localBuf, aligned_size, out->urma_workspace
             )) {
-            out->urma_workspace.reset();
+            reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -1011,6 +1036,7 @@ static int domain_alloc_via_ipc(
             "[comm rank %d] alloc_domain: URMA workspace disabled for non-dense rank mapping", h->rank
         );
     }
+#endif
 
     CommContext ctx{};
     ctx.rankId = domain_rank;
@@ -1030,7 +1056,7 @@ static int domain_alloc_via_ipc(
                 "[comm rank %d] alloc_domain: ImportFromShareableHandle(peer_dr=%d) -> %d", h->rank, p,
                 static_cast<int>(aret)
             );
-            out->urma_workspace.reset();
+            reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -1043,7 +1069,7 @@ static int domain_alloc_via_ipc(
                 static_cast<int>(aret)
             );
             aclrtFreePhysical(peerHandle);
-            out->urma_workspace.reset();
+            reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -1053,7 +1079,7 @@ static int domain_alloc_via_ipc(
             LOG_ERROR("[comm rank %d] alloc_domain: peer MapMem(peer_dr=%d) -> %d", h->rank, p, static_cast<int>(aret));
             aclrtReleaseMemAddress(peerVa);
             aclrtFreePhysical(peerHandle);
-            out->urma_workspace.reset();
+            reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -1066,7 +1092,7 @@ static int domain_alloc_via_ipc(
             aclrtUnmapMem(peerVa);
             aclrtReleaseMemAddress(peerVa);
             aclrtFreePhysical(peerHandle);
-            out->urma_workspace.reset();
+            reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
             release_own_vmm_window(localBuf, handle);
             return -1;
@@ -1079,7 +1105,7 @@ static int domain_alloc_via_ipc(
     aret = aclrtMalloc(&newDevMem, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ctx aclrtMalloc -> %d", h->rank, static_cast<int>(aret));
-        out->urma_workspace.reset();
+        reset_domain_urma_workspace(*out);
         release_domain_peer_windows(*out);
         release_own_vmm_window(localBuf, handle);
         return -1;
@@ -1088,7 +1114,7 @@ static int domain_alloc_via_ipc(
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ctx Memcpy H2D -> %d", h->rank, static_cast<int>(aret));
         aclrtFree(newDevMem);
-        out->urma_workspace.reset();
+        reset_domain_urma_workspace(*out);
         release_domain_peer_windows(*out);
         release_own_vmm_window(localBuf, handle);
         return -1;
@@ -1122,8 +1148,10 @@ extern "C" int comm_alloc_windows(CommHandle h, size_t win_size, uint64_t *devic
     // Optional PTO-ISA async SDMA workspace pre-allocation (overlays the comm
     // backend's output; comm-side flow does not care about workSpace).
     ensure_sdma_workspace(h);
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     if (!ensure_base_urma_workspace(h)) return -1;
     if (!file_barrier(h->rootinfo_path, h->rank, h->nranks, "base_urma_ready", h->run_token)) return -1;
+#endif
 
     void *newDevMem = nullptr;
     aclError aRet = aclrtMalloc(&newDevMem, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
@@ -1285,7 +1313,7 @@ extern "C" int comm_alloc_domain_windows(
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
         aclrtFree(alloc->device_ctx);
-        alloc->urma_workspace.reset();
+        reset_domain_urma_workspace(*alloc);
         release_domain_peer_windows(*alloc);
         release_own_vmm_window(alloc->local_buf, alloc->own_handle);
         return -1;
@@ -1339,7 +1367,7 @@ comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_co
         aclError aret = aclrtFree(alloc->device_ctx);
         if (aret != ACL_SUCCESS && rc == 0) rc = -1;
     }
-    alloc->urma_workspace.reset();
+    reset_domain_urma_workspace(*alloc);
     // local_buf and every peer import are VMM-mapped VAs, not aclrtMalloc
     // pointers: unmap + release the VA reservation, then free the physical
     // handle.
@@ -1385,12 +1413,12 @@ extern "C" int comm_destroy(CommHandle h) try {
     for (auto &kv : h->domain_allocations) {
         auto &alloc = kv.second;
         if (alloc->device_ctx) aclrtFree(alloc->device_ctx);
-        alloc->urma_workspace.reset();
+        reset_domain_urma_workspace(*alloc);
         release_domain_peer_windows(*alloc);
         if (alloc->local_buf) release_own_vmm_window(alloc->local_buf, alloc->own_handle);
     }
     h->domain_allocations.clear();
-    h->urma_workspace.reset();
+    reset_base_urma_workspace(h);
     if (h->hccl_comm) {
         HcclResult hret = hccl_comm_destroy(h->hccl_comm);
         if (hret != HCCL_SUCCESS) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -116,6 +116,12 @@ struct AICoreCompletionMailbox {
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
     bool try_push_condition(
+        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+    ) {
+        return try_push_condition(task_token, addr, 0, expected_value, engine, completion_type);
+    }
+
+    bool try_push_condition(
         PTO2TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
         int32_t completion_type
     ) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -56,11 +56,12 @@ struct AICoreCompletionMailboxMessage {
     // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
+    uint64_t backend_cookie;
     uint32_t expected_value;
     uint32_t engine;
     int32_t completion_type;
     uint32_t kind;
-    uint32_t _pad[5];
+    uint32_t _pad[3];
 };
 
 static_assert(sizeof(AICoreCompletionMailboxMessage) == PTO2_ALIGN_SIZE, "AICoreCompletionMailboxMessage layout drift");
@@ -79,6 +80,7 @@ static_assert(
 struct AICoreCompletionMsgView {
     PTO2TaskId task_token{PTO2TaskId::invalid()};
     uint64_t addr{0};
+    uint64_t backend_cookie{0};
     uint32_t expected_value{0};
     uint32_t engine{0};
     int32_t completion_type{0};
@@ -114,7 +116,8 @@ struct AICoreCompletionMailbox {
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+        PTO2TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
+        int32_t completion_type
     ) {
         while (true) {
             uint64_t h = head.load(std::memory_order_relaxed);
@@ -125,6 +128,7 @@ struct AICoreCompletionMailbox {
                 AICoreCompletionMailboxMessage *slot = &entries[h & AICORE_COMPLETION_MAILBOX_MASK];
                 slot->task_token.raw = task_token.raw;
                 slot->addr = addr;
+                slot->backend_cookie = backend_cookie;
                 slot->expected_value = expected_value;
                 slot->engine = engine;
                 slot->completion_type = completion_type;
@@ -149,6 +153,7 @@ struct AICoreCompletionMailbox {
                 AICoreCompletionMailboxMessage *slot = &entries[h & AICORE_COMPLETION_MAILBOX_MASK];
                 slot->task_token.raw = task_token.raw;
                 slot->addr = slot_state_addr;
+                slot->backend_cookie = 0;
                 slot->expected_value = 0;
                 slot->engine = 0;
                 slot->completion_type = 0;
@@ -173,6 +178,7 @@ struct AICoreCompletionMailbox {
         if (slot->seq.load(std::memory_order_acquire) != t + 1) return false;
         out.task_token.raw = slot->task_token.raw;
         out.addr = slot->addr;
+        out.backend_cookie = slot->backend_cookie;
         out.expected_value = slot->expected_value;
         out.engine = slot->engine;
         out.completion_type = slot->completion_type;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
@@ -35,6 +35,7 @@ inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 
 #define COMPLETION_TYPE_COUNTER 0
 #define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
+#define COMPLETION_TYPE_URMA_EVENT_HANDLE 2
 
 // DeferredCompletionEntry / DeferredCompletionSlab back the per-task scratch
 // area that AICore writes into to record "this completion has to be observed
@@ -45,13 +46,14 @@ inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 // pin the compiler against caching / reordering on either side.
 struct DeferredCompletionEntry {
     uint64_t addr;
+    uint64_t backend_cookie;
     uint32_t expected_value;
     uint32_t engine;
     int32_t completion_type;
     uint32_t _pad;
 };
 
-static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
+static_assert(sizeof(DeferredCompletionEntry) == 32, "DeferredCompletionEntry layout drift");
 
 struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
     volatile uint32_t count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_kernel.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_kernel.h
@@ -164,12 +164,16 @@ template <typename TensorT>
 inline __aicore__ TensorT make_tensor_slice(TensorT &tensor, uint64_t elem_offset, uint64_t elem_count) {
     using ShapeT = typename TensorT::Shape;
     using StrideT = typename TensorT::Stride;
-    ShapeT shape(tensor.GetShape(pto::GlobalTensorDim::DIM_0), tensor.GetShape(pto::GlobalTensorDim::DIM_1),
-                 tensor.GetShape(pto::GlobalTensorDim::DIM_2), tensor.GetShape(pto::GlobalTensorDim::DIM_3),
-                 static_cast<int64_t>(elem_count));
-    StrideT stride(tensor.GetStride(pto::GlobalTensorDim::DIM_0), tensor.GetStride(pto::GlobalTensorDim::DIM_1),
-                   tensor.GetStride(pto::GlobalTensorDim::DIM_2), tensor.GetStride(pto::GlobalTensorDim::DIM_3),
-                   tensor.GetStride(pto::GlobalTensorDim::DIM_4));
+    ShapeT shape(
+        tensor.GetShape(pto::GlobalTensorDim::DIM_0), tensor.GetShape(pto::GlobalTensorDim::DIM_1),
+        tensor.GetShape(pto::GlobalTensorDim::DIM_2), tensor.GetShape(pto::GlobalTensorDim::DIM_3),
+        static_cast<int64_t>(elem_count)
+    );
+    StrideT stride(
+        tensor.GetStride(pto::GlobalTensorDim::DIM_0), tensor.GetStride(pto::GlobalTensorDim::DIM_1),
+        tensor.GetStride(pto::GlobalTensorDim::DIM_2), tensor.GetStride(pto::GlobalTensorDim::DIM_3),
+        tensor.GetStride(pto::GlobalTensorDim::DIM_4)
+    );
     return TensorT(tensor.data() + elem_offset, shape, stride);
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_kernel.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_kernel.h
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_URMA_URMA_COMPLETION_KERNEL_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_URMA_URMA_COMPLETION_KERNEL_H_
+
+#include <stdint.h>
+
+#include <type_traits>
+
+#if defined(__CPU_SIM)
+#include <type_traits>
+#else
+#include "pto_async_kernel_api.h"
+
+#include <pto/comm/async_common/async_event_impl.hpp>
+#if defined(PTO_URMA_SUPPORTED)
+#include <pto/comm/async/urma/urma_async_intrin.hpp>
+#endif
+#endif
+
+#include "aicore_completion_mailbox_types.h"
+#include "intrinsic.h"
+#include "pto_completion_token.h"
+#include "pto_runtime_status.h"
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+#ifndef __gm__
+#define __gm__
+#endif
+
+#if defined(__CPU_SIM)
+namespace pto {
+
+struct GlobalTensorDim {
+    static constexpr int DIM_0 = 0;
+    static constexpr int DIM_1 = 1;
+    static constexpr int DIM_2 = 2;
+    static constexpr int DIM_3 = 3;
+    static constexpr int DIM_4 = 4;
+};
+
+enum class Layout : uint8_t {
+    ND = 0,
+    DN = 1,
+};
+
+namespace comm {
+enum class DmaEngine : uint8_t {
+    SDMA = 0,
+    URMA = 1,
+};
+}  // namespace comm
+
+}  // namespace pto
+#endif
+
+enum class UrmaOp : uint8_t {
+    TGET = 0,
+    TPUT = 1,
+};
+
+template <typename DstTensor, typename SrcTensor>
+struct UrmaRequestDescriptor {
+    UrmaOp op;
+    DstTensor dst;
+    SrcTensor src;
+    __gm__ uint8_t *workspace;
+    uint32_t remote_rank;
+};
+
+template <typename DstTensor, typename SrcTensor>
+inline __aicore__ UrmaRequestDescriptor<DstTensor, SrcTensor>
+UrmaTget(const DstTensor &dst, const SrcTensor &src, __gm__ uint8_t *workspace, uint32_t src_rank) {
+    return UrmaRequestDescriptor<DstTensor, SrcTensor>{UrmaOp::TGET, dst, src, workspace, src_rank};
+}
+
+template <typename DstTensor, typename SrcTensor>
+inline __aicore__ UrmaRequestDescriptor<DstTensor, SrcTensor>
+UrmaTput(const DstTensor &dst, const SrcTensor &src, __gm__ uint8_t *workspace, uint32_t dest_rank) {
+    return UrmaRequestDescriptor<DstTensor, SrcTensor>{UrmaOp::TPUT, dst, src, workspace, dest_rank};
+}
+
+namespace pto2::detail {
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ void register_urma_async_event(
+    AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
+);
+
+}  // namespace pto2::detail
+
+namespace pto2::urma_backend {
+
+inline constexpr uint64_t kUrmaMaxTransferBytes = 256ULL * 1024ULL * 1024ULL;
+
+#if defined(PTO_URMA_SUPPORTED)
+static_assert(kUrmaMaxTransferBytes == pto::comm::urma::kUrmaMaxWqeTransferBytes, "URMA transfer limit drift");
+#endif
+
+inline __aicore__ uint64_t peer_mr_base_addr(__gm__ uint8_t *workspace, uint32_t peer) {
+#if defined(__CPU_SIM)
+    (void)workspace;
+    (void)peer;
+    return 0;
+#elif defined(PTO_URMA_SUPPORTED)
+    return pto::comm::urma::UrmaPeerMrBaseAddr(workspace, peer);
+#else
+    (void)workspace;
+    (void)peer;
+    return 0;
+#endif
+}
+
+template <typename T>
+inline __aicore__ __gm__ T *peer_mr_ptr(__gm__ uint8_t *workspace, uint32_t peer, uint64_t local_offset) {
+    return reinterpret_cast<__gm__ T *>(peer_mr_base_addr(workspace, peer) + local_offset);
+}
+
+template <typename TensorT>
+inline __aicore__ uint64_t tensor_element_count(TensorT &tensor) {
+    return static_cast<uint64_t>(tensor.GetShape(pto::GlobalTensorDim::DIM_0)) *
+           static_cast<uint64_t>(tensor.GetShape(pto::GlobalTensorDim::DIM_1)) *
+           static_cast<uint64_t>(tensor.GetShape(pto::GlobalTensorDim::DIM_2)) *
+           static_cast<uint64_t>(tensor.GetShape(pto::GlobalTensorDim::DIM_3)) *
+           static_cast<uint64_t>(tensor.GetShape(pto::GlobalTensorDim::DIM_4));
+}
+
+inline __aicore__ uint64_t chunk_count(uint64_t total_bytes) {
+    return (total_bytes + kUrmaMaxTransferBytes - 1) / kUrmaMaxTransferBytes;
+}
+
+template <typename TensorT>
+inline __aicore__ bool is_flat_contiguous_1d(TensorT &tensor) {
+    const int64_t shp0 = tensor.GetShape(pto::GlobalTensorDim::DIM_0);
+    const int64_t shp1 = tensor.GetShape(pto::GlobalTensorDim::DIM_1);
+    const int64_t shp2 = tensor.GetShape(pto::GlobalTensorDim::DIM_2);
+    const int64_t shp3 = tensor.GetShape(pto::GlobalTensorDim::DIM_3);
+    const int64_t shp4 = tensor.GetShape(pto::GlobalTensorDim::DIM_4);
+
+    const int64_t step0 = tensor.GetStride(pto::GlobalTensorDim::DIM_0);
+    const int64_t step1 = tensor.GetStride(pto::GlobalTensorDim::DIM_1);
+    const int64_t step2 = tensor.GetStride(pto::GlobalTensorDim::DIM_2);
+    const int64_t step3 = tensor.GetStride(pto::GlobalTensorDim::DIM_3);
+    const int64_t step4 = tensor.GetStride(pto::GlobalTensorDim::DIM_4);
+
+    const bool packed_layout = (step4 == 1) && (step3 == shp4) && (step2 == shp3 * step3) && (step1 == shp2 * step2) &&
+                               (step0 == shp1 * step1);
+    const bool one_dim_logical = (shp0 == 1 && shp1 == 1 && shp2 == 1 && shp3 == 1);
+    return packed_layout && one_dim_logical;
+}
+
+template <typename TensorT>
+inline __aicore__ TensorT make_tensor_slice(TensorT &tensor, uint64_t elem_offset, uint64_t elem_count) {
+    using ShapeT = typename TensorT::Shape;
+    using StrideT = typename TensorT::Stride;
+    ShapeT shape(tensor.GetShape(pto::GlobalTensorDim::DIM_0), tensor.GetShape(pto::GlobalTensorDim::DIM_1),
+                 tensor.GetShape(pto::GlobalTensorDim::DIM_2), tensor.GetShape(pto::GlobalTensorDim::DIM_3),
+                 static_cast<int64_t>(elem_count));
+    StrideT stride(tensor.GetStride(pto::GlobalTensorDim::DIM_0), tensor.GetStride(pto::GlobalTensorDim::DIM_1),
+                   tensor.GetStride(pto::GlobalTensorDim::DIM_2), tensor.GetStride(pto::GlobalTensorDim::DIM_3),
+                   tensor.GetStride(pto::GlobalTensorDim::DIM_4));
+    return TensorT(tensor.data() + elem_offset, shape, stride);
+}
+
+template <typename DstTensor, typename SrcTensor>
+inline __aicore__ bool submit_urma_request_once(AsyncCtx &ctx, UrmaRequestDescriptor<DstTensor, SrcTensor> desc) {
+#if defined(PTO_URMA_SUPPORTED)
+    pto::comm::AsyncSession session;
+    if (!pto::comm::BuildAsyncSession<pto::comm::DmaEngine::URMA>(desc.workspace, desc.remote_rank, session)) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return false;
+    }
+
+    pto::comm::AsyncEvent event;
+    if (desc.op == UrmaOp::TGET) {
+        event = pto::comm::TGET_ASYNC<pto::comm::DmaEngine::URMA>(desc.dst, desc.src, session);
+    } else {
+        event = pto::comm::TPUT_ASYNC<pto::comm::DmaEngine::URMA>(desc.dst, desc.src, session);
+    }
+    pto2::detail::register_urma_async_event(ctx, event, session, desc.workspace);
+    pto2::detail::defer_flush(ctx);
+    return true;
+#else
+    (void)desc;
+    pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+    return false;
+#endif
+}
+
+template <typename DstTensor, typename SrcTensor>
+inline __aicore__ bool submit_chunked_urma_request(AsyncCtx &ctx, UrmaRequestDescriptor<DstTensor, SrcTensor> desc) {
+    using RawDType = typename DstTensor::RawDType;
+    static_assert(std::is_same_v<RawDType, typename SrcTensor::RawDType>, "URMA transfer requires matching dtypes");
+
+    if (!is_flat_contiguous_1d(desc.dst) || !is_flat_contiguous_1d(desc.src)) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return false;
+    }
+
+    const uint64_t elem_count = tensor_element_count(desc.dst);
+    const uint64_t total_bytes = elem_count * sizeof(RawDType);
+    const uint64_t max_bytes = kUrmaMaxTransferBytes;
+    if (total_bytes <= max_bytes) {
+        return submit_urma_request_once(ctx, desc);
+    }
+
+    const uint64_t chunk_elems = max_bytes / sizeof(RawDType);
+    if (chunk_elems == 0 || (max_bytes % sizeof(RawDType)) != 0) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return false;
+    }
+
+    uint64_t offset = 0;
+    while (offset < elem_count) {
+        const uint64_t remaining = elem_count - offset;
+        const uint64_t current_elems = (remaining < chunk_elems) ? remaining : chunk_elems;
+        auto chunk_desc = desc;
+        chunk_desc.dst = make_tensor_slice(desc.dst, offset, current_elems);
+        chunk_desc.src = make_tensor_slice(desc.src, offset, current_elems);
+        if (!submit_urma_request_once(ctx, chunk_desc)) {
+            return false;
+        }
+        offset += current_elems;
+    }
+    return true;
+}
+
+}  // namespace pto2::urma_backend
+
+#if defined(__CPU_SIM)
+inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
+    __gm__ LocalContext *lc =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
+    AsyncCtx ctx{};
+    ctx.completion_count = lc->async_ctx.completion_count;
+    ctx.completion_error_code = lc->async_ctx.completion_error_code;
+    ctx.completion_entries = lc->async_ctx.completion_entries;
+    ctx.completion_capacity = lc->async_ctx.completion_capacity;
+    ctx.task_token.raw = lc->async_ctx.task_token.raw;
+    return ctx;
+}
+
+inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
+    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        return false;
+    }
+
+    uint32_t idx = *ctx.completion_count;
+    if (idx >= ctx.completion_capacity) {
+        if (ctx.completion_error_code != nullptr) {
+            *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+        }
+        return false;
+    }
+
+    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
+    slot->addr = token.addr;
+    slot->backend_cookie = token.backend_cookie;
+    slot->expected_value = token.expected_value;
+    slot->engine = token.engine;
+    slot->completion_type = token.completion_type;
+    slot->_pad = 0;
+    *ctx.completion_count = idx + 1;
+    return true;
+}
+#endif
+
+namespace pto2::detail {
+
+#if defined(__CPU_SIM)
+inline __aicore__ void defer_load_slab(AsyncCtx & /*ctx*/) { __asm__ __volatile__("" ::: "memory"); }
+
+inline __aicore__ void defer_error(AsyncCtx &ctx, int32_t error_code) {
+    if (ctx.task_token.is_valid() && ctx.completion_error_code != nullptr) {
+        *ctx.completion_error_code = error_code;
+    }
+}
+
+inline __aicore__ void defer_flush(AsyncCtx & /*ctx*/) { __asm__ __volatile__("" ::: "memory"); }
+#endif
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ void register_urma_async_event(
+    AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
+) {
+    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        (void)event.Wait(session);
+        return;
+    }
+    if (event.handle == 0) {
+        return;
+    }
+
+    const uint32_t engine = static_cast<uint32_t>(event.engine);
+    if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::URMA) || workspace == nullptr) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return;
+    }
+
+    CompletionToken token{
+        event.handle,
+        0,
+        COMPLETION_ENGINE_URMA,
+        COMPLETION_TYPE_URMA_EVENT_HANDLE,
+        reinterpret_cast<uint64_t>(workspace),
+    };
+    if (!register_completion_condition(ctx, token)) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_REGISTRATION_FAILED);
+    }
+}
+
+}  // namespace pto2::detail
+
+template <typename DstTensor, typename SrcTensor>
+inline __aicore__ bool send_request_entry(AsyncCtx &ctx, UrmaRequestDescriptor<DstTensor, SrcTensor> desc) {
+    return pto2::urma_backend::submit_chunked_urma_request(ctx, desc);
+}
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_URMA_URMA_COMPLETION_KERNEL_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_kernel.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_kernel.h
@@ -94,7 +94,7 @@ UrmaTput(const DstTensor &dst, const SrcTensor &src, __gm__ uint8_t *workspace, 
 namespace pto2::detail {
 
 template <typename PtoAsyncEvent, typename PtoAsyncSession>
-inline __aicore__ void register_urma_async_event(
+inline __aicore__ bool register_urma_async_event(
     AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
 );
 
@@ -188,7 +188,9 @@ inline __aicore__ bool submit_urma_request_once(AsyncCtx &ctx, UrmaRequestDescri
     } else {
         event = pto::comm::TPUT_ASYNC<pto::comm::DmaEngine::URMA>(desc.dst, desc.src, session);
     }
-    pto2::detail::register_urma_async_event(ctx, event, session, desc.workspace);
+    if (!pto2::detail::register_urma_async_event(ctx, event, session, desc.workspace)) {
+        return false;
+    }
     pto2::detail::defer_flush(ctx);
     return true;
 #else
@@ -209,6 +211,10 @@ inline __aicore__ bool submit_chunked_urma_request(AsyncCtx &ctx, UrmaRequestDes
     }
 
     const uint64_t elem_count = tensor_element_count(desc.dst);
+    if (elem_count != tensor_element_count(desc.src)) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return false;
+    }
     const uint64_t total_bytes = elem_count * sizeof(RawDType);
     const uint64_t max_bytes = kUrmaMaxTransferBytes;
     if (total_bytes <= max_bytes) {
@@ -291,21 +297,22 @@ inline __aicore__ void defer_flush(AsyncCtx & /*ctx*/) { __asm__ __volatile__(""
 #endif
 
 template <typename PtoAsyncEvent, typename PtoAsyncSession>
-inline __aicore__ void register_urma_async_event(
+inline __aicore__ bool register_urma_async_event(
     AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
 ) {
     if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
         (void)event.Wait(session);
-        return;
+        return true;
     }
     if (event.handle == 0) {
-        return;
+        return true;
     }
 
     const uint32_t engine = static_cast<uint32_t>(event.engine);
     if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::URMA) || workspace == nullptr) {
         defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
-        return;
+        (void)event.Wait(session);
+        return false;
     }
 
     CompletionToken token{
@@ -317,7 +324,10 @@ inline __aicore__ void register_urma_async_event(
     };
     if (!register_completion_condition(ctx, token)) {
         defer_error(ctx, PTO2_ERROR_ASYNC_REGISTRATION_FAILED);
+        (void)event.Wait(session);
+        return false;
     }
+    return true;
 }
 
 }  // namespace pto2::detail

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_scheduler.h
@@ -86,6 +86,13 @@ inline uintptr_t cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
 }
 
+inline void invalidate_object(const volatile void *addr, std::size_t size) {
+    const uintptr_t object_addr = reinterpret_cast<uintptr_t>(addr);
+    const uintptr_t begin = cache_line(addr);
+    const uintptr_t end = (object_addr + size + PTO2_ALIGN_SIZE - 1u) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
+    cache_invalidate_range(reinterpret_cast<const void *>(begin), end - begin);
+}
+
 inline bool has_reached(uint32_t current, uint32_t target) { return static_cast<int32_t>(current - target) >= 0; }
 
 inline bool is_power_of_two(uint32_t value) { return value != 0 && (value & (value - 1u)) == 0; }
@@ -139,7 +146,7 @@ inline CompletionPollResult poll_urma_event_handle(uint64_t event_handle, uint64
     }
 
     auto *info = reinterpret_cast<volatile UrmaInfo *>(static_cast<uintptr_t>(workspace_addr));
-    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(info)), PTO2_ALIGN_SIZE);
+    invalidate_object(info, sizeof(*info));
     const uint32_t qp_num = __atomic_load_n(&info->qp_num, __ATOMIC_ACQUIRE);
     const uint32_t rank_count = __atomic_load_n(&info->rank_count, __ATOMIC_ACQUIRE);
     const uint64_t sq_ptr = __atomic_load_n(&info->sq_ptr, __ATOMIC_ACQUIRE);
@@ -155,8 +162,8 @@ inline CompletionPollResult poll_urma_event_handle(uint64_t event_handle, uint64
     auto *wq_entry = reinterpret_cast<volatile UrmaWqCtx *>(
         static_cast<uintptr_t>(sq_ptr + ctx_index * static_cast<uint64_t>(sizeof(UrmaWqCtx)))
     );
-    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(cq_entry)), PTO2_ALIGN_SIZE);
-    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(wq_entry)), PTO2_ALIGN_SIZE);
+    invalidate_object(cq_entry, sizeof(*cq_entry));
+    invalidate_object(wq_entry, sizeof(*wq_entry));
 
     UrmaCqCtx cq_ctx{};
     cq_ctx.buf_addr = __atomic_load_n(&cq_entry->buf_addr, __ATOMIC_ACQUIRE);
@@ -192,6 +199,8 @@ inline CompletionPollResult poll_urma_event_handle(uint64_t event_handle, uint64
         const uint8_t substatus = static_cast<uint8_t>((dw0 >> 16) & 0xFFu);
         const uint8_t status = static_cast<uint8_t>((dw0 >> 24) & 0xFFu);
         if (status != 0 || substatus != 0) {
+            ++next_tail;
+            update_tail_info(cq_ctx, wq_ctx, next_tail);
             return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
         }
         next_tail++;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/urma/urma_completion_scheduler.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_URMA_URMA_COMPLETION_SCHEDULER_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_URMA_URMA_COMPLETION_SCHEDULER_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+#include "aicore_completion_mailbox.h"
+#include "pto_completion_token.h"
+#include "pto_runtime_status.h"
+
+namespace pto2::urma_backend {
+
+inline constexpr uint32_t kHandleRankIdShift = 32;
+inline constexpr uint32_t kCqeBytes = 64;
+inline constexpr uint32_t kMaxCqeShift = 12;
+
+enum class UrmaDbMode : int32_t {
+    INVALID_DB = -1,
+    HW_DB = 0,
+    SW_DB = 1,
+};
+
+struct UrmaInfo {
+    uint32_t qp_num;
+    uint32_t local_token_id;
+    uint32_t rank_count;
+    uint64_t sq_ptr;
+    uint64_t rq_ptr;
+    uint64_t scq_ptr;
+    uint64_t rcq_ptr;
+    uint64_t mem_ptr;
+};
+
+struct UrmaWqCtx {
+    uint32_t wqn;
+    uint64_t buf_addr;
+    uint32_t wqe_shift_size;
+    uint32_t depth;
+    uint64_t head_addr;
+    uint64_t tail_addr;
+    UrmaDbMode db_mode;
+    uint64_t db_addr;
+    uint32_t sl;
+};
+
+struct UrmaCqCtx {
+    uint32_t cqn;
+    uint64_t buf_addr;
+    uint32_t cqe_shift_size;
+    uint32_t depth;
+    uint64_t head_addr;
+    uint64_t tail_addr;
+    UrmaDbMode db_mode;
+    uint64_t db_addr;
+};
+
+static_assert(sizeof(UrmaInfo) == 56, "URMA info ABI drift");
+static_assert(offsetof(UrmaInfo, sq_ptr) == 16, "URMA info ABI drift");
+static_assert(sizeof(UrmaWqCtx) == 64, "URMA WQ context ABI drift");
+static_assert(offsetof(UrmaWqCtx, db_addr) == 48, "URMA WQ context ABI drift");
+static_assert(sizeof(UrmaCqCtx) == 56, "URMA CQ context ABI drift");
+static_assert(offsetof(UrmaCqCtx, db_addr) == 48, "URMA CQ context ABI drift");
+
+inline uint64_t encode_urma_event_handle(uint32_t remote_rank, uint32_t target_head) {
+    return (static_cast<uint64_t>(remote_rank) << kHandleRankIdShift) | static_cast<uint64_t>(target_head);
+}
+
+inline void decode_urma_event_handle(uint64_t handle, uint32_t &remote_rank, uint32_t &target_head) {
+    remote_rank = static_cast<uint32_t>(handle >> kHandleRankIdShift);
+    target_head = static_cast<uint32_t>(handle & 0xFFFFFFFFu);
+}
+
+inline uintptr_t cache_line(const volatile void *addr) {
+    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
+}
+
+inline bool has_reached(uint32_t current, uint32_t target) { return static_cast<int32_t>(current - target) >= 0; }
+
+inline bool is_power_of_two(uint32_t value) { return value != 0 && (value & (value - 1u)) == 0; }
+
+inline uint32_t load_device_u32(uint64_t addr) {
+    auto *ptr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline void store_device_u32(uint64_t addr, uint32_t value) {
+    auto *ptr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+    __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
+#if defined(__aarch64__)
+    __asm__ __volatile__("dsb sy" ::: "memory");
+#else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+inline uint32_t load_cqe_dw0(uint64_t cqe_addr) {
+    auto *ptr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(cqe_addr));
+    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(ptr)), PTO2_ALIGN_SIZE);
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline void update_tail_info(const UrmaCqCtx &cq_ctx, const UrmaWqCtx &wq_ctx, uint32_t cur_tail) {
+    if (cq_ctx.tail_addr != 0) {
+        store_device_u32(cq_ctx.tail_addr, cur_tail);
+    }
+    if (cq_ctx.db_addr != 0) {
+        store_device_u32(cq_ctx.db_addr, cur_tail & 0xFFFFFFu);
+    }
+    if (wq_ctx.tail_addr != 0) {
+        store_device_u32(wq_ctx.tail_addr, cur_tail);
+    }
+}
+
+inline CompletionPollResult poll_urma_event_handle(uint64_t event_handle, uint64_t workspace_addr) {
+    if (event_handle == 0) {
+        return {CompletionPollState::READY, PTO2_ERROR_NONE};
+    }
+    if (workspace_addr == 0) {
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+
+    uint32_t remote_rank = 0;
+    uint32_t target_head = 0;
+    decode_urma_event_handle(event_handle, remote_rank, target_head);
+    if (target_head == 0) {
+        return {CompletionPollState::READY, PTO2_ERROR_NONE};
+    }
+
+    auto *info = reinterpret_cast<volatile UrmaInfo *>(static_cast<uintptr_t>(workspace_addr));
+    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(info)), PTO2_ALIGN_SIZE);
+    const uint32_t qp_num = __atomic_load_n(&info->qp_num, __ATOMIC_ACQUIRE);
+    const uint32_t rank_count = __atomic_load_n(&info->rank_count, __ATOMIC_ACQUIRE);
+    const uint64_t sq_ptr = __atomic_load_n(&info->sq_ptr, __ATOMIC_ACQUIRE);
+    const uint64_t scq_ptr = __atomic_load_n(&info->scq_ptr, __ATOMIC_ACQUIRE);
+    if (qp_num == 0 || remote_rank >= rank_count || sq_ptr == 0 || scq_ptr == 0) {
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+
+    const uint64_t ctx_index = static_cast<uint64_t>(remote_rank) * qp_num;
+    auto *cq_entry = reinterpret_cast<volatile UrmaCqCtx *>(
+        static_cast<uintptr_t>(scq_ptr + ctx_index * static_cast<uint64_t>(sizeof(UrmaCqCtx)))
+    );
+    auto *wq_entry = reinterpret_cast<volatile UrmaWqCtx *>(
+        static_cast<uintptr_t>(sq_ptr + ctx_index * static_cast<uint64_t>(sizeof(UrmaWqCtx)))
+    );
+    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(cq_entry)), PTO2_ALIGN_SIZE);
+    cache_invalidate_range(reinterpret_cast<const void *>(cache_line(wq_entry)), PTO2_ALIGN_SIZE);
+
+    UrmaCqCtx cq_ctx{};
+    cq_ctx.buf_addr = __atomic_load_n(&cq_entry->buf_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.cqe_shift_size = __atomic_load_n(&cq_entry->cqe_shift_size, __ATOMIC_ACQUIRE);
+    cq_ctx.depth = __atomic_load_n(&cq_entry->depth, __ATOMIC_ACQUIRE);
+    cq_ctx.tail_addr = __atomic_load_n(&cq_entry->tail_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.db_addr = __atomic_load_n(&cq_entry->db_addr, __ATOMIC_ACQUIRE);
+
+    UrmaWqCtx wq_ctx{};
+    wq_ctx.tail_addr = __atomic_load_n(&wq_entry->tail_addr, __ATOMIC_ACQUIRE);
+    if (cq_ctx.buf_addr == 0 || cq_ctx.tail_addr == 0 || cq_ctx.cqe_shift_size > kMaxCqeShift ||
+        !is_power_of_two(cq_ctx.depth)) {
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+
+    const uint32_t cqe_size = 1u << cq_ctx.cqe_shift_size;
+    uint32_t cur_tail = load_device_u32(cq_ctx.tail_addr);
+    if (has_reached(cur_tail, target_head)) {
+        return {CompletionPollState::READY, PTO2_ERROR_NONE};
+    }
+
+    uint32_t next_tail = cur_tail;
+    while (!has_reached(next_tail, target_head)) {
+        const uint64_t cqe_addr =
+            cq_ctx.buf_addr + static_cast<uint64_t>(cqe_size) * static_cast<uint64_t>(next_tail & (cq_ctx.depth - 1));
+        const uint32_t dw0 = load_cqe_dw0(cqe_addr);
+        const bool valid_owner = ((next_tail / cq_ctx.depth) & 1u) != 0;
+        const bool owner = ((dw0 >> 2) & 1u) != 0;
+        if ((valid_owner ^ owner) == 0) {
+            break;
+        }
+
+        const uint8_t substatus = static_cast<uint8_t>((dw0 >> 16) & 0xFFu);
+        const uint8_t status = static_cast<uint8_t>((dw0 >> 24) & 0xFFu);
+        if (status != 0 || substatus != 0) {
+            return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+        }
+        next_tail++;
+    }
+
+    if (next_tail != cur_tail) {
+        update_tail_info(cq_ctx, wq_ctx, next_tail);
+    }
+    return {
+        has_reached(next_tail, target_head) ? CompletionPollState::READY : CompletionPollState::PENDING, PTO2_ERROR_NONE
+    };
+}
+
+inline void retire_urma_event_handle(uint64_t /*event_handle*/, uint64_t /*workspace_addr*/) {}
+
+}  // namespace pto2::urma_backend
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_URMA_URMA_COMPLETION_SCHEDULER_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -130,6 +130,7 @@ inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const Comple
 
     volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
     slot->addr = token.addr;
+    slot->backend_cookie = token.backend_cookie;
     slot->expected_value = token.expected_value;
     slot->engine = token.engine;
     slot->completion_type = token.completion_type;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -18,6 +18,7 @@
 
 #include "aicpu/platform_regs.h"
 #include "backend/sdma/sdma_completion_scheduler.h"
+#include "backend/urma/urma_completion_scheduler.h"
 #include "intrinsic.h"
 #include "aicore_completion_mailbox.h"
 #include "pto_completion_token.h"
@@ -50,6 +51,7 @@ struct CompletionCondition {
     bool retired{false};
     volatile uint32_t *counter_addr{nullptr};
     uint64_t addr{0};
+    uint64_t backend_cookie{0};
     uint32_t expected_value{0};
 
     CompletionPollResult test() const;
@@ -77,10 +79,19 @@ inline CompletionPollResult sdma_event_record_poll_op(const CompletionCondition 
 
 inline void sdma_event_record_retire_op(CompletionCondition &cond) { retire_sdma_event_record(cond.addr); }
 
+inline CompletionPollResult urma_event_handle_poll_op(const CompletionCondition &cond) {
+    return pto2::urma_backend::poll_urma_event_handle(cond.addr, cond.backend_cookie);
+}
+
+inline void urma_event_handle_retire_op(CompletionCondition &cond) {
+    pto2::urma_backend::retire_urma_event_handle(cond.addr, cond.backend_cookie);
+}
+
 inline const CompletionBackendOps *completion_backend_ops_for(int completion_type) {
     static const CompletionBackendOps kOps[] = {
         {counter_poll_op, counter_retire_op},                      // COMPLETION_TYPE_COUNTER = 0
         {sdma_event_record_poll_op, sdma_event_record_retire_op},  // COMPLETION_TYPE_SDMA_EVENT_RECORD = 1
+        {urma_event_handle_poll_op, urma_event_handle_retire_op},  // COMPLETION_TYPE_URMA_EVENT_HANDLE = 2
     };
     constexpr int kOpsCount = static_cast<int>(sizeof(kOps) / sizeof(kOps[0]));
     if (completion_type < 0 || completion_type >= kOpsCount) return nullptr;
@@ -222,8 +233,8 @@ struct AsyncWaitList {
                     entry->normal_done = false;
                 }
                 if (!append_condition_locked(
-                        *entry, msg.addr, msg.expected_value, static_cast<AsyncEngine>(msg.engine), msg.completion_type,
-                        error_code
+                        *entry, msg.addr, msg.backend_cookie, msg.expected_value, static_cast<AsyncEngine>(msg.engine),
+                        msg.completion_type, error_code
                     )) {
                     return drained;
                 }
@@ -267,8 +278,8 @@ struct AsyncWaitList {
     }
 
     bool append_condition_locked(
-        AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine, int32_t completion_type,
-        int32_t &error_code
+        AsyncWaitEntry &entry, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, AsyncEngine engine,
+        int32_t completion_type, int32_t &error_code
     ) {
         if (entry.condition_count >= MAX_COMPLETIONS_PER_TASK) {
             error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
@@ -280,6 +291,7 @@ struct AsyncWaitList {
         cond.satisfied = false;
         cond.retired = false;
         cond.addr = addr;
+        cond.backend_cookie = backend_cookie;
         cond.counter_addr = completion_type == COMPLETION_TYPE_COUNTER ?
                                 reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr)) :
                                 nullptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -116,7 +116,9 @@ void SchedulerContext::complete_slot_task(
             const PTO2TaskId token = slot_state.task->task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
-                while (!mailbox->try_push_condition(token, e->addr, e->expected_value, e->engine, e->completion_type)) {
+                while (!mailbox->try_push_condition(
+                    token, e->addr, e->backend_cookie, e->expected_value, e->engine, e->completion_type
+                )) {
                     sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
                     SPIN_WAIT_HINT();
                 }


### PR DESCRIPTION
 ## Summary
- Add AICore-side URMA async request submission for TGET/TPUT.
- Register URMA async events as deferred completion tokens.
- Add AICPU-side URMA CQ polling and task retirement.
- Wire URMA completion type through the existing async wait framework.
- Initialize PTO-ISA URMA workspace in A5 onboard host communication setup.

## Testing
- Real A5 deferred demo validated manually on devices 0,1.
- `git diff --check`