### PR TITLE
Support: label false predicated dispatches in L2 swimlanes

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -50,16 +50,24 @@ available.
   / `dispatch` / `release` / `dummy` / `early_dispatch`), one logical
   **inner** phase (`resolve`, parent = Complete or Dummy) rendered on a
   sibling scheduler sub-lane with the same `Sched_N` label and adjacent tid,
-  and one **separate-lane**
-  phase (`dummy_task`, sampled immediately before `on_task_complete()` begins
-  dependency resolution and rendered as a synthetic 0.02 us marker on Worker
-  View AICPU_N rather than on the sched lane). It is emitted by both a2a3
-  runtimes and by a5 `tensormap_and_ringbuffer`; a5 `host_build_graph` has no
-  dummy-task phase path. Idle iterations no longer emit a record on a2a3; the
-  host tooling reconstructs idle spans from the gap between
-  consecutive work records on the same thread. See §3.2 for the
-  full per-phase table. Legacy captures may carry `scan` / `poll` /
-  `idle` / `fanout` / `prestage` — current a2a3 builds no longer
+  and two **separate-lane**
+  phases (`dummy_task` and `predicated_skip`, sampled immediately before
+  `on_task_complete()` begins dependency resolution and rendered as synthetic
+  0.02 us markers on Worker View AICPU_N rather than on the sched lane).
+  `predicated_skip` identifies a real task whose dispatch predicate evaluated
+  false. Its marker uses the task's ordinary function name and carries
+  `predicated_pass: false` in its Perfetto arguments; a predicate that evaluates
+  true follows the ordinary task timing path with no special argument. The
+  source `predicated_skip` phase remains in `l2_swimlane_records.json` and is
+  not copied into the merged Worker View event's arguments.
+  `dummy_task` is emitted by both a2a3 runtimes and by a5
+  `tensormap_and_ringbuffer`; `predicated_skip` is emitted by the a2a3 and a5
+  `tensormap_and_ringbuffer` runtimes, where predicated dispatch is
+  implemented. a5 `host_build_graph` has no dummy-task phase path. Idle
+  iterations no longer emit a record on a2a3; the host tooling reconstructs
+  idle spans from the gap between consecutive work records on the same thread.
+  See §3.2 for the full per-phase table. Legacy captures may carry `scan` /
+  `poll` / `idle` / `fanout` / `prestage` — current a2a3 builds no longer
   emit them (PR #1079's Scan/Poll debug overlay was removed;
   Fanout was renamed Resolve and now also filters out <1 µs walks;
   Prestage was renamed EarlyDispatch).
