### PR TITLE
Add: characterize SceneTest rehost stride and storage-split behavior

### DIFF
--- a/tests/ut/py/test_scene_test_rehost.py
+++ b/tests/ut/py/test_scene_test_rehost.py
@@ -134,6 +134,115 @@ def test_rehost_rejects_noncontiguous():
 
 
 # ---------------------------------------------------------------------------
+# Characterization (partial) — SceneTest host-tensor rehost adapter.
+#
+# These pin CURRENT behavior of the Python rehost / arg-build layer as input to
+# a planned typed-BufferHandle change (that planning context lives in the PR
+# description). They assert what is, not what should be:
+#   - a size-1 dimension's stride is normalized away, and
+#   - non-overlapping views of one storage are split into independent buffers.
+#
+# SCOPE: they cover the rehost adapter and `make_tensor_arg` output only. They
+# do NOT exercise the C++ orchestrator's dependency-key derivation
+# (`TensorKey::local_host` in src/common/hierarchical/orchestrator.cpp), which
+# runs inside a real submit and is out of device-free reach here. The
+# canonical-identity / dependency-key behavior is therefore NOT characterized by
+# this file — that remains open work.
+# ---------------------------------------------------------------------------
+
+
+def _make_tensor_arg(t):
+    # Imported lazily: torch_interop pulls in the task_interface binding, which
+    # the builder-only tests above do not need.
+    from simpler_setup.torch_interop import make_tensor_arg  # noqa: PLC0415
+
+    return make_tensor_arg(t)
+
+
+def test_char_singleton_stride_dropped_by_make_tensor_arg():
+    # The wire Tensor's strides are a pure function of shape (row-major), so a
+    # size-1 dimension's stride value never survives into the Tensor. Two tensors
+    # equal in shape+values but differing ONLY in their singleton-dim stride get
+    # identical consumer-visible geometry (shape / stride / start_offset); the
+    # inactive-dim and padding bytes are unspecified, so this is a geometry
+    # equality, not a byte-for-byte one.
+    base = torch.arange(4, dtype=torch.float32)
+    weird = base.as_strided((4, 1), (1, 7))  # singleton-dim stride = 7
+    canon = base.as_strided((4, 1), (1, 1))  # singleton-dim stride = 1
+    # Pin the fixture strides so a future torch that normalizes them at
+    # construction fails here loudly instead of silently voiding the coverage.
+    assert weird.stride() == (1, 7)
+    assert canon.stride() == (1, 1)
+    # Both are contiguous per torch (a size-1 dim's stride is free), so
+    # make_tensor_arg accepts them rather than rejecting as non-contiguous.
+    assert weird.is_contiguous() and canon.is_contiguous()
+    assert torch.equal(weird, canon)
+
+    w_weird = _make_tensor_arg(weird)
+    w_canon = _make_tensor_arg(canon)
+    # The 7 is normalized to the row-major 1; consumer-visible geometry matches.
+    assert tuple(w_weird.strides) == (1, 1)
+    assert tuple(w_weird.strides) == tuple(w_canon.strides)
+    assert tuple(w_weird.shapes) == tuple(w_canon.shapes)
+    assert w_weird.start_offset == w_canon.start_offset == 0
+
+
+def test_char_singleton_stride_dropped_by_rehost():
+    # The rehost `.view(shape)` re-canonicalizes strides, so a non-canonical
+    # singleton-dim stride on the input host tensor is lost after rehosting into
+    # the born-shared buffer.
+    base = torch.arange(4, dtype=torch.float32)
+    weird = base.as_strided((4, 1), (1, 7))
+    assert weird.stride() == (1, 7)  # pin fixture (see note above)
+    ta = TaskArgsBuilder(Tensor("a", weird))
+    w = _FakeWorker()
+    rehosted = _RehostedTaskArgs(w, ta)
+    try:
+        assert ta.a.stride() == (1, 1)  # input singleton stride 7 → normalized
+        assert torch.equal(ta.a, weird)
+    finally:
+        rehosted.release()
+
+
+def test_char_nonoverlapping_shared_storage_not_rejected():
+    # Two non-overlapping views of ONE backing storage are not rejected (the
+    # alias guard tests byte-range overlap, not shared backing) and rehost into
+    # INDEPENDENT born-shared buffers — the shared-backing relationship is not
+    # preserved across the rehost.
+    base = torch.zeros(8, dtype=torch.float32)
+    a, b = base[:4], base[4:]  # non-overlapping byte ranges, same storage
+    assert a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
+    ta = TaskArgsBuilder(Tensor("a", a), Tensor("b", b))
+    w = _FakeWorker()
+    rehosted = _RehostedTaskArgs(w, ta)
+    try:
+        # Not rejected; split into two independent born-shared buffers.
+        assert len(w.created) == 2
+        assert ta.a.untyped_storage().data_ptr() != ta.b.untyped_storage().data_ptr()
+    finally:
+        rehosted.release()
+
+
+def test_char_make_tensor_arg_carries_backing_as_addr_only():
+    # `make_tensor_arg` records backing location solely as the raw address
+    # (`data` == buffer.addr); there is no separate backing-identity field. Two
+    # non-overlapping views of one storage therefore get DISTINCT `data` values,
+    # offset by the view's byte offset.
+    #
+    # NOTE: this characterizes make_tensor_arg's output only, NOT the
+    # orchestrator's dependency key. It does not, on its own, pin what a future
+    # typed handle must change — a handle could add a canonical identity while
+    # leaving these addresses as-is. The dependency-key path is not exercised
+    # here (see SCOPE above).
+    base = torch.zeros(8, dtype=torch.float32)
+    a, b = base[:4], base[4:]  # both 1-D contiguous slices
+    w_a = _make_tensor_arg(a)
+    w_b = _make_tensor_arg(b)
+    assert w_b.data - w_a.data == 4 * a.element_size()
+    assert w_a.data != w_b.data
+
+
+# ---------------------------------------------------------------------------
 # TaskArgsBuilder duplicate-name fail-fast
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Four device-free characterization tests that **pin current behavior of the
SceneTest Python rehost / `make_tensor_arg` layer**, as input to a planned
typed-`BufferHandle` change. **Test-only — no source or wire behavior change.**

