### PR TITLE
Fix: extend PTO-ISA version guard to a5 async workspace overlays

### DIFF
--- a/docs/a5-sdma-overlay.md
+++ b/docs/a5-sdma-overlay.md
@@ -52,11 +52,18 @@ Controlled by the build-time macro / env var `SIMPLER_ENABLE_PTO_SDMA_WORKSPACE`
 
 ### Gating points
 
-| File | What |
-| ---- | ---- |
-| `src/a5/platform/onboard/host/CMakeLists.txt` | `option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ... OFF)`; `PTO_ISA_ROOT` check + pto-isa include guarded |
+Everything below keys on the a5 async workspace overlays. When SDMA
+(`SIMPLER_ENABLE_PTO_SDMA_WORKSPACE`) or URMA (`SIMPLER_ENABLE_PTO_URMA_WORKSPACE`)
+is ON the a5 onboard host `.so` embeds pto-isa headers, so the same pin /
+metadata / staleness / ccache guard that protects a2a3 onboard applies to a5
+too (#1351); when both are OFF none of it runs.
+
+| File / mechanism | What |
+| ---------------- | ---- |
+| `src/a5/platform/onboard/host/CMakeLists.txt` | `option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ... OFF)`; under the option: `PTO_ISA_ROOT` check + pto-isa include. After the option blocks, the shared `SIMPLER_PTO_ISA_BUILD_COMMIT` cache-string → compile-define block bakes the pinned commit into the `host_runtime` ccache key (mirror of the a2a3 block); it is a no-op until an overlay populates the cache var |
 | `src/a5/platform/onboard/host/comm_hccl.cpp` | `ensure_sdma_workspace` body under `#ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE` |
-| `simpler_setup/runtime_compiler.py` | `_init_a5` `PTO_ISA_ROOT` ensure + `_sdma_workspace_enabled()` |
+| `simpler_setup/runtime_compiler.py` | `_init_a5` resolves the pinned managed pto-isa checkout via `ensure_pto_isa_root` (same contract as `_init_a2a3`) when the overlay is ON, then `env_manager.ensure("PTO_ISA_ROOT")` |
+| `simpler_setup/runtime_builder.py` (`platform_embeds_pto_isa`) | Single predicate every guard site keys on: a2a3 onboard always, a5 onboard only when the SDMA or URMA overlay is on (`_sdma_workspace_enabled() or _urma_workspace_enabled()`). Drives pin resolution (`_resolve_build_pto_isa_commit`), the `SIMPLER_PTO_ISA_BUILD_COMMIT` stamp, `pto_isa_build.json` metadata write, and load-time staleness validation (`_requires_pto_isa_metadata_validation`) |
 | `simpler_setup/runtime_builder.py` | `_compile_target` forwards the env var to the host CMake define |
 | `examples/a5/.../sdma_async_completion_demo/test_sdma_async_completion_demo.py` | `pytest.skip` when env var unset |
 
@@ -91,7 +98,7 @@ pip install -e .
 The env-var→CMake-define forwarding and the test skip gate pick it up
 automatically.
 
-**Option B — make SDMA the a5 default** (revert the 5 gating points above):
+**Option B — make SDMA the a5 default** (revert the gating points above):
 flip `option(... OFF)` → `set(... ON)`, make `_init_a5`'s `PTO_ISA_ROOT`
 ensure unconditional (mirror `_init_a2a3`), and remove the test skip gate.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -185,7 +185,7 @@ This builds the nanobind `_task_interface` extension **and** pre-builds all runt
 | Nanobind bindings (`python/bindings/`) | Re-run `pip install --no-build-isolation -e .` (no rebuild-on-import; `editable.rebuild = false`) |
 | Python-only code (`python/*.py`, `simpler_setup/*.py`) | No rebuild needed (editable install) |
 | Examples / kernels (`examples/{arch}/`, `tests/st/`) | No rebuild needed, just re-run |
-| `pto_isa.pin` changed | Re-run `pip install`. The cmake cache stamp and the `host_runtime` ccache key include the pinned PTO-ISA commit for a2a3 onboard, so a pin bump invalidates stale runtime objects automatically. |
+| `pto_isa.pin` changed | Re-run `pip install`. The cmake cache stamp and the `host_runtime` ccache key include the pinned PTO-ISA commit for a2a3 onboard (and a5 onboard when the SDMA overlay is enabled), so a pin bump invalidates stale runtime objects automatically. |
 
 A `pto_isa.pin` bump changes the SDMA headers embedded by
 `host_runtime.so`. Install-time runtime builds and run-time kernel compilation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,8 +55,9 @@ To use a different PTO-ISA revision, update `pto_isa.pin` to the desired
 diff and applies the same revision to install-time runtime builds and run-time
 kernel compilation.
 
-For a2a3 onboard runtimes, builds record the actual PTO-ISA git HEAD used for
-each runtime in `build/lib/pto_isa_build.json`. This JSON is artifact
+For a2a3 onboard runtimes (and a5 onboard when the SDMA overlay is enabled),
+builds record the actual PTO-ISA git HEAD used for each runtime in
+`build/lib/pto_isa_build.json`. This JSON is artifact
 provenance, not a second configuration source. If the metadata says a
 pre-built runtime was built for an older pin, or a partial rebuild did not
 record that runtime, lookup fails with a stale-binary diagnostic and asks you

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -37,7 +37,7 @@ sys.path.insert(0, str(_project_root))
 sys.path.insert(0, str(_project_root / "python"))
 
 from simpler_setup.platform_info import PROJECT_ROOT, discover_runtimes, parse_platform  # noqa: E402
-from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: E402
+from simpler_setup.runtime_builder import RuntimeBuilder, platform_embeds_pto_isa  # noqa: E402
 from simpler_setup.sanitizers import SANITIZER_PRESETS, resolve, validate  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -112,12 +112,12 @@ def build_all(
     pto_isa_root_for_metadata: Optional[str] = None
     pto_isa_runtime_keys: list[str] = []
 
-    # a2a3 onboard host_runtime hard-depends on pto-isa headers + CANN-9.0
-    # aclnn syms (cf. src/a2a3/platform/onboard/host/CMakeLists.txt
-    # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE marker). Resolve PTO_ISA_ROOT now so
-    # the runtime compiler consumes the same pinned managed checkout as kernel
-    # compilation. Skipped when only sim platforms are being built.
-    if "a2a3" in platforms:
+    # Onboard hosts that embed pto-isa headers (a2a3 always; a5 when the SDMA
+    # overlay is opted in) hard-depend on the pinned managed checkout + CANN
+    # aclnn syms. Resolve PTO_ISA_ROOT now so the runtime compiler consumes the
+    # same pin as kernel compilation. Skipped when no embedding platform is
+    # being built (sim-only, or a5 with overlay OFF). See issue #1351.
+    if any(platform_embeds_pto_isa(p) for p in platforms):
         from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
         pto_isa_root = ensure_pto_isa_root(verbose=True)
@@ -156,7 +156,7 @@ def build_all(
 
         for runtime_name in runtimes:
             tasks.append((platform, runtime_name))
-            if arch == "a2a3" and variant == "onboard":
+            if platform_embeds_pto_isa(platform):
                 from simpler_setup.pto_isa import pto_isa_runtime_artifact_key  # noqa: PLC0415
 
                 pto_isa_runtime_keys.append(pto_isa_runtime_artifact_key(arch, variant, runtime_name))

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -129,7 +129,7 @@ def write_pto_isa_build_metadata(lib_dir: Path, pto_isa_root: str, runtime_keys:
         raise RuntimeError(
             "Cannot record PTO-ISA build revision: "
             f"{pto_isa_root} is not a git checkout or git HEAD is unavailable. "
-            "Building a2a3 onboard runtimes requires the managed build/pto-isa checkout."
+            "Building PTO-ISA-embedding onboard runtimes requires the managed build/pto-isa checkout."
         )
     if actual_commit != required_commit:
         raise RuntimeError(

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -19,11 +19,34 @@ from typing import Optional
 
 from .environment import PROJECT_ROOT
 from .platform_info import TARGETS, load_build_config, parse_platform
-from .runtime_compiler import RuntimeCompiler
+from .runtime_compiler import (
+    RuntimeCompiler,
+    _sdma_workspace_enabled,
+    _urma_workspace_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
 _GIT_COMMIT_FILE = ".git_commit"
+
+
+def platform_embeds_pto_isa(platform: str) -> bool:
+    """Return True when this platform's onboard host embeds PTO-ISA headers.
+
+    a2a3 onboard always embeds (workspace forced ON in CMake). a5 onboard
+    embeds only when the SDMA or URMA async workspace overlay is opted in
+    (``SIMPLER_ENABLE_PTO_SDMA_WORKSPACE`` / ``SIMPLER_ENABLE_PTO_URMA_WORKSPACE``
+    truthy) — the overlays are opt-in, so default-OFF a5 builds must not pull
+    in pin/metadata machinery. See issues #1351 (SDMA) and #1392 (URMA).
+    """
+    arch, variant = parse_platform(platform)
+    if variant != "onboard":
+        return False
+    if arch == "a2a3":
+        return True
+    if arch == "a5":
+        return _sdma_workspace_enabled() or _urma_workspace_enabled()
+    return False
 
 
 def _get_git_head(repo_root: Path) -> str:
@@ -181,30 +204,28 @@ class RuntimeBuilder:
     def _requires_pto_isa_metadata_validation(self) -> bool:
         """Return True when this runtime embeds PTO-ISA headers into host code.
 
-        Scoped on arch/variant, not on ``SIMPLER_ENABLE_PTO_SDMA_WORKSPACE``
-        (the actual flag that pulls pto-isa headers into the host .so). This is
-        deliberately coarser: should a2a3 onboard ever turn that workspace off,
-        a pto-isa bump would still invalidate this target's cache even though it
-        no longer embeds pto-isa. That over-invalidation only costs an extra
-        recompile — it can never serve a stale object — so erring wide is the
-        safe direction, and keeping the scope arch/variant-based matches the
-        cmake-side define gating in src/a2a3/platform/onboard/host/CMakeLists.txt.
+        Driven by :func:`platform_embeds_pto_isa`: a2a3 onboard always (CMake
+        forces the SDMA workspace ON), a5 onboard only when the SDMA or URMA
+        async workspace overlay is truthy. a5 must key on the overlay env/CMake
+        option — not bare ``arch == "a5"`` — so default-OFF a5 builds never
+        clone pto-isa or write metadata for nothing (#1351).
         """
-        return self._arch == "a2a3" and self._variant == "onboard"
+        return platform_embeds_pto_isa(self.platform)
 
     def _resolve_build_pto_isa_commit(self) -> str:
         """Return the pinned pto-isa commit baked into this build.
 
-        Only a2a3 onboard host code embeds pto-isa headers, so a pto-isa bump
-        must invalidate that build's cmake cache even when the runtime repo
-        HEAD is unchanged (issue #1139: a stale host_runtime.so compiled
-        against the old headers otherwise survives a reinstall). For every
-        other arch/variant the pto-isa revision does not affect the compiled
-        objects, so return "" and leave the stamp keyed on the runtime HEAD.
+        When host code embeds pto-isa headers (a2a3 onboard, or a5 onboard
+        with the SDMA or URMA overlay ON), a pto-isa bump must invalidate that build's
+        cmake cache even when the runtime repo HEAD is unchanged (issue #1139:
+        a stale host_runtime.so compiled against the old headers otherwise
+        survives a reinstall). For every other arch/variant the pto-isa
+        revision does not affect the compiled objects, so return "" and leave
+        the stamp keyed on the runtime HEAD.
 
         ``pto_isa.pin`` is the single source of truth. If the pin is missing or
-        invalid, let ``read_pto_isa_pin`` raise so an a2a3 onboard build cannot
-        silently proceed with unknown PTO-ISA headers.
+        invalid, let ``read_pto_isa_pin`` raise so an embedding onboard build
+        cannot silently proceed with unknown PTO-ISA headers.
         """
         if not self._requires_pto_isa_metadata_validation():
             return ""

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -189,9 +189,14 @@ class RuntimeCompiler:
     def _init_a5(self):
         """Initialize toolchains for real a5 hardware."""
         env_manager.ensure("ASCEND_HOME_PATH")
-        # A5 PTO async workspace overlays are opt-in until the CI CANN package
-        # exposes the required primitives reliably; see #1315.
+        # The PTO async workspace overlays (SDMA / URMA) are opt-in until the
+        # CI CANN package exposes the required primitives reliably; see #1315.
+        # When either is opted in the host build embeds pto-isa headers and
+        # must use the same pinned managed checkout as a2a3 (#1351).
         if _sdma_workspace_enabled() or _urma_workspace_enabled():
+            from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
+
+            os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(verbose=True)
             env_manager.ensure("PTO_ISA_ROOT")
 
         # AICore: Bisheng CCE compiler with A5 platform

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -130,6 +130,12 @@ if(SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_URMA_WORKSPACE=1)
 endif()
 
+# Bake the resolved pto-isa commit into the compile command when an overlay
+# embeds pto-isa headers into this .so. A pto-isa pin bump leaves runtime HEAD
+# — and often header mtimes — untouched, so without this define ccache
+# (compiler_check=mtime) can serve a stale object. Mirror of the a2a3 block
+# (#1351); the cache var stays empty for default-OFF a5 builds, so this is a
+# no-op unless the SDMA or URMA overlay is on.
 set(SIMPLER_PTO_ISA_BUILD_COMMIT "" CACHE STRING
     "PTO-ISA commit used for host_runtime cache key")
 if(NOT "${SIMPLER_PTO_ISA_BUILD_COMMIT}" STREQUAL "")

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -153,21 +153,31 @@ class TestRuntimeBuilderErrors:
 
 
 class TestRuntimeBuilderPtoIsaValidation:
-    """Test PTO-ISA metadata validation is scoped to affected runtimes."""
+    """Test PTO-ISA metadata validation is scoped to embedding runtimes."""
 
     @pytest.mark.parametrize(
-        ("platform", "should_validate"),
+        ("platform", "overlay", "should_validate", "expected_key"),
         [
-            ("a2a3", True),
-            ("a2a3sim", False),
-            ("a5", False),
-            ("a5sim", False),
+            ("a2a3", None, True, "a2a3/onboard/test_rt"),
+            ("a2a3sim", None, False, None),
+            ("a5", None, False, None),
+            ("a5", "ON", True, "a5/onboard/test_rt"),
+            ("a5sim", "ON", False, None),
+            ("a5sim", None, False, None),
         ],
     )
-    def test_pto_isa_validation_only_runs_for_a2a3_onboard(self, tmp_path, monkeypatch, platform, should_validate):
+    def test_pto_isa_validation_scoped_to_embedding_platforms(
+        self, tmp_path, monkeypatch, platform, overlay, should_validate, expected_key
+    ):
         from simpler_setup import pto_isa  # noqa: PLC0415
         from simpler_setup.platform_info import TARGETS, parse_platform  # noqa: PLC0415
         from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+        if overlay is None:
+            monkeypatch.delenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", raising=False)
+        else:
+            monkeypatch.setenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", overlay)
 
         class _Target:
             def __init__(self, name):
@@ -197,7 +207,7 @@ class TestRuntimeBuilderPtoIsaValidation:
         if should_validate:
             with pytest.raises(RuntimeError, match="pto-isa validation called"):
                 builder._lookup_binaries("test_rt", tmp_path / "out")
-            assert calls == [(builder._LIB_DIR, "a2a3/onboard/test_rt")]
+            assert calls == [(builder._LIB_DIR, expected_key)]
         else:
             with pytest.raises(FileNotFoundError, match="Pre-built runtime binaries not found"):
                 builder._lookup_binaries("test_rt", tmp_path / "out")
@@ -361,8 +371,77 @@ class TestRuntimeBuilderGetBinaries:
         assert all(call.kwargs["cmake_defines"] is None for call in non_host_calls)
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_a5_overlay_on_direct_build_writes_pto_isa_metadata(self, MockCompiler, tmp_path, monkeypatch):
+        """a5 onboard with SDMA overlay ON records PTO-ISA provenance (#1351)."""
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        self._make_runtime(tmp_path, "a5")
+        calls = []
+
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "ON")
+        mock_instance = MockCompiler.get_instance.return_value
+        mock_instance.compile.side_effect = lambda target, *a, **kw: (Path(kw["output_dir"]) / f"lib{target}.so")
+        mock_instance.compile_simpler_log.return_value = tmp_path / "build" / "lib" / "libsimpler_log.so"
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: "a" * 40)
+        monkeypatch.setattr(pto_isa, "ensure_pto_isa_root", lambda verbose=False: "/tmp/pto-isa")
+        monkeypatch.setattr(
+            pto_isa,
+            "write_pto_isa_build_metadata",
+            lambda lib_dir, pto_isa_root, runtime_keys: calls.append((lib_dir, pto_isa_root, runtime_keys)),
+        )
+
+        builder = RuntimeBuilder(platform="a5")
+        builder.get_binaries("test_rt", build=True)
+
+        assert calls == [(RuntimeBuilder._LIB_DIR, "/tmp/pto-isa", ["a5/onboard/test_rt"])]
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_a5_overlay_on_host_build_passes_pto_isa_cmake_define(self, MockCompiler, tmp_path, monkeypatch):
+        """a5 overlay ON host ccache key includes the pinned PTO-ISA commit."""
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        pin = "b" * 40
+        self._make_runtime(tmp_path, "a5")
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "ON")
+
+        mock_instance = MockCompiler.get_instance.return_value
+        mock_instance.compile.side_effect = lambda target, *a, **kw: (Path(kw["output_dir"]) / f"lib{target}.so")
+        mock_instance.compile_simpler_log.return_value = tmp_path / "build" / "lib" / "libsimpler_log.so"
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: pin)
+        monkeypatch.setattr(pto_isa, "ensure_pto_isa_root", lambda verbose=False: "/tmp/pto-isa")
+        monkeypatch.setattr(pto_isa, "write_pto_isa_build_metadata", lambda *args: None)
+
+        builder = RuntimeBuilder(platform="a5")
+        builder.get_binaries("test_rt", build=True)
+
+        host_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "host")
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_PTO_ISA_BUILD_COMMIT"] == pin
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"] == "ON"
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_a5_overlay_off_direct_build_does_not_write_pto_isa_metadata(self, MockCompiler, tmp_path, monkeypatch):
+        """Default a5 (overlay OFF) must not touch PTO-ISA metadata (#1351)."""
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        self._make_runtime(tmp_path, "a5")
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", raising=False)
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+
+        mock_instance = MockCompiler.get_instance.return_value
+        mock_instance.compile.side_effect = lambda target, *a, **kw: (Path(kw["output_dir"]) / f"lib{target}.so")
+        mock_instance.compile_simpler_log.return_value = tmp_path / "build" / "lib" / "libsimpler_log.so"
+        monkeypatch.setattr(pto_isa, "write_pto_isa_build_metadata", lambda *args: pytest.fail("unexpected metadata"))
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: pytest.fail("unexpected pin read"))
+
+        builder = RuntimeBuilder(platform="a5")
+        builder.get_binaries("test_rt", build=True)
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_sim_direct_build_does_not_write_pto_isa_metadata(self, MockCompiler, tmp_path, monkeypatch):
-        """get_binaries(build=True) only writes PTO-ISA metadata for onboard a2a3."""
+        """get_binaries(build=True) only writes PTO-ISA metadata for embedding onboard."""
         from simpler_setup import pto_isa  # noqa: PLC0415
         from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
 
