### PR TITLE
Support: add critical-path Perfetto traces

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -242,7 +242,7 @@ The default text output contains:
   - `perf_sidecar`: `yes` when `l2_swimlane_records.json` was successfully loaded
   - `func_name_map`: `yes` when at least one task label resolved to a named `func_name`
     from either an explicit `--func-names` file or an auto-discovered sibling
-    `name_map_*.json`. When the `kernel_ids` fallback is used, `func_id=` shows an
+    `name_map*.json`. When the `kernel_ids` fallback is used, `func_id=` shows an
     aligned 3-slot integer array in `[aic,aiv0,aiv1]` order; inactive slots remain
     `-1`. `func_name_map` stays `no` unless a real human-readable name was resolved.
 - `TASK INDEX` — one line per task with `kind=` + `func_id=` and unique

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -11,14 +11,78 @@ no repo checkout required.
 
 - **[swimlane_converter](#swimlane_converter)** — perf JSON → Chrome Trace Event (Perfetto)
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
+- **[critical_path](#critical_path)** — L2 swimlane critical-path compute/stall analysis
 - **[strace_timing](#strace_timing)** — per-stage `simpler_run` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
-Auto-detection paths (`outputs/*/l2_swimlane_records.json`, `outputs/*/args_dump/`)
-are resolved relative to the **current working directory** — run these from the
-directory that holds your `outputs/`. Each test case writes into its own
-`outputs/<case>_<ts>/` directory; the tools auto-pick the latest by mtime.
+For CLIs that allow an omitted input, auto-detection paths
+(`outputs/*/l2_swimlane_records.json`, `outputs/*/args_dump/`) are resolved
+relative to the **current working directory** — run these from the directory
+that holds your `outputs/`. Each test case writes into its own
+`outputs/<case>_<ts>/` directory; those tools auto-pick the latest by mtime.
+
+---
+
+## critical_path
+
+Post-processing analysis over an L2-swimlane run. Given a run directory, it
+recursively discovers every directory containing all three required artifacts:
+
+- `l2_swimlane_records.json` (or legacy `l2_perf_records.json`)
+- `deps.json`
+- `name_map*.json` (the newest matching sibling is used when several exist)
+
+When a sibling `merged_swimlane*.json` is present, the newest matching file is
+used as the source for two additional Perfetto-compatible traces:
+
+- `CPM_static.json` — highlights the Static CPM task set.
+- `CPM_observed.json` — highlights the Observed path task set.
+
+Both files retain every view, metadata event, bar, and flow from the merged
+trace. Only AIC/AIV task bars in Worker View (`pid=4`) outside the selected path
+are renamed to `·(rXtY)` (or `·(tY)` for ring 0); path bars and every slice
+in other views keep their original names. With Perfetto's default name-based
+coloring, the middle dot maps to a light blue-purple while digits are removed
+before hashing, so anonymous Worker View bars share a subdued color and path
+bars remain grouped by function. `dummy(...)` and `alloc(...)` bars keep their
+original names because the AICore critical-path model does not classify them.
+
+This supports both simpler directories such as `outputs/<case>_<ts>/` and
+PyPTO directories such as `build_output/<case>/dfx_outputs/`, including nested
+rank/device layouts. Each discovered artifact directory is analyzed separately,
+and its `critical_path_report.md` is written beside
+`l2_swimlane_records.json`. Pointing the command at a whole run therefore
+creates one local report per rank/device rather than one combined report at the
+scan root.
+
+For each rank/device, the tool builds a happens-before DAG from the dependency
+graph oriented by observed timestamps, then computes two critical paths:
+
+- **Static CPM** — the longest duration-weighted path, i.e. the
+  dependency-limited latency floor with unlimited cores.
+- **Observed** — the as-executed backward blame walk from the last-finishing
+  task. Each task's compute plus its preceding scheduling stall (`data-wait`,
+  `core-wait`, or `front-gap`) tiles the makespan exactly.
+
+The report contains a makespan/CPM/compute/stall overview, a per-kernel-family
+table, and a full per-task listing. It is pure post-processing: no C++ or device
+is required. If no sibling `merged_swimlane*.json` exists, Markdown analysis
+still succeeds and the tool prints a warning that the two Perfetto traces were
+skipped.
+
+```bash
+# Analyze one simpler output directory or an entire PyPTO run tree
+python -m simpler_setup.tools.critical_path outputs/<case>_<ts>
+python -m simpler_setup.tools.critical_path build_output/<case>
+
+# Customize each local report filename/table size and print a combined stdout view
+python -m simpler_setup.tools.critical_path <run-dir> \
+    --report critical_path_report.md --top 25 --stdout
+```
+
+`--report` accepts a filename, not a path, so the report cannot be redirected
+away from the directory containing its source `l2_swimlane_records.json`.
 
 ---
 
@@ -285,7 +349,7 @@ this is the structural view.
     - `annotated_edges`: total number of annotated edge rows
     - `perf_sidecar`: `yes` when `l2_swimlane_records.json` was successfully loaded
     - `func_name_map`: `yes` when at least one task name resolved to a named
-      `func_name` from `--func-names` or an auto-discovered `name_map_*.json`.
+      `func_name` from `--func-names` or an auto-discovered `name_map*.json`.
       `func_name_map` stays `no` unless a real human-readable name was resolved.
   - `TASK INDEX` (one line per task for grep)
     - `kind=` distinguishes `submit` / `dummy` / `alloc` / `unknown`

--- a/simpler_setup/tools/__init__.py
+++ b/simpler_setup/tools/__init__.py
@@ -12,6 +12,7 @@ Invoke via ``python -m simpler_setup.tools.<name>``:
 
 - ``swimlane_converter``   : perf JSON -> Perfetto/Chrome trace
 - ``sched_overhead_analysis``: scheduler overhead deep-dive
+- ``critical_path``          : L2 swimlane critical-path compute/stall analysis
 - ``deps_viewer``           : deps.json -> text or pan/zoom HTML dependency graph
 - ``dump_viewer``           : inspect args dumps
 - ``strace_timing``         : per-stage / per-round timing from [STRACE] log markers

--- a/simpler_setup/tools/critical_path.py
+++ b/simpler_setup/tools/critical_path.py
@@ -9,17 +9,18 @@
 
 """Critical-path analysis over an L2-swimlane build_output.
 
-Given a ``build_output/<case>`` directory produced by a ``--enable-l2-swimlane``
-run, this reconstructs the critical path of the device execution and writes a
-report describing, for every task on that path, its wall-clock duration, the
-compute time it contributes, and the runtime-scheduling stall (wait) before it,
-each as a fraction of the global makespan.
+Given a run directory produced by a ``--enable-l2-swimlane`` run, this
+reconstructs the critical path of each device execution and writes a report
+beside each discovered swimlane-records file. The report describes, for every
+task on that path, its wall-clock duration, the compute time it contributes,
+and the runtime-scheduling stall (wait) before it, each as a fraction of the
+global makespan.
 
-Inputs consumed per rank (auto-discovered under the given directory, next to the
-``merged_swimlane_*.json`` files):
+Inputs consumed per rank (auto-discovered under the given directory):
   - ``l2_swimlane_records.json`` : per (task, core-block) execution slices
   - ``deps.json``                : task dependency DAG (producer -> consumer)
-  - ``name_map.json``            : callable_id -> kernel name
+  - ``name_map*.json``           : callable_id -> kernel name
+  - ``merged_swimlane*.json``    : optional Perfetto Worker View source
 
 Two critical paths are computed:
   A) Static CPM  : longest duration-weighted path in the happens-before DAG,
@@ -30,8 +31,8 @@ Two critical paths are computed:
                    Its compute + stall segments tile the makespan exactly.
 
 Usage:
-    python tools/critical_path.py build_output/_jit_l3_decode_fwd_<ts>
-    python tools/critical_path.py build_output/<case> --top 60 --stdout
+    python -m simpler_setup.tools.critical_path build_output/_jit_l3_decode_fwd_<ts>
+    python -m simpler_setup.tools.critical_path build_output/<case> --top 60 --stdout
 """
 
 from __future__ import annotations
@@ -44,12 +45,16 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .swimlane_converter import format_task_display
+
 INF = float("inf")
 
 # Structured per-task L2 records file. Current runs emit ``l2_swimlane_records.json``;
 # ``l2_perf_records.json`` is the name used in some docs / older runtimes. The first
 # name that exists in a rank dir is used.
 SWIMLANE_RECORD_NAMES = ("l2_swimlane_records.json", "l2_perf_records.json")
+STATIC_TRACE_NAME = "CPM_static.json"
+OBSERVED_TRACE_NAME = "CPM_observed.json"
 
 
 def _read_json(path: Path):
@@ -62,6 +67,24 @@ def _find_records(d: Path) -> Path | None:
         if (d / name).exists():
             return d / name
     return None
+
+
+def _find_name_map(d: Path) -> Path | None:
+    """Return the newest sibling ``name_map*.json`` file in *d*, or None."""
+    candidates = sorted(
+        (path for path in d.glob("name_map*.json") if path.is_file()),
+        key=lambda path: (path.stat().st_mtime, path.name),
+    )
+    return candidates[-1] if candidates else None
+
+
+def _find_merged_swimlane(d: Path) -> Path | None:
+    """Return the newest sibling ``merged_swimlane*.json`` file in *d*, or None."""
+    candidates = sorted(
+        (path for path in d.glob("merged_swimlane*.json") if path.is_file()),
+        key=lambda path: (path.stat().st_mtime, path.name),
+    )
+    return candidates[-1] if candidates else None
 
 
 # --------------------------------------------------------------------------- #
@@ -93,7 +116,7 @@ def discover_rank_dirs(root: Path) -> list[Path]:
     for name in SWIMLANE_RECORD_NAMES:
         for rec in root.rglob(name):
             d = rec.parent
-            if (d / "deps.json").exists() and (d / "name_map.json").exists():
+            if (d / "deps.json").exists() and _find_name_map(d) is not None:
                 dirs.add(d)
     return sorted(dirs)
 
@@ -102,9 +125,12 @@ def build_graph(rank_dir: Path, root: Path, tol: int) -> RankGraph:
     rec_file = _find_records(rank_dir)
     if rec_file is None:
         raise FileNotFoundError(f"no swimlane records ({' / '.join(SWIMLANE_RECORD_NAMES)}) in {rank_dir}")
+    name_map_file = _find_name_map(rank_dir)
+    if name_map_file is None:
+        raise FileNotFoundError(f"no name_map*.json in {rank_dir}")
     sw = _read_json(rec_file)
     deps = _read_json(rank_dir / "deps.json")
-    name_map = _read_json(rank_dir / "name_map.json").get("callable_id_to_name", {})
+    name_map = _read_json(name_map_file).get("callable_id_to_name", {})
 
     freq = int(sw["metadata"]["clock_freq_hz"])
     # aicore_tasks rows are [core_id, task_token, reg_task_id, start_tick, end_tick,
@@ -252,6 +278,7 @@ class RankResult:
     makespan: int
     cpm_len: int
     cpm_ntasks: int
+    cpm_path: list[str]
     cpm_head: list[str]
     segments: list[Segment] = field(default_factory=list)
     compute_total: int = 0
@@ -313,6 +340,7 @@ def analyze_rank(g: RankGraph, tol: int) -> RankResult:
         makespan=g.t1 - g.t0,
         cpm_len=cpm_len,
         cpm_ntasks=len(cpm_path),
+        cpm_path=cpm_path,
         cpm_head=[g.name[t] for t in cpm_path[:10]],
         segments=segments,
         compute_total=compute_total,
@@ -338,7 +366,10 @@ def render_report(results: list[RankResult], top: int) -> str:
     out: list[str] = []
     w = out.append
     w("# Critical-path report (L2 swimlane)\n")
-    w("Generated by `tools/critical_path.py`. Times are device wall-clock; percentages are of each rank's makespan.\n")
+    w(
+        "Generated by `python -m simpler_setup.tools.critical_path`. "
+        "Times are device wall-clock; percentages are of each rank's makespan.\n"
+    )
     w("- **Static CPM path**: dependency-limited latency floor (unlimited cores).")
     w(
         "- **Observed path**: the as-executed critical path; its per-task compute + "
@@ -427,20 +458,87 @@ def render_summary(results: list[RankResult]) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Perfetto critical-path traces                                              #
+# --------------------------------------------------------------------------- #
+def _trace_events(trace_data) -> list[dict]:
+    if isinstance(trace_data, dict):
+        events = trace_data.get("traceEvents")
+    elif isinstance(trace_data, list):
+        events = trace_data
+    else:
+        events = None
+    if not isinstance(events, list) or not all(isinstance(event, dict) for event in events):
+        raise ValueError("merged swimlane JSON must contain a traceEvents list")
+    return events
+
+
+def _critical_trace(trace_data, critical_task_ids: set[str]):
+    """Copy the merged trace and anonymize non-critical Worker View task bars."""
+    events = [event.copy() for event in _trace_events(trace_data)]
+    visible_task_ids = {
+        str(event.get("args", {}).get("taskId"))
+        for event in events
+        if event.get("ph") == "X" and event.get("pid") == 4 and event.get("args", {}).get("taskId") is not None
+    }
+    missing = critical_task_ids - visible_task_ids
+    if missing:
+        sample = ", ".join(sorted(missing)[:5])
+        raise ValueError(f"merged Worker View is missing {len(missing)} critical task(s): {sample}")
+
+    for event in events:
+        task_id = event.get("args", {}).get("taskId")
+        if event.get("ph") != "X" or event.get("pid") != 4 or task_id is None or str(task_id) in critical_task_ids:
+            continue
+        event["name"] = f"·({format_task_display(task_id)})"
+
+    if isinstance(trace_data, dict):
+        output = trace_data.copy()
+        output["traceEvents"] = events
+        return output
+    return events
+
+
+def _write_critical_path_traces(rank_dir: Path, result: RankResult) -> list[Path]:
+    merged_path = _find_merged_swimlane(rank_dir)
+    if merged_path is None:
+        return []
+    merged_trace = _read_json(merged_path)
+    paths = (
+        (STATIC_TRACE_NAME, set(result.cpm_path)),
+        (OBSERVED_TRACE_NAME, {segment.task for segment in result.segments}),
+    )
+    traces: list[tuple[Path, object]] = []
+    for filename, critical_task_ids in paths:
+        output_path = rank_dir / filename
+        trace = _critical_trace(merged_trace, critical_task_ids)
+        traces.append((output_path, trace))
+
+    output_paths: list[Path] = []
+    for output_path, trace in traces:
+        output_path.write_text(json.dumps(trace, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        output_paths.append(output_path)
+    return output_paths
+
+
+# --------------------------------------------------------------------------- #
 # CLI                                                                         #
 # --------------------------------------------------------------------------- #
 def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Reconstruct the critical path of an L2-swimlane build_output "
-        "and write a per-task compute/stall report.",
+        description="Reconstruct the critical path of an L2-swimlane run tree "
+        "and write a compute/stall report plus Perfetto critical-path traces.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument(
         "build_dir",
         type=Path,
-        help="build_output/<case> directory (or any dir containing dfx_outputs/rank*/d*/l2_swimlane_records.json)",
+        help="directory containing outputs/... or dfx_outputs/.../l2_swimlane_records.json artifacts",
     )
-    p.add_argument("--report", default="critical_path_report.md", help="report filename, written under build_dir")
+    p.add_argument(
+        "--report",
+        default="critical_path_report.md",
+        help="report filename, written beside each discovered swimlane records file",
+    )
     p.add_argument("--top", type=int, default=25, help="rows in the kernel-family table")
     p.add_argument("--tol", type=int, default=2, help="tick tolerance when deciding 'finished before' (clock ticks)")
     p.add_argument("--stdout", action="store_true", help="also print a one-line-per-rank summary to stdout")
@@ -457,30 +555,56 @@ def main(argv: list[str]) -> int:
     # relative-path labels on its parent directory.
     if root.is_file():
         root = root.parent
+    report_name = Path(args.report)
+    if report_name.is_absolute() or report_name.name != args.report:
+        print("error: --report must be a filename, not a path", file=sys.stderr)
+        return 2
     rank_dirs = discover_rank_dirs(root)
     if not rank_dirs:
         print(
-            f"error: no l2_swimlane_records.json (+deps.json+name_map.json) found "
+            f"error: no l2_swimlane_records.json (+deps.json+name_map*.json) found "
             f"under {root}. Did the run use --enable-l2-swimlane?",
             file=sys.stderr,
         )
         return 2
 
     results: list[RankResult] = []
+    report_paths: list[Path] = []
+    trace_paths: list[Path] = []
+    had_trace_errors = False
     for d in rank_dirs:
         g = build_graph(d, root, args.tol)
-        results.append(analyze_rank(g, args.tol))
-
-    report = render_report(results, args.top)
-    out_path = root / args.report
-    out_path.write_text(report, encoding="utf-8")
+        result = analyze_rank(g, args.tol)
+        results.append(result)
+        out_path = d / args.report
+        out_path.write_text(render_report([result], args.top), encoding="utf-8")
+        report_paths.append(out_path)
+        try:
+            written_traces = _write_critical_path_traces(d, result)
+        except (OSError, ValueError) as exc:
+            print(
+                f"error: invalid merged_swimlane*.json in {d}: {exc}",
+                file=sys.stderr,
+            )
+            had_trace_errors = True
+            continue
+        if written_traces:
+            trace_paths.extend(written_traces)
+        else:
+            print(
+                f"Warning: no merged_swimlane*.json in {d}; skipped Perfetto critical-path traces",
+                file=sys.stderr,
+            )
 
     print(f"Analyzed {len(results)} rank(s) under {root}")
     print(render_summary(results))
-    print(f"Report written to: {out_path}")
+    for out_path in report_paths:
+        print(f"Report written to: {out_path}")
+    for trace_path in trace_paths:
+        print(f"Perfetto trace written to: {trace_path}")
     if args.stdout:
-        print("\n" + report)
-    return 0
+        print("\n" + render_report(results, args.top))
+    return 2 if had_trace_errors else 0
 
 
 if __name__ == "__main__":

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -1438,8 +1438,11 @@ def _load_func_names_json(path):
 
 
 def _autoload_name_map(deps_path):
-    """Look for a ``name_map_*.json`` next to deps.json."""
-    candidates = sorted(Path(deps_path).parent.glob("name_map_*.json"), key=lambda p: p.stat().st_mtime)
+    """Look for a ``name_map*.json`` next to deps.json."""
+    candidates = sorted(
+        (path for path in Path(deps_path).parent.glob("name_map*.json") if path.is_file()),
+        key=lambda path: (path.stat().st_mtime, path.name),
+    )
     if not candidates:
         return {}
     return _load_func_names_json(candidates[-1])

--- a/tests/ut/py/test_critical_path.py
+++ b/tests/ut/py/test_critical_path.py
@@ -1,0 +1,229 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Contract tests for simpler_setup.tools.critical_path."""
+
+import json
+
+from simpler_setup.tools import critical_path
+
+
+def _write_rank_artifacts(rank_dir, name_map_filename):
+    rank_dir.mkdir(parents=True)
+    (rank_dir / "l2_swimlane_records.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"clock_freq_hz": 1_000_000},
+                "aicore_tasks": [[0, 1, 0, 0, 10, 0]],
+            }
+        )
+    )
+    (rank_dir / "deps.json").write_text(
+        json.dumps(
+            {
+                "tasks": [{"task_id": 1, "kernel_ids": [7, -1, -1]}],
+                "edges": [],
+            }
+        )
+    )
+    (rank_dir / name_map_filename).write_text(json.dumps({"callable_id_to_name": {"7": "kernel_add"}}))
+
+
+def _write_visualization_artifacts(rank_dir):
+    rank_dir.mkdir(parents=True)
+    (rank_dir / "l2_swimlane_records.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"clock_freq_hz": 1_000_000},
+                "aicore_tasks": [
+                    [0, 1, 0, 0, 10, 0],
+                    [1, 2, 0, 0, 19, 0],
+                    [1, 3, 0, 20, 30, 0],
+                ],
+            }
+        )
+    )
+    (rank_dir / "deps.json").write_text(
+        json.dumps(
+            {
+                "tasks": [
+                    {"task_id": 1, "kernel_ids": [1, -1, -1]},
+                    {"task_id": 2, "kernel_ids": [2, -1, -1]},
+                    {"task_id": 3, "kernel_ids": [3, -1, -1]},
+                ],
+                "edges": [{"pred": 1, "succ": 3}],
+            }
+        )
+    )
+    (rank_dir / "name_map_case.json").write_text(
+        json.dumps(
+            {
+                "callable_id_to_name": {
+                    "1": "kernel_a",
+                    "2": "kernel_b",
+                    "3": "kernel_c",
+                }
+            }
+        )
+    )
+    events = [
+        {"args": {"name": "Worker View"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 4},
+        {
+            "args": {"name": "AIC_0"},
+            "cat": "__metadata",
+            "name": "thread_name",
+            "ph": "M",
+            "pid": 4,
+            "tid": 10000,
+        },
+        {
+            "args": {"taskId": 1},
+            "cat": "event",
+            "id": 10,
+            "name": "kernel_a(t1)",
+            "ph": "X",
+            "pid": 4,
+            "tid": 10000,
+            "ts": 0,
+            "dur": 10,
+        },
+        {
+            "args": {"taskId": 2},
+            "cat": "event",
+            "id": 11,
+            "name": "kernel_b(t2)",
+            "ph": "X",
+            "pid": 4,
+            "tid": 10010,
+            "ts": 0,
+            "dur": 19,
+        },
+        {
+            "args": {"taskId": 3},
+            "cat": "event",
+            "id": 12,
+            "name": "kernel_c(t3)",
+            "ph": "X",
+            "pid": 4,
+            "tid": 10010,
+            "ts": 20,
+            "dur": 10,
+        },
+        {
+            "args": {"phase": "dummy_task", "task_id": 99},
+            "cat": "event",
+            "id": 13,
+            "name": "dummy(t99)",
+            "ph": "X",
+            "pid": 4,
+            "tid": 19000,
+            "ts": 5,
+            "dur": 0.02,
+        },
+        {"cat": "flow", "id": 100, "name": "dependency", "ph": "s", "pid": 4, "tid": 10000, "ts": 0},
+        {"cat": "flow", "id": 100, "name": "dependency", "ph": "f", "pid": 4, "tid": 10010, "ts": 20},
+        {"cat": "flow", "id": 101, "name": "dispatch", "ph": "s", "pid": 3, "tid": 10000, "ts": 0},
+        {"cat": "flow", "id": 101, "name": "dispatch", "ph": "f", "pid": 4, "tid": 10000, "ts": 0},
+        {"cat": "flow", "id": 102, "name": "complete", "ph": "s", "pid": 4, "tid": 10010, "ts": 30},
+        {"cat": "flow", "id": 102, "name": "complete", "ph": "f", "pid": 2, "tid": 0, "ts": 31},
+        {"args": {"taskId": 1}, "cat": "event", "name": "kernel_a(t1)", "ph": "X", "pid": 3, "tid": 1},
+    ]
+    (rank_dir / "merged_swimlane_20260720_120000.json").write_text(
+        json.dumps({"traceEvents": events, "displayTimeUnit": "us", "source": "unit-test"})
+    )
+
+
+def test_main_accepts_name_map_variants_and_writes_report_beside_each_records(tmp_path):
+    simpler_output = tmp_path / "outputs" / "case"
+    pypto_output = tmp_path / "build_output" / "case" / "dfx_outputs"
+    _write_rank_artifacts(simpler_output, "name_map_TestCase.json")
+    _write_rank_artifacts(pypto_output, "name_map.json")
+
+    rc = critical_path.main([str(tmp_path)])
+
+    assert rc == 0
+    for output_dir in (simpler_output, pypto_output):
+        report = output_dir / "critical_path_report.md"
+        assert report.exists()
+        assert "kernel_add" in report.read_text()
+    assert not (tmp_path / "critical_path_report.md").exists()
+
+
+def test_main_writes_static_and_observed_full_traces(tmp_path):
+    output_dir = tmp_path / "outputs" / "case"
+    _write_visualization_artifacts(output_dir)
+
+    rc = critical_path.main([str(output_dir)])
+
+    assert rc == 0
+    static_trace = json.loads((output_dir / "CPM_static.json").read_text())
+    observed_trace = json.loads((output_dir / "CPM_observed.json").read_text())
+    assert static_trace["displayTimeUnit"] == observed_trace["displayTimeUnit"] == "us"
+    assert static_trace["source"] == observed_trace["source"] == "unit-test"
+
+    static_events = static_trace["traceEvents"]
+    observed_events = observed_trace["traceEvents"]
+    source_events = json.loads((output_dir / "merged_swimlane_20260720_120000.json").read_text())["traceEvents"]
+    assert len(static_events) == len(observed_events) == len(source_events)
+    assert {event["pid"] for event in static_events + observed_events} == {2, 3, 4}
+
+    def worker_task_names(events):
+        return {
+            event["args"]["taskId"]: event["name"]
+            for event in events
+            if event.get("ph") == "X" and event.get("pid") == 4 and "taskId" in event.get("args", {})
+        }
+
+    assert worker_task_names(static_events) == {
+        1: "kernel_a(t1)",
+        2: "·(t2)",
+        3: "kernel_c(t3)",
+    }
+    assert worker_task_names(observed_events) == {
+        1: "·(t1)",
+        2: "kernel_b(t2)",
+        3: "kernel_c(t3)",
+    }
+    for events in (static_events, observed_events):
+        other_view_tasks = [event for event in events if event.get("ph") == "X" and event.get("pid") != 4]
+        assert other_view_tasks == [
+            {"args": {"taskId": 1}, "cat": "event", "name": "kernel_a(t1)", "ph": "X", "pid": 3, "tid": 1}
+        ]
+    assert "dummy(t99)" in {event.get("name") for event in static_events}
+    assert "dummy(t99)" in {event.get("name") for event in observed_events}
+    assert {event["id"] for event in static_events if event.get("cat") == "flow"} == {100, 101, 102}
+    assert {event["id"] for event in observed_events if event.get("cat") == "flow"} == {100, 101, 102}
+
+
+def test_main_reports_stale_merged_trace_and_continues_without_partial_cpm_outputs(tmp_path, capsys):
+    stale_output = tmp_path / "outputs" / "a_stale"
+    good_output = tmp_path / "outputs" / "b_good"
+    _write_visualization_artifacts(stale_output)
+    _write_visualization_artifacts(good_output)
+
+    merged_path = stale_output / "merged_swimlane_20260720_120000.json"
+    merged_trace = json.loads(merged_path.read_text())
+    merged_trace["traceEvents"] = [
+        event
+        for event in merged_trace["traceEvents"]
+        if not (event.get("pid") == 4 and event.get("ph") == "X" and event.get("args", {}).get("taskId") == 2)
+    ]
+    merged_path.write_text(json.dumps(merged_trace))
+
+    rc = critical_path.main([str(tmp_path)])
+
+    assert rc == 2
+    assert (stale_output / "critical_path_report.md").exists()
+    assert not (stale_output / "CPM_static.json").exists()
+    assert not (stale_output / "CPM_observed.json").exists()
+    assert (good_output / "critical_path_report.md").exists()
+    assert (good_output / "CPM_static.json").exists()
+    assert (good_output / "CPM_observed.json").exists()
+    error = capsys.readouterr().err
+    assert "error: invalid merged_swimlane*.json" in error
+    assert "missing 1 critical task(s): 2" in error

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -14,6 +14,14 @@ from simpler_setup.tools import deps_viewer
 from simpler_setup.tools.deps_viewer import _merge_task_meta_with_kernel_ids, emit_text
 
 
+def test_autoload_name_map_accepts_exact_name(tmp_path):
+    deps_path = tmp_path / "deps.json"
+    deps_path.write_text("{}")
+    (tmp_path / "name_map.json").write_text(json.dumps({"callable_id_to_name": {"7": "kernel_add"}}))
+
+    assert deps_viewer._autoload_name_map(deps_path) == {"7": "kernel_add"}
+
+
 def test_emit_text_marks_alloc_without_task_entry():
     text = emit_text(
         edges=[],

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,42 +7,6 @@ End-user profiling / debug CLIs live in
 [`simpler_setup/tools/`](../simpler_setup/tools/) and ship with the wheel —
 invoke them via `python -m simpler_setup.tools.<name>`.
 
-## critical_path.py
-
-Post-processing analysis over an L2-swimlane run. Given a directory produced by
-a `--enable-l2-swimlane` run, it reconstructs the critical path of the device
-execution and writes a per-task compute/stall report.
-
-It recursively discovers every directory under the given path that holds the
-full triple — a records file (`l2_swimlane_records.json`, or `l2_perf_records.json`
-for older runtimes) plus `deps.json` and `name_map.json` — so it is not
-restricted to a `dfx_outputs/rank*/d*` layout. For each such rank/device it
-builds a happens-before DAG from the dependency graph oriented by observed
-timestamps, then computes two critical paths:
-
-- **Static CPM** — the longest duration-weighted path, i.e. the
-  dependency-limited latency floor (unlimited cores).
-- **Observed** — the as-executed backward "blame" walk from the last-finishing
-  task; each task's compute plus the scheduling stall before it (`data-wait` =
-  waiting on a producer, `core-wait` = waiting for a core to free) tiles the
-  makespan exactly.
-
-It writes `critical_path_report.md` into the given directory: an overview
-(makespan, CPM floor, compute vs. stall split), a per-kernel-family table, and a
-full per-task listing. Pure post-processing — no C++, no device; O(N log N).
-
-```bash
-# Analyze a case run produced with --enable-l2-swimlane
-python tools/critical_path.py <run-dir>
-
-# Options: report filename, kernel-family rows, tick tolerance, echo summary
-python tools/critical_path.py <run-dir> \
-    --report critical_path_report.md --top 25 --stdout
-```
-
-It auto-discovers all ranks, so you can equally point it at a single
-`dfx_outputs/rank0/d0` directory or at the whole run tree.
-
 ## benchmark_rounds.sh
 
 Batch-run a predefined set of ST examples on hardware, parse `orch_start` /


### PR DESCRIPTION
- Move critical_path into the wheel-shipped DFX tools and discover name_map*.json beside each L2 records file.
- Emit static and observed CPM traces while preserving every merged view and anonymizing only non-critical Worker View tasks.
- Extend deps_viewer name-map discovery and cover both tools with unit tests and user documentation.