@@ -233,14 +241,14 @@ Phase records (per scheduler thread, level >= 3 for
 | `start_time_us` / `end_time_us` | Phase start / end timestamps in microseconds (reader-side cycle→µs conversion) |
 | `phase` | Lowercase phase name. Scheduler: see the table below. Orchestrator: `orch_submit` — one record per `submit_task()` / `alloc_tensors()` call spanning its full `[start, end]` window. Legacy per-sub-step strings (`orch_sync` / `orch_alloc` / `orch_params` / `orch_lookup` / `orch_insert` / `orch_fanin`) may appear in old captures. |
 | `loop_iter` (scheduler) / `submit_idx` (orchestrator) | Iteration / submit-call counter for the producing thread |
-| `tasks_processed` (scheduler) | Number of tasks or blocks handled by the phase; `dummy_task` records one task |
-| `task_id` | Full runtime task id on orchestrator records and scheduler `dummy_task` records |
+| `tasks_processed` (scheduler) | Number of tasks or blocks handled by the phase; `dummy_task` and `predicated_skip` record one task |
+| `task_id` | Full runtime task id on orchestrator records and scheduler `dummy_task` / `predicated_skip` records |
 | `pop_hit` / `pop_miss` (dispatch only) | Ready-queue pop deltas since the previous dispatch emit |
 
 The raw scheduler record has a phase-tagged union: `dispatch` stores
-`pop_hit` / `pop_miss`, while `dummy_task` stores the 32-bit `local_id` and
-`ring_id` components of its full task id. The Host collector reconstructs the
-`task_id` JSON field.
+`pop_hit` / `pop_miss`, while `dummy_task` and `predicated_skip` store the
+32-bit `local_id` and `ring_id` components of their full task id. The Host
+collector reconstructs the `task_id` JSON field.
 
 Scheduler phase taxonomy — three role classes share one `phase`
 field but render differently in Perfetto:
@@ -251,10 +259,11 @@ field but render differently in Perfetto:
 | `async_poll` | outer | sched | async-wait (SDMA/RoCE/URMA/CCU) subtasks completed this iter; split from `complete` |
 | `dispatch` | outer | sched | subtasks published this iter |
 | `release` | outer | sched | deferred-release slots drained this iter |
-| `dummy` | outer | sched | dummies handled by `dummy_drain` this iter |
+| `dummy` | outer | sched | `dummy_ready_queue` entries handled this iter (explicit dummies and false-predicate tasks) |
 | `early_dispatch` | outer | sched | blocks staged by speculative early-dispatch this pass |
 | `resolve` | inner | sched sub-lane, same `Sched_N` label as its outer lane | consumers visited in `on_task_complete` |
 | `dummy_task` | separate-lane | Worker View AICPU_N (pid=4) | one dummy entering `on_task_complete()`; full identity is in `task_id` |
+| `predicated_skip` | separate-lane | Worker View AICPU_N (pid=4) | one real task retired inline after its dispatch predicate evaluated false; full identity is in `task_id` |
 
 Fanin/fanout wiring is not a scheduler phase: it runs on the
 orchestrator submit path, so it has no swimlane lane. Read its cost
@@ -321,14 +330,16 @@ in. The trace contains:
 - **Worker View** (pid=4) — one swim-lane per physical worker:
   - `AIC_N` — matrix cores (receive → kernel end from level >= 1)
   - `AIV_N` — vector cores (receive → kernel end from level >= 1)
-  - `AICPU_N` — AICPU acting as worker; carries `dummy_task`
-    0.02 us pre-resolve markers (one per dummy entering
-    `on_task_complete()` on AICPU N) and `alloc` bars (from `alloc_tensors()`
-    calls inline-completed by the dedicated orchestrator on the last
-    AICPU runtime thread).
+  - `AICPU_N` — AICPU acting as worker; carries `dummy(...)` markers and
+    ordinary task-named markers with `predicated_pass: false` in their Perfetto
+    arguments. These 0.02 us pre-resolve markers represent one dependency-only
+    completion entering `on_task_complete()` on AICPU N. It also carries
+    `alloc` bars
+    (from `alloc_tensors()` calls inline-completed by the dedicated
+    orchestrator on the last AICPU runtime thread).
     Both are activities the AICPU performs as a worker, so they
     share the same lane tier as AIC/AIV. When `deps.json` is joined,
-    dependency arrows involving dummy/alloc DAG nodes anchor on these
+    dependency arrows involving dummy/predicated-skip/alloc DAG nodes anchor on these
     AICPU worker slices. The converter identifies dummy nodes from
     `deps.json` before consulting runtime timing records. If a dummy's
     scheduler record is missing, it warns and omits that Worker View bar

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -671,6 +671,16 @@ def resolve_func_id_from_kernel_map(task_id, core_type, kernel_map):
     return -1
 
 
+def resolve_task_func_id_from_kernel_map(task_id, kernel_map):
+    """Look up the first active ``func_id`` for a task without an AICore row."""
+    if kernel_map is None or task_id is None:
+        return -1
+    kids = kernel_map.get(int(task_id))
+    if not kids:
+        return -1
+    return next((func_id for func_id in kids if func_id >= 0), -1)
+
+
 def load_kernel_config(config_path):
     """Load kernel configuration from kernel_config.py file.
 
@@ -1480,10 +1490,9 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     continue
                 finishes_per_complete[id(t_comp)] += 1
 
-        # Dummy task X event width — start/end on the device coincide
-        # (identification is a single MSR read); render as a 0.02 µs sliver
-        # so Perfetto picks it up instead of collapsing it to a hairline.
-        DUMMY_BAR_MIN_DUR_US = 0.02  # noqa: N806
+        # AICPU worker-marker width — start/end on the device coincide; render
+        # as a 0.02 us sliver so Perfetto does not collapse it to a hairline.
+        AICPU_WORKER_MARKER_MIN_DUR_US = 0.02  # noqa: N806
 
         for thread_idx, thread_records in enumerate(scheduler_phases):
             tid = sched_lane_tid(thread_idx, 0)
@@ -1517,30 +1526,43 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             # that retired nothing; release = on_task_release drain). Genuine
             # spin emits no record and shows as a blank gap.
             #
-            # `dummy_task` is special: it does NOT live on the sched track —
-            # it represents a DAG fence node briefly inhabiting the AICPU as a
-            # virtual worker, so we route it to Worker View (pid=4) AICPU_N
-            # (where N = the AICPU id of the sched thread that drained it).
+            # Dependency-only task markers do NOT live on the sched track —
+            # they represent DAG nodes briefly inhabiting the AICPU as a
+            # virtual worker, so we route them to Worker View (pid=4) AICPU_N
+            # (where N = the AICPU id of the sched thread that drained them).
             for record in thread_records:
                 phase = record.get("phase", "unknown")
-                if phase == "dummy_task":
+                if phase in ("dummy_task", "predicated_skip"):
                     start_us = record["start_time_us"]
                     end_us = record["end_time_us"]
-                    dur = max(end_us - start_us, DUMMY_BAR_MIN_DUR_US)
+                    dur = max(end_us - start_us, AICPU_WORKER_MARKER_MIN_DUR_US)
                     task_id = normalize_pto2_task_id_int(record.get("task_id"))
                     task_label = format_task_display(task_id) if task_id is not None else "unknown"
+                    if phase == "dummy_task":
+                        event_name = f"dummy({task_label})"
+                    else:
+                        func_id = resolve_task_func_id_from_kernel_map(task_id, deps_kernel_map)
+                        event_name = _task_display_name(
+                            func_id,
+                            func_id_to_name,
+                            task_label,
+                            spmd=task_id in spmd_task_ids,
+                        )
+                    event_args = {
+                        "loop_iter": record.get("loop_iter", 0),
+                        "task_id": task_id,
+                        "event-hint": event_name,
+                    }
+                    if phase == "dummy_task":
+                        event_args["phase"] = phase
+                    else:
+                        event_args["predicated_pass"] = False
                     events.append(
                         {
-                            "args": {
-                                "phase": "dummy_task",
-                                "loop_iter": record.get("loop_iter", 0),
-                                "task_id": task_id,
-                                "event-hint": f"dummy({task_label})",
-                            },
+                            "args": event_args,
                             "cat": "event",
-                            "cname": "grey",
                             "id": event_id,
-                            "name": f"dummy({task_label})",
+                            "name": event_name,
                             "ph": "X",
                             "pid": 4,
                             "tid": AICPU_TID_BASE + thread_idx,
@@ -1729,13 +1751,18 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         # identity source when a runtime timing record is missing.
         regular_task_ids = {int(t.get("task_id", -1)) for t in tasks}
         dummy_task_ids = set()
+        predicated_skip_task_ids = set()
         if scheduler_phases:
             for thread_records in scheduler_phases:
                 for rec in thread_records:
-                    if rec.get("phase") == "dummy_task":
+                    phase = rec.get("phase")
+                    if phase in ("dummy_task", "predicated_skip"):
                         task_id = normalize_pto2_task_id_int(rec.get("task_id"))
                         if task_id is not None:
-                            dummy_task_ids.add(task_id)
+                            if phase == "dummy_task":
+                                dummy_task_ids.add(task_id)
+                            else:
+                                predicated_skip_task_ids.add(task_id)
         deps_dummy_task_ids = {
             task_id
             for task_id, kernel_ids in (deps_kernel_map or {}).items()
@@ -1793,7 +1820,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     else:
                         is_regular = task_id in regular_task_ids
                         is_dummy = task_id in dummy_task_ids
-                    if not is_regular and not is_dummy:
+                    is_predicated_skip = task_id in predicated_skip_task_ids
+                    if not is_regular and not is_dummy and not is_predicated_skip:
                         events.append(
                             {
                                 "args": {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1182,11 +1182,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
 #if SIMPLER_DFX
-            // Dummy outer phase: covers handling of all dummies popped this
-            // iter. Per-dummy DummyTask markers are emitted to a SEPARATE lane
-            // (Worker View AICPU_N) by the converter, so they do not nest
-            // under this bar. Resolve emits below DO land on the sched lane
-            // and nest under this Dummy outer by time containment.
+            // Dummy outer phase: covers all dependency-only items popped this
+            // iter. Per-item identity markers are emitted to a SEPARATE lane
+            // (Worker View AICPU_N) by the converter, so they do not nest under
+            // this bar. Resolve emits below DO land on the sched lane and nest
+            // under this Dummy outer by time containment.
             uint64_t dummy_outer_t0 =
                 (dummy_got > 0 && l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
 #endif
@@ -1219,15 +1219,22 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                             sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_consumers
                         );
                     }
-                    l2_swimlane_aicpu_record_dummy_task(
-                        thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
-                        dummy_slot.task->task_id.raw
-                    );
+                    if (dummy_slot.active_mask.has_predicate()) {
+                        l2_swimlane_aicpu_record_predicated_skip(
+                            thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                            dummy_slot.task->task_id.raw
+                        );
+                    } else {
+                        l2_swimlane_aicpu_record_dummy_task(
+                            thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                            dummy_slot.task->task_id.raw
+                        );
+                    }
                 }
 #endif
-                // Dummy tasks have no subtasks to retire and no fanout pre-conditions
-                // beyond their own producers; release self-reference so the slot can
-                // reach CONSUMED once all consumers drain.
+                // Dependency-only completions have no dispatched subtasks to retire
+                // and no fanout pre-conditions beyond their own producers; release
+                // self-reference so the slot can reach CONSUMED once all consumers drain.
                 deferred_release_slot_states[deferred_release_count++] = &dummy_slot;
                 if (deferred_release_count >= PTO2_DEFERRED_RELEASE_CAP) {
                     while (deferred_release_count > 0) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1028,10 +1028,17 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 #if SIMPLER_DFX
                 if (dummy_resolve_t0 != 0) {
-                    l2_swimlane_aicpu_record_dummy_task(
-                        thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
-                        dummy_slot.task->task_id.raw
-                    );
+                    if (dummy_slot.active_mask.has_predicate()) {
+                        l2_swimlane_aicpu_record_predicated_skip(
+                            thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                            dummy_slot.task->task_id.raw
+                        );
+                    } else {
+                        l2_swimlane_aicpu_record_dummy_task(
+                            thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
+                            dummy_slot.task->task_id.raw
+                        );
+                    }
                 }
 #endif
                 // Dummy tasks have no subtasks to retire and no fanout pre-conditions

--- a/src/common/platform/include/aicpu/l2_swimlane_collector_aicpu.h
+++ b/src/common/platform/include/aicpu/l2_swimlane_collector_aicpu.h
@@ -194,7 +194,7 @@ void l2_swimlane_aicpu_init_phase(int worker_count, int num_sched_phase_threads,
  * record's corresponding slot is zero-filled).
  *
  * @param thread_idx       Scheduler thread index
- * @param kind             Scheduler phase kind; DummyTask uses l2_swimlane_aicpu_record_dummy_task
+ * @param kind             Scheduler phase kind; separate-lane task markers use their dedicated record helpers
  * @param start_time       Phase start timestamp
  * @param end_time         Phase end timestamp
  * @param loop_iter        Current scheduler-loop iteration number
@@ -221,6 +221,18 @@ void l2_swimlane_aicpu_record_sched_phase(
  * @param task_id        Full PTO2 task identity
  */
 void l2_swimlane_aicpu_record_dummy_task(int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id);
+
+/**
+ * Record the completion point of one task skipped by a false dispatch predicate.
+ *
+ * @param thread_idx     Scheduler thread that completed the task
+ * @param complete_time  Timestamp sampled immediately before completion propagation
+ * @param loop_iter      Current scheduler-loop iteration number
+ * @param task_id        Full PTO2 task identity
+ */
+void l2_swimlane_aicpu_record_predicated_skip(
+    int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id
+);
 
 /**
  * Set orchestrator thread index for per-task phase recording

--- a/src/common/platform/include/common/l2_swimlane_profiling.h
+++ b/src/common/platform/include/common/l2_swimlane_profiling.h
@@ -495,10 +495,10 @@ static_assert(sizeof(L2SwimlaneDataHeader) % 64 == 0, "L2SwimlaneDataHeader must
  *     FIN-observation sites that call on_task_complete.
  *
  *   SEPARATE-LANE (converter routes to Worker View pid=4, not the sched lane):
- *     DummyTask. One zero-width marker per dummy so the DAG node is visually
- *     present on its handling AICPU's lane; the surrounding Dummy outer bar
- *     (sched lane) carries the actual drain time, and Resolve inside that
- *     bar carries the consumer-release work.
+ *     DummyTask and PredicatedSkip. One zero-width marker per dependency-only
+ *     completion keeps the DAG node visible on its handling AICPU's lane; the
+ *     surrounding Dummy outer bar (sched lane) carries the actual drain time,
+ *     and Resolve inside that bar carries the consumer-release work.
  */
 enum class L2SwimlaneSchedPhaseKind : uint32_t {
     // Outer
@@ -509,8 +509,9 @@ enum class L2SwimlaneSchedPhaseKind : uint32_t {
                         // tasks_processed = subtasks published this iter.
     Release = 2,        // Deferred-release drain (on_task_release work).
                         // tasks_processed = slots released this iter.
-    Dummy = 4,          // dummy_drain outer bar: covers handling of all dummies
-                        // popped this iter. tasks_processed = dummy_got count.
+    Dummy = 4,          // dummy_drain outer bar: covers explicit dummies and
+                        // false-predicate tasks popped this iter.
+                        // tasks_processed = dummy_got count.
     EarlyDispatch = 5,  // try_early_dispatch: early-dispatch pre-staging
                         // of a flagged producer's consumer's gated blocks.
                         // tasks_processed = blocks staged this pass.
@@ -534,6 +535,10 @@ enum class L2SwimlaneSchedPhaseKind : uint32_t {
     // so async-engine (SDMA/RoCE/URMA/CCU) wait time is attributed to its own
     // bar. tasks_processed = async subtasks completed this iter.
     AsyncPoll = 11,
+    // Separate-lane (Worker View pid=4 AICPU_N)
+    PredicatedSkip = 12,  // Per-task marker for a real task retired inline because
+                          // its dispatch predicate evaluated false. Uses the same
+                          // phase_data.dummy_task identity payload as DummyTask.
 };
 
 /** Index layout of the queue-depth snapshot arrays below: AIC=0, AIV=1, MIX=2.
@@ -547,8 +552,8 @@ constexpr int L2SWIMLANE_NUM_QUEUE_SHAPES = 3;
  * Position in the per-thread buffer is the identity — no thread_id field.
  *
  * phase_data is tagged by kind: Dispatch uses its ready-queue counters and
- * DummyTask uses the local/ring components of the full task id. Other kinds
- * store zero in the Dispatch view.
+ * DummyTask and PredicatedSkip use the local/ring components of the full task
+ * id. Other kinds store zero in the Dispatch view.
  *
  * Queue-depth snapshots (shared_depth_*) record the per-shape scheduler ready
  * queue occupancy at phase boundaries. They surface the dep-release-then-

--- a/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
@@ -961,15 +961,27 @@ void l2_swimlane_aicpu_record_sched_phase(
     record->phase_data.dispatch.pop_miss = pop_miss;
 }
 
-void l2_swimlane_aicpu_record_dummy_task(int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id) {
+static void record_aicpu_worker_task(
+    int thread_idx, L2SwimlaneSchedPhaseKind kind, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id
+) {
     auto *record = acquire_sched_phase_record(thread_idx);
     if (record == nullptr) return;
     fill_sched_phase_record(
-        record, L2SwimlaneSchedPhaseKind::DummyTask, complete_time, complete_time, loop_iter,
-        /*tasks_processed=*/1, /*shared_at_start=*/nullptr, /*shared_at_end=*/nullptr
+        record, kind, complete_time, complete_time, loop_iter, /*tasks_processed=*/1, /*shared_at_start=*/nullptr,
+        /*shared_at_end=*/nullptr
     );
     record->phase_data.dummy_task.local_id = static_cast<uint32_t>(task_id);
     record->phase_data.dummy_task.ring_id = static_cast<uint32_t>(task_id >> 32);
+}
+
+void l2_swimlane_aicpu_record_dummy_task(int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id) {
+    record_aicpu_worker_task(thread_idx, L2SwimlaneSchedPhaseKind::DummyTask, complete_time, loop_iter, task_id);
+}
+
+void l2_swimlane_aicpu_record_predicated_skip(
+    int thread_idx, uint64_t complete_time, uint32_t loop_iter, uint64_t task_id
+) {
+    record_aicpu_worker_task(thread_idx, L2SwimlaneSchedPhaseKind::PredicatedSkip, complete_time, loop_iter, task_id);
 }
 
 void l2_swimlane_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }

--- a/src/common/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/l2_swimlane_collector.cpp
@@ -1036,6 +1036,8 @@ int L2SwimlaneCollector::export_swimlane_json() {
                 return "resolve";
             case L2SwimlaneSchedPhaseKind::DummyTask:
                 return "dummy_task";
+            case L2SwimlaneSchedPhaseKind::PredicatedSkip:
+                return "predicated_skip";
             case L2SwimlaneSchedPhaseKind::Drain:
                 return "drain";
             case L2SwimlaneSchedPhaseKind::DrainPrepare:
@@ -1064,7 +1066,8 @@ int L2SwimlaneCollector::export_swimlane_json() {
                     outfile << ", \"pop_hit\": " << pr.phase_data.dispatch.pop_hit
                             << ", \"pop_miss\": " << pr.phase_data.dispatch.pop_miss;
                 }
-                if (pr.kind == L2SwimlaneSchedPhaseKind::DummyTask) {
+                if (pr.kind == L2SwimlaneSchedPhaseKind::DummyTask ||
+                    pr.kind == L2SwimlaneSchedPhaseKind::PredicatedSkip) {
                     uint64_t task_id = (static_cast<uint64_t>(pr.phase_data.dummy_task.ring_id) << 32) |
                                        pr.phase_data.dummy_task.local_id;
                     outfile << ", \"task_id\": " << task_id;

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -498,3 +498,75 @@ def test_deps_dummy_without_runtime_record_is_not_rendered_as_alloc(tmp_path, ca
         events = json.load(f)["traceEvents"]
     assert not any(event.get("name") == "alloc(r1t1)" for event in events)
     assert "dummy(r1t1) has no dummy_task scheduler record" in capsys.readouterr().err
+
+
+def test_predicated_skip_uses_aicpu_worker_lane_and_dependency_anchor(tmp_path):
+    out = tmp_path / "trace.json"
+    skipped_task_id = (1 << 32) | 2
+    consumer_task_id = (1 << 32) | 3
+    scheduler_phases = [
+        [{"phase": "predicated_skip", "task_id": skipped_task_id, "start_time_us": 2.0, "end_time_us": 2.0}]
+    ]
+    orchestrator_phases = [
+        [{"phase": "orch_submit", "task_id": skipped_task_id, "start_time_us": 1.0, "end_time_us": 1.5}]
+    ]
+
+    sc.generate_chrome_trace_json(
+        [_task_row(consumer_task_id, 0, dispatch=3.0, start=4.0, end=5.0, receive=3.5)],
+        str(out),
+        func_id_to_name={"21": "exp_gate_mm"},
+        scheduler_phases=scheduler_phases,
+        orchestrator_phases=orchestrator_phases,
+        core_to_thread=[0],
+        deps_edges={skipped_task_id: [consumer_task_id]},
+        deps_kernel_map={skipped_task_id: [21, -1, -1]},
+        deps_block_map={skipped_task_id: 2, consumer_task_id: 1},
+    )
+
+    with open(out) as f:
+        events = json.load(f)["traceEvents"]
+    marker = next(event for event in events if event.get("name") == "exp_gate_mm_spmd(r1t2)")
+    assert marker["pid"] == 4
+    assert marker["tid"] == 19000
+    assert marker["dur"] == 0.02
+    assert marker["args"] == {
+        "loop_iter": 0,
+        "task_id": skipped_task_id,
+        "event-hint": "exp_gate_mm_spmd(r1t2)",
+        "predicated_pass": False,
+    }
+    assert "cname" not in marker
+    assert not any(event.get("name") == "alloc(r1t2)" for event in events)
+
+    flow = _first_worker_dependency_flow(out)
+    assert [(event["ph"], event["tid"]) for event in flow] == [("s", 19000), ("f", _core_tid(0))]
+
+
+def test_predicated_skip_without_deps_is_not_rendered_as_alloc(tmp_path):
+    out = tmp_path / "trace.json"
+    skipped_task_id = (1 << 32) | 2
+
+    sc.generate_chrome_trace_json(
+        [],
+        str(out),
+        scheduler_phases=[
+            [{"phase": "predicated_skip", "task_id": skipped_task_id, "start_time_us": 2.0, "end_time_us": 2.0}]
+        ],
+        orchestrator_phases=[
+            [{"phase": "orch_submit", "task_id": skipped_task_id, "start_time_us": 1.0, "end_time_us": 1.5}]
+        ],
+        core_to_thread=[0],
+    )
+
+    with open(out) as f:
+        events = json.load(f)["traceEvents"]
+    marker = next(event for event in events if event.get("name") == "task(r1t2)")
+    assert marker["pid"] == 4
+    assert marker["tid"] == 19000
+    assert marker["args"] == {
+        "loop_iter": 0,
+        "task_id": skipped_task_id,
+        "event-hint": "task(r1t2)",
+        "predicated_pass": False,
+    }
+    assert not any(event.get("name") == "alloc(r1t2)" for event in events)


### PR DESCRIPTION
- Emit a distinct PredicatedSkip phase for false predicated dispatches on a2a3 and a5
- Render skipped tasks on Worker View AICPU lanes by callable name
- Expose only predicated_pass=false in merged marker arguments
- Keep passing tasks unchanged and document the trace semantics
- Cover naming, dependency anchors, and captures without dependency metadata