### PR TITLE
Add: support mixed local and remote L4 CommDomains

### DIFF
--- a/.github/workflows/_st-pod.yml
+++ b/.github/workflows/_st-pod.yml
@@ -189,6 +189,24 @@ jobs:
           env-prefix: SIMPLER_VECTOR_ADD_MIXED_L3
           parent-script: examples/workers/l4/vector_add_mixed_l3/run_parent.sh
 
+      - name: global_tload_mixed_l3
+        id: global-tload-mixed-l3
+        continue-on-error: true
+        uses: ./.github/actions/pod-run-example
+        with:
+          example: global_tload_mixed_l3
+          env-prefix: SIMPLER_GLOBAL_TLOAD_MIXED_L3
+          parent-script: examples/workers/l4/global_tload_mixed_l3/run_parent.sh
+
+      - name: compute_then_tload_mixed_l3
+        id: compute-then-tload-mixed-l3
+        continue-on-error: true
+        uses: ./.github/actions/pod-run-example
+        with:
+          example: compute_then_tload_mixed_l3
+          env-prefix: SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3
+          parent-script: examples/workers/l4/compute_then_tload_mixed_l3/run_parent.sh
+
       - name: Clear the pod staging tree
         if: always()
         uses: ./.github/actions/pod-teardown
@@ -201,6 +219,8 @@ jobs:
         run: |
           FAILED=""
           [ "${{ steps.vector-add-mixed-l3.outcome }}" = "success" ] || FAILED="$FAILED vector_add_mixed_l3"
+          [ "${{ steps.global-tload-mixed-l3.outcome }}" = "success" ] || FAILED="$FAILED global_tload_mixed_l3"
+          [ "${{ steps.compute-then-tload-mixed-l3.outcome }}" = "success" ] || FAILED="$FAILED compute_then_tload_mixed_l3"
           if [ -n "$FAILED" ]; then
             echo "::error::pod examples failed:$FAILED"
             exit 1

--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -49,6 +49,71 @@ Kernels read peer windows through `device_ctx` (which holds every rank's
 window base, local + imported peer); `buffers[name]` is the local slice —
 name it in a task arg with `buffers[name].tensor(shapes, dtype)`.
 
+### Global CommDomain across local and remote L3 nodes
+
+An L4 worker can build the same `CommContext` shape across any combination of
+forked local L3 workers (`add_worker`) and TCP-connected L3 workers
+(`add_remote_worker`) without `mpirun`:
+
+```python
+with orch.allocate_global_domain(
+    name="tp",
+    members=[(node0_worker_id, 0), (node1_worker_id, 0)],
+    window_size=4096,
+    buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+) as domain:
+    ...
+```
+
+Each member is `(l3_worker_id, local_l2_worker_id)`. The order defines dense
+domain ranks. A remote node reads `comm_profile` and `global_device_ranks`
+from `RemoteWorkerSpec`; a local L3 reads the same fields from its `Worker`
+configuration. All participating nodes must use the same profile.
+
+Global CommDomain capability follows the backend that the node actually
+loads: a platform ending in `sim` supports the `sim` profile, and a real
+`a2a3` platform supports `a3-fabric-v1`. Real A5 and any other
+platform/profile combination currently reject allocation before `PREPARE`.
+Each local or remote L3 repeats the same check during `COMM_INIT`, so an
+unsupported backend never advertises a usable descriptor capability.
+
+The control flow is:
+
+1. L4 sends `COMM_INIT` with cluster, node, global-device, and domain-rank
+   identities.
+2. Each L3 asks its participating L2 children to create a local window and
+   export a transport descriptor.
+3. L4 validates and assembles one complete rank-ordered descriptor table.
+4. L4 returns that table to every L3, which forwards it to each L2 for import.
+5. L4 commits only after all imports succeed. Any earlier failure sends
+   `ABORT` and releases every prepared local window.
+
+The descriptor reports the backend's actual mapped size. A3 Fabric may align
+the requested size to its VMM granularity; buffer carving and bounds checks
+therefore use the returned mapping size. Handles and device pointers never
+cross the public Python API. Remote orchestration code calls
+`orch.get_global_domain(domain_id)` to obtain only its committed L3-local
+contexts.
+
+`copy_to_global_domain` and `copy_from_global_domain` provide bounded
+control-plane staging and smoke checks. Normal communication still runs in
+L2 kernels through the imported `CommContext`.
+
+By default a live Global CommDomain is swept after the current `Worker.run`
+drains. Set `retain_after_run=True` when a communication kernel writes results
+into the window and a second L4 run must inspect them. The later run should
+call `domain.release()` after copying the results; `Worker.close()` is the
+final safety net.
+
+Repository CI exercises the complete transaction, rollback, and mixed
+local/remote paths with the `sim` backend. It also exercises the real
+`a3-fabric-v1` backend: the two-machine `st-pod-onboard-a2a3` job runs
+`global_tload_mixed_l3` and `compute_then_tload_mixed_l3`, whose default
+profile is `a3-fabric-v1` on real A3 devices. Those two examples are the
+in-repository harness for the Fabric path; a run that needs to know whether
+Fabric was covered should read that job rather than infer it from the
+simulation checks.
+
 ---
 
 ## 2. Lifetime model

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -67,11 +67,18 @@ Implemented:
   imported-handle scheduling eligibility, and deferred owner free.
 - Registry-scope-aware remote callable manifest/control install for dispatcher
   `PYTHON_IMPORT`, inner `PYTHON_IMPORT`, and inner inline `CHIP_CALLABLE`.
+  Pre-init `ChipCallable` registrations on an L4 worker are serialized into
+  each remote session manifest and installed on that L3's L2 children.
+- The repository contains simulation coverage for the no-`mpirun` Global
+  CommDomain transaction and mixed local/remote L3 topology.
+- The two-machine `st-pod-onboard-a2a3` job covers the real `a3-fabric-v1`
+  backend through `global_tload_mixed_l3` (L4-brokered peer `TLOAD`) and
+  `compute_then_tload_mixed_l3` (one L2 compute round followed by
+  cross-machine communication through the same domain).
 
 Still pending:
 
 - A2 RoCE, A3 HCCS, and A5 UB HCOMM profiles.
-- Remote `CommDomain` allocation/import and hardware-gated validation.
 - Negotiated `PYTHON_SERIALIZED` remote callable payloads and staged
   `CHIP_CALLABLE` blob adapters.
 
@@ -449,10 +456,9 @@ Session execution rules:
   the current one-`WorkerThread`-per-child local scheduling model and keeps
   ordering, buffer lifetime, and callable visibility simple.
 - State-changing CONTROL frames such as register, unregister, buffer free,
-  copy, export/import, and import release serialize with TASK execution on the
-  ordered command lane. They are not applied concurrently with a running TASK
-  on the same endpoint. Future Remote CommDomain controls follow the same
-  ordering rule when they enter scope.
+  copy, export/import, import release, and Global CommDomain transactions
+  serialize with TASK execution on the ordered command lane. They are not
+  applied concurrently with a running TASK on the same endpoint.
 - Bulk data movement may use a separate data plane, but the state change that
   makes staged bytes, callable payloads, or imported handles visible is ordered
   by the command lane.

--- a/docs/remote-l3-worker-design/implementation-record.md
+++ b/docs/remote-l3-worker-design/implementation-record.md
@@ -16,7 +16,7 @@ It is updated as each documented feature is completed and verified.
 | 5 | Versioned remote frame codec | In progress | TASK/COMPLETION/CONTROL_REPLY/HELLO/CONTROL/HEALTH exist; core fuzz/bounds coverage is present, with more exhaustive corpus testing still possible. |
 | 6 | Remote callable registry | In progress | Dispatcher `PYTHON_IMPORT`, inner manifest/control `PYTHON_IMPORT`, and inner manifest/control inline `CHIP_CALLABLE` are implemented; serialized payloads and staged chip blobs remain negotiated extensions. |
 | 7 | Fork-safe host_tcp session runner | In progress | Daemon/session bootstrap and HELLO READY barrier are implemented for host_tcp transport. |
-| 8 | Remote control-plane parity | In progress | Registry, alloc/free/copy, export/import/release-import controls are implemented for host_tcp; Remote CommDomain controls are reserved/unsupported. |
+| 8 | Remote control-plane parity | In progress | Registry, alloc/free/copy, export/import/release-import, and Global CommDomain prepare/import/commit/release/copy controls are implemented for host_tcp. |
 | 9 | Remote buffer registry | In progress | host_tcp owner/imported buffers, TASK materialization, public memory API, opaque handles, slot/import-ref capture, and deferred free/release-import are implemented. |
 | 10 | A2 RoCE HCOMM profile | Pending | Hardware-gated profile. |
 | 11 | A3 HCCS HCOMM profile | Pending | Hardware-gated profile. |
@@ -88,6 +88,18 @@ It is updated as each documented feature is completed and verified.
   Imports use shared-memory backed mappings in the session runner, imported
   handles remain opaque on the parent, and owner frees wait for live imports
   and slot refs to drain.
+- Added L4-brokered Global CommDomain setup without MPI. L2 export
+  descriptors are collected by L3, assembled by L4, returned to every L3/L2
+  for import, and released after the L4 DAG drain by default. Domains created
+  with `retain_after_run=True` remain live for a later run until explicitly
+  released or the Worker closes. Sim shm and A3 Fabric V2 use the same
+  descriptor ABI.
+- Added startup-manifest delivery for pre-registered inner `CHIP_CALLABLE`
+  payloads, allowing remote sessions to resolve installed chip callables
+  before task dispatch.
+- Remote buffers use L3-owned child-visible host buffers whenever the L3 has
+  forked chip children, while childless sim sessions keep the shared-memory
+  fallback.
 - Documented the v1 remote registry target/kind matrix, inner
   `INNER_L3_WORKER` visibility rules, remote `CHIP_CALLABLE` staged/inline
   payload contract, partial-register cleanup outcomes, and health-expiry
@@ -95,6 +107,8 @@ It is updated as each documented feature is completed and verified.
 
 ## Verification
 
+- Global CommDomain codec/validation tests and the Linux two-daemon sim
+  transaction test live in `tests/ut/py/test_global_comm_domain.py`.
 - Python focused sidecar/callable tests:
   `tests/ut/py/test_task_interface.py tests/ut/py/test_callable_identity.py`
   passed with `145 passed`.

--- a/docs/remote-l3-worker-design/protocol.md
+++ b/docs/remote-l3-worker-design/protocol.md
@@ -299,15 +299,29 @@ Required remote controls:
 - `IMPORT_BUFFER`
 - `RELEASE_IMPORT`
 
-Reserved future controls for Remote CommDomain:
+Required Global CommDomain controls:
 
 - `COMM_INIT`
 - `ALLOC_DOMAIN`
 - `RELEASE_DOMAIN`
+- `COPY_TO_DOMAIN`
+- `COPY_FROM_DOMAIN`
 
-The first Remote L3 task-dispatch cut rejects the reserved domain controls
-with an unsupported-control reply. They become required only when Remote
-CommDomain enters scope.
+`COMM_INIT` validates the cluster id, node identity, communication profile,
+global device ranks, and dense domain-rank table. `ALLOC_DOMAIN` is a
+transaction with `PREPARE_EXPORT`, `IMPORT`, `COMMIT`, and `ABORT` phases.
+Each L2 exports its local transport descriptor during prepare. L4 assembles
+the complete rank-ordered table and sends it to every L3; each L3 forwards it
+to its L2 children for import. No domain becomes visible to a remote task
+before every node acknowledges `COMMIT`.
+
+`RELEASE_DOMAIN` is idempotent and normally runs after the L4 DAG drain.
+An allocation marked `retain_after_run` may remain live for a later L4 run
+that reads kernel results; explicit release or session shutdown then performs
+the same teardown.
+`COPY_TO_DOMAIN` and `COPY_FROM_DOMAIN` are bounded smoke/control data
+operations for a committed local window. They do not replace kernel data
+movement through `CommContext`.
 
 The register-family controls are registry-scope-aware.
 `PREPARE_REGISTER_CALLABLE` carries:

--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -35,6 +35,8 @@ workers/
     child_memory/           # orch.malloc + child_memory=True, weight reuse across tasks
   l4/                       # Multi-machine examples (one L3 here, one over TCP)
     vector_add_mixed_l3/    # Worker(level=4) + add_remote_worker, golden checked on both sides
+    global_tload_mixed_l3/  # Global CommDomain build + cross-machine peer TLOAD on both ranks
+    compute_then_tload_mixed_l3/  # compute round on both L2s, then peer TLOAD through the same domain
 ```
 
 Why no `tensormap_and_ringbuffer/` layer? Because every example here hard-codes

--- a/examples/workers/l4/compute_then_tload_mixed_l3/README.md
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/README.md
@@ -1,0 +1,86 @@
+# Compute then TLOAD mixed L3 example
+
+This example keeps one L4/L3/L2 process tree alive across two ordered task
+rounds — a local compute round, then a cross-machine communication round
+through the same Global CommDomain:
+
+```text
+L4 parent on machine A -> local L3 on machine A  -> local NPU, rank 0
+                       -> remote L3 on machine B -> remote NPU, rank 1
+
+round 1 (compute):        each rank runs input = lhs + rhs on its own L2
+round 2 (communication):  each rank peer-TLOADs every rank's input, sums, stores result
+```
+
+Both rounds run in the same Worker lifetime and the same committed domain. The
+parent verifies the compute outputs before issuing any communication task —
+`Worker.run()` drains the DAG before returning, so the round boundary is also
+the completion barrier — then verifies the communication outputs. Compute and
+communication are checked separately, so a communication failure cannot hide
+behind a correct compute result or vice versa.
+
+`global_tload_mixed_l3` covers the domain build and the peer `TLOAD` alone;
+this example exists for the phase ordering — device results produced by one
+round feeding the next round's cross-machine reads.
+
+## Prepare both machines
+
+Use the same source revision on machine A and machine B:
+
+```bash
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install --no-build-isolation -e .
+```
+
+## Start the remote L3 daemon
+
+Start this on machine B. `192.0.2.20` is a documentation placeholder, not a
+usable address:
+
+```bash
+source .venv/bin/activate
+python -m simpler.remote_l3_worker --host 192.0.2.20 --port 19073
+```
+
+## Run on the L4 parent
+
+Run this on machine A. Only the first id of each device list is used — each L3
+owns exactly one L2:
+
+```bash
+source .venv/bin/activate
+export SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE=192.0.2.20:19073
+export SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_LOCAL_DEVICES=0
+export SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE_DEVICES=0
+bash examples/workers/l4/compute_then_tload_mixed_l3/run_parent.sh
+```
+
+Expected output ends with:
+
+```text
+[compute-then-tload-mixed-l3] compute local rank=0 max_diff=0.000e+00
+[compute-then-tload-mixed-l3] compute remote rank=1 max_diff=0.000e+00
+[compute-then-tload-mixed-l3] communication local rank=0 max_diff=0.000e+00
+[compute-then-tload-mixed-l3] communication remote rank=1 max_diff=0.000e+00
+compute_then_tload_mixed_l3 passed
+```
+
+Any `max_diff` above its tolerance exits non-zero.
+
+## Configuration
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE` | (required) | Remote daemon endpoint, `HOST:PORT` |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_LOCAL_DEVICES` | `0` | Device list; the first id is the local L3's L2 |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE_DEVICES` | `0` | Device list; the first id is the remote L3's L2 |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_PLATFORM` | `a2a3` | Target platform |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_RUNTIME` | `tensormap_and_ringbuffer` | Runtime |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_COMM_PROFILE` | `a3-fabric-v1` | Global CommDomain backend profile |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_SESSION_LISTEN_HOST` | `0.0.0.0` | Interface the parent's session runner binds |
+| `SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_SESSION_TIMEOUT` | `120` | Seconds to wait on the remote session |
+
+The peer `TLOAD` needs real cross-device windows, so the default profile is
+`a3-fabric-v1` and requires real A3 devices on both machines. In CI the pod
+job drives this script through `pod-run-example` with the same variables.

--- a/examples/workers/l4/compute_then_tload_mixed_l3/kernels/aiv/global_tload_kernel.cpp
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/kernels/aiv/global_tload_kernel.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t kCount = 256;
+static constexpr int kMaxRanks = 16;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *input_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *result_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+    int rank_count = static_cast<int>(args[2]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
+
+    if (rank_count <= 0 || rank_count > kMaxRanks) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+    __gm__ float *input = reinterpret_cast<__gm__ float *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    using Shape = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Stride = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Global = pto::GlobalTensor<float, Shape, Stride, pto::Layout::ND>;
+    using Tile = pto::Tile<pto::TileType::Vec, float, 1, kCount, pto::BLayout::RowMajor, -1, -1>;
+
+    Shape shape(1, 1, 1, 1, kCount);
+    Stride stride(kCount, kCount, kCount, kCount, 1);
+    Tile accumulator(1, kCount);
+    Tile peer_tile(1, kCount);
+    TASSIGN(accumulator, 0x0);
+    TASSIGN(peer_tile, 0x10000);
+
+    Global local_input(input, shape, stride);
+    TLOAD(accumulator, local_input);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    int my_rank = static_cast<int>(comm_ctx->rankId);
+    for (int peer = 0; peer < rank_count; ++peer) {
+        if (peer == my_rank) continue;
+        __gm__ float *peer_input = CommRemotePtr(comm_ctx, input, peer);
+        Global peer_global(peer_input, shape, stride);
+        TLOAD(peer_tile, peer_global);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TADD(accumulator, accumulator, peer_tile);
+        set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+    }
+
+    Global result_global(result, shape, stride);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(result_global, accumulator);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l4/compute_then_tload_mixed_l3/kernels/aiv/local_add_kernel.cpp
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/kernels/aiv/local_add_kernel.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t kCount = 256;
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *lhs_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *rhs_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+    __gm__ ChipTensor *result_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
+    __gm__ float *lhs = reinterpret_cast<__gm__ float *>(lhs_tensor->buffer.addr) + lhs_tensor->start_offset;
+    __gm__ float *rhs = reinterpret_cast<__gm__ float *>(rhs_tensor->buffer.addr) + rhs_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    using Shape = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Stride = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Global = pto::GlobalTensor<float, Shape, Stride, pto::Layout::ND>;
+    using Tile = pto::Tile<pto::TileType::Vec, float, 1, kCount, pto::BLayout::RowMajor, -1, -1>;
+
+    Shape shape(1, 1, 1, 1, kCount);
+    Stride stride(kCount, kCount, kCount, kCount, 1);
+    Tile lhs_tile(1, kCount);
+    Tile rhs_tile(1, kCount);
+    Tile result_tile(1, kCount);
+    TASSIGN(lhs_tile, 0x0);
+    TASSIGN(rhs_tile, 0x10000);
+    TASSIGN(result_tile, 0x20000);
+
+    Global lhs_global(lhs, shape, stride);
+    Global rhs_global(rhs, shape, stride);
+    Global result_global(result, shape, stride);
+    TLOAD(lhs_tile, lhs_global);
+    TLOAD(rhs_tile, rhs_global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(result_tile, lhs_tile, rhs_tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(result_global, result_tile);
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+global_tload_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,
+    };
+}
+
+__attribute__((visibility("default"))) void global_tload_orchestration(const ChipTaskArgs &orch_args) {
+    CoreTaskArgs params;
+    params.add_input(orch_args.tensor(0).ref());
+    params.add_output(orch_args.tensor(1).ref());
+    params.add_scalar(orch_args.scalar(0));
+    params.add_scalar(orch_args.scalar(1));
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/local_add_orch.cpp
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/local_add_orch.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+local_add_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,
+    };
+}
+
+__attribute__((visibility("default"))) void local_add_orchestration(const ChipTaskArgs &orch_args) {
+    CoreTaskArgs params;
+    params.add_input(orch_args.tensor(0).ref());
+    params.add_input(orch_args.tensor(1).ref());
+    params.add_output(orch_args.tensor(2).ref());
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l4/compute_then_tload_mixed_l3/main.py
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/main.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Compute on both L2s first, then run a Global CommDomain peer TLOAD in the same Worker lifetime."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import struct
+from pathlib import Path
+
+from simpler.callable_identity import CallableHandle
+from simpler.remote_l3_protocol import HOST_TCP_TRANSPORT_PROFILE
+from simpler.task_interface import (
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    CommBufferSpec,
+    CoreCallable,
+    DataType,
+    GlobalCommDomainHandle,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import RemoteCallable, RemoteWorkerSpec, Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+REMOTE_COMPUTE_TARGET = "examples.workers.l4.compute_then_tload_mixed_l3.main:remote_compute_orch"
+REMOTE_TLOAD_TARGET = "examples.workers.l4.compute_then_tload_mixed_l3.main:remote_tload_orch"
+COUNT = 256
+FLOAT_NBYTES = 4
+WINDOW_SIZE = 4096
+RANK_LABELS = ("local", "remote")
+_LOCAL_COMPUTE_HANDLE: CallableHandle | None = None
+_LOCAL_TLOAD_HANDLE: CallableHandle | None = None
+_LOCAL_KEEPALIVE: list[TaskArgs] = []
+_REMOTE_KEEPALIVE: list[TaskArgs] = []
+
+
+def _digest_from_scalars(args: TaskArgs, start: int) -> bytes:
+    return b"".join(int(args.scalar(start + index)).to_bytes(8, "little") for index in range(4))
+
+
+def _window_tensor(context, buffer_name: str):
+    return context.buffers[buffer_name].tensor((COUNT,), DataType.FLOAT32)
+
+
+def _submit_compute_task(orch, chip_handle: CallableHandle, args: TaskArgs, cfg: CallConfig) -> TaskArgs:
+    domain_id = int(args.scalar(0))
+    local_worker_id = int(args.scalar(1))
+    context = orch.get_global_domain(domain_id)[local_worker_id]
+
+    chip_args = TaskArgs()
+    chip_args.add_tensor(_window_tensor(context, "lhs"), TensorArgType.INPUT)
+    chip_args.add_tensor(_window_tensor(context, "rhs"), TensorArgType.INPUT)
+    chip_args.add_tensor(_window_tensor(context, "input"), TensorArgType.OUTPUT_EXISTING)
+    orch.submit_next_level(chip_handle, chip_args, cfg, worker=local_worker_id)
+    return chip_args
+
+
+def _submit_tload_task(orch, chip_handle: CallableHandle, args: TaskArgs, cfg: CallConfig) -> TaskArgs:
+    domain_id = int(args.scalar(0))
+    local_worker_id = int(args.scalar(1))
+    context = orch.get_global_domain(domain_id)[local_worker_id]
+
+    chip_args = TaskArgs()
+    chip_args.add_tensor(_window_tensor(context, "input"), TensorArgType.INPUT)
+    chip_args.add_tensor(_window_tensor(context, "result"), TensorArgType.OUTPUT_EXISTING)
+    chip_args.add_scalar(context.domain_size)
+    chip_args.add_scalar(context.device_ctx)
+    orch.submit_next_level(chip_handle, chip_args, cfg, worker=local_worker_id)
+    return chip_args
+
+
+def local_compute_orch(orch, args: TaskArgs, cfg: CallConfig) -> None:
+    """Submit the vector-add chip task from the forked local L3 worker."""
+    if _LOCAL_COMPUTE_HANDLE is None:
+        raise RuntimeError("local L3 compute handle was not installed before fork")
+    if args.scalar_count() != 2:
+        raise ValueError("local compute task expects domain_id and local_worker_id")
+    _LOCAL_KEEPALIVE.append(_submit_compute_task(orch, _LOCAL_COMPUTE_HANDLE, args, cfg))
+
+
+def local_tload_orch(orch, args: TaskArgs, cfg: CallConfig) -> None:
+    """Submit the peer-TLOAD chip task from the forked local L3 worker."""
+    if _LOCAL_TLOAD_HANDLE is None:
+        raise RuntimeError("local L3 TLOAD handle was not installed before fork")
+    if args.scalar_count() != 2:
+        raise ValueError("local TLOAD task expects domain_id and local_worker_id")
+    _LOCAL_KEEPALIVE.append(_submit_tload_task(orch, _LOCAL_TLOAD_HANDLE, args, cfg))
+
+
+def remote_compute_orch(orch, args: TaskArgs, cfg: CallConfig) -> None:
+    """Submit the vector-add chip task from the daemon-started remote L3 worker."""
+    from simpler.remote_l3_session import get_inner_handle  # noqa: PLC0415
+
+    if args.scalar_count() != 6:
+        raise ValueError("remote compute task expects domain_id, local_worker_id, and four digest scalars")
+    chip_handle = get_inner_handle(_digest_from_scalars(args, 2).hex())
+    _REMOTE_KEEPALIVE.append(_submit_compute_task(orch, chip_handle, args, cfg))
+
+
+def remote_tload_orch(orch, args: TaskArgs, cfg: CallConfig) -> None:
+    """Submit the peer-TLOAD chip task from the daemon-started remote L3 worker."""
+    from simpler.remote_l3_session import get_inner_handle  # noqa: PLC0415
+
+    if args.scalar_count() != 6:
+        raise ValueError("remote TLOAD task expects domain_id, local_worker_id, and four digest scalars")
+    chip_handle = get_inner_handle(_digest_from_scalars(args, 2).hex())
+    _REMOTE_KEEPALIVE.append(_submit_tload_task(orch, chip_handle, args, cfg))
+
+
+def _build_chip_callable(
+    *,
+    platform: str,
+    runtime: str,
+    kernel_name: str,
+    orch_name: str,
+    signature: list[ArgDirection],
+    func_name: str,
+    config_name: str,
+) -> ChipCallable:
+    kernels = Path(__file__).resolve().parent / "kernels"
+    compiler = KernelCompiler(platform=platform)
+    include_dirs = list(compiler.get_orchestration_include_dirs(runtime))
+    include_dirs.append(str(compiler.project_root / "src" / "common"))
+    kernel_binary = compiler.compile_incore(
+        source_path=str(kernels / "aiv" / kernel_name),
+        core_type="aiv",
+        pto_isa_root=ensure_pto_isa_root(),
+        extra_include_dirs=include_dirs,
+    )
+    if not platform.endswith("sim"):
+        kernel_binary = extract_text_section(kernel_binary)
+    orch_binary = compiler.compile_orchestration(
+        runtime_name=runtime,
+        source_path=str(kernels / "orchestration" / orch_name),
+    )
+    core = CoreCallable.build(signature=signature, binary=kernel_binary)
+    return ChipCallable.build(
+        signature=signature,
+        func_name=func_name,
+        config_name=config_name,
+        binary=orch_binary,
+        children=[(0, core)],
+    )
+
+
+def _build_compute_callable(platform: str, runtime: str) -> ChipCallable:
+    return _build_chip_callable(
+        platform=platform,
+        runtime=runtime,
+        kernel_name="local_add_kernel.cpp",
+        orch_name="local_add_orch.cpp",
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        func_name="local_add_orchestration",
+        config_name="local_add_orchestration_config",
+    )
+
+
+def _build_tload_callable(platform: str, runtime: str) -> ChipCallable:
+    return _build_chip_callable(
+        platform=platform,
+        runtime=runtime,
+        kernel_name="global_tload_kernel.cpp",
+        orch_name="global_tload_orch.cpp",
+        signature=[ArgDirection.IN, ArgDirection.OUT],
+        func_name="global_tload_orchestration",
+        config_name="global_tload_orchestration_config",
+    )
+
+
+def _add_digest_scalars(task_args: TaskArgs, digest: bytes) -> None:
+    if len(digest) != 32:
+        raise ValueError("inner chip callable digest must be 32 bytes")
+    for offset in range(0, 32, 8):
+        task_args.add_scalar(int.from_bytes(digest[offset : offset + 8], "little"))
+
+
+def _parse_first_device(value: str, *, label: str) -> int:
+    device_ids = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if not device_ids or device_ids[0] < 0:
+        raise ValueError(f"{label} device list must start with a non-negative device id")
+    return device_ids[0]
+
+
+def _lhs_values(rank: int) -> tuple[float, ...]:
+    return tuple(float(rank * 100 + index) for index in range(COUNT))
+
+
+def _rhs_values(rank: int) -> tuple[float, ...]:
+    return tuple(float(rank * 10 + 2 * index) for index in range(COUNT))
+
+
+def _expected_compute(rank: int) -> tuple[float, ...]:
+    return tuple(lhs + rhs for lhs, rhs in zip(_lhs_values(rank), _rhs_values(rank)))
+
+
+def _expected_communication(rank_count: int) -> tuple[float, ...]:
+    rank_results = tuple(_expected_compute(rank) for rank in range(rank_count))
+    return tuple(sum(rank_result[index] for rank_result in rank_results) for index in range(COUNT))
+
+
+def _unpack_floats(raw: bytes) -> tuple[float, ...]:
+    return tuple(float(value) for value in struct.unpack(f"<{COUNT}f", raw))
+
+
+def _max_diff(actual: tuple[float, ...], expected: tuple[float, ...]) -> float:
+    return max(abs(observed - wanted) for observed, wanted in zip(actual, expected))
+
+
+def _local_args(domain) -> TaskArgs:
+    args = TaskArgs()
+    args.add_scalar(domain.domain_id)
+    args.add_scalar(0)
+    return args
+
+
+def _remote_args(domain, digest: bytes) -> TaskArgs:
+    args = _local_args(domain)
+    _add_digest_scalars(args, digest)
+    return args
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--remote", required=True, help="remote L3 daemon endpoint, HOST:PORT")
+    parser.add_argument("--local-devices", default="0", help="device list whose first id the forked local L3 owns")
+    parser.add_argument("--remote-devices", default="0", help="device list whose first id the daemon L3 owns")
+    parser.add_argument("--platform", default="a2a3")
+    parser.add_argument("--runtime", default="tensormap_and_ringbuffer")
+    parser.add_argument("--comm-profile", default="a3-fabric-v1")
+    parser.add_argument("--session-timeout", type=float, default=120.0)
+    parser.add_argument("--session-listen-host", default="0.0.0.0")
+    return parser.parse_args()
+
+
+def main() -> int:  # noqa: PLR0915 -- one linear two-phase scenario; splitting it would scatter the phase ordering this example exists to show
+    # The local L3 is a fork of this process, so its orchestration functions
+    # reach the handles only through module state; locals would not survive
+    # into the child.
+    global _LOCAL_COMPUTE_HANDLE, _LOCAL_TLOAD_HANDLE  # noqa: PLW0603
+
+    args = _parse_args()
+    local_device = _parse_first_device(args.local_devices, label="local")
+    remote_device = _parse_first_device(args.remote_devices, label="remote")
+
+    compute_callable = _build_compute_callable(args.platform, args.runtime)
+    tload_callable = _build_tload_callable(args.platform, args.runtime)
+    local_l3 = Worker(
+        level=3,
+        device_ids=[local_device],
+        num_sub_workers=0,
+        platform=args.platform,
+        runtime=args.runtime,
+        comm_profile=args.comm_profile,
+        global_device_ranks=(0,),
+    )
+    _LOCAL_COMPUTE_HANDLE = local_l3.register(compute_callable)
+    _LOCAL_TLOAD_HANDLE = local_l3.register(tload_callable)
+
+    worker = Worker(level=4, num_sub_workers=0, remote_session_timeout_s=args.session_timeout)
+    domain_handle: GlobalCommDomainHandle | None = None
+    parent_keepalive: list[TaskArgs] = []
+    try:
+        local_node = worker.add_worker(local_l3)
+        remote_node = worker.add_remote_worker(
+            RemoteWorkerSpec(
+                endpoint=args.remote,
+                platform=args.platform,
+                runtime=args.runtime,
+                device_ids=(remote_device,),
+                transport=HOST_TCP_TRANSPORT_PROFILE,
+                comm_profile=args.comm_profile,
+                global_device_ranks=(1,),
+                session_listen_host=args.session_listen_host,
+                allow_wildcard_session_bind=True,
+            )
+        )
+        compute_handle = worker.register(compute_callable)
+        tload_handle = worker.register(tload_callable)
+        local_compute_handle = worker.register(local_compute_orch)
+        local_tload_handle = worker.register(local_tload_orch)
+        remote_compute_handle = worker.register(RemoteCallable(REMOTE_COMPUTE_TARGET), workers=[remote_node])
+        remote_tload_handle = worker.register(RemoteCallable(REMOTE_TLOAD_TARGET), workers=[remote_node])
+        worker.init()
+
+        def compute_phase(orch, _args, cfg):
+            nonlocal domain_handle
+            domain = orch.allocate_global_domain(
+                name="compute-then-tload-mixed-l3",
+                members=((local_node, 0), (remote_node, 0)),
+                window_size=WINDOW_SIZE,
+                buffers=(
+                    CommBufferSpec("lhs", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                    CommBufferSpec("rhs", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                    CommBufferSpec("input", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                    CommBufferSpec("result", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                ),
+                retain_after_run=True,
+            )
+            for rank in range(len(RANK_LABELS)):
+                orch.copy_to_global_domain(domain, rank, struct.pack(f"<{COUNT}f", *_lhs_values(rank)), buffer="lhs")
+                orch.copy_to_global_domain(domain, rank, struct.pack(f"<{COUNT}f", *_rhs_values(rank)), buffer="rhs")
+            local_task = _local_args(domain)
+            remote_task = _remote_args(domain, compute_handle.digest)
+            parent_keepalive[:] = [local_task, remote_task]
+            orch.submit_next_level(local_compute_handle, local_task, cfg, worker=local_node)
+            orch.submit_next_level(remote_compute_handle, remote_task, cfg, worker=remote_node)
+            domain_handle = domain
+
+        # run() drains the DAG before returning, so the compute tasks are
+        # complete on both L2s before the communication phase reads their
+        # outputs or issues any peer TLOAD.
+        worker.run(compute_phase, args=None, config=CallConfig())
+        if domain_handle is None:
+            raise RuntimeError("the Global CommDomain was not allocated")
+        domain = domain_handle
+        observed_compute: list[tuple[float, ...]] = []
+        observed_communication: list[tuple[float, ...]] = []
+
+        def communication_phase(orch, _args, cfg):
+            for rank in range(len(RANK_LABELS)):
+                raw = orch.copy_from_global_domain(domain, rank, COUNT * FLOAT_NBYTES, buffer="input")
+                observed_compute.append(_unpack_floats(raw))
+            local_task = _local_args(domain)
+            remote_task = _remote_args(domain, tload_handle.digest)
+            parent_keepalive[:] = [local_task, remote_task]
+            orch.submit_next_level(local_tload_handle, local_task, cfg, worker=local_node)
+            orch.submit_next_level(remote_tload_handle, remote_task, cfg, worker=remote_node)
+
+        worker.run(communication_phase, args=None, config=CallConfig())
+
+        def verify_phase(orch, _args, _cfg):
+            try:
+                for rank in range(len(RANK_LABELS)):
+                    raw = orch.copy_from_global_domain(domain, rank, COUNT * FLOAT_NBYTES, buffer="result")
+                    observed_communication.append(_unpack_floats(raw))
+            finally:
+                domain.release()
+
+        worker.run(verify_phase, args=None, config=CallConfig())
+
+        failed: list[str] = []
+        for rank, result in enumerate(observed_compute):
+            max_diff = _max_diff(result, _expected_compute(rank))
+            print(f"[compute-then-tload-mixed-l3] compute {RANK_LABELS[rank]} rank={rank} max_diff={max_diff:.3e}")
+            if max_diff > 1e-5:
+                failed.append(f"compute rank {rank}")
+
+        expected_communication = _expected_communication(len(RANK_LABELS))
+        for rank, result in enumerate(observed_communication):
+            max_diff = _max_diff(result, expected_communication)
+            print(
+                f"[compute-then-tload-mixed-l3] communication {RANK_LABELS[rank]} rank={rank} max_diff={max_diff:.3e}"
+            )
+            if max_diff > 1e-3:
+                failed.append(f"communication rank {rank}")
+        if failed:
+            raise AssertionError(f"golden mismatch: {', '.join(failed)}")
+
+        print("compute_then_tload_mixed_l3 passed")
+        return 0
+    finally:
+        parent_keepalive.clear()
+        _LOCAL_KEEPALIVE.clear()
+        _REMOTE_KEEPALIVE.clear()
+        if domain_handle is not None and not domain_handle.freed:
+            with contextlib.suppress(Exception):
+                domain_handle.release()
+        worker.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workers/l4/compute_then_tload_mixed_l3/run_parent.sh
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/run_parent.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE:?set remote L3 daemon as HOST:PORT}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_LOCAL_DEVICES:=0}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE_DEVICES:=0}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_PLATFORM:=a2a3}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_RUNTIME:=tensormap_and_ringbuffer}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_COMM_PROFILE:=a3-fabric-v1}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_SESSION_LISTEN_HOST:=0.0.0.0}"
+: "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_SESSION_TIMEOUT:=120}"
+
+cd "${ROOT_DIR}"
+# The pod job builds the venv in an earlier step, so a staging failure reaches
+# this script before it reaches python — name it here rather than let `set -e`
+# abort on a bare "No such file or directory".
+if [[ ! -f .venv/bin/activate ]]; then
+  echo "error: ${ROOT_DIR}/.venv/bin/activate not found; create the virtual environment first" >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source .venv/bin/activate
+
+exec python -m examples.workers.l4.compute_then_tload_mixed_l3.main \
+  --remote "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE}" \
+  --local-devices "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_LOCAL_DEVICES}" \
+  --remote-devices "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_REMOTE_DEVICES}" \
+  --platform "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_PLATFORM}" \
+  --runtime "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_RUNTIME}" \
+  --comm-profile "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_COMM_PROFILE}" \
+  --session-listen-host "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_SESSION_LISTEN_HOST}" \
+  --session-timeout "${SIMPLER_COMPUTE_THEN_TLOAD_MIXED_L3_SESSION_TIMEOUT}"

