### PR TITLE
Fix: restore missing L2 swimlane dependency arrows in Perfetto

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -311,7 +311,9 @@ carries `fanout[]`, so there is no longer a `fanout ⊆ deps` cross-check —
 of flow events in the Perfetto trace, and flags any edge whose
 `pred.end_time > succ.start_time` as `hb_violation` (rendered as a
 distinct flow event name so Perfetto colors it apart from regular
-dependencies).
+dependencies). Dependency flows connect the source and destination
+bar starts; the completion timestamps are used only for the
+`hb_violation` classification, not for flow geometry.
 
 ---
 

--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -499,6 +499,11 @@ Scheduler View independently chooses the earliest visible AICPU slice by
 `dispatch_time_us`. Equal start times are resolved by the smaller `core_id`.
 The two views can therefore select different physical subtask records. Within
 each view, dependency and `complete` arrows use that view's selected anchor.
+Dependency flows connect the visual starts of the selected source and
+destination bars. The source completion timestamp still determines whether
+the flow is named `dependency` or `hb_violation`; it does not become the flow
+start because a completion later than the destination bar start would create
+a reverse-time flow that Perfetto cannot display.
 
 The grouping includes both the function identity and the logical `task_id`
 (ring/local id), so MIX tasks that share a `task_id` across AIC/AIV functions

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -1389,7 +1389,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     hb_violation_count = 0
     deps_flow_count = 0
     edges_by_pred = deps_edges or {}
-    flow_epsilon = 0.01
 
     # AICPU Scheduler phase events (l2_swimlane_level >= 3)
     if scheduler_phases:
@@ -1856,9 +1855,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             output_task_count = _dependency_task_fan_count(pred_id, spmd_task_ids, task_map, deps_block_map)
             input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
             for pred_row, succ_row in row_pairs:
-                src_ts_end = pred_row["end_time_us"] - flow_epsilon
+                src_bar_start_us = _task_slice_start_us(pred_row)
+                src_end_us = pred_row["end_time_us"]
                 dst_ts_start = _task_slice_start_us(succ_row)
-                hb_violated = (src_ts_end + flow_epsilon) > dst_ts_start
+                hb_violated = src_end_us > dst_ts_start
                 flow_name = "hb_violation" if hb_violated else "dependency"
                 if hb_violated:
                     hb_violation_count += 1
@@ -1870,7 +1870,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     flow_name,
                     4,
                     src_tid,
-                    src_ts_end,
+                    src_bar_start_us,
                     src_event_id,
                     4,
                     dst_tid,
@@ -1918,15 +1918,15 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 output_task_count = _dependency_task_fan_count(pred_id, spmd_task_ids, task_map, deps_block_map)
                 input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
                 for pred_row, succ_row in row_pairs:
+                    src_dispatch_us = pred_row.get("dispatch_time_us", 0)
                     src_finish_us = pred_row.get("finish_time_us", 0)
                     dst_dispatch_us = succ_row.get("dispatch_time_us", 0)
                     dst_finish_us = succ_row.get("finish_time_us", 0)
                     # Skip when AICPU timestamps are missing or zero (matches Scheduler
                     # View bar emission, which rejects finish_us <= 0).
-                    if src_finish_us <= 0 or dst_dispatch_us < 0 or dst_finish_us <= 0:
+                    if src_dispatch_us < 0 or src_finish_us <= 0 or dst_dispatch_us < 0 or dst_finish_us <= 0:
                         continue
-                    src_ts = src_finish_us - flow_epsilon
-                    aicpu_hb_violated = (src_ts + flow_epsilon) > dst_dispatch_us
+                    aicpu_hb_violated = src_finish_us > dst_dispatch_us
                     aicpu_flow_name = "hb_violation" if aicpu_hb_violated else "dependency"
                     _append_dependency_flow_pair(
                         events,
@@ -1936,7 +1936,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         task_to_aicpu_tid.get(
                             (pred_row["task_id"], pred_row["core_id"]), core_to_tid[pred_row["core_id"]]
                         ),
-                        src_ts,
+                        src_dispatch_us,
                         task_to_aicpu_event_id.get((pred_row["task_id"], pred_row["core_id"])),
                         3,
                         task_to_aicpu_tid.get(

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -182,10 +182,11 @@ def test_spmd_pred_routes_dependency_to_earliest_slice(tmp_path):
     assert flow[0]["output_task_count"] == 4
     assert flow[0]["input_task_count"] == 1
     assert flow[0]["tid"] == _core_tid(0)
+    assert flow[0]["ts"] == tasks[0]["receive_time_us"]
     sched_flow = _first_scheduler_dependency_flow(out)
     assert sched_flow[0]["output_task_count"] == 4
     assert sched_flow[0]["input_task_count"] == 1
-    assert sched_flow[0]["ts"] == tasks[0]["finish_time_us"] - 0.01
+    assert sched_flow[0]["ts"] == tasks[0]["dispatch_time_us"]
     assert sched_flow[1]["ts"] == tasks[4]["dispatch_time_us"]
 
 
@@ -211,6 +212,25 @@ def test_spmd_succ_routes_dependency_to_earliest_slice(tmp_path):
     assert worker_flow[1]["ts"] == 0.0
     assert scheduler_flow[1]["tid"] == _aicpu_tid(33)
     assert scheduler_flow[1]["ts"] == 0.1
+
+
+def test_hb_violation_flows_render_between_bar_starts(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [
+        _task_row(pred_id, 0, dispatch=10.0, start=11.0, end=20.0, receive=10.5),
+        _task_row(succ_id, 1, dispatch=15.0, start=22.0, end=30.0, receive=19.0),
+    ]
+
+    out = _generate_trace(tasks, {pred_id: [succ_id]}, {pred_id: 1, succ_id: 1}, tmp_path)
+
+    worker_flow = _first_worker_dependency_flow(out)
+    assert [event["name"] for event in worker_flow] == ["hb_violation", "hb_violation"]
+    assert [event["ts"] for event in worker_flow] == [10.5, 19.0]
+
+    scheduler_flow = _first_scheduler_dependency_flow(out)
+    assert [event["name"] for event in scheduler_flow] == ["hb_violation", "hb_violation"]
+    assert [event["ts"] for event in scheduler_flow] == [10.0, 15.0]
 
 
 def test_spmd_to_spmd_one_edge_on_earliest_slice(tmp_path):


### PR DESCRIPTION
swimlane_converter can emit reverse-time dependency flows into merged_swimlane when a producer completion timestamp is later than its successor bar start. Perfetto cannot display those dependency arrows.

- Draw flows from source bar start to destination bar start so Worker and Scheduler dependency arrows remain visible
- Preserve completion-based hb_violation classification
- Add regression coverage and update L2 swimlane documentation