### PR TITLE
docs(fix-pr): squash fixes into the PR commit and evolve its message

### DIFF
--- a/.claude/lib/github/commit-and-push.md
+++ b/.claude/lib/github/commit-and-push.md
@@ -42,24 +42,43 @@ COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count 2>/dev/null || echo 
 
 ### Squash procedure (when `COMMITS_AHEAD > 1`)
 
-1. Collect other human authors before squashing (to preserve attribution):
+1. Capture the original PR commit's message **before** the reset destroys it —
+   `/git-commit` regenerates from the diff and has no other way to see it, so
+   without this the "evolve the original message" rule below cannot hold:
+
+   ```bash
+   # Oldest commit ahead of base = the original PR commit
+   ORIG_COMMIT=$(git rev-list --reverse "$BASE_REF"..HEAD | head -1)
+   git log -1 --format='%B' "$ORIG_COMMIT" > /tmp/orig_pr_msg.txt
+   ```
+
+2. Collect other human authors before squashing (to preserve attribution):
+
    ```bash
    CURRENT_USER_EMAIL=$(git config user.email)
    OTHER_AUTHORS=$(git log "$BASE_REF"..HEAD --format='%aN <%aE>' \
      | grep -v -F "<$CURRENT_USER_EMAIL>" | sort -u)
    ```
-2. Soft-reset to base:
+
+3. Soft-reset to base:
+
    ```bash
    git reset --soft "$BASE_REF"
    ```
-3. All changes are now staged. Delegate to `/git-commit` to create a single commit with a proper message based on the combined diff. If `OTHER_AUTHORS` is non-empty, append `Co-authored-by:` trailers for each human author.
-4. **Re-verify** the count:
+
+4. All changes are now staged. Delegate to `/git-commit`, passing the captured
+   `/tmp/orig_pr_msg.txt` as the starting point so the single squashed commit
+   **evolves** the original subject/body to cover the combined diff (see the
+   message rule below) rather than inventing a generic one. If `OTHER_AUTHORS`
+   is non-empty, append `Co-authored-by:` trailers for each human author.
+5. **Re-verify** the count:
+
    ```bash
    COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count)
    # Must be exactly 1. If not, something went wrong — do NOT push.
    ```
 
-**Important:** When squashing, the commit message must be regenerated based on the final combined diff, not copied from any single commit.
+**Important:** When squashing, the commit message must describe the final combined diff. Start from the original PR commit's message (keep its type/scope/subject and intent) and evolve it to absorb the folded-in fixes — do not replace it with a generic `fix(pr): …` message, and do not leave it frozen when the fix changed the commit's behavior or scope.
 
 ## 3. Push
 

--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -14,7 +14,7 @@ Create tasks to track progress through this workflow:
 1. Match input to PR
 2. Detect & classify issues
 3. Get user confirmation
-4. Fix issues & push
+4. Fix issues & push (fold into one commit — amend/squash, never append)
 5. Resolve comment threads
 6. Re-check (loop until clean)
 
@@ -190,15 +190,59 @@ Run [checkout-fork-branch](../../lib/github/checkout-fork-branch.md) to create/s
 
 1. Read affected files, make changes with Edit tool
 2. For CI: analyze logs online first, reproduce locally only as last resort
-3. Commit using `/git-commit` skill (skip testing/review for minor fixes)
 
-Then run [commit-and-push](../../lib/github/commit-and-push.md):
+**Fold the fix into the PR — never append a standalone "fix(pr)" commit.**
+The PR must stay as **one commit** (its original commit + your fixes squashed
+in), so reviewers see a single clean diff, not a running log of review
+churn. This is the default on **every** iteration.
 
-1. Rebase onto `$BASE_REF`
-2. Ensure single valid commit (squash with original PR commit)
+Stage all changes, then squash based on how many commits the PR has ahead of
+`$BASE_REF`:
+
+```bash
+git add -A
+COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count)
+```
+
+| `COMMITS_AHEAD` | How to fold the fix in |
+| --------------- | ---------------------- |
+| `0` | **Error — stop.** Nothing ahead of base to fold into; do not rebase or push. Matches [commit-and-push](../../lib/github/commit-and-push.md) §2. |
+| `1` | **Amend with an updated message.** Pass the message non-interactively — `git commit --amend -F <msgfile>` (or `-m`), never bare `--amend` (it opens an editor and hangs in a non-interactive/agent shell) and never `--no-edit` (leaves the message stale). Write the evolved message per the rule below into `<msgfile>` first. |
+| `> 1` | **Squash to one** via the [commit-and-push](../../lib/github/commit-and-push.md) squash procedure (capture the original message, soft-reset to `$BASE_REF`, recommit once) |
+
+Do NOT run `/git-commit` to create a *new* commit here — that is what causes
+the appended-commit problem. `/git-commit` is only for regenerating the
+squashed message when `COMMITS_AHEAD > 1`.
+
+Then push and verify exactly one commit landed:
+
+1. Rebase onto `$BASE_REF` (see [commit-and-push](../../lib/github/commit-and-push.md) §1)
+2. **Verify single commit:** `git rev-list HEAD --not "$BASE_REF" --count` must print `1`. If not, squash again before pushing — never push a multi-commit PR.
 3. Push (update push with `--force-with-lease` to `$PUSH_REMOTE`)
 
