### PR TITLE
example: merged 3-stage pipeline with intra-task cross-core barrier

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/aiv/merge_pipeline.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/aiv/merge_pipeline.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The whole 3-stage pipeline (x+1 -> *2 -> +1) as ONE block_num=8 SPMD task,
+ * with a uniform cross-core barrier between segments instead of inter-task
+ * deps: stage A does 8 tiles on block 0 only, stage B 2 tiles each on blocks
+ * 0..3, stage C 1 tile each on all 8. Every block hits every barrier (idle
+ * blocks still arrive), so each barrier waits for block_num. Bulk data uses
+ * tile DMA; the barrier uses ld_dev/st_dev (see MERGE_BARRIER_COUNTER below).
+ *
+ * args: [0]=x, [1]=sync (block_num int32 slots, zero-init), [2]=s1, [3]=s2,
+ *       [4]=out, [5]=timing (per-block get_sys_cnt gaps, 32-int32 stride)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+#include "intrinsic.h"
+
+using namespace pto;
+
+#include "pipe_sync.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#if defined(__CCE_AICORE__) && !defined(__CPU_SIM) && !defined(__COSTMODEL)
+#define MERGE_USE_DEV_INTRIN 1
+#else
+#define MERGE_USE_DEV_INTRIN 0
+#endif
+
+static __aicore__ inline void st_i32_dev(__gm__ int32_t *p, int32_t v) {
+#if MERGE_USE_DEV_INTRIN
+    st_dev(static_cast<uint32_t>(v), reinterpret_cast<__gm__ uint32_t *>(p), 0);
+#else
+    // CPU_SIM fallback is thread-based; volatile stops the spin loop hoisting.
+    *reinterpret_cast<volatile int32_t *>(p) = v;
+#endif
+}
+
+static __aicore__ inline int32_t ld_i32_dev(__gm__ int32_t *p) {
+#if MERGE_USE_DEV_INTRIN
+    return static_cast<int32_t>(ld_dev(reinterpret_cast<__gm__ uint32_t *>(p), 0));
+#else
+    return *reinterpret_cast<volatile int32_t *>(p);
+#endif
+}
+
+static __aicore__ inline void ddr_fence() {
+#if MERGE_USE_DEV_INTRIN
+    dsb(DSB_DDR);
+#endif
+}
+
+// Per-slot cross-core barrier over `n` blocks; slot advances monotonically per
+// epoch. Single-writer per slot (no atomic), ld_dev poll (no dcci). Reader polls
+// all n slots -> O(n) non-cacheable reads per barrier.
+static __aicore__ inline void barrier_slots(__gm__ int32_t *sync, int32_t n, int32_t i, int32_t epoch) {
+    ddr_fence();
+    st_i32_dev(&sync[i], epoch);
+    for (int32_t j = 0; j < n; ++j) {
+        while (ld_i32_dev(&sync[j]) < epoch) {}
+    }
+    ddr_fence();
+}
+
+// Scalar hardware atomic-add to a GM int32 (no UB/DMA). The dcci writes the line
+// out atomically; the reader polls with ld_dev, so no dcci on the hot path.
+static __aicore__ inline void atomic_add_i32(__gm__ int32_t *p, int32_t v) {
+#if MERGE_USE_DEV_INTRIN
+    set_st_atomic_cfg(ATOMIC_S32, ATOMIC_SUM);
+    dcci(reinterpret_cast<__gm__ void *>(p), SINGLE_CACHE_LINE);
+    st_atomic<int32_t>(v, p);
+    dcci(reinterpret_cast<__gm__ void *>(p), SINGLE_CACHE_LINE);
+    dsb(DSB_DDR);
+    set_st_atomic_cfg(ATOMIC_NONE, ATOMIC_SUM);
+#else
+    volatile int32_t *vp = reinterpret_cast<volatile int32_t *>(p);
+    *vp = *vp + v;
+#endif
+}
+
+// Single shared counter barrier: atomic-add arrival, poll ONE counter with
+// ld_dev until it reaches epoch*n -> O(1) read per barrier.
+static __aicore__ inline void barrier_counter(__gm__ int32_t *counter, int32_t n, int32_t epoch) {
+    ddr_fence();
+    atomic_add_i32(counter, 1);
+    while (ld_i32_dev(counter) < epoch * n) {}
+    ddr_fence();
+}
+
+// Select the barrier at compile time: 0 = per-slot st_dev, 1 = atomic counter.
+#ifndef MERGE_BARRIER_COUNTER
+#define MERGE_BARRIER_COUNTER 1
+#endif
+static __aicore__ inline void barrier(__gm__ int32_t *sync, int32_t n, int32_t i, int32_t epoch) {
+#if MERGE_BARRIER_COUNTER
+    (void)i;
+    barrier_counter(sync, n, epoch);
+#else
+    barrier_slots(sync, n, i, epoch);
+#endif
+}
+
+constexpr int32_t kR = 1;
+constexpr int32_t kC = 128;
+using GData = GlobalTensor<float, Shape<1, 1, 1, kR, kC>, Stride<1, 1, 1, kC, 1>>;
+using VTile = Tile<TileType::Vec, float, kR, kC, BLayout::RowMajor, -1, -1>;
+
+static __aicore__ inline void wait_store_done() {
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}
+
+// tile compute: dst[t] = op0 ? (src[t] + b) : (src[t] + src[t])
+static __aicore__ inline void
+stage_tile(__gm__ float *src, __gm__ float *dst, int32_t t, int32_t op, float b, VTile &t0, VTile &t1) {
+    GData ig(src + t * kC);
+    GData og(dst + t * kC);
+    TLOAD(t0, ig);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    if (op == 0) {
+        TADDS(t1, t0, b);
+    } else {
+        TADD(t1, t0, t0);
+    }
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(og, t1);
+    // Drain this store before the caller reuses t0/t1 for the next tile.
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID6);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID6);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *x_t = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *sync_t = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *s1_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *s2_t = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *out_t = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *tm_t = reinterpret_cast<__gm__ Tensor *>(args[5]);
+
+    __gm__ float *x = reinterpret_cast<__gm__ float *>(x_t->buffer.addr) + x_t->start_offset;
+    __gm__ int32_t *sync = reinterpret_cast<__gm__ int32_t *>(sync_t->buffer.addr) + sync_t->start_offset;
+    __gm__ float *s1 = reinterpret_cast<__gm__ float *>(s1_t->buffer.addr) + s1_t->start_offset;
+    __gm__ float *s2 = reinterpret_cast<__gm__ float *>(s2_t->buffer.addr) + s2_t->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_t->buffer.addr) + out_t->start_offset;
+    __gm__ int32_t *tm = reinterpret_cast<__gm__ int32_t *>(tm_t->buffer.addr) + tm_t->start_offset;
+
+    int32_t N = get_block_num(args);  // 8
+    int32_t i = get_block_idx(args);
+
+    VTile t0(kR, kC), t1(kR, kC);
+    TASSIGN(t0, 0x0);
+    TASSIGN(t1, 0x10000);
+
+    // get_sys_cnt() = 50 MHz counter (20 ns/tick). Deltas below are in ticks.
+    int64_t c0 = get_sys_cnt();
+
+    // Segment A (stage 1): block 0 does all 8 tiles: s1 = x + 1
+    if (i == 0) {
+        for (int32_t t = 0; t < 8; ++t) {
+            stage_tile(x, s1, t, 0, 1.0f, t0, t1);
+        }
+        wait_store_done();
+    }
+    int64_t c1 = get_sys_cnt();  // arrived at barrier 1
+    barrier(sync, N, i, 1);
+    int64_t c2 = get_sys_cnt();  // released from barrier 1
+
+    // Segment B (stage 2): blocks 0..3 do 2 tiles each: s2 = s1 * 2
+    if (i < 4) {
+        for (int32_t t = i * 2; t < i * 2 + 2; ++t) {
+            stage_tile(s1, s2, t, 1, 0.0f, t0, t1);
+        }
+        wait_store_done();
+    }
+    int64_t c3 = get_sys_cnt();  // arrived at barrier 2
+    barrier(sync, N, i, 2);
+    int64_t c4 = get_sys_cnt();  // released from barrier 2
+
+    // Segment C (stage 3): all 8 blocks do 1 tile each: out = s2 + 1
+    stage_tile(s2, out, i, 0, 1.0f, t0, t1);
+    int64_t c5 = get_sys_cnt();  // end
+
+    // Per-block timing (ticks): [segA, barrier1_gap, segB, barrier2_gap, segC, total].
+    // Stride each block by 32 int32 (one 128B cacheline): scalar st_dev only
+    // commits the first 8 int32 of a cacheline, so keep all 6 writes in that head.
+    st_i32_dev(&tm[i * 32 + 0], static_cast<int32_t>(c1 - c0));
+    st_i32_dev(&tm[i * 32 + 1], static_cast<int32_t>(c2 - c1));
+    st_i32_dev(&tm[i * 32 + 2], static_cast<int32_t>(c3 - c2));
+    st_i32_dev(&tm[i * 32 + 3], static_cast<int32_t>(c4 - c3));
+    st_i32_dev(&tm[i * 32 + 4], static_cast<int32_t>(c5 - c4));
+    st_i32_dev(&tm[i * 32 + 5], static_cast<int32_t>(c5 - c0));
+    ddr_fence();  // flush timing writes to HBM before the task completes / copy-back
+
+    pipe_sync();
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/orchestration/merge_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/orchestration/merge_orch.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Merge mode: one block_num=8 SPMD task (merge_pipeline, func 0) runs all three
+ * stages with an intra-task barrier between segments. s1/s2 are runtime scratch;
+ * sync is a caller-provided zero-initialized barrier buffer.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_x = orch_args.tensor(0).ref();
+    const Tensor &ext_sync = orch_args.tensor(1).ref();
+    const Tensor &ext_out = orch_args.tensor(2).ref();
+    const Tensor &ext_timing = orch_args.tensor(3).ref();
+
+    uint32_t SIZE = ext_x.shapes[0];
+    uint32_t sh[1] = {SIZE};
+    TensorCreateInfo ci(sh, 1, DataType::FLOAT32);
+
+    L0TaskArgs p;
+    p.add_input(ext_x);        // args[0]
+    p.add_input(ext_sync);     // args[1]
+    p.add_output(ci);          // args[2] s1 scratch
+    p.add_output(ci);          // args[3] s2 scratch
+    p.add_output(ext_out);     // args[4]
+    p.add_output(ext_timing);  // args[5] per-block timing (ticks)
+    p.launch_spec.set_block_num(8);
+    rt_submit_aiv_task(0, p);
+}
+
+}  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Merged 3-stage pipeline as ONE SPMD task with an intra-task cross-core barrier.
+
+Three stages (x+1 -> *2 -> +1 = 2x+3) run as a single block_num=8 AIV task; the
+inter-stage ordering is an intra-task cross-core barrier instead of separate
+scheduled tasks. Stage A does 8 tiles on block 0 only, stage B 2 tiles each on
+blocks 0..3, stage C 1 tile each on all 8; every block hits every barrier (idle
+blocks still arrive), so each barrier waits for block_num.
+
+The barrier has two compile-time variants (MERGE_BARRIER_COUNTER in
+merge_pipeline.cpp): a per-slot st_dev poll (O(n) non-cacheable reads) and a
+single-counter st_atomic+dcci arrival + one-ld_dev poll (O(1) read). The kernel
+records each block's per-barrier gap with get_sys_cnt; the hook below prints
+them (ticks at 50 MHz -> us) and skips golden-checking the diagnostic output.
+"""
+
+import sys
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+import simpler_setup.scene_test  # noqa: F401
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+TILES = 8
+M = 128
+SIZE = TILES * M  # 1024
+NBLK = 8
+
+# Print the kernel's per-block timing (get_sys_cnt deltas, ticks->us at 50 MHz)
+# and skip golden-checking the diagnostic 'timing' output. Each block's slots are
+# strided by 32 int32 (one cacheline) because scalar st_dev only commits the
+# first 8 int32 of a 128B line.
+_st = sys.modules["simpler_setup.scene_test"]
+_orig_cmp = _st._compare_outputs
+
+
+def _cmp_with_gaps(test_args, golden_args, output_names, rtol, atol):
+    if "timing" in output_names:
+        tm = test_args.timing.reshape(NBLK, 32)[:, :6].to(torch.float64) / 50.0
+        labels = ["segA", "bar1", "segB", "bar2", "segC", "total"]
+        print("[GAP] per-block us (50 MHz counter):")
+        print("  blk " + " ".join(f"{lbl:>7}" for lbl in labels))
+        for b in range(NBLK):
+            print(f"  {b:>3} " + " ".join(f"{tm[b, k]:7.2f}" for k in range(6)))
+        print(
+            f"[GAP] barrier1: max={tm[:, 1].max():.2f} min={tm[:, 1].min():.2f} us | "
+            f"barrier2: max={tm[:, 3].max():.2f} min={tm[:, 3].min():.2f} us"
+        )
+        output_names = [n for n in output_names if n != "timing"]
+    return _orig_cmp(test_args, golden_args, output_names, rtol, atol)
+
+
+_st._compare_outputs = _cmp_with_gaps
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestMergePipelineBarrier(SceneTestCase):
+    """out = 2x + 3 across 3 stages, ordered by an intra-task cross-core barrier."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/merge_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": "kernels/aiv/merge_pipeline.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT, D.OUT, D.OUT, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            # Onboard only: the busy-wait barrier needs all block_num logical
+            # blocks co-resident, so config block_dim (24) > block_num (8, set
+            # per-task via launch_spec.set_block_num in merge_orch.cpp).
+            "name": "merge",
+            "platforms": ["a2a3"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            Tensor("x", torch.arange(SIZE, dtype=torch.float32) / 7.0),
+            Tensor("sync", torch.zeros(NBLK, dtype=torch.int32)),  # barrier slots / counter (zero-init)
+            Tensor("out", torch.zeros(SIZE, dtype=torch.float32)),
+            Tensor("timing", torch.zeros(NBLK * 32, dtype=torch.int32)),  # per-block gaps (32-int32 stride)
+        )
+
+    def compute_golden(self, args, params):
+        args.out[:] = 2.0 * args.x + 3.0
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

