### PR TITLE
feat(deps-viewer): show fanin/fanout counts and name_hint breakdown

### DIFF
--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -25,7 +25,9 @@ with ``kind=``, ``func_id=``, and SPMD block num when applicable. Text-mode
 tasks render as ``func_id=none``. ``SPMD block num = N`` is the logical block
 num captured from ``block_num``. In HTML mode SPMD nodes use a red border plus a
 transparent right-side ``xN`` block num label; nodes are colored by
-``core_type`` when a perf sidecar is colocated (AIC blue, AIV orange).
+``core_type`` when a perf sidecar is colocated (AIC blue, AIV orange). Each
+HTML node label also shows ``↓fanin ↑fanout`` peer counts; clicking a node opens
+a detail panel that buckets those peers by ``name_hint`` (``func_name``).
 
 Usage:
     python -m simpler_setup.tools.deps_viewer DEPS_JSON
@@ -450,19 +452,70 @@ def _load_task_meta(deps_path, func_names=None):
     return meta
 
 
-def _label(task_id, meta, task_table, fmt_task, marker=""):
+def _task_name_hint(task_id, meta, task_table):
+    """Classification key for a task — the profiling ``name_hint`` / ``func_name``.
+
+    Falls back to alloc / dummy / f<id> / unknown when no human-readable name
+    is available. Used to bucket predecessor / successor peers in the HTML
+    detail panel.
+    """
+    kind = _task_kind(task_id, meta, task_table)
+    if kind == "alloc":
+        return "alloc"
+    if kind == "dummy":
+        return "dummy"
+    entry = meta.get(task_id) or {}
+    func_name = entry.get("func_name")
+    if func_name:
+        return str(func_name)
+    func_id = entry.get("func_id")
+    if func_id is not None:
+        return f"f{func_id}"
+    return "unknown"
+
+
+def _fan_maps(edges, nodes):
+    """Unique predecessor / successor peer sets per task (same semantics as text FANIN/FANOUT)."""
+    pred_map = {tid: set() for tid in nodes}
+    succ_map = {tid: set() for tid in nodes}
+    for pred, succ in edges:
+        pred_map[succ].add(pred)
+        succ_map[pred].add(succ)
+    return pred_map, succ_map
+
+
+def _count_by_name_hint(peer_ids, meta, task_table):
+    """Count peers grouped by ``_task_name_hint``, largest-count-first then name.
+
+    Returns a list of ``[hint, count]`` pairs (not a dict) so ordering survives
+    ``json.dumps(..., sort_keys=True)``.
+    """
+    counts: dict[str, int] = {}
+    for peer in peer_ids:
+        hint = _task_name_hint(peer, meta, task_table)
+        counts[hint] = counts.get(hint, 0) + 1
+    return [[hint, count] for hint, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))]
+
+
+def _fan_suffix(fanin, fanout):
+    if fanin is None or fanout is None:
+        return ""
+    return f" ↓{fanin} ↑{fanout}"
+
+
+def _label(task_id, meta, task_table, fmt_task, marker="", fanin=None, fanout=None):
     base = fmt_task(task_id)
     pfx = f"{marker} " if marker else ""
     normalized_task_id = _normalize_task_id(task_id)
     kind = _task_kind(normalized_task_id, meta, task_table)
     if kind == "alloc":
