### PR TITLE
Fix: pass pin-resolved PTO_ISA_ROOT by value and -D

### DIFF
--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -21,7 +21,7 @@ There are **three distinct qwen3 entry points with different invocation
 styles**. They measure different things; don't confuse them:
 
 | aspect | Path 0 (in-repo) | Path A (serving) | Path B (decode_fwd) |
-| ------ | ---------------- | ---------------- | --------------------- |
+| ------ | ---------------- | ---------------- | ------------------- |
 | repo | simpler (this) | pypto-serving | pypto-lib |
 | entry | qwen3_14b_decode | npu_generate.py | decode_fwd.py |
 | cross-repo? | no | yes | yes |
@@ -264,7 +264,9 @@ the pinned PTO-ISA + a context length:
 ```bash
 .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
 cd "$PWD/build/pypto-lib"
-export PTO_ISA_ROOT="$PWD/build/pto-isa" SIMPLER_PTO_ISA_COMMIT=<pinned-commit>
+# PTO-ISA is auto-resolved from simpler's pto_isa.pin via ensure_pto_isa_root();
+# do NOT export PTO_ISA_ROOT (#1403). An ambient path can drift off-pin and
+# simpler now rejects a checkout whose HEAD does not match the pin.
 export PTO2_MANUAL_MAX_SEQ=3338   # ctx length used by --max-seq
 ```
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -415,7 +415,8 @@ This repo vendors the `pto-isa` headers from a **pinned** git commit. When the p
 **Pin source of truth:** repo-root `pto_isa.pin` (a 40-hex SHA). CI
 reads it via `.github/actions/read-pto-isa` and feeds it both to
 test-time (`--pto-isa-commit`) and to the onboard `host_runtime.so`
-build (`SIMPLER_PTO_ISA_COMMIT` cmake define). Unpinned sentinel
+build (`SIMPLER_PTO_ISA_BUILD_COMMIT` cmake define; path is
+`-DPTO_ISA_ROOT=` from the managed pin checkout, not ambient env). Unpinned sentinel
 values (use latest HEAD): `""`, `head`, `latest`, `none` — see
 `simpler_setup/pto_isa.py` `_UNPINNED_COMMIT_VALUES`.
 
@@ -478,7 +479,7 @@ echo "new pto includes:";        printf '%s\n' "$NEW_PTO_INC"
 
 Note: this detects *include-path* changes, **not** edits to files that merely happen to `#include` pto-isa. A logic-only change inside an existing pto-isa consumer keeps the paragraph at the default advisory level — it does not by itself escalate.
 