@@ -469,6 +548,31 @@ class TestBuildCacheStamp:
         builder = self._make_builder("a2a3")
         assert builder._build_cache_stamp() == "runtime_sha:pto-isa=isa_sha"
 
+    def test_a5_overlay_on_folds_in_pto_isa_commit(self, monkeypatch):
+        """a5 overlay ON folds the pto-isa pin into the cache stamp (#1351)."""
+        import simpler_setup.runtime_builder as rb_module  # noqa: PLC0415
+        from simpler_setup import pto_isa  # noqa: PLC0415
+
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "ON")
+        monkeypatch.setattr(rb_module, "_get_git_head", lambda _root: "runtime_sha")
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: "isa_sha")
+
+        builder = self._make_builder("a5")
+        assert builder._build_cache_stamp() == "runtime_sha:pto-isa=isa_sha"
+
+    def test_a5_overlay_off_uses_pure_runtime_sha(self, monkeypatch):
+        """a5 overlay OFF ignores pto-isa → stamp keyed on runtime HEAD only."""
+        import simpler_setup.runtime_builder as rb_module  # noqa: PLC0415
+        from simpler_setup import pto_isa  # noqa: PLC0415
+
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", raising=False)
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+        monkeypatch.setattr(rb_module, "_get_git_head", lambda _root: "runtime_sha")
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: pytest.fail("unexpected pin read"))
+
+        builder = self._make_builder("a5")
+        assert builder._build_cache_stamp() == "runtime_sha"
+
     def test_non_a2a3_onboard_uses_pure_runtime_sha(self, monkeypatch):
         """Other arch/variant ignores pto-isa → stamp keyed on runtime HEAD only."""
         import simpler_setup.runtime_builder as rb_module  # noqa: PLC0415
