### PR TITLE
Update: deps_viewer HTML uses conventional scroll/zoom gestures

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -210,9 +210,10 @@ observed task and tensor — that is not an error.
 
 `simpler_setup/tools/deps_viewer.py` turns `deps.json` into either a
 plain-text dependency view (default) or a self-contained pan/zoom HTML page
-(Graphviz SVG + inline vanilla-JS drag-pan + wheel-zoom). The text view is
-optimized for grep / diff / "what does task X depend on?" debugging; the HTML
-view stays available when you want a visual layout.
+(Graphviz SVG with inline vanilla-JS drag/scroll panning and Ctrl+scroll or
+pinch zooming). The text view is optimized for grep / diff / "what does task X
+depend on?" debugging; the HTML view stays available when you want a visual
+layout.
 
 ```bash
 # Newest deps.json under outputs/ -> deps_viewer.txt
@@ -273,7 +274,8 @@ and arg-port edge routing, rerun the HTML export with `--show-tensor-info`.
 Browser controls in the HTML viewer:
 
 - **drag** → pan
-- **wheel** → zoom about cursor
+- **scroll / two-finger swipe** → pan
+- **Ctrl+scroll / trackpad pinch** → zoom about cursor
 - **`f` key** → fit to view
 - **`r` key** → reset to 1:1
 

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -387,7 +387,8 @@ at view time.
 ### Browser controls
 
 - **drag** → pan
-- **wheel** → zoom about cursor
+- **scroll / two-finger swipe** → pan
+- **Ctrl+scroll / trackpad pinch** → zoom about cursor
 - **f** → fit to view
 - **r** → reset to 1:1
 
@@ -504,8 +505,8 @@ The tools extract the `func_id` to `name` mapping from the `KERNELS` list.
 
 - A structural view of task dependencies (who feeds whom)
 - Fast grep-friendly inspection via the default text output
-- A single-file HTML you can open offline, drag-pan / wheel-zoom in any
-  browser when you want a visual layout
+- A single-file HTML you can open offline and pan by dragging or scrolling;
+  use Ctrl+scroll or trackpad pinch to zoom
 - Optional per-task tensor rows and arg-port routing in HTML via
   `--show-tensor-info`
 - A graph that survives without an associated timing run (deps.json is

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -1078,7 +1078,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   <span class="stat">{n_edges} edges</span>
   <span class="divider"></span>
   <kbd>drag</kbd><span>pan</span>
-  <kbd>wheel</kbd><span>zoom</span>
+  <kbd>scroll</kbd><span>pan</span>
+  <kbd>ctrl+scroll</kbd><span>zoom</span>
   <kbd>click</kbd><span>task</span>
   <kbd>f</kbd><span>fit</span>
   <kbd>r</kbd><span>reset</span>
@@ -1235,13 +1236,29 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
 
   stage.addEventListener('wheel', (e) => {{
     e.preventDefault();
-    const rect = stage.getBoundingClientRect();
-    const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
-    const factor = Math.exp(-e.deltaY * 0.001);
-    const newScale = Math.min(20, Math.max(0.02, scale * factor));
-    tx = cx - (cx - tx) * (newScale / scale);
-    ty = cy - (cy - ty) * (newScale / scale);
-    scale = newScale;
+    let dx = e.deltaX, dy = e.deltaY;
+    if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) {{
+      dx *= 16;
+      dy *= 16;
+    }} else if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) {{
+      dx *= stage.clientWidth;
+      dy *= stage.clientHeight;
+    }}
+
+    // ctrlKey is set by a real Ctrl+wheel and by trackpad pinch-to-zoom;
+    // a bare wheel / two-finger swipe pans.
+    if (e.ctrlKey) {{
+      const rect = stage.getBoundingClientRect();
+      const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
+      const factor = Math.min(1.25, Math.max(0.8, Math.exp(-dy * 0.003)));
+      const newScale = Math.min(20, Math.max(0.02, scale * factor));
+      tx = cx - (cx - tx) * (newScale / scale);
+      ty = cy - (cy - ty) * (newScale / scale);
+      scale = newScale;
+    }} else {{
+      tx -= dx;
+      ty -= dy;
+    }}
     apply();
   }}, {{ passive: false }});
 


### PR DESCRIPTION
Route bare wheel and two-finger swipe events to pan, while Ctrl+wheel and trackpad pinch zoom around the cursor.

Normalize pixel, line, and page deltas before applying movement. Reduce zoom sensitivity and cap each event so physical mouse wheels remain controllable across platforms.

Update the HUD and user documentation for the new controls.