--- a/examples/workers/l4/global_tload_mixed_l3/README.md
+++ b/examples/workers/l4/global_tload_mixed_l3/README.md
@@ -1,0 +1,84 @@
+# Global TLOAD mixed L3 example
+
+This example validates the L4-brokered Global CommDomain path across one local
+and one remote L3 node, ending in a device-side peer `TLOAD`:
+
+```text
+L4 parent on machine A -> local L3 on machine A  -> local NPU, rank 0
+                       -> remote L3 on machine B -> remote NPU, rank 1
+```
+
+Both ranks join one Global CommDomain without `mpirun`. The domain build runs
+the complete control flow: every L2 exports its window descriptor (PREPARE),
+L4 collects the rank-ordered table, sends it back to every L3 (IMPORT), and
+commits only after all imports succeed. Each rank's AIV kernel then reads the
+peer rank's `input` window with `TLOAD`, sums all rank inputs, and stores the
+sum to its own `result` window. The parent reads both `result` windows back and
+checks them against the golden sum, so a successful descriptor exchange
+without working peer `TLOAD` is not reported as success.
+
+`vector_add_mixed_l3` covers the same mixed local/remote topology for plain
+task dispatch and remote buffers; this example exists for what that one leaves
+out — the Global CommDomain build and the cross-machine peer read.
+
+## Prepare both machines
+
+Use the same source revision on machine A and machine B:
+
+```bash
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install --no-build-isolation -e .
+```
+
+## Start the remote L3 daemon
+
+Start this on machine B. The daemon is the generic session server — nothing
+about it is specific to this example. `192.0.2.20` is a documentation
+placeholder, not a usable address:
+
+```bash
+source .venv/bin/activate
+python -m simpler.remote_l3_worker --host 192.0.2.20 --port 19073
+```
+
+## Run on the L4 parent
+
+Run this on machine A. The local device id is owned by the forked local L3 on
+machine A; the remote device id is owned by the daemon-started L3 on machine B.
+Only the first id of each device list is used — each L3 owns exactly one L2:
+
+```bash
+source .venv/bin/activate
+export SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE=192.0.2.20:19073
+export SIMPLER_GLOBAL_TLOAD_MIXED_L3_LOCAL_DEVICES=0
+export SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE_DEVICES=0
+bash examples/workers/l4/global_tload_mixed_l3/run_parent.sh
+```
+
+Expected output ends with:
+
+```text
+[global-tload-mixed-l3] local rank=0 max_diff=0.000e+00
+[global-tload-mixed-l3] remote rank=1 max_diff=0.000e+00
+global_tload_mixed_l3 passed
+```
+
+Any `max_diff` above the tolerance exits non-zero.
+
+## Configuration
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE` | (required) | Remote daemon endpoint, `HOST:PORT` |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_LOCAL_DEVICES` | `0` | Device list; the first id is the local L3's L2 |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE_DEVICES` | `0` | Device list; the first id is the remote L3's L2 |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_PLATFORM` | `a2a3` | Target platform |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_RUNTIME` | `tensormap_and_ringbuffer` | Runtime |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_COMM_PROFILE` | `a3-fabric-v1` | Global CommDomain backend profile |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_SESSION_LISTEN_HOST` | `0.0.0.0` | Interface the parent's session runner binds |
+| `SIMPLER_GLOBAL_TLOAD_MIXED_L3_SESSION_TIMEOUT` | `120` | Seconds to wait on the remote session |
+
+The peer `TLOAD` needs real cross-device windows, so the default profile is
+`a3-fabric-v1` and requires real A3 devices on both machines. In CI the pod
+job drives this script through `pod-run-example` with the same variables.

--- a/examples/workers/l4/global_tload_mixed_l3/kernels/aiv/global_tload_kernel.cpp
+++ b/examples/workers/l4/global_tload_mixed_l3/kernels/aiv/global_tload_kernel.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t kCount = 256;
+static constexpr int kMaxRanks = 16;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *input_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *result_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+    int rank_count = static_cast<int>(args[2]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
+
+    if (rank_count <= 0 || rank_count > kMaxRanks) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+    __gm__ float *input = reinterpret_cast<__gm__ float *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    using Shape = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Stride = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Global = pto::GlobalTensor<float, Shape, Stride, pto::Layout::ND>;
+    using Tile = pto::Tile<pto::TileType::Vec, float, 1, kCount, pto::BLayout::RowMajor, -1, -1>;
+
+    Shape shape(1, 1, 1, 1, kCount);
+    Stride stride(kCount, kCount, kCount, kCount, 1);
+    Tile accumulator(1, kCount);
+    Tile peer_tile(1, kCount);
+    TASSIGN(accumulator, 0x0);
+    TASSIGN(peer_tile, 0x10000);
+
+    Global local_input(input, shape, stride);
+    TLOAD(accumulator, local_input);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    int my_rank = static_cast<int>(comm_ctx->rankId);
+    for (int peer = 0; peer < rank_count; ++peer) {
+        if (peer == my_rank) continue;
+        __gm__ float *peer_input = CommRemotePtr(comm_ctx, input, peer);
+        Global peer_global(peer_input, shape, stride);
+        TLOAD(peer_tile, peer_global);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TADD(accumulator, accumulator, peer_tile);
+        set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+    }
+
+    Global result_global(result, shape, stride);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(result_global, accumulator);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l4/global_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
+++ b/examples/workers/l4/global_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+global_tload_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,
+    };
+}
+
+__attribute__((visibility("default"))) void global_tload_orchestration(const ChipTaskArgs &orch_args) {
+    CoreTaskArgs params;
+    params.add_input(orch_args.tensor(0).ref());
+    params.add_output(orch_args.tensor(1).ref());
+    params.add_scalar(orch_args.scalar(0));
+    params.add_scalar(orch_args.scalar(1));
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l4/global_tload_mixed_l3/main.py
+++ b/examples/workers/l4/global_tload_mixed_l3/main.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run one local L3 and one remote L3 rank through a Global CommDomain peer TLOAD."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import struct
+from pathlib import Path
+
+from simpler.callable_identity import CallableHandle
+from simpler.remote_l3_protocol import HOST_TCP_TRANSPORT_PROFILE
+from simpler.task_interface import (
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    CommBufferSpec,
+    CoreCallable,
+    DataType,
+    GlobalCommDomainHandle,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import RemoteCallable, RemoteWorkerSpec, Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+REMOTE_ORCH_TARGET = "examples.workers.l4.global_tload_mixed_l3.main:remote_rank_orch"
+COUNT = 256
+FLOAT_NBYTES = 4
+WINDOW_SIZE = 4096
+RANK_LABELS = ("local", "remote")
+_LOCAL_CHIP_HANDLE: CallableHandle | None = None
+_LOCAL_KEEPALIVE: list[TaskArgs] = []
+_REMOTE_KEEPALIVE: list[TaskArgs] = []
+
+
+def _digest_from_scalars(args: TaskArgs, start: int) -> bytes:
+    return b"".join(int(args.scalar(start + index)).to_bytes(8, "little") for index in range(4))
+
+
+def _submit_tload_task(orch, chip_handle: CallableHandle, args: TaskArgs, cfg: CallConfig) -> TaskArgs:
+    domain_id = int(args.scalar(0))
+    local_worker_id = int(args.scalar(1))
+    context = orch.get_global_domain(domain_id)[local_worker_id]
+
+    chip_args = TaskArgs()
+    chip_args.add_tensor(
+        context.buffers["input"].tensor((COUNT,), DataType.FLOAT32),
+        TensorArgType.INPUT,
+    )
+    chip_args.add_tensor(
+        context.buffers["result"].tensor((COUNT,), DataType.FLOAT32),
+        TensorArgType.OUTPUT_EXISTING,
+    )
+    chip_args.add_scalar(context.domain_size)
+    chip_args.add_scalar(context.device_ctx)
+    orch.submit_next_level(chip_handle, chip_args, cfg, worker=local_worker_id)
+    return chip_args
+
+
+def local_rank_orch(orch, args: TaskArgs, cfg: CallConfig) -> None:
+    """Submit the peer-TLOAD chip task from the forked local L3 worker."""
+    if _LOCAL_CHIP_HANDLE is None:
+        raise RuntimeError("local L3 chip handle was not installed before fork")
+    if args.scalar_count() != 2:
+        raise ValueError("local TLOAD task expects domain_id and local_worker_id")
+    _LOCAL_KEEPALIVE[:] = [_submit_tload_task(orch, _LOCAL_CHIP_HANDLE, args, cfg)]
+
+
+def remote_rank_orch(orch, args: TaskArgs, cfg: CallConfig) -> None:
+    """Submit the peer-TLOAD chip task from the daemon-started remote L3 worker."""
+    from simpler.remote_l3_session import get_inner_handle  # noqa: PLC0415
+
+    if args.scalar_count() != 6:
+        raise ValueError("remote TLOAD task expects domain_id, local_worker_id, and four digest scalars")
+    chip_handle = get_inner_handle(_digest_from_scalars(args, 2).hex())
+    _REMOTE_KEEPALIVE[:] = [_submit_tload_task(orch, chip_handle, args, cfg)]
+
+
+def _build_tload_callable(platform: str, runtime: str) -> ChipCallable:
+    kernels = Path(__file__).resolve().parent / "kernels"
+    compiler = KernelCompiler(platform=platform)
+    include_dirs = list(compiler.get_orchestration_include_dirs(runtime))
+    include_dirs.append(str(compiler.project_root / "src" / "common"))
+    kernel_binary = compiler.compile_incore(
+        source_path=str(kernels / "aiv" / "global_tload_kernel.cpp"),
+        core_type="aiv",
+        pto_isa_root=ensure_pto_isa_root(),
+        extra_include_dirs=include_dirs,
+    )
+    if not platform.endswith("sim"):
+        kernel_binary = extract_text_section(kernel_binary)
+    orch_binary = compiler.compile_orchestration(
+        runtime_name=runtime,
+        source_path=str(kernels / "orchestration" / "global_tload_orch.cpp"),
+    )
+    core = CoreCallable.build(signature=[ArgDirection.IN, ArgDirection.OUT], binary=kernel_binary)
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT],
+        func_name="global_tload_orchestration",
+        config_name="global_tload_orchestration_config",
+        binary=orch_binary,
+        children=[(0, core)],
+    )
+
+
+def _add_digest_scalars(task_args: TaskArgs, digest: bytes) -> None:
+    if len(digest) != 32:
+        raise ValueError("inner chip callable digest must be 32 bytes")
+    for offset in range(0, 32, 8):
+        task_args.add_scalar(int.from_bytes(digest[offset : offset + 8], "little"))
+
+
+def _parse_first_device(value: str, *, label: str) -> int:
+    device_ids = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if not device_ids or device_ids[0] < 0:
+        raise ValueError(f"{label} device list must start with a non-negative device id")
+    return device_ids[0]
+
+
+def _input_values(rank: int) -> tuple[float, ...]:
+    return tuple(float(rank * 100 + index) for index in range(COUNT))
+
+
+def _expected_values(rank_count: int) -> tuple[float, ...]:
+    rank_bias = 100 * rank_count * (rank_count - 1) // 2
+    return tuple(float(rank_count * index + rank_bias) for index in range(COUNT))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--remote", required=True, help="remote L3 daemon endpoint, HOST:PORT")
+    parser.add_argument("--local-devices", default="0", help="device list whose first id the forked local L3 owns")
+    parser.add_argument("--remote-devices", default="0", help="device list whose first id the daemon L3 owns")
+    parser.add_argument("--platform", default="a2a3")
+    parser.add_argument("--runtime", default="tensormap_and_ringbuffer")
+    parser.add_argument("--comm-profile", default="a3-fabric-v1")
+    parser.add_argument("--session-timeout", type=float, default=120.0)
+    parser.add_argument("--session-listen-host", default="0.0.0.0")
+    return parser.parse_args()
+
+
+def main() -> int:
+    # The local L3 is a fork of this process, so its orchestration function
+    # reaches the handle only through module state; a local would not survive
+    # into the child.
+    global _LOCAL_CHIP_HANDLE  # noqa: PLW0603
+
+    args = _parse_args()
+    local_device = _parse_first_device(args.local_devices, label="local")
+    remote_device = _parse_first_device(args.remote_devices, label="remote")
+
+    chip_callable = _build_tload_callable(args.platform, args.runtime)
+    local_l3 = Worker(
+        level=3,
+        device_ids=[local_device],
+        num_sub_workers=0,
+        platform=args.platform,
+        runtime=args.runtime,
+        comm_profile=args.comm_profile,
+        global_device_ranks=(0,),
+    )
+    _LOCAL_CHIP_HANDLE = local_l3.register(chip_callable)
+
+    worker = Worker(level=4, num_sub_workers=0, remote_session_timeout_s=args.session_timeout)
+    domain_handle: GlobalCommDomainHandle | None = None
+    parent_keepalive: list[TaskArgs] = []
+    try:
+        local_node = worker.add_worker(local_l3)
+        remote_node = worker.add_remote_worker(
+            RemoteWorkerSpec(
+                endpoint=args.remote,
+                platform=args.platform,
+                runtime=args.runtime,
+                device_ids=(remote_device,),
+                transport=HOST_TCP_TRANSPORT_PROFILE,
+                comm_profile=args.comm_profile,
+                global_device_ranks=(1,),
+                session_listen_host=args.session_listen_host,
+                allow_wildcard_session_bind=True,
+            )
+        )
+        chip_handle = worker.register(chip_callable)
+        local_handle = worker.register(local_rank_orch)
+        remote_handle = worker.register(RemoteCallable(REMOTE_ORCH_TARGET), workers=[remote_node])
+        worker.init()
+
+        def build_and_run(orch, _args, cfg):
+            nonlocal domain_handle
+            domain = orch.allocate_global_domain(
+                name="global-tload-mixed-l3",
+                members=((local_node, 0), (remote_node, 0)),
+                window_size=WINDOW_SIZE,
+                buffers=(
+                    CommBufferSpec("input", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                    CommBufferSpec("result", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                ),
+                retain_after_run=True,
+            )
+            for rank in range(len(RANK_LABELS)):
+                orch.copy_to_global_domain(
+                    domain,
+                    rank,
+                    struct.pack(f"<{COUNT}f", *_input_values(rank)),
+                    buffer="input",
+                )
+            local_args = TaskArgs()
+            local_args.add_scalar(domain.domain_id)
+            local_args.add_scalar(0)
+            remote_args = TaskArgs()
+            remote_args.add_scalar(domain.domain_id)
+            remote_args.add_scalar(0)
+            _add_digest_scalars(remote_args, chip_handle.digest)
+            parent_keepalive[:] = [local_args, remote_args]
+            orch.submit_next_level(local_handle, local_args, cfg, worker=local_node)
+            orch.submit_next_level(remote_handle, remote_args, cfg, worker=remote_node)
+            domain_handle = domain
+
+        worker.run(build_and_run, args=None, config=CallConfig())
+        if domain_handle is None:
+            raise RuntimeError("the Global CommDomain was not allocated")
+        domain = domain_handle
+        observed: list[tuple[float, ...]] = []
+
+        def read_and_release(orch, _args, _cfg):
+            try:
+                for rank in range(len(RANK_LABELS)):
+                    raw = orch.copy_from_global_domain(domain, rank, COUNT * FLOAT_NBYTES, buffer="result")
+                    observed.append(tuple(float(value) for value in struct.unpack(f"<{COUNT}f", raw)))
+            finally:
+                domain.release()
+
+        worker.run(read_and_release, args=None, config=CallConfig())
+
+        expected = _expected_values(len(RANK_LABELS))
+        failed_ranks: list[int] = []
+        for rank, result in enumerate(observed):
+            max_diff = max(abs(actual - wanted) for actual, wanted in zip(result, expected))
+            print(f"[global-tload-mixed-l3] {RANK_LABELS[rank]} rank={rank} max_diff={max_diff:.3e}")
+            if max_diff > 1e-3:
+                failed_ranks.append(rank)
+        if failed_ranks:
+            raise AssertionError(f"peer TLOAD golden mismatch on rank(s) {failed_ranks}")
+
+        print("global_tload_mixed_l3 passed")
+        return 0
+    finally:
+        parent_keepalive.clear()
+        _LOCAL_KEEPALIVE.clear()
+        _REMOTE_KEEPALIVE.clear()
+        if domain_handle is not None and not domain_handle.freed:
+            with contextlib.suppress(Exception):
+                domain_handle.release()
+        worker.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workers/l4/global_tload_mixed_l3/run_parent.sh
+++ b/examples/workers/l4/global_tload_mixed_l3/run_parent.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE:?set remote L3 daemon as HOST:PORT}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_LOCAL_DEVICES:=0}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE_DEVICES:=0}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_PLATFORM:=a2a3}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_RUNTIME:=tensormap_and_ringbuffer}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_COMM_PROFILE:=a3-fabric-v1}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_SESSION_LISTEN_HOST:=0.0.0.0}"
+: "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_SESSION_TIMEOUT:=120}"
+
+cd "${ROOT_DIR}"
+# The pod job builds the venv in an earlier step, so a staging failure reaches
+# this script before it reaches python — name it here rather than let `set -e`
+# abort on a bare "No such file or directory".
+if [[ ! -f .venv/bin/activate ]]; then
+  echo "error: ${ROOT_DIR}/.venv/bin/activate not found; create the virtual environment first" >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source .venv/bin/activate
+
+exec python -m examples.workers.l4.global_tload_mixed_l3.main \
+  --remote "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE}" \
+  --local-devices "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_LOCAL_DEVICES}" \
+  --remote-devices "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_REMOTE_DEVICES}" \
+  --platform "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_PLATFORM}" \
+  --runtime "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_RUNTIME}" \
+  --comm-profile "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_COMM_PROFILE}" \
+  --session-listen-host "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_SESSION_LISTEN_HOST}" \
+  --session-timeout "${SIMPLER_GLOBAL_TLOAD_MIXED_L3_SESSION_TIMEOUT}"

