### PR TITLE
Update: skip runtime status copy after successful execution

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -163,8 +163,8 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 | `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
 | `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
 | `total_size` | Init | Both | Total shared memory size |
-| `graph_output_ptr` | Orchestrator | Host | Address of final output (packed buffer) |
-| `graph_output_size` | Orchestrator | Host | Size of final output in bytes |
+| `graph_output_ptr` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
+| `graph_output_size` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
 
 ### 3.2 Size Calculation
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -946,10 +946,11 @@ extern "C" int bind_callable_to_runtime_impl(
  * 2. Frees device memory for recorded tensors
  * 3. Clears tensor pair state
  *
- * @param runtime  Pointer to Runtime
+ * @param runtime       Pointer to Runtime
+ * @param execution_rc  Status returned by DeviceRunner::run
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -969,32 +970,23 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
 
     LOG_INFO_V0("Tensor pairs to process: %d", tensor_pair_count);
 
-    // PTO2: graph output may be in packed buffer
-    uint64_t graph_out_ptr = 0;
-    uint64_t graph_out_size = 0;
-    bool skip_tensor_copy_back = false;
+    bool skip_tensor_copy_back = execution_rc != 0;
     int32_t runtime_status = 0;
     PTO2SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
 
-    runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
+    if (execution_rc != 0) {
+        runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
+    }
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
         LOG_RUNTIME_FAILURE(orch_error_code, sched_error_code, runtime_status);
-        skip_tensor_copy_back = true;
-    } else {
-        graph_out_ptr = host_header.graph_output_ptr;
-        graph_out_size = host_header.graph_output_size;
-        if (graph_out_ptr != 0) {
-            LOG_INFO_V0("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
-        }
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
+        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
     } else {
-        bool first_output_tensor = true;
         for (int i = 0; i < tensor_pair_count; i++) {
             const TensorPair &pair = tensor_pairs[i];
 
@@ -1018,18 +1010,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 continue;
             }
 
-            void *src_ptr = pair.dev_ptr;
-            size_t copy_size = pair.size;
-
-            // Use graph_output_ptr for the first output tensor if available
-            if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-                src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
-                copy_size = static_cast<size_t>(graph_out_size);
-                LOG_INFO_V0("Using packed output buffer for tensor %d", i);
-                first_output_tensor = false;
-            }
-
-            int copy_rc = api->copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -123,10 +123,10 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // Total shared memory size (for validation)
     uint64_t total_size;
 
-    // Graph output for copy-back (set by orchestrator when using packed buffer)
-    // Host finalize copies from this address instead of dev_ptr when non-zero
-    std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
-    std::atomic<uint64_t> graph_output_size;  // Size in bytes
+    // Reserved legacy packed-output metadata. Keep these zero and retain them
+    // only for shared-memory layout compatibility; host finalize ignores them.
+    std::atomic<uint64_t> graph_output_ptr;
+    std::atomic<uint64_t> graph_output_size;
 
     // === ERROR REPORTING ===
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -164,8 +164,8 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 | `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
 | `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
 | `total_size` | Init | Both | Total shared memory size |
-| `graph_output_ptr` | Orchestrator | Host | Address of final output (packed buffer) |
-| `graph_output_size` | Orchestrator | Host | Size of final output in bytes |
+| `graph_output_ptr` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
+| `graph_output_size` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
 
 ### 3.2 Size Calculation
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -941,10 +941,11 @@ extern "C" int prewarm_config_impl(
  * 2. Releases recorded tensor leases
  * 3. Clears tensor lease state
  *
- * @param runtime  Pointer to Runtime
+ * @param runtime       Pointer to Runtime
+ * @param execution_rc  Status returned by DeviceRunner::run
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -964,15 +965,14 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
 
     LOG_INFO_V0("Tensor leases to process: %d", tensor_lease_count);
 
-    // PTO2 (device orchestration): graph output may be in packed buffer
-    uint64_t graph_out_ptr = 0;
-    uint64_t graph_out_size = 0;
-    bool skip_tensor_copy_back = false;
+    bool skip_tensor_copy_back = execution_rc != 0;
     int32_t runtime_status = 0;
     PTO2SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
 
-    runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
+    if (execution_rc != 0) {
+        runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
+    }
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
@@ -995,19 +995,11 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 host_header.sched_stall_core.load(std::memory_order_relaxed)
             );
         }