@@ -511,6 +615,35 @@ class TestResolveBuildPtoIsaCommit:
 
         builder = self._make_builder("a2a3sim")
         assert builder._resolve_build_pto_isa_commit() == ""
+
+    def test_a5_overlay_off_returns_empty(self, monkeypatch):
+        from simpler_setup import pto_isa  # noqa: PLC0415
+
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", raising=False)
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: pytest.fail("unexpected pin read"))
+
+        builder = self._make_builder("a5")
+        assert builder._resolve_build_pto_isa_commit() == ""
+
+    def test_a5_overlay_on_reads_pin(self, monkeypatch):
+        from simpler_setup import pto_isa  # noqa: PLC0415
+
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "ON")
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: "isa_sha")
+        builder = self._make_builder("a5")
+        assert builder._resolve_build_pto_isa_commit() == "isa_sha"
+
+    def test_a5_urma_overlay_on_reads_pin(self, monkeypatch):
+        """URMA overlay also embeds pto-isa, so it reads the pin too (#1392)."""
+        from simpler_setup import pto_isa  # noqa: PLC0415
+
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", raising=False)
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", "ON")
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: "isa_sha")
+        builder = self._make_builder("a5")
+        assert builder._resolve_build_pto_isa_commit() == "isa_sha"
 
     def test_a2a3_onboard_reads_pin(self, monkeypatch):
         from simpler_setup import pto_isa  # noqa: PLC0415