### Scope (partial — please read)

These cover the **rehost adapter and `make_tensor_arg` output only**. They do
**NOT** exercise the C++ orchestrator's dependency-key derivation
(`TensorKey::local_host` in `src/common/hierarchical/orchestrator.cpp`), which
runs inside a real submit and is out of device-free reach here. **The
canonical-identity / dependency-key behavior is therefore not characterized by
this PR** — that remains open work (a cpput or onboard test that runs the
orchestrator). This PR is deliberately a *partial* characterization of the
Python arg-build layer, not a complete identity/dependency baseline.

### What is pinned

**A size-1 dimension's stride is dropped at construction:**
- `make_tensor_arg` reads only shape + `data_ptr` and derives row-major strides;
  the rehost `.view(shape)` re-canonicalizes. A non-canonical singleton stride
  (`as_strided((4,1),(1,7))`, contiguous per torch) never reaches the wire
  `Tensor`. The two results match on **consumer-visible geometry**
  (shape/stride/start_offset) — inactive dims and padding are unspecified, so
  this is a geometry equality, **not** a byte-for-byte one. Fixture strides are
  asserted up front so a future torch that normalizes them at construction fails
  loudly instead of silently voiding the coverage.

**Non-overlapping views of one storage lose their backing relationship:**
- Two non-overlapping views (`base[:4]`, `base[4:]`) are not rejected by the
  byte-range alias guard and rehost into **independent** buffers.
  `make_tensor_arg` records backing location only as the raw address, so the two
  views get distinct addresses. This characterizes `make_tensor_arg`'s output,
  **not** the orchestrator dependency key.

### Coverage

| Goal | Status |
| ---- | ------ |
| `make_tensor_arg` drops singleton stride | ✅ pinned (with input-stride assertions) |
| rehost drops singleton stride | ✅ pinned (with input-stride assertion) |
| non-overlapping shared storage split into two buffers | ✅ pinned |
| wire / canonical-identity / dependency-key behavior | ❌ **not covered** (out of device-free scope; open) |

### Planning context

The eventual target is a typed `BufferHandle` / `BufferRef` that carries explicit
stride (no singleton normalization) and a canonical allocation identity
(owner-instance + worker-path + buffer-id + generation) so dependency keys stop
relying on raw VA. These tests document what the current SceneTest layer does at
that boundary; they are not the contract and do not gate that design.

## Testing
- [x] `pytest tests/ut/py/test_scene_test_rehost.py` — 15 passed
- [x] `ruff check` — clean