### PR TITLE
Fix: bind runner TLS during arena prewarm

### DIFF
--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -330,6 +330,13 @@ int simpler_init(
     if (ctx == NULL) return -1;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+    // HostApi callbacks, including the prewarm path below, recover their
+    // DeviceRunner from this thread-local binding.
+    pthread_once(&g_runner_key_once, create_runner_key);
+    pthread_setspecific(g_runner_key, ctx);
+    auto tsd_guard = RAIIScopeGuard([]() {
+        pthread_setspecific(g_runner_key, nullptr);
+    });
 
     // CANN dlog must be levelled BEFORE the device context is opened
     // (rtSetDevice inside attach_current_thread): CANN snapshots the

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -331,6 +331,14 @@ int simpler_init(
     if (ctx == NULL) return -1;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
+    // HostApi callbacks, including the prewarm path below, recover their
+    // DeviceRunner from this thread-local binding.
+    pthread_once(&g_runner_key_once, create_runner_key);
+    pthread_setspecific(g_runner_key, ctx);
+    auto tsd_guard = RAIIScopeGuard([]() {
+        pthread_setspecific(g_runner_key, nullptr);
+    });
+
     int rc;
     try {
         rc = runner->attach_current_thread(device_id);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_prewarm_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_prewarm_config.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Regression test for runtime-arena prewarm during L2 worker initialization."""
+
+import pytest
+from simpler.task_interface import CallConfig
+from simpler.worker import Worker
+
+_RUNTIME = "tensormap_and_ringbuffer"
+
+
+@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.device_count(1)
+@pytest.mark.runtime(_RUNTIME)
+def test_l2_init_with_prewarm_config(st_platform, st_device_ids):
+    config = CallConfig()
+    config.runtime_env.ring_task_window = 64
+
+    worker = Worker(
+        level=2,
+        device_id=int(st_device_ids[0]),
+        platform=st_platform,
+        runtime=_RUNTIME,
+    )
+    try:
+        worker.init(prewarm_config=config)
+    finally:
+        worker.close()


### PR DESCRIPTION
## Summary

- bind the active `DeviceRunner` in thread-local storage for the full `simpler_init()` call
- clear the binding on every return path with `RAIIScopeGuard`
- prevent eager arena prewarming from dereferencing a null runner on sim and onboard
- add an in-repo a2a3sim TRB regression test for L2 `Worker.init(prewarm_config=...)`

## Root cause

`HostApi` callbacks recover the current runner through thread-local storage. The eager prewarm path runs during `simpler_init()`, before the existing register/run entry points establish that binding.

## Validation

- `git diff --check`
- `clang-format --dry-run --Werror` on both modified C++ files
- Python syntax validation for `test_prewarm_config.py`
- Simpler PR CI runs the new test under the existing a2a3sim scene-test job
- downstream PyPTO #2085 previously passed the five system jobs that crashed before the fix

A full local runtime rebuild was not run because the development host had only 3.07 GB available RAM; PR CI provides the runtime build and simulator execution.

## Related

- https://github.com/hw-native-sys/pypto/pull/2085
- https://github.com/hw-native-sys/pypto/pull/2068