### PR TITLE
host_build_graph: all AICPU threads schedule (drop orch/sched split)

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -79,9 +79,6 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
 static PTO2Runtime *rt{nullptr};
 
 struct AicpuExecutor {
-    int32_t sched_thread_num_;
-    bool orch_to_sched_{false};
-
     // ===== Thread management state =====
     std::atomic<int32_t> thread_idx_{0};
     std::atomic<bool> init_done_{false};
@@ -166,13 +163,11 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 
     if (is_leader) {
         LOG_INFO_V0("AicpuExecutor: Initializing");
-        // The 0 → 1 fixup already applied above; derive scheduler count from it.
+        // The 0 → 1 fixup already applied above.
         aicpu_thread_num_ = nthreads;
-        sched_thread_num_ = nthreads - 1;
-        orch_to_sched_ = runtime->orch_to_sched;
 
         hs_arrived_.store(0, std::memory_order_relaxed);
-        if (sched_ctx_.pre_handshake_init(runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs()) != 0) {
+        if (sched_ctx_.pre_handshake_init(runtime, aicpu_thread_num_, get_platform_regs()) != 0) {
             init_failed_.store(true, std::memory_order_release);
             hs_setup_done_.store(true, std::memory_order_release);
             return -1;
@@ -225,15 +220,17 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t run_rc = 0;
     LOG_INFO_V0("Thread %d: Start (exec_idx=%d)", thread_idx, affinity_exec_idx);
 
-    // Boot thread (thread N-1): host_build_graph host-orch boot. The
-    // orchestrator already ran on the host, which also relocated every
-    // cross-task pointer to its final device address before H2D — so the
-    // SM/arena this thread sees are already fully device-addressed. This thread
-    // attaches the prebuilt arena, points the SM handle's ring-header pointers
-    // at the device SM WITHOUT resetting the host-populated data, releases the
-    // scheduler threads, and hands the host-computed task count to the
-    // scheduler. It owns no AICore cores, so it does not dispatch.
-    if (thread_idx >= sched_thread_num_) {
+    // Boot: the last AICPU thread (aicpu_thread_num_ - 1) performs the one-time
+    // host-orch attach. host_build_graph's orchestrator already ran on the host,
+    // which also relocated every cross-task pointer to its final device address
+    // before H2D — so the SM/arena this thread sees are already fully
+    // device-addressed. This thread attaches the prebuilt arena, points the SM
+    // handle's ring-header pointers at the device SM WITHOUT resetting the
+    // host-populated data, hands the host-computed task count to the scheduler,
+    // and releases the other threads. It then falls through and schedules its own
+    // cores like every other thread — host_build_graph has no device-side
+    // orchestrator, so there is no orch/sched split.
+    if (thread_idx == aicpu_thread_num_ - 1) {
         void *prebuilt_arena = runtime->get_prebuilt_arena_base();
         size_t off_runtime = runtime->get_prebuilt_runtime_offset();
         if (prebuilt_arena == nullptr) {
@@ -282,9 +279,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         LOG_INFO_V0("Thread %d: host-orch boot complete (%d tasks)", thread_idx, runtime->host_total_tasks);
     }
 
-    // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
-    if (!sched_ctx_.is_completed() && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
-        // Device orchestration: wait for the primary orchestrator to initialize the SM header
+    // Every AICPU thread schedules its assigned cores; the boot thread above
+    // falls through to here after publishing runtime_init_ready_.
+    if (!sched_ctx_.is_completed()) {
+        // Wait for the boot thread to attach the SM header and publish the task count.
         while (!runtime_init_ready_.load(std::memory_order_acquire)) {
             SPIN_WAIT_HINT();
         }
@@ -303,8 +301,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     }
 
     // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
-    // platform_deinit_aicore_regs is idempotent; orchestrator threads have
-    // core_trackers_[thread_idx].core_num() == 0 so they skip the loop harmlessly.
+    // platform_deinit_aicore_regs is idempotent.
     int32_t shutdown_rc = sched_ctx_.shutdown(thread_idx);
     if (shutdown_rc != 0 && run_rc == 0) {
         run_rc = shutdown_rc;
@@ -342,8 +339,6 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     runtime_init_ready_.store(false, std::memory_order_release);
 
     aicpu_thread_num_ = 0;
-    sched_thread_num_ = 0;
-    orch_to_sched_ = false;
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -616,11 +616,11 @@ Public surface (called from `AicpuExecutor::init/run/deinit`):
 
 | Method | Phase | Purpose |
 | ------ | ----- | ------- |
-| `init(runtime, aicpu_thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
+| `init(runtime, aicpu_thread_num, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
 | `bind_runtime(rt)` | boot thread | Wire `sched_` to `rt->scheduler` once the boot thread attaches the host-built `rt` |
 | `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
 | `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled |
-| `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | orchestrator thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_`, drive orch→sched core transition (or `emergency_shutdown` on fatal) |
+| `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | boot thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_` (or `emergency_shutdown` on fatal) |
 | `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
 | Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` |
 

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -128,7 +128,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 | Constant | Value | Description |
 | -------- | ----- | ----------- |
 | `PLATFORM_MAX_BLOCKDIM` | 24 | Maximum blocks (each = 1 AIC + 2 AIV) |
-| `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (3 schedulers + 1 orchestrator) |
+| `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (all schedulers; the highest-index thread also runs the host-orch boot) |
 | `PLATFORM_MAX_AIC_PER_THREAD` | 24 | Max AIC cores per scheduler thread |
 | `PLATFORM_MAX_AIV_PER_THREAD` | 48 | Max AIV cores per scheduler thread |
 | `PLATFORM_PROF_SYS_CNT_FREQ` | 50 MHz | System counter frequency for profiling |
@@ -555,16 +555,18 @@ verified by review.
 
 ### 8.1 Thread Model
 
-With `aicpu_thread_num=4`, the AICPU runs 4 threads:
+With `aicpu_thread_num=4`, the AICPU runs 4 scheduler threads (thread 3 also
+performs the one-time host-orch boot before it starts dispatching):
 
-| Thread | Role | Cores |
+| Thread | Role | Cores (block_dim=24) |
 | ------ | ---- | ----- |
-| 0 | Scheduler | 6 AIC + ~13 AIV |
-| 1 | Scheduler | 6 AIC + ~13 AIV |
-| 2 | Scheduler | 6 AIC + ~13 AIV |
-| 3 | Orchestrator | none |
+| 0 | Scheduler | 6 AIC + 12 AIV |
+| 1 | Scheduler | 6 AIC + 12 AIV |
+| 2 | Scheduler | 6 AIC + 12 AIV |
+| 3 | Scheduler (+ host-orch boot) | 6 AIC + 12 AIV |
 
-Core assignment: AICs and AIVs are divided equally among the 3 scheduler threads.
+Core assignment: clusters (1 AIC + 2 AIV) are divided equally among all 4
+scheduler threads.
 
 ### 8.2 Scheduler Main Loop
 

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -555,10 +555,11 @@ verified by review.
 
 ### 8.1 Thread Model
 
-With `aicpu_thread_num=4`, the AICPU runs 4 scheduler threads (thread 3 also
-performs the one-time host-orch boot before it starts dispatching):
+With `aicpu_thread_num=4` and `block_dim=24`, the AICPU runs 4 scheduler
+threads (thread 3 also performs the one-time host-orch boot before it starts
+dispatching):
 
-| Thread | Role | Cores (block_dim=24) |
+| Thread | Role | Cores |
 | ------ | ---- | ----- |
 | 0 | Scheduler | 6 AIC + 12 AIV |
 | 1 | Scheduler | 6 AIC + 12 AIV |

--- a/src/a2a3/runtime/host_build_graph/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/host_build_graph/docs/device_log_profiling.md
@@ -86,7 +86,7 @@ Thread 3: PTO2 total submitted tasks = 16704
 
 ## Block 2: PTO2 Scheduler Summary
 
-Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after completing all tasks. The output has two sub-sections: **summary** and **phase breakdown**.
+Each scheduler thread (Thread 0–3 at `aicpu_thread_num=4`) prints its own summary after completing all tasks. The output has two sub-sections: **summary** and **phase breakdown**.
 
 ### Example (Thread 0, from a different run: batch=1, 1044 tasks)
 

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -9,7 +9,7 @@ PTO Runtime2 uses a hierarchical profiling system with compile-time macros to co
 > **host_build_graph (host-orch) note.** The profiling **macros** below
 > (`SIMPLER_DFX`, `SIMPLER_ORCH_PROFILING`, …) are shared with
 > `tensormap_and_ringbuffer`. But the orchestrator-timing **device-log lines**
-> (`orch_start` / `orch_end` / `orch_cost` / `orch_stage_end`) and the
+> (`orch_start` / `orch_end` / `orch_cost`) and the
 > device-log line-count formulas that include `N_orch` describe the
 > **device-orch** case that `tensormap_and_ringbuffer` runs. In
 > host_build_graph the orchestrator runs on the **host** and the device boots
@@ -85,7 +85,6 @@ Each sub-level macro requires `SIMPLER_DFX=1`:
 
 - Base timing counters for scheduler loop (`sched_complete/dispatch/idle/scan`)
 - Per-thread orchestration timing (`orch_start`, `orch_end`, `orch_cost`)
-- Stage-level orchestration end timestamp (`orch_stage_end`, printed by last orch thread only, marks the moment all orch threads have finished and core transition is about to be requested; only when `orch_to_sched_` is true)
 - PTO2 total submitted tasks count (printed by last orch thread, after orch timing line)
 - Scheduler summary output (`total_time`, `loops`, `tasks_scheduled`)
 - Scheduler lifetime timestamps and cost (`sched_start`, `sched_end`, `sched_cost` — captured inside `resolve_and_dispatch_pto2()`, printed before Scheduler summary)
@@ -99,19 +98,17 @@ Each sub-level macro requires `SIMPLER_DFX=1`:
 
 - `Thread %d: orch_start=%llu orch_end=%llu orch_cost=%.3fus` — each orch thread, after orchestration fully complete
 - `PTO2 total submitted tasks = %d, already executed %d tasks` — last orch thread only (×1), after orch timing line
-- `Thread %d: orch_stage_end=%llu` — last orch thread only (×1), only when `orch_to_sched_=true`
 - `Thread %d: sched_start=%llu sched_end=%llu sched_cost=%.3fus` — each sched thread, printed before Scheduler summary
 - `Thread %d: Scheduler summary: total_time=%.3fus, loops=%llu, tasks_scheduled=%d` — each sched thread
 - `Thread %d: sched_start=%llu sched_end(timeout)=%llu sched_cost=%.3fus` — timeout path only (replaces normal `sched_end`)
 
 **LOG_INFO_V9 count (normal run):**
 
-- `orch_to_sched_=false` (default): `N_sched*2 + N_orch*1 + 1` (orch_timing + PTO2_total + sched_timing + Scheduler_summary)
-- `orch_to_sched_=true` (`PTO2_ORCH_TO_SCHED=1`): adds 1 (`orch_stage_end`)
+- `N_sched*2 + N_orch*1 + 1` (orch_timing + PTO2_total + sched_timing + Scheduler_summary)
 
 > See the table at the end for concrete counts based on the `paged_attention` example.
 
-**Example log output — `orch_to_sched_=false`** (from `paged_attention`, device 10):
+**Example log output** (from `paged_attention`, device 10):
 
 ```text
 Thread 2: orch_start=48214752948321 orch_end=48214752959379 orch_cost=230.000us
@@ -123,26 +120,10 @@ Thread 0: sched_start=48214752948200 sched_end=48214752963571 sched_cost=320.000
 Thread 0: Scheduler summary: total_time=183.180us, loops=4611, tasks_scheduled=7
 ```
 
-**Example log output — `orch_to_sched_=true`** (`PTO2_ORCH_TO_SCHED=1`, from `paged_attention`, device 11):
-
-```text
-Thread 3: orch_stage_end=48236915058307
-Thread 3: orch_start=48236915044001 orch_end=48236915058781 orch_cost=308.000us
-Thread 2: orch_start=48236915044003 orch_end=48236915058782 orch_cost=308.000us
-PTO2 total submitted tasks = 13, already executed 13 tasks
-Thread 0: sched_start=48236915043911 sched_end=48236915059191 sched_cost=318.000us
-Thread 0: Scheduler summary: total_time=187.920us, loops=4561, tasks_scheduled=4
-Thread 1: sched_start=48236915043947 sched_end=48236915061881 sched_cost=372.000us
-Thread 1: Scheduler summary: total_time=168.620us, loops=3880, tasks_scheduled=9
-```
-
-> With `orch_to_sched_=true`, orch threads transition to schedulers after orchestration. They print `orch_end` but do NOT print `Scheduler summary` or `sched_end` (they have no cores assigned at shutdown time).
-
 **Note:**
 
 - All logs above are controlled by compile-time macro `SIMPLER_DFX`, not by `enable_l2_swimlane`.
 - `enable_l2_swimlane` only controls shared-memory data collection / swimlane export.
-- Enable `orch_to_sched_` via environment variable: `PTO2_ORCH_TO_SCHED=1`.
 
 ---
 
@@ -430,15 +411,15 @@ definitions to runtime headers.
 
 ## Log Output Summary
 
-> Example: `paged_attention` on Ascend hardware, 2 sched threads + 2 orch threads, normal run (no stall/timeout).
+> Example: `paged_attention` on Ascend hardware, normal run (no stall/timeout).
 
-| Level | Macro Settings | LOG_INFO_V9 Count (`orch_to_sched_=false`) | LOG_INFO_V9 Count (`orch_to_sched_=true`) | Description |
-| ----- | -------------- | ------------------------------------------ | ----------------------------------------- | ----------- |
-| 0 | `SIMPLER_DFX=0` | 0 | 0 | No timing output |
-| 1 | `SIMPLER_DFX=1` | 7 | 8 | Timing timestamps + scheduler summary |
-| 2 | `+SIMPLER_SCHED_PROFILING=1` | — | — | Scheduler detailed phase breakdown |
-| 3 | `+SIMPLER_ORCH_PROFILING=1` | — | — | Orchestrator detailed phase breakdown |
-| 4 | `+SIMPLER_TENSORMAP_PROFILING=1` | — | — | TensorMap lookup stats |
+| Level | Macro Settings | LOG_INFO_V9 Count | Description |
+| ----- | -------------- | ----------------- | ----------- |
+| 0 | `SIMPLER_DFX=0` | 0 | No timing output |
+| 1 | `SIMPLER_DFX=1` | 7 | Timing timestamps + scheduler summary |
+| 2 | `+SIMPLER_SCHED_PROFILING=1` | — | Scheduler detailed phase breakdown |
+| 3 | `+SIMPLER_ORCH_PROFILING=1` | — | Orchestrator detailed phase breakdown |
+| 4 | `+SIMPLER_TENSORMAP_PROFILING=1` | — | TensorMap lookup stats |
 
 ---
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -799,15 +799,6 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     int64_t t_args_end = _now_ms();
 
-    // Read orchestrator-to-scheduler transition flag from environment
-    {
-        const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");
-        if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
-            runtime->orch_to_sched = true;
-        }
-        LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
-    }
-
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena all live in a single backing allocation;
     // setup_static_arena reserves the three regions and commits in one shot.

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -177,12 +177,6 @@ public:
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Orchestrator-to-scheduler transition control
-    // When true, orchestrator threads convert to scheduler threads after orchestration completes.
-    // When false (default), orchestrator threads exit after orchestration without dispatching tasks.
-    // Controlled via PTO2_ORCH_TO_SCHED environment variable.
-    bool orch_to_sched;
-
     // Total tasks submitted by the host orchestrator — handed to the scheduler
     // (SchedulerContext::on_orchestration_done) in place of latching the SM ring
     // head on device. host_build_graph builds the whole graph on the host, so

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -54,7 +54,7 @@
 #define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 4MB max for orchestration SO
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
 
-// Default ready queue shards: one shard per worker thread (total minus orchestrator)
+// Default number of ready-queue shards.
 constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 1;
 
 // =============================================================================
@@ -156,19 +156,19 @@ public:
 
     // Execution parameters for AICPU scheduling.
     //
-    // aicpu_thread_num is the *total* AICPU thread count launched on this run
-    // (= orch + schedulers). AicpuExecutor splits this into one orchestrator
-    // thread (highest idx, runs aicpu_orchestration_entry) and the remaining
-    // aicpu_thread_num-1 scheduler threads that dispatch tasks to AICore.
-    // The orch thread also dispatches when env PTO2_ORCH_TO_SCHED is set.
+    // aicpu_thread_num is the total AICPU thread count launched on this run.
+    // host_build_graph builds the task graph on the host, so there is no
+    // on-device orchestrator: every thread is a scheduler that dispatches tasks
+    // to AICore. The highest-index thread additionally performs the one-time
+    // host-orch boot (attach SM, latch task count) before it starts dispatching.
     int aicpu_thread_num;
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Filter-style affinity gate input (a2a3 onboard). Host fills these
     // before launch from AICPU OCCUPY, and the device gate keeps threads whose
     // sched_getcpu() lands on one of the cpu_ids. The array position is the
-    // deterministic exec_idx used by AicpuExecutor for sched/orch role
-    // assignment; the highest active index is the orchestrator slot.
+    // deterministic exec_idx used by AicpuExecutor for scheduler-thread
+    // assignment; the highest active index additionally runs the host-orch boot.
     int32_t aicpu_allowed_cpus[MAX_GATE_THREADS];
     int32_t aicpu_allowed_cpu_count;
     int32_t aicpu_launch_count;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -692,7 +692,7 @@ void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32
 bool SchedulerContext::assign_cores_to_threads() {
     // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
     // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
-    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
+    active_sched_threads_ = aicpu_thread_num_;
     int32_t cluster_count = aic_count_;
 
     // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
@@ -776,17 +776,14 @@ void SchedulerContext::emergency_shutdown(Runtime *runtime) {
 // =============================================================================
 // Lifecycle: init / deinit
 // =============================================================================
-int32_t SchedulerContext::pre_handshake_init(
-    Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base
-) {
+int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, uint64_t regs_base) {
     always_assert(runtime != nullptr);
 
     // Zero all per-core execution state before handshake
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
 
-    // Wire thread/transition configuration that handshake/assign need to read.
+    // Wire thread configuration that handshake/assign need to read.
     aicpu_thread_num_ = aicpu_thread_num;
-    sched_thread_num_ = sched_thread_num;
     regs_ = regs_base;
 
 #if SIMPLER_DFX
@@ -804,12 +801,11 @@ int32_t SchedulerContext::pre_handshake_init(
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
             // Sched-phase pool count must match the dump_args_init thread count
             // below. This block runs before assign_cores_to_threads, so the
-            // active_sched_threads_ member isn't set yet — recompute the same
-            // normalization locally: sched_thread_num_ <= 0 means "use all AICPU
-            // threads as scheduler threads" (see assign_cores_to_threads'
-            // active_sched_threads_). Without it, init_phase would prime zero
-            // sched pools and all sched_phase emits would silently drop.
-            const int sched_phase_threads = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
+            // active_sched_threads_ member isn't set yet; every AICPU thread is a
+            // scheduler, so the count is aicpu_thread_num_. Without it, init_phase
+            // would prime zero sched pools and all sched_phase emits would silently
+            // drop.
+            const int sched_phase_threads = aicpu_thread_num_;
             // Orchestration is always single-threaded, so orch-phase is one pool
             // (ordinal 0) — see record_orch_phase.
             const int orch_phase_threads = 1;
@@ -920,7 +916,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
 
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
-    for (int32_t t = 0; t < sched_thread_num_; t++) {
+    for (int32_t t = 0; t < active_sched_threads_; t++) {
         CoreTracker &tracker = core_trackers_[t];
         for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
             int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
@@ -1009,7 +1005,6 @@ void SchedulerContext::deinit() {
     aiv_count_ = 0;
     cores_total_num_ = 0;
     aicpu_thread_num_ = 0;
-    sched_thread_num_ = 0;
     active_sched_threads_ = 0;
     for (int32_t t = 0; t < MAX_AICPU_THREADS; t++) {
         core_trackers_[t] = CoreTracker{};

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -66,8 +66,7 @@ public:
     // Leader-only: per-core state + config + swimlane buffers + core count. Must
     // be published before any thread enters handshake_partition. Returns 0 on
     // success, negative on failure.
-    int32_t
-    pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
+    int32_t pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, uint64_t regs_base);
     // All threads: handshake this thread's contiguous slice [lo, hi) of cores
     // (partitioned by tidx/nthreads). Each core is touched by exactly one thread.
     void handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads);
@@ -155,7 +154,6 @@ private:
 
     // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};
-    int32_t sched_thread_num_{0};
     int32_t aicpu_thread_num_{0};
     int32_t cores_total_num_{0};
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -37,7 +37,6 @@ Runtime::Runtime() {
     memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
-    orch_to_sched = false;
     host_total_tasks = 0;
 
     // Initialize shared-memory / orchestration argument plumbing


### PR DESCRIPTION
## What

`host_build_graph` builds the task graph on the **host**, so no AICPU thread orchestrates on-device at runtime. Despite that, the runtime reserved thread `N-1` as a no-op "orchestrator": it owned **zero** AICore cores and never dispatched, leaving only `aicpu_thread_num - 1` scheduling threads (**3 of 4** in every scene test).

This PR removes the vestigial orch/sched split (a `tensormap_and_ringbuffer` / device-orch concept) so **all `aicpu_thread_num` threads schedule**, matching what `a5` host_build_graph already does:

- Delete `orch_to_sched_`, `runtime.orch_to_sched`, and the `PTO2_ORCH_TO_SCHED` env read — meaningless in HBG (no device orchestration).
- Delete the `sched_thread_num_` split; distribute cores over all threads (`active_sched_threads_ = aicpu_thread_num_`). The drain barrier, completion counting, and cluster-id math already key off `active_sched_threads_`, so they scale automatically.
- The last thread still performs the one-time host-orch boot preamble, then joins scheduling like every other thread.

Net effect at `aicpu_thread_num=4`: **4 scheduling threads instead of 3.** NUMA locality is unchanged — `compute_allowed_cpus` still pins all threads to a single AICPU cluster (cpu_ids `{4,5,6,7}`) because `active_count` stays 4. Do **not** raise `aicpu_thread_num` past a single cluster's core count, or threads spill across the NUMA boundary.

## Hardware validation (a2a3, 910B2)

`bgemm` onboard passes with **4 scheduler summaries — one per thread, including thread 3**, which now schedules real work instead of sitting idle:

| Thread | tasks_scheduled | total_time |
| ------ | --------------- | ---------- |
| 0 | 36 | 88.40 µs |
| 1 | 34 | 88.38 µs |
| 2 | 31 | 88.26 µs |
| 3 | **27** (was 0) | 87.82 µs |

## Benchmark 1: 3 vs 4 scheduling threads

Same build, `aicpu_thread_num` toggled at runtime (**3 → cpus `{4,5,6}`, 4 → cpus `{4,5,6,7}`** — same NUMA cluster, isolating only the thread count). Metric = per-thread device-side scheduler `total_time`, 15 rounds; lower is faster.

| Example | 3 threads (mean / min) | 4 threads (mean / min) | Δ mean |
| ------- | ---------------------- | ---------------------- | ------ |
| **bgemm** (block_dim 24) | 81.8 / 74.1 µs | 65.1 / 57.9 µs | **−20%** |
| matmul | 22.5 / 16.4 µs | 22.1 / 15.2 µs | −2% |
| paged_attention | 22.4 / 17.1 µs | 23.1 / 17.8 µs | +3% |
| vector_example | 21.1 / 13.9 µs | 21.0 / 13.8 µs | ~0% |

Dispatch-bound compute (**bgemm, ~20% faster**) is the clear win: 4 threads shorten each thread's serial MMIO poll round (~95 ns/core), feeding cores sooner. `matmul` gains modestly; `vector_example` is neutral (only ~3 clusters, so the 4th thread has no cores); `paged_attention` at scene-test scale (~a dozen tasks) is fixed-overhead-dominated, so ±3% is within noise — its production-shape win is documented in the PyPTO2 report. Consistent with that report directionally.

## Benchmark 2: 3 vs 4 scheduling threads

Same build, `aicpu_thread_num` toggled at runtime (3 → cpus `{4,5,6}`, 4 → `{4,5,6,7}` — same NUMA cluster). Metric = device-wall (`[STRACE] device_wall` via `strace_timing`), lower is faster. Measured across `paged_attention` (Case1 params) scaled by `batch` to span the ms range (ring/heap bumps applied equally to both configs):

| Workload (device @ 3 thr) | batch | 3 threads | 4 threads | Δ |
| ------------------------- | ----- | --------- | --------- | - |
| paged_attention (~2.6 ms) | 16  | 2.65 ms  | 1.99 ms  | **−25%** |
| paged_attention (~5 ms)   | 32  | 5.23 ms  | 3.77 ms  | **−28%** |
| paged_attention (~10 ms)  | 64  | 10.39 ms | 7.43 ms  | **−28%** |
| paged_attention (~21 ms)  | 128 | 21.21 ms | 15.03 ms | **−29%** |
| paged_attention (~43 ms)  | 256 | 43.36 ms | 30.23 ms | **−30%** |

n=8/point, σ<0.5% at scale. The 4th scheduler thread delivers a **consistent ~29% device-time reduction across the whole ms range**, growing with dispatch pressure (task count). Sub-millisecond scene tests (`bgemm` ~0.3 ms, `matmul`/`vector` ~0.1–0.2 ms) are overhead-bound — too few tasks for a 4th scheduler to help — so they're flat-to-slightly-slower, which is immaterial for production shapes. Corroborates the PyPTO2 report.

