### PR TITLE
docs(skill): update qwen multi-repo Path B for decode_fwd

### DIFF
--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-repo-qwen-setup
-description: Concrete qwen3-14B guide on NPU against the current worktree's simpler. Points at simpler's own in-repo qwen3_14b_decode example (zero cross-repo), then covers the two cross-repo paths — the pypto-serving runner (prefill/decode TPOT) and the pypto-lib decode_layer kernel (scheduler-overhead DFX). Defers cross-repo clone/install to multi-repo-setup, then gives the exact run commands (batch-1 and batch-16), the prefill ring/timeout gotchas that otherwise surface as 507018, how to read the per-token timing layers, and the kernel-level overhead-analysis flow. Invoke when running qwen3 on simpler, measuring decode/prefill TPOT, reproducing a qwen3 perf number, running qwen3 decode_layer overhead analysis, or chasing a 507018 on the qwen3 path.
+description: Concrete qwen3-14B guide on NPU against the current worktree's simpler. Points at simpler's own in-repo qwen3_14b_decode example (zero cross-repo), then covers the two cross-repo paths — the pypto-serving runner (prefill/decode TPOT) and the pypto-lib decode_fwd kernel (device decode TPOT + scheduler DFX). Defers cross-repo clone/install to multi-repo-setup, then gives the exact run commands (batch-1 and batch-16), the prefill ring/timeout gotchas that otherwise surface as 507018, how to read the per-token timing layers, and the kernel-level device-timing / swimlane flow. Invoke when running qwen3 on simpler, measuring decode/prefill TPOT, reproducing a qwen3 perf number, running qwen3 decode_fwd device-timing or swimlane/overhead analysis, or chasing a 507018 on the qwen3 path.
 ---
 
 # Qwen3-14B on NPU: setup + TPOT / overhead measurement
@@ -8,8 +8,8 @@ description: Concrete qwen3-14B guide on NPU against the current worktree's simp
 This skill is the **qwen3-specific concrete guide**. It first points at
 simpler's own in-repo qwen3 example (the zero-cross-repo path), then covers
 the two cross-repo paths against the worktree's simpler: the **pypto-serving
-runner** (prefill/decode TPOT) and the **pypto-lib `decode_layer` kernel**
-(scheduler-overhead DFX). For the cross-repo paths it gives the exact run
+runner** (prefill/decode TPOT) and the **pypto-lib `decode_fwd` kernel**
+(device decode TPOT + scheduler DFX). For the cross-repo paths it gives the exact run
 commands, the prefill ring/timeout gotchas, and how to read per-token timing
 — distilled from real runs plus each upstream repo's own docs — sitting on
 top of [`multi-repo-setup`](../multi-repo-setup/SKILL.md), which owns the
@@ -20,12 +20,12 @@ generic repo-graph + clone + install steps this skill does not repeat.
 There are **three distinct qwen3 entry points with different invocation
 styles**. They measure different things; don't confuse them:
 
-| aspect | Path 0 (in-repo) | Path A (serving) | Path B (decode_layer) |
+| aspect | Path 0 (in-repo) | Path A (serving) | Path B (decode_fwd) |
 | ------ | ---------------- | ---------------- | --------------------- |
 | repo | simpler (this) | pypto-serving | pypto-lib |
-| entry | qwen3_14b_decode | npu_generate.py | decode_layer.py |
+| entry | qwen3_14b_decode | npu_generate.py | decode_fwd.py |
 | cross-repo? | no | yes | yes |
-| measures | 2-layer decode correctness/timing | end-to-end TPOT | layer sched overhead |
+| measures | 2-layer decode correctness/timing | end-to-end TPOT | device decode TPOT + sched DFX |
 | see | this section | sections 2-5 | section 6 |
 
 - **Path 0 — in-repo example (simpler itself, NO cross-repo).** Start here
@@ -56,11 +56,12 @@ styles**. They measure different things; don't confuse them:
   Measures **end-to-end prefill/decode TPOT** for the whole model; read via
   the `--profile` report + `strace_timing --rounds-table` (§2–§5). Use it
   to reproduce a serving perf number or chase a serving `507018`.
