### PR TITLE
perf(bench): quiet CANN driver log on multi-round timing runs

### DIFF
--- a/.claude/rules/running-onboard.md
+++ b/.claude/rules/running-onboard.md
@@ -156,6 +156,28 @@ task-submit --device auto --device-num 1 --run "python ... -d \$TASK_DEVICE"
 Then read it directly (`$LOGDIR/device-*/device-*.log`) — no more `grep`-ing
 `~/ascend/log/debug/` and guessing which file is yours.
 
+## Device log *level*: quiet the CANN driver log for timing runs
+
+`ASCEND_PROCESS_LOG_PATH` (above) sets *where* the log goes;
+**`ASCEND_GLOBAL_LOG_LEVEL`** sets *how much*. Unset, it defaults to **INFO**,
+so the CANN driver/runtime writes hundreds of `[INFO]` lines per run into
+`device-<id>/*.log` (device-side `aicpu-sd`) and `plog/*.log` (host `RUNTIME`).
+The device-side writes land inside the measured device wall: on
+`paged_attention` they cost **~4–6%** (measured n=8, a2a3) and recur every
+`--rounds` iteration (~178 lines/round on top of a ~870-line one-time init).
+
+For any timing/benchmark run, set it to **ERROR** so only real failures log:
+
+```bash
+export ASCEND_GLOBAL_LOG_LEVEL=3   # 0=DEBUG 1=INFO(default) 2=WARNING 3=ERROR 4=NULL
+```
+
+It is a **severity floor** — higher = quieter — and is a *different* system from
+simpler's `--log-level` V0..V9 verbosity (independent knobs). Use `3` (ERROR),
+not `4` (NULL), so `507018`-class errors still surface. Scene tests set this
+automatically when `--rounds > 1` (a timing run, standalone or pytest) unless you
+pin it.
+
 ## `507018` triage: classify the mechanism before concluding
 
 `507018` (and `507014` / `507899`) is a **generic host-side code** —

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -110,10 +110,19 @@ WORKTREE_ABS="/home/user/simpler/tmp/worktree_baseline_20260331_102302"
 
 ## Step 5: Run Benchmarks
 
+**Prefix every benchmark invocation below with `ASCEND_GLOBAL_LOG_LEVEL=3`** — in
+both single and (especially) compare mode, baseline *and* current. The CANN driver
+log defaults to INFO, whose per-round device-side writes land inside the measured
+device wall (~4–6% on `paged_attention`). Pinning it to ERROR holds the log level
+constant across both sides, so a compare-mode delta reflects code under test, not
+logging: the merge-base worktree may predate the scene-test auto-set (which only
+fires when the var is unset), leaving the baseline noisy otherwise. An explicit
+value wins over the auto-set, so this is safe.
+
 ### Single Mode
 
 ```bash
-./tools/benchmark_rounds.sh $BENCH_ARGS -r "$RUNTIME" 2>&1 | tee "tmp/benchmark_${TIMESTAMP}.txt"
+ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh $BENCH_ARGS -r "$RUNTIME" 2>&1 | tee "tmp/benchmark_${TIMESTAMP}.txt"
 ```
 
 Use `--serial-orch-sched` to run each case once in the default overlapped mode
@@ -161,7 +170,7 @@ Activate the venv so `benchmark_rounds.sh` (which calls `python3`) picks up the 
 cd "$WORKTREE_ABS" && \
   source .venv/bin/activate && \
   pwd && \
-  ./tools/benchmark_rounds.sh -d "$BASELINE_DEVICE" -r "$RUNTIME" \
+  ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh -d "$BASELINE_DEVICE" -r "$RUNTIME" \
   2>&1 | tee "${PROJECT_ROOT}/tmp/benchmark_baseline_${TIMESTAMP}_${RUNTIME}.txt"
 ```
 
@@ -171,7 +180,7 @@ cd "$WORKTREE_ABS" && \
 
 ```bash
 # Runs from the main workspace (Bash tool default cwd)
