### PR TITLE
Add: cache communication domains across Worker runs

### DIFF
--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -2,9 +2,10 @@
 
 A **communication domain** is a symmetric device-memory window shared by a
 subset of ranks, used for cross-rank reads/writes (collectives, SDMA, notify
-protocols). Domains are allocated **dynamically from inside the orchestration
-function** via `orch.allocate_domain(...)` — there is no init-time / static
-declaration path.
+protocols). Domains are created **dynamically from inside the orchestration
+function**. Use `orch.allocate_domain(...)` for a one-run domain, or
+`orch.acquire_domain(...)` for a domain cached by the owning `Worker` and
+reused across runs. There is no init-time / static declaration path.
 
 For where the Orchestrator sits among the engine components see
 [hierarchical_level_runtime.md](hierarchical_level_runtime.md); for the DAG
@@ -30,8 +31,27 @@ with orch.allocate_domain(
 ```
 
 `window_size` is validated on the orch thread **before** any chip-side
-allocation: if `sum(b.nbytes) > window_size`, `allocate_domain` raises
-`ValueError` immediately and no backend allocation is registered.
+allocation: if `sum(b.nbytes) > window_size`, either API raises `ValueError`
+immediately and no backend allocation is registered.
+
+Generated PyPTO orchestration uses the persistent form:
+
+```python
+with orch.acquire_domain(
+    name="default",
+    workers=[0, 1],
+    window_size=4096,
+    buffers=[CommBufferSpec(name="scratch", dtype="float32", count=1024, nbytes=4096)],
+) as handle:
+    ...
+```
+
+The cache key contains the name, workers, window size, and complete buffer
+layout. A cache miss performs the same allocation as `allocate_domain`; a hit
+keeps the allocation and device context but resets every participating local
+window to zero before returning the handle. A given cache key may be acquired
+only once in one `Worker.run()`, because a second reset could race queued work
+from the first lease.
 
 ### `ChipDomainContext` (one per participating chip, via `handle[chip_idx]`)
 
@@ -75,15 +95,16 @@ lexical (end of block), the physical teardown is managed for you. Use
 you must assert physical teardown.
 
 Cleanup is **drain-safe**: even if a chip task fails and `drain()` re-raises,
-`Worker.run` still executes the pending releases and sweeps any live domains the
-orch fn forgot to release (LIFO), so a failed run cannot strand backend
-allocations into the next run.
+`Worker.run` still executes pending one-run releases and sweeps any live
+one-run domains the orch fn forgot to release (LIFO). Cached domains remain
+owned by the Worker and are physically released by `Worker.close()`.
 
 ---
 
-## 3. Lazy base communicator (created once, cached)
+## 3. Reuse boundaries
 
-`Worker.init()` does **no** comm work. The first `allocate_domain(...)` lazily
+`Worker.init()` does **no** comm work. The first `allocate_domain(...)` or
+`acquire_domain(...)` lazily
 fires `CTRL_COMM_INIT` to every chip in parallel, which runs the base HCCL
 `comm_init` (RootInfo handshake + membership). This base communicator is
 **cached** (`_comm_base_ready`), and `ChipWorker.comm_init` itself caches the
@@ -98,6 +119,19 @@ called many times:
   `allocate_domain` / `run`. Each allocation gets a fresh `allocation_id` so
   concurrent or sequential domains never collide on IPC handshake / barrier
   names.
+
+`acquire_domain(...)` adds a second cache at Worker scope:
+
+- the first matching acquire allocates the domain windows;
+- later `run()` calls reuse the same `allocation_id`, contexts, and window
+  addresses after a synchronous zero reset;
+- leaving the `with` block releases only that run's lexical lease;
+- `Worker.close()` releases the cached backend allocation.
+
+This cache cannot be implemented by generated Python alone: before this API,
+`Worker.run()` owned and released every allocated domain after draining the
+DAG. The runtime must own the persistent allocation and define reset/teardown
+semantics; code generation only selects that runtime policy.
 
 ---
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1492,6 +1492,10 @@ NB_MODULE(_task_interface, m) {
             "(device_ctx, local_window_base) for this rank."
         )
         .def(
+            "comm_reset_domain_windows", &ChipWorker::comm_reset_domain_windows, nb::arg("comm_handle"),
+            nb::arg("allocation_id"), "Zero this rank's local window for a live dynamic allocation."
+        )
+        .def(
             "comm_release_domain_windows", &ChipWorker::comm_release_domain_windows, nb::arg("comm_handle"),
             nb::arg("allocation_id"), nb::arg("rank_count"), nb::arg("domain_rank"),
             "Pair to comm_alloc_domain_windows: collectively release the per-rank pool."

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -713,6 +713,10 @@ inline void bind_worker(nb::module_ &m) {
             "participating chips in parallel (one Python thread per chip)."
         )
         .def(
+            "control_reset_domain", &Worker::control_reset_domain, nb::arg("worker_id"), nb::arg("request_shm_name"),
+            nb::call_guard<nb::gil_scoped_release>(), "Drive one NEXT_LEVEL chip child through CTRL_RESET_DOMAIN."
+        )
+        .def(
             "control_release_domain", &Worker::control_release_domain, nb::arg("worker_id"),
             nb::arg("request_shm_name"), nb::call_guard<nb::gil_scoped_release>(),
             "Drive one NEXT_LEVEL chip child through CTRL_RELEASE_DOMAIN.  Same serialisation "

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -359,6 +359,35 @@ class Orchestrator:
             buffers=list(buffers),
         )
 
+    def acquire_domain(
+        self,
+        *,
+        name: str,
+        workers: Sequence[int],
+        window_size: int,
+        buffers: Sequence[CommBufferSpec] = (),
+    ) -> CommDomainHandle:
+        """Acquire a zero-initialized lease over a Worker-cached CommDomain.
+
+        The first acquisition performs the same backend allocation as
+        :meth:`allocate_domain`. Later Worker.run calls reuse its VMM mappings
+        and CommContext, resetting every rank's local window before returning.
+        Exiting the lease does not free the backing allocation; Worker.close
+        owns physical teardown.
+
+        The same structural domain may be acquired only once per Worker.run,
+        because a second reset could race tasks already submitted through the
+        first lease.
+        """
+        if self._worker is None:
+            raise RuntimeError("acquire_domain requires an Orchestrator bound to a Worker")
+        return self._worker._acquire_domain(
+            name=str(name),
+            workers=tuple(int(w) for w in workers),
+            window_size=int(window_size),
+            buffers=list(buffers),
+        )
+
     def release_domain(self, handle: CommDomainHandle) -> None:
         """Collective release.  Equivalent to ``handle.release()``."""
         handle.release()

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -264,6 +264,7 @@ _CTRL_PY_IMPORT_REGISTER = 12
 # for the buffer's registered lifetime — see docs/comm-domain.md.
 _CTRL_MAP_HOST = 14
 _CTRL_UNMAP_HOST = 15
+_CTRL_RESET_DOMAIN = 18
 
 # MAP_HOST payload: token (u64), parent_va (u64), nbytes (u64), then the
 # NUL-free host-buffer shm name as the trailing bytes. UNMAP_HOST payload is the
@@ -1319,6 +1320,22 @@ def _handle_ctrl_release_domain(cw: ChipWorker, buf: memoryview) -> None:
     cw._impl.comm_release_domain_windows(int(handle), int(allocation_id), int(rank_count), int(domain_rank))
 
 
+def _handle_ctrl_reset_domain(cw: ChipWorker, buf: memoryview) -> None:
+    """CTRL_RESET_DOMAIN handler — zero this rank's cached local window."""
+    request_shm_name = _read_shm_name(buf, _OFF_ARGS)
+    req_shm = SharedMemory(name=request_shm_name)
+    req_buf = req_shm.buf
+    assert req_buf is not None
+    try:
+        (allocation_id, _rank_count, _domain_rank, _ws, _bc) = _DOMAIN_REQ_HEADER.unpack_from(req_buf, 0)
+    finally:
+        req_buf.release()
+        req_shm.close()
+
+    handle = _comm_base_handle(cw)
+    cw._impl.comm_reset_domain_windows(int(handle), int(allocation_id))
+
+
 def _comm_base_handle(cw: ChipWorker) -> int:
     """Return the cached base-communicator handle the chip allocated during bootstrap.
 
@@ -1514,6 +1531,8 @@ def _run_chip_main_loop(  # noqa: PLR0912, PLR0913, PLR0915 -- unified TASK_READ
                             prepared.discard(int(cid))
                     elif sub_cmd == _CTRL_ALLOC_DOMAIN:
                         _handle_ctrl_alloc_domain(cw, buf)
+                    elif sub_cmd == _CTRL_RESET_DOMAIN:
+                        _handle_ctrl_reset_domain(cw, buf)
                     elif sub_cmd == _CTRL_RELEASE_DOMAIN:
                         _handle_ctrl_release_domain(cw, buf)
                     elif sub_cmd == _CTRL_COMM_INIT:
@@ -1934,6 +1953,15 @@ class Worker:
         # tasks already submitted with this domain's device_ctx / buffer_ptrs
         # see live memory through execution.
         self._pending_release_domains: list[CommDomainHandle] = []
+        # Persistent domains acquired by generated orchestration.  The backend
+        # allocation survives Worker.run boundaries and is reset to the same
+        # zero-initialized state before each later run.  Cache entries are
+        # physically released only by Worker.close().
+        self._cached_domains: dict[tuple[Any, ...], CommDomainHandle] = {}
+        # A cached domain may be acquired at most once in one Worker.run.  This
+        # prevents resetting it while tasks submitted through an earlier lease
+        # in the same DAG are still pending.
+        self._cached_domains_used_this_run: set[tuple[Any, ...]] = set()
         # Monotonic per-Worker counter; mixed into IPC barrier filenames so
         # two concurrent allocations don't share a marker file.  Wraps after
         # 2^64 allocations — far beyond any realistic Worker lifetime.
@@ -4378,6 +4406,66 @@ class Worker:
         self._live_domains[name] = handle
         return handle
 
+    @staticmethod
+    def _domain_cache_key(
+        *, name: str, workers: tuple[int, ...], window_size: int, buffers: list[CommBufferSpec]
+    ) -> tuple[Any, ...]:
+        """Build a structural cache key for one generated communication domain."""
+        buffer_key = tuple(
+            (b.name, b.dtype, int(b.count), int(b.nbytes), bool(b.load_from_host), bool(b.store_to_host))
+            for b in buffers
+        )
+        return (name, workers, int(window_size), buffer_key)
+
+    def _acquire_domain(
+        self,
+        *,
+        name: str,
+        workers: tuple[int, ...],
+        window_size: int,
+        buffers: list[CommBufferSpec],
+    ) -> CommDomainHandle:
+        """Acquire a Worker-cached domain lease for the current run.
+
+        A cache miss performs the existing fresh backend allocation.  A hit
+        keeps the VMM/IPC mappings and CommContext alive, but zeros every
+        rank's local window before returning so scratch and signal protocols
+        observe the same initial state as a fresh allocation.
+        """
+        key = self._domain_cache_key(name=name, workers=workers, window_size=window_size, buffers=buffers)
+        if key in self._cached_domains_used_this_run:
+            raise RuntimeError(
+                f"acquire_domain: domain {name!r} with the same layout may only be acquired once per Worker.run"
+            )
+
+        backing = self._cached_domains.get(key)
+        if backing is None:
+            backing = self._allocate_domain(
+                name=name,
+                workers=workers,
+                window_size=window_size,
+                buffers=buffers,
+            )
+            # Persistent allocations are not part of the per-run fresh-domain
+            # sweep. Their physical lifetime is owned by _cached_domains.
+            self._live_domains.pop(name, None)
+            self._cached_domains[key] = backing
+        else:
+            self._reset_domain_now(backing)
+
+        self._cached_domains_used_this_run.add(key)
+
+        # Return a lexical lease rather than the backing handle. Releasing the
+        # lease prevents further indexing but intentionally does not free the
+        # cached allocation; Worker.close owns physical teardown.
+        return CommDomainHandle(
+            name=backing.name,
+            workers=backing.workers,
+            contexts=backing.contexts,
+            allocation_id=backing.allocation_id,
+            _release_fn=lambda _lease: None,
+        )
+
     def _release_domain_handle(self, handle: CommDomainHandle) -> None:
         """Mark a handle for release.  Actual backend free is deferred.
 
@@ -4423,12 +4511,18 @@ class Worker:
     def _release_domain_now(self, handle: CommDomainHandle) -> None:
         """Synchronous backend release for one handle.  Used by the
         deferred-release path and by the abort/close cleanup helpers."""
+        self._dispatch_domain_lifecycle(handle, op="release")
+        self._live_domains.pop(handle.name, None)
+
+    def _reset_domain_now(self, handle: CommDomainHandle) -> None:
+        """Synchronously zero every rank's local window for a cached domain."""
+        self._dispatch_domain_lifecycle(handle, op="reset")
+
+    def _dispatch_domain_lifecycle(self, handle: CommDomainHandle, *, op: str) -> None:
+        """Dispatch a reset or release request for an existing allocation."""
         if self._worker is None:
             return
         workers = handle.workers
-        # Release payload is just the fixed header — no rank_ids tail; the
-        # backend looked them up from its own per-allocation record at
-        # alloc time and doesn't need them again.
         req_size = _DOMAIN_REQ_HEADER.size
         worker_to_rank = {w: r for r, w in enumerate(workers)}
 
@@ -4444,8 +4538,8 @@ class Worker:
                     int(handle.allocation_id),
                     int(len(workers)),
                     int(worker_to_rank[chip_idx]),
-                    0,  # window_size — ignored on release
-                    0,  # buffer_count — ignored on release
+                    0,
+                    0,
                 )
                 request_shms[chip_idx] = req
 
@@ -4453,7 +4547,7 @@ class Worker:
                 workers=workers,
                 request_shms=request_shms,
                 reply_shms=None,
-                op="release",
+                op=op,
                 allocation_id=handle.allocation_id,
             )
         finally:
@@ -4463,7 +4557,6 @@ class Worker:
                     shm.unlink()
                 except Exception:  # noqa: BLE001
                     pass
-        self._live_domains.pop(handle.name, None)
 
     def _dispatch_control_domain(
         self,
@@ -4490,6 +4583,8 @@ class Worker:
                 if op == "alloc":
                     assert reply_shms is not None
                     dw.control_alloc_domain(chip_idx, req_name, reply_shms[chip_idx].name)
+                elif op == "reset":
+                    dw.control_reset_domain(chip_idx, req_name)
                 else:
                     dw.control_release_domain(chip_idx, req_name)
             except BaseException as e:  # noqa: BLE001
@@ -4535,6 +4630,21 @@ class Worker:
                 # Drop from live_domains anyway — leaving a known-bad handle
                 # would just block close().
                 self._live_domains.pop(handle.name, None)
+
+    def _release_all_cached_domains(self) -> None:
+        """Best-effort physical teardown of Worker-cached domains in LIFO order."""
+        for key, handle in list(self._cached_domains.items())[::-1]:
+            try:
+                self._release_domain_now(handle)
+                handle._released = True  # noqa: SLF001 -- runtime owns backing handles
+                handle._freed = True  # noqa: SLF001
+            except Exception as e:  # noqa: BLE001
+                sys.stderr.write(
+                    f"Worker._release_all_cached_domains: {handle.name!r} release failed: {type(e).__name__}: {e}\n"
+                )
+                sys.stderr.flush()
+            finally:
+                self._cached_domains.pop(key, None)
 
     # ------------------------------------------------------------------
     # memory management — forward to C++ Orchestrator, which holds
@@ -4922,6 +5032,7 @@ class Worker:
         # leaves the error slot empty, but an unrelated caller may have
         # poked it.
         self._orch._clear_error()
+        self._cached_domains_used_this_run.clear()
         self._orch._scope_begin()
         try:
             callable(self._orch, args, cfg)
@@ -4959,6 +5070,7 @@ class Worker:
                 self._execute_pending_domain_releases()
                 if self._live_domains:
                     self._release_all_live_domains()
+                self._cached_domains_used_this_run.clear()
         # L3+ returns None like every other worker level; per-L2-child timing
         # is emitted as `[STRACE]` markers from each simpler_run.
         return None
@@ -5007,6 +5119,8 @@ class Worker:
         self._cleanup_l3_l2_regions()
         if self._live_domains:
             self._release_all_live_domains()
+        if self._cached_domains:
+            self._release_all_cached_domains()
         try:
             self._release_active_remote_slot_refs()
             self._flush_pending_remote_frees()

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -1207,6 +1207,32 @@ extern "C" int comm_alloc_domain_windows(
     return -1;
 }
 
+extern "C" int comm_reset_domain_windows(CommHandle h, uint64_t allocation_id) try {
+    if (!h) return -1;
+    auto it = h->domain_allocations.find(allocation_id);
+    if (it == h->domain_allocations.end()) {
+        LOG_ERROR(
+            "[comm rank %d] reset_domain: allocation_id=%llu not found", h->rank,
+            static_cast<unsigned long long>(allocation_id)
+        );
+        return -1;
+    }
+    auto &alloc = it->second;
+    if (!alloc->local_buf || alloc->alloc_size == 0) return -1;
+    aclError aret = aclrtMemset(alloc->local_buf, alloc->alloc_size, 0, alloc->alloc_size);
+    if (aret != ACL_SUCCESS) {
+        LOG_ERROR("[comm rank %d] reset_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
+        return -1;
+    }
+    return 0;
+} catch (const std::exception &e) {
+    LOG_ERROR("[comm] reset_domain: exception: %s", e.what());
+    return -1;
+} catch (...) {
+    LOG_ERROR("[comm] reset_domain: unknown exception");
+    return -1;
+}
+
 extern "C" int
 comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank) try {
     if (!h) return -1;

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -1209,6 +1209,32 @@ extern "C" int comm_alloc_domain_windows(
     return -1;
 }
 
+extern "C" int comm_reset_domain_windows(CommHandle h, uint64_t allocation_id) try {
+    if (!h) return -1;
+    auto it = h->domain_allocations.find(allocation_id);
+    if (it == h->domain_allocations.end()) {
+        LOG_ERROR(
+            "[comm rank %d] reset_domain: allocation_id=%llu not found", h->rank,
+            static_cast<unsigned long long>(allocation_id)
+        );
+        return -1;
+    }
+    auto &alloc = it->second;
+    if (!alloc->local_buf || alloc->alloc_size == 0) return -1;
+    aclError aret = aclrtMemset(alloc->local_buf, alloc->alloc_size, 0, alloc->alloc_size);
+    if (aret != ACL_SUCCESS) {
+        LOG_ERROR("[comm rank %d] reset_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
+        return -1;
+    }
+    return 0;
+} catch (const std::exception &e) {
+    LOG_ERROR("[comm] reset_domain: exception: %s", e.what());
+    return -1;
+} catch (...) {
+    LOG_ERROR("[comm] reset_domain: unknown exception");
+    return -1;
+}
+
 extern "C" int
 comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank) try {
     if (!h) return -1;

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -107,6 +107,9 @@ public:
     void control_alloc_domain(int worker_id, const std::string &request_shm_name, const std::string &reply_shm_name) {
         manager_.control_alloc_domain(worker_id, request_shm_name.c_str(), reply_shm_name.c_str());
     }
+    void control_reset_domain(int worker_id, const std::string &request_shm_name) {
+        manager_.control_reset_domain(worker_id, request_shm_name.c_str());
+    }
     void control_release_domain(int worker_id, const std::string &request_shm_name) {
         manager_.control_release_domain(worker_id, request_shm_name.c_str());
     }

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -113,6 +113,7 @@ void WorkerEndpoint::control_generic(uint64_t, const char *, size_t, double, con
 void WorkerEndpoint::control_alloc_domain(const char *, const char *) {
     throw_unsupported_control("control_alloc_domain");
 }
+void WorkerEndpoint::control_reset_domain(const char *) { throw_unsupported_control("control_reset_domain"); }
 void WorkerEndpoint::control_release_domain(const char *) { throw_unsupported_control("control_release_domain"); }
 void WorkerEndpoint::control_comm_init(const char *) { throw_unsupported_control("control_comm_init"); }
 void WorkerEndpoint::control_l3_l2_region_create(const char *, const char *) {
@@ -709,6 +710,17 @@ void LocalMailboxEndpoint::control_alloc_domain(const char *request_shm_name, co
     run_control_command("control_alloc_domain");
 }
 
+void LocalMailboxEndpoint::control_reset_domain(const char *request_shm_name) {
+    if (!request_shm_name || !*request_shm_name) {
+        throw std::runtime_error("control_reset_domain: request shm name must be non-empty");
+    }
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    uint64_t sub_cmd = CTRL_RESET_DOMAIN;
+    std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &sub_cmd, sizeof(uint64_t));
+    write_shm_name_pair(mbox(), request_shm_name, "");
+    run_control_command("control_reset_domain");
+}
+
 void LocalMailboxEndpoint::control_release_domain(const char *request_shm_name) {
     if (!request_shm_name || !*request_shm_name) {
         throw std::runtime_error("control_release_domain: request shm name must be non-empty");
@@ -866,6 +878,11 @@ void WorkerThread::control_alloc_domain(const char *request_shm_name, const char
     endpoint_->control_alloc_domain(request_shm_name, reply_shm_name);
 }
 
+void WorkerThread::control_reset_domain(const char *request_shm_name) {
+    if (!endpoint_) throw std::runtime_error("control_reset_domain: null endpoint");
+    endpoint_->control_reset_domain(request_shm_name);
+}
+
 void WorkerThread::control_release_domain(const char *request_shm_name) {
     if (!endpoint_) throw std::runtime_error("control_release_domain: null endpoint");
     endpoint_->control_release_domain(request_shm_name);
@@ -997,6 +1014,14 @@ void WorkerManager::control_alloc_domain(int worker_id, const char *request_shm_
         throw std::runtime_error("control_alloc_domain: invalid worker_id " + std::to_string(worker_id));
     }
     wt->control_alloc_domain(request_shm_name, reply_shm_name);
+}
+
+void WorkerManager::control_reset_domain(int worker_id, const char *request_shm_name) {
+    auto *wt = get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_reset_domain: invalid worker_id " + std::to_string(worker_id));
+    }
+    wt->control_reset_domain(request_shm_name);
 }
 
 void WorkerManager::control_release_domain(int worker_id, const char *request_shm_name) {

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -156,7 +156,8 @@ static constexpr uint64_t CTRL_PY_REGISTER = 10;
 static constexpr uint64_t CTRL_PY_UNREGISTER = 11;
 static constexpr uint64_t CTRL_L3_L2_REGION_CREATE = 16;
 static constexpr uint64_t CTRL_L3_L2_REGION_RELEASE = 17;
-
+// Reset one cached dynamic CommDomain's local window between Worker.run calls.
+static constexpr uint64_t CTRL_RESET_DOMAIN = 18;
 // Control args reuse the task mailbox region (mutually exclusive with task dispatch):
 //   offset 16: uint64 arg0 (size for malloc/register; ptr for free; dst for copy)
 //   offset 24: uint64 arg1 (src for copy)
@@ -241,6 +242,7 @@ public:
         uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
     );
     virtual void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name);
+    virtual void control_reset_domain(const char *request_shm_name);
     virtual void control_release_domain(const char *request_shm_name);
     virtual void control_comm_init(const char *request_shm_name);
     virtual void control_l3_l2_region_create(const char *request_shm_name, const char *reply_shm_name);
@@ -292,6 +294,7 @@ public:
         uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
     ) override;
     void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name) override;
+    void control_reset_domain(const char *request_shm_name) override;
     void control_release_domain(const char *request_shm_name) override;
     void control_comm_init(const char *request_shm_name) override;
     void control_l3_l2_region_create(const char *request_shm_name, const char *reply_shm_name) override;
@@ -427,6 +430,7 @@ public:
     // CTRL_SHM_NAME_BYTES-1.  Holds mailbox_mu_ so it serialises with task
     // dispatch on the same chip mailbox.
     void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name);
+    void control_reset_domain(const char *request_shm_name);
     void control_release_domain(const char *request_shm_name);
 
     // Lazy comm_init driver — payload shm carries (rank, nranks, rootinfo_path).
@@ -493,6 +497,7 @@ public:
     // allocation across a subset of chips — caller dispatches to each
     // participating chip and joins on completion.
     void control_alloc_domain(int worker_id, const char *request_shm_name, const char *reply_shm_name);
+    void control_reset_domain(int worker_id, const char *request_shm_name);
     void control_release_domain(int worker_id, const char *request_shm_name);
     void control_comm_init(int worker_id, const char *request_shm_name);
     void control_l3_l2_region_create(int worker_id, const char *request_shm_name, const char *reply_shm_name);

--- a/src/common/platform_comm/comm.h
+++ b/src/common/platform_comm/comm.h
@@ -169,6 +169,19 @@ int comm_alloc_domain_windows(
 );
 
 /**
+ * Reset this rank's local window for a live dynamic domain allocation.
+ *
+ * The caller must ensure that no device work is still using the allocation.
+ * The hierarchical Worker satisfies that contract by resetting cached domains
+ * only at the start of a new run, after the previous run has drained.
+ *
+ * @param h               Base handle from comm_init().
+ * @param allocation_id   Id of a live comm_alloc_domain_windows allocation.
+ * @return 0 on success, non-zero on failure.
+ */
+int comm_reset_domain_windows(CommHandle h, uint64_t allocation_id);
+
+/**
  * Collectively release a domain window pool allocated by
  * comm_alloc_domain_windows().
  *

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -607,6 +607,31 @@ extern "C" int comm_alloc_domain_windows(
     return -1;
 }
 
+extern "C" int comm_reset_domain_windows(CommHandle h, uint64_t allocation_id) try {
+    if (h == nullptr) return -1;
+    auto it = h->domain_allocations.find(allocation_id);
+    if (it == h->domain_allocations.end()) {
+        std::fprintf(
+            stderr, "[comm_sim rank %d] reset_domain: allocation_id=%llu not found\n", h->rank,
+            static_cast<unsigned long long>(allocation_id)
+        );
+        return -1;
+    }
+    auto &alloc = it->second;
+    if (!alloc->host_ctx) return -1;
+    auto &ctx = *alloc->host_ctx;
+    void *local_window = reinterpret_cast<void *>(ctx.windowsIn[ctx.rankId]);
+    if (local_window == nullptr || ctx.winSize == 0) return -1;
+    std::memset(local_window, 0, static_cast<size_t>(ctx.winSize));
+    return 0;
+} catch (const std::exception &e) {
+    std::fprintf(stderr, "[comm_sim] reset_domain: exception: %s\n", e.what());
+    return -1;
+} catch (...) {
+    std::fprintf(stderr, "[comm_sim] reset_domain: unknown exception\n");
+    return -1;
+}
+
 extern "C" int
 comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank) try {
     // The shm header's `destroy_count` atomic is the subset-scoped release

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -123,6 +123,7 @@ void ChipWorker::init(
         comm_get_window_size_fn_ = load_symbol<CommGetWindowSizeFn>(handle, "comm_get_window_size");
         comm_derive_context_fn_ = load_symbol<CommDeriveContextFn>(handle, "comm_derive_context");
         comm_alloc_domain_windows_fn_ = load_symbol<CommAllocDomainWindowsFn>(handle, "comm_alloc_domain_windows");
+        comm_reset_domain_windows_fn_ = load_symbol<CommResetDomainWindowsFn>(handle, "comm_reset_domain_windows");
         comm_release_domain_windows_fn_ =
             load_symbol<CommReleaseDomainWindowsFn>(handle, "comm_release_domain_windows");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
@@ -201,6 +202,7 @@ void ChipWorker::init(
         comm_get_local_window_base_fn_ = nullptr;
         comm_get_window_size_fn_ = nullptr;
         comm_alloc_domain_windows_fn_ = nullptr;
+        comm_reset_domain_windows_fn_ = nullptr;
         comm_release_domain_windows_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
@@ -240,6 +242,7 @@ void ChipWorker::init(
         comm_get_window_size_fn_ = nullptr;
         comm_derive_context_fn_ = nullptr;
         comm_alloc_domain_windows_fn_ = nullptr;
+        comm_reset_domain_windows_fn_ = nullptr;
         comm_release_domain_windows_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
@@ -289,6 +292,7 @@ void ChipWorker::finalize() {
     comm_get_window_size_fn_ = nullptr;
     comm_derive_context_fn_ = nullptr;
     comm_alloc_domain_windows_fn_ = nullptr;
+    comm_reset_domain_windows_fn_ = nullptr;
     comm_release_domain_windows_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
@@ -598,6 +602,16 @@ std::pair<uint64_t, uint64_t> ChipWorker::comm_alloc_domain_windows(
         throw std::runtime_error("comm_alloc_domain_windows returned null device_ctx / local_window_base");
     }
     return {device_ctx, local_window_base};
+}
+
+void ChipWorker::comm_reset_domain_windows(uint64_t comm_handle, uint64_t allocation_id) {
+    if (comm_reset_domain_windows_fn_ == nullptr) {
+        throw std::runtime_error("comm_reset_domain_windows is not supported by this runtime");
+    }
+    int rc = comm_reset_domain_windows_fn_(reinterpret_cast<void *>(comm_handle), allocation_id);
+    if (rc != 0) {
+        throw std::runtime_error("comm_reset_domain_windows failed with code " + std::to_string(rc));
+    }
 }
 
 void ChipWorker::comm_release_domain_windows(

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -119,6 +119,9 @@ public:
         uint64_t comm_handle, uint64_t allocation_id, const std::vector<uint32_t> &rank_ids, uint32_t domain_rank,
         size_t window_size
     );
+    /// Zero this rank's local window for a live dynamic allocation. The caller
+    /// must ensure all prior device work using the allocation has drained.
+    void comm_reset_domain_windows(uint64_t comm_handle, uint64_t allocation_id);
     /// Pair to `comm_alloc_domain_windows`: collectively free the per-rank
     /// pool and the device CommContext, then drop the allocation record.
     /// `rank_count` + `domain_rank` size the subset barrier; the rank list
@@ -162,6 +165,7 @@ private:
     using CommDeriveContextFn = int (*)(void *, const uint32_t *, size_t, uint32_t, size_t, size_t, uint64_t *);
     using CommAllocDomainWindowsFn =
         int (*)(void *, uint64_t, const uint32_t *, size_t, uint32_t, size_t, uint64_t *, uint64_t *);
+    using CommResetDomainWindowsFn = int (*)(void *, uint64_t);
     using CommReleaseDomainWindowsFn = int (*)(void *, uint64_t, size_t, uint32_t);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
@@ -207,6 +211,7 @@ private:
     CommGetWindowSizeFn comm_get_window_size_fn_ = nullptr;
     CommDeriveContextFn comm_derive_context_fn_ = nullptr;
     CommAllocDomainWindowsFn comm_alloc_domain_windows_fn_ = nullptr;
+    CommResetDomainWindowsFn comm_reset_domain_windows_fn_ = nullptr;
     CommReleaseDomainWindowsFn comm_release_domain_windows_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;

--- a/tests/ut/py/test_worker/test_dynamic_alloc_hw.py
+++ b/tests/ut/py/test_worker/test_dynamic_alloc_hw.py
@@ -7,21 +7,22 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ruff: noqa: PLC0415
-"""Hardware smoke test for `Orchestrator.allocate_domain` on HCCL.
+"""Hardware smoke test for cached `Orchestrator.acquire_domain` on HCCL.
 
 Mirrors the happy-path case from `test_dynamic_alloc_sim.py` but drives the
 real ``tensormap_and_ringbuffer`` runtime on Ascend.  The flow under test:
 
   1. Build an L3 ``Worker`` and call ``init()``.  No static comm_plan —
      base HCCL membership is established lazily on the first
-     ``orch.allocate_domain`` call inside ``Worker.run``.
-  2. Inside ``Worker.run(orch_fn)``, call ``orch.allocate_domain(...)``
+     ``orch.acquire_domain`` call inside ``Worker.run``.
+  2. Inside ``Worker.run(orch_fn)``, call ``orch.acquire_domain(...)``
      to drive ``comm_alloc_domain_windows`` (aclrtMalloc + IPC announce +
      SetImportPid + ImportByKey).
   3. Verify the returned per-chip ``ChipDomainContext`` carries a non-zero
      ``device_ctx`` + ``local_window_base`` on every participating chip.
-  4. Exit the ``with`` block to mark the handle for release; the actual
-     ``comm_release_domain_windows`` runs after Worker.run drains.
+  4. Run the same orchestration again and verify the allocation identity and
+     addresses are reused while the window contents are reset to zero.
+  5. ``Worker.close`` performs the actual ``comm_release_domain_windows``.
 
 Deliberately no ``comm_barrier`` after alloc — HCCL 507018 surfaces only
 on the explicit HcclBarrier path, not in our IPC alloc/release.
@@ -31,7 +32,9 @@ the C ABI.
 
 from __future__ import annotations
 
+import ctypes
 import os
+from multiprocessing.shared_memory import SharedMemory
 
 import pytest
 
@@ -39,8 +42,8 @@ import pytest
 @pytest.mark.requires_hardware
 @pytest.mark.platforms(["a2a3", "a5"])
 @pytest.mark.device_count(2)
-def test_two_rank_allocate_release_round_trip(st_platform, st_device_ids):
-    """End-to-end 2-rank hardware alloc + release round trip.
+def test_two_rank_cached_domain_reuse_and_reset(st_platform, st_device_ids):
+    """End-to-end 2-rank hardware allocation reuse and reset round trip.
 
     Single allocation, one CommBufferSpec, both chips participate.  Locks
     in the same fields the sim happy-path test does, on real HCCL.
@@ -56,10 +59,16 @@ def test_two_rank_allocate_release_round_trip(st_platform, st_device_ids):
     device_ids = [int(d) for d in st_device_ids[:2]]
     nranks = len(device_ids)
 
-    captured: dict[str, object] = {}
+    captured: dict[str, object] = {"runs": []}
+    shared = SharedMemory(create=True, size=16)
+    shared_buf = shared.buf
+    assert shared_buf is not None
+    shared_buf[:] = b"\x5a" * 16
+    exported = ctypes.c_char.from_buffer(shared_buf)
+    shared_addr = ctypes.addressof(exported)
 
     def orch_fn(orch, _args, _cfg):
-        with orch.allocate_domain(
+        with orch.acquire_domain(
             name="tp",
             workers=list(range(nranks)),
             window_size=4 * 1024 * 1024,
@@ -68,19 +77,36 @@ def test_two_rank_allocate_release_round_trip(st_platform, st_device_ids):
                 CommBufferSpec(name="signal", dtype="uint32", count=4, nbytes=16),
             ],
         ) as tp:
-            captured["workers"] = tuple(tp.workers)
-            captured["alloc_id"] = tp.allocation_id
-            captured["contexts"] = {
-                chip_idx: {
-                    "domain_rank": tp[chip_idx].domain_rank,
-                    "domain_size": tp[chip_idx].domain_size,
-                    "device_ctx": int(tp[chip_idx].device_ctx),
-                    "local_window_base": int(tp[chip_idx].local_window_base),
-                    "buffer_ptrs": dict(tp[chip_idx].buffer_ptrs),
-                }
-                for chip_idx in tp.workers
+            run = {
+                "workers": tuple(tp.workers),
+                "alloc_id": tp.allocation_id,
+                "contexts": {
+                    chip_idx: {
+                        "domain_rank": tp[chip_idx].domain_rank,
+                        "domain_size": tp[chip_idx].domain_size,
+                        "device_ctx": int(tp[chip_idx].device_ctx),
+                        "local_window_base": int(tp[chip_idx].local_window_base),
+                        "buffer_ptrs": dict(tp[chip_idx].buffer_ptrs),
+                    }
+                    for chip_idx in tp.workers
+                },
             }
-        captured["released_after_with"] = tp.released
+            captured["runs"].append(run)  # type: ignore[union-attr]
+            if len(captured["runs"]) == 1:  # type: ignore[arg-type]
+                for chip_idx in tp.workers:
+                    orch.copy_to(
+                        chip_idx,
+                        dst=tp[chip_idx].buffer_ptrs["signal"],
+                        src=shared_addr,
+                        size=16,
+                    )
+            else:
+                orch.copy_from(
+                    0,
+                    dst=shared_addr,
+                    src=tp[0].buffer_ptrs["signal"],
+                    size=16,
+                )
 
     worker = Worker(
         level=3,
@@ -92,13 +118,23 @@ def test_two_rank_allocate_release_round_trip(st_platform, st_device_ids):
     try:
         worker.init()
         worker.run(orch_fn, args=None, config=CallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
+        reset_bytes = bytes(shared_buf)
     finally:
         worker.close()
+        del exported
+        shared_buf.release()
+        shared.close()
+        shared.unlink()
 
-    assert captured["released_after_with"] is True
-    assert captured["workers"] == tuple(range(nranks))
+    runs: list[dict[str, object]] = captured["runs"]  # type: ignore[assignment]
+    assert len(runs) == 2
+    assert runs[0]["workers"] == tuple(range(nranks))
+    assert runs[1]["workers"] == tuple(range(nranks))
+    assert runs[0]["alloc_id"] == runs[1]["alloc_id"]
 
-    contexts: dict[int, dict[str, object]] = captured["contexts"]  # type: ignore[assignment]
+    contexts: dict[int, dict[str, object]] = runs[0]["contexts"]  # type: ignore[assignment]
+    reused_contexts: dict[int, dict[str, object]] = runs[1]["contexts"]  # type: ignore[assignment]
     # Dense domain ranks follow worker order.
     assert contexts[0]["domain_rank"] == 0
     assert contexts[1]["domain_rank"] == 1
@@ -113,3 +149,7 @@ def test_two_rank_allocate_release_round_trip(st_platform, st_device_ids):
         assert isinstance(ptrs, dict)
         assert ptrs["scratch"] == ctx["local_window_base"]
         assert ptrs["signal"] == ctx["local_window_base"] + 64
+        assert reused_contexts[chip_idx]["device_ctx"] == ctx["device_ctx"]
+        assert reused_contexts[chip_idx]["local_window_base"] == ctx["local_window_base"]
+
+    assert reset_bytes == b"\x00" * 16

--- a/tests/ut/py/test_worker/test_dynamic_alloc_sim.py
+++ b/tests/ut/py/test_worker/test_dynamic_alloc_sim.py
@@ -30,6 +30,9 @@ The flow under test:
 
 from __future__ import annotations
 
+import ctypes
+from multiprocessing.shared_memory import SharedMemory
+
 import pytest
 
 
@@ -175,7 +178,90 @@ class TestDynamicAllocateContextManager:
 
 
 # ---------------------------------------------------------------------------
-# 3. Re-alloc with the same name after release succeeds (canonical "resize"
+# 3. Cached acquire persists across Worker.run and resets the local window.
+# ---------------------------------------------------------------------------
+
+
+class TestCachedDomainAcquire:
+    def test_acquire_reuses_allocation_and_resets_window(self):
+        from simpler.task_interface import CallConfig, CommBufferSpec
+
+        shared = SharedMemory(create=True, size=16)
+        shared_buf = shared.buf
+        assert shared_buf is not None
+        shared_buf[:] = b"\x5a" * 16
+        exported = ctypes.c_char.from_buffer(shared_buf)
+        shared_addr = ctypes.addressof(exported)
+        observations: list[tuple[int, int]] = []
+
+        def populate(orch, _args, _cfg):
+            with orch.acquire_domain(
+                name="tp_cached",
+                workers=[0, 1],
+                window_size=4096,
+                buffers=[CommBufferSpec(name="scratch", dtype="opaque", count=16, nbytes=16)],
+            ) as domain:
+                observations.append((domain.allocation_id, int(domain[0].local_window_base)))
+                for chip_idx in domain.workers:
+                    orch.copy_to(
+                        chip_idx,
+                        dst=domain[chip_idx].buffer_ptrs["scratch"],
+                        src=shared_addr,
+                        size=16,
+                    )
+
+        def observe_after_reset(orch, _args, _cfg):
+            with orch.acquire_domain(
+                name="tp_cached",
+                workers=[0, 1],
+                window_size=4096,
+                buffers=[CommBufferSpec(name="scratch", dtype="opaque", count=16, nbytes=16)],
+            ) as domain:
+                observations.append((domain.allocation_id, int(domain[0].local_window_base)))
+                orch.copy_from(
+                    0,
+                    dst=shared_addr,
+                    src=domain[0].buffer_ptrs["scratch"],
+                    size=16,
+                )
+
+        worker = _make_worker(nranks=2)
+        try:
+            worker.init()
+            worker.run(populate, args=None, config=CallConfig())
+            assert bytes(shared_buf) == b"\x5a" * 16
+            worker.run(observe_after_reset, args=None, config=CallConfig())
+            assert bytes(shared_buf) == b"\x00" * 16
+            assert len(worker._cached_domains) == 1
+        finally:
+            worker.close()
+            del exported
+            shared_buf.release()
+            shared.close()
+            shared.unlink()
+
+        assert observations[0] == observations[1]
+        assert worker._cached_domains == {}
+
+    def test_same_domain_cannot_be_reacquired_in_one_run(self):
+        from simpler.task_interface import CallConfig
+
+        def orch_fn(orch, _args, _cfg):
+            first = orch.acquire_domain(name="tp_cached", workers=[0, 1], window_size=4096)
+            first.release()
+            with pytest.raises(RuntimeError, match="only be acquired once per Worker.run"):
+                orch.acquire_domain(name="tp_cached", workers=[0, 1], window_size=4096)
+
+        worker = _make_worker(nranks=2)
+        try:
+            worker.init()
+            worker.run(orch_fn, args=None, config=CallConfig())
+        finally:
+            worker.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. Re-alloc with the same name after release succeeds (canonical "resize"
 #    pattern: release, then allocate a bigger one under the same name).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- add `Orchestrator.acquire_domain()` for Worker-scoped communication-domain reuse
- reset every participating local window before a cached domain is leased by a later `Worker.run()`
- keep transient `allocate_domain()` behavior unchanged and release cached allocations at `Worker.close()`
- implement reset support in simulation, A2/A3 HCCL, and A5 HCCL backends
- document the lifetime contract and add simulation/hardware regression coverage

## Performance

DeepSeek V4 EP2 decode, 105 runs on the same two devices:

| mode | alloc / reset / free | mean `Worker.run` | median | p95 |
| --- | --- | ---: | ---: | ---: |
| transient per-run | 105 / 0 / 105 | 203.151 ms | 205.279 ms | 206.648 ms |
| Worker-cached | 1 / 104 / 1 | 52.965 ms | 52.849 ms | 55.329 ms |

Mean host-observed latency improves by 73.9% (3.84x). Device effective
execution remains unchanged at approximately 48.09 ms before and 48.08 ms
after.

## Testing

- `pre-commit run --files <changed files>`
  - check-headers, English-only, clang-format, clang-tidy, cpplint,
    markdownlint, ruff, and pyright passed
- `pytest tests/ut/py/test_worker/ -q -m "not requires_hardware"`
  - 199 passed, 2 deselected
- two-card A2/A3 hardware cached-domain reuse/reset test
  - 1 passed via `task-submit` task `task_20260719_182922_349158514068`
- DeepSeek V4 EP2 normal and `pypto_bench` modes passed during integration validation

Fixes #824