-- **Path B — `decode_layer` kernel (pypto-lib).** A single JIT case for one
-  decode layer, not the engine. Entry
-  `models/qwen3/14b/decode_layer.py`, flags `-p <platform> -d <device>`,
-  run in two rounds (`--no-dep-gen --enable-l2-swimlane`). Measures **one
-  layer's scheduler overhead** (Orch/Sched breakdown); read via
+- **Path B — `decode_fwd` kernel (pypto-lib).** A single JIT case, not the
+  engine. Entry `models/qwen3/14b/decode_fwd.py`, flags `-p <platform> -d
+  <device>` plus `--validate-fwd --fwd-layers N --decode-steps M --max-seq`
+  (device TPOT) and `--enable-dep-gen` / `--enable-l2-swimlane <1-4>` (DFX,
+  two separate rounds). Measures **per-step device decode cost + scheduler
+  timeline** (per-op / Orch/Sched breakdown); read via
   `sched_overhead_analysis` / `swimlane_converter` (§6). Use it to dig into
   per-layer scheduling cost / the overhead model.
 
@@ -84,7 +85,7 @@ anything this skill doesn't cover:
 - **Path A** — `build/pypto-serving/.claude/skills/` (if present) and its
   `README.md` (engine config, model-dir layout, weights conversion).
 - **Path B** — `build/pypto-lib/.claude/skills/` / `README.md` and the
-  `decode_layer.py` docstring / `--help` (case flags, golden data).
+  `decode_fwd.py` docstring / `--help` (case flags, golden data).
 
 Then, from the worktree, the qwen runs assume this env:
 