-./tools/benchmark_rounds.sh -d $CURRENT_DEVICE -r "$RUNTIME" \
+ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh -d $CURRENT_DEVICE -r "$RUNTIME" \
   2>&1 | tee "tmp/benchmark_current_${TIMESTAMP}_${RUNTIME}.txt"
 ```
 
@@ -195,8 +204,8 @@ When two devices are available, run baseline and current **for the same runtime*
 # For each runtime (serially):
 for RUNTIME in "${RUNTIMES_TO_BENCH[@]}"; do
   # Baseline on device A (from worktree with venv), current on device B (from main) — parallel
-  (cd "$WORKTREE_ABS" && source .venv/bin/activate && pwd && ./tools/benchmark_rounds.sh -d $DEVICE_BASELINE -r "$RUNTIME" ...) &
-  ./tools/benchmark_rounds.sh -d $DEVICE_CURRENT -r "$RUNTIME" ... &
+  (cd "$WORKTREE_ABS" && source .venv/bin/activate && pwd && ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh -d $DEVICE_BASELINE -r "$RUNTIME" ...) &
+  ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh -d $DEVICE_CURRENT -r "$RUNTIME" ... &
   wait  # Both finish before starting next runtime
 done
 ```
@@ -213,11 +222,11 @@ done
 cd "$WORKTREE_ABS" && \
   source .venv/bin/activate && \
   pwd && \
-  ./tools/benchmark_rounds.sh -d "$DEVICE" -r "$RUNTIME" \
+  ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh -d "$DEVICE" -r "$RUNTIME" \
   2>&1 | tee "${PROJECT_ROOT}/tmp/benchmark_baseline_${TIMESTAMP}_${RUNTIME}.txt"
 
 #    Then current (from main workspace — default cwd, no venv)
-./tools/benchmark_rounds.sh -d $DEVICE -r "$RUNTIME" \
+ASCEND_GLOBAL_LOG_LEVEL=3 ./tools/benchmark_rounds.sh -d $DEVICE -r "$RUNTIME" \
   2>&1 | tee "tmp/benchmark_current_${TIMESTAMP}_${RUNTIME}.txt"
 
 # 3. Cleanup

--- a/conftest.py
+++ b/conftest.py
@@ -54,7 +54,7 @@ import pytest  # noqa: E402
 from simpler_setup import parallel_scheduler as _ps  # noqa: E402
 from simpler_setup.log_config import DEFAULT_LOG_LEVEL, configure_logging  # noqa: E402
 from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: E402
-from simpler_setup.scene_test import clear_compile_cache  # noqa: E402
+from simpler_setup.scene_test import _default_quiet_driver_log, clear_compile_cache  # noqa: E402
 
 # Exit code used when the session watchdog fires. Matches the GNU `timeout`
 # convention so shell wrappers (e.g. CI) can distinguish timeout from other
@@ -424,6 +424,10 @@ def pytest_configure(config):
     # --log-level still overrides the default threshold.
     log_level = config.getoption("--log-level", default=None)
     configure_logging(log_level or DEFAULT_LOG_LEVEL)
+
+    # Quiet the CANN driver log for multi-round timing runs before the st_worker
+    # fixture initializes the Worker/ACL context (after which the level is fixed).
+    _default_quiet_driver_log(config.getoption("--rounds", default=1))
 
     # Pre-clone / refresh PTO-ISA up front so scene-test children inherit the
     # pinned managed checkout resolved from pto_isa.pin.

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -783,6 +783,20 @@ def _plot_case_scope_stats(case_label: str, output_prefix: Path) -> None:
         sys.path.remove(str(tools_dir))
 
 
