### PR TITLE
Fix: use task_attrs.has_predicate() in the L2 swimlane predicated-skip path

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1219,7 +1219,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                             sched_l2_swimlane_[thread_idx].sched_loop_count, dummy_consumers
                         );
                     }
-                    if (dummy_slot.active_mask.has_predicate()) {
+                    if (dummy_slot.task_attrs.has_predicate()) {
                         l2_swimlane_aicpu_record_predicated_skip(
                             thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
                             dummy_slot.task->task_id.raw

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1028,7 +1028,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 #if SIMPLER_DFX
                 if (dummy_resolve_t0 != 0) {
-                    if (dummy_slot.active_mask.has_predicate()) {
+                    if (dummy_slot.task_attrs.has_predicate()) {
                         l2_swimlane_aicpu_record_predicated_skip(
                             thread_idx, dummy_resolve_t0, sched_l2_swimlane_[thread_idx].sched_loop_count,
                             dummy_slot.task->task_id.raw


### PR DESCRIPTION
## Summary

`#1410` consolidated the per-task dispatch predicates into the `TaskAttrs` byte — moving `has_predicate()` from `ActiveMask` to `TaskAttrs` and updating the scheduler call sites — but missed the two dummy-drain swimlane-skip calls that `#1419` added:

- `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp:1222`
- `src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp:1031`

Both still call `dummy_slot.active_mask.has_predicate()`. `ActiveMask` no longer has that member, and the calls sit under `#if SIMPLER_DFX` (on by default), so the default `a2a3sim` / `a5sim` build fails to compile on the current `main` tip:

```
scheduler_dispatch.cpp:1222:48: error: 'class ActiveMask' has no member named 'has_predicate'
```

Each PR was green against its own base; the break only surfaces once both `#1410` and `#1419` are on `main` together (a merge-order semantic conflict).

## Fix

Point both call sites at `dummy_slot.task_attrs.has_predicate()`, matching every other `has_predicate()` caller in the scheduler (e.g. `pto_scheduler.h:537/872/938/968/1041/1082`).

## Validation

`a2a3sim` and `a5sim` build clean (host + aicpu + aicore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)