@@ -250,42 +251,87 @@ view); see
 grammar and span tree. The L3-side tensor-management ask is
 [pypto-serving #44](https://github.com/hw-native-sys/pypto-serving/issues/44).
 
-## 6. Path B — `decode_layer` kernel: scheduler-overhead DFX
+## 6. Path B — `decode_fwd.py` kernel: correctness, device TPOT, DFX
 
 *Path B is a different repo (**pypto-lib**) and a different entry point
 than §2–§5 — a single JIT kernel case, not the serving engine.*
 
-Path A above measures end-to-end TPOT through the serving runner. Path B
-instead digs into the **scheduler overhead** of the qwen3 decode kernel
-itself: run `build/pypto-lib/models/qwen3/14b/decode_layer.py` in two
-rounds and feed both into simpler's overhead tools. Onboard rules apply
-(per-die lock + `onboard-arch-precheck`).
+The entry is **`build/pypto-lib/models/qwen3/14b/decode_fwd.py`** (the old
+`decode_layer.py` is gone). One script, three workflows via flags. Onboard
+rules apply (per-die lock + `onboard-arch-precheck`), and every run wants
+the pinned PTO-ISA + a context length:
 
 ```bash
 .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
-cd "$PWD/build/pypto-lib/models/qwen3/14b"
-# Round 1 — dep_gen (topology); Round 2 — swimlane (clean timing). NEVER co-run:
-# dep_gen perturbs the timing the overhead analysis reads.
-task-submit --device auto --device-num 1 --run "python decode_layer.py -p a2a3 -d \$TASK_DEVICE"
-task-submit --device auto --device-num 1 --run "python decode_layer.py -p a2a3 -d \$TASK_DEVICE --no-dep-gen --enable-l2-swimlane"
+cd "$PWD/build/pypto-lib"
+export PTO_ISA_ROOT="$PWD/build/pto-isa" SIMPLER_PTO_ISA_COMMIT=<pinned-commit>
+export PTO2_MANUAL_MAX_SEQ=3338   # ctx length used by --max-seq
 ```
 
-Both write to `build_output/_jit_*/dfx_outputs/` (`deps.json` from round 1,
-`l2_swimlane_records.json` from round 2). Analyze from the simpler worktree
+**(a) Correctness — single-layer golden.** Bare invocation = one decode
+layer vs a torch golden (N==1):
+
+```bash
+task-submit --device auto --device-num 1 \
+  --run "python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
+```
+
+**(b) Device decode TPOT — the base-vs-X perf number.** `--validate-fwd`
+stacks N layers + LM head; `--decode-steps M` grows ctx one token/step for a
+device-cost sweep; `--max-seq` pins every seq to `PTO2_MANUAL_MAX_SEQ`:
+
+```bash
+task-submit --device 6 \
+  --run "python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE \
+         --validate-fwd --fwd-layers 40 --decode-steps 32 --max-seq"
+```
+
+Read the **per-step device makespan** from the `[STRACE] … device_wall`
+markers — one per `inv`, **`dur` is in nanoseconds**. Drop `inv=1` (warmup),
+mean the rest:
+
+```bash
+grep 'runner_run.device_wall ' <log> | sed -E 's/.*inv=([0-9]+).*dur=([0-9]+).*/\1 \2/'
+# inv dur(ns);  ns/1e6 = ms/step;  ~36 ms at 3.3k ctx / 40 layers
+```
+
+**(c) Swimlane / dep-graph — per-op + scheduler timeline.** Two rounds,
+**never co-run** (dep_gen perturbs the timing). Capture with a **small layer
+count** (`--fwd-layers 2`, *not* the 40-layer perf config): a full-model
+swimlane trace is huge (~MB/layer in Perfetto) and the SHM record buffer can
+overflow ("records dropped"). Two layers gives one warmup + one steady-state
+layer — enough to read per-op / scheduler structure.
+
+```bash
+python models/qwen3/14b/decode_fwd.py -p a2a3 -d $DEV --validate-fwd --fwd-layers 2 --max-seq --enable-dep-gen        # topology -> deps.json
+python models/qwen3/14b/decode_fwd.py -p a2a3 -d $DEV --validate-fwd --fwd-layers 2 --max-seq --enable-l2-swimlane 4  # 1=AICore 2=+dispatch 3=+sched 4=+orch
+```
+
+Both write `build_output/_jit_*/dfx_outputs/`: `deps.json`,
+`l2_swimlane_records.json`, and a ready-to-load **`merged_swimlane_*.json`**
+(Perfetto — drag into ui.perfetto.dev). Analyze from the simpler worktree
 (its `simpler_setup/tools` wins by cwd precedence):
 
 ```bash
-# ROUND1_DIR / ROUND2_DIR are the two build_output/_jit_*/dfx_outputs/ dirs above.
-$PY -m simpler_setup.tools.sched_overhead_analysis \
-    --l2-swimlane-records-json "ROUND2_DIR/l2_swimlane_records.json" \
-    --deps-json "ROUND1_DIR/deps.json"
-# Visual: add the Overhead Analysis track to the Perfetto trace
-$PY -m simpler_setup.tools.swimlane_converter "ROUND2_DIR/l2_swimlane_records.json" \
-    --deps-json "ROUND1_DIR/deps.json" --overhead -o swimlane.json
+$PY -m simpler_setup.tools.swimlane_converter RECORDS.json --deps-json DEPS.json [--overhead] -o swim.json
+$PY -m simpler_setup.tools.sched_overhead_analysis --l2-swimlane-records-json RECORDS.json --deps-json DEPS.json
+$PY -m simpler_setup.tools.deps_viewer DEPS.json --format html --func-names NAME_MAP.json -o deps.html
 ```
 
 See [docs/dfx/sched-overhead-model.md](../../../docs/dfx/sched-overhead-model.md)
-for what the report and the overhead tracks mean.
+for the overhead model.
+
+**Perf gotchas (measured).**
+
+- A 3.3k-ctx 40-layer decode step (~36 ms) is **memory-bound** (weights + KV);
+  per-layer scheduling changes are sub-noise at this scale.
+- **Run-to-run noise is ~0.1 ms** on a shared box — *larger* than most
+  scheduler-level effects. For a sub-0.1 ms A/B (base vs a variant, stock vs a
+  patched `.so`), **interleave the variants in one session** in ABBA/palindrome
+  order so session drift cancels; a single before/after pair flips sign and
+  misleads. Swap the `.so` between invocations (each `python decode_fwd.py` is a
+  fresh process) rather than across separate `task-submit` jobs.
+- Use an **even die** and hold it exclusively.
 
 ## 7. When you change simpler C++ (instrumentation)
 
@@ -295,21 +341,30 @@ changes (new instrumentation, log lines), `pip install` may skip the runtime
 [`multi-repo-setup`](../multi-repo-setup/SKILL.md) Step 3 — arch-parametrized
 and python-version-agnostic, so it works on a2a3 / a5 and any venv layout):
 
