### PR TITLE
Enable -cce-vf-aa-between-iters by default for A5 CCEC builds

### DIFF
--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -167,7 +167,7 @@ class CCECToolchain(Toolchain):
         else:
             raise ValueError(f"Unknown platform: {self.platform}. Supported: a2a3, a2a3sim, a5, a5sim")
 
-        return [
+        flags = [
             "-c",
             "-O3",
             "-g",
@@ -189,6 +189,14 @@ class CCECToolchain(Toolchain):
             "-cce-aicore-dcci-insert-for-scalar=false",
             "-DMEMORY_BASE",
         ]
+        # A5 hardware only: enable VF alias analysis between loop iterations.
+        # a5sim uses Gxx15Toolchain (KernelCompiler leaves self.ccec unset), so this
+        # LLVM option does not apply there. Stricter inter-iteration AA constrains
+        # BiSheng VF fusion scale/correctness; BiSheng plans to make this always-on
+        # later, so pin it for A5 CCEC builds now.
+        if self.platform == "a5":
+            flags.extend(["-mllvm", "-cce-vf-aa-between-iters=true"])
+        return flags
 
     def get_cmake_args(self) -> list[str]:
         return [


### PR DESCRIPTION
## Summary
- Add `-mllvm -cce-vf-aa-between-iters=true` to the default CCEC flags for A5 hardware.
- This option enables alias analysis across loop iterations. With it on, AA is stricter and directly affects BiSheng VF fusion scale and correctness.
- Context: without this option, BiSheng fusion can misbehave in some cases; fusion still needs to run under the stricter AA setting. BiSheng plans to make this always-on later; simpler enables it by default on A5 CCEC now to align with that direction.
- a5sim is unchanged: `KernelCompiler` leaves `ccec` unset and uses `Gxx15Toolchain`, so this LLVM option does not apply there.
- Board check: DeepSeek V4 `qkv_proj_rope.py` (decode, `-p a5`) fails with VF fusion alone (AICore / scheduler stall); adding this option makes it PASS. Turning fusion off also PASSes.

## Test plan
- [ ] Confirm `CCECToolchain(platform="a5").get_compile_flags()` includes `-mllvm` / `-cce-vf-aa-between-iters=true`
- [ ] Confirm `CCECToolchain(platform="a2a3")` and a5sim kernel path do **not** add this option
- [ ] A5 board: `qkv_proj_rope.py -p a5 --mode decode` PASSes