-        skip_tensor_copy_back = true;
-    } else {
-        graph_out_ptr = host_header.graph_output_ptr;
-        graph_out_size = host_header.graph_output_size;
-        if (graph_out_ptr != 0) {
-            LOG_INFO_V0("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
-        }
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
+        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
     } else {
-        bool first_output_tensor = true;
         for (int i = 0; i < tensor_lease_count; i++) {
             const TensorLease &lease = tensor_leases[i];
 
@@ -1031,18 +1023,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 continue;
             }
 
-            void *src_ptr = lease.dev_ptr;
-            size_t copy_size = lease.size;
-
-            // Use graph_output_ptr for the first output tensor if available
-            if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-                src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
-                copy_size = static_cast<size_t>(graph_out_size);
-                LOG_INFO_V0("Using packed output buffer for tensor %d", i);
-                first_output_tensor = false;
-            }
-
-            int copy_rc = api->copy_from_device(lease.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(lease.host_ptr, lease.dev_ptr, lease.size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -129,10 +129,10 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // Total shared memory size (for validation)
     uint64_t total_size;
 
-    // Graph output for copy-back (set by orchestrator when using packed buffer)
-    // Host finalize copies from this address instead of dev_ptr when non-zero
-    std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
-    std::atomic<uint64_t> graph_output_size;  // Size in bytes
+    // Reserved legacy packed-output metadata. Keep these zero and retain them
+    // only for shared-memory layout compatibility; host finalize ignores them.
+    std::atomic<uint64_t> graph_output_ptr;
+    std::atomic<uint64_t> graph_output_size;
 
     // === ERROR REPORTING ===
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -466,10 +466,11 @@ int bind_callable_to_runtime_impl(
  * 2. Frees device memory for recorded tensors
  * 3. Clears tensor pair state
  *
- * @param runtime  Pointer to Runtime
+ * @param runtime       Pointer to Runtime
+ * @param execution_rc  Status returned by DeviceRunner::run
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
+int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -487,15 +488,19 @@ int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
     int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
 
-    for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair &pair = tensor_pairs[i];
-        int copy_rc = api->copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
-        if (copy_rc != 0) {
-            LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
-            rc = copy_rc;
-            // Continue with cleanup anyway
-        } else {
-            LOG_DEBUG("Tensor %d: %zu bytes copied to host", i, pair.size);
+    if (execution_rc != 0) {
+        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
+    } else {
+        for (int i = 0; i < tensor_pair_count; i++) {
+            const TensorPair &pair = tensor_pairs[i];
+            int copy_rc = api->copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
+            if (copy_rc != 0) {
+                LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
+                rc = copy_rc;
+                // Continue with cleanup anyway
+            } else {
+                LOG_DEBUG("Tensor %d: %zu bytes copied to host", i, pair.size);
+            }
         }
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -164,8 +164,8 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 | `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
 | `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
 | `total_size` | Init | Both | Total shared memory size |
-| `graph_output_ptr` | Orchestrator | Host | Address of final output (packed buffer) |
-| `graph_output_size` | Orchestrator | Host | Size of final output in bytes |
+| `graph_output_ptr` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
+| `graph_output_size` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
 
 ### 3.2 Size Calculation
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -896,10 +896,11 @@ extern "C" int bind_callable_to_runtime_impl(
  * 2. Releases recorded tensor leases
  * 3. Clears tensor lease state
  *
- * @param runtime  Pointer to Runtime
+ * @param runtime       Pointer to Runtime
+ * @param execution_rc  Status returned by DeviceRunner::run
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -919,15 +920,14 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
 
     LOG_INFO_V0("Tensor leases to process: %d", tensor_lease_count);
 
-    // PTO2 (device orchestration): graph output may be in packed buffer
-    uint64_t graph_out_ptr = 0;
-    uint64_t graph_out_size = 0;
-    bool skip_tensor_copy_back = false;
+    bool skip_tensor_copy_back = execution_rc != 0;
     int32_t runtime_status = 0;
     PTO2SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
 
-    runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
+    if (execution_rc != 0) {
+        runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
+    }
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
@@ -950,19 +950,11 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 host_header.sched_stall_core.load(std::memory_order_relaxed)
             );
         }
-        skip_tensor_copy_back = true;
-    } else {
-        graph_out_ptr = host_header.graph_output_ptr;
-        graph_out_size = host_header.graph_output_size;
-        if (graph_out_ptr != 0) {
-            LOG_INFO_V0("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
-        }
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
+        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
     } else {
-        bool first_output_tensor = true;
         for (int i = 0; i < tensor_lease_count; i++) {
             const TensorLease &lease = tensor_leases[i];
 
@@ -986,18 +978,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 continue;
             }
 
-            void *src_ptr = lease.dev_ptr;
-            size_t copy_size = lease.size;
-
-            // Use graph_output_ptr for the first output tensor if available
-            if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-                src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
-                copy_size = static_cast<size_t>(graph_out_size);
-                LOG_INFO_V0("Using packed output buffer for tensor %d", i);
-                first_output_tensor = false;
-            }
-
-            int copy_rc = api->copy_from_device(lease.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(lease.host_ptr, lease.dev_ptr, lease.size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -129,10 +129,10 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // Total shared memory size (for validation)
     uint64_t total_size;
 
-    // Graph output for copy-back (set by orchestrator when using packed buffer)
-    // Host finalize copies from this address instead of dev_ptr when non-zero
-    std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
-    std::atomic<uint64_t> graph_output_size;  // Size in bytes
+    // Reserved legacy packed-output metadata. Keep these zero and retain them
+    // only for shared-memory layout compatibility; host finalize ignores them.
+    std::atomic<uint64_t> graph_output_ptr;
+    std::atomic<uint64_t> graph_output_size;
 
     // === ERROR REPORTING ===
 

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -56,7 +56,7 @@ extern "C" {
  * Runtime Implementation Functions (defined in each runtime's runtime_maker.cpp)
  * =========================================================================== */
 int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
-int validate_runtime_impl(Runtime *runtime, const HostApi *api);
+int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
 
 /* ===========================================================================
  * Per-thread DeviceRunnerBase binding (set by simpler_register_callable / simpler_run)
@@ -594,8 +594,8 @@ int simpler_run(
         }
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
-            validate_runtime_impl(r, &g_host_api);
-            return rc;
+            int validation_rc = validate_runtime_impl(r, &g_host_api, rc);
+            return validation_rc != 0 ? validation_rc : rc;
         }
 
         {
@@ -605,13 +605,13 @@ int simpler_run(
             rc = runner->run(*r, *config);
         }
         if (rc != 0) {
-            validate_runtime_impl(r, &g_host_api);
-            return rc;
+            int validation_rc = validate_runtime_impl(r, &g_host_api, rc);
+            return validation_rc != 0 ? validation_rc : rc;
         }
 
         {
             STRACE("simpler_run.validate");
-            rc = validate_runtime_impl(r, &g_host_api);
+            rc = validate_runtime_impl(r, &g_host_api, 0);
         }
         // Device-domain phase markers: the AICPU subdivision of the on-NPU wall
         // (device_wall + preamble/so_load/graph_build/post_orch/orch/sched).

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -51,7 +51,7 @@ extern "C" {
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
 int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
-int validate_runtime_impl(Runtime *runtime, const HostApi *api);
+int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
 
 /* ===========================================================================
  * Per-thread DeviceRunner binding
@@ -550,9 +550,9 @@ int simpler_run(
         }
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
-            validate_runtime_impl(r, &g_host_api);
+            int validation_rc = validate_runtime_impl(r, &g_host_api, rc);
             pthread_setspecific(g_runner_key, nullptr);
-            return rc;
+            return validation_rc != 0 ? validation_rc : rc;
         }
 
         {
@@ -562,14 +562,14 @@ int simpler_run(
             rc = runner->run(*r, *config);
         }
         if (rc != 0) {
-            validate_runtime_impl(r, &g_host_api);
+            int validation_rc = validate_runtime_impl(r, &g_host_api, rc);
             pthread_setspecific(g_runner_key, nullptr);
-            return rc;
+            return validation_rc != 0 ? validation_rc : rc;
         }
 
         {
             STRACE("simpler_run.validate");
-            rc = validate_runtime_impl(r, &g_host_api);
+            rc = validate_runtime_impl(r, &g_host_api, 0);
         }
         pthread_setspecific(g_runner_key, nullptr);
         emit_device_phase_markers(runner);

--- a/tests/st/aicore_op_timeout/test_aicore_op_timeout.py
+++ b/tests/st/aicore_op_timeout/test_aicore_op_timeout.py
@@ -78,9 +78,11 @@ def test_aicore_op_timeout_surfaces_as_runtime_error(st_platform, st_device_ids,
         config.aicpu_thread_num = 2
 
         t0 = time.monotonic()
-        # Acceptable error codes for the STARS-killed AICore op. Which one
-        # surfaces is timing-dependent — it's whichever stream sync sees the
-        # AIC failure first:
+        # Acceptable error codes for the STARS-killed AICore op. Device status
+        # takes precedence when finalization can read it; otherwise the host
+        # falls back to whichever stream-sync error surfaced first:
+        #   -100   = PTO2 scheduler timeout — the device classified the stalled
+        #            AIC task before finalization read the shared header.
         #   507046 = ACL_ERROR_RT_STREAM_SYNC_TIMEOUT — AICore stream's 4 s
         #            sync budget fires before AICPU sync notices.
         #   507018 = ACL_ERROR_RT_AICPU_EXCEPTION — AICPU stream sync surfaces
@@ -88,12 +90,12 @@ def test_aicore_op_timeout_surfaces_as_runtime_error(st_platform, st_device_ids,
         #            orchestration kernel detects the dead AIC task first.
         #   507000 = ACL_ERROR_RT_INTERNAL_ERROR — same detection on a5,
         #            mapped through a different code path.
-        # All three are valid on both a2a3 and a5: the timing race is between
-        # AICPU and AICore stream sync on host, not arch-specific. The
-        # regression we care about is that the timeout chain reaps the hang
-        # in single-digit seconds and surfaces *some* 507xxx code rather than
-        # deadlocking.
-        with pytest.raises(RuntimeError, match=r"run failed with code 507(046|018|000)"):
+        # The generic codes are valid on both a2a3 and a5: the timing race is
+        # between AICPU and AICore stream sync on host, not arch-specific. The
+        # regression we care about is that the timeout chain reaps the hang in
+        # single-digit seconds and surfaces either the device classification or
+        # a valid host fallback rather than deadlocking.
+        with pytest.raises(RuntimeError, match=r"run failed with code (-100|507(046|018|000))"):
             worker.run(handle, ChipStorageTaskArgs(), config)
         elapsed = time.monotonic() - t0
 

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -29,7 +29,9 @@
 
 #include "arg_direction.h"
 #include "common/host_api.h"
+#include "pto_runtime_status.h"
 #include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
 #include "runtime.h"
 #include "task_args.h"
 
@@ -38,7 +40,7 @@ extern "C" int bind_callable_to_runtime_impl(
     const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
     const uint64_t *ring_dep_pool
 );
-extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api);
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
 
 namespace {
 
@@ -239,6 +241,71 @@ protected:
 
 }  // namespace
 
+TEST_F(TrbRuntimeTempBufferTest, SuccessfulValidateCopiesOnlyOutputTensor) {
+    fake_.reset();
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(output));
+    ArgDirection signature[1] = {ArgDirection::OUT};
+
+    ASSERT_EQ(bind_runtime(runtime, api_, args, signature, 1), 0);
+    ASSERT_EQ(runtime.tensor_leases_.size(), 1u);
+    std::memset(runtime.tensor_leases_[0].dev_ptr, 0x2a, output.size());
+
+    // Legacy packed-output metadata is retained only for shared-memory layout
+    // compatibility. Finalization must copy from the tensor's own allocation.
+    std::vector<uint8_t> legacy_packed_output(output.size(), 0x7f);
+    auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime.get_gm_sm_ptr());
+    ASSERT_NE(header, nullptr);
+    header->graph_output_ptr.store(reinterpret_cast<uint64_t>(legacy_packed_output.data()), std::memory_order_relaxed);
+    header->graph_output_size.store(legacy_packed_output.size(), std::memory_order_relaxed);
+
+    ASSERT_EQ(validate_runtime_impl(&runtime, &api_, 0), 0);
+    EXPECT_EQ(fake_.copy_from_count, 1);
+    EXPECT_TRUE(std::all_of(output.begin(), output.end(), [](uint8_t value) {
+        return value == 0x2a;
+    }));
+}
+
+TEST_F(TrbRuntimeTempBufferTest, FailedExecutionCopiesRuntimeStatus) {
+    fake_.reset();
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(output));
+    ArgDirection signature[1] = {ArgDirection::OUT};
+
+    ASSERT_EQ(bind_runtime(runtime, api_, args, signature, 1), 0);
+    auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime.get_gm_sm_ptr());
+    ASSERT_NE(header, nullptr);
+    header->orch_error_code.store(PTO2_ERROR_EXPLICIT_ORCH_FATAL, std::memory_order_relaxed);
+
+    EXPECT_EQ(validate_runtime_impl(&runtime, &api_, -1), -PTO2_ERROR_EXPLICIT_ORCH_FATAL);
+    EXPECT_EQ(fake_.copy_from_count, 1);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, FailedExecutionWithoutDeviceStatusSkipsTensorCopyBack) {
+    fake_.reset();
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(output));
+    ArgDirection signature[1] = {ArgDirection::OUT};
+
+    ASSERT_EQ(bind_runtime(runtime, api_, args, signature, 1), 0);
+    ASSERT_EQ(runtime.tensor_leases_.size(), 1u);
+    std::memset(runtime.tensor_leases_[0].dev_ptr, 0x2a, output.size());
+
+    // A stream/bind failure may happen before the device publishes a PTO2
+    // status. The one D2H is the diagnostic header; tensor data stays untouched.
+    EXPECT_EQ(validate_runtime_impl(&runtime, &api_, -1), 0);
+    EXPECT_EQ(fake_.copy_from_count, 1);
+    EXPECT_TRUE(std::all_of(output.begin(), output.end(), [](uint8_t value) {
+        return value == 0;
+    }));
+}
+
 // The retained buffer is malloc'd once for the run and sliced (not per-tensor
 // malloc'd); copies/memsets are unchanged from the fallback path.
 TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
@@ -254,9 +321,9 @@ TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
     EXPECT_EQ(fake_.device_malloc_count, 2);
     EXPECT_EQ(fake_.copy_to_count, 2);
     EXPECT_EQ(fake_.device_memset_count, 0);
-    ASSERT_EQ(validate_runtime_impl(&malloc_runtime, &malloc_api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&malloc_runtime, &malloc_api_, 0), 0);
     EXPECT_EQ(fake_.device_free_count, 2);
-    EXPECT_EQ(fake_.copy_from_count, 2);
+    EXPECT_EQ(fake_.copy_from_count, 1);
 
     // Retained-buffer path: single device_malloc for the whole run (two
     // 64-byte tensors pack to 2 * 1024-aligned = 2048 bytes), sliced in place.
@@ -267,10 +334,10 @@ TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
     EXPECT_EQ(fake_.retained_size, align_up(64, kAlign) * 2);
     EXPECT_EQ(fake_.copy_to_count, 2);
     EXPECT_EQ(fake_.device_memset_count, 0);
-    ASSERT_EQ(validate_runtime_impl(&buffer_runtime, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&buffer_runtime, &api_, 0), 0);
     // Retained buffer is NOT freed at end of run — it lives on the slot.
     EXPECT_EQ(fake_.device_free_count, 0);
-    EXPECT_EQ(fake_.copy_from_count, 2);
+    EXPECT_EQ(fake_.copy_from_count, 1);
     EXPECT_NE(fake_.retained_addr, nullptr);
 }
 
@@ -283,13 +350,13 @@ TEST_F(TrbRuntimeTempBufferTest, SecondSameShapeRunReusesRetainedBuffer) {
     fake_.reset();
     Runtime run1 = make_runtime();
     ASSERT_EQ(bind_runtime(run1, api_, args, signature, 2), 0);
-    ASSERT_EQ(validate_runtime_impl(&run1, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&run1, &api_, 0), 0);
     EXPECT_EQ(fake_.device_malloc_count, 1);
     void *first_addr = fake_.retained_addr;
 
     Runtime run2 = make_runtime();
     ASSERT_EQ(bind_runtime(run2, api_, args, signature, 2), 0);
-    ASSERT_EQ(validate_runtime_impl(&run2, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&run2, &api_, 0), 0);
     // Same shape → no new allocation, same retained buffer.
     EXPECT_EQ(fake_.device_malloc_count, 1);
     EXPECT_EQ(fake_.device_free_count, 0);
@@ -305,7 +372,7 @@ TEST_F(TrbRuntimeTempBufferTest, LargerRunGrowsSmallerRunKeepsBuffer) {
     ChipStorageTaskArgs small = make_args(small_in, small_out);
     Runtime run1 = make_runtime();
     ASSERT_EQ(bind_runtime(run1, api_, small, signature, 2), 0);
-    ASSERT_EQ(validate_runtime_impl(&run1, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&run1, &api_, 0), 0);
     EXPECT_EQ(fake_.device_malloc_count, 1);
     EXPECT_EQ(fake_.retained_size, align_up(64, kAlign) * 2);
 
@@ -315,7 +382,7 @@ TEST_F(TrbRuntimeTempBufferTest, LargerRunGrowsSmallerRunKeepsBuffer) {
     ChipStorageTaskArgs big = make_args(big_in, big_out);
     Runtime run2 = make_runtime();
     ASSERT_EQ(bind_runtime(run2, api_, big, signature, 2), 0);
-    ASSERT_EQ(validate_runtime_impl(&run2, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&run2, &api_, 0), 0);
     EXPECT_EQ(fake_.device_malloc_count, 2);
     EXPECT_EQ(fake_.device_free_count, 1);
     EXPECT_EQ(fake_.retained_size, align_up(4096, kAlign) * 2);
@@ -324,7 +391,7 @@ TEST_F(TrbRuntimeTempBufferTest, LargerRunGrowsSmallerRunKeepsBuffer) {
     // Smaller run again: retained buffer is big enough, no free/malloc.
     Runtime run3 = make_runtime();
     ASSERT_EQ(bind_runtime(run3, api_, small, signature, 2), 0);
-    ASSERT_EQ(validate_runtime_impl(&run3, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&run3, &api_, 0), 0);
     EXPECT_EQ(fake_.device_malloc_count, static_cast<int>(after_grow_mallocs));
     EXPECT_EQ(fake_.device_free_count, 1);
     EXPECT_EQ(fake_.retained_size, align_up(4096, kAlign) * 2);
@@ -351,7 +418,7 @@ TEST_F(TrbRuntimeTempBufferTest, ChildMemoryIsPassThroughAndPureOutSkipsStaging)
     // runtime arena image upload that every bind performs.
     EXPECT_EQ(fake_.copy_to_count, 1);
     EXPECT_EQ(fake_.device_memset_count, 0);
-    ASSERT_EQ(validate_runtime_impl(&runtime, &api_), 0);
+    ASSERT_EQ(validate_runtime_impl(&runtime, &api_, 0), 0);
     EXPECT_EQ(fake_.device_free_count, 0);
 }
 


### PR DESCRIPTION
## Summary

- propagate execution results into runtime finalization across sim and onboard
- skip the PTO2 shared-header D2H copy after successful execution
- never copy tensors back after a failed execution, even when no device status was published
- prefer detailed device runtime status over generic runner or stream errors
- retire the unused packed graph-output fallback while preserving shared-memory layout compatibility

## Testing

- [x] .venv/bin/pip install --no-build-isolation -e . (a2a3sim, a5sim, a2a3, and a5 runtimes)
- [x] cmake --build tests/ut/cpp/build --target test_trb_runtime_temp_buffer -j 8
- [x] ctest --test-dir tests/ut/cpp/build -R test_trb_runtime_temp_buffer --output-on-failure (10 tests passed)
- [x] ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure (59 passed in sandbox; socket test passed separately outside the sandbox)
- [x] clang-tidy plus header, English-only, formatting, and diff checks
- [x] GitHub CI full matrix, including st-onboard-a2a3 and st-onboard-a5

## Additional Context

The legacy packed graph-output fields remain in the shared-memory header only for layout compatibility. Runtime finalization no longer reads them and copies each output from its tensor allocation.

Fixes #1408