+**Pick the target by where the code lives:** the host-orchestration / runtime
+entry is in `…/host/libhost_runtime.so`; the **AICPU scheduler, orchestrator,
+dispatch, drain, and early-dispatch** code (`runtime/scheduler/*`,
+`pto_orchestrator.cpp`) compiles into `…/aicpu/libaicpu_kernel.so`. Rebuild the
+one you touched:
+
 ```bash
-ARCH=a2a3   # or a5
-BD="build/cache/$ARCH/onboard/tensormap_and_ringbuffer/host"
+ARCH=a2a3                                     # or a5
+LIB=aicpu; SO=libaicpu_kernel.so              # scheduler/orch/dispatch  (host: LIB=host SO=libhost_runtime.so)
+BD="build/cache/$ARCH/onboard/tensormap_and_ringbuffer/$LIB"
 cmake --build "$BD" -j"$(nproc)"
-SO="$BD/libhost_runtime.so"
 # sync to every load location (build/lib AND the installed venv), no hardcoded
 # python version — the glob matches whatever site-packages path exists:
-for d in $(find .venv build/lib -path "*onboard*tensormap_and_ringbuffer*$(basename "$SO")"); do
-  cp -f "$SO" "$d"
+for d in $(find .venv build/lib -path "*onboard*tensormap_and_ringbuffer*$SO"); do
+  cp -f "$BD/$SO" "$d"
 done
-strings "$SO" | grep -m1 '<your-new-log-string>'   # confirm it baked in
+strings "$BD/$SO" | grep -m1 '<your-new-log-string>'   # confirm it baked in
 ```
 
-(`.venv/lib64` is a symlink to `lib`, so the `find` covers both.) Host-side
-instrumentation lives in the **host** lib; only that target needs rebuilding.
+(`.venv/lib64` is a symlink to `lib`, so the `find` covers both.) AICPU device
+logs land in `ASCEND_PROCESS_LOG_PATH/.../device-*/device-*.log` — set that var
+per run (see `running-onboard`) and note AICPU `LOG_INFO_V*` uses **inverted**
+verbosity: `v=9` is must-see (default threshold 5), `v=0` is filtered — use
+`LOG_INFO_V9` for a diagnostic you need to read back.
 
 ## Anti-patterns
 


### PR DESCRIPTION
## Summary

- The pypto-lib qwen test entry moved from `decode_layer.py` to
  `decode_fwd.py` (the old file is gone); rewrite Path B (§6) of the
  `multi-repo-qwen-setup` skill for it.
- Three concrete workflows: single-layer golden (correctness),
  `--validate-fwd --fwd-layers N --decode-steps M --max-seq` for per-step
  device decode TPOT (read `device_wall` from `[STRACE]` markers, dur in ns,
  drop warmup), and `--enable-dep-gen` + `--enable-l2-swimlane <1-4>` DFX in
  two separate rounds, with the `swimlane_converter` /
  `sched_overhead_analysis` / `deps_viewer` recipes.
- New perf-gotchas block: decode is memory-bound (~36 ms/step at 3.3k ctx);
  ~0.1 ms run-to-run noise on a shared box means interleaving variants in one
  session (ABBA/palindrome), not before/after pairs; even-die hygiene.
- §7 rebuild note generalized to the AICPU lib — scheduler/orchestrator/
  dispatch compile into `libaicpu_kernel.so`, not host — plus the inverted
  AICPU `LOG_INFO_V*` verbosity (V9 = must-see, V0 filtered).
- Fix stale `decode_layer` references in the header, table, and frontmatter.

## Testing

- [x] Docs-only change (skill markdown); no code touched.
- [x] `markdownlint` config: MD013 (line length) disabled in `tests/lint/.markdownlint.yaml`, so no line-wrap violations.