### PR TITLE
Refactor: remove legacy graph output metadata

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -163,8 +163,6 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 | `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
 | `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
 | `total_size` | Init | Both | Total shared memory size |
-| `graph_output_ptr` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
-| `graph_output_size` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
 
 ### 3.2 Size Calculation
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -985,7 +985,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
+        LOG_WARN("Skipping tensor copy-back because execution failed");
     } else {
         for (int i = 0; i < tensor_pair_count; i++) {
             const TensorPair &pair = tensor_pairs[i];

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -108,6 +110,12 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     }
 };
 
+static_assert(sizeof(PTO2SharedMemoryRingHeader) == 192, "PTO2SharedMemoryRingHeader layout drift");
+static_assert(
+    offsetof(PTO2SharedMemoryRingHeader, task_descriptors_offset) == 152,
+    "PTO2SharedMemoryRingHeader task_descriptors_offset layout drift"
+);
+
 /**
  * Shared memory header structure
  *
@@ -123,11 +131,6 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // Total shared memory size (for validation)
     uint64_t total_size;
 
-    // Reserved legacy packed-output metadata. Keep these zero and retain them
-    // only for shared-memory layout compatibility; host finalize ignores them.
-    std::atomic<uint64_t> graph_output_ptr;
-    std::atomic<uint64_t> graph_output_size;
-
     // === ERROR REPORTING ===
 
     // Orchestrator fatal error code (Orchestrator → Scheduler, AICPU → Host)
@@ -141,9 +144,10 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
 };
 
+static_assert(sizeof(PTO2SharedMemoryHeader) == 256, "PTO2SharedMemoryHeader layout drift");
+static_assert(offsetof(PTO2SharedMemoryHeader, total_size) == 200, "PTO2SharedMemoryHeader total_size layout drift");
 static_assert(
-    (sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0) && (sizeof(PTO2SharedMemoryHeader) < 4096),
-    "PTO2SharedMemoryHeader should be reasonably sized"
+    offsetof(PTO2SharedMemoryHeader, orch_error_code) == 208, "PTO2SharedMemoryHeader orch_error_code layout drift"
 );
 
 // =============================================================================

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -166,8 +166,6 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
     offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
 
     header->total_size = sm_size;
-    header->graph_output_ptr.store(0, std::memory_order_relaxed);
-    header->graph_output_size.store(0, std::memory_order_relaxed);
 
     // Error reporting
     header->orch_error_code.store(PTO2_ERROR_NONE, std::memory_order_relaxed);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -164,8 +164,6 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 | `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
 | `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
 | `total_size` | Init | Both | Total shared memory size |
-| `graph_output_ptr` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
-| `graph_output_size` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
 
 ### 3.2 Size Calculation
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -998,7 +998,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
+        LOG_WARN("Skipping tensor copy-back because execution failed");
     } else {
         for (int i = 0; i < tensor_lease_count; i++) {
             const TensorLease &lease = tensor_leases[i];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -114,6 +116,12 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     }
 };
 
+static_assert(sizeof(PTO2SharedMemoryRingHeader) == 192, "PTO2SharedMemoryRingHeader layout drift");
+static_assert(
+    offsetof(PTO2SharedMemoryRingHeader, task_descriptors_offset) == 152,
+    "PTO2SharedMemoryRingHeader task_descriptors_offset layout drift"
+);
+
 /**
  * Shared memory header structure
  *
@@ -128,11 +136,6 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Total shared memory size (for validation)
     uint64_t total_size;
-
-    // Reserved legacy packed-output metadata. Keep these zero and retain them
-    // only for shared-memory layout compatibility; host finalize ignores them.
-    std::atomic<uint64_t> graph_output_ptr;
-    std::atomic<uint64_t> graph_output_size;
 
     // === ERROR REPORTING ===
 
@@ -162,9 +165,14 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     std::atomic<int32_t> sched_stall_core;         // S1: stuck core id (-1 if N/A)
 };
 
+static_assert(sizeof(PTO2SharedMemoryHeader) == 896, "PTO2SharedMemoryHeader layout drift");
+static_assert(offsetof(PTO2SharedMemoryHeader, total_size) == 776, "PTO2SharedMemoryHeader total_size layout drift");
 static_assert(
-    (sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0) && (sizeof(PTO2SharedMemoryHeader) < 4096),
-    "PTO2SharedMemoryHeader should be reasonably sized"
+    offsetof(PTO2SharedMemoryHeader, orch_error_code) == 784, "PTO2SharedMemoryHeader orch_error_code layout drift"
+);
+static_assert(
+    offsetof(PTO2SharedMemoryHeader, sched_stall_task_id) == 832,
+    "PTO2SharedMemoryHeader sched_stall_task_id layout drift"
 );
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -157,8 +157,6 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
     }
 
     header->total_size = sm_size;
-    header->graph_output_ptr.store(0, std::memory_order_relaxed);
-    header->graph_output_size.store(0, std::memory_order_relaxed);
 
     // Error reporting
     header->orch_error_code.store(PTO2_ERROR_NONE, std::memory_order_relaxed);

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -489,7 +489,7 @@ int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc
     int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
 
     if (execution_rc != 0) {
-        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
+        LOG_WARN("Skipping tensor copy-back because execution failed");
     } else {
         for (int i = 0; i < tensor_pair_count; i++) {
             const TensorPair &pair = tensor_pairs[i];

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -164,8 +164,6 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 | `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
 | `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
 | `total_size` | Init | Both | Total shared memory size |
-| `graph_output_ptr` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
-| `graph_output_size` | Reserved | None | Legacy packed-output field retained for layout compatibility; remains zero |
 
 ### 3.2 Size Calculation
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -953,7 +953,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because execution failed (rc=%d)", execution_rc);
+        LOG_WARN("Skipping tensor copy-back because execution failed");
     } else {
         for (int i = 0; i < tensor_lease_count; i++) {
             const TensorLease &lease = tensor_leases[i];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -114,6 +116,12 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     }
 };
 
+static_assert(sizeof(PTO2SharedMemoryRingHeader) == 192, "PTO2SharedMemoryRingHeader layout drift");
+static_assert(
+    offsetof(PTO2SharedMemoryRingHeader, task_descriptors_offset) == 152,
+    "PTO2SharedMemoryRingHeader task_descriptors_offset layout drift"
+);
+
 /**
  * Shared memory header structure
  *
@@ -128,11 +136,6 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Total shared memory size (for validation)
     uint64_t total_size;
-
-    // Reserved legacy packed-output metadata. Keep these zero and retain them
-    // only for shared-memory layout compatibility; host finalize ignores them.
-    std::atomic<uint64_t> graph_output_ptr;
-    std::atomic<uint64_t> graph_output_size;
 
     // === ERROR REPORTING ===
 
@@ -162,9 +165,14 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     std::atomic<int32_t> sched_stall_core;         // S1: stuck core id (-1 if N/A)
 };
 
+static_assert(sizeof(PTO2SharedMemoryHeader) == 896, "PTO2SharedMemoryHeader layout drift");
+static_assert(offsetof(PTO2SharedMemoryHeader, total_size) == 776, "PTO2SharedMemoryHeader total_size layout drift");
 static_assert(
-    (sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0) && (sizeof(PTO2SharedMemoryHeader) < 4096),
-    "PTO2SharedMemoryHeader should be reasonably sized"
+    offsetof(PTO2SharedMemoryHeader, orch_error_code) == 784, "PTO2SharedMemoryHeader orch_error_code layout drift"
+);
+static_assert(
+    offsetof(PTO2SharedMemoryHeader, sched_stall_task_id) == 832,
+    "PTO2SharedMemoryHeader sched_stall_task_id layout drift"
 );
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -157,8 +157,6 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
     }
 
     header->total_size = sm_size;
-    header->graph_output_ptr.store(0, std::memory_order_relaxed);
-    header->graph_output_size.store(0, std::memory_order_relaxed);
 
     // Error reporting
     header->orch_error_code.store(PTO2_ERROR_NONE, std::memory_order_relaxed);

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -253,14 +253,6 @@ TEST_F(TrbRuntimeTempBufferTest, SuccessfulValidateCopiesOnlyOutputTensor) {
     ASSERT_EQ(runtime.tensor_leases_.size(), 1u);
     std::memset(runtime.tensor_leases_[0].dev_ptr, 0x2a, output.size());
 
-    // Legacy packed-output metadata is retained only for shared-memory layout
-    // compatibility. Finalization must copy from the tensor's own allocation.
-    std::vector<uint8_t> legacy_packed_output(output.size(), 0x7f);
-    auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime.get_gm_sm_ptr());
-    ASSERT_NE(header, nullptr);
-    header->graph_output_ptr.store(reinterpret_cast<uint64_t>(legacy_packed_output.data()), std::memory_order_relaxed);
-    header->graph_output_size.store(legacy_packed_output.size(), std::memory_order_relaxed);
-
     ASSERT_EQ(validate_runtime_impl(&runtime, &api_, 0), 0);
     EXPECT_EQ(fake_.copy_from_count, 1);
     EXPECT_TRUE(std::all_of(output.begin(), output.end(), [](uint8_t value) {


### PR DESCRIPTION
## Summary
- Remove unused `graph_output_ptr` and `graph_output_size` metadata, initialization, documentation, and obsolete test scaffolding
- Pin shared-memory header sizes and key offsets with compile-time assertions so ABI layout drift fails during the build
- Simplify failed-execution copy-back warnings to avoid repeating error codes already reported centrally

## Testing
- [x] Full editable runtime rebuild for A2/A3 and A5, simulation and onboard variants
- [x] C++ unit tests: 60/60 passed
- [x] A2/A3 and A5 simulation smoke tests for both runtime implementations
- [ ] Onboard runtime smoke tests not run locally because device architecture detection was unavailable

Follow-up to #1412.