### PR TITLE
Fix: scalar_data_test check tensor reads uninitialized device slot

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/test_scalar_data.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/test_scalar_data.py
@@ -60,7 +60,10 @@ class TestScalarData(SceneTestCase):
             Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
             Tensor("b", torch.arange(SIZE, dtype=torch.float32)),
             Tensor("result", torch.zeros(SIZE, dtype=torch.float32)),
-            Tensor("check", torch.zeros(10, dtype=torch.float32)),
+            # Exactly 9 slots: the orchestration writes check[0..8] via
+            # set_tensor_data. Output-tensor slots are not seeded from the host,
+            # so any extra slot reads undefined device memory.
+            Tensor("check", torch.zeros(9, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):


### PR DESCRIPTION
## Summary

`scalar_data_test` intermittently fails `st-onboard-a2a3` with a golden mismatch on `check` (`max_diff≈9.4e-4`, `rtol/atol=1e-5`). Root-caused on a2a3 silicon.

## Root cause

The `check` output tensor is sized **10**, but the orchestration writes only `check[0..8]` (9 values via `set_tensor_data`). Output-tensor slots are **not** seeded from the host buffer on device (confirmed on hardware: a 123.0 host sentinel reads back as `0.0`), so the never-written `check[9]` reads whatever the device output buffer holds:

- **In isolation** it's `0.0` → matches the zero golden → passes.
- **Under the full onboard suite** (all tests share one device) it reads recycled buffer **residue** (`~9.4e-4`) → golden mismatch. This is why it's intermittent and survives re-runs.

Decisive evidence (a2a3, sentinel-seeded `check`):
```
mismatch on 'check': argmax_idx=9  actual=0.0  expected=123.0
actual  =[2.0,102.0,77.0,77.0,79.0,42.0,12.0,88.0,55.0, 0.0]
expected=[2.0,102.0,77.0,77.0,79.0,42.0,12.0,88.0,55.0, 123.0]
```

## Fix

Size `check` to exactly the 9 written slots. Verified onboard on a2a3: a size-9 sentinel-seeded run passes (every slot overwritten). No golden change (it only sets 0..8); sim is bit-exact and unaffected. Unrelated to #1436 (this is a `level=2` device-runtime test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)