### PR DESCRIPTION
## Summary
- Generalize the PTO-ISA pin/metadata/staleness/ccache guard from a2a3-onboard-only to "host embeds pto-isa headers", via a new `platform_embeds_pto_isa` predicate: a2a3 onboard always; a5 onboard only when an async workspace overlay is ON — SDMA (`SIMPLER_ENABLE_PTO_SDMA_WORKSPACE`) **or** URMA (`SIMPLER_ENABLE_PTO_URMA_WORKSPACE`, added in #1392).
- Resolve the managed pin in `build_runtimes` / `_init_a5` when embedding, write a5 provenance metadata, and bake `SIMPLER_PTO_ISA_BUILD_COMMIT` into the a5 host ccache key whenever an overlay populates it.
- Extend `test_runtime_builder` coverage for a5 SDMA/URMA overlay ON (validate / metadata / stamp / cmake define / pin) and OFF (no-op); OFF cases now also clear the URMA env var.
- Docs: refresh the `docs/a5-sdma-overlay.md` "Gating points" table for the guard sites that activate when the overlay is ON, and note the a5 case in `getting-started.md` / `developer-guide.md`.

Rebased onto latest `main`; composes with the URMA overlay (#1392) so both a5 async overlays get the same stale-binary guard.

Fixes #1351