-**What to convey (both levels):** the current pinned SHA from `pto_isa.pin`; and that a pin bump requires rebuilding onboard `a2a3` `host_runtime.so` against the new commit via `--config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT=<sha>` (the SDMA headers are compiled into `host_runtime.so`; see `docs/developer-guide.md`, issue #1067). The exact wording per level is given by the Step 8 blockquotes.
+**What to convey (both levels):** the current pinned SHA from `pto_isa.pin`; and that a pin bump requires rebuilding onboard `a2a3` `host_runtime.so` against the new commit via `--config-settings=cmake.define.SIMPLER_PTO_ISA_BUILD_COMMIT=<sha>` (the SDMA headers are compiled into `host_runtime.so`; see `docs/developer-guide.md`, issue #1067). The exact wording per level is given by the Step 8 blockquotes.
 
 ## Step 7: Optional Cross-Check with External CLI Reviewers
 
@@ -721,11 +722,11 @@ From Step 6.5. **Always rendered when the pin is active** (`PIN_ACTIVE=1`), at o
 
 - **No header-reference change** (`PTO_REFS` and `NEW_PTO_INC` empty) → **advisory**. A light, always-on nudge that the pin exists; does not by itself block the merge. Render as a single info line, e.g.:
 
-  > ℹ️ **pto-isa pin:** `pto_isa.pin` is pinned to `<sha>`. No pto-isa header references changed in this PR — confirm the pinned commit is still adequate; bump + rebuild onboard `a2a3` `host_runtime.so` (`SIMPLER_PTO_ISA_COMMIT`) only if needed.
+  > ℹ️ **pto-isa pin:** `pto_isa.pin` is pinned to `<sha>`. No pto-isa header references changed in this PR — confirm the pinned commit is still adequate; bump + rebuild onboard `a2a3` `host_runtime.so` (`SIMPLER_PTO_ISA_BUILD_COMMIT`) only if needed.
 
 - **Header-reference changed** (`PTO_REFS` or `NEW_PTO_INC` non-empty) → escalate to **recommendation**. Surface a visible reminder and mirror it as a **Should-fix / check** row in Issues Found below so it cannot be missed at Verdict time:
 
-  > ⚠️ **pto-isa pin check:** this PR changes how it references pto-isa while `pto_isa.pin` is pinned to `<sha>`. Verify the pinned commit still provides every pto-isa header the PR references — a **changed pto-isa include path** (e.g. `pto/npu/...` → `pto/...`) is the strongest hint a bump is needed; a newly added pto-isa include is a weaker hint. If the pin is bumped, rebuild onboard `a2a3` `host_runtime.so` against the new commit (`SIMPLER_PTO_ISA_COMMIT`).
+  > ⚠️ **pto-isa pin check:** this PR changes how it references pto-isa while `pto_isa.pin` is pinned to `<sha>`. Verify the pinned commit still provides every pto-isa header the PR references — a **changed pto-isa include path** (e.g. `pto/npu/...` → `pto/...`) is the strongest hint a bump is needed; a newly added pto-isa include is a weaker hint. If the pin is bumped, rebuild onboard `a2a3` `host_runtime.so` against the new commit (`SIMPLER_PTO_ISA_BUILD_COMMIT`).
 
   List the triggering signals verbatim (changed pto-isa include paths / newly added pto-isa includes). `PIN_TOUCHED` (the PR edited `pto_isa.pin`) is reported alongside, at whichever level applies, with a note to verify the new SHA and the `host_runtime.so` rebuild.
 

--- a/conftest.py
+++ b/conftest.py
@@ -436,14 +436,13 @@ def pytest_configure(config):
     # (CI scene-test jobs) want the session to die here rather than fan out
     # into device subprocesses that each re-attempt the clone.
     try:
-        root = ensure_pto_isa_root(verbose=True)
+        # Eager clone only — do not export PTO_ISA_ROOT into the ambient env
+        # (#1403). Downstream host builds receive the path via -DPTO_ISA_ROOT=.
+        ensure_pto_isa_root(verbose=True)
     except OSError as e:
         if config.getoption("--require-pto-isa"):
             pytest.exit(f"PTO-ISA required but unavailable: {e}", returncode=pytest.ExitCode.USAGE_ERROR)
         print(f"[pytest] PTO-ISA pre-clone skipped: {e}", file=sys.stderr)
-        root = None
-    if root:
-        os.environ["PTO_ISA_ROOT"] = root
 
     timeout = config.getoption("--pto-session-timeout")
     if timeout and timeout > 0:
@@ -1382,10 +1381,13 @@ def st_worker(request, st_platform, device_pool, _l2_worker_pool, _l2_poisoned):
                 handle = w.register(entry["callable"])
                 sub_handles[entry["name"]] = handle
             elif "orchestration" in entry:
-                from simpler_setup.scene_test import _compile_chip_callable_from_spec  # noqa: PLC0415
+                from simpler_setup.scene_test import (  # noqa: PLC0415
+                    _compile_chip_callable_from_spec,
+                    l3_compile_cache_key,
+                )
 
                 name = entry["name"]
-                cache_key = (cls.__qualname__, name, st_platform, runtime)
+                cache_key = l3_compile_cache_key(cls.__qualname__, name, st_platform, runtime)
                 chip = _compile_chip_callable_from_spec(entry, st_platform, runtime, cache_key)
                 handle = w.register(chip)
                 chip_handles[name] = handle

--- a/docs/a5-sdma-overlay.md
+++ b/docs/a5-sdma-overlay.md
@@ -6,7 +6,9 @@ or re-enable it once the a5 CANN environment supports it.
 
 > Tracking: PR [#1179](https://github.com/hw-native-sys/simpler/pull/1179),
 > issue [#1315](https://github.com/hw-native-sys/simpler/issues/1315)
-> (re-enable checklist).
+> (re-enable checklist). PTO-ISA version guard for a5 overlays: [#1351](https://github.com/hw-native-sys/simpler/issues/1351)
+> (closed via [#1404](https://github.com/hw-native-sys/simpler/pull/1404)).
+> Pin path transport: [#1403](https://github.com/hw-native-sys/simpler/issues/1403).
 
 ---
 
@@ -23,19 +25,21 @@ This is the a5 mirror of the a2a3 SDMA path, which is always on.
 
 ## Why it is gated off
 
-The available a5 CANN drops do not expose a working
-`aclnnShmemSdmaStarsQuery`:
+Symbol presence is not enough. `aclnnShmemSdmaStarsQuery*` was introduced in
+**CANN 9.0** and on 9.1.T500 the symbols live in `libopapi.so` (not
+`libascendcl.so`). Calling the API can still fail at STARS sync time and
+poison the AICPU context:
 
 | CANN | Failure |
 | ---- | ------- |
-| 9.1.T500 | STARS streams created but `aclrtSynchronizeStream` fails → AICPU exception `0x715002a` → every later kernel launch reports `507018`. **Breaks all a5 comm cases**, not just SDMA. |
+| 9.1.T500 | STARS streams created but `aclrtSynchronizeStream` fails → AICPU exception `0x715002a` → every later kernel launch reports `507018`. **Breaks all a5 comm cases**, not just SDMA. Reconfirmed 2026-07-21 on current `pto_isa.pin` (`83d01313…`): overlay ON → `Created 48 STARS streams OK` → sync fail → `507018` / `0x715002a`. |
 | 9.1.0 (`timestamp=20260625`) | `HcclCommInitRootInfo` returns `HCCL_E_INTERNAL (4)` — base HCCL never comes up. |
 
 `ensure_sdma_workspace` runs inside `comm_alloc_windows` / `alloc_domain`, so
 every communication case flows through it. Leaving it on unconditionally would
 poison the whole a5 comm test surface. The overlay was verified **working** on
-a separate a5 box whose CANN exposes the primitive (`sdma_async_completion_demo`
-passes), so this is an environment issue, not a code defect.
+a separate a5 box whose CANN completes the primitive (`sdma_async_completion_demo`
+passes), so this remains an environment issue, not a simpler code defect.
 
 ## Current state (default OFF)
 
@@ -58,13 +62,16 @@ is ON the a5 onboard host `.so` embeds pto-isa headers, so the same pin /
 metadata / staleness / ccache guard that protects a2a3 onboard applies to a5
 too (#1351); when both are OFF none of it runs.
 
+The pin-resolved checkout path is passed to host CMake as `-DPTO_ISA_ROOT=`
+(from `ensure_pto_isa_root()` / `pto_isa.pin`). It is **not** transported via
+`os.environ["PTO_ISA_ROOT"]` or `$ENV{PTO_ISA_ROOT}` (#1403).
+
 | File / mechanism | What |
 | ---------------- | ---- |
-| `src/a5/platform/onboard/host/CMakeLists.txt` | `option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ... OFF)`; under the option: `PTO_ISA_ROOT` check + pto-isa include. After the option blocks, the shared `SIMPLER_PTO_ISA_BUILD_COMMIT` cache-string → compile-define block bakes the pinned commit into the `host_runtime` ccache key (mirror of the a2a3 block); it is a no-op until an overlay populates the cache var |
+| `src/a5/platform/onboard/host/CMakeLists.txt` | `option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ... OFF)`; under overlay ON: require `-DPTO_ISA_ROOT=` + pto-isa include; `SIMPLER_PTO_ISA_BUILD_COMMIT` cache-bust define |
 | `src/a5/platform/onboard/host/comm_hccl.cpp` | `ensure_sdma_workspace` body under `#ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE` |
-| `simpler_setup/runtime_compiler.py` | `_init_a5` resolves the pinned managed pto-isa checkout via `ensure_pto_isa_root` (same contract as `_init_a2a3`) when the overlay is ON, then `env_manager.ensure("PTO_ISA_ROOT")` |
-| `simpler_setup/runtime_builder.py` (`platform_embeds_pto_isa`) | Single predicate every guard site keys on: a2a3 onboard always, a5 onboard only when the SDMA or URMA overlay is on (`_sdma_workspace_enabled() or _urma_workspace_enabled()`). Drives pin resolution (`_resolve_build_pto_isa_commit`), the `SIMPLER_PTO_ISA_BUILD_COMMIT` stamp, `pto_isa_build.json` metadata write, and load-time staleness validation (`_requires_pto_isa_metadata_validation`) |
-| `simpler_setup/runtime_builder.py` | `_compile_target` forwards the env var to the host CMake define |
+| `simpler_setup/runtime_compiler.py` | `_init_a5` resolves pin into `self.pto_isa_root` when overlay ON (no env export) |
+| `simpler_setup/runtime_builder.py` (`platform_embeds_pto_isa`) | Predicate for pin/metadata/stamp/validation; host compile passes `-DPTO_ISA_ROOT=` + overlay cmake defines |
 | `examples/a5/.../sdma_async_completion_demo/test_sdma_async_completion_demo.py` | `pytest.skip` when env var unset |
 
 ## Developing under the isolation
@@ -73,40 +80,45 @@ too (#1351); when both are OFF none of it runs.
   overlay being off is transparent to these paths.
 - **New SDMA features**: build locally with
   `SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON` (see below) on a box whose CANN
-  supports it. The kernel-side SDMA primitives (`SdmaTget`, `SdmaTput`,
-  `TGET_ASYNC`, `TPUT_ASYNC`) live in pto-isa and are independent of this
-  host-side workspace gate.
-- **Do not** make `ensure_sdma_workspace` unconditional again without
-  confirming the target CANN exposes a working `aclnnShmemSdmaStarsQuery`.
+  **behaviorally** supports it. The kernel-side SDMA primitives (`SdmaTget`,
+  `SdmaTput`, `TGET_ASYNC`, `TPUT_ASYNC`) live in pto-isa and are independent
+  of this host-side workspace gate.
+- **Do not** make `ensure_sdma_workspace` unconditional again without a
+  passing `sdma_async_completion_demo` + non-SDMA allreduce regression on the
+  target CANN.
 
 ## Re-enabling (once CANN is ready)
 
-Verify the primitive first:
+Checklist before flipping anything:
+
+- [x] #1351 resolved (PTO-ISA version guard covers a5 overlays)
+- [ ] CANN **behaviorally** completes `aclnnShmemSdmaStarsQuery` (not just symbols)
+- [ ] Option A verified; only then consider Option B
+
+Symbol probe (opapi — `libascendcl.so` is often 0 and misleading):
 
 ```bash
-nm -D $ASCEND_HOME_PATH/lib64/libascendcl.so | grep -ic SdmaStars   # must be > 0
+nm -D "$ASCEND_HOME_PATH/lib64/libopapi.so" | grep -c SdmaStars   # expect > 0
 ```
 
-**Option A — CI env var only (no code change):**
+**Behavior probe** (must PASS; symbols alone are insufficient):
 
 ```bash
 export SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON
-export PTO_ISA_ROOT=<managed checkout>
-pip install -e .
+# pto_isa.pin → ensure_pto_isa_root() → -DPTO_ISA_ROOT= (no manual export)
+python examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py \
+    -p a5 -d <ids>
+python -m pytest examples/workers/l3/allreduce_distributed/test_allreduce.py \
+    -v --platform a5 --device <ids> -k onephase
 ```
 
-The env-var→CMake-define forwarding and the test skip gate pick it up
-automatically.
-
-**Option B — make SDMA the a5 default** (revert the gating points above):
-flip `option(... OFF)` → `set(... ON)`, make `_init_a5`'s `PTO_ISA_ROOT`
-ensure unconditional (mirror `_init_a2a3`), and remove the test skip gate.
-
-Verify:
+**Option A — CI / local env var only (no default flip):**
 
 ```bash
-python -m pytest examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py \
-    -v --platform a5 --device <ids> -s          # must PASS, not skip
-python -m pytest examples/workers/l3/allreduce_distributed/test_allreduce.py \
-    -v --platform a5 --device <ids> -k onephase  # regression must stay green
+export SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON
+pip install --no-build-isolation -e .
 ```
+
+**Option B — make SDMA the a5 default** (do **not** do this while 9.1.T500-class
+CANN is the CI/default environment): flip `option(... OFF)` → `set(... ON)`,
+make `_init_a5` resolve the pin unconditionally, and remove the demo skip gate.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,20 +55,17 @@ To use a different PTO-ISA revision, update `pto_isa.pin` to the desired
 diff and applies the same revision to install-time runtime builds and run-time
 kernel compilation.
 
-For a2a3 onboard runtimes (and a5 onboard when the SDMA overlay is enabled),
-builds record the actual PTO-ISA git HEAD used for each runtime in
-`build/lib/pto_isa_build.json`. This JSON is artifact
-provenance, not a second configuration source. If the metadata says a
-pre-built runtime was built for an older pin, or a partial rebuild did not
-record that runtime, lookup fails with a stale-binary diagnostic and asks you
-to reinstall or rebuild:
+For platforms that embed PTO-ISA headers into onboard host runtimes (a2a3
+always; a5 when an async workspace overlay is ON), builds record the actual
+PTO-ISA git HEAD used for each runtime in `build/lib/pto_isa_build.json`.
+This JSON is artifact provenance, not a second configuration source. Lookup
+of those runtimes **requires** the metadata file: if it is missing, or if it
+says a pre-built runtime was built for an older pin / omitted that runtime,
+lookup fails with a diagnostic and asks you to reinstall or rebuild:
 
 ```bash
 cat build/lib/pto_isa_build.json
 ```
-
-Existing installs that do not have `build/lib/pto_isa_build.json` continue to
-work; they simply skip this stale-artifact check.
 
 **Troubleshooting:**
 
@@ -76,8 +73,11 @@ work; they simply skip this stale-artifact check.
   `build/pto-isa` on a machine that can access GitHub.
 - If clone fails due to network: try again or manually clone with HTTPS into
   `build/pto-isa`.
-- If runtime lookup reports stale PTO-ISA binaries: rerun `pip install` so
-  `build/lib` is rebuilt for the current `pto_isa.pin`.
+- If runtime lookup reports missing or stale PTO-ISA metadata/binaries: rerun
+  `pip install` so `build/lib` is rebuilt for the current `pto_isa.pin`.
+- Host compile receives the pin-resolved checkout as `-DPTO_ISA_ROOT=` (not
+  via ambient `PTO_ISA_ROOT`); kernel compile uses the same
+  `ensure_pto_isa_root()` path.
 
 Note: for simulation platforms, PTO ISA headers are optional and only needed if
 your kernels use PTO ISA intrinsics.

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -112,17 +112,16 @@ def build_all(
     pto_isa_root_for_metadata: Optional[str] = None
     pto_isa_runtime_keys: list[str] = []
 
-    # Onboard hosts that embed pto-isa headers (a2a3 always; a5 when the SDMA
-    # overlay is opted in) hard-depend on the pinned managed checkout + CANN
-    # aclnn syms. Resolve PTO_ISA_ROOT now so the runtime compiler consumes the
-    # same pin as kernel compilation. Skipped when no embedding platform is
-    # being built (sim-only, or a5 with overlay OFF). See issue #1351.
+    # Onboard hosts that embed pto-isa headers (a2a3 always; a5 when an async
+    # workspace overlay is opted in) hard-depend on the pinned managed
+    # checkout + CANN aclnn syms. Resolve once for metadata recording;
+    # RuntimeBuilder passes the path to CMake as -DPTO_ISA_ROOT= (#1403) —
+    # do not export it via os.environ. Skipped when no embedding platform is
+    # being built (sim-only, or a5 with overlays OFF). See issue #1351.
     if any(platform_embeds_pto_isa(p) for p in platforms):
         from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
-        pto_isa_root = ensure_pto_isa_root(verbose=True)
-        os.environ["PTO_ISA_ROOT"] = pto_isa_root
-        pto_isa_root_for_metadata = pto_isa_root
+        pto_isa_root_for_metadata = ensure_pto_isa_root(verbose=True)
 
     # libsimpler_log.so and libcpu_sim_context.so are process-global (one per
     # host toolchain, not per arch/variant) — build them once before iterating

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -578,7 +578,9 @@ class KernelCompiler:
         cmd = [self.gxx15.cxx_path] + self.gxx15.get_compile_flags(core_type=core_type)
         cmd += self._sanitizer_flags(self.gxx15)
 
-        # Add PTO ISA header paths if provided
+        # Add PTO ISA header paths if provided. The path always comes from
+        # ensure_pto_isa_root(), which has already verified HEAD == pto_isa.pin,
+        # so no per-compile re-check is needed here.
         if pto_isa_root:
             pto_include = os.path.join(pto_isa_root, "include")
             pto_pto_include = os.path.join(pto_isa_root, "include", "pto")

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -179,13 +179,24 @@ def read_pto_isa_build_metadata(lib_dir: Path) -> Optional[dict]:
 
 
 def validate_runtime_pto_isa_current_pin(lib_dir: Path, runtime_key: Optional[str] = None) -> None:
-    """Raise when pre-built runtime binaries do not match the current pin."""
-    metadata = read_pto_isa_build_metadata(lib_dir)
-    if metadata is None:
-        return
+    """Raise when pre-built runtime binaries do not match the current pin.
 
+    Called only for platforms that embed PTO-ISA headers into host runtimes
+    (see :func:`simpler_setup.runtime_builder.platform_embeds_pto_isa`). Missing
+    metadata is a hard failure — silent skip would let a pin bump load a stale
+    ``host_runtime.so``.
+    """
     required_commit = read_pto_isa_pin()
     metadata_path = pto_isa_build_metadata_path(lib_dir)
+    metadata = read_pto_isa_build_metadata(lib_dir)
+    if metadata is None:
+        raise RuntimeError(
+            "Missing PTO-ISA build metadata: "
+            f"current pto_isa.pin requires {required_commit}, but {metadata_path} "
+            "is absent.\n"
+            "Reinstall simpler or rebuild this runtime so build/lib records the pin."
+        )
+
     if metadata.get("schema_version") == 3 and runtime_key is not None:
         artifacts = metadata.get("runtime_artifacts")
         if not isinstance(artifacts, dict):

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -367,6 +367,17 @@ class RuntimeBuilder:
                 defines: dict[str, str] = {}
                 if build_pto_isa_commit:
                     defines["SIMPLER_PTO_ISA_BUILD_COMMIT"] = build_pto_isa_commit
+                # Pin-resolved checkout path for host CMake include dirs (#1403).
+                # Prefer the path already resolved on the RuntimeCompiler; fall
+                # back to ensure_pto_isa_root when embedding but the compiler
+                # field is unset (e.g. mocked UT / partial construction).
+                if self._requires_pto_isa_metadata_validation():
+                    pto_root = getattr(compiler, "pto_isa_root", None)
+                    if not isinstance(pto_root, str) or not pto_root:
+                        from .pto_isa import ensure_pto_isa_root  # noqa: PLC0415
+
+                        pto_root = ensure_pto_isa_root(verbose=True)
+                    defines["PTO_ISA_ROOT"] = pto_root
                 for opt_in_define in (
                     "SIMPLER_ENABLE_PTO_SDMA_WORKSPACE",
                     "SIMPLER_ENABLE_PTO_URMA_WORKSPACE",

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -119,6 +119,10 @@ class RuntimeCompiler:
     def __init__(self, platform: str = "a2a3"):
         self.platform = platform
         self.project_root = PROJECT_ROOT
+        # Pin-resolved pto-isa checkout path when this platform's host embeds
+        # pto-isa headers; None otherwise. Passed to CMake as -DPTO_ISA_ROOT=
+        # by RuntimeBuilder (#1403) — never via os.environ.
+        self.pto_isa_root: Optional[str] = None
 
         # Map platform name to architecture path
         if platform == "a2a3":
@@ -151,13 +155,12 @@ class RuntimeCompiler:
         env_manager.ensure("ASCEND_HOME_PATH")
         # a2a3 onboard host_runtime hard-depends on pto-isa headers + CANN-9.0
         # aclnn syms (cf. src/a2a3/platform/onboard/host/CMakeLists.txt
-        # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE marker). Use the same pinned
-        # managed checkout as kernel compilation and expose it through
-        # PTO_ISA_ROOT for the existing CMake/build_config surface.
+        # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE marker). Resolve the pinned managed
+        # checkout once; RuntimeBuilder passes it to CMake as -DPTO_ISA_ROOT=
+        # (#1403 — do not smuggle via os.environ).
         from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
-        os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(verbose=True)
-        env_manager.ensure("PTO_ISA_ROOT")
+        self.pto_isa_root = ensure_pto_isa_root(verbose=True)
 
         # AICore: Bisheng CCE compiler
         ccec = CCECToolchain(platform="a2a3")
@@ -192,12 +195,12 @@ class RuntimeCompiler:
         # The PTO async workspace overlays (SDMA / URMA) are opt-in until the
         # CI CANN package exposes the required primitives reliably; see #1315.
         # When either is opted in the host build embeds pto-isa headers and
-        # must use the same pinned managed checkout as a2a3 (#1351).
+        # must use the same pinned managed checkout as a2a3 (#1351). Path is
+        # stored for RuntimeBuilder to pass as -DPTO_ISA_ROOT= (#1403).
         if _sdma_workspace_enabled() or _urma_workspace_enabled():
             from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
-            os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(verbose=True)
-            env_manager.ensure("PTO_ISA_ROOT")
+            self.pto_isa_root = ensure_pto_isa_root(verbose=True)
 
         # AICore: Bisheng CCE compiler with A5 platform
         ccec = CCECToolchain(platform="a5")

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -36,7 +36,31 @@ from .pto_isa import ensure_pto_isa_root
 
 logger = logging.getLogger(__name__)
 
-_compile_cache: dict[tuple[str, str, str], object] = {}
+_compile_cache: dict[tuple, object] = {}
+
+
+def _pto_isa_compile_cache_token() -> str:
+    """Pin SHA included in session compile-cache keys.
+
+    ``ensure_pto_isa_root()`` always resolves the managed checkout, but the
+    session cache previously keyed only on (qualname, platform, runtime). A
+    mid-session pin bump could then reuse kernels built against the old ISA.
+    """
+    from .pto_isa import read_pto_isa_pin  # noqa: PLC0415
+
+    return read_pto_isa_pin()
+
+
+def l3_compile_cache_key(qualname: str, name: str, platform: str, runtime: str) -> tuple:
+    """Session compile-cache key for an L3 orchestration entry.
+
+    Every L3 compile path (scene-test ``test_run``, standalone worker, the
+    ``st_worker`` pytest fixture) keys ``_compile_cache`` through here so they
+    share one entry per orchestration; a divergent key format recompiles the
+    same kernels once per path. The pin token pins the key to the current
+    pto-isa revision.
+    """
+    return (qualname, name, platform, runtime, _pto_isa_compile_cache_token())
 
 
 def clear_compile_cache() -> None:
@@ -958,7 +982,7 @@ class SceneTestCase:
     @classmethod
     def compile_chip_callable(cls, platform):
         """Compile CALLABLE -> ChipCallable (L2). Session-cached."""
-        cache_key = (cls.__qualname__, platform, cls._st_runtime)
+        cache_key = (cls.__qualname__, platform, cls._st_runtime, _pto_isa_compile_cache_token())
         return _compile_chip_callable_from_spec(cls.CALLABLE, platform, cls._st_runtime, cache_key)
 
     @classmethod
@@ -968,7 +992,7 @@ class SceneTestCase:
         for entry in cls.CALLABLE["callables"]:
             if "orchestration" in entry:
                 name = entry["name"]
-                cache_key = (cls.__qualname__, name, platform, cls._st_runtime)
+                cache_key = l3_compile_cache_key(cls.__qualname__, name, platform, cls._st_runtime)
                 chip = _compile_chip_callable_from_spec(entry, platform, cls._st_runtime, cache_key)
                 compiled[name] = chip
                 compiled[f"{name}_sig"] = entry["orchestration"].get("signature", [])
@@ -1524,7 +1548,9 @@ class SceneTestCase:
                     f"  {_san.preload_command(_san_tokens, args.platform)} python {module_name} ..."
                 )
 
-        os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(verbose=True)
+        # Eager pin checkout for kernel/orchestration compiles that pass
+        # pto_isa_root explicitly. Do not export PTO_ISA_ROOT (#1403).
+        ensure_pto_isa_root(verbose=True)
 
         if args.rounds > 1 and args.enable_l2_swimlane:
             logger.warning("Profiling disabled: --rounds > 1")
@@ -1935,7 +1961,7 @@ def _create_standalone_worker(group, level, args, selected_by_cls):
                 cls_sub_handles[entry["name"]] = handle
             elif "orchestration" in entry:
                 name = entry["name"]
-                cache_key = (cls.__qualname__, name, args.platform, cls._st_runtime)
+                cache_key = l3_compile_cache_key(cls.__qualname__, name, args.platform, cls._st_runtime)
                 chip = _compile_chip_callable_from_spec(entry, args.platform, cls._st_runtime, cache_key)
                 handle = worker.register(chip)
                 cls_chip_handles[name] = handle

--- a/simpler_setup/tools/l0_swimlane.py
+++ b/simpler_setup/tools/l0_swimlane.py
@@ -821,7 +821,11 @@ if(NOT DEFINED ENV{{ASCEND_HOME_PATH}})
 endif()
 set(ASCEND_HOME_PATH $ENV{{ASCEND_HOME_PATH}})
 set(SOC_VERSION {cfg["soc"]} CACHE STRING "Simulator SoC version")
-set(PTO_ISA_ROOT $ENV{{PTO_ISA_ROOT}} CACHE PATH "PTO ISA root")
+# Passed by the Python driver as -DPTO_ISA_ROOT= (pin-resolved); never $ENV (#1403).
+set(PTO_ISA_ROOT "" CACHE PATH "PTO ISA root")
+if(NOT PTO_ISA_ROOT)
+    message(FATAL_ERROR "PTO_ISA_ROOT must be passed as -DPTO_ISA_ROOT=<pin-resolved path>")
+endif()
 set(REPO_ROOT $ENV{{REPO_ROOT}} CACHE PATH "simpler repo root")
 
 add_compile_options(
@@ -883,20 +887,21 @@ target_link_libraries(replay_host PRIVATE
 """
 
 
-def emit_run_collect(cfg) -> str:
-    # Plain string (bash uses ${} braces) — substitute the SoC default via token.
-    return _RUN_COLLECT_TEMPLATE.replace("__SOC_DEFAULT__", cfg["soc"])
+def emit_run_collect(cfg, pto_isa_root: str) -> str:
+    # Plain string (bash uses ${} braces) — bake SoC default and the
+    # pin-resolved pto-isa path via tokens (no ambient PTO_ISA_ROOT env #1403).
+    return _RUN_COLLECT_TEMPLATE.replace("__SOC_DEFAULT__", cfg["soc"]).replace("__PTO_ISA_ROOT__", pto_isa_root)
 
 
 _RUN_COLLECT_TEMPLATE = """\
 #!/usr/bin/env bash
 set -euo pipefail
 : "${CANN_HOME:?CANN_HOME must be set}"
-: "${PTO_ISA_ROOT:?PTO_ISA_ROOT must be set}"
 : "${REPO_ROOT:?REPO_ROOT must be set}"
 
 WS="${WS:-$(dirname "$(readlink -f "$0")")}"
 SOC_VERSION="${SOC_VERSION:-__SOC_DEFAULT__}"
+PTO_ISA_ROOT="__PTO_ISA_ROOT__"
 DEVICE_ID="${TARGET_DEVICE_ID:-${NPU_LOCKED_DEVICE:-0}}"
 BUILD_DIR="$WS/build"
 COLLECT_DIR="$WS/msprof_collect"
@@ -941,6 +946,7 @@ def generate_workspace(  # noqa: PLR0913
     name: str,
     tensor_count: int,
     args,
+    pto_isa_root: str,
     debug: bool = False,
     block_num: int = 1,
 ):
@@ -954,7 +960,7 @@ def generate_workspace(  # noqa: PLR0913
     (ws / "replay_host.cpp").write_text(emit_replay_host(tensor_count, args, block_num))
     (ws / "CMakeLists.txt").write_text(emit_cmakelists(arch, name, cfg, debug))
     rc = ws / "run_collect.sh"
-    rc.write_text(emit_run_collect(cfg))
+    rc.write_text(emit_run_collect(cfg, pto_isa_root))
     rc.chmod(0o755)
 
 
@@ -969,11 +975,10 @@ def _build_env():
     env["ASCEND_HOME_PATH"] = cann
     env["CANN_HOME"] = cann
     env["REPO_ROOT"] = str(PROJECT_ROOT)
-    env["PTO_ISA_ROOT"] = ensure_pto_isa_root(verbose=True)
     return env
 
 
-def smoke_build(ws: Path, env, cfg):
+def smoke_build(ws: Path, env, cfg, pto_isa_root: str):
     build = ws / "build"
     build.mkdir(exist_ok=True)
     subprocess.run(
@@ -986,7 +991,7 @@ def smoke_build(ws: Path, env, cfg):
             "-B",
             str(build),
             f"-DSOC_VERSION={cfg['soc']}",
-            f"-DPTO_ISA_ROOT={env['PTO_ISA_ROOT']}",
+            f"-DPTO_ISA_ROOT={pto_isa_root}",
             f"-DREPO_ROOT={env['REPO_ROOT']}",
         ],
         cwd=str(ws),
@@ -1157,8 +1162,8 @@ def collect(ws: Path, env, max_time: int, device=None, dest_name: str = "trace.j
             "--max-time",
             str(max_time),
             "--run",
-            f"CANN_HOME={env['CANN_HOME']} PTO_ISA_ROOT={env['PTO_ISA_ROOT']} "
-            f"REPO_ROOT={env['REPO_ROOT']} TARGET_DEVICE_ID=$TASK_DEVICE "
+            f"CANN_HOME={env['CANN_HOME']} REPO_ROOT={env['REPO_ROOT']} "
+            f"TARGET_DEVICE_ID=$TASK_DEVICE "
             f"bash {ws}/run_collect.sh",
         ]
     else:
@@ -1403,6 +1408,10 @@ def main():
     label = f"{class_name}_{case}_{args.platform}_{name}_mix{mix_tag}"
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     ws = PROJECT_ROOT / "outputs" / f"l0_swimlane_{label}_{ts}"
+    # Pin-resolved checkout, threaded by value into the workspace generator (bakes
+    # it into run_collect.sh) and smoke_build (-DPTO_ISA_ROOT=). Never exported
+    # into the subprocess environment — CMakeLists does not read $ENV (#1403).
+    pto_isa_root = ensure_pto_isa_root(verbose=True)
     generate_workspace(
         ws,
         arch,
@@ -1411,13 +1420,14 @@ def main():
         name,
         tensor_count,
         kargs,
+        pto_isa_root,
         debug=args.debug_line,
         block_num=block_num,
     )
     print(f"[l0_swimlane] workspace: {ws}")
 
     env = _build_env()
-    smoke_build(ws, env, cfg)
+    smoke_build(ws, env, cfg, pto_isa_root)
     if args.no_collect:
         print(f"[l0_swimlane] --no-collect: stopping after smoke build.\n  {ws}")
         return

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -40,12 +40,14 @@ endif()
 # refactored away, the macro is forced ON: PTO_ISA_ROOT and CANN 9.0+ are
 # hard build/runtime preconditions for a2a3 onboard.
 set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ON)
-if(NOT DEFINED ENV{PTO_ISA_ROOT})
+# Pin-resolved checkout path is passed by RuntimeBuilder as -DPTO_ISA_ROOT=
+# (#1403). Do not read $ENV{PTO_ISA_ROOT} — ambient exports are not the pin.
+if(NOT PTO_ISA_ROOT)
     message(FATAL_ERROR
-        "a2a3 onboard host_runtime requires PTO_ISA_ROOT "
+        "a2a3 onboard host_runtime requires -DPTO_ISA_ROOT=<pin-resolved path> "
         "(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE is forced ON; needs pto-isa headers + CANN 9.0+)")
 endif()
-list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
+list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${PTO_ISA_ROOT}/include")
 
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS
 set(HOST_RUNTIME_SOURCES "")

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -52,12 +52,14 @@ if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE AND SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
         "because CommContext exposes a single workSpace/workSpaceSize pair")
 endif()
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE OR SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
-    if(NOT DEFINED ENV{PTO_ISA_ROOT})
+    # Pin-resolved checkout path is passed by RuntimeBuilder as -DPTO_ISA_ROOT=
+    # (#1403). Do not read $ENV{PTO_ISA_ROOT} — ambient exports are not the pin.
+    if(NOT PTO_ISA_ROOT)
         message(FATAL_ERROR
-            "a5 onboard host_runtime PTO async workspace overlays require PTO_ISA_ROOT "
-            "(needs pto-isa host headers)")
+            "a5 onboard host_runtime PTO async workspace overlays require "
+            "-DPTO_ISA_ROOT=<pin-resolved path> (needs pto-isa host headers)")
     endif()
-    list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
+    list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${PTO_ISA_ROOT}/include")
 endif()
 
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS

--- a/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
+++ b/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
@@ -239,7 +239,7 @@ def _build_chip_callable(platform: str, case: dict) -> ChipCallable:
     pto_isa_root = None
     if case["kernel"] is not None or not platform.endswith("sim"):
         pto_isa_root = ensure_pto_isa_root()
-        os.environ["PTO_ISA_ROOT"] = pto_isa_root
+        # Path is passed explicitly to KernelCompiler; do not export (#1403).
 
     children = []
     if case["kernel"] is not None:

--- a/tests/ut/py/test_pto_isa.py
+++ b/tests/ut/py/test_pto_isa.py
@@ -341,3 +341,10 @@ def test_validate_runtime_pto_isa_current_pin_accepts_legacy_global_metadata(tmp
     monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
 
     pto_isa.validate_runtime_pto_isa_current_pin(tmp_path, runtime_key=RUNTIME_A)
+
+
+def test_validate_runtime_pto_isa_current_pin_rejects_missing_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
+
+    with pytest.raises(RuntimeError, match="Missing PTO-ISA build metadata"):
+        pto_isa.validate_runtime_pto_isa_current_pin(tmp_path, runtime_key=RUNTIME_A)

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -367,7 +367,10 @@ class TestRuntimeBuilderGetBinaries:
 
         host_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "host")
         non_host_calls = [call for call in mock_instance.compile.call_args_list if call.args[0] != "host"]
-        assert host_call.kwargs["cmake_defines"] == {"SIMPLER_PTO_ISA_BUILD_COMMIT": pin}
+        assert host_call.kwargs["cmake_defines"] == {
+            "PTO_ISA_ROOT": "/tmp/pto-isa",
+            "SIMPLER_PTO_ISA_BUILD_COMMIT": pin,
+        }
         assert all(call.kwargs["cmake_defines"] is None for call in non_host_calls)
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
@@ -419,6 +422,7 @@ class TestRuntimeBuilderGetBinaries:
         host_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "host")
         assert host_call.kwargs["cmake_defines"]["SIMPLER_PTO_ISA_BUILD_COMMIT"] == pin
         assert host_call.kwargs["cmake_defines"]["SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"] == "ON"
+        assert host_call.kwargs["cmake_defines"]["PTO_ISA_ROOT"] == "/tmp/pto-isa"
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_a5_overlay_off_direct_build_does_not_write_pto_isa_metadata(self, MockCompiler, tmp_path, monkeypatch):

--- a/tests/ut/py/test_scene_test_cache.py
+++ b/tests/ut/py/test_scene_test_cache.py
@@ -25,7 +25,7 @@ from _task_interface import ArgDirection, ChipCallable  # pyright: ignore[report
 # ``simpler_setup/__init__.py`` re-exports the ``scene_test`` *decorator*,
 # which shadows the submodule attribute when accessed via ``simpler_setup``.
 # Importing the names directly from the submodule avoids that ambiguity.
-from simpler_setup.scene_test import _compile_cache, clear_compile_cache
+from simpler_setup.scene_test import _compile_cache, _pto_isa_compile_cache_token, clear_compile_cache
 
 
 def _build_chip_callable(tag: str) -> ChipCallable:
@@ -49,9 +49,19 @@ def test_clear_compile_cache_drops_cached_chip_callables():
     """
     _compile_cache.clear()
     for i in range(3):
-        _compile_cache[("t", "plat", f"rt{i}")] = _build_chip_callable(f"n{i}")
+        _compile_cache[("t", "plat", f"rt{i}", "pin")] = _build_chip_callable(f"n{i}")
     assert len(_compile_cache) == 3
 
     clear_compile_cache()
 
     assert _compile_cache == {}
+
+
+def test_pto_isa_compile_cache_token_tracks_pin(monkeypatch):
+    """Session cache keys must change when pto_isa.pin changes."""
+    pin_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    pin_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    monkeypatch.setattr("simpler_setup.pto_isa.read_pto_isa_pin", lambda: pin_a)
+    assert _pto_isa_compile_cache_token() == pin_a
+    monkeypatch.setattr("simpler_setup.pto_isa.read_pto_isa_pin", lambda: pin_b)
+    assert _pto_isa_compile_cache_token() == pin_b


### PR DESCRIPTION
## Summary
- Stop smuggling the managed pto-isa checkout through `os.environ["PTO_ISA_ROOT"]` / `$ENV{PTO_ISA_ROOT}`. `ensure_pto_isa_root()` remains the pin source of truth; host CMake gets `-DPTO_ISA_ROOT=` (a2a3 always; a5 when an async overlay is ON).
- Drop ambient env exports in `runtime_compiler`, `build_runtimes`, `conftest`, `scene_test`, `runtime_fatal_codes`, and bake the path in `l0_swimlane`.
- Update `docs/a5-sdma-overlay.md` with the 2026-07-21 CANN 9.1.T500 repro (`libopapi.so` probe, `507018` / `0x715002a`), mark #1351 done, and keep SDMA default OFF (no Option B on broken CANN).

Fixes #1403
Related to #1315