-**Commit message:** `fix(pr): resolve issues for #<number>` with bullet list of fixes.
+**Commit message — evolve it, don't replace or freeze it.** The message must
+describe the commit's *final combined diff*, so it has to change when the fix
+changes the code's behavior or scope. Two failure modes to avoid equally:
+
+- ❌ **Frozen** (`--no-edit`): the message now under-describes what the commit
+  does — a reviewer reads it and the diff disagrees.
+- ❌ **Replaced** (`fix(pr): resolve review comments`): the original intent and
+  its scope/type/subject are lost, and the message becomes a changelog of
+  review churn rather than a description of the code.
+
+Instead: **keep the original subject and body, then edit them to absorb the
+fix.** Match the type/scope/style of the original message.
+
+- Small fix that doesn't change what the commit does (typo, lint, comment) →
+  message may stay as-is; amend without message edits only in this case.
+- Fix that adds/changes behavior → work it into the existing body (extend or
+  correct the relevant bullet/sentence); adjust the subject only if the
+  headline scope actually changed.
+
+Example — original `feat(runtime): add predicated dispatch`; review found a
+missing null check on the predicate. Update the body to note the guard, keep
+the `feat(runtime): add predicated dispatch` subject — not `fix(pr): address
+comments`, not the untouched original.
 
 ### Step 7: Reply and Resolve Comment Threads
 
@@ -224,7 +268,7 @@ For each comment, **both steps are mandatory** (see [reply-and-resolve](../../li
 
 Reply templates:
 
-- **Fixed** → "Fixed in `<commit>` — description of change"
+- **Fixed** → "Fixed — description of change" (do **not** cite a commit SHA: the PR commit is amended/squashed and force-pushed each iteration, so any SHA you quote is immediately stale)
 - **Skip** → "Follows `.claude/rules/<file>` — explanation"
 - **Ack** → "Acknowledged!"
 
@@ -262,8 +306,9 @@ Then loop back to Step 2.
 - [ ] PR matched and validated
 - [ ] Review comments and CI status fetched
 - [ ] ALL issues presented to user for selection
-- [ ] Code changes made and committed (use `/git-commit`)
-- [ ] Changes pushed (single valid commit, squashed with original PR commit)
+- [ ] Fixes folded into the PR (amended/squashed — **no appended `fix(pr)` commit**)
+- [ ] Verified `git rev-list HEAD --not "$BASE_REF" --count` == 1 before pushing
+- [ ] Changes force-pushed with `--force-with-lease` (single commit)
 - [ ] Review comment threads replied to and resolved
 - [ ] Waited for CI/reviews and re-checked
 - [ ] Loop exited: all clean OR max iterations reached


### PR DESCRIPTION
## Summary

Reworks the `fix-pr` skill so that addressing review comments / CI failures **folds into the existing PR commit** instead of appending a standalone `fix(pr)` commit on every iteration — the reported behavior where the PR accumulates review-churn commits.

- **Step 6 makes squash the primary action.** Stage all changes, then either `git commit --amend` (1 commit ahead) or squash-to-one via the commit-and-push procedure (>1), and **verify exactly one commit ahead of base** before force-pushing. `/git-commit` is no longer used to mint a new commit here — only to regenerate a squashed message.
- **Commit message must evolve, not freeze or be replaced.** Keep the original subject/body and absorb the fix into it. Explicitly forbids both `--no-edit` staleness (message under-describes the diff) and a generic `fix(pr): resolve comments` rewrite that drops the original intent/scope/type. Includes a worked example.
- **Step 7 reply template** drops the now-stale ``Fixed in `<commit>` `` SHA, since the commit is amended/force-pushed each iteration.
- **`commit-and-push.md`** squash guidance aligned with the same message rule; incidental markdownlint blank-line fixes in the same file.

## Testing

Docs/skill-only change — no code paths affected.
- [x] pre-commit hooks (markdownlint, check-english-only, headers) pass