Adds an onboard a2a3 example under
`examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/` that runs a
3-stage pipeline (`x+1 -> *2 -> +1 = 2x+3`) as **one** `block_num=8` SPMD task,
ordering the stages with an **intra-task cross-core barrier** instead of three
separately scheduled tasks. Stage A does 8 tiles on block 0, stage B 2 tiles
each on blocks 0..3, stage C 1 tile each on all 8; every block hits every
barrier (idle blocks still arrive), so each barrier waits for `block_num`.

Two compile-time barrier variants (`MERGE_BARRIER_COUNTER` in
`merge_pipeline.cpp`), both dcci-free on the poll path:

- **per-slot** — `st_dev` write to own slot + poll all N slots via `ld_dev`
  (O(n) non-cacheable reads).
- **single counter** — `st_atomic`+`dcci` arrival + one `ld_dev` poll to
  `epoch*N` (O(1) read). Only the arrival dccis (that write-back is the atomic
  point); the poll stays dcci-free.

The kernel records each block's per-barrier gap with `get_sys_cnt`. Onboard,
the single-counter barrier's mechanism is **~1 us** vs **~10 us** for the
8-slot `ld_dev` poll — the poll cost is what the single counter removes.

Notes baked into the example:
- Bulk data moves through **tile DMA**; scalar `ld_dev`/`st_dev` is reserved for
  the small barrier slots/counter and the timing output. The timing output is
  strided one cacheline (32 int32) per block because scalar `st_dev` only
  commits the first 8 int32 of a 128 B line.
- **Onboard-only** (`platforms: ["a2a3"]`): the busy-wait barrier needs all
  `block_num` logical blocks co-resident, so config `block_dim` (24) is set
  above `block_num` (8, per-task via `launch_spec.set_block_num`).

## Testing

- [x] Onboard a2a3: `TestMergePipelineBarrier` passes (golden `2x+3`); the
      `[GAP]` per-block timing prints and reproduces the ~1 us single-counter
      barrier.
- [ ] Sim: N/A — the example is inherently onboard (cache-bypass intrinsics +
      concurrent-core busy-wait barrier).