+def _default_quiet_driver_log(rounds: int) -> None:
+    """For a multi-round timing run, default ``ASCEND_GLOBAL_LOG_LEVEL`` to ``3``
+    (ERROR) so the CANN driver's per-round INFO writes stay out of the measured
+    device wall. Must run before the CANN driver initializes, so both entry points
+    call it early: ``run_module`` (standalone CLI) and ``pytest_configure`` (pytest,
+    where the Worker/ACL init lives in the ``st_worker`` fixture). An explicitly-set
+    ``ASCEND_GLOBAL_LOG_LEVEL`` is left untouched; ERROR keeps real failures visible."""
+    if rounds > 1 and "ASCEND_GLOBAL_LOG_LEVEL" not in os.environ:
+        os.environ["ASCEND_GLOBAL_LOG_LEVEL"] = "3"
+        logger.warning(
+            "Multi-round timing: set ASCEND_GLOBAL_LOG_LEVEL=3 (quiet CANN driver log; set it yourself to override)"
+        )
+
+
 def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI surface
     worker,
     cls_inst,
@@ -1529,6 +1543,8 @@ class SceneTestCase:
         if args.rounds > 1 and args.enable_l2_swimlane:
             logger.warning("Profiling disabled: --rounds > 1")
             args.enable_l2_swimlane = 0
+
+        _default_quiet_driver_log(args.rounds)
         if args.rounds > 1 and args.enable_dep_gen:
             logger.warning("dep_gen disabled: --rounds > 1")
             args.enable_dep_gen = False


### PR DESCRIPTION
**NOTE: This is not an optimization PR! This only fixes the problem of reducing noise when benchmarking!**

## Summary

Multi-round timing runs (`--rounds N`, N>1) inherit the CANN driver's default
INFO log level (`ASCEND_GLOBAL_LOG_LEVEL` unset), which writes hundreds of
device-side `[INFO]` lines per run into `~/ascend/log/debug`. Those device_log
writes land inside the measured device wall — **~4–6%** on `paged_attention`
(n=8, a2a3), recurring every round (~178 lines/round + ~870-line one-time init).
simpler's own AICPU logging contributes **0** lines (codestyle rule 7).

Default `ASCEND_GLOBAL_LOG_LEVEL=3` (ERROR) when `--rounds > 1`, so timing runs
aren't taxed by driver log spam while real failures still surface; an
explicitly-set value is respected. Also documents the level knob in
`running-onboard.md` (which previously covered only the log *path*).

Verified onboard (a2a3, device 2): `--rounds 8` drops the driver log 1092 → 1
line; `--rounds 1` unchanged; explicit `ASCEND_GLOBAL_LOG_LEVEL` respected.

## Benchmark

`tools/benchmark_rounds.sh -d 3 -n 100`, a2a3 onboard, **same device, sequential**
(baseline first, then this branch). Baseline = `main` (`321b88ee`); current = this
branch. Metric: `[STRACE]` device-domain spans via `strace_timing --rounds-table`.
Negative Δ = faster on this branch.

Driver log confirmed quieted on this branch (`--rounds 100`, same example):

| build | driver-log lines / run |
| ----- | ---------------------- |
| baseline (`main`) | 12,257 |
| this branch | **1** |

| Example | Device Δ | Effective Δ | Orch Δ |
| ------- | -------- | ----------- | ------ |
| `batch_paged_attention` (Case1) | **−4.56%** | **−4.94%** | **−6.82%** |
| `alternating_matmul_add` (Case1) | **−2.95%** | **−3.04%** | −3.04% |
| `benchmark_bgemm` (Case0) | −0.55% | −0.42% | −0.46% |
| `paged_attention_unroll` (Case1) | −0.03% | +0.04% | +1.02% |
| `paged_attention_unroll` (Case2) | −0.47% | −0.37% | −1.26% |
| `paged_attention_unroll_manual_scope` (Case1) | −0.44% | −0.38% | +0.26% |
| `paged_attention_unroll_manual_scope` (Case2) | −0.22% | −0.07% | +0.30% |

Improvement is example-dependent — largest on dispatch-heavy workloads
(`batch_paged_attention`: −4.9% Effective) and within noise on the light
`paged_attention_unroll` cases — because the CANN driver-log tax scales with
per-round device-log volume. **0 regressions > 2%.** (Host-wall reductions were
larger, up to −16%, but Host is noisy so Device/Effective are the headline.)