-        return f"{pfx}{base} · alloc"
-    if kind == "dummy":
-        return f"{pfx}{base} · dummy"
-    func_name = (meta.get(normalized_task_id) or {}).get("func_name")
-    if func_name:
-        return f"{pfx}{base} · {func_name}"
-    return f"{pfx}{base}"
+        text = f"{pfx}{base} · alloc"
+    elif kind == "dummy":
+        text = f"{pfx}{base} · dummy"
+    else:
+        func_name = (meta.get(normalized_task_id) or {}).get("func_name")
+        text = f"{pfx}{base} · {func_name}" if func_name else f"{pfx}{base}"
+    return text + _fan_suffix(fanin, fanout)
 
 
 _CORE_STYLE = {
@@ -571,10 +624,10 @@ def _arg_row_html(arg, tensor_table, side):
     return f'<TR><TD ALIGN="LEFT" PORT="{port}" BGCOLOR="{bg}">{body}</TD></TR>'
 
 
-def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task, marker=""):
+def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task, marker="", fanin=None, fanout=None):
     """Build a Graphviz HTML-like label for a task node showing:
         - input rows (top)     INPUT + INOUT slots
-        - identity header      "<marker> (ring, local) · <func_name>"
+        - identity header      "<marker> (ring, local) · <func_name> ↓fanin ↑fanout"
         - output rows (bottom) INOUT + OUTPUT_EXISTING + OUTPUT slots
     INOUT slots appear in BOTH compartments (read-then-write semantics).
     ``marker`` is the 🔥 / ⭐ early-dispatch badge (empty for most tasks).
@@ -594,6 +647,7 @@ def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task, mar
         ident = f"{ident} · {func_name}"
     if marker:
         ident = f"{marker} {ident}"
+    ident = ident + _fan_suffix(fanin, fanout)
 
     rows = []
     for a in inputs:
@@ -664,7 +718,7 @@ def _task_blocks_text(task_entry):
     return f"SPMD block num = {block_num}"
 
 
-def _plain_node_attrs(task_id, meta, task_table, fmt_task, marker=""):
+def _plain_node_attrs(task_id, meta, task_table, fmt_task, marker="", fanin=None, fanout=None):
     meta_entry = meta.get(task_id)
     kind = _task_kind(task_id, meta, task_table)
     if kind == "submit" and meta_entry:
@@ -675,7 +729,7 @@ def _plain_node_attrs(task_id, meta, task_table, fmt_task, marker=""):
         style = _DEFAULT_STYLE
 
     task_entry = task_table.get(task_id)
-    label = _dot_escape_label(_label(task_id, meta, task_table, fmt_task, marker=marker))
+    label = _dot_escape_label(_label(task_id, meta, task_table, fmt_task, marker=marker, fanin=fanin, fanout=fanout))
     label_attr = f'label="{label}"'
     style_attr = style["style"]
     if _task_block_num(task_entry) > 1:
@@ -818,6 +872,7 @@ def emit_dot(
     hidden_edges = set(hidden_edges or ())
     show_tensor = bool(task_table) if show_tensor_info is None else bool(show_tensor_info and task_table)
     markers = _task_markers(nodes, edges, meta, task_table)
+    pred_map, succ_map = _fan_maps(edges, nodes)
     lines = [
         "digraph deps {",
         f"  rankdir={direction};",
@@ -829,11 +884,16 @@ def emit_dot(
     for n in nodes:
         m = meta.get(n)
         marker = markers.get(n, "")
+        fanin = len(pred_map.get(n, set()))
+        fanout = len(succ_map.get(n, set()))
         if show_tensor and n in task_table:
-            html = _task_node_html(n, task_table.get(n), m, tensor_table, fmt_task, marker=marker)
+            html = _task_node_html(
+                n, task_table.get(n), m, tensor_table, fmt_task, marker=marker, fanin=fanin, fanout=fanout
+            )
             lines.append(f"  {_node_id(n)} [shape=none, margin=0, label=<{html}>];")
             continue
-        lines.append(f"  {_node_id(n)} [{_plain_node_attrs(n, meta, task_table, fmt_task, marker=marker)}];")
+        attrs = _plain_node_attrs(n, meta, task_table, fmt_task, marker=marker, fanin=fanin, fanout=fanout)
+        lines.append(f"  {_node_id(n)} [{attrs}];")
 
     def edge_attr_str(edge_attrs):
         return (" [" + ", ".join(edge_attrs) + "]") if edge_attrs else ""
@@ -906,6 +966,27 @@ def _spmd_badges_json(nodes, task_table):
     return json.dumps(badges, sort_keys=True, separators=(",", ":"))
 
 
+def _dep_stats_json(nodes, edges, meta, task_table):
+    """Per-node fanin/fanout totals plus name_hint histograms for the HTML panel."""
+    task_table = task_table or {}
+    meta = meta or {}
+    fmt_task = _make_task_formatter(nodes)
+    pred_map, succ_map = _fan_maps(edges, nodes)
+    stats = {}
+    for tid in nodes:
+        preds = pred_map[tid]
+        succs = succ_map[tid]
+        stats[_node_id(tid)] = {
+            "label": fmt_task(tid),
+            "name_hint": _task_name_hint(tid, meta, task_table),
+            "fanin": len(preds),
+            "fanout": len(succs),
+            "pred_by_hint": _count_by_name_hint(preds, meta, task_table),
+            "succ_by_hint": _count_by_name_hint(succs, meta, task_table),
+        }
+    return json.dumps(stats, sort_keys=True, separators=(",", ":"))
+
+
 _HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -919,7 +1000,7 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     color: #0f172a; overflow: hidden; -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
   }}
-  #hud, #legend {{
+  #hud, #legend, #detail {{
     position: fixed; z-index: 10; display: flex; align-items: center;
     background: rgba(255,255,255,0.94); border: 1px solid rgba(203,213,225,0.9);
     border-radius: 10px; color: #0f172a; font-size: 12px;
@@ -939,6 +1020,38 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   }}
   #legend .swatch {{ display: inline-flex; align-items: center; gap: 6px; color: #334155; white-space: nowrap; }}
   #legend svg {{ display: block; }}
+  #detail {{
+    display: none; top: 64px; left: 12px; width: min(360px, calc(100vw - 24px));
+    max-height: calc(100vh - 88px); flex-direction: column; align-items: stretch;
+    padding: 0; overflow: hidden;
+  }}
+  #detail.open {{ display: flex; }}
+  #detail header {{
+    display: flex; align-items: flex-start; justify-content: space-between; gap: 8px;
+    padding: 10px 12px; border-bottom: 1px solid #e2e8f0;
+  }}
+  #detail header .title {{ font-weight: 600; color: #020617; line-height: 1.35; }}
+  #detail header .sub {{ color: #64748b; font-size: 11px; margin-top: 2px; }}
+  #detail header button {{
+    border: 0; background: #f1f5f9; color: #334155; width: 24px; height: 24px;
+    border-radius: 6px; cursor: pointer; font-size: 14px; line-height: 1; flex: 0 0 auto;
+  }}
+  #detail header button:hover {{ background: #e2e8f0; }}
+  #detail .body {{ padding: 10px 12px 12px; overflow: auto; }}
+  #detail .section {{ margin-top: 10px; }}
+  #detail .section:first-child {{ margin-top: 0; }}
+  #detail .section h3 {{
+    margin: 0 0 6px; font-size: 11px; font-weight: 600; color: #475569;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }}
+  #detail table {{ width: 100%; border-collapse: collapse; font-size: 12px; }}
+  #detail td {{ padding: 3px 0; vertical-align: baseline; }}
+  #detail td.hint {{
+    color: #0f172a; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    word-break: break-word;
+  }}
+  #detail td.count {{ text-align: right; font-weight: 600; color: #020617; width: 3em; padding-left: 8px; }}
+  #detail .empty {{ color: #94a3b8; font-size: 12px; }}
   #stage {{ width: 100vw; height: 100vh; overflow: hidden; cursor: grab; background:
     radial-gradient(circle at 20px 20px, rgba(100,116,139,0.18) 1px, transparent 1px), #eef2f7;
     background-size: 24px 24px; }}
@@ -947,8 +1060,13 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     transform-origin: 0 0; transition: none; max-width: none; overflow: visible;
     filter: drop-shadow(0 16px 28px rgba(15,23,42,0.10));
   }}
+  #stage .node {{ cursor: pointer; }}
   #stage .node path, #stage .node ellipse, #stage .node polygon {{
     filter: drop-shadow(0 3px 4px rgba(15,23,42,0.18));
+  }}
+  #stage .node.selected path, #stage .node.selected ellipse, #stage .node.selected polygon,
+  #stage .node.selected rect {{
+    stroke: #2563eb !important; stroke-width: 2.5px !important;
   }}
   #stage .edge path, #stage .edge polygon {{ opacity: 0.78; }}
 </style>
@@ -961,8 +1079,10 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   <span class="divider"></span>
   <kbd>drag</kbd><span>pan</span>
   <kbd>wheel</kbd><span>zoom</span>
+  <kbd>click</kbd><span>task</span>
   <kbd>f</kbd><span>fit</span>
   <kbd>r</kbd><span>reset</span>
+  <kbd>esc</kbd><span>close</span>
 </div>
 <div id="legend">
   <span class="swatch">
@@ -998,6 +1118,17 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     </svg>
     SPMD block num
   </span>
+  <span class="swatch">↓N ↑M = pred / succ</span>
+</div>
+<div id="detail">
+  <header>
+    <div>
+      <div class="title" id="detail-title"></div>
+      <div class="sub" id="detail-sub"></div>
+    </div>
+    <button type="button" id="detail-close" aria-label="Close">×</button>
+  </header>
+  <div class="body" id="detail-body"></div>
 </div>
 <div id="stage">
 {svg_body}
@@ -1010,7 +1141,13 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   svg.removeAttribute('width');
   svg.removeAttribute('height');
   const spmdBlocks = {spmd_badges_json};
+  const depStats = {dep_stats_json};
+  const detail = document.getElementById('detail');
+  const detailTitle = document.getElementById('detail-title');
+  const detailSub = document.getElementById('detail-sub');
+  const detailBody = document.getElementById('detail-body');
   const svgNS = 'http://www.w3.org/2000/svg';
+  let selectedNode = null;
 
   function svgEl(name, attrs) {{
     const el = document.createElementNS(svgNS, name);
@@ -1046,6 +1183,53 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   }}
   addSpmdBadges();
 
+  function escapeHtml(text) {{
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }}
+
+  function hintTable(counts) {{
+    const entries = counts || [];
+    if (!entries.length) return '<div class="empty">none</div>';
+    return '<table>' + entries.map(([hint, count]) =>
+      `<tr><td class="hint">${{escapeHtml(hint)}}</td><td class="count">${{count}}</td></tr>`
+    ).join('') + '</table>';
+  }}
+
+  function closeDetail() {{
+    detail.classList.remove('open');
+    if (selectedNode) {{
+      selectedNode.classList.remove('selected');
+      selectedNode = null;
+    }}
+  }}
+
+  function openDetail(nodeGroup) {{
+    const titleEl = nodeGroup.querySelector(':scope > title');
+    const nodeId = titleEl ? titleEl.textContent : '';
+    const stats = depStats[nodeId];
+    if (!stats) return;
+    if (selectedNode) selectedNode.classList.remove('selected');
+    selectedNode = nodeGroup;
+    selectedNode.classList.add('selected');
+    detailTitle.textContent = `${{stats.label}} · ${{stats.name_hint}}`;
+    detailSub.textContent = `↓${{stats.fanin}} predecessors · ↑${{stats.fanout}} successors`;
+    detailBody.innerHTML =
+      `<div class="section"><h3>Predecessors by name_hint (${{stats.fanin}})</h3>` +
+      `${{hintTable(stats.pred_by_hint)}}</div>` +
+      `<div class="section"><h3>Successors by name_hint (${{stats.fanout}})</h3>` +
+      `${{hintTable(stats.succ_by_hint)}}</div>`;
+    detail.classList.add('open');
+  }}
+
+  document.getElementById('detail-close').addEventListener('click', (e) => {{
+    e.stopPropagation();
+    closeDetail();
+  }});
+
   let scale = 1, tx = 0, ty = 0;
   const apply = () => {{ svg.style.transform = `translate(${{tx}}px, ${{ty}}px) scale(${{scale}})`; }};
 
@@ -1061,18 +1245,31 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     apply();
   }}, {{ passive: false }});
 
-  let dragging = false, lastX = 0, lastY = 0;
+  let dragging = false, panMoved = false, lastX = 0, lastY = 0;
   stage.addEventListener('mousedown', (e) => {{
-    dragging = true; lastX = e.clientX; lastY = e.clientY;
+    if (e.button !== 0) return;
+    dragging = true; panMoved = false; lastX = e.clientX; lastY = e.clientY;
     stage.classList.add('panning');
   }});
   window.addEventListener('mousemove', (e) => {{
     if (!dragging) return;
-    tx += e.clientX - lastX; ty += e.clientY - lastY;
+    const dx = e.clientX - lastX, dy = e.clientY - lastY;
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) panMoved = true;
+    tx += dx; ty += dy;
     lastX = e.clientX; lastY = e.clientY;
     apply();
   }});
   window.addEventListener('mouseup', () => {{ dragging = false; stage.classList.remove('panning'); }});
+
+  stage.addEventListener('click', (e) => {{
+    if (panMoved) return;
+    const node = e.target.closest('g.node');
+    if (node && svg.contains(node)) {{
+      openDetail(node);
+      return;
+    }}
+    closeDetail();
+  }});
 
   const fit = () => {{
     const bb = svg.getBoundingClientRect();
@@ -1086,6 +1283,7 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   document.addEventListener('keydown', (e) => {{
     if (e.key === 'f') fit();
     else if (e.key === 'r') {{ scale = 1; tx = 0; ty = 0; apply(); }}
+    else if (e.key === 'Escape') closeDetail();
   }});
   requestAnimationFrame(fit);
 }})();
@@ -1194,6 +1392,7 @@ def emit_html(
         n_edges=visible_edge_count,
         svg_body=svg_text,
         spmd_badges_json=_spmd_badges_json(nodes, task_table),
+        dep_stats_json=_dep_stats_json(nodes, edges, meta, task_table),
     )
 
 

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -206,7 +206,7 @@ def test_emit_dot_marks_spmd_nodes_without_expanding_labels():
         show_tensor_info=False,
     )
 
-    assert 'label="1"' in plain
+    assert 'label="1 ↓0 ↑0"' in plain
     assert 'color="#C62828"' in plain
     assert "penwidth=1.5" in plain
     assert 'style="filled"' in plain
@@ -222,6 +222,7 @@ def test_emit_dot_marks_spmd_nodes_without_expanding_labels():
     )
 
     assert '<TABLE BORDER="1" COLOR="#C62828"' in rich
+    assert "↓0 ↑0" in rich
     assert "SPMD" not in rich
     assert "4 blocks" not in rich
 
@@ -237,10 +238,42 @@ def test_spmd_badges_json_includes_only_multiblock_tasks():
     assert badges == '{"T0_2":8}'
 
 
+def test_dep_stats_json_groups_peers_by_name_hint():
+    task_table = {
+        2: {"task_id": 2, "kernel_ids": [-1, 7, -1]},
+        3: {"task_id": 3, "kernel_ids": [-1, 8, -1]},
+        4: {"task_id": 4, "kernel_ids": [-1, 7, -1]},
+        5: {"task_id": 5, "kernel_ids": [-1, 9, -1]},
+    }
+    meta = _merge_task_meta_with_kernel_ids(
+        {
+            2: {"func_name": "q_proj", "func_id": 7},
+            3: {"func_name": "k_proj", "func_id": 8},
+            4: {"func_name": "q_proj", "func_id": 7},
+        },
+        task_table,
+        func_names={9: "v_proj"},
+    )
+    stats = json.loads(
+        deps_viewer._dep_stats_json(
+            nodes=[1, 2, 3, 4, 5],
+            edges=[(1, 5), (2, 5), (3, 5), (4, 5), (5, 1)],
+            meta=meta,
+            task_table=task_table,
+        )
+    )
+
+    assert stats["T0_5"]["fanin"] == 4
+    assert stats["T0_5"]["fanout"] == 1
+    assert stats["T0_5"]["pred_by_hint"] == [["q_proj", 2], ["alloc", 1], ["k_proj", 1]]
+    assert stats["T0_5"]["succ_by_hint"] == [["alloc", 1]]
+    assert stats["T0_5"]["name_hint"] == "v_proj"
+
+
 def test_emit_dot_handles_missing_task_table():
     dot = deps_viewer.emit_dot(edges=[], nodes=[1], meta={}, task_table=None)
 
-    assert 'label="🔥 1 · alloc"' in dot
+    assert 'label="🔥 1 · alloc ↓0 ↑0"' in dot
 
 
 def test_emit_dot_does_not_mark_alloc_only_successor_with_star():
@@ -252,9 +285,9 @@ def test_emit_dot_does_not_mark_alloc_only_successor_with_star():
         show_tensor_info=False,
     )
 
-    assert 'label="🔥 1 · alloc"' in dot
-    assert 'label="🔥 2 · alloc"' in dot
-    assert 'label="3"' in dot
+    assert 'label="🔥 1 · alloc ↓0 ↑1"' in dot
+    assert 'label="🔥 2 · alloc ↓0 ↑1"' in dot
+    assert 'label="3 ↓2 ↑0"' in dot
 
 
 def test_emit_dot_marks_star_with_alloc_and_early_dispatch_predecessors():
@@ -269,9 +302,9 @@ def test_emit_dot_marks_star_with_alloc_and_early_dispatch_predecessors():
         show_tensor_info=False,
     )
 
-    assert 'label="🔥 1 · alloc"' in dot
-    assert 'label="🔥 2"' in dot
-    assert 'label="⭐ 3"' in dot
+    assert 'label="🔥 1 · alloc ↓0 ↑1"' in dot
+    assert 'label="🔥 2 ↓0 ↑1"' in dot
+    assert 'label="⭐ 3 ↓2 ↑0"' in dot
 
 
 def test_emit_dot_does_not_mark_star_when_any_predecessor_lacks_fire():
@@ -287,7 +320,36 @@ def test_emit_dot_does_not_mark_star_when_any_predecessor_lacks_fire():
         show_tensor_info=False,
     )
 
-    assert 'label="4"' in dot
+    assert 'label="4 ↓3 ↑0"' in dot
+
+
+def test_emit_html_includes_dep_stats_and_detail_panel(monkeypatch):
+    monkeypatch.setattr(
+        deps_viewer,
+        "emit_dot",
+        lambda *args, **kwargs: "digraph deps { T0_1 [label=<1>]; }",
+    )
+    monkeypatch.setattr(
+        deps_viewer,
+        "render_svg",
+        lambda dot, engine="dot": b"<svg><g class='node'><title>T0_1</title></g></svg>",
+    )
+
+    html = deps_viewer.emit_html(
+        edges=[(1, 2)],
+        nodes=[1, 2],
+        meta={2: {"func_name": "q_proj", "func_id": 7}},
+        task_table={
+            2: {"task_id": 2, "kernel_ids": [-1, 7, -1], "args": []},
+        },
+    )
+
+    assert 'id="detail"' in html
+    assert "const depStats =" in html
+    assert '"T0_2"' in html
+    assert '"pred_by_hint"' in html
+    assert "openDetail" in html
+    assert "↓N ↑M = pred / succ" in html
 
 
 def test_emit_dot_hides_selected_edges_with_background_color():


### PR DESCRIPTION
## Summary
- HTML dependency graph nodes now show `↓fanin ↑fanout` unique peer counts on every task label.
- Clicking a task opens a detail panel that buckets predecessors and successors by `name_hint` (`func_name` from the name map; alloc/dummy fall back to kind).
- Unit tests cover the fan-count labels, name_hint histograms, and HTML detail-panel wiring.