--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(_task_interface PRIVATE
     ${CMAKE_SOURCE_DIR}/src/common/task_interface
     ${CMAKE_SOURCE_DIR}/src/common/worker
     ${CMAKE_SOURCE_DIR}/src/common/hierarchical
+    ${CMAKE_SOURCE_DIR}/src/common/platform/include
     ${CMAKE_SOURCE_DIR}/src/common/platform/include/common
     ${CMAKE_SOURCE_DIR}/src/common/platform/include/host
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2262,6 +2262,36 @@ NB_MODULE(_task_interface, m) {
             nb::arg("allocation_id"), nb::arg("rank_count"), nb::arg("domain_rank"),
             "Pair to comm_alloc_domain_windows: collectively release the per-rank pool."
         )
+        .def(
+            "comm_global_domain_prepare",
+            [](ChipWorker &self, uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size,
+               uint32_t profile) {
+                auto [descriptor, local_window_base, actual_window_size] =
+                    self.comm_global_domain_prepare(domain_id, domain_rank, rank_count, window_size, profile);
+                return nb::make_tuple(
+                    nb::bytes(reinterpret_cast<const char *>(descriptor.data()), descriptor.size()), local_window_base,
+                    actual_window_size
+                );
+            },
+            nb::arg("domain_id"), nb::arg("domain_rank"), nb::arg("rank_count"), nb::arg("window_size"),
+            nb::arg("profile"), "Create a Global CommDomain local window and return its transport descriptor."
+        )
+        .def(
+            "comm_global_domain_import",
+            [](ChipWorker &self, uint64_t domain_id, nb::bytes descriptors) {
+                std::vector<uint8_t> descriptor_bytes(
+                    reinterpret_cast<const uint8_t *>(descriptors.c_str()),
+                    reinterpret_cast<const uint8_t *>(descriptors.c_str()) + descriptors.size()
+                );
+                return self.comm_global_domain_import(domain_id, descriptor_bytes);
+            },
+            nb::arg("domain_id"), nb::arg("descriptors"),
+            "Import a rank-ordered Global CommDomain descriptor table and return the device context."
+        )
+        .def(
+            "comm_global_domain_release", &ChipWorker::comm_global_domain_release, nb::arg("domain_id"),
+            "Release a prepared or imported Global CommDomain."
+        )
         .def("comm_barrier", &ChipWorker::comm_barrier, nb::arg("comm_handle"), "Synchronize all ranks.")
         .def(
             "comm_destroy", &ChipWorker::comm_destroy, nb::arg("comm_handle"),

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -727,6 +727,25 @@ inline void bind_worker(nb::module_ &m) {
             nb::arg("import_id"), "Release an imported remote buffer mapping."
         )
         .def(
+            "remote_domain_control",
+            [](Worker &self, int worker_id, uint32_t control_name, nb::bytes command) {
+                std::vector<uint8_t> command_bytes(
+                    reinterpret_cast<const uint8_t *>(command.c_str()),
+                    reinterpret_cast<const uint8_t *>(command.c_str()) + command.size()
+                );
+                std::vector<uint8_t> result;
+                {
+                    nb::gil_scoped_release release;
+                    result = self.remote_domain_control(
+                        worker_id, static_cast<remote_l3::ControlName>(control_name), command_bytes
+                    );
+                }
+                return nb::bytes(reinterpret_cast<const char *>(result.data()), result.size());
+            },
+            nb::arg("worker_id"), nb::arg("control_name"), nb::arg("command"),
+            "Send one Global CommDomain control to a remote L3 endpoint."
+        )
+        .def(
             "broadcast_unregister_all",
             [](Worker &self, nb::object digest) {
                 std::string digest_bytes = bytes_from_digest_arg(digest);
@@ -766,6 +785,25 @@ inline void bind_worker(nb::module_ &m) {
             "Broadcast an arbitrary CONTROL_REQUEST to the selected worker pool. "
             "If payload is a Python buffer, C++ stages it in POSIX shm and writes the shm name "
             "into the mailbox. Returns per-child ControlResult entries."
+        )
+        .def(
+            "control_payload",
+            [](Worker &self, WorkerType worker_type, int worker_id, uint64_t sub_cmd, nb::object payload,
+               nb::object timeout_s) {
+                std::string payload_bytes = buffer_to_string(payload, "payload");
+                double timeout_val = timeout_s.is_none() ? -1.0 : nb::cast<double>(timeout_s);
+                std::vector<uint8_t> result;
+                {
+                    nb::gil_scoped_release release;
+                    result = self.control_payload(
+                        worker_type, worker_id, sub_cmd, payload_bytes.data(), payload_bytes.size(), timeout_val
+                    );
+                }
+                return nb::bytes(reinterpret_cast<const char *>(result.data()), result.size());
+            },
+            nb::arg("worker_type"), nb::arg("worker_id"), nb::arg("sub_cmd"), nb::arg("payload"),
+            nb::arg("timeout_s") = nb::none(),
+            "Drive one local worker control with a mutable staged payload and return its final bytes."
         )
         .def(
             "control_alloc_domain", &Worker::control_alloc_domain, nb::arg("worker_id"), nb::arg("request_shm_name"),

--- a/python/simpler/global_comm_domain.py
+++ b/python/simpler/global_comm_domain.py
@@ -1,0 +1,574 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Versioned codecs and data models for L4-brokered Global CommDomains."""
+
+from __future__ import annotations
+
+import enum
+import struct
+from dataclasses import dataclass
+
+GLOBAL_DOMAIN_VERSION = 1
+GLOBAL_DOMAIN_MAX_RANKS = 64
+GLOBAL_DOMAIN_HANDLE_BYTES = 256
+GLOBAL_DOMAIN_DESCRIPTOR = struct.Struct("<IIIIQII256s")
+GLOBAL_DOMAIN_DESCRIPTOR_BYTES = GLOBAL_DOMAIN_DESCRIPTOR.size
+GLOBAL_DOMAIN_PROFILE_SIM = "sim"
+GLOBAL_DOMAIN_PROFILE_A3_FABRIC = "a3-fabric-v1"
+GLOBAL_DOMAIN_PROFILE_IDS = {
+    GLOBAL_DOMAIN_PROFILE_SIM: 1,
+    GLOBAL_DOMAIN_PROFILE_A3_FABRIC: 2,
+}
+GLOBAL_DOMAIN_MAX_STRING_BYTES = 1024
+GLOBAL_DOMAIN_MAX_COPY_BYTES = 8 * 1024 * 1024
+
+CTRL_GLOBAL_DOMAIN_PREPARE = 19
+CTRL_GLOBAL_DOMAIN_IMPORT = 20
+CTRL_GLOBAL_DOMAIN_RELEASE = 21
+CTRL_GLOBAL_DOMAIN_COPY_TO = 22
+CTRL_GLOBAL_DOMAIN_COPY_FROM = 23
+
+LOCAL_DOMAIN_MAGIC = b"SGD1"
+LOCAL_PREPARE_REQUEST = struct.Struct("<4sIQQIIIQ")
+LOCAL_PREPARE_REPLY = struct.Struct("<4sIQQQQ")
+LOCAL_IMPORT_REQUEST = struct.Struct("<4sIQQI")
+LOCAL_IMPORT_REPLY = struct.Struct("<4sIQQQQQ")
+LOCAL_RELEASE_REQUEST = struct.Struct("<4sIQQ")
+LOCAL_COPY_REQUEST = struct.Struct("<4sIQQQQ")
+LOCAL_COPY_REPLY = struct.Struct("<4sIQQQ")
+
+
+class GlobalDomainPhase(enum.IntEnum):
+    PREPARE_EXPORT = 1
+    IMPORT = 2
+    COMMIT = 3
+    ABORT = 4
+
+
+@dataclass(frozen=True)
+class GlobalDomainMember:
+    node_worker_id: int
+    local_worker_id: int
+    global_device_rank: int
+    domain_rank: int
+
+
+@dataclass(frozen=True)
+class GlobalDomainBuffer:
+    name: str
+    nbytes: int
+
+
+@dataclass(frozen=True)
+class GlobalDomainDescriptor:
+    version: int
+    profile_id: int
+    domain_rank: int
+    rank_count: int
+    mapping_size: int
+    handle: bytes
+
+    def encode(self) -> bytes:
+        _validate_descriptor(self)
+        handle = bytes(self.handle)
+        return GLOBAL_DOMAIN_DESCRIPTOR.pack(
+            int(self.version),
+            int(self.profile_id),
+            int(self.domain_rank),
+            int(self.rank_count),
+            int(self.mapping_size),
+            len(handle),
+            0,
+            handle + b"\x00" * (GLOBAL_DOMAIN_HANDLE_BYTES - len(handle)),
+        )
+
+    @classmethod
+    def decode(cls, data: bytes) -> GlobalDomainDescriptor:
+        if len(data) != GLOBAL_DOMAIN_DESCRIPTOR_BYTES:
+            raise ValueError("global domain descriptor size mismatch")
+        version, profile_id, domain_rank, rank_count, mapping_size, handle_size, reserved, handle = (
+            GLOBAL_DOMAIN_DESCRIPTOR.unpack(data)
+        )
+        if reserved != 0:
+            raise ValueError("global domain descriptor reserved field must be zero")
+        if handle_size > GLOBAL_DOMAIN_HANDLE_BYTES:
+            raise ValueError("global domain descriptor handle size exceeds maximum")
+        descriptor = cls(
+            version=int(version),
+            profile_id=int(profile_id),
+            domain_rank=int(domain_rank),
+            rank_count=int(rank_count),
+            mapping_size=int(mapping_size),
+            handle=bytes(handle[:handle_size]),
+        )
+        _validate_descriptor(descriptor)
+        return descriptor
+
+
+@dataclass(frozen=True)
+class GlobalCommInitCommand:
+    cluster_id: str
+    topology_hash: str
+    profile: str
+    node_rank: int
+    node_count: int
+    members: tuple[GlobalDomainMember, ...]
+
+
+@dataclass(frozen=True)
+class GlobalCommInitResult:
+    profile: str
+    max_ranks: int
+    descriptor_bytes: int
+    local_device_count: int
+
+
+def resolve_global_comm_capability(*, platform: str, profile: str, local_device_count: int) -> GlobalCommInitResult:
+    """Return the capability implemented by the selected platform backend."""
+    platform = str(platform)
+    profile = str(profile)
+    supported = (platform.endswith("sim") and profile == GLOBAL_DOMAIN_PROFILE_SIM) or (
+        platform.startswith("a2a3") and not platform.endswith("sim") and profile == GLOBAL_DOMAIN_PROFILE_A3_FABRIC
+    )
+    if not supported:
+        raise ValueError(f"Global CommDomain is not supported by platform {platform!r} with comm_profile {profile!r}")
+    if local_device_count <= 0:
+        raise ValueError("Global CommDomain capability requires at least one local device")
+    return GlobalCommInitResult(
+        profile=profile,
+        max_ranks=GLOBAL_DOMAIN_MAX_RANKS,
+        descriptor_bytes=GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
+        local_device_count=int(local_device_count),
+    )
+
+
+@dataclass(frozen=True)
+class GlobalDomainCommand:
+    phase: GlobalDomainPhase
+    domain_id: int
+    generation: int
+    name: str
+    profile: str
+    window_size: int
+    members: tuple[GlobalDomainMember, ...]
+    buffers: tuple[GlobalDomainBuffer, ...]
+    descriptors: tuple[GlobalDomainDescriptor, ...] = ()
+
+
+@dataclass(frozen=True)
+class GlobalDomainReleaseCommand:
+    domain_id: int
+    generation: int
+
+
+@dataclass(frozen=True)
+class GlobalDomainCopyCommand:
+    domain_id: int
+    generation: int
+    domain_rank: int
+    offset: int
+    nbytes: int
+    data: bytes = b""
+
+
+class _Reader:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._offset = 0
+
+    def _take(self, size: int, field: str) -> bytes:
+        if size < 0 or self._offset > len(self._data) or size > len(self._data) - self._offset:
+            raise ValueError(f"global domain wire truncated {field}")
+        result = self._data[self._offset : self._offset + size]
+        self._offset += size
+        return result
+
+    def u32(self) -> int:
+        return int(struct.unpack("<I", self._take(4, "uint32"))[0])
+
+    def i32(self) -> int:
+        return int(struct.unpack("<i", self._take(4, "int32"))[0])
+
+    def u64(self) -> int:
+        return int(struct.unpack("<Q", self._take(8, "uint64"))[0])
+
+    def string(self, field: str) -> str:
+        size = self.u32()
+        if size > GLOBAL_DOMAIN_MAX_STRING_BYTES:
+            raise ValueError(f"global domain wire {field} exceeds maximum")
+        return self._take(size, field).decode("utf-8")
+
+    def blob(self, maximum: int, field: str) -> bytes:
+        size = self.u32()
+        if size > maximum:
+            raise ValueError(f"global domain wire {field} exceeds maximum")
+        return self._take(size, field)
+
+    def fixed(self, size: int, field: str) -> bytes:
+        return self._take(size, field)
+
+    def done(self, field: str) -> None:
+        if self._offset != len(self._data):
+            raise ValueError(f"global domain wire trailing bytes after {field}")
+
+
+def _put_string(out: bytearray, value: str, field: str) -> None:
+    encoded = str(value).encode("utf-8")
+    if len(encoded) > GLOBAL_DOMAIN_MAX_STRING_BYTES:
+        raise ValueError(f"global domain wire {field} exceeds maximum")
+    out.extend(struct.pack("<I", len(encoded)))
+    out.extend(encoded)
+
+
+def _put_blob(out: bytearray, value: bytes, maximum: int, field: str) -> None:
+    encoded = bytes(value)
+    if len(encoded) > maximum:
+        raise ValueError(f"global domain wire {field} exceeds maximum")
+    out.extend(struct.pack("<I", len(encoded)))
+    out.extend(encoded)
+
+
+def _validate_descriptor(descriptor: GlobalDomainDescriptor) -> None:
+    if descriptor.version != GLOBAL_DOMAIN_VERSION:
+        raise ValueError("global domain descriptor version mismatch")
+    if descriptor.profile_id not in GLOBAL_DOMAIN_PROFILE_IDS.values():
+        raise ValueError("global domain descriptor profile is unknown")
+    if descriptor.rank_count <= 0 or descriptor.rank_count > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain descriptor rank_count is invalid")
+    if descriptor.domain_rank < 0 or descriptor.domain_rank >= descriptor.rank_count:
+        raise ValueError("global domain descriptor domain_rank is invalid")
+    if descriptor.mapping_size <= 0:
+        raise ValueError("global domain descriptor mapping_size must be positive")
+    if not descriptor.handle or len(descriptor.handle) > GLOBAL_DOMAIN_HANDLE_BYTES:
+        raise ValueError("global domain descriptor handle size is invalid")
+
+
+def validate_member_table(members: tuple[GlobalDomainMember, ...]) -> None:
+    if not members or len(members) > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain members must contain between 1 and 64 devices")
+    ranks = [member.domain_rank for member in members]
+    if ranks != list(range(len(members))):
+        raise ValueError("global domain members must be in dense domain-rank order")
+    devices = [(member.node_worker_id, member.local_worker_id) for member in members]
+    if len(set(devices)) != len(devices):
+        raise ValueError("global domain members contain duplicate node/local devices")
+    if any(node < 0 or local < 0 for node, local in devices):
+        raise ValueError("global domain member node/local ids must be non-negative")
+    global_ranks = [member.global_device_rank for member in members]
+    if len(set(global_ranks)) != len(global_ranks) or any(rank < 0 for rank in global_ranks):
+        raise ValueError("global domain members require unique non-negative global device ranks")
+
+
+def validate_descriptor_table(
+    descriptors: tuple[GlobalDomainDescriptor, ...], *, rank_count: int, profile: str
+) -> None:
+    if profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+        raise ValueError(f"unsupported global domain profile {profile!r}")
+    if len(descriptors) != rank_count:
+        raise ValueError("global domain descriptor table is incomplete")
+    expected_profile = GLOBAL_DOMAIN_PROFILE_IDS[profile]
+    ranks: set[int] = set()
+    mapping_size: int | None = None
+    for descriptor in descriptors:
+        _validate_descriptor(descriptor)
+        if descriptor.profile_id != expected_profile or descriptor.rank_count != rank_count:
+            raise ValueError("global domain descriptor profile or rank_count mismatch")
+        if descriptor.domain_rank in ranks:
+            raise ValueError("global domain descriptor table contains a duplicate rank")
+        ranks.add(descriptor.domain_rank)
+        if mapping_size is None:
+            mapping_size = descriptor.mapping_size
+        elif mapping_size != descriptor.mapping_size:
+            raise ValueError("global domain descriptor mapping sizes differ")
+    if ranks != set(range(rank_count)):
+        raise ValueError("global domain descriptor table has missing ranks")
+
+
+def _put_member(out: bytearray, member: GlobalDomainMember) -> None:
+    out.extend(
+        struct.pack(
+            "<iIII",
+            int(member.node_worker_id),
+            int(member.local_worker_id),
+            int(member.global_device_rank),
+            int(member.domain_rank),
+        )
+    )
+
+
+def _read_member(reader: _Reader) -> GlobalDomainMember:
+    return GlobalDomainMember(
+        node_worker_id=reader.i32(),
+        local_worker_id=reader.u32(),
+        global_device_rank=reader.u32(),
+        domain_rank=reader.u32(),
+    )
+
+
+def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
+    validate_member_table(command.members)
+    if not command.cluster_id or not command.topology_hash:
+        raise ValueError("global comm init cluster_id and topology_hash must be non-empty")
+    if command.profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+        raise ValueError(f"unsupported global domain profile {command.profile!r}")
+    if command.node_rank < 0 or command.node_count <= 0 or command.node_rank >= command.node_count:
+        raise ValueError("global comm init node identity is invalid")
+    out = bytearray(struct.pack("<III", GLOBAL_DOMAIN_VERSION, command.node_rank, command.node_count))
+    _put_string(out, command.cluster_id, "cluster_id")
+    _put_string(out, command.topology_hash, "topology_hash")
+    _put_string(out, command.profile, "profile")
+    out.extend(struct.pack("<I", len(command.members)))
+    for member in command.members:
+        _put_member(out, member)
+    return bytes(out)
+
+
+def decode_comm_init(data: bytes) -> GlobalCommInitCommand:
+    reader = _Reader(data)
+    version = reader.u32()
+    if version != GLOBAL_DOMAIN_VERSION:
+        raise ValueError("global comm init version mismatch")
+    node_rank = reader.u32()
+    node_count = reader.u32()
+    cluster_id = reader.string("cluster_id")
+    topology_hash = reader.string("topology_hash")
+    profile = reader.string("profile")
+    member_count = reader.u32()
+    if member_count > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global comm init member count exceeds maximum")
+    members = tuple(_read_member(reader) for _ in range(member_count))
+    reader.done("COMM_INIT")
+    command = GlobalCommInitCommand(cluster_id, topology_hash, profile, node_rank, node_count, members)
+    validate_member_table(command.members)
+    if not command.cluster_id or not command.topology_hash:
+        raise ValueError("global comm init cluster_id and topology_hash must be non-empty")
+    if command.profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+        raise ValueError(f"unsupported global domain profile {command.profile!r}")
+    if node_count <= 0 or node_rank >= node_count:
+        raise ValueError("global comm init node identity is invalid")
+    return command
+
+
+def encode_comm_init_result(result: GlobalCommInitResult) -> bytes:
+    out = bytearray(
+        struct.pack(
+            "<III",
+            int(result.max_ranks),
+            int(result.descriptor_bytes),
+            int(result.local_device_count),
+        )
+    )
+    _put_string(out, result.profile, "profile")
+    return bytes(out)
+
+
+def decode_comm_init_result(data: bytes) -> GlobalCommInitResult:
+    reader = _Reader(data)
+    result = GlobalCommInitResult(
+        profile="",
+        max_ranks=reader.u32(),
+        descriptor_bytes=reader.u32(),
+        local_device_count=reader.u32(),
+    )
+    result = GlobalCommInitResult(
+        profile=reader.string("profile"),
+        max_ranks=result.max_ranks,
+        descriptor_bytes=result.descriptor_bytes,
+        local_device_count=result.local_device_count,
+    )
+    reader.done("COMM_INIT result")
+    return result
+
+
+def encode_domain_command(command: GlobalDomainCommand) -> bytes:
+    validate_member_table(command.members)
+    if command.domain_id == 0 or command.generation == 0 or command.window_size <= 0:
+        raise ValueError("global domain command identity and window_size must be positive")
+    if not command.name:
+        raise ValueError("global domain command name must be non-empty")
+    if command.profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+        raise ValueError(f"unsupported global domain profile {command.profile!r}")
+    if len({buffer.name for buffer in command.buffers}) != len(command.buffers):
+        raise ValueError("global domain command contains duplicate buffer names")
+    if any(not buffer.name or buffer.nbytes <= 0 for buffer in command.buffers):
+        raise ValueError("global domain buffers require a name and positive size")
+    if sum(buffer.nbytes for buffer in command.buffers) > command.window_size:
+        raise ValueError("global domain buffers exceed the requested window")
+    if command.descriptors:
+        validate_descriptor_table(command.descriptors, rank_count=len(command.members), profile=command.profile)
+    if command.phase in (GlobalDomainPhase.IMPORT, GlobalDomainPhase.COMMIT):
+        if len(command.descriptors) != len(command.members):
+            raise ValueError("global domain IMPORT/COMMIT requires a complete descriptor table")
+    elif command.descriptors:
+        raise ValueError("global domain PREPARE/ABORT must not carry descriptors")
+
+    out = bytearray(
+        struct.pack(
+            "<IIQQQ",
+            GLOBAL_DOMAIN_VERSION,
+            int(command.phase),
+            int(command.domain_id),
+            int(command.generation),
+            int(command.window_size),
+        )
+    )
+    _put_string(out, command.name, "name")
+    _put_string(out, command.profile, "profile")
+    out.extend(struct.pack("<I", len(command.members)))
+    for member in command.members:
+        _put_member(out, member)
+    out.extend(struct.pack("<I", len(command.buffers)))
+    for buffer in command.buffers:
+        _put_string(out, buffer.name, "buffer.name")
+        out.extend(struct.pack("<Q", int(buffer.nbytes)))
+    out.extend(struct.pack("<I", len(command.descriptors)))
+    for descriptor in command.descriptors:
+        out.extend(descriptor.encode())
+    return bytes(out)
+
+
+def decode_domain_command(data: bytes) -> GlobalDomainCommand:
+    reader = _Reader(data)
+    version = reader.u32()
+    if version != GLOBAL_DOMAIN_VERSION:
+        raise ValueError("global domain command version mismatch")
+    try:
+        phase = GlobalDomainPhase(reader.u32())
+    except ValueError as exc:
+        raise ValueError("global domain command phase is unknown") from exc
+    domain_id = reader.u64()
+    generation = reader.u64()
+    window_size = reader.u64()
+    name = reader.string("name")
+    profile = reader.string("profile")
+    member_count = reader.u32()
+    if member_count > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain command member count exceeds maximum")
+    members = tuple(_read_member(reader) for _ in range(member_count))
+    buffer_count = reader.u32()
+    if buffer_count > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain command buffer count exceeds maximum")
+    buffers = tuple(GlobalDomainBuffer(reader.string("buffer.name"), reader.u64()) for _ in range(buffer_count))
+    descriptor_count = reader.u32()
+    if descriptor_count > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain command descriptor count exceeds maximum")
+    descriptors = tuple(
+        GlobalDomainDescriptor.decode(reader.fixed(GLOBAL_DOMAIN_DESCRIPTOR_BYTES, "descriptor"))
+        for _ in range(descriptor_count)
+    )
+    reader.done("ALLOC_DOMAIN")
+    command = GlobalDomainCommand(
+        phase=phase,
+        domain_id=domain_id,
+        generation=generation,
+        name=name,
+        profile=profile,
+        window_size=window_size,
+        members=members,
+        buffers=buffers,
+        descriptors=descriptors,
+    )
+    encode_domain_command(command)
+    return command
+
+
+def encode_descriptor_table(descriptors: tuple[GlobalDomainDescriptor, ...]) -> bytes:
+    if len(descriptors) > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain descriptor table exceeds maximum")
+    return struct.pack("<I", len(descriptors)) + b"".join(descriptor.encode() for descriptor in descriptors)
+
+
+def decode_descriptor_table(data: bytes) -> tuple[GlobalDomainDescriptor, ...]:
+    reader = _Reader(data)
+    count = reader.u32()
+    if count > GLOBAL_DOMAIN_MAX_RANKS:
+        raise ValueError("global domain descriptor table exceeds maximum")
+    descriptors = tuple(
+        GlobalDomainDescriptor.decode(reader.fixed(GLOBAL_DOMAIN_DESCRIPTOR_BYTES, "descriptor")) for _ in range(count)
+    )
+    reader.done("descriptor table")
+    return descriptors
+
+
+def encode_release_command(command: GlobalDomainReleaseCommand) -> bytes:
+    if command.domain_id == 0 or command.generation == 0:
+        raise ValueError("global domain release identity must be positive")
+    return struct.pack("<IQQ", GLOBAL_DOMAIN_VERSION, int(command.domain_id), int(command.generation))
+
+
+def decode_release_command(data: bytes) -> GlobalDomainReleaseCommand:
+    if len(data) != struct.calcsize("<IQQ"):
+        raise ValueError("global domain release size mismatch")
+    version, domain_id, generation = struct.unpack("<IQQ", data)
+    if version != GLOBAL_DOMAIN_VERSION or domain_id == 0 or generation == 0:
+        raise ValueError("global domain release identity or version is invalid")
+    return GlobalDomainReleaseCommand(int(domain_id), int(generation))
+
+
+def encode_copy_command(command: GlobalDomainCopyCommand, *, include_data: bool) -> bytes:
+    if (
+        command.domain_id == 0
+        or command.generation == 0
+        or command.domain_rank < 0
+        or command.offset < 0
+        or command.nbytes <= 0
+        or command.nbytes > GLOBAL_DOMAIN_MAX_COPY_BYTES
+    ):
+        raise ValueError("global domain copy fields are invalid")
+    if include_data and len(command.data) != command.nbytes:
+        raise ValueError("global domain copy payload size mismatch")
+    if not include_data and command.data:
+        raise ValueError("global domain copy-from request must not contain data")
+    out = bytearray(
+        struct.pack(
+            "<IQQIQQ",
+            GLOBAL_DOMAIN_VERSION,
+            int(command.domain_id),
+            int(command.generation),
+            int(command.domain_rank),
+            int(command.offset),
+            int(command.nbytes),
+        )
+    )
+    if include_data:
+        out.extend(command.data)
+    return bytes(out)
+
+
+def decode_copy_command(data: bytes, *, include_data: bool) -> GlobalDomainCopyCommand:
+    header_size = struct.calcsize("<IQQIQQ")
+    if len(data) < header_size:
+        raise ValueError("global domain copy request is truncated")
+    version, domain_id, generation, domain_rank, offset, nbytes = struct.unpack_from("<IQQIQQ", data)
+    payload = data[header_size:]
+    command = GlobalDomainCopyCommand(
+        domain_id=int(domain_id),
+        generation=int(generation),
+        domain_rank=int(domain_rank),
+        offset=int(offset),
+        nbytes=int(nbytes),
+        data=bytes(payload),
+    )
+    if version != GLOBAL_DOMAIN_VERSION:
+        raise ValueError("global domain copy version mismatch")
+    encode_copy_command(command, include_data=include_data)
+    return command
+
+
+def encode_copy_result(data: bytes) -> bytes:
+    out = bytearray()
+    _put_blob(out, data, GLOBAL_DOMAIN_MAX_COPY_BYTES, "copy result")
+    return bytes(out)
+
+
+def decode_copy_result(data: bytes) -> bytes:
+    reader = _Reader(data)
+    result = reader.blob(GLOBAL_DOMAIN_MAX_COPY_BYTES, "copy result")
+    reader.done("copy result")
+    return result

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -50,6 +50,8 @@ from .task_interface import (
     CommBufferSpec,
     CommDomainHandle,
     DataType,
+    GlobalCommDomainHandle,
+    GlobalCommDomainView,
     RemoteAddressSpace,
     TaskArgs,
     _empty_remote_sidecar_for,
@@ -528,6 +530,89 @@ class Orchestrator:
     def release_domain(self, handle: CommDomainHandle) -> None:
         """Collective release.  Equivalent to ``handle.release()``."""
         handle.release()
+
+    def allocate_global_domain(
+        self,
+        *,
+        name: str,
+        members: Sequence[tuple[int, int]],
+        window_size: int,
+        buffers: Sequence[CommBufferSpec] = (),
+        retain_after_run: bool = False,
+    ) -> GlobalCommDomainHandle:
+        """Create a CommDomain across local and/or remote L3 nodes without MPI.
+
+        Each member is ``(l3_worker_id, local_l2_worker_id)``. The L3 worker
+        may have been registered by ``Worker.add_worker`` or
+        ``Worker.add_remote_worker``. L4 collects every L2 export descriptor,
+        sends the complete rank-ordered table back to every L3, and commits
+        only after all L2 imports succeed.
+        ``retain_after_run=True`` keeps the domain live after the current DAG
+        drains so a later run can inspect communication results; explicit
+        release or ``Worker.close()`` still tears it down.
+        """
+        if self._worker is None:
+            raise RuntimeError("allocate_global_domain requires an Orchestrator bound to a Worker")
+        return self._worker._allocate_global_domain(
+            name=str(name),
+            members=tuple((int(node), int(local)) for node, local in members),
+            window_size=int(window_size),
+            buffers=list(buffers),
+            retain_after_run=bool(retain_after_run),
+        )
+
+    def release_global_domain(self, handle: GlobalCommDomainHandle) -> None:
+        handle.release()
+
+    def get_global_domain(self, domain_id: int) -> GlobalCommDomainView:
+        """Return the committed L3-local view for a domain created by L4."""
+        if self._worker is None:
+            raise RuntimeError("get_global_domain requires an Orchestrator bound to a Worker")
+        return self._worker._get_global_domain(int(domain_id))
+
+    @staticmethod
+    def _global_copy_range(handle: GlobalCommDomainHandle, *, buffer: str | None, offset: int, nbytes: int) -> int:
+        absolute = int(offset)
+        if absolute < 0 or nbytes <= 0:
+            raise ValueError("Global CommDomain copy offset must be non-negative and size must be positive")
+        limit = handle.mapping_size
+        if buffer is not None:
+            buffer_offset, buffer_nbytes = handle.buffer_range(str(buffer))
+            if absolute > buffer_nbytes or nbytes > buffer_nbytes - absolute:
+                raise ValueError(f"Global CommDomain copy exceeds buffer {buffer!r}")
+            absolute += buffer_offset
+        elif absolute > limit or nbytes > limit - absolute:
+            raise ValueError("Global CommDomain copy exceeds the mapped window")
+        return absolute
+
+    def copy_to_global_domain(
+        self,
+        handle: GlobalCommDomainHandle,
+        domain_rank: int,
+        data: bytes,
+        *,
+        buffer: str | None = None,
+        offset: int = 0,
+    ) -> None:
+        payload = bytes(data)
+        absolute = self._global_copy_range(handle, buffer=buffer, offset=int(offset), nbytes=len(payload))
+        if self._worker is None:
+            raise RuntimeError("copy_to_global_domain requires an Orchestrator bound to a Worker")
+        self._worker._copy_to_global_domain(handle, int(domain_rank), payload, absolute)
+
+    def copy_from_global_domain(
+        self,
+        handle: GlobalCommDomainHandle,
+        domain_rank: int,
+        nbytes: int,
+        *,
+        buffer: str | None = None,
+        offset: int = 0,
+    ) -> bytes:
+        absolute = self._global_copy_range(handle, buffer=buffer, offset=int(offset), nbytes=int(nbytes))
+        if self._worker is None:
+            raise RuntimeError("copy_from_global_domain requires an Orchestrator bound to a Worker")
+        return self._worker._copy_from_global_domain(handle, int(domain_rank), int(nbytes), absolute)
 
     def create_worker_chip_region(self, *, worker_id: int, payload_bytes: int, counter_bytes: int):
         """Create an L3-L2 communication region on one NEXT_LEVEL chip worker."""

--- a/python/simpler/remote_l3_protocol.py
+++ b/python/simpler/remote_l3_protocol.py
@@ -65,6 +65,8 @@ class ControlName(enum.IntEnum):
     COMM_INIT = 13
     ALLOC_DOMAIN = 14
     RELEASE_DOMAIN = 15
+    COPY_TO_DOMAIN = 16
+    COPY_FROM_DOMAIN = 17
 
 
 class RemoteRegistryTarget(enum.IntEnum):

--- a/python/simpler/remote_l3_session.py
+++ b/python/simpler/remote_l3_session.py
@@ -53,6 +53,19 @@ from .callable_identity import (
     parse_python_import_target,
     validate_hashid,
 )
+from .global_comm_domain import (
+    GLOBAL_DOMAIN_PROFILE_SIM,
+    GlobalDomainPhase,
+    GlobalDomainReleaseCommand,
+    decode_comm_init,
+    decode_copy_command,
+    decode_domain_command,
+    decode_release_command,
+    encode_comm_init_result,
+    encode_copy_result,
+    encode_descriptor_table,
+    resolve_global_comm_capability,
+)
 from .remote_l3_protocol import (
     HOST_TCP_TRANSPORT_PROFILE,
     PROTOCOL_VERSION,
@@ -512,6 +525,20 @@ def _control_reply(
     send_frame(conn, FrameHeader(FrameType.CONTROL_REPLY, session_id, worker_id, sequence), payload)
 
 
+def _control_result_reply(
+    conn: socket.socket,
+    manifest: dict[str, Any],
+    sequence: int,
+    control_name: ControlName,
+    version: int,
+    result: bytes,
+) -> None:
+    session_id = int(manifest["session_id"])
+    worker_id = int(manifest["worker_id"])
+    payload = encode_control_reply(sequence, control_name, version, 0, "", bytes(result))
+    send_frame(conn, FrameHeader(FrameType.CONTROL_REPLY, session_id, worker_id, sequence), payload)
+
+
 def _copy_command_header(data: bytes) -> tuple[int, int, int, int, int, bytes]:
     if len(data) < 36:
         raise ValueError("remote buffer copy command is truncated")
@@ -646,6 +673,7 @@ def _run_command_loop(  # noqa: PLR0912, PLR0915
     # One nonce per runner incarnation, backing the identity of every buffer this loop mints itself
     # (the inner Worker mints its own for the ones it owns).
     session_owner_instance_id = mint_owner_instance_id()
+    global_comm_inits: dict[str, Any] = {}
 
     def mint_session_buffer(nbytes: int) -> Buffer:
         """A POSIX_SHM backing this loop owns, under a buffer_id no other one in the session reuses.
@@ -667,7 +695,7 @@ def _run_command_loop(  # noqa: PLR0912, PLR0915
         session_id=session_id,
         worker_id=worker_id,
         protocol_version=PROTOCOL_VERSION,
-        comm_profile=str(manifest["transport"]),
+        comm_profile=str(manifest.get("comm_profile", GLOBAL_DOMAIN_PROFILE_SIM)),
         feature_flags=0,
         ready_state=ReadyState.READY,
     )
@@ -986,19 +1014,136 @@ def _run_command_loop(  # noqa: PLR0912, PLR0915
                         _control_reply(
                             conn, manifest, header.sequence, control.control_name, control.control_version, 0, ""
                         )
-                    elif control.control_name in (
-                        ControlName.COMM_INIT,
-                        ControlName.ALLOC_DOMAIN,
-                        ControlName.RELEASE_DOMAIN,
-                    ):
+                    elif control.control_name == ControlName.COMM_INIT:
+                        command = decode_comm_init(control.command_bytes)
+                        manifest_profile = str(manifest.get("comm_profile", GLOBAL_DOMAIN_PROFILE_SIM))
+                        if command.cluster_id != str(manifest.get("cluster_id", "")):
+                            raise ValueError("COMM_INIT cluster_id does not match the session manifest")
+                        if command.profile != manifest_profile:
+                            raise ValueError("COMM_INIT profile does not match the session manifest")
+                        if command.node_rank != int(manifest.get("node_rank", 0)) or command.node_count != int(
+                            manifest.get("node_count", 1)
+                        ):
+                            raise ValueError("COMM_INIT node identity does not match the session manifest")
+                        global_ranks = tuple(int(rank) for rank in manifest.get("global_device_ranks", ()))
+                        local_members = tuple(
+                            member for member in command.members if member.node_worker_id == worker_id
+                        )
+                        if not local_members:
+                            raise ValueError("COMM_INIT topology has no local members")
+                        for member in local_members:
+                            if member.local_worker_id < 0 or member.local_worker_id >= len(global_ranks):
+                                raise ValueError("COMM_INIT local worker id exceeds the session device list")
+                            if member.global_device_rank != global_ranks[member.local_worker_id]:
+                                raise ValueError("COMM_INIT global device rank does not match the manifest")
+                        prior = global_comm_inits.get(command.topology_hash)
+                        if prior is not None and prior != command:
+                            raise ValueError("COMM_INIT topology hash conflicts with an earlier command")
+                        result = resolve_global_comm_capability(
+                            platform=str(manifest["platform"]),
+                            profile=manifest_profile,
+                            local_device_count=len(global_ranks),
+                        )
+                        global_comm_inits[command.topology_hash] = command
+                        _control_result_reply(
+                            conn,
+                            manifest,
+                            header.sequence,
+                            control.control_name,
+                            control.control_version,
+                            encode_comm_init_result(result),
+                        )
+                    elif control.control_name == ControlName.ALLOC_DOMAIN:
+                        command = decode_domain_command(control.command_bytes)
+                        if not any(
+                            init.profile == command.profile and init.members == command.members
+                            for init in global_comm_inits.values()
+                        ):
+                            raise RuntimeError("ALLOC_DOMAIN requires a matching COMM_INIT topology")
+                        if command.phase is GlobalDomainPhase.PREPARE_EXPORT:
+                            if command.descriptors:
+                                raise ValueError("PREPARE_EXPORT must not carry descriptors")
+                            descriptors = inner_worker._prepare_global_domain_node(command, worker_id)  # noqa: SLF001
+                            _control_result_reply(
+                                conn,
+                                manifest,
+                                header.sequence,
+                                control.control_name,
+                                control.control_version,
+                                encode_descriptor_table(descriptors),
+                            )
+                        elif command.phase is GlobalDomainPhase.IMPORT:
+                            inner_worker._import_global_domain_node(command, worker_id)  # noqa: SLF001
+                            _control_reply(
+                                conn,
+                                manifest,
+                                header.sequence,
+                                control.control_name,
+                                control.control_version,
+                                0,
+                                "",
+                            )
+                        elif command.phase is GlobalDomainPhase.COMMIT:
+                            inner_worker._commit_global_domain_node(command)  # noqa: SLF001
+                            _control_reply(
+                                conn,
+                                manifest,
+                                header.sequence,
+                                control.control_name,
+                                control.control_version,
+                                0,
+                                "",
+                            )
+                        elif command.phase is GlobalDomainPhase.ABORT:
+                            inner_worker._release_global_domain_node(  # noqa: SLF001
+                                GlobalDomainReleaseCommand(command.domain_id, command.generation),
+                                suppress_errors=True,
+                            )
+                            _control_reply(
+                                conn,
+                                manifest,
+                                header.sequence,
+                                control.control_name,
+                                control.control_version,
+                                0,
+                                "",
+                            )
+                        else:
+                            raise ValueError("ALLOC_DOMAIN phase is not supported")
+                    elif control.control_name == ControlName.RELEASE_DOMAIN:
+                        command = decode_release_command(control.command_bytes)
+                        inner_worker._release_global_domain_node(command)  # noqa: SLF001
                         _control_reply(
                             conn,
                             manifest,
                             header.sequence,
                             control.control_name,
                             control.control_version,
-                            1,
-                            f"unsupported reserved remote domain control {control.control_name.name}",
+                            0,
+                            "",
+                        )
+                    elif control.control_name == ControlName.COPY_TO_DOMAIN:
+                        command = decode_copy_command(control.command_bytes, include_data=True)
+                        inner_worker._copy_global_domain_node(command, copy_to_device=True)  # noqa: SLF001
+                        _control_reply(
+                            conn,
+                            manifest,
+                            header.sequence,
+                            control.control_name,
+                            control.control_version,
+                            0,
+                            "",
+                        )
+                    elif control.control_name == ControlName.COPY_FROM_DOMAIN:
+                        command = decode_copy_command(control.command_bytes, include_data=False)
+                        result = inner_worker._copy_global_domain_node(command, copy_to_device=False)  # noqa: SLF001
+                        _control_result_reply(
+                            conn,
+                            manifest,
+                            header.sequence,
+                            control.control_name,
+                            control.control_version,
+                            encode_copy_result(result),
                         )
                     else:
                         _control_reply(

--- a/python/simpler/remote_l3_worker.py
+++ b/python/simpler/remote_l3_worker.py
@@ -26,6 +26,7 @@ import threading
 import time
 from typing import Any
 
+from .global_comm_domain import GLOBAL_DOMAIN_PROFILE_SIM
 from .remote_l3_protocol import HOST_TCP_TRANSPORT_PROFILE
 
 
@@ -66,6 +67,23 @@ def _validate_manifest(manifest: dict[str, Any]) -> None:
         raise ValueError("manifest platform must be non-empty")
     if str(manifest["transport"]) != HOST_TCP_TRANSPORT_PROFILE:
         raise ValueError(f"only {HOST_TCP_TRANSPORT_PROFILE} transport is accepted by simpler-remote-worker")
+    comm_profile = str(manifest.get("comm_profile", GLOBAL_DOMAIN_PROFILE_SIM))
+    if comm_profile not in ("sim", "a3-fabric-v1"):
+        raise ValueError("manifest comm_profile is not supported")
+    if comm_profile == "a3-fabric-v1" and not str(manifest["platform"]).startswith("a2a3"):
+        raise ValueError("manifest a3-fabric-v1 comm_profile requires an a2a3 platform")
+    if comm_profile == "a3-fabric-v1" and str(manifest["platform"]).endswith("sim"):
+        raise ValueError("manifest a3-fabric-v1 comm_profile requires real A3 devices")
+    node_rank = int(manifest.get("node_rank", 0))
+    node_count = int(manifest.get("node_count", 1))
+    if node_count <= 0 or node_rank < 0 or node_rank >= node_count:
+        raise ValueError("manifest node identity is invalid")
+    device_ids = [int(device_id) for device_id in manifest.get("device_ids", [])]
+    global_device_ranks = [int(rank) for rank in manifest.get("global_device_ranks", range(len(device_ids)))]
+    if len(global_device_ranks) != len(device_ids):
+        raise ValueError("manifest global_device_ranks must match device_ids length")
+    if any(rank < 0 for rank in global_device_ranks) or len(set(global_device_ranks)) != len(global_device_ranks):
+        raise ValueError("manifest global_device_ranks must be unique and non-negative")
 
 
 def _session_timeout_s(manifest: dict[str, Any]) -> float:

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -138,6 +138,8 @@ def _assert_bindings_match_source_tree() -> None:
 
 _assert_bindings_match_source_tree()
 
+from .global_comm_domain import GlobalDomainBuffer, GlobalDomainMember  # noqa: E402
+
 __all__ = [
     "DataType",
     "get_element_size",
@@ -173,6 +175,8 @@ __all__ = [
     "CommBufferSpec",
     "ChipDomainContext",
     "CommDomainHandle",
+    "GlobalCommDomainHandle",
+    "GlobalCommDomainView",
 ]
 
 COMM_MAX_RANK_NUM = 64
@@ -1082,6 +1086,132 @@ class CommDomainHandle:
         else:
             state = "live"
         return f"CommDomainHandle(name={self.name!r}, workers={self.workers}, {state})"
+
+
+class GlobalCommDomainHandle:
+    """L4-owned handle for one CommDomain spanning local and/or remote L3 nodes.
+
+    The handle contains stable topology and buffer offsets only. Device
+    addresses remain in the L3/L2 process that imported the transport handles.
+    """
+
+    __slots__ = (
+        "_freed",
+        "_release_fn",
+        "_released",
+        "buffers",
+        "domain_id",
+        "generation",
+        "mapping_size",
+        "members",
+        "name",
+        "retain_after_run",
+    )
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        members: tuple[GlobalDomainMember, ...],
+        buffers: tuple[GlobalDomainBuffer, ...],
+        domain_id: int,
+        generation: int,
+        mapping_size: int,
+        retain_after_run: bool,
+        _release_fn,
+    ) -> None:
+        self.name = str(name)
+        self.members = tuple(members)
+        self.buffers = tuple(buffers)
+        self.domain_id = int(domain_id)
+        self.generation = int(generation)
+        self.mapping_size = int(mapping_size)
+        self.retain_after_run = bool(retain_after_run)
+        self._release_fn = _release_fn
+        self._released = False
+        self._freed = False
+
+    def member(self, domain_rank: int) -> GlobalDomainMember:
+        if self._released:
+            raise RuntimeError(f"GlobalCommDomainHandle({self.name!r}) is already released")
+        rank = int(domain_rank)
+        if rank < 0 or rank >= len(self.members):
+            raise IndexError(f"global domain rank {rank} is out of range")
+        member = self.members[rank]
+        if member.domain_rank != rank:
+            raise RuntimeError("global domain member table is not rank ordered")
+        return member
+
+    def buffer_range(self, name: str) -> tuple[int, int]:
+        if self._released:
+            raise RuntimeError(f"GlobalCommDomainHandle({self.name!r}) is already released")
+        offset = 0
+        for buffer in self.buffers:
+            if buffer.name == name:
+                return offset, buffer.nbytes
+            offset += buffer.nbytes
+        raise KeyError(f"global domain {self.name!r} has no buffer {name!r}")
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    @property
+    def freed(self) -> bool:
+        return self._freed
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._release_fn(self)
+        self._released = True
+
+    def __enter__(self) -> GlobalCommDomainHandle:
+        return self
+
+    def __exit__(self, *_):
+        self.release()
+
+
+class GlobalCommDomainView:
+    """L3-local imported view exposed to remote orchestration callables."""
+
+    __slots__ = (
+        "_committed",
+        "contexts",
+        "domain_id",
+        "generation",
+        "mapping_size",
+        "members",
+        "name",
+    )
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        members: tuple[GlobalDomainMember, ...],
+        contexts: dict[int, ChipDomainContext],
+        domain_id: int,
+        generation: int,
+        mapping_size: int,
+    ) -> None:
+        self.name = str(name)
+        self.members = tuple(members)
+        self.contexts = dict(contexts)
+        self.domain_id = int(domain_id)
+        self.generation = int(generation)
+        self.mapping_size = int(mapping_size)
+        self._committed = False
+
+    def __getitem__(self, local_worker_id: int) -> ChipDomainContext:
+        if not self._committed:
+            raise RuntimeError(f"GlobalCommDomainView({self.name!r}) is not committed")
+        return self.contexts[int(local_worker_id)]
+
+    @property
+    def committed(self) -> bool:
+        return self._committed
 
 
 # Process-wide RTLD_GLOBAL preload registry. host_runtime.so resolves its

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -149,6 +149,51 @@ from .comm_endpoints import (
     _normalize_node_identity,
     parse_endpoint_path,
 )
+from .global_comm_domain import (
+    CTRL_GLOBAL_DOMAIN_COPY_FROM,
+    CTRL_GLOBAL_DOMAIN_COPY_TO,
+    CTRL_GLOBAL_DOMAIN_IMPORT,
+    CTRL_GLOBAL_DOMAIN_PREPARE,
+    CTRL_GLOBAL_DOMAIN_RELEASE,
+    GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
+    GLOBAL_DOMAIN_MAX_COPY_BYTES,
+    GLOBAL_DOMAIN_MAX_RANKS,
+    GLOBAL_DOMAIN_MAX_STRING_BYTES,
+    GLOBAL_DOMAIN_PROFILE_IDS,
+    GLOBAL_DOMAIN_VERSION,
+    LOCAL_COPY_REPLY,
+    LOCAL_COPY_REQUEST,
+    LOCAL_DOMAIN_MAGIC,
+    LOCAL_IMPORT_REPLY,
+    LOCAL_IMPORT_REQUEST,
+    LOCAL_PREPARE_REPLY,
+    LOCAL_PREPARE_REQUEST,
+    LOCAL_RELEASE_REQUEST,
+    GlobalCommInitCommand,
+    GlobalDomainBuffer,
+    GlobalDomainCommand,
+    GlobalDomainCopyCommand,
+    GlobalDomainDescriptor,
+    GlobalDomainMember,
+    GlobalDomainPhase,
+    GlobalDomainReleaseCommand,
+    decode_comm_init,
+    decode_comm_init_result,
+    decode_copy_command,
+    decode_copy_result,
+    decode_descriptor_table,
+    decode_domain_command,
+    decode_release_command,
+    encode_comm_init,
+    encode_comm_init_result,
+    encode_copy_command,
+    encode_copy_result,
+    encode_descriptor_table,
+    encode_domain_command,
+    encode_release_command,
+    resolve_global_comm_capability,
+    validate_descriptor_table,
+)
 from .orchestrator import Orchestrator, _callback_run, direct_control
 from .remote_l3_protocol import HOST_TCP_TRANSPORT_PROFILE
 from .task_interface import (
@@ -162,6 +207,8 @@ from .task_interface import (
     ChipWorker,
     CommBufferSpec,
     CommDomainHandle,
+    GlobalCommDomainHandle,
+    GlobalCommDomainView,
     RemoteAddressSpace,
     RemoteBufferExport,
     RemoteBufferHandle,
@@ -391,6 +438,12 @@ _CTRL_OP_NAMES = {
 _CTRL_WORKER_CHIP_REGION_CREATE = 16
 _CTRL_WORKER_CHIP_REGION_RELEASE = 17
 _CTRL_COMMITTED_DEVICE_MEMORY = 18
+# L4-to-local-L3 envelope for the Global CommDomain control protocol. The
+# enclosed command uses remote_l3_protocol.ControlName; values 18-23 belong to
+# chip-child controls.
+_CTRL_GLOBAL_DOMAIN_NODE = 24
+_LOCAL_GLOBAL_CONTROL_HEADER = struct.Struct("<IIQ")
+_CTRL_OP_NAMES[_CTRL_GLOBAL_DOMAIN_NODE] = "global_domain"
 
 # Layout of the CTRL_COMM_INIT request shm.
 _COMM_INIT_HEADER = struct.Struct("<II")  # rank (u32), nranks (u32)
@@ -499,6 +552,8 @@ class RemoteWorkerSpec:
     device_ids: tuple[int, ...] = ()
     num_sub_workers: int = 0
     transport: str = HOST_TCP_TRANSPORT_PROFILE
+    comm_profile: str = "sim"
+    global_device_ranks: tuple[int, ...] = ()
     session_listen_host: str | None = None
     allow_wildcard_session_bind: bool = False
 
@@ -513,6 +568,7 @@ class RemoteWorkerSpec:
         object.__setattr__(self, "platform", str(self.platform))
         object.__setattr__(self, "runtime", str(self.runtime))
         object.__setattr__(self, "transport", str(self.transport))
+        object.__setattr__(self, "comm_profile", str(self.comm_profile))
         object.__setattr__(
             self,
             "session_listen_host",
@@ -520,9 +576,26 @@ class RemoteWorkerSpec:
         )
         object.__setattr__(self, "allow_wildcard_session_bind", bool(self.allow_wildcard_session_bind))
         object.__setattr__(self, "device_ids", tuple(int(x) for x in self.device_ids))
+        object.__setattr__(self, "global_device_ranks", tuple(int(x) for x in self.global_device_ranks))
         object.__setattr__(self, "num_sub_workers", int(self.num_sub_workers))
         if self.num_sub_workers < 0:
             raise ValueError("RemoteWorkerSpec.num_sub_workers must be non-negative")
+        if self.transport != HOST_TCP_TRANSPORT_PROFILE:
+            raise ValueError(
+                f"RemoteWorkerSpec.transport must be {HOST_TCP_TRANSPORT_PROFILE!r} for the TCP daemon control plane"
+            )
+        if self.comm_profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+            raise ValueError(f"RemoteWorkerSpec.comm_profile {self.comm_profile!r} is not supported")
+        if self.comm_profile == "a3-fabric-v1" and not self.platform.startswith("a2a3"):
+            raise ValueError("RemoteWorkerSpec.comm_profile 'a3-fabric-v1' requires an a2a3 platform")
+        if self.comm_profile == "a3-fabric-v1" and self.platform.endswith("sim"):
+            raise ValueError("RemoteWorkerSpec.comm_profile 'a3-fabric-v1' requires real A3 devices")
+        if self.global_device_ranks and len(self.global_device_ranks) != len(self.device_ids):
+            raise ValueError("RemoteWorkerSpec.global_device_ranks must match device_ids length")
+        if any(rank < 0 for rank in self.global_device_ranks) or len(set(self.global_device_ranks)) != len(
+            self.global_device_ranks
+        ):
+            raise ValueError("RemoteWorkerSpec.global_device_ranks must be unique and non-negative")
 
 
 @dataclass(frozen=True)
@@ -534,6 +607,31 @@ class _RemoteSession:
     health_host: str
     health_port: int
     pid: int
+
+
+@dataclass
+class _GlobalNodeDomainState:
+    command: GlobalDomainCommand
+    prepared_domain_ranks: set[int] = field(default_factory=set)
+    descriptors: dict[int, GlobalDomainDescriptor] = field(default_factory=dict)
+    local_window_bases: dict[int, int] = field(default_factory=dict)
+    mapping_sizes: dict[int, int] = field(default_factory=dict)
+    contexts: dict[int, ChipDomainContext] = field(default_factory=dict)
+    view: GlobalCommDomainView | None = None
+    phase: GlobalDomainPhase = GlobalDomainPhase.PREPARE_EXPORT
+
+
+@dataclass(frozen=True)
+class _GlobalNodeRuntime:
+    worker_id: int
+    device_ids: tuple[int, ...]
+    platform: str
+    comm_profile: str
+    global_device_ranks: tuple[int, ...]
+    node_rank: int
+    node_count: int
+    cluster_id: str
+    is_remote: bool
 
 
 _IdentitySnapshotEntry = tuple[bytes, Any, int, str, str]
@@ -1896,6 +1994,25 @@ class _HostWorkerChipRegionStore:
     next_region_id: int = 1
 
 
+@dataclass
+class _L2GlobalDomain:
+    domain_id: int
+    generation: int
+    domain_rank: int
+    rank_count: int
+    descriptor: GlobalDomainDescriptor
+    local_window_base: int
+    mapping_size: int
+    requested_window_size: int
+    device_ctx: int = 0
+    descriptor_table: bytes = b""
+
+
+@dataclass
+class _L2GlobalDomainStore:
+    domains: dict[int, _L2GlobalDomain] = field(default_factory=dict)
+
+
 @dataclass(frozen=True)
 class _HostWorkerChipRegionReplyMeta:
     payload_base: int
@@ -2057,6 +2174,223 @@ def _sweep_host_worker_chip_regions(store: _HostWorkerChipRegionStore) -> None:
             pass
 
 
+def _open_global_domain_payload(buf: memoryview) -> tuple[SharedMemory, memoryview, int]:
+    payload_size = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0])
+    if payload_size <= 0:
+        raise RuntimeError("Global CommDomain control payload must be non-empty")
+    staged = SharedMemory(name=_read_ctrl_staged_shm_name(buf))
+    staged_buf = cast(memoryview, staged.buf)
+    if payload_size > staged.size:
+        staged_buf.release()
+        staged.close()
+        raise RuntimeError("Global CommDomain control payload exceeds staged shm")
+    return staged, staged_buf, payload_size
+
+
+def _validate_local_global_header(
+    magic: bytes, version: int, domain_id: int, generation: int, *, operation: str
+) -> None:
+    if magic != LOCAL_DOMAIN_MAGIC or version != GLOBAL_DOMAIN_VERSION:
+        raise RuntimeError(f"{operation}: local protocol magic or version mismatch")
+    if domain_id == 0 or generation == 0:
+        raise RuntimeError(f"{operation}: domain identity must be positive")
+
+
+def _handle_ctrl_global_domain_prepare(cw: ChipWorker, buf: memoryview, store: _L2GlobalDomainStore) -> None:
+    staged, payload, payload_size = _open_global_domain_payload(buf)
+    try:
+        if payload_size < max(LOCAL_PREPARE_REQUEST.size, LOCAL_PREPARE_REPLY.size + GLOBAL_DOMAIN_DESCRIPTOR_BYTES):
+            raise RuntimeError("Global CommDomain prepare payload is too small")
+        fields = LOCAL_PREPARE_REQUEST.unpack_from(payload, 0)
+        magic, version, domain_id, generation, domain_rank, rank_count, profile_id, window_size = fields
+        _validate_local_global_header(magic, version, domain_id, generation, operation="prepare")
+        if rank_count <= 0 or rank_count > GLOBAL_DOMAIN_MAX_RANKS or domain_rank >= rank_count:
+            raise RuntimeError("Global CommDomain prepare rank identity is invalid")
+        if profile_id not in GLOBAL_DOMAIN_PROFILE_IDS.values() or window_size <= 0:
+            raise RuntimeError("Global CommDomain prepare profile or window size is invalid")
+        prior = store.domains.get(int(domain_id))
+        if prior is not None:
+            if (
+                prior.generation != generation
+                or prior.domain_rank != domain_rank
+                or prior.rank_count != rank_count
+                or prior.descriptor.profile_id != profile_id
+                or prior.requested_window_size != window_size
+            ):
+                raise RuntimeError("Global CommDomain prepare conflicts with a live domain")
+            descriptor = prior.descriptor
+            local_base = prior.local_window_base
+            mapping_size = prior.mapping_size
+        else:
+            descriptor_bytes, local_base, mapping_size = cw._impl.comm_global_domain_prepare(
+                int(domain_id),
+                int(domain_rank),
+                int(rank_count),
+                int(window_size),
+                int(profile_id),
+            )
+            descriptor = GlobalDomainDescriptor.decode(bytes(descriptor_bytes))
+            if (
+                descriptor.domain_rank != domain_rank
+                or descriptor.rank_count != rank_count
+                or descriptor.profile_id != profile_id
+                or descriptor.mapping_size != mapping_size
+                or descriptor.mapping_size < window_size
+            ):
+                cw._impl.comm_global_domain_release(int(domain_id))
+                raise RuntimeError("Global CommDomain backend returned an inconsistent descriptor")
+            store.domains[int(domain_id)] = _L2GlobalDomain(
+                domain_id=int(domain_id),
+                generation=int(generation),
+                domain_rank=int(domain_rank),
+                rank_count=int(rank_count),
+                descriptor=descriptor,
+                local_window_base=int(local_base),
+                mapping_size=int(mapping_size),
+                requested_window_size=int(window_size),
+            )
+        LOCAL_PREPARE_REPLY.pack_into(
+            payload,
+            0,
+            LOCAL_DOMAIN_MAGIC,
+            GLOBAL_DOMAIN_VERSION,
+            int(domain_id),
+            int(generation),
+            int(local_base),
+            int(mapping_size),
+        )
+        start = LOCAL_PREPARE_REPLY.size
+        payload[start : start + GLOBAL_DOMAIN_DESCRIPTOR_BYTES] = descriptor.encode()
+    finally:
+        payload.release()
+        staged.close()
+
+
+def _handle_ctrl_global_domain_import(cw: ChipWorker, buf: memoryview, store: _L2GlobalDomainStore) -> None:
+    staged, payload, payload_size = _open_global_domain_payload(buf)
+    try:
+        if payload_size < LOCAL_IMPORT_REQUEST.size:
+            raise RuntimeError("Global CommDomain import payload is truncated")
+        magic, version, domain_id, generation, descriptor_count = LOCAL_IMPORT_REQUEST.unpack_from(payload, 0)
+        _validate_local_global_header(magic, version, domain_id, generation, operation="import")
+        expected_size = LOCAL_IMPORT_REQUEST.size + int(descriptor_count) * GLOBAL_DOMAIN_DESCRIPTOR_BYTES
+        if descriptor_count <= 0 or descriptor_count > GLOBAL_DOMAIN_MAX_RANKS or expected_size > payload_size:
+            raise RuntimeError("Global CommDomain import descriptor table size is invalid")
+        entry = store.domains.get(int(domain_id))
+        if entry is None or entry.generation != generation:
+            raise RuntimeError("Global CommDomain import requires a matching prepared domain")
+        descriptor_bytes = bytes(payload[LOCAL_IMPORT_REQUEST.size : expected_size])
+        descriptors = tuple(
+            GlobalDomainDescriptor.decode(descriptor_bytes[offset : offset + GLOBAL_DOMAIN_DESCRIPTOR_BYTES])
+            for offset in range(0, len(descriptor_bytes), GLOBAL_DOMAIN_DESCRIPTOR_BYTES)
+        )
+        profile = next(
+            name for name, profile_id in GLOBAL_DOMAIN_PROFILE_IDS.items() if profile_id == entry.descriptor.profile_id
+        )
+        validate_descriptor_table(descriptors, rank_count=entry.rank_count, profile=profile)
+        if descriptors[entry.domain_rank] != entry.descriptor:
+            raise RuntimeError("Global CommDomain import table does not contain the local exported descriptor")
+        if entry.descriptor_table and entry.descriptor_table != descriptor_bytes:
+            raise RuntimeError("Global CommDomain repeated import carries a different descriptor table")
+        if entry.device_ctx == 0:
+            entry.device_ctx = int(cw._impl.comm_global_domain_import(int(domain_id), descriptor_bytes))
+            if entry.device_ctx == 0:
+                raise RuntimeError("Global CommDomain backend returned a zero device context")
+            entry.descriptor_table = descriptor_bytes
+        if payload_size < LOCAL_IMPORT_REPLY.size:
+            raise RuntimeError("Global CommDomain import reply capacity is too small")
+        LOCAL_IMPORT_REPLY.pack_into(
+            payload,
+            0,
+            LOCAL_DOMAIN_MAGIC,
+            GLOBAL_DOMAIN_VERSION,
+            int(domain_id),
+            int(generation),
+            entry.device_ctx,
+            entry.local_window_base,
+            entry.mapping_size,
+        )
+    finally:
+        payload.release()
+        staged.close()
+
+
+def _handle_ctrl_global_domain_release(cw: ChipWorker, buf: memoryview, store: _L2GlobalDomainStore) -> None:
+    staged, payload, payload_size = _open_global_domain_payload(buf)
+    try:
+        if payload_size < LOCAL_RELEASE_REQUEST.size:
+            raise RuntimeError("Global CommDomain release payload is truncated")
+        magic, version, domain_id, generation = LOCAL_RELEASE_REQUEST.unpack_from(payload, 0)
+        _validate_local_global_header(magic, version, domain_id, generation, operation="release")
+        entry = store.domains.get(int(domain_id))
+        if entry is not None and entry.generation != generation:
+            raise RuntimeError("Global CommDomain release generation mismatch")
+        if entry is not None:
+            cw._impl.comm_global_domain_release(int(domain_id))
+            store.domains.pop(int(domain_id), None)
+    finally:
+        payload.release()
+        staged.close()
+
+
+def _handle_ctrl_global_domain_copy(
+    cw: ChipWorker, buf: memoryview, store: _L2GlobalDomainStore, *, copy_to_device: bool
+) -> None:
+    staged, payload, payload_size = _open_global_domain_payload(buf)
+    try:
+        if payload_size < LOCAL_COPY_REQUEST.size:
+            raise RuntimeError("Global CommDomain copy payload is truncated")
+        magic, version, domain_id, generation, offset, nbytes = LOCAL_COPY_REQUEST.unpack_from(payload, 0)
+        operation = "copy-to" if copy_to_device else "copy-from"
+        _validate_local_global_header(magic, version, domain_id, generation, operation=operation)
+        entry = store.domains.get(int(domain_id))
+        if entry is None or entry.generation != generation or entry.device_ctx == 0:
+            raise RuntimeError(f"Global CommDomain {operation} requires an imported live domain")
+        if nbytes <= 0 or nbytes > GLOBAL_DOMAIN_MAX_COPY_BYTES:
+            raise RuntimeError(f"Global CommDomain {operation} size is invalid")
+        if offset > entry.mapping_size or nbytes > entry.mapping_size - offset:
+            raise RuntimeError(f"Global CommDomain {operation} range exceeds the local window")
+        if copy_to_device:
+            data_offset = LOCAL_COPY_REQUEST.size
+            if data_offset + nbytes > payload_size:
+                raise RuntimeError("Global CommDomain copy-to data is truncated")
+            exported = ctypes.c_char.from_buffer(payload, data_offset)
+            try:
+                cw.copy_to(entry.local_window_base + int(offset), ctypes.addressof(exported), int(nbytes))
+            finally:
+                del exported
+        else:
+            data_offset = LOCAL_COPY_REPLY.size
+            if data_offset + nbytes > payload_size:
+                raise RuntimeError("Global CommDomain copy-from reply capacity is too small")
+            exported = ctypes.c_char.from_buffer(payload, data_offset)
+            try:
+                cw.copy_from(ctypes.addressof(exported), entry.local_window_base + int(offset), int(nbytes))
+            finally:
+                del exported
+        LOCAL_COPY_REPLY.pack_into(
+            payload,
+            0,
+            LOCAL_DOMAIN_MAGIC,
+            GLOBAL_DOMAIN_VERSION,
+            int(domain_id),
+            int(generation),
+            int(nbytes),
+        )
+    finally:
+        payload.release()
+        staged.close()
+
+
+def _sweep_l2_global_domains(cw: ChipWorker, store: _L2GlobalDomainStore) -> None:
+    for domain_id in list(store.domains):
+        store.domains.pop(domain_id, None)
+        try:
+            cw._impl.comm_global_domain_release(int(domain_id))
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def _handle_ctrl_release_domain(cw: ChipWorker, buf: memoryview) -> None:
     """CTRL_RELEASE_DOMAIN handler — collective free for one allocation."""
     request_shm_name = _read_shm_name(buf, _OFF_ARGS)
@@ -2130,6 +2464,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     prepared = prepared if prepared is not None else set()
     worker_chip_region_store = _HostWorkerChipRegionStore()
     import_registry = ImportRegistry()  # lazy per-endpoint import cache: canonical identity -> local base
+    global_domain_store = _L2GlobalDomainStore()
 
     def handle_task(task_buf) -> tuple[int, str]:
         task_addr = ctypes.addressof(ctypes.c_char.from_buffer(task_buf))
@@ -2188,7 +2523,9 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             code, msg = on_task_done_success()
         return code, msg
 
-    def handle_control(sub_cmd: int) -> tuple[int, str]:  # noqa: PLR0912 -- one branch per control sub-command
+    def handle_control(  # noqa: PLR0912, PLR0915 -- one branch per control sub-command
+        sub_cmd: int,
+    ) -> tuple[int, str]:
         code = 0
         msg = ""
         try:
@@ -2291,6 +2628,26 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 _handle_ctrl_worker_chip_region_release(buf, worker_chip_region_store)
             elif sub_cmd == _CTRL_COMMITTED_DEVICE_MEMORY:
                 struct.pack_into("Q", buf, _CTRL_OFF_RESULT, cw.committed_device_memory)
+            elif sub_cmd == CTRL_GLOBAL_DOMAIN_PREPARE:
+                _handle_ctrl_global_domain_prepare(cw, buf, global_domain_store)
+            elif sub_cmd == CTRL_GLOBAL_DOMAIN_IMPORT:
+                _handle_ctrl_global_domain_import(cw, buf, global_domain_store)
+            elif sub_cmd == CTRL_GLOBAL_DOMAIN_RELEASE:
+                _handle_ctrl_global_domain_release(cw, buf, global_domain_store)
+            elif sub_cmd == CTRL_GLOBAL_DOMAIN_COPY_TO:
+                _handle_ctrl_global_domain_copy(
+                    cw,
+                    buf,
+                    global_domain_store,
+                    copy_to_device=True,
+                )
+            elif sub_cmd == CTRL_GLOBAL_DOMAIN_COPY_FROM:
+                _handle_ctrl_global_domain_copy(
+                    cw,
+                    buf,
+                    global_domain_store,
+                    copy_to_device=False,
+                )
             else:
                 raise RuntimeError(f"unknown control sub-command {int(sub_cmd)}")
         except Exception as e:  # noqa: BLE001
@@ -2699,6 +3056,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             _run_mailbox_loop(buf, state_addr, handle_task=handle_task, handle_control=handle_control)
     finally:
         import_registry.close()
+        _sweep_l2_global_domains(cw, global_domain_store)
         _sweep_host_worker_chip_regions(worker_chip_region_store)
 
 
@@ -2825,12 +3183,91 @@ def _read_config_from_mailbox(buf: memoryview) -> CallConfig:
     return cfg
 
 
+def _run_local_global_domain_control(  # noqa: PLR0912 -- one ordered dispatcher for the Global CommDomain protocol
+    inner_worker: Worker,
+    runtime: _GlobalNodeRuntime,
+    comm_inits: dict[str, GlobalCommInitCommand],
+    control_name: int,
+    request: bytes,
+) -> bytes:
+    """Execute one Global CommDomain command inside an add_worker L3 child."""
+    from .remote_l3_protocol import ControlName  # noqa: PLC0415
+
+    control = ControlName(control_name)
+    if control is ControlName.COMM_INIT:
+        command = decode_comm_init(request)
+        if command.cluster_id != runtime.cluster_id:
+            raise ValueError("COMM_INIT cluster_id does not match the local L3 topology")
+        if command.profile != runtime.comm_profile:
+            raise ValueError("COMM_INIT profile does not match the local L3 topology")
+        if command.node_rank != runtime.node_rank or command.node_count != runtime.node_count:
+            raise ValueError("COMM_INIT node identity does not match the local L3 topology")
+        local_members = tuple(member for member in command.members if member.node_worker_id == runtime.worker_id)
+        if not local_members:
+            raise ValueError("COMM_INIT topology has no local members")
+        for member in local_members:
+            if member.local_worker_id < 0 or member.local_worker_id >= len(runtime.global_device_ranks):
+                raise ValueError("COMM_INIT local worker id exceeds the local L3 device list")
+            if member.global_device_rank != runtime.global_device_ranks[member.local_worker_id]:
+                raise ValueError("COMM_INIT global device rank does not match the local L3 topology")
+        prior = comm_inits.get(command.topology_hash)
+        if prior is not None and prior != command:
+            raise ValueError("COMM_INIT topology hash conflicts with an earlier command")
+        capability = resolve_global_comm_capability(
+            platform=runtime.platform,
+            profile=runtime.comm_profile,
+            local_device_count=len(runtime.global_device_ranks),
+        )
+        comm_inits[command.topology_hash] = command
+        return encode_comm_init_result(capability)
+
+    if control is ControlName.ALLOC_DOMAIN:
+        command = decode_domain_command(request)
+        if not any(init.profile == command.profile and init.members == command.members for init in comm_inits.values()):
+            raise RuntimeError("ALLOC_DOMAIN requires a matching COMM_INIT topology")
+        if command.phase is GlobalDomainPhase.PREPARE_EXPORT:
+            if command.descriptors:
+                raise ValueError("PREPARE_EXPORT must not carry descriptors")
+            return encode_descriptor_table(inner_worker._prepare_global_domain_node(command, runtime.worker_id))
+        if command.phase is GlobalDomainPhase.IMPORT:
+            inner_worker._import_global_domain_node(command, runtime.worker_id)
+            return b""
+        if command.phase is GlobalDomainPhase.COMMIT:
+            inner_worker._commit_global_domain_node(command)
+            return b""
+        if command.phase is GlobalDomainPhase.ABORT:
+            inner_worker._release_global_domain_node(
+                GlobalDomainReleaseCommand(command.domain_id, command.generation),
+                suppress_errors=True,
+            )
+            return b""
+        raise ValueError("ALLOC_DOMAIN phase is not supported")
+
+    if control is ControlName.RELEASE_DOMAIN:
+        inner_worker._release_global_domain_node(decode_release_command(request))
+        return b""
+    if control is ControlName.COPY_TO_DOMAIN:
+        inner_worker._copy_global_domain_node(
+            decode_copy_command(request, include_data=True),
+            copy_to_device=True,
+        )
+        return b""
+    if control is ControlName.COPY_FROM_DOMAIN:
+        result = inner_worker._copy_global_domain_node(
+            decode_copy_command(request, include_data=False),
+            copy_to_device=False,
+        )
+        return encode_copy_result(result)
+    raise ValueError(f"unsupported local Global CommDomain control {int(control)}")
+
+
 def _child_worker_loop(
     buf: memoryview,
     registry: dict[int, Any],
     identity_table: dict[bytes, int],
     identity_refs: dict[bytes, int],
     inner_worker: Worker,
+    global_node: _GlobalNodeRuntime | None = None,
 ) -> None:
     """Runs in forked child process. Any-level Worker as child of its parent.
 
@@ -2842,6 +3279,7 @@ def _child_worker_loop(
     into the inner Worker (see docs section 7).
     """
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
+    global_comm_inits: dict[str, GlobalCommInitCommand] = {}
 
     def handle_task(task_buf) -> tuple[int, str]:
         digest = _read_task_digest(task_buf)
@@ -2895,6 +3333,41 @@ def _child_worker_loop(
                     sub_cmd,
                     context=f"child_worker level={inner_worker.level}",
                 )
+            elif sub_cmd == _CTRL_GLOBAL_DOMAIN_NODE:
+                if global_node is None:
+                    raise RuntimeError("Global CommDomain control requires a local L3 child")
+                staged, payload, payload_size = _open_global_domain_payload(buf)
+                try:
+                    if payload_size < _LOCAL_GLOBAL_CONTROL_HEADER.size:
+                        raise RuntimeError("local Global CommDomain control payload is truncated")
+                    control_name, request_size, response_size = _LOCAL_GLOBAL_CONTROL_HEADER.unpack_from(payload, 0)
+                    capacity = payload_size - _LOCAL_GLOBAL_CONTROL_HEADER.size
+                    if request_size > capacity:
+                        raise RuntimeError("local Global CommDomain request exceeds staged payload")
+                    if response_size != 0:
+                        raise RuntimeError("local Global CommDomain request contains a response")
+                    start = _LOCAL_GLOBAL_CONTROL_HEADER.size
+                    request = bytes(payload[start : start + request_size])
+                    response = _run_local_global_domain_control(
+                        inner_worker,
+                        global_node,
+                        global_comm_inits,
+                        int(control_name),
+                        request,
+                    )
+                    if len(response) > capacity:
+                        raise RuntimeError("local Global CommDomain response exceeds staged payload")
+                    payload[start : start + len(response)] = response
+                    _LOCAL_GLOBAL_CONTROL_HEADER.pack_into(
+                        payload,
+                        0,
+                        int(control_name),
+                        int(request_size),
+                        len(response),
+                    )
+                finally:
+                    payload.release()
+                    staged.close()
             else:
                 raise RuntimeError(f"unknown control sub-command {sub_cmd}")
         except Exception as e:  # noqa: BLE001
@@ -3147,6 +3620,8 @@ class _RunResources:
     remote_slot_refs: list[_RemoteSlotRefClaim | RemoteBufferHandle] = field(default_factory=list)
     live_domains: dict[str, CommDomainHandle] = field(default_factory=dict)
     pending_release_domains: list[CommDomainHandle] = field(default_factory=list)
+    live_global_domains: dict[str, GlobalCommDomainHandle] = field(default_factory=dict)
+    pending_release_global_domains: list[GlobalCommDomainHandle] = field(default_factory=list)
     worker_chip_regions: list[Any] = field(default_factory=list)
     worker_chip_orch_comm_host_buffers: dict[int, int] = field(default_factory=dict)
     # True once the owning run's fence has claimed the domains above. A release
@@ -3856,6 +4331,10 @@ class Worker:
         # among live handles).  ``orch.allocate_domain`` adds entries here;
         # ``release()`` removes them and queues a deferred backend free.
         self._live_domains: dict[str, CommDomainHandle] = {}
+        self._live_global_domains: dict[str, GlobalCommDomainHandle] = {}
+        self._failed_global_domain_releases: dict[int, GlobalCommDomainHandle] = {}
+        self._global_node_domains: dict[int, _GlobalNodeDomainState] = {}
+        self._global_cluster_id = uuid.uuid4().hex
         # Monotonic per-Worker counter; mixed into IPC barrier filenames so
         # two concurrent allocations don't share a marker file.  Wraps after
         # 2^64 allocations — far beyond any realistic Worker lifetime.
@@ -3869,6 +4348,8 @@ class Worker:
         # down under an in-flight release.
         self._domain_free_mu = threading.Lock()
         self._domain_free_results: dict[int, BaseException | None] = {}
+        self._global_domain_free_mu = threading.Lock()
+        self._global_domain_free_results: dict[int, BaseException | None] = {}
         self._alloc_id_lock = threading.Lock()
         # Base HCCL/sim communicator is built lazily on the first
         # ``orch.allocate_domain`` call (see ``_ensure_comm_base``).  We
@@ -4173,6 +4654,109 @@ class Worker:
             )
         return entries
 
+    @staticmethod
+    def _validate_global_node_config(
+        *,
+        label: str,
+        platform: str,
+        device_ids: tuple[int, ...],
+        comm_profile: str,
+        global_device_ranks: tuple[int, ...],
+    ) -> None:
+        if comm_profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+            raise ValueError(f"{label} comm_profile {comm_profile!r} is not supported")
+        if comm_profile == "a3-fabric-v1" and (not platform.startswith("a2a3") or platform.endswith("sim")):
+            raise ValueError(f"{label} comm_profile 'a3-fabric-v1' requires real A3 devices")
+        if global_device_ranks and len(global_device_ranks) != len(device_ids):
+            raise ValueError(f"{label} global_device_ranks must match device_ids length")
+        if any(rank < 0 for rank in global_device_ranks) or len(set(global_device_ranks)) != len(global_device_ranks):
+            raise ValueError(f"{label} global_device_ranks must be unique and non-negative")
+
+    def _resolved_global_nodes(self) -> dict[int, _GlobalNodeRuntime]:
+        configs: list[tuple[int, tuple[int, ...], str, str, tuple[int, ...], bool]] = []
+        for worker_id, spec in zip(self._remote_worker_ids, self._remote_worker_specs):
+            configs.append(
+                (
+                    int(worker_id),
+                    tuple(spec.device_ids),
+                    spec.platform,
+                    spec.comm_profile,
+                    tuple(spec.global_device_ranks),
+                    True,
+                )
+            )
+        for worker_id, child in zip(self._next_level_worker_ids, self._next_level_workers):
+            if child.level != 3:
+                continue
+            device_ids = tuple(int(device_id) for device_id in child._config.get("device_ids", ()))
+            platform = str(child._config.get("platform", ""))
+            comm_profile = str(child._config.get("comm_profile", "sim"))
+            global_device_ranks = tuple(int(rank) for rank in child._config.get("global_device_ranks", ()))
+            self._validate_global_node_config(
+                label=f"local L3 worker {worker_id}",
+                platform=platform,
+                device_ids=device_ids,
+                comm_profile=comm_profile,
+                global_device_ranks=global_device_ranks,
+            )
+            configs.append(
+                (
+                    int(worker_id),
+                    device_ids,
+                    platform,
+                    comm_profile,
+                    global_device_ranks,
+                    False,
+                )
+            )
+        configs.sort(key=lambda item: item[0])
+
+        explicit_ranks: set[int] = set()
+        for worker_id, _device_ids, _platform, _profile, ranks, _is_remote in configs:
+            overlap = explicit_ranks.intersection(ranks)
+            if overlap:
+                raise ValueError(
+                    f"Global CommDomain worker {worker_id} duplicates global_device_ranks {sorted(overlap)}"
+                )
+            explicit_ranks.update(ranks)
+
+        used = set(explicit_ranks)
+        next_rank = 0
+        resolved: dict[int, _GlobalNodeRuntime] = {}
+        node_count = len(configs)
+        for node_rank, (worker_id, device_ids, platform, profile, ranks, is_remote) in enumerate(configs):
+            self._validate_global_node_config(
+                label=f"{'remote' if is_remote else 'local'} L3 worker {worker_id}",
+                platform=platform,
+                device_ids=device_ids,
+                comm_profile=profile,
+                global_device_ranks=ranks,
+            )
+            if not ranks:
+                assigned: list[int] = []
+                for _device_id in device_ids:
+                    while next_rank in used:
+                        next_rank += 1
+                    assigned.append(next_rank)
+                    used.add(next_rank)
+                    next_rank += 1
+                ranks = tuple(assigned)
+            resolved[worker_id] = _GlobalNodeRuntime(
+                worker_id=worker_id,
+                device_ids=device_ids,
+                platform=platform,
+                comm_profile=profile,
+                global_device_ranks=ranks,
+                node_rank=node_rank,
+                node_count=node_count,
+                cluster_id=self._global_cluster_id,
+                is_remote=is_remote,
+            )
+        return resolved
+
+    def _resolved_global_device_ranks(self) -> dict[int, tuple[int, ...]]:
+        return {worker_id: runtime.global_device_ranks for worker_id, runtime in self._resolved_global_nodes().items()}
+
     def _build_remote_manifest(
         self, *, spec: RemoteWorkerSpec, worker_id: int, session_id: int, startup_remaining_s: float
     ) -> dict[str, Any]:
@@ -4180,6 +4764,15 @@ class Worker:
         listen_host = spec.session_listen_host or ("127.0.0.1" if daemon_host == "localhost" else daemon_host)
         if self._is_wildcard_session_host(listen_host) and not spec.allow_wildcard_session_bind:
             raise ValueError("RemoteWorkerSpec wildcard session bind requires allow_wildcard_session_bind=True")
+        if worker_id in self._remote_worker_ids:
+            runtime = self._resolved_global_nodes()[int(worker_id)]
+            node_rank = runtime.node_rank
+            node_count = runtime.node_count
+            global_device_ranks = runtime.global_device_ranks
+        else:
+            node_rank = 0
+            node_count = 1
+            global_device_ranks = spec.global_device_ranks or tuple(range(len(spec.device_ids)))
         return {
             "session_id": int(session_id),
             "parent_worker_level": int(self.level),
@@ -4191,6 +4784,11 @@ class Worker:
             "num_sub_workers": int(spec.num_sub_workers),
             "heap_ring_size": self._config.get("remote_heap_ring_size", None),
             "transport": spec.transport,
+            "comm_profile": spec.comm_profile,
+            "cluster_id": self._global_cluster_id,
+            "node_rank": node_rank,
+            "node_count": node_count,
+            "global_device_ranks": list(global_device_ranks),
             # session_timeout_s bounds the runtime command socket; startup_remaining_s
             # bounds this session's slice of the single root startup budget. They are
             # distinct: the remote must not spend runtime-command time as startup time.
@@ -6521,7 +7119,7 @@ class Worker:
                 self._worker.add_remote_l3_socket(
                     session.worker_id,
                     session.session_id,
-                    spec.transport,
+                    spec.comm_profile,
                     session.command_host,
                     session.command_port,
                     session.health_host,
@@ -6553,6 +7151,7 @@ class Worker:
         deadline = self._startup_deadline
         direct_chip_pipeline_depth = PTO_PIPELINE_MAX_DEPTH
         chip_depths: list[int] = []
+        global_nodes = self._resolved_global_nodes() if self.level >= 4 else {}
 
         # Freeze the startup registry snapshot. init() already holds the epoch in
         # the INITIALIZING state, so a concurrent register/unregister is blocked
@@ -6675,6 +7274,8 @@ class Worker:
         # L3 child → L3's chip/sub grandchildren) and INIT_READY propagates up
         # only after the whole subtree is ready.
         for idx, inner_worker in enumerate(self._next_level_workers):
+            worker_id = self._next_level_worker_ids[idx]
+            global_node = global_nodes.get(worker_id)
             pid = os.fork()
             if pid == 0:
                 buf = self._next_level_shms[idx].buf
@@ -6706,7 +7307,12 @@ class Worker:
                     buf,
                     f"next_level worker {idx}",
                     _setup,
-                    lambda tables, b=buf, inner=inner_worker: _child_worker_loop(b, *tables, inner),
+                    lambda tables, b=buf, inner=inner_worker, node=global_node: _child_worker_loop(
+                        b,
+                        *tables,
+                        inner,
+                        node,
+                    ),
                     make_group_leader=self._is_startup_root,
                 )
             else:
@@ -7642,7 +8248,10 @@ class Worker:
         with resources.domain_lock:
             resources.retired = True
             stragglers = list(resources.pending_release_domains)
+            global_stragglers = list(resources.pending_release_global_domains)
+            resources.live_global_domains.clear()
         self._drain_pending_domain_snapshot(resources, stragglers)
+        self._drain_pending_global_domain_snapshot(resources, global_stragglers)
 
     def _drain_pending_domain_snapshot(self, resources: _RunResources, pending: list[CommDomainHandle]) -> None:
         """Free a snapshot while each source-queue claim stays durable."""
@@ -7656,6 +8265,23 @@ class Worker:
                 for index, candidate in enumerate(resources.pending_release_domains):
                     if candidate is handle:
                         del resources.pending_release_domains[index]
+                        break
+
+        _raise_first(_release, pending)
+
+    def _drain_pending_global_domain_snapshot(
+        self,
+        resources: _RunResources,
+        pending: list[GlobalCommDomainHandle],
+    ) -> None:
+        """Free global-domain claims without dropping unfinished cleanup debt."""
+
+        def _release(handle: GlobalCommDomainHandle) -> None:
+            self._free_global_domain_after_fence(handle)
+            with resources.domain_lock:
+                for index, candidate in enumerate(resources.pending_release_global_domains):
+                    if candidate is handle:
+                        del resources.pending_release_global_domains[index]
                         break
 
         _raise_first(_release, pending)
@@ -7837,6 +8463,735 @@ class Worker:
                 f"{op}_domain(allocation_id={allocation_id}) failed on "
                 f"{len(errors)}/{len(workers)} chips; first error chip={first[0]}: {first[1]}"
             )
+
+    @staticmethod
+    def _global_domain_command_identity(command: GlobalDomainCommand) -> tuple[Any, ...]:
+        return (
+            command.domain_id,
+            command.generation,
+            command.name,
+            command.profile,
+            command.window_size,
+            command.members,
+            command.buffers,
+        )
+
+    @staticmethod
+    def _global_domain_provenance_id(domain_id: int) -> int:
+        # Local CommDomain allocation ids are positive. Keep remote Global
+        # CommDomains in a disjoint namespace while reusing the same exact-pointer
+        # provenance table that protects child-memory task submissions.
+        return -int(domain_id)
+
+    def _global_local_members(
+        self, command: GlobalDomainCommand, node_worker_id: int
+    ) -> tuple[GlobalDomainMember, ...]:
+        members = tuple(member for member in command.members if member.node_worker_id == node_worker_id)
+        if not members:
+            raise ValueError(f"Global CommDomain has no members on node worker {node_worker_id}")
+        local_count = len(self._config.get("device_ids", []))
+        for member in members:
+            if member.local_worker_id < 0 or member.local_worker_id >= local_count:
+                raise ValueError(
+                    f"Global CommDomain local worker {member.local_worker_id} is outside [0, {local_count})"
+                )
+        return members
+
+    def _prepare_global_domain_node(
+        self, command: GlobalDomainCommand, node_worker_id: int
+    ) -> tuple[GlobalDomainDescriptor, ...]:
+        if self.level != 3 or self._worker is None:
+            raise RuntimeError("Global CommDomain node prepare requires a ready L3 Worker")
+        prior = self._global_node_domains.get(command.domain_id)
+        if prior is not None:
+            if self._global_domain_command_identity(prior.command) != self._global_domain_command_identity(command):
+                raise RuntimeError("Global CommDomain prepare conflicts with a live domain")
+            return tuple(prior.descriptors[rank] for rank in sorted(prior.descriptors))
+
+        state = _GlobalNodeDomainState(command=command)
+        self._global_node_domains[command.domain_id] = state
+        local_members = self._global_local_members(command, node_worker_id)
+        capacity = max(LOCAL_PREPARE_REQUEST.size, LOCAL_PREPARE_REPLY.size + GLOBAL_DOMAIN_DESCRIPTOR_BYTES)
+        try:
+            for member in local_members:
+                payload = bytearray(capacity)
+                LOCAL_PREPARE_REQUEST.pack_into(
+                    payload,
+                    0,
+                    LOCAL_DOMAIN_MAGIC,
+                    GLOBAL_DOMAIN_VERSION,
+                    command.domain_id,
+                    command.generation,
+                    member.domain_rank,
+                    len(command.members),
+                    GLOBAL_DOMAIN_PROFILE_IDS[command.profile],
+                    command.window_size,
+                )
+                state.prepared_domain_ranks.add(member.domain_rank)
+                reply = bytes(
+                    self._worker.control_payload(
+                        WorkerType.NEXT_LEVEL,
+                        member.local_worker_id,
+                        CTRL_GLOBAL_DOMAIN_PREPARE,
+                        payload,
+                        self._py_control_timeout_s,
+                    )
+                )
+                fields = LOCAL_PREPARE_REPLY.unpack_from(reply, 0)
+                magic, version, domain_id, generation, local_base, mapping_size = fields
+                _validate_local_global_header(magic, version, domain_id, generation, operation="prepare reply")
+                if domain_id != command.domain_id or generation != command.generation:
+                    raise RuntimeError("Global CommDomain prepare reply identity mismatch")
+                start = LOCAL_PREPARE_REPLY.size
+                descriptor = GlobalDomainDescriptor.decode(reply[start : start + GLOBAL_DOMAIN_DESCRIPTOR_BYTES])
+                if descriptor.domain_rank != member.domain_rank:
+                    raise RuntimeError("Global CommDomain prepare reply rank mismatch")
+                state.descriptors[member.domain_rank] = descriptor
+                state.local_window_bases[member.local_worker_id] = int(local_base)
+                state.mapping_sizes[member.local_worker_id] = int(mapping_size)
+            return tuple(state.descriptors[rank] for rank in sorted(state.descriptors))
+        except BaseException:
+            self._release_global_domain_node(
+                GlobalDomainReleaseCommand(command.domain_id, command.generation),
+                suppress_errors=True,
+            )
+            raise
+
+    def _import_global_domain_node(self, command: GlobalDomainCommand, node_worker_id: int) -> None:
+        if self.level != 3 or self._worker is None:
+            raise RuntimeError("Global CommDomain node import requires a ready L3 Worker")
+        state = self._global_node_domains.get(command.domain_id)
+        if state is None or state.command.generation != command.generation:
+            raise RuntimeError("Global CommDomain import requires a matching prepared domain")
+        if self._global_domain_command_identity(state.command) != self._global_domain_command_identity(command):
+            raise RuntimeError("Global CommDomain import command conflicts with prepare")
+        validate_descriptor_table(
+            command.descriptors,
+            rank_count=len(command.members),
+            profile=command.profile,
+        )
+        local_members = self._global_local_members(command, node_worker_id)
+        descriptor_bytes = b"".join(descriptor.encode() for descriptor in command.descriptors)
+        request_size = LOCAL_IMPORT_REQUEST.size + len(descriptor_bytes)
+        capacity = max(request_size, LOCAL_IMPORT_REPLY.size)
+        try:
+            for member in local_members:
+                payload = bytearray(capacity)
+                LOCAL_IMPORT_REQUEST.pack_into(
+                    payload,
+                    0,
+                    LOCAL_DOMAIN_MAGIC,
+                    GLOBAL_DOMAIN_VERSION,
+                    command.domain_id,
+                    command.generation,
+                    len(command.descriptors),
+                )
+                payload[LOCAL_IMPORT_REQUEST.size : request_size] = descriptor_bytes
+                reply = bytes(
+                    self._worker.control_payload(
+                        WorkerType.NEXT_LEVEL,
+                        member.local_worker_id,
+                        CTRL_GLOBAL_DOMAIN_IMPORT,
+                        payload,
+                        self._py_control_timeout_s,
+                    )
+                )
+                fields = LOCAL_IMPORT_REPLY.unpack_from(reply, 0)
+                magic, version, domain_id, generation, device_ctx, local_base, mapping_size = fields
+                _validate_local_global_header(magic, version, domain_id, generation, operation="import reply")
+                if domain_id != command.domain_id or generation != command.generation:
+                    raise RuntimeError("Global CommDomain import reply identity mismatch")
+                if mapping_size != command.descriptors[member.domain_rank].mapping_size:
+                    raise RuntimeError("Global CommDomain import reply mapping size mismatch")
+                offset = 0
+                buffer_bases: dict[str, int] = {}
+                domain_buffers: dict[str, Buffer] = {}
+                for buffer in command.buffers:
+                    base = int(local_base) + offset
+                    buffer_bases[buffer.name] = base
+                    domain_buffers[buffer.name] = wrap_vmm_window(
+                        base,
+                        int(buffer.nbytes),
+                        self._owner_instance_id,
+                        self._next_buffer_id(),
+                        f"L{self.level}",
+                        owner_worker_id=int(member.local_worker_id),
+                    )
+                    offset += buffer.nbytes
+                state.contexts[member.local_worker_id] = ChipDomainContext(
+                    name=command.name,
+                    domain_rank=member.domain_rank,
+                    domain_size=len(command.members),
+                    device_ctx=int(device_ctx),
+                    local_window_base=int(local_base),
+                    actual_window_size=int(mapping_size),
+                    buffers=domain_buffers,
+                )
+                provenance_id = self._global_domain_provenance_id(command.domain_id)
+                with self._child_prov_lock:
+                    self._child_prov_record_domain(
+                        member.local_worker_id,
+                        int(local_base),
+                        provenance_id,
+                        int(mapping_size),
+                    )
+                    for buffer in command.buffers:
+                        self._child_prov_record_domain(
+                            member.local_worker_id,
+                            buffer_bases[buffer.name],
+                            provenance_id,
+                            buffer.nbytes,
+                        )
+            state.command = command
+            state.phase = GlobalDomainPhase.IMPORT
+            state.view = GlobalCommDomainView(
+                name=command.name,
+                members=command.members,
+                contexts=state.contexts,
+                domain_id=command.domain_id,
+                generation=command.generation,
+                mapping_size=command.descriptors[0].mapping_size,
+            )
+        except BaseException:
+            # A node may have imported one local rank before a later local rank
+            # fails. Roll that partial node back here; the L4 ABORT fanout is an
+            # idempotent second safety net, not the only cleanup owner.
+            self._release_global_domain_node(
+                GlobalDomainReleaseCommand(command.domain_id, command.generation),
+                suppress_errors=True,
+            )
+            raise
+
+    def _commit_global_domain_node(self, command: GlobalDomainCommand) -> None:
+        state = self._global_node_domains.get(command.domain_id)
+        if state is None or state.command.generation != command.generation:
+            raise RuntimeError("Global CommDomain commit requires a matching imported domain")
+        if state.phase is not GlobalDomainPhase.IMPORT or state.view is None:
+            raise RuntimeError("Global CommDomain commit requires IMPORT completion")
+        if (
+            self._global_domain_command_identity(state.command) != self._global_domain_command_identity(command)
+            or state.command.descriptors != command.descriptors
+        ):
+            raise RuntimeError("Global CommDomain commit command conflicts with IMPORT")
+        state.phase = GlobalDomainPhase.COMMIT
+        state.view._committed = True  # noqa: SLF001 -- session owns the transaction
+
+    def _release_global_domain_node(
+        self, command: GlobalDomainReleaseCommand, *, suppress_errors: bool = False
+    ) -> None:
+        state = self._global_node_domains.get(command.domain_id)
+        if state is None:
+            return
+        if state.command.generation != command.generation:
+            raise RuntimeError("Global CommDomain release generation mismatch")
+        # Invalidate the public view before the first destructive child call.
+        # If fanout later fails, callers can no longer retrieve or use pointers
+        # into windows that may already have been released on some local ranks.
+        state.phase = GlobalDomainPhase.ABORT
+        if state.view is not None:
+            state.view._committed = False  # noqa: SLF001 -- node session owns the transaction
+        with self._child_prov_lock:
+            self._child_prov_drop_domain(self._global_domain_provenance_id(command.domain_id))
+        if self._worker is None:
+            return
+        errors: list[BaseException] = []
+        local_members = tuple(
+            member for member in state.command.members if member.domain_rank in state.prepared_domain_ranks
+        )
+        for member in local_members:
+            payload = bytearray(LOCAL_RELEASE_REQUEST.size)
+            LOCAL_RELEASE_REQUEST.pack_into(
+                payload,
+                0,
+                LOCAL_DOMAIN_MAGIC,
+                GLOBAL_DOMAIN_VERSION,
+                command.domain_id,
+                command.generation,
+            )
+            try:
+                self._worker.control_payload(
+                    WorkerType.NEXT_LEVEL,
+                    member.local_worker_id,
+                    CTRL_GLOBAL_DOMAIN_RELEASE,
+                    payload,
+                    self._py_control_timeout_s,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+        if not errors:
+            self._global_node_domains.pop(command.domain_id, None)
+        if errors and not suppress_errors:
+            raise RuntimeError(f"Global CommDomain node release failed: {errors[0]}") from errors[0]
+
+    def _release_all_global_domain_nodes(self) -> None:
+        for state in list(self._global_node_domains.values())[::-1]:
+            try:
+                self._release_global_domain_node(
+                    GlobalDomainReleaseCommand(state.command.domain_id, state.command.generation)
+                )
+            except Exception as exc:  # noqa: BLE001
+                # A node release that fails during teardown leaves device state
+                # nothing else tracks; the same boundary as the ABORT fan-out
+                # applies.
+                self._record_unreclaimable(
+                    f"Global CommDomain node release failed for domain_id={state.command.domain_id}; "
+                    "backend windows may remain mapped",
+                    exc,
+                )
+
+    def _get_global_domain(self, domain_id: int) -> GlobalCommDomainView:
+        state = self._global_node_domains.get(int(domain_id))
+        if state is None or state.phase is not GlobalDomainPhase.COMMIT or state.view is None:
+            raise KeyError(f"Global CommDomain {domain_id} is not committed on this L3 node")
+        return state.view
+
+    def _copy_global_domain_node(self, command: GlobalDomainCopyCommand, *, copy_to_device: bool) -> bytes:
+        state = self._global_node_domains.get(command.domain_id)
+        if (
+            state is None
+            or state.command.generation != command.generation
+            or state.phase is not GlobalDomainPhase.COMMIT
+        ):
+            raise RuntimeError("Global CommDomain copy requires a committed live domain")
+        if command.domain_rank >= len(state.command.members):
+            raise ValueError("Global CommDomain copy rank is out of range")
+        member = state.command.members[command.domain_rank]
+        if member.local_worker_id not in state.contexts:
+            raise RuntimeError("Global CommDomain copy rank is not local to this L3 node")
+        request_size = LOCAL_COPY_REQUEST.size + (command.nbytes if copy_to_device else 0)
+        reply_size = LOCAL_COPY_REPLY.size + (command.nbytes if not copy_to_device else 0)
+        payload = bytearray(max(request_size, reply_size))
+        LOCAL_COPY_REQUEST.pack_into(
+            payload,
+            0,
+            LOCAL_DOMAIN_MAGIC,
+            GLOBAL_DOMAIN_VERSION,
+            command.domain_id,
+            command.generation,
+            command.offset,
+            command.nbytes,
+        )
+        if copy_to_device:
+            payload[LOCAL_COPY_REQUEST.size : request_size] = command.data
+        assert self._worker is not None
+        reply = bytes(
+            self._worker.control_payload(
+                WorkerType.NEXT_LEVEL,
+                member.local_worker_id,
+                CTRL_GLOBAL_DOMAIN_COPY_TO if copy_to_device else CTRL_GLOBAL_DOMAIN_COPY_FROM,
+                payload,
+                self._py_control_timeout_s,
+            )
+        )
+        magic, version, domain_id, generation, nbytes = LOCAL_COPY_REPLY.unpack_from(reply, 0)
+        _validate_local_global_header(magic, version, domain_id, generation, operation="copy reply")
+        if domain_id != command.domain_id or generation != command.generation or nbytes != command.nbytes:
+            raise RuntimeError("Global CommDomain copy reply mismatch")
+        if copy_to_device:
+            return b""
+        return reply[LOCAL_COPY_REPLY.size : LOCAL_COPY_REPLY.size + command.nbytes]
+
+    @staticmethod
+    def _local_global_domain_response_capacity(control_name: int, payload: bytes) -> int:
+        from .remote_l3_protocol import ControlName  # noqa: PLC0415
+
+        control = ControlName(control_name)
+        if control is ControlName.COMM_INIT:
+            return struct.calcsize("<III") + 4 + GLOBAL_DOMAIN_MAX_STRING_BYTES
+        if control is ControlName.ALLOC_DOMAIN:
+            command = decode_domain_command(payload)
+            if command.phase is GlobalDomainPhase.PREPARE_EXPORT:
+                return 4 + GLOBAL_DOMAIN_MAX_RANKS * GLOBAL_DOMAIN_DESCRIPTOR_BYTES
+            return 0
+        if control is ControlName.COPY_FROM_DOMAIN:
+            command = decode_copy_command(payload, include_data=False)
+            return 4 + command.nbytes
+        return 0
+
+    def _local_global_domain_control(self, worker_id: int, control_name: int, payload: bytes) -> bytes:
+        if self._worker is None:
+            raise RuntimeError("Global CommDomain control requires a ready hierarchical Worker")
+        if worker_id not in self._next_level_worker_ids:
+            raise ValueError(f"Global CommDomain worker {worker_id} is not a local L3 worker")
+        response_capacity = self._local_global_domain_response_capacity(control_name, payload)
+        capacity = max(len(payload), response_capacity)
+        staged = bytearray(_LOCAL_GLOBAL_CONTROL_HEADER.size + capacity)
+        _LOCAL_GLOBAL_CONTROL_HEADER.pack_into(staged, 0, int(control_name), len(payload), 0)
+        start = _LOCAL_GLOBAL_CONTROL_HEADER.size
+        staged[start : start + len(payload)] = payload
+        reply = bytes(
+            self._worker.control_payload(
+                WorkerType.NEXT_LEVEL,
+                int(worker_id),
+                _CTRL_GLOBAL_DOMAIN_NODE,
+                staged,
+                self._py_control_timeout_s,
+            )
+        )
+        reply_control, reply_request_size, response_size = _LOCAL_GLOBAL_CONTROL_HEADER.unpack_from(reply, 0)
+        if reply_control != int(control_name) or reply_request_size != len(payload) or response_size > capacity:
+            raise RuntimeError("local Global CommDomain control reply is invalid")
+        return reply[start : start + response_size]
+
+    def _global_domain_control(self, worker_id: int, control_name: int, payload: bytes) -> bytes:
+        if self._worker is None:
+            raise RuntimeError("Global CommDomain control requires a ready hierarchical Worker")
+        if worker_id in self._remote_worker_ids:
+            return bytes(self._worker.remote_domain_control(int(worker_id), int(control_name), bytes(payload)))
+        if worker_id in self._next_level_worker_ids:
+            return self._local_global_domain_control(worker_id, control_name, payload)
+        raise ValueError(f"Global CommDomain worker {worker_id} is not a registered L3 worker")
+
+    def _allocate_global_domain(  # noqa: PLR0912 -- transaction validation and prepare/import/commit rollback stay ordered
+        self,
+        *,
+        name: str,
+        members: tuple[tuple[int, int], ...],
+        window_size: int,
+        buffers: list[CommBufferSpec],
+        retain_after_run: bool,
+    ) -> GlobalCommDomainHandle:
+        from .remote_l3_protocol import ControlName  # noqa: PLC0415
+
+        if self.level < 4 or self._worker is None:
+            raise RuntimeError("allocate_global_domain requires a ready L4+ Worker")
+        resources = self._building_run_resources
+        if resources is None:
+            raise RuntimeError("allocate_global_domain is only valid while a run's graph is being built")
+        if not name:
+            raise ValueError("allocate_global_domain: name must be non-empty")
+        if name in self._live_global_domains:
+            raise ValueError(f"allocate_global_domain: domain {name!r} is already live")
+        if not members or len(members) > GLOBAL_DOMAIN_MAX_RANKS:
+            raise ValueError("allocate_global_domain: members must contain between 1 and 64 devices")
+        if len(set(members)) != len(members):
+            raise ValueError("allocate_global_domain: members contain duplicate node/local devices")
+        if window_size <= 0:
+            raise ValueError("allocate_global_domain: window_size must be positive")
+        if len({buffer.name for buffer in buffers}) != len(buffers):
+            raise ValueError("allocate_global_domain: buffer names must be unique")
+        if any(not buffer.name or int(buffer.nbytes) <= 0 for buffer in buffers):
+            raise ValueError("allocate_global_domain: buffers require a name and positive nbytes")
+        if sum(int(buffer.nbytes) for buffer in buffers) > window_size:
+            raise ValueError("allocate_global_domain: buffers exceed window_size")
+
+        nodes = self._resolved_global_nodes()
+        profiles: set[str] = set()
+        domain_members: list[GlobalDomainMember] = []
+        for domain_rank, (node_worker_id, local_worker_id) in enumerate(members):
+            node = nodes.get(int(node_worker_id))
+            if node is None:
+                raise ValueError(f"allocate_global_domain: worker {node_worker_id} is not a registered L3")
+            if local_worker_id < 0 or local_worker_id >= len(node.device_ids):
+                raise ValueError(
+                    f"allocate_global_domain: local worker {local_worker_id} is outside "
+                    f"worker {node_worker_id}'s device list"
+                )
+            profiles.add(node.comm_profile)
+            domain_members.append(
+                GlobalDomainMember(
+                    node_worker_id=int(node_worker_id),
+                    local_worker_id=int(local_worker_id),
+                    global_device_rank=node.global_device_ranks[int(local_worker_id)],
+                    domain_rank=domain_rank,
+                )
+            )
+        if len(profiles) != 1:
+            raise ValueError("allocate_global_domain: all participating nodes must use the same comm_profile")
+        profile = next(iter(profiles))
+        global_buffers = tuple(GlobalDomainBuffer(buffer.name, int(buffer.nbytes)) for buffer in buffers)
+        domain_members_tuple = tuple(domain_members)
+        involved_nodes = tuple(dict.fromkeys(member.node_worker_id for member in domain_members_tuple))
+        for node_worker_id in involved_nodes:
+            node = nodes[node_worker_id]
+            resolve_global_comm_capability(
+                platform=node.platform,
+                profile=node.comm_profile,
+                local_device_count=len(node.device_ids),
+            )
+        topology_bytes = repr(
+            (
+                self._global_cluster_id,
+                profile,
+                tuple(
+                    (
+                        member.node_worker_id,
+                        member.local_worker_id,
+                        member.global_device_rank,
+                        member.domain_rank,
+                    )
+                    for member in domain_members_tuple
+                ),
+            )
+        ).encode()
+        topology_hash = hashlib.sha256(topology_bytes).hexdigest()
+        with self._alloc_id_lock:
+            self._next_alloc_id += 1
+            domain_id = self._next_alloc_id
+        generation = 1
+        base_command = GlobalDomainCommand(
+            phase=GlobalDomainPhase.PREPARE_EXPORT,
+            domain_id=domain_id,
+            generation=generation,
+            name=name,
+            profile=profile,
+            window_size=int(window_size),
+            members=domain_members_tuple,
+            buffers=global_buffers,
+        )
+
+        prepared_nodes: list[int] = []
+        try:
+            for node_worker_id in involved_nodes:
+                node = nodes[node_worker_id]
+                init = GlobalCommInitCommand(
+                    cluster_id=self._global_cluster_id,
+                    topology_hash=topology_hash,
+                    profile=profile,
+                    node_rank=node.node_rank,
+                    node_count=node.node_count,
+                    members=domain_members_tuple,
+                )
+                result = decode_comm_init_result(
+                    self._global_domain_control(node_worker_id, ControlName.COMM_INIT, encode_comm_init(init))
+                )
+                if (
+                    result.profile != profile
+                    or result.max_ranks < len(domain_members_tuple)
+                    or result.descriptor_bytes != GLOBAL_DOMAIN_DESCRIPTOR_BYTES
+                    or result.local_device_count != len(node.device_ids)
+                ):
+                    raise RuntimeError(f"Global CommDomain COMM_INIT capability mismatch on node {node_worker_id}")
+
+            descriptor_by_rank: dict[int, GlobalDomainDescriptor] = {}
+            for node_worker_id in involved_nodes:
+                prepared_nodes.append(node_worker_id)
+                reply = self._global_domain_control(
+                    node_worker_id,
+                    ControlName.ALLOC_DOMAIN,
+                    encode_domain_command(base_command),
+                )
+                for descriptor in decode_descriptor_table(reply):
+                    if descriptor.domain_rank in descriptor_by_rank:
+                        raise RuntimeError("Global CommDomain prepare returned a duplicate rank")
+                    descriptor_by_rank[descriptor.domain_rank] = descriptor
+            descriptors = tuple(descriptor_by_rank[rank] for rank in range(len(domain_members_tuple)))
+            validate_descriptor_table(descriptors, rank_count=len(domain_members_tuple), profile=profile)
+            if descriptors[0].mapping_size < window_size:
+                raise RuntimeError("Global CommDomain backend mapped less than the requested window size")
+
+            import_command = GlobalDomainCommand(
+                phase=GlobalDomainPhase.IMPORT,
+                domain_id=domain_id,
+                generation=generation,
+                name=name,
+                profile=profile,
+                window_size=int(window_size),
+                members=domain_members_tuple,
+                buffers=global_buffers,
+                descriptors=descriptors,
+            )
+            for node_worker_id in involved_nodes:
+                self._global_domain_control(
+                    node_worker_id,
+                    ControlName.ALLOC_DOMAIN,
+                    encode_domain_command(import_command),
+                )
+            commit_command = GlobalDomainCommand(
+                phase=GlobalDomainPhase.COMMIT,
+                domain_id=domain_id,
+                generation=generation,
+                name=name,
+                profile=profile,
+                window_size=int(window_size),
+                members=domain_members_tuple,
+                buffers=global_buffers,
+                descriptors=descriptors,
+            )
+            for node_worker_id in involved_nodes:
+                self._global_domain_control(
+                    node_worker_id,
+                    ControlName.ALLOC_DOMAIN,
+                    encode_domain_command(commit_command),
+                )
+        except BaseException:
+            abort_command = GlobalDomainCommand(
+                phase=GlobalDomainPhase.ABORT,
+                domain_id=domain_id,
+                generation=generation,
+                name=name,
+                profile=profile,
+                window_size=int(window_size),
+                members=domain_members_tuple,
+                buffers=global_buffers,
+            )
+            for node_worker_id in prepared_nodes:
+                try:
+                    self._global_domain_control(
+                        node_worker_id,
+                        ControlName.ALLOC_DOMAIN,
+                        encode_domain_command(abort_command),
+                    )
+                except BaseException as abort_error:  # noqa: BLE001
+                    # The domain is not registered on this path, so no run fence
+                    # and no close() sweep can reach whatever the failed ABORT
+                    # leaves mapped. Refusing further work is the only boundary
+                    # that keeps a later run from being admitted as if the
+                    # teardown had succeeded.
+                    self._record_unreclaimable(
+                        f"Global CommDomain {name!r} ABORT cleanup failed for node worker "
+                        f"{node_worker_id}; backend windows may remain mapped",
+                        abort_error,
+                    )
+            raise
+
+        handle = GlobalCommDomainHandle(
+            name=name,
+            members=domain_members_tuple,
+            buffers=global_buffers,
+            domain_id=domain_id,
+            generation=generation,
+            mapping_size=descriptors[0].mapping_size,
+            retain_after_run=retain_after_run,
+            _release_fn=lambda released, owner=resources: self._release_global_domain_handle(released, owner),
+        )
+        self._live_global_domains[name] = handle
+        resources.live_global_domains[name] = handle
+        resources.requires_ordered_cleanup = True
+        return handle
+
+    def _release_global_domain_handle(
+        self,
+        handle: GlobalCommDomainHandle,
+        resources: _RunResources,
+    ) -> None:
+        if self._worker is None:
+            return
+        with resources.domain_lock:
+            if resources.live_global_domains.get(handle.name) is handle:
+                resources.live_global_domains.pop(handle.name)
+            if self._live_global_domains.get(handle.name) is handle:
+                self._live_global_domains.pop(handle.name)
+            if not resources.retired:
+                resources.pending_release_global_domains.append(handle)
+                resources.requires_ordered_cleanup = True
+                return
+        # A retained handle may be released while a later run is being built.
+        # Its allocation run is already retired then, so bind the release to the
+        # current run's fence without losing the original-run capture that
+        # protects release calls made after submit returns.
+        current_resources = self._building_run_resources
+        if current_resources is not None and current_resources is not resources:
+            with current_resources.domain_lock:
+                if not current_resources.retired:
+                    current_resources.pending_release_global_domains.append(handle)
+                    current_resources.requires_ordered_cleanup = True
+                    return
+        self._free_global_domain_after_fence(handle)
+
+    def _free_global_domain_after_fence(self, handle: GlobalCommDomainHandle) -> None:
+        if handle.freed:
+            return
+        try:
+            self._release_global_domain_now(handle)
+            handle._freed = True  # noqa: SLF001 -- runtime owns this transition
+            self._failed_global_domain_releases.pop(handle.domain_id, None)
+        except Exception:
+            self._failed_global_domain_releases[handle.domain_id] = handle
+            raise
+
+    def _release_global_domain_now(self, handle: GlobalCommDomainHandle) -> None:
+        with self._global_domain_free_mu:
+            if handle.domain_id in self._global_domain_free_results:
+                failure = self._global_domain_free_results[handle.domain_id]
+                if failure is not None:
+                    raise failure
+                return
+            try:
+                self._release_global_domain_claimed(handle)
+            except BaseException as exc:
+                self._global_domain_free_results[handle.domain_id] = exc
+                raise
+            self._global_domain_free_results[handle.domain_id] = None
+
+    def _release_global_domain_claimed(self, handle: GlobalCommDomainHandle) -> None:
+        from .remote_l3_protocol import ControlName  # noqa: PLC0415
+
+        command = encode_release_command(GlobalDomainReleaseCommand(handle.domain_id, handle.generation))
+        errors: list[BaseException] = []
+        for node_worker_id in dict.fromkeys(member.node_worker_id for member in handle.members):
+            try:
+                self._global_domain_control(node_worker_id, ControlName.RELEASE_DOMAIN, command)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+        if errors:
+            raise RuntimeError(f"Global CommDomain release failed: {errors[0]}") from errors[0]
+        if self._live_global_domains.get(handle.name) is handle:
+            self._live_global_domains.pop(handle.name)
+
+    def _execute_pending_global_domain_releases(self, resources: _RunResources) -> None:
+        with resources.domain_lock:
+            pending = list(resources.pending_release_global_domains)
+        self._drain_pending_global_domain_snapshot(resources, pending)
+
+    def _release_all_live_global_domains(
+        self,
+        resources: _RunResources | None = None,
+        *,
+        include_retained: bool = True,
+    ) -> None:
+        live_domains = self._live_global_domains if resources is None else resources.live_global_domains
+
+        def _release(handle: GlobalCommDomainHandle) -> None:
+            if handle.retain_after_run and not include_retained:
+                return
+            handle._released = True  # noqa: SLF001 -- runtime owns this transition
+            self._free_global_domain_after_fence(handle)
+            if live_domains.get(handle.name) is handle:
+                live_domains.pop(handle.name)
+
+        _raise_first(_release, list(live_domains.values())[::-1])
+
+    def _copy_to_global_domain(
+        self, handle: GlobalCommDomainHandle, domain_rank: int, data: bytes, offset: int
+    ) -> None:
+        from .remote_l3_protocol import ControlName  # noqa: PLC0415
+
+        payload = bytes(data)
+        member = handle.member(domain_rank)
+        command = GlobalDomainCopyCommand(
+            domain_id=handle.domain_id,
+            generation=handle.generation,
+            domain_rank=int(domain_rank),
+            offset=int(offset),
+            nbytes=len(payload),
+            data=payload,
+        )
+        self._global_domain_control(
+            member.node_worker_id,
+            ControlName.COPY_TO_DOMAIN,
+            encode_copy_command(command, include_data=True),
+        )
+
+    def _copy_from_global_domain(
+        self, handle: GlobalCommDomainHandle, domain_rank: int, nbytes: int, offset: int
+    ) -> bytes:
+        from .remote_l3_protocol import ControlName  # noqa: PLC0415
+
+        member = handle.member(domain_rank)
+        command = GlobalDomainCopyCommand(
+            domain_id=handle.domain_id,
+            generation=handle.generation,
+            domain_rank=int(domain_rank),
+            offset=int(offset),
+            nbytes=int(nbytes),
+        )
+        reply = self._global_domain_control(
+            member.node_worker_id,
+            ControlName.COPY_FROM_DOMAIN,
+            encode_copy_command(command, include_data=False),
+        )
+        return decode_copy_result(reply)
 
     def _release_all_live_domains(self, resources: _RunResources | None = None) -> None:
         """Best-effort release of every still-live domain handle (LIFO).
@@ -8774,6 +10129,17 @@ class Worker:
                     ("remote_frees", self._flush_pending_remote_frees),
                     ("worker_chip_regions", lambda: self._cleanup_worker_chip_regions(resources)),
                     ("worker_chip_host_buffers", resources.worker_chip_orch_comm_host_buffers.clear),
+                    (
+                        "pending_global_domains",
+                        lambda: self._execute_pending_global_domain_releases(resources),
+                    ),
+                    (
+                        "live_global_domains",
+                        lambda: self._release_all_live_global_domains(
+                            resources,
+                            include_retained=False,
+                        ),
+                    ),
                     ("pending_domains", lambda: self._execute_pending_domain_releases(resources)),
                     ("live_domains", lambda: self._release_all_live_domains(resources)),
                     ("retire_domains", lambda: self._retire_run_domains(resources)),
@@ -8913,6 +10279,8 @@ class Worker:
             or bool(self._sub_shms or self._chip_shms or self._next_level_shms)
             or bool(self._live_worker_chip_regions)
             or bool(self._live_domains)
+            or bool(self._live_global_domains or self._failed_global_domain_releases)
+            or bool(self._global_node_domains)
             or bool(self._remote_sessions)
             or bool(self._pending_remote_buffer_frees or self._pending_remote_import_releases)
             or not self._cleanup_journal.empty
@@ -8934,6 +10302,12 @@ class Worker:
             parts.append(f"{len(self._live_worker_chip_regions)} L3-L2 region(s)")
         if self._live_domains:
             parts.append(f"{len(self._live_domains)} comm domain(s)")
+        if self._live_global_domains or self._failed_global_domain_releases:
+            live_global_ids = {handle.domain_id for handle in self._live_global_domains.values()}
+            live_global_ids.update(self._failed_global_domain_releases)
+            parts.append(f"{len(live_global_ids)} global comm domain(s)")
+        if self._global_node_domains:
+            parts.append(f"{len(self._global_node_domains)} imported global comm domain(s)")
         if self._remote_sessions:
             parts.append(f"{len(self._remote_sessions)} remote session(s)")
         n_remote = len(self._pending_remote_buffer_frees) + len(self._pending_remote_import_releases)
@@ -9407,6 +10781,8 @@ class Worker:
         pre_transport_keys: set[tuple[str, str]] = set()
         for kind, identity, cleanup in (
             ("region", "all Worker-Chip regions", self._cleanup_worker_chip_regions),
+            ("domain", "all Global CommDomains", self._release_all_live_global_domains),
+            ("domain", "Global CommDomain nodes", self._release_all_global_domain_nodes),
             ("domain", "all CommDomains", self._release_all_live_domains),
             ("provenance", "child allocation provenance", self._clear_child_prov),
             ("remote", "active remote slot references", self._release_active_remote_slot_refs),

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -83,10 +83,17 @@ struct DomainAllocation {
 
     int rank = 0;
     int nranks = 0;
+    bool release_failed = false;
     VmmWindow local_window;
     std::vector<VmmWindow> peer_windows;
     CommContext *device_ctx = nullptr;  // aclrtMalloc'd CommContext mirror
 };
+
+static_assert(sizeof(CommGlobalDomainDescriptor) == 288, "global domain descriptor ABI changed");
+static_assert(
+    sizeof(aclrtMemFabricHandle) <= COMM_GLOBAL_DOMAIN_HANDLE_BYTES, "Fabric handle exceeds global descriptor"
+);
+static std::unordered_map<uint64_t, std::unique_ptr<DomainAllocation>> global_domain_allocations;
 
 struct CommHandle_ {
     int rank;
@@ -1515,6 +1522,192 @@ comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_co
     return -1;
 } catch (...) {
     LOG_ERROR("[comm] release_domain: unknown exception");
+    return -1;
+}
+
+extern "C" int comm_global_domain_prepare(
+    uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile,
+    CommGlobalDomainDescriptor *descriptor_out, uint64_t *local_window_base_out
+) try {
+    if (domain_id == 0 || rank_count == 0 || rank_count > COMM_MAX_RANK_NUM || domain_rank >= rank_count ||
+        window_size == 0 || profile != COMM_GLOBAL_DOMAIN_PROFILE_A3_FABRIC || descriptor_out == nullptr ||
+        local_window_base_out == nullptr || global_domain_allocations.count(domain_id) != 0) {
+        return -1;
+    }
+
+    int32_t device_id = -1;
+    if (aclrtGetDevice(&device_id) != ACL_SUCCESS) {
+        return -1;
+    }
+    auto allocation = std::make_unique<DomainAllocation>();
+    aclError status = create_local_fabric_window(device_id, window_size, &allocation->local_window);
+    if (status != ACL_SUCCESS) {
+        LOG_ERROR("[global domain rank %u] create local Fabric window -> %d", domain_rank, static_cast<int>(status));
+        return -1;
+    }
+
+    aclrtMemFabricHandle fabric_handle{};
+    status = export_fabric_window(allocation->local_window, &fabric_handle);
+    if (status != ACL_SUCCESS) {
+        LOG_ERROR("[global domain rank %u] export Fabric handle -> %d", domain_rank, static_cast<int>(status));
+        release_domain_windows(allocation.get());
+        return -1;
+    }
+    status =
+        aclrtMemset(allocation->local_window.base, allocation->local_window.size, 0, allocation->local_window.size);
+    if (status != ACL_SUCCESS) {
+        LOG_ERROR("[global domain rank %u] zero local Fabric window -> %d", domain_rank, static_cast<int>(status));
+        release_domain_windows(allocation.get());
+        return -1;
+    }
+
+    allocation->rank = static_cast<int>(domain_rank);
+    allocation->nranks = static_cast<int>(rank_count);
+    CommGlobalDomainDescriptor descriptor{};
+    descriptor.version = COMM_GLOBAL_DOMAIN_VERSION;
+    descriptor.profile = COMM_GLOBAL_DOMAIN_PROFILE_A3_FABRIC;
+    descriptor.domain_rank = domain_rank;
+    descriptor.rank_count = rank_count;
+    descriptor.mapping_size = allocation->local_window.size;
+    descriptor.handle_size = sizeof(fabric_handle);
+    std::memcpy(descriptor.handle, &fabric_handle, sizeof(fabric_handle));
+
+    *descriptor_out = descriptor;
+    *local_window_base_out = reinterpret_cast<uint64_t>(allocation->local_window.base);
+    global_domain_allocations.emplace(domain_id, std::move(allocation));
+    return 0;
+} catch (const std::exception &e) {
+    LOG_ERROR("[global domain] prepare exception: %s", e.what());
+    return -1;
+} catch (...) {
+    LOG_ERROR("[global domain] prepare unknown exception");
+    return -1;
+}
+
+extern "C" int comm_global_domain_import(
+    uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
+) try {
+    auto it = global_domain_allocations.find(domain_id);
+    if (it == global_domain_allocations.end() || descriptors == nullptr || device_ctx_out == nullptr) {
+        return -1;
+    }
+    auto &allocation = it->second;
+    if (descriptor_count != static_cast<size_t>(allocation->nranks) || allocation->device_ctx != nullptr) {
+        return -1;
+    }
+
+    std::vector<const CommGlobalDomainDescriptor *> rank_order(descriptor_count, nullptr);
+    for (size_t i = 0; i < descriptor_count; ++i) {
+        const auto &descriptor = descriptors[i];
+        if (descriptor.version != COMM_GLOBAL_DOMAIN_VERSION ||
+            descriptor.profile != COMM_GLOBAL_DOMAIN_PROFILE_A3_FABRIC ||
+            descriptor.rank_count != static_cast<uint32_t>(allocation->nranks) ||
+            descriptor.domain_rank >= static_cast<uint32_t>(allocation->nranks) ||
+            descriptor.mapping_size != allocation->local_window.size ||
+            descriptor.handle_size != sizeof(aclrtMemFabricHandle) || rank_order[descriptor.domain_rank] != nullptr) {
+            return -1;
+        }
+        rank_order[descriptor.domain_rank] = &descriptor;
+    }
+
+    int32_t device_id = -1;
+    if (aclrtGetDevice(&device_id) != ACL_SUCCESS) {
+        return -1;
+    }
+    CommContext ctx{};
+    ctx.rankId = static_cast<uint32_t>(allocation->rank);
+    ctx.rankNum = static_cast<uint32_t>(allocation->nranks);
+    ctx.winSize = allocation->local_window.size;
+    std::vector<VmmWindow> peer_windows;
+    peer_windows.reserve(descriptor_count - 1);
+    for (uint32_t rank = 0; rank < static_cast<uint32_t>(allocation->nranks); ++rank) {
+        const auto *descriptor = rank_order[rank];
+        if (descriptor == nullptr) {
+            return -1;
+        }
+        uint64_t window_addr = reinterpret_cast<uint64_t>(allocation->local_window.base);
+        if (rank != static_cast<uint32_t>(allocation->rank)) {
+            aclrtMemFabricHandle fabric_handle{};
+            std::memcpy(&fabric_handle, descriptor->handle, sizeof(fabric_handle));
+            VmmWindow peer_window;
+            aclError status = import_fabric_window(device_id, fabric_handle, descriptor->mapping_size, &peer_window);
+            if (status != ACL_SUCCESS) {
+                LOG_ERROR(
+                    "[global domain rank %d] import peer rank %u -> %d", allocation->rank, rank,
+                    static_cast<int>(status)
+                );
+                return -1;
+            }
+            window_addr = reinterpret_cast<uint64_t>(peer_window.base);
+            peer_windows.push_back(std::move(peer_window));
+        }
+        ctx.windowsIn[rank] = window_addr;
+        ctx.windowsOut[rank] = window_addr;
+    }
+
+    void *device_ctx = nullptr;
+    aclError status = aclrtMalloc(&device_ctx, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
+    if (status != ACL_SUCCESS) {
+        return -1;
+    }
+    status = aclrtMemcpy(device_ctx, sizeof(CommContext), &ctx, sizeof(CommContext), ACL_MEMCPY_HOST_TO_DEVICE);
+    if (status != ACL_SUCCESS) {
+        aclrtFree(device_ctx);
+        return -1;
+    }
+    allocation->peer_windows = std::move(peer_windows);
+    allocation->device_ctx = static_cast<CommContext *>(device_ctx);
+    *device_ctx_out = reinterpret_cast<uint64_t>(device_ctx);
+    return 0;
+} catch (const std::exception &e) {
+    LOG_ERROR("[global domain] import exception: %s", e.what());
+    return -1;
+} catch (...) {
+    LOG_ERROR("[global domain] import unknown exception");
+    return -1;
+}
+
+extern "C" int comm_global_domain_release(uint64_t domain_id) try {
+    auto it = global_domain_allocations.find(domain_id);
+    if (it == global_domain_allocations.end()) {
+        return 0;
+    }
+    auto &allocation = it->second;
+    if (allocation->release_failed) {
+        LOG_ERROR(
+            "[global domain] domain %llu previously failed a partial release",
+            static_cast<unsigned long long>(domain_id)
+        );
+        return -1;
+    }
+    int rc = 0;
+    if (allocation->device_ctx != nullptr) {
+        if (aclrtFree(allocation->device_ctx) != ACL_SUCCESS) {
+            rc = -1;
+        }
+        allocation->device_ctx = nullptr;
+    }
+    if (release_domain_windows(allocation.get()) != ACL_SUCCESS) {
+        rc = -1;
+    }
+    if (rc != 0) {
+        // The release helpers are destructive: some fields may already be
+        // cleared before a later ACL operation fails. Keep a terminal failure
+        // record so a repeated call cannot falsely report success.
+        allocation->release_failed = true;
+        LOG_ERROR(
+            "[global domain] domain %llu entered terminal partial-release state",
+            static_cast<unsigned long long>(domain_id)
+        );
+        return rc;
+    }
+    global_domain_allocations.erase(it);
+    return 0;
+} catch (const std::exception &e) {
+    LOG_ERROR("[global domain] release exception: %s", e.what());
+    return -1;
+} catch (...) {
+    LOG_ERROR("[global domain] release unknown exception");
     return -1;
 }
 

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -1382,6 +1382,22 @@ comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_co
     return -1;
 }
 
+extern "C" int
+comm_global_domain_prepare(uint64_t, uint32_t, uint32_t, size_t, uint32_t, CommGlobalDomainDescriptor *, uint64_t *) {
+    LOG_ERROR("[comm] Global CommDomain is not supported by the a5 backend");
+    return -1;
+}
+
+extern "C" int comm_global_domain_import(uint64_t, const CommGlobalDomainDescriptor *, size_t, uint64_t *) {
+    LOG_ERROR("[comm] Global CommDomain is not supported by the a5 backend");
+    return -1;
+}
+
+extern "C" int comm_global_domain_release(uint64_t) {
+    LOG_ERROR("[comm] Global CommDomain is not supported by the a5 backend");
+    return -1;
+}
+
 extern "C" int comm_destroy(CommHandle h) try {
     if (!h) return -1;
 

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -1090,6 +1090,12 @@ void RemoteL3Endpoint::control_remote_release_import(const RemoteBufferHandle &h
     run_control(remote_l3::ControlName::RELEASE_IMPORT, remote_l3::encode_release_import_request(request));
 }
 
+std::vector<uint8_t> RemoteL3Endpoint::control_remote_domain(
+    remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+) {
+    return run_control(control_name, command_bytes).result_bytes;
+}
+
 void RemoteL3Endpoint::shutdown_child() {
     if (!transport_) return;
     try {

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -127,6 +127,8 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     ) override;
     void control_remote_release_import(const RemoteBufferHandle &handle) override;
+    std::vector<uint8_t>
+    control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) override;
 
 private:
     WorkerEndpointCaps caps_;

--- a/src/common/hierarchical/remote_wire.cpp
+++ b/src/common/hierarchical/remote_wire.cpp
@@ -146,6 +146,8 @@ bool valid_control_name(uint32_t v) {
     case ControlName::COMM_INIT:
     case ControlName::ALLOC_DOMAIN:
     case ControlName::RELEASE_DOMAIN:
+    case ControlName::COPY_TO_DOMAIN:
+    case ControlName::COPY_FROM_DOMAIN:
         return true;
     }
     return false;

--- a/src/common/hierarchical/remote_wire.h
+++ b/src/common/hierarchical/remote_wire.h
@@ -65,6 +65,8 @@ enum class ControlName : uint32_t {
     COMM_INIT = 13,
     ALLOC_DOMAIN = 14,
     RELEASE_DOMAIN = 15,
+    COPY_TO_DOMAIN = 16,
+    COPY_FROM_DOMAIN = 17,
 };
 
 enum class ReadyState : uint32_t {

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -134,6 +134,11 @@ public:
     control_digest_only(WorkerType type, int worker_id, uint64_t sub_cmd, const uint8_t *digest, double timeout_s) {
         return manager_.control_digest_only(type, worker_id, sub_cmd, digest, timeout_s);
     }
+    std::vector<uint8_t> control_payload(
+        WorkerType type, int worker_id, uint64_t sub_cmd, const void *payload, size_t payload_size, double timeout_s
+    ) {
+        return manager_.control_payload(type, worker_id, sub_cmd, payload, payload_size, timeout_s);
+    }
     ControlResult remote_prepare_register(
         int worker_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const void *payload,
         size_t payload_size, const uint8_t *digest
@@ -181,6 +186,11 @@ public:
         return manager_.control_remote_import(importer_worker_id, export_desc, requested_access_flags);
     }
     void remote_release_import(const RemoteBufferHandle &handle) { manager_.control_remote_release_import(handle); }
+    std::vector<uint8_t> remote_domain_control(
+        int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+    ) {
+        return manager_.control_remote_domain(worker_id, control_name, command_bytes);
+    }
 
     // Device memory on a next-level worker. The Worker is the sole owner of buffer lifecycle; the
     // Python Orchestrator's malloc/free/copy are thin wrappers that route back here. Each resolves

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -131,6 +131,9 @@ RemoteBufferHandle WorkerEndpoint::control_remote_import(int32_t, const RemoteBu
 void WorkerEndpoint::control_remote_release_import(const RemoteBufferHandle &) {
     throw_unsupported_control("control_remote_release_import");
 }
+std::vector<uint8_t> WorkerEndpoint::control_remote_domain(remote_l3::ControlName, const std::vector<uint8_t> &) {
+    throw_unsupported_control("control_remote_domain");
+}
 void WorkerEndpoint::control_generic(uint64_t, const char *, size_t, double, const uint8_t *) {
     throw_unsupported_control("control_generic");
 }
@@ -1436,6 +1439,12 @@ void WorkerThread::control_remote_release_import(const RemoteBufferHandle &handl
     endpoint_->control_remote_release_import(handle);
 }
 
+std::vector<uint8_t>
+WorkerThread::control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) {
+    if (!endpoint_) throw std::runtime_error("control_remote_domain: null endpoint");
+    return endpoint_->control_remote_domain(control_name, command_bytes);
+}
+
 void WorkerThread::control_generic(
     uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
 ) {
@@ -1662,6 +1671,24 @@ ControlResult WorkerManager::control_digest_only(
     return result;
 }
 
+std::vector<uint8_t> WorkerManager::control_payload(
+    WorkerType type, int worker_id, uint64_t sub_cmd, const void *payload, size_t payload_size, double timeout_s
+) {
+    if (payload == nullptr || payload_size == 0) {
+        throw std::runtime_error("control_payload: payload must be non-empty");
+    }
+    WorkerThread *wt = get_worker_by_id(type, worker_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_payload: invalid worker_id " + std::to_string(worker_id));
+    }
+    std::string shm_name = make_shm_name();
+    PosixShmHolder shm(shm_name, payload_size);
+    std::memcpy(shm.addr(), payload, payload_size);
+    wt->control_generic(sub_cmd, shm_name.c_str(), payload_size, timeout_s, nullptr);
+    auto *begin = static_cast<const uint8_t *>(shm.addr());
+    return {begin, begin + payload_size};
+}
+
 ControlResult WorkerManager::control_remote_prepare_register(
     int worker_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const void *payload,
     size_t payload_size, const uint8_t *digest
@@ -1802,6 +1829,25 @@ void WorkerManager::control_remote_release_import(const RemoteBufferHandle &hand
         );
     }
     wt->control_remote_release_import(handle);
+}
+
+std::vector<uint8_t> WorkerManager::control_remote_domain(
+    int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+) {
+    WorkerThread *wt = get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_remote_domain: invalid worker_id " + std::to_string(worker_id));
+    }
+    switch (control_name) {
+    case remote_l3::ControlName::COMM_INIT:
+    case remote_l3::ControlName::ALLOC_DOMAIN:
+    case remote_l3::ControlName::RELEASE_DOMAIN:
+    case remote_l3::ControlName::COPY_TO_DOMAIN:
+    case remote_l3::ControlName::COPY_FROM_DOMAIN:
+        return wt->control_remote_domain(control_name, command_bytes);
+    default:
+        throw std::runtime_error("control_remote_domain: control name is not a domain operation");
+    }
 }
 
 std::vector<ControlResult>

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -364,6 +364,8 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     );
     virtual void control_remote_release_import(const RemoteBufferHandle &handle);
+    virtual std::vector<uint8_t>
+    control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
     virtual void control_generic(
         uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
     );
@@ -595,6 +597,8 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     );
     void control_remote_release_import(const RemoteBufferHandle &handle);
+    std::vector<uint8_t>
+    control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
     void control_generic(
         uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
     );
@@ -725,6 +729,9 @@ public:
     void control_worker_chip_region_release(int worker_id, uint64_t region_id);
     ControlResult
     control_digest_only(WorkerType type, int worker_id, uint64_t sub_cmd, const uint8_t *digest, double timeout_s);
+    std::vector<uint8_t> control_payload(
+        WorkerType type, int worker_id, uint64_t sub_cmd, const void *payload, size_t payload_size, double timeout_s
+    );
     ControlResult control_remote_prepare_register(
         int worker_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const void *payload,
         size_t payload_size, const uint8_t *digest
@@ -753,6 +760,9 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     );
     void control_remote_release_import(const RemoteBufferHandle &handle);
+    std::vector<uint8_t> control_remote_domain(
+        int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+    );
 
     // Broadcast CTRL_REGISTER for `digest` to every NEXT_LEVEL worker in
     // parallel. Stages `blob_size` bytes from `blob_ptr` into a per-call

--- a/src/common/platform_comm/comm.h
+++ b/src/common/platform_comm/comm.h
@@ -37,6 +37,49 @@ extern "C" {
 
 typedef struct CommHandle_ *CommHandle;
 
+#define COMM_GLOBAL_DOMAIN_VERSION 1U
+#define COMM_GLOBAL_DOMAIN_HANDLE_BYTES 256U
+#define COMM_GLOBAL_DOMAIN_DESCRIPTOR_BYTES 288U
+
+typedef enum CommGlobalDomainProfile {
+    COMM_GLOBAL_DOMAIN_PROFILE_SIM_SHM = 1,
+    COMM_GLOBAL_DOMAIN_PROFILE_A3_FABRIC = 2,
+} CommGlobalDomainProfile;
+
+typedef struct CommGlobalDomainDescriptor {
+    uint32_t version;
+    uint32_t profile;
+    uint32_t domain_rank;
+    uint32_t rank_count;
+    uint64_t mapping_size;
+    uint32_t handle_size;
+    uint32_t reserved;
+    uint8_t handle[COMM_GLOBAL_DOMAIN_HANDLE_BYTES];
+} CommGlobalDomainDescriptor;
+
+#ifdef __cplusplus
+static_assert(
+    sizeof(CommGlobalDomainDescriptor) == COMM_GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
+    "CommGlobalDomainDescriptor wire size drift"
+);
+static_assert(offsetof(CommGlobalDomainDescriptor, version) == 0, "CommGlobalDomainDescriptor.version offset drift");
+static_assert(offsetof(CommGlobalDomainDescriptor, profile) == 4, "CommGlobalDomainDescriptor.profile offset drift");
+static_assert(
+    offsetof(CommGlobalDomainDescriptor, domain_rank) == 8, "CommGlobalDomainDescriptor.domain_rank offset drift"
+);
+static_assert(
+    offsetof(CommGlobalDomainDescriptor, rank_count) == 12, "CommGlobalDomainDescriptor.rank_count offset drift"
+);
+static_assert(
+    offsetof(CommGlobalDomainDescriptor, mapping_size) == 16, "CommGlobalDomainDescriptor.mapping_size offset drift"
+);
+static_assert(
+    offsetof(CommGlobalDomainDescriptor, handle_size) == 24, "CommGlobalDomainDescriptor.handle_size offset drift"
+);
+static_assert(offsetof(CommGlobalDomainDescriptor, reserved) == 28, "CommGlobalDomainDescriptor.reserved offset drift");
+static_assert(offsetof(CommGlobalDomainDescriptor, handle) == 32, "CommGlobalDomainDescriptor.handle offset drift");
+#endif
+
 /** Bit mask of DmaWorkspaceKind values this platform can provision. */
 uint32_t dma_workspace_supported_mask(void);
 
@@ -222,6 +265,42 @@ int comm_alloc_domain_windows(
  * @return 0 on success, non-zero on failure.
  */
 int comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank);
+
+/**
+ * Create one local window for a Global CommDomain and export its transport
+ * descriptor. This operation has no
+ * HCCL or filesystem bootstrap dependency.
+ *
+ * The caller relays the descriptor through its control plane. It later
+ * passes
+ * the complete rank-ordered table to comm_global_domain_import(). A live
+ * domain_id is unique within one
+ * ChipWorker process.
+ */
+int comm_global_domain_prepare(
+    uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile,
+    CommGlobalDomainDescriptor *descriptor_out, uint64_t *local_window_base_out
+);
+
+/**
+ * Import every peer descriptor and publish a device CommContext.
+ *
+ * descriptors must contain exactly one entry
+ * for every dense domain rank.
+ * The returned context and all imported mappings remain live until
+ *
+ * comm_global_domain_release().
+ */
+int comm_global_domain_import(
+    uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
+);
+
+/**
+ * Release a prepared or imported Global CommDomain. This is local teardown.
+ * The L4 owner is responsible for
+ * draining all rank tasks before fanout.
+ */
+int comm_global_domain_release(uint64_t domain_id);
 
 /**
  * Synchronize all ranks.

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -165,6 +165,63 @@ struct DomainAllocation {
     std::unique_ptr<CommContext> host_ctx;  // device_ctx points here on sim
 };
 
+struct GlobalPeerMapping {
+    void *base = nullptr;
+    size_t size = 0;
+
+    GlobalPeerMapping() = default;
+    GlobalPeerMapping(void *mapping_base, size_t mapping_size) :
+        base(mapping_base),
+        size(mapping_size) {}
+    ~GlobalPeerMapping() {
+        if (base != nullptr) {
+            munmap(base, size);
+        }
+    }
+    GlobalPeerMapping(const GlobalPeerMapping &) = delete;
+    GlobalPeerMapping &operator=(const GlobalPeerMapping &) = delete;
+    GlobalPeerMapping(GlobalPeerMapping &&other) noexcept :
+        base(other.base),
+        size(other.size) {
+        other.base = nullptr;
+        other.size = 0;
+    }
+    GlobalPeerMapping &operator=(GlobalPeerMapping &&other) noexcept {
+        if (this != &other) {
+            if (base != nullptr) {
+                munmap(base, size);
+            }
+            base = other.base;
+            size = other.size;
+            other.base = nullptr;
+            other.size = 0;
+        }
+        return *this;
+    }
+};
+
+struct GlobalDomainAllocation {
+    ~GlobalDomainAllocation() {
+        if (local_base != nullptr) {
+            munmap(local_base, mapping_size);
+        }
+        if (!shm_name.empty()) {
+            shm_unlink(shm_name.c_str());
+        }
+    }
+
+    uint32_t rank = 0;
+    uint32_t nranks = 0;
+    std::string shm_name;
+    void *local_base = nullptr;
+    size_t mapping_size = 0;
+    std::vector<GlobalPeerMapping> peer_mappings;
+    std::unique_ptr<CommContext> host_ctx;
+};
+
+static_assert(sizeof(CommGlobalDomainDescriptor) == 288, "global domain descriptor ABI changed");
+static std::unordered_map<uint64_t, std::unique_ptr<GlobalDomainAllocation>> global_domain_allocations;
+
 struct CommHandle_ {
     int rank;
     int nranks;
@@ -682,6 +739,154 @@ comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_co
     return -1;
 } catch (...) {
     std::fprintf(stderr, "[comm_sim] release_domain: unknown exception\n");
+    return -1;
+}
+
+extern "C" int comm_global_domain_prepare(
+    uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile,
+    CommGlobalDomainDescriptor *descriptor_out, uint64_t *local_window_base_out
+) try {
+    if (domain_id == 0 || rank_count == 0 || rank_count > COMM_MAX_RANK_NUM || domain_rank >= rank_count ||
+        window_size == 0 || profile != COMM_GLOBAL_DOMAIN_PROFILE_SIM_SHM || descriptor_out == nullptr ||
+        local_window_base_out == nullptr) {
+        return -1;
+    }
+    if (global_domain_allocations.count(domain_id) != 0) {
+        return -1;
+    }
+
+    std::string identity =
+        std::to_string(static_cast<unsigned long long>(domain_id)) + ":" + std::to_string(domain_rank);
+    std::string shm_name = make_shm_name(static_cast<uint32_t>(getpid()), hash_id(identity.c_str()));
+    if (shm_name.empty() || shm_name.size() > COMM_GLOBAL_DOMAIN_HANDLE_BYTES) {
+        return -1;
+    }
+
+    int fd = shm_open(shm_name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (fd < 0) {
+        return -1;
+    }
+    if (ftruncate(fd, static_cast<off_t>(window_size)) != 0) {
+        close(fd);
+        shm_unlink(shm_name.c_str());
+        return -1;
+    }
+    void *base = mmap(nullptr, window_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (base == MAP_FAILED) {
+        shm_unlink(shm_name.c_str());
+        return -1;
+    }
+    std::memset(base, 0, window_size);
+
+    auto allocation = std::make_unique<GlobalDomainAllocation>();
+    allocation->rank = domain_rank;
+    allocation->nranks = rank_count;
+    allocation->shm_name = shm_name;
+    allocation->local_base = base;
+    allocation->mapping_size = window_size;
+
+    CommGlobalDomainDescriptor descriptor{};
+    descriptor.version = COMM_GLOBAL_DOMAIN_VERSION;
+    descriptor.profile = COMM_GLOBAL_DOMAIN_PROFILE_SIM_SHM;
+    descriptor.domain_rank = domain_rank;
+    descriptor.rank_count = rank_count;
+    descriptor.mapping_size = window_size;
+    descriptor.handle_size = static_cast<uint32_t>(shm_name.size());
+    std::memcpy(descriptor.handle, shm_name.data(), shm_name.size());
+
+    *descriptor_out = descriptor;
+    *local_window_base_out = reinterpret_cast<uint64_t>(base);
+    global_domain_allocations.emplace(domain_id, std::move(allocation));
+    return 0;
+} catch (const std::exception &e) {
+    std::fprintf(stderr, "[comm_sim] global_domain_prepare: exception: %s\n", e.what());
+    return -1;
+} catch (...) {
+    std::fprintf(stderr, "[comm_sim] global_domain_prepare: unknown exception\n");
+    return -1;
+}
+
+extern "C" int comm_global_domain_import(
+    uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
+) try {
+    auto it = global_domain_allocations.find(domain_id);
+    if (it == global_domain_allocations.end() || descriptors == nullptr || device_ctx_out == nullptr) {
+        return -1;
+    }
+    auto &allocation = it->second;
+    if (descriptor_count != allocation->nranks || allocation->host_ctx != nullptr) {
+        return -1;
+    }
+
+    std::vector<const CommGlobalDomainDescriptor *> rank_order(descriptor_count, nullptr);
+    for (size_t i = 0; i < descriptor_count; ++i) {
+        const auto &descriptor = descriptors[i];
+        if (descriptor.version != COMM_GLOBAL_DOMAIN_VERSION ||
+            descriptor.profile != COMM_GLOBAL_DOMAIN_PROFILE_SIM_SHM || descriptor.rank_count != allocation->nranks ||
+            descriptor.domain_rank >= allocation->nranks || descriptor.mapping_size != allocation->mapping_size ||
+            descriptor.handle_size == 0 || descriptor.handle_size > COMM_GLOBAL_DOMAIN_HANDLE_BYTES ||
+            rank_order[descriptor.domain_rank] != nullptr) {
+            return -1;
+        }
+        rank_order[descriptor.domain_rank] = &descriptor;
+    }
+
+    auto ctx = std::make_unique<CommContext>();
+    ctx->rankId = allocation->rank;
+    ctx->rankNum = allocation->nranks;
+    ctx->winSize = allocation->mapping_size;
+    std::vector<GlobalPeerMapping> peer_mappings;
+    peer_mappings.reserve(allocation->nranks - 1);
+    for (uint32_t rank = 0; rank < allocation->nranks; ++rank) {
+        const auto *descriptor = rank_order[rank];
+        if (descriptor == nullptr) {
+            return -1;
+        }
+        void *base = allocation->local_base;
+        if (rank != allocation->rank) {
+            std::string peer_name(
+                reinterpret_cast<const char *>(descriptor->handle), static_cast<size_t>(descriptor->handle_size)
+            );
+            int fd = shm_open(peer_name.c_str(), O_RDWR, 0600);
+            if (fd < 0) {
+                return -1;
+            }
+            base = mmap(nullptr, allocation->mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            close(fd);
+            if (base == MAP_FAILED) {
+                return -1;
+            }
+            peer_mappings.emplace_back(base, allocation->mapping_size);
+        }
+        ctx->windowsIn[rank] = reinterpret_cast<uint64_t>(base);
+        ctx->windowsOut[rank] = reinterpret_cast<uint64_t>(base);
+    }
+
+    allocation->peer_mappings = std::move(peer_mappings);
+    *device_ctx_out = reinterpret_cast<uint64_t>(ctx.get());
+    allocation->host_ctx = std::move(ctx);
+    return 0;
+} catch (const std::exception &e) {
+    std::fprintf(stderr, "[comm_sim] global_domain_import: exception: %s\n", e.what());
+    return -1;
+} catch (...) {
+    std::fprintf(stderr, "[comm_sim] global_domain_import: unknown exception\n");
+    return -1;
+}
+
+extern "C" int comm_global_domain_release(uint64_t domain_id) try {
+    auto it = global_domain_allocations.find(domain_id);
+    if (it == global_domain_allocations.end()) {
+        return 0;
+    }
+    global_domain_allocations.erase(it);
+    return 0;
+} catch (const std::exception &e) {
+    std::fprintf(stderr, "[comm_sim] global_domain_release: exception: %s\n", e.what());
+    return -1;
+} catch (...) {
+    std::fprintf(stderr, "[comm_sim] global_domain_release: unknown exception\n");
     return -1;
 }
 

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -192,6 +192,9 @@ void ChipWorker::init(
         comm_alloc_domain_windows_fn_ = load_symbol<CommAllocDomainWindowsFn>(handle, "comm_alloc_domain_windows");
         comm_release_domain_windows_fn_ =
             load_symbol<CommReleaseDomainWindowsFn>(handle, "comm_release_domain_windows");
+        comm_global_domain_prepare_fn_ = load_symbol<CommGlobalDomainPrepareFn>(handle, "comm_global_domain_prepare");
+        comm_global_domain_import_fn_ = load_symbol<CommGlobalDomainImportFn>(handle, "comm_global_domain_import");
+        comm_global_domain_release_fn_ = load_symbol<CommGlobalDomainReleaseFn>(handle, "comm_global_domain_release");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
         comm_destroy_fn_ = load_symbol<CommDestroyFn>(handle, "comm_destroy");
     } catch (...) {
@@ -313,6 +316,9 @@ void ChipWorker::init(
         comm_get_window_size_fn_ = nullptr;
         comm_alloc_domain_windows_fn_ = nullptr;
         comm_release_domain_windows_fn_ = nullptr;
+        comm_global_domain_prepare_fn_ = nullptr;
+        comm_global_domain_import_fn_ = nullptr;
+        comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
         runtime_bufs_.clear();
@@ -364,6 +370,9 @@ void ChipWorker::init(
         comm_derive_context_fn_ = nullptr;
         comm_alloc_domain_windows_fn_ = nullptr;
         comm_release_domain_windows_fn_ = nullptr;
+        comm_global_domain_prepare_fn_ = nullptr;
+        comm_global_domain_import_fn_ = nullptr;
+        comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
         runtime_bufs_.clear();
@@ -395,6 +404,15 @@ void ChipWorker::init(
 
 void ChipWorker::finalize() {
     cleanup_native_runs_noexcept();
+    // Global domains are independent of the legacy communicator sessions.
+    // Release them while the host runtime and device context are still alive.
+    if (comm_global_domain_release_fn_ != nullptr) {
+        for (uint64_t domain_id : global_domain_ids_) {
+            comm_global_domain_release_fn_(domain_id);
+        }
+    }
+    global_domain_ids_.clear();
+
     // Defensive: if the user never called comm_destroy, reclaim all owned
     // communicator handles and streams before tearing down the device context.
     clear_comm_sessions();
@@ -445,6 +463,9 @@ void ChipWorker::finalize() {
     comm_derive_context_fn_ = nullptr;
     comm_alloc_domain_windows_fn_ = nullptr;
     comm_release_domain_windows_fn_ = nullptr;
+    comm_global_domain_prepare_fn_ = nullptr;
+    comm_global_domain_import_fn_ = nullptr;
+    comm_global_domain_release_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
     runtime_bufs_.clear();
@@ -1094,6 +1115,67 @@ void ChipWorker::comm_release_domain_windows(
     if (rc != 0) {
         throw std::runtime_error("comm_release_domain_windows failed with code " + std::to_string(rc));
     }
+}
+
+std::tuple<std::vector<uint8_t>, uint64_t, size_t> ChipWorker::comm_global_domain_prepare(
+    uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile
+) {
+    if (comm_global_domain_prepare_fn_ == nullptr) {
+        throw std::runtime_error("comm_global_domain_prepare is not supported by this runtime");
+    }
+    auto [tracked, inserted] = global_domain_ids_.insert(domain_id);
+    if (!inserted) {
+        throw std::runtime_error("comm_global_domain_prepare received a duplicate domain_id");
+    }
+    CommGlobalDomainDescriptor descriptor{};
+    uint64_t local_window_base = 0;
+    int rc = comm_global_domain_prepare_fn_(
+        domain_id, domain_rank, rank_count, window_size, profile, &descriptor, &local_window_base
+    );
+    if (rc != 0) {
+        global_domain_ids_.erase(tracked);
+        throw std::runtime_error("comm_global_domain_prepare failed with code " + std::to_string(rc));
+    }
+    if (local_window_base == 0 || descriptor.mapping_size == 0) {
+        comm_global_domain_release_fn_(domain_id);
+        global_domain_ids_.erase(domain_id);
+        throw std::runtime_error("comm_global_domain_prepare returned an invalid window");
+    }
+    const auto *begin = reinterpret_cast<const uint8_t *>(&descriptor);
+    std::vector<uint8_t> descriptor_bytes(begin, begin + sizeof(descriptor));
+    return {std::move(descriptor_bytes), local_window_base, static_cast<size_t>(descriptor.mapping_size)};
+}
+
+uint64_t ChipWorker::comm_global_domain_import(uint64_t domain_id, const std::vector<uint8_t> &descriptors) {
+    if (comm_global_domain_import_fn_ == nullptr) {
+        throw std::runtime_error("comm_global_domain_import is not supported by this runtime");
+    }
+    if (descriptors.empty() || descriptors.size() % sizeof(CommGlobalDomainDescriptor) != 0) {
+        throw std::runtime_error("comm_global_domain_import descriptor table size is invalid");
+    }
+    uint64_t device_ctx = 0;
+    int rc = comm_global_domain_import_fn_(
+        domain_id, reinterpret_cast<const CommGlobalDomainDescriptor *>(descriptors.data()),
+        descriptors.size() / sizeof(CommGlobalDomainDescriptor), &device_ctx
+    );
+    if (rc != 0) {
+        throw std::runtime_error("comm_global_domain_import failed with code " + std::to_string(rc));
+    }
+    if (device_ctx == 0) {
+        throw std::runtime_error("comm_global_domain_import returned a null device context");
+    }
+    return device_ctx;
+}
+
+void ChipWorker::comm_global_domain_release(uint64_t domain_id) {
+    if (comm_global_domain_release_fn_ == nullptr) {
+        throw std::runtime_error("comm_global_domain_release is not supported by this runtime");
+    }
+    int rc = comm_global_domain_release_fn_(domain_id);
+    if (rc != 0) {
+        throw std::runtime_error("comm_global_domain_release failed with code " + std::to_string(rc));
+    }
+    global_domain_ids_.erase(domain_id);
 }
 
 void ChipWorker::comm_barrier(uint64_t comm_handle) {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -16,9 +16,12 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
+#include "../platform_comm/comm.h"
 #include "../task_interface/call_config.h"
 #include "../task_interface/task_args.h"
 #include "pipeline_slot_pool.h"
@@ -188,6 +191,11 @@ public:
     /// inside the backend's per-allocation record).
     void
     comm_release_domain_windows(uint64_t comm_handle, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank);
+    std::tuple<std::vector<uint8_t>, uint64_t, size_t> comm_global_domain_prepare(
+        uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile
+    );
+    uint64_t comm_global_domain_import(uint64_t domain_id, const std::vector<uint8_t> &descriptors);
+    void comm_global_domain_release(uint64_t domain_id);
     void comm_barrier(uint64_t comm_handle);
     void comm_destroy(uint64_t comm_handle);
     void comm_destroy_all();
@@ -251,6 +259,10 @@ private:
     using CommAllocDomainWindowsFn =
         int (*)(void *, uint64_t, const uint32_t *, size_t, uint32_t, size_t, uint64_t *, uint64_t *);
     using CommReleaseDomainWindowsFn = int (*)(void *, uint64_t, size_t, uint32_t);
+    using CommGlobalDomainPrepareFn =
+        int (*)(uint64_t, uint32_t, uint32_t, size_t, uint32_t, CommGlobalDomainDescriptor *, uint64_t *);
+    using CommGlobalDomainImportFn = int (*)(uint64_t, const CommGlobalDomainDescriptor *, size_t, uint64_t *);
+    using CommGlobalDomainReleaseFn = int (*)(uint64_t);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
 
@@ -308,11 +320,15 @@ private:
     CommDeriveContextFn comm_derive_context_fn_ = nullptr;
     CommAllocDomainWindowsFn comm_alloc_domain_windows_fn_ = nullptr;
     CommReleaseDomainWindowsFn comm_release_domain_windows_fn_ = nullptr;
+    CommGlobalDomainPrepareFn comm_global_domain_prepare_fn_ = nullptr;
+    CommGlobalDomainImportFn comm_global_domain_import_fn_ = nullptr;
+    CommGlobalDomainReleaseFn comm_global_domain_release_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;
     void *device_ctx_ = nullptr;
     std::vector<CommSession> comm_sessions_;
     std::unordered_map<uint64_t, size_t> comm_session_index_;
+    std::unordered_set<uint64_t> global_domain_ids_;
     uint64_t base_comm_handle_ = 0;
 
     // Slot 0 with no generation bookkeeping: an unleased run is a caller that

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -224,6 +224,7 @@ add_library(hierarchical_objs OBJECT
 )
 target_include_directories(hierarchical_objs PUBLIC
     ${HIERARCHICAL_SRC_DIR}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
     ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
     ${WORKER_SRC_DIR}
 )

--- a/tests/ut/py/test_callable_identity.py
+++ b/tests/ut/py/test_callable_identity.py
@@ -681,6 +681,44 @@ def test_remote_session_manifest_uses_endpoint_host_as_default_bind():
         worker.close()
 
 
+def test_remote_manifest_carries_pre_registered_inner_chip_callable():
+    worker = Worker(level=4, num_sub_workers=0)
+    chip = ChipCallable.build(signature=[], func_name="x", binary=b"\x01", children=[])
+    try:
+        worker_id = worker.add_remote_worker(
+            RemoteWorkerSpec(
+                endpoint="127.0.0.1:19073",
+                platform="a2a3sim",
+                device_ids=(0,),
+            )
+        )
+        handle = worker.register(chip)
+        manifest = worker._build_remote_manifest(
+            spec=worker._remote_worker_specs[0],
+            worker_id=worker_id,
+            session_id=1,
+            startup_remaining_s=30.0,
+        )
+
+        assert len(manifest["inner_l3_worker"]) == 1
+        entry = manifest["inner_l3_worker"][0]
+        assert entry["hashid"] == handle.digest.hex()
+        command = encode_register_callable_command(
+            RemoteRegistryTarget.INNER_L3_WORKER,
+            CallableKind.CHIP_CALLABLE,
+            handle.digest,
+            1,
+            bytes.fromhex(entry["payload_hex"]),
+        )
+        digest, kind, registry, target = _prepare_register_callable(command, manifest)
+        assert digest == handle.digest
+        assert kind is CallableKind.CHIP_CALLABLE
+        assert registry is RemoteRegistryTarget.INNER_L3_WORKER
+        assert isinstance(target, ChipCallable)
+    finally:
+        worker.close()
+
+
 def test_remote_session_manifest_requires_wildcard_bind_opt_in():
     worker = Worker(level=4, num_sub_workers=0)
     try:
@@ -1579,7 +1617,12 @@ def test_remote_sim_imported_buffer_runs_on_peer_worker():
         owner_daemon.await_ready()
         peer_daemon.await_ready()
         owner_worker_id = worker.add_remote_worker(
-            RemoteWorkerSpec(endpoint=f"127.0.0.1:{owner_port}", platform="a2a3sim", transport="host_tcp")
+            RemoteWorkerSpec(
+                endpoint=f"127.0.0.1:{owner_port}",
+                platform="a2a3sim",
+                transport="host_tcp",
+                device_ids=(0,),
+            )
         )
         peer_worker_id = worker.add_remote_worker(
             RemoteWorkerSpec(endpoint=f"127.0.0.1:{peer_port}", platform="a2a3sim", transport="host_tcp")

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -1,0 +1,1002 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+from simpler.global_comm_domain import (
+    GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
+    GLOBAL_DOMAIN_PROFILE_IDS,
+    GLOBAL_DOMAIN_VERSION,
+    GlobalCommInitCommand,
+    GlobalDomainBuffer,
+    GlobalDomainCommand,
+    GlobalDomainDescriptor,
+    GlobalDomainMember,
+    GlobalDomainPhase,
+    GlobalDomainReleaseCommand,
+    decode_comm_init,
+    decode_descriptor_table,
+    decode_domain_command,
+    encode_comm_init,
+    encode_comm_init_result,
+    encode_descriptor_table,
+    encode_domain_command,
+    resolve_global_comm_capability,
+    validate_descriptor_table,
+)
+
+
+def _members() -> tuple[GlobalDomainMember, ...]:
+    return (
+        GlobalDomainMember(0, 0, 3, 0),
+        GlobalDomainMember(1, 0, 7, 1),
+    )
+
+
+def _descriptors() -> tuple[GlobalDomainDescriptor, ...]:
+    return tuple(
+        GlobalDomainDescriptor(
+            version=GLOBAL_DOMAIN_VERSION,
+            profile_id=GLOBAL_DOMAIN_PROFILE_IDS["sim"],
+            domain_rank=rank,
+            rank_count=2,
+            mapping_size=4096,
+            handle=f"/simpler-test-{rank}".encode(),
+        )
+        for rank in range(2)
+    )
+
+
+@pytest.mark.parametrize(
+    ("platform", "profile"),
+    (
+        ("a2a3sim", "sim"),
+        ("a5sim", "sim"),
+        ("a2a3", "a3-fabric-v1"),
+    ),
+)
+def test_global_comm_capability_reports_only_implemented_backends(platform, profile):
+    result = resolve_global_comm_capability(platform=platform, profile=profile, local_device_count=2)
+
+    assert result.profile == profile
+    assert result.max_ranks == 64
+    assert result.descriptor_bytes == GLOBAL_DOMAIN_DESCRIPTOR_BYTES
+    assert result.local_device_count == 2
+
+
+@pytest.mark.parametrize(
+    ("platform", "profile"),
+    (
+        ("a2a3", "sim"),
+        ("a2a3sim", "a3-fabric-v1"),
+        ("a5", "sim"),
+        ("a5", "a3-fabric-v1"),
+    ),
+)
+def test_global_comm_capability_rejects_unimplemented_backends(platform, profile):
+    with pytest.raises(ValueError, match="Global CommDomain is not supported"):
+        resolve_global_comm_capability(platform=platform, profile=profile, local_device_count=2)
+
+
+def test_local_l3_comm_init_rejects_unsupported_capability_without_caching_topology():
+    from simpler.remote_l3_protocol import ControlName  # noqa: PLC0415
+    from simpler.worker import Worker, _GlobalNodeRuntime, _run_local_global_domain_control  # noqa: PLC0415
+
+    inner_worker = Worker(level=3, num_sub_workers=0)
+    runtime = _GlobalNodeRuntime(
+        worker_id=0,
+        device_ids=(0,),
+        platform="a5",
+        comm_profile="sim",
+        global_device_ranks=(0,),
+        node_rank=0,
+        node_count=1,
+        cluster_id="cluster",
+        is_remote=False,
+    )
+    comm_inits = {}
+    command = GlobalCommInitCommand(
+        cluster_id="cluster",
+        topology_hash="topology",
+        profile="sim",
+        node_rank=0,
+        node_count=1,
+        members=(GlobalDomainMember(0, 0, 0, 0),),
+    )
+
+    try:
+        with pytest.raises(ValueError, match="Global CommDomain is not supported"):
+            _run_local_global_domain_control(
+                inner_worker,
+                runtime,
+                comm_inits,
+                ControlName.COMM_INIT,
+                encode_comm_init(command),
+            )
+
+        assert comm_inits == {}
+    finally:
+        inner_worker.close()
+
+
+def test_global_domain_wire_round_trips_topology_and_descriptor_table():
+    init = GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, _members())
+    command = GlobalDomainCommand(
+        phase=GlobalDomainPhase.IMPORT,
+        domain_id=11,
+        generation=1,
+        name="tp",
+        profile="sim",
+        window_size=2048,
+        members=_members(),
+        buffers=(GlobalDomainBuffer("payload", 128),),
+        descriptors=_descriptors(),
+    )
+
+    assert decode_comm_init(encode_comm_init(init)) == init
+    assert decode_domain_command(encode_domain_command(command)) == command
+    assert decode_descriptor_table(encode_descriptor_table(_descriptors())) == _descriptors()
+    assert GLOBAL_DOMAIN_DESCRIPTOR_BYTES == 288
+
+
+def _failure_injection_worker(*, platform: str = "a2a3sim", profile: str = "sim"):
+    from simpler.worker import RemoteWorkerSpec, Worker, _RunResources  # noqa: PLC0415
+
+    worker = Worker(level=4, num_sub_workers=0)
+    node_ids = tuple(
+        worker.add_remote_worker(
+            RemoteWorkerSpec(
+                endpoint=f"127.0.0.1:{19073 + index}",
+                platform=platform,
+                device_ids=(0,),
+                comm_profile=profile,
+                global_device_ranks=(index,),
+            )
+        )
+        for index in range(2)
+    )
+    resources = _RunResources()
+    worker._worker = object()
+    worker._building_run_resources = resources
+    return worker, resources, node_ids
+
+
+def _install_global_domain_failure_injector(monkeypatch, worker, *, fail_phase, fail_node):
+    from simpler.remote_l3_protocol import ControlName  # noqa: PLC0415
+
+    calls = []
+
+    def control(worker_id, control_name, payload):
+        control_name = ControlName(control_name)
+        if control_name is ControlName.COMM_INIT:
+            init = decode_comm_init(payload)
+            calls.append(("COMM_INIT", worker_id))
+            return encode_comm_init_result(
+                resolve_global_comm_capability(
+                    platform="a2a3sim",
+                    profile=init.profile,
+                    local_device_count=1,
+                )
+            )
+
+        assert control_name is ControlName.ALLOC_DOMAIN
+        command = decode_domain_command(payload)
+        calls.append((command.phase, worker_id))
+        if command.phase is fail_phase and worker_id == fail_node:
+            raise RuntimeError(f"injected {command.phase.name} failure")
+        if command.phase is not GlobalDomainPhase.PREPARE_EXPORT:
+            return b""
+        descriptors = tuple(
+            GlobalDomainDescriptor(
+                version=GLOBAL_DOMAIN_VERSION,
+                profile_id=GLOBAL_DOMAIN_PROFILE_IDS[command.profile],
+                domain_rank=member.domain_rank,
+                rank_count=len(command.members),
+                mapping_size=4096,
+                handle=f"/injected-{member.domain_rank}".encode(),
+            )
+            for member in command.members
+            if member.node_worker_id == worker_id
+        )
+        return encode_descriptor_table(descriptors)
+
+    monkeypatch.setattr(worker, "_global_domain_control", control)
+    return calls
+
+
+def _close_failure_injection_worker(worker, resources):
+    worker._building_run_resources = None
+    worker._live_global_domains.clear()
+    resources.live_global_domains.clear()
+    worker._worker = None
+    worker.close()
+
+
+@pytest.mark.parametrize(
+    "fail_phase",
+    (
+        GlobalDomainPhase.PREPARE_EXPORT,
+        GlobalDomainPhase.IMPORT,
+        GlobalDomainPhase.COMMIT,
+    ),
+)
+def test_global_domain_transaction_aborts_all_prepared_nodes_after_phase_failure(monkeypatch, fail_phase):
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+
+    worker, resources, node_ids = _failure_injection_worker()
+    calls = _install_global_domain_failure_injector(
+        monkeypatch,
+        worker,
+        fail_phase=fail_phase,
+        fail_node=node_ids[1],
+    )
+    try:
+        with pytest.raises(RuntimeError, match=f"injected {fail_phase.name} failure"):
+            worker._allocate_global_domain(
+                name="failure-injection",
+                members=((node_ids[0], 0), (node_ids[1], 0)),
+                window_size=4096,
+                buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+                retain_after_run=False,
+            )
+
+        abort_nodes = [node_id for phase, node_id in calls if phase is GlobalDomainPhase.ABORT]
+        assert abort_nodes == list(node_ids)
+        assert worker._live_global_domains == {}
+        assert resources.live_global_domains == {}
+    finally:
+        _close_failure_injection_worker(worker, resources)
+
+
+def test_global_domain_abort_failure_preserves_primary_error_and_poisons_admission(monkeypatch):
+    from simpler.remote_l3_protocol import ControlName  # noqa: PLC0415
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+
+    worker, resources, node_ids = _failure_injection_worker()
+    calls = _install_global_domain_failure_injector(
+        monkeypatch,
+        worker,
+        fail_phase=GlobalDomainPhase.IMPORT,
+        fail_node=node_ids[1],
+    )
+    original_control = worker._global_domain_control
+
+    def fail_first_abort(worker_id, control_name, payload):
+        if ControlName(control_name) is ControlName.ALLOC_DOMAIN:
+            command = decode_domain_command(payload)
+            if command.phase is GlobalDomainPhase.ABORT and worker_id == node_ids[0]:
+                calls.append((command.phase, worker_id))
+                raise RuntimeError("injected ABORT failure")
+        return original_control(worker_id, control_name, payload)
+
+    monkeypatch.setattr(worker, "_global_domain_control", fail_first_abort)
+    try:
+        with pytest.raises(RuntimeError, match="injected IMPORT failure"):
+            worker._allocate_global_domain(
+                name="abort-failure-injection",
+                members=((node_ids[0], 0), (node_ids[1], 0)),
+                window_size=4096,
+                buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+                retain_after_run=False,
+            )
+
+        abort_nodes = [node_id for phase, node_id in calls if phase is GlobalDomainPhase.ABORT]
+        assert abort_nodes == list(node_ids)
+        # A failed ABORT leg leaves backend windows that nothing tracks: the
+        # domain is never registered, so no run fence and no close() sweep can
+        # reach it. Refusing further work is the only remaining boundary.
+        leaked = worker._ordered_cleanup_error
+        assert leaked is not None
+        assert "abort-failure-injection" in str(leaked)
+        assert f"node worker {node_ids[0]}" in str(leaked)
+        assert isinstance(leaked.__cause__, RuntimeError)
+        assert "injected ABORT failure" in str(leaked.__cause__)
+        assert worker._live_global_domains == {}
+        assert resources.live_global_domains == {}
+    finally:
+        _close_failure_injection_worker(worker, resources)
+
+
+def test_mixed_local_remote_import_failure_rolls_back_local_node(monkeypatch):
+    from simpler.remote_l3_protocol import ControlName  # noqa: PLC0415
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+    from simpler.worker import (  # noqa: PLC0415
+        CTRL_GLOBAL_DOMAIN_IMPORT,
+        CTRL_GLOBAL_DOMAIN_PREPARE,
+        CTRL_GLOBAL_DOMAIN_RELEASE,
+        LOCAL_DOMAIN_MAGIC,
+        LOCAL_IMPORT_REPLY,
+        LOCAL_IMPORT_REQUEST,
+        LOCAL_PREPARE_REPLY,
+        LOCAL_PREPARE_REQUEST,
+        RemoteWorkerSpec,
+        Worker,
+        _run_local_global_domain_control,
+        _RunResources,
+    )
+
+    released_local_workers = []
+
+    class FakeLocalNativeWorker:
+        def control_payload(self, _kind, worker_id, control, payload, _timeout):
+            if control == CTRL_GLOBAL_DOMAIN_PREPARE:
+                (
+                    _magic,
+                    _version,
+                    domain_id,
+                    generation,
+                    domain_rank,
+                    rank_count,
+                    profile_id,
+                    window_size,
+                ) = LOCAL_PREPARE_REQUEST.unpack_from(payload, 0)
+                descriptor = GlobalDomainDescriptor(
+                    version=GLOBAL_DOMAIN_VERSION,
+                    profile_id=profile_id,
+                    domain_rank=domain_rank,
+                    rank_count=rank_count,
+                    mapping_size=window_size,
+                    handle=b"/mixed-local",
+                )
+                return (
+                    LOCAL_PREPARE_REPLY.pack(
+                        LOCAL_DOMAIN_MAGIC,
+                        GLOBAL_DOMAIN_VERSION,
+                        domain_id,
+                        generation,
+                        0x1000,
+                        window_size,
+                    )
+                    + descriptor.encode()
+                )
+            if control == CTRL_GLOBAL_DOMAIN_IMPORT:
+                _magic, _version, domain_id, generation, _rank_count = LOCAL_IMPORT_REQUEST.unpack_from(payload, 0)
+                return LOCAL_IMPORT_REPLY.pack(
+                    LOCAL_DOMAIN_MAGIC,
+                    GLOBAL_DOMAIN_VERSION,
+                    domain_id,
+                    generation,
+                    0x2000,
+                    0x1000,
+                    4096,
+                )
+            assert control == CTRL_GLOBAL_DOMAIN_RELEASE
+            released_local_workers.append(worker_id)
+            return b""
+
+    parent = Worker(level=4, num_sub_workers=0)
+    local = Worker(
+        level=3,
+        device_ids=(0,),
+        num_sub_workers=0,
+        platform="a2a3sim",
+        comm_profile="sim",
+        global_device_ranks=(0,),
+    )
+    local_node_id = parent.add_worker(local)
+    remote_node_id = parent.add_remote_worker(
+        RemoteWorkerSpec(
+            endpoint="127.0.0.1:19073",
+            platform="a2a3sim",
+            device_ids=(0,),
+            comm_profile="sim",
+            global_device_ranks=(1,),
+        )
+    )
+    resources = _RunResources()
+    parent._worker = object()
+    parent._building_run_resources = resources
+    local._worker = FakeLocalNativeWorker()
+    local_runtime = parent._resolved_global_nodes()[local_node_id]
+    local_comm_inits = {}
+    calls = []
+
+    def control(worker_id, control_name, payload):
+        control_name = ControlName(control_name)
+        if worker_id == local_node_id:
+            event = decode_domain_command(payload).phase if control_name is ControlName.ALLOC_DOMAIN else control_name
+            calls.append(("local", event))
+            return _run_local_global_domain_control(
+                local,
+                local_runtime,
+                local_comm_inits,
+                control_name,
+                payload,
+            )
+
+        assert worker_id == remote_node_id
+        if control_name is ControlName.COMM_INIT:
+            command = decode_comm_init(payload)
+            calls.append(("remote", control_name))
+            return encode_comm_init_result(
+                resolve_global_comm_capability(
+                    platform="a2a3sim",
+                    profile=command.profile,
+                    local_device_count=1,
+                )
+            )
+
+        command = decode_domain_command(payload)
+        calls.append(("remote", command.phase))
+        if command.phase is GlobalDomainPhase.PREPARE_EXPORT:
+            descriptor = GlobalDomainDescriptor(
+                version=GLOBAL_DOMAIN_VERSION,
+                profile_id=GLOBAL_DOMAIN_PROFILE_IDS[command.profile],
+                domain_rank=1,
+                rank_count=2,
+                mapping_size=4096,
+                handle=b"/mixed-remote",
+            )
+            return encode_descriptor_table((descriptor,))
+        if command.phase is GlobalDomainPhase.IMPORT:
+            raise RuntimeError("remote import failed")
+        return b""
+
+    monkeypatch.setattr(parent, "_global_domain_control", control)
+    try:
+        with pytest.raises(RuntimeError, match="remote import failed"):
+            parent._allocate_global_domain(
+                name="mixed-rollback",
+                members=((local_node_id, 0), (remote_node_id, 0)),
+                window_size=4096,
+                buffers=[CommBufferSpec("payload", "uint8", 64, 64)],
+                retain_after_run=False,
+            )
+
+        assert released_local_workers == [0]
+        assert local._global_node_domains == {}
+        assert ("local", GlobalDomainPhase.ABORT) in calls
+        assert ("remote", GlobalDomainPhase.ABORT) in calls
+        assert parent._live_global_domains == {}
+        assert resources.live_global_domains == {}
+    finally:
+        parent._building_run_resources = None
+        parent._worker = None
+        local._global_node_domains.clear()
+        local._worker = None
+        parent.close()
+
+
+def test_allocate_global_domain_rejects_unsupported_capability_before_control(monkeypatch):
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+
+    worker, resources, node_ids = _failure_injection_worker(platform="a5", profile="sim")
+    calls = []
+    monkeypatch.setattr(worker, "_global_domain_control", lambda *args: calls.append(args))
+    try:
+        with pytest.raises(ValueError, match="Global CommDomain is not supported"):
+            worker._allocate_global_domain(
+                name="unsupported",
+                members=((node_ids[0], 0), (node_ids[1], 0)),
+                window_size=4096,
+                buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+                retain_after_run=False,
+            )
+
+        assert calls == []
+        assert worker._live_global_domains == {}
+        assert resources.live_global_domains == {}
+    finally:
+        _close_failure_injection_worker(worker, resources)
+
+
+def test_global_domain_descriptor_table_rejects_different_mapping_sizes():
+    descriptors = list(_descriptors())
+    descriptors[1] = GlobalDomainDescriptor(
+        version=GLOBAL_DOMAIN_VERSION,
+        profile_id=GLOBAL_DOMAIN_PROFILE_IDS["sim"],
+        domain_rank=1,
+        rank_count=2,
+        mapping_size=8192,
+        handle=b"/simpler-test-1",
+    )
+
+    with pytest.raises(ValueError, match="mapping sizes differ"):
+        validate_descriptor_table(tuple(descriptors), rank_count=2, profile="sim")
+
+
+def test_global_domain_release_retries_after_callback_failure():
+    from simpler.task_interface import GlobalCommDomainHandle  # noqa: PLC0415
+
+    attempts = 0
+
+    def release_fn(_handle):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient release failure")
+
+    handle = GlobalCommDomainHandle(
+        name="retry",
+        members=(),
+        buffers=(),
+        domain_id=17,
+        generation=1,
+        mapping_size=4096,
+        retain_after_run=False,
+        _release_fn=release_fn,
+    )
+
+    with pytest.raises(RuntimeError, match="transient release failure"):
+        handle.release()
+
+    assert not handle.released
+    handle.release()
+    assert handle.released
+    assert attempts == 2
+
+
+def test_old_global_domain_release_does_not_remove_same_name_replacement():
+    from simpler.task_interface import GlobalCommDomainHandle  # noqa: PLC0415
+    from simpler.worker import Worker, _RunResources  # noqa: PLC0415
+
+    worker = Worker(level=4, num_sub_workers=0)
+    resources = _RunResources()
+
+    def make_handle(domain_id: int) -> GlobalCommDomainHandle:
+        return GlobalCommDomainHandle(
+            name="reuse",
+            members=(),
+            buffers=(),
+            domain_id=domain_id,
+            generation=1,
+            mapping_size=4096,
+            retain_after_run=False,
+            _release_fn=lambda released: worker._release_global_domain_handle(released, resources),
+        )
+
+    first = make_handle(17)
+    second = make_handle(18)
+    worker._worker = object()
+    worker._building_run_resources = resources
+    worker._live_global_domains[first.name] = first
+    resources.live_global_domains[first.name] = first
+    try:
+        first.release()
+        worker._live_global_domains[second.name] = second
+        resources.live_global_domains[second.name] = second
+
+        worker._execute_pending_global_domain_releases(resources)
+
+        assert first.freed
+        assert worker._live_global_domains[second.name] is second
+        assert resources.live_global_domains[second.name] is second
+    finally:
+        worker._building_run_resources = None
+        worker._live_global_domains.clear()
+        resources.live_global_domains.clear()
+        worker._worker = None
+        worker.close()
+
+
+def test_global_domain_backend_release_failure_is_terminal(monkeypatch):
+    from simpler.task_interface import GlobalCommDomainHandle  # noqa: PLC0415
+    from simpler.worker import Worker, _RunResources  # noqa: PLC0415
+
+    attempts = 0
+    worker = Worker(level=4, num_sub_workers=0)
+    worker._worker = object()
+    resources = _RunResources()
+
+    def fail_control(_worker_id, _control_name, _payload):
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("partial backend release")
+
+    monkeypatch.setattr(worker, "_global_domain_control", fail_control)
+    handle = GlobalCommDomainHandle(
+        name="terminal",
+        members=(_members()[0],),
+        buffers=(),
+        domain_id=19,
+        generation=1,
+        mapping_size=4096,
+        retain_after_run=False,
+        _release_fn=lambda released: worker._release_global_domain_handle(released, resources),
+    )
+    try:
+        with pytest.raises(RuntimeError, match="partial backend release"):
+            worker._free_global_domain_after_fence(handle)
+        with pytest.raises(RuntimeError, match="partial backend release"):
+            worker._free_global_domain_after_fence(handle)
+
+        assert attempts == 1
+        assert not handle.freed
+        assert worker._failed_global_domain_releases[handle.domain_id] is handle
+    finally:
+        worker._failed_global_domain_releases.clear()
+        worker._worker = None
+        worker.close()
+
+
+def test_global_domain_release_uses_allocation_run_after_graph_build(monkeypatch):
+    from simpler.remote_l3_protocol import ControlName  # noqa: PLC0415
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+
+    worker, resources, node_ids = _failure_injection_worker()
+    _install_global_domain_failure_injector(
+        monkeypatch,
+        worker,
+        fail_phase=None,
+        fail_node=-1,
+    )
+    try:
+        handle = worker._allocate_global_domain(
+            name="run-owned-release",
+            members=((node_ids[0], 0), (node_ids[1], 0)),
+            window_size=4096,
+            buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+            retain_after_run=True,
+        )
+        release_nodes = []
+
+        def release_control(worker_id, control_name, _payload):
+            assert ControlName(control_name) is ControlName.RELEASE_DOMAIN
+            release_nodes.append(worker_id)
+            return b""
+
+        monkeypatch.setattr(worker, "_global_domain_control", release_control)
+        worker._building_run_resources = None
+        handle.release()
+
+        assert resources.pending_release_global_domains == [handle]
+        assert release_nodes == []
+        assert not handle.freed
+
+        worker._execute_pending_global_domain_releases(resources)
+        assert release_nodes == list(node_ids)
+        assert resources.pending_release_global_domains == []
+        assert handle.freed
+    finally:
+        _close_failure_injection_worker(worker, resources)
+
+
+def _local_node_domain_commands():
+    members = (
+        GlobalDomainMember(0, 0, 0, 0),
+        GlobalDomainMember(0, 1, 1, 1),
+    )
+    descriptors = tuple(
+        GlobalDomainDescriptor(
+            version=GLOBAL_DOMAIN_VERSION,
+            profile_id=GLOBAL_DOMAIN_PROFILE_IDS["sim"],
+            domain_rank=rank,
+            rank_count=2,
+            mapping_size=4096,
+            handle=f"/local-node-{rank}".encode(),
+        )
+        for rank in range(2)
+    )
+    common = {
+        "domain_id": 29,
+        "generation": 3,
+        "name": "local-node",
+        "profile": "sim",
+        "window_size": 4096,
+        "members": members,
+        "buffers": (GlobalDomainBuffer("payload", 64),),
+    }
+    prepare = GlobalDomainCommand(phase=GlobalDomainPhase.PREPARE_EXPORT, **common)
+    imported = GlobalDomainCommand(phase=GlobalDomainPhase.IMPORT, descriptors=descriptors, **common)
+    return prepare, imported
+
+
+def test_node_import_failure_rolls_back_partial_local_ranks_and_uses_configured_timeout():
+    from simpler.worker import (  # noqa: PLC0415
+        CTRL_GLOBAL_DOMAIN_IMPORT,
+        CTRL_GLOBAL_DOMAIN_RELEASE,
+        LOCAL_DOMAIN_MAGIC,
+        LOCAL_IMPORT_REPLY,
+        Worker,
+        _GlobalNodeDomainState,
+    )
+
+    prepare, imported = _local_node_domain_commands()
+    release_workers = []
+    timeouts = []
+
+    class FakeNativeWorker:
+        def control_payload(self, _kind, worker_id, control, _payload, timeout):
+            timeouts.append(timeout)
+            if control == CTRL_GLOBAL_DOMAIN_IMPORT:
+                if worker_id == 1:
+                    raise RuntimeError("second local import failed")
+                return LOCAL_IMPORT_REPLY.pack(
+                    LOCAL_DOMAIN_MAGIC,
+                    GLOBAL_DOMAIN_VERSION,
+                    imported.domain_id,
+                    imported.generation,
+                    0x1000,
+                    0x2000,
+                    4096,
+                )
+            assert control == CTRL_GLOBAL_DOMAIN_RELEASE
+            release_workers.append(worker_id)
+            return b""
+
+    worker = Worker(level=3, device_ids=(0, 1), py_control_timeout_s=7.25)
+    worker._worker = FakeNativeWorker()
+    state = _GlobalNodeDomainState(command=prepare)
+    state.prepared_domain_ranks.update((0, 1))
+    worker._global_node_domains[prepare.domain_id] = state
+    try:
+        with pytest.raises(RuntimeError, match="second local import failed"):
+            worker._import_global_domain_node(imported, 0)
+
+        assert release_workers == [0, 1]
+        assert worker._global_node_domains == {}
+        assert timeouts == [7.25, 7.25, 7.25, 7.25]
+    finally:
+        worker._global_node_domains.clear()
+        worker._worker = None
+        worker.close()
+
+
+def test_node_release_invalidates_committed_view_before_partial_fanout_failure():
+    from simpler.task_interface import GlobalCommDomainView  # noqa: PLC0415
+    from simpler.worker import (  # noqa: PLC0415
+        CTRL_GLOBAL_DOMAIN_RELEASE,
+        Worker,
+        _GlobalNodeDomainState,
+    )
+
+    prepare, imported = _local_node_domain_commands()
+    timeouts = []
+
+    class FakeNativeWorker:
+        fail_second = True
+
+        def control_payload(self, _kind, worker_id, control, _payload, timeout):
+            assert control == CTRL_GLOBAL_DOMAIN_RELEASE
+            timeouts.append(timeout)
+            if self.fail_second and worker_id == 1:
+                raise RuntimeError("partial release failed")
+            return b""
+
+    native = FakeNativeWorker()
+    worker = Worker(level=3, device_ids=(0, 1), py_control_timeout_s=6.5)
+    worker._worker = native
+    view = GlobalCommDomainView(
+        name=imported.name,
+        members=imported.members,
+        contexts={},
+        domain_id=imported.domain_id,
+        generation=imported.generation,
+        mapping_size=4096,
+    )
+    view._committed = True
+    state = _GlobalNodeDomainState(
+        command=imported,
+        prepared_domain_ranks={0, 1},
+        view=view,
+        phase=GlobalDomainPhase.COMMIT,
+    )
+    worker._global_node_domains[imported.domain_id] = state
+    try:
+        with pytest.raises(RuntimeError, match="partial release failed"):
+            worker._release_global_domain_node(GlobalDomainReleaseCommand(imported.domain_id, imported.generation))
+
+        assert state.phase is GlobalDomainPhase.ABORT
+        assert not view.committed
+        with pytest.raises(KeyError, match="not committed"):
+            worker._get_global_domain(imported.domain_id)
+        with pytest.raises(RuntimeError, match="not committed"):
+            view[0]
+
+        native.fail_second = False
+        worker._release_global_domain_node(GlobalDomainReleaseCommand(imported.domain_id, imported.generation))
+        assert worker._global_node_domains == {}
+        assert timeouts == [6.5, 6.5, 6.5, 6.5]
+    finally:
+        worker._global_node_domains.clear()
+        worker._worker = None
+        worker.close()
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_tcp_ports(ports: tuple[int, ...], timeout_s: float = 5.0) -> None:
+    pending = set(ports)
+    deadline = time.monotonic() + timeout_s
+    while pending:
+        for port in tuple(pending):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"remote L3 daemons did not become ready on ports {sorted(pending)}")
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=min(0.1, remaining)):
+                    pending.remove(port)
+            except OSError:
+                pass
+        if pending:
+            time.sleep(0.01)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="hierarchical workers require fork")
+def test_two_remote_daemons_build_and_copy_global_domain_without_mpirun():
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+    from simpler.worker import RemoteWorkerSpec, Worker  # noqa: PLC0415
+
+    ports = (_free_tcp_port(), _free_tcp_port())
+    daemons = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "simpler.remote_l3_worker",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        for port in ports
+    ]
+    worker = Worker(level=4, num_sub_workers=0, remote_session_timeout_s=20)
+    captured: dict[str, object] = {}
+    try:
+        _wait_for_tcp_ports(ports)
+        node_ids = tuple(
+            worker.add_remote_worker(
+                RemoteWorkerSpec(
+                    endpoint=f"127.0.0.1:{port}",
+                    platform="a2a3sim",
+                    device_ids=(0,),
+                    comm_profile="sim",
+                )
+            )
+            for port in ports
+        )
+        worker.init()
+
+        def parent_orch(orch, _args, _cfg):
+            domain = orch.allocate_global_domain(
+                name="tcp-global",
+                members=((node_ids[0], 0), (node_ids[1], 0)),
+                window_size=4096,
+                buffers=(CommBufferSpec("payload", "uint8", 64, 64),),
+                retain_after_run=True,
+            )
+            orch.copy_to_global_domain(domain, 0, b"node-zero", buffer="payload")
+            orch.copy_to_global_domain(domain, 1, b"node-one", buffer="payload")
+            captured["ranks"] = tuple(member.global_device_rank for member in domain.members)
+            captured["handle"] = domain
+
+        worker.run(parent_orch)
+        assert not captured["handle"].freed
+
+        def read_orch(orch, _args, _cfg):
+            domain = captured["handle"]
+            try:
+                captured["rank0"] = orch.copy_from_global_domain(domain, 0, len(b"node-zero"), buffer="payload")
+                captured["rank1"] = orch.copy_from_global_domain(domain, 1, len(b"node-one"), buffer="payload")
+            finally:
+                domain.release()
+
+        worker.run(read_orch)
+        assert captured["rank0"] == b"node-zero"
+        assert captured["rank1"] == b"node-one"
+        assert captured["ranks"] == (0, 1)
+        assert captured["handle"].freed
+    finally:
+        worker.close()
+        for daemon in daemons:
+            daemon.terminate()
+            try:
+                daemon.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                daemon.kill()
+                daemon.wait(timeout=5)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="hierarchical workers require fork")
+def test_local_and_remote_l3_build_and_copy_global_domain_without_mpirun():
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+    from simpler.worker import RemoteWorkerSpec, Worker  # noqa: PLC0415
+
+    port = _free_tcp_port()
+    daemon = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "simpler.remote_l3_worker",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    worker = Worker(level=4, num_sub_workers=0, remote_session_timeout_s=20)
+    captured: dict[str, object] = {}
+    try:
+        _wait_for_tcp_ports((port,))
+        local_node_id = worker.add_worker(
+            Worker(
+                level=3,
+                device_ids=[0],
+                num_sub_workers=0,
+                platform="a2a3sim",
+                runtime="tensormap_and_ringbuffer",
+                comm_profile="sim",
+                global_device_ranks=(0,),
+            )
+        )
+        remote_node_id = worker.add_remote_worker(
+            RemoteWorkerSpec(
+                endpoint=f"127.0.0.1:{port}",
+                platform="a2a3sim",
+                device_ids=(0,),
+                comm_profile="sim",
+                global_device_ranks=(1,),
+            )
+        )
+        worker.init()
+
+        def build_orch(orch, _args, _cfg):
+            domain = orch.allocate_global_domain(
+                name="mixed-global",
+                members=((local_node_id, 0), (remote_node_id, 0)),
+                window_size=4096,
+                buffers=(CommBufferSpec("payload", "uint8", 64, 64),),
+                retain_after_run=True,
+            )
+            orch.copy_to_global_domain(domain, 0, b"local-l3", buffer="payload")
+            orch.copy_to_global_domain(domain, 1, b"remote-l3", buffer="payload")
+            captured["ranks"] = tuple(member.global_device_rank for member in domain.members)
+            captured["domain"] = domain
+
+        worker.run(build_orch)
+        domain = captured["domain"]
+        assert not domain.freed
+
+        def read_orch(orch, _args, _cfg):
+            try:
+                captured["local"] = orch.copy_from_global_domain(
+                    domain,
+                    0,
+                    len(b"local-l3"),
+                    buffer="payload",
+                )
+                captured["remote"] = orch.copy_from_global_domain(
+                    domain,
+                    1,
+                    len(b"remote-l3"),
+                    buffer="payload",
+                )
+            finally:
+                domain.release()
+
+        worker.run(read_orch)
+        assert captured["local"] == b"local-l3"
+        assert captured["remote"] == b"remote-l3"
+        assert captured["ranks"] == (0, 1)
+        assert domain.freed
+    finally:
+        worker.close()
+        daemon.terminate()
+        try:
+            daemon.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+            daemon.wait(timeout=5)


### PR DESCRIPTION
## Summary
- Add an L4-brokered Global CommDomain flow that collects rank-ordered L2 export descriptors through L3 and returns the complete table for L2 import, without `mpirun`.
- Support one domain spanning both forked local L3 workers (`add_worker`) and TCP-connected remote L3 workers (`add_remote_worker`).
- Report only backend capabilities that are actually implemented: sim platforms accept `sim`, real A2/A3 accepts `a3-fabric-v1`, and unsupported platform/profile pairs are rejected before `PREPARE` and again at L3 `COMM_INIT`.
- Carve each imported window slice as a `VMM_WINDOW` `Buffer`, so a task arg names it as a self-describing `Tensor` view (`context.buffers[name].tensor(...)`) instead of a bare device address.
- Harden the full lifecycle: partial node/backend imports roll back staged mappings, partial release invalidates committed views before fan-out, configured control timeouts are honored, and Global handles release behind the correct run fence.
- When a rollback leg itself fails, refuse further work on that worker. The domain is never registered on that path, so no run fence and no `close()` sweep can reach what the failed rollback leaves mapped; both the `ALLOC_DOMAIN` ABORT fan-out and the L3-node close path route through `Worker._record_unreclaimable`.
- Add two-machine pod scene tests `global_tload_mixed_l3` (L4-brokered peer `TLOAD`) and `compute_then_tload_mixed_l3` (an L2 compute round, then cross-machine communication through the same retained domain), registered in `_st-pod.yml`.
- Add focused codec, capability, transaction, node-side rollback, remote-only sim, and mixed local/remote sim coverage.

## Testing
- Head `322b337c` is a single commit rebased onto `upstream/main` after #1729 (the self-describing `Tensor` wire ABI cutover).
- Python unit tests: 1276 passed, 13 skipped. `tests/ut/py/test_global_comm_domain.py` is 24 passed.
- `test_global_domain_abort_failure_preserves_primary_error_and_poisons_admission` is the regression barrier for the rollback-failure path: it asserts the primary error still propagates, every prepared node still receives ABORT, and the worker then refuses further work with the injected failure as `__cause__`. Confirmed failing against the pre-fix code and passing after.
- Two end-to-end tests run without mocks: `test_two_remote_daemons_build_and_copy_global_domain_without_mpirun` and `test_local_and_remote_l3_build_and_copy_global_domain_without_mpirun` spawn real `simpler.remote_l3_worker` daemons over TCP and fork a real local L3, then build, copy into, read back and release a domain across the mixed topology.
- Other regression coverage: HostBuffer-backed remote export, local-rank import rollback, committed-view invalidation and retry after partial release, run-owned deferred release, and a mixed local/remote control path where remote import failure must roll back the already-imported local L3 node.
- Repository hooks passed (headers, English-only content, large files, EOF/whitespace, clang-format, cpplint, Markdown, Ruff, Pyright).

## A3 Fabric coverage
- The real `a3-fabric-v1` backend is covered by repository CI. The two-machine `st-pod-onboard-a2a3` job runs both new examples with their default `--platform a2a3 --comm-profile a3-fabric-v1`; `pod-run-example` injects only the endpoint, device lists and session settings, so the Fabric profile is the one actually exercised.
- Observed on hardware, not inferred from a green check: `[global-tload-mixed-l3] local rank=0 max_diff=0.000e+00` / `remote rank=1 max_diff=0.000e+00`.
- Control plane and data plane are separate here: descriptors are relayed over the TCP control plane, while peer access goes through `aclrtMemFabricHandle` VMM import, so the imported window is read directly by the AICore kernel.
- The `sim` backend still covers the transaction, rollback and mixed local/remote paths in the GitHub-hosted jobs.
