### PR TITLE
Add: rt_available_cluster_count / rt_available_aiv_count orch helpers

### DIFF
--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1147,9 +1147,9 @@ class ChipWorker:
             config: Optional CallConfig. If None, a default is created.
             **kwargs: Overrides applied to config (e.g. ``block_dim=8`` to
                 pin a smaller value than the default). Omit ``block_dim`` (or
-                set it to 0) to have DeviceRunner auto-resolve it to the max
-                the AICore stream allows (``aclrtGetStreamResLimit`` on
-                onboard, ``PLATFORM_MAX_BLOCKDIM`` on sim).
+                set it to 0) to have DeviceRunner auto-resolve it: every
+                cluster the AICore stream reports on onboard
+                (``aclrtGetStreamResLimit``), ``SIM_AUTO_BLOCKDIM`` on sim.
 
         Returns ``None``. Per-stage run timing is emitted as ``[STRACE]`` log
         markers by the platform — see ``docs/dfx/host-trace.md``.

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -195,7 +195,9 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // Latch this run's diagnostic enables onto the runner before the collector
     // paths below read them; block_dim/aicpu_thread_num are consumed locally.
     apply_call_config(config);
-    int block_dim = config.block_dim;
+    // prepare_launch_shape() resolved block_dim before the graph was built, so
+    // the geometry this run launches with is already on the runner.
+    const int block_dim = block_dim_;
     const int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade into
@@ -224,8 +226,10 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
 
     ensure_device_wall_buffer();
 
-    block_dim = resolve_block_dim(block_dim);
-    if (block_dim < 0) return -1;
+    if (block_dim < 1) {
+        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
+        return -1;
+    }
     int num_aicore = block_dim * cores_per_blockdim_;
 
     // Scope guards for register-address cleanup on all exit paths. Declared
@@ -274,7 +278,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     if (enable_scope_stats_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
 
-    if (prepare_runtime_for_launch(runtime, block_dim, launch_aicpu_num) != 0) return -1;
+    resolve_task_binary_addrs(runtime);
 
     // a2a3 onboard now uses the same host-computed, device-filtered affinity
     // shape as a5. Host probes the AICPU user pool once, chooses the active

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -208,23 +208,13 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
 
 int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     apply_call_config(config);
-    int block_dim = config.block_dim;
+    // prepare_launch_shape() resolved block_dim before the graph was built, so
+    // the geometry this run launches with is already on the runner.
+    const int block_dim = block_dim_;
     const int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
-    if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
-        return -1;
-    }
-
-    // Validate block_dim. Sim has no stream resource query, so the static
-    // platform capacity is the bound. block_dim == 0 is the CallConfig "auto"
-    // sentinel.
-    if (block_dim == 0) {
-        block_dim = PLATFORM_MAX_BLOCKDIM;
-        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
-    }
-    if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
+    if (block_dim < 1) {
+        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
         return -1;
     }
 
@@ -245,19 +235,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         }
     }
 
-    block_dim_ = block_dim;
     int num_aicore = block_dim * cores_per_blockdim_;
-
-    if (num_aicore > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)", num_aicore, RUNTIME_MAX_WORKER);
-        return -1;
-    }
-
-    runtime.set_worker_count(num_aicore);
-    worker_count_ = num_aicore;
-    runtime.set_aicpu_thread_num(launch_aicpu_num);
-
-    int num_aic = block_dim;
     uint32_t enable_profiling_flag = SIMPLER_DFX_FLAG_NONE;
     if (enable_dump_args_) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
@@ -275,14 +253,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     }
     kernel_args_.enable_profiling_flag = enable_profiling_flag;
-
-    Handshake *workers = runtime.get_workers();
-    for (int i = 0; i < num_aicore; i++) {
-        workers[i].aicpu_ready = 0;
-        workers[i].aicore_done = 0;
-        workers[i].task = 0;
-        workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-    }
 
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");
     for (int i = 0; i < runtime.get_task_count(); i++) {
@@ -310,8 +280,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
             return rc;
         }
         // Publish per-core core_type to the collector so the level=1 host
-        // emit path can label lanes without an AICPU record. Sim already set
-        // workers[i].core_type via the (i < num_aic) rule at line ~240.
+        // emit path can label lanes without an AICPU record. prepare_launch_shape
+        // already typed workers[i].core_type (first block_dim cores are AIC).
         std::vector<CoreType> core_types(num_aicore);
         for (int i = 0; i < num_aicore; i++) {
             core_types[i] = runtime.get_workers()[i].core_type;

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -445,11 +445,11 @@ int32_t run_host_orchestration(
         return -1;
     }
 
-    // Install the ops table (host s_runtime_ops). The SPMD core counts are
-    // re-applied with the real device values on the AICPU at boot; the values
-    // here only feed cluster spreading during this host submit and are unused
-    // by the migrated non-cluster examples.
-    runtime_finalize_after_wire(rt, /*aic*/ 24, /*aiv*/ 48);
+    // Install the ops table (host s_runtime_ops) and latch the this-run cluster
+    // counts from worker_count (the driver-reported core count) so host-orch
+    // sees the real value. The AICPU re-derives the same counts at boot.
+    int32_t wc = runtime->get_worker_count();
+    runtime_finalize_after_wire(rt, wc / 3, (wc * 2) / 3);
     rt->mode = PTO2_MODE_EXECUTE;
     // get_tensor_data/set_tensor_data dereference buffer.addr directly: the
     // input tensors were mapped into host address space at staging time

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -445,11 +445,18 @@ int32_t run_host_orchestration(
         return -1;
     }
 
-    // Install the ops table (host s_runtime_ops) and latch the this-run cluster
-    // counts from worker_count (the driver-reported core count) so host-orch
-    // sees the real value. The AICPU re-derives the same counts at boot.
-    int32_t wc = runtime->get_worker_count();
-    runtime_finalize_after_wire(rt, wc / 3, (wc * 2) / 3);
+    // Install the ops table (host s_runtime_ops) and latch this run's cluster
+    // counts. worker_count is published by DeviceRunner::prepare_launch_shape
+    // before this bind, so the host orchestrator sees the same geometry the
+    // AICPU re-derives from the handshake at boot.
+    const int32_t block_dim = runtime->get_worker_count() / PLATFORM_CORES_PER_BLOCKDIM;
+    if (block_dim < 1) {
+        LOG_ERROR("host-orch: worker_count %d yields no clusters", runtime->get_worker_count());
+        return -1;
+    }
+    runtime_finalize_after_wire(
+        rt, block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM, block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM
+    );
     rt->mode = PTO2_MODE_EXECUTE;
     // get_tensor_data/set_tensor_data dereference buffer.addr directly: the
     // input tensors were mapped into host address space at staging time

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -87,6 +87,11 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
+    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // (one AIC each) and standalone AIV cores.
+    int32_t (*available_cluster_count)(PTO2Runtime *rt);
+    int32_t (*available_aiv_count)(PTO2Runtime *rt);
+
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
@@ -223,6 +228,18 @@ static inline void rt_scope_end() {
 static inline void rt_orchestration_done() {
     PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
+}
+
+/** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
+static inline int32_t rt_available_cluster_count() {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->available_cluster_count(rt);
+}
+
+/** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
+static inline int32_t rt_available_aiv_count() {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -284,6 +284,9 @@ void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, cons
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
+static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
+static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
+
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
@@ -299,6 +302,8 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
     .submit_dummy_task = submit_dummy_task_impl,
+    .available_cluster_count = available_cluster_count_impl,
+    .available_aiv_count = available_aiv_count_impl,
 #if SIMPLER_DFX
     .scope_set_site = scope_set_site_impl,
 #else

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -89,6 +89,11 @@ struct PTO2RuntimeOps {
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
+
+    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // (one AIC each) and standalone AIV cores.
+    int32_t (*available_cluster_count)(PTO2Runtime *rt);
+    int32_t (*available_aiv_count)(PTO2Runtime *rt);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -660,11 +660,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 // Fill ops / core counts (host can't resolve s_runtime_ops's
                 // device address nor know the SchedulerContext's core fan-out).
-                // Core counts come from cores_total_num_ (fixed 1 AIC : 2 AIV
-                // cluster ratio). On the decoupled path aic_count()/aiv_count() are
-                // not populated until after this SM reset, so they cannot be read here.
-                int32_t spike_total = sched_ctx_.cores_total_num();
-                runtime_finalize_after_wire(rt, spike_total / 3, (spike_total * 2) / 3);
+                // aic_count()/aiv_count() carry the handshake-derived cluster
+                // count: cores_total_num_/3 on the fixed 1:2 blocked layout, or
+                // the core-type-classified count post_handshake_init produces on
+                // the serial path.
+                runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
 #if SIMPLER_DFX
                 rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level();
                 {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -87,6 +87,9 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
+    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    int32_t (*available_cluster_count)(PTO2Runtime *rt);
+
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
@@ -223,6 +226,12 @@ static inline void rt_scope_end() {
 static inline void rt_orchestration_done() {
     PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
+}
+
+/** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
+static inline int32_t rt_available_cluster_count() {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->available_cluster_count(rt);
 }
 
 static inline bool rt_is_fatal() {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -87,8 +87,10 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
-    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
+    int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -232,6 +234,12 @@ static inline void rt_orchestration_done() {
 static inline int32_t rt_available_cluster_count() {
     PTO2Runtime *rt = current_runtime();
     return rt->ops->available_cluster_count(rt);
+}
+
+/** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
+static inline int32_t rt_available_aiv_count() {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -258,6 +258,8 @@ void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, cons
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
+static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
+
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
@@ -273,6 +275,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
     .submit_dummy_task = submit_dummy_task_impl,
+    .available_cluster_count = available_cluster_count_impl,
 #if SIMPLER_DFX
     .scope_set_site = scope_set_site_impl,
 #else

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -259,6 +259,7 @@ static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pe
 #endif
 
 static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
+static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
@@ -276,6 +277,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .alloc_tensors = alloc_tensors_impl,
     .submit_dummy_task = submit_dummy_task_impl,
     .available_cluster_count = available_cluster_count_impl,
+    .available_aiv_count = available_aiv_count_impl,
 #if SIMPLER_DFX
     .scope_set_site = scope_set_site_impl,
 #else

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -89,6 +89,10 @@ struct PTO2RuntimeOps {
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
+
+    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    int32_t (*available_cluster_count)(PTO2Runtime *rt);
+
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -90,8 +90,10 @@ struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
-    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
+    int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1127,8 +1127,9 @@ int32_t SchedulerContext::pre_handshake_init(
     // ratio makes these exact pre-handshake, so scheduler threads can self-assign
     // their owned clusters (assign_own_clusters) without the post-handshake
     // discovery pass and its all-thread barrier.
-    aic_count_ = cores_total_num_ / 3;
-    aiv_count_ = (cores_total_num_ * 2) / 3;
+    const int32_t cluster_num = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
+    aic_count_ = cluster_num * PLATFORM_AIC_CORES_PER_BLOCKDIM;
+    aiv_count_ = cluster_num * PLATFORM_AIV_CORES_PER_BLOCKDIM;
     active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
     handshake_failed_.store(false, std::memory_order_release);
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -153,7 +153,9 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // Latch this run's diagnostic enables onto the runner before the collector
     // paths below read them; block_dim/aicpu_thread_num are consumed locally.
     apply_call_config(config);
-    int block_dim = config.block_dim;
+    // prepare_launch_shape() resolved block_dim before the graph was built, so
+    // the geometry this run launches with is already on the runner.
+    const int block_dim = block_dim_;
     const int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade
@@ -182,8 +184,10 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
 
     ensure_device_wall_buffer();
 
-    block_dim = resolve_block_dim(block_dim);
-    if (block_dim < 0) return -1;
+    if (block_dim < 1) {
+        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
+        return -1;
+    }
     int num_aicore = block_dim * cores_per_blockdim_;
 
     rc = init_aicore_register_addresses(&kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_);
@@ -201,7 +205,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     if (enable_scope_stats_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
 
-    if (prepare_runtime_for_launch(runtime, block_dim, launch_aicpu_num) != 0) return -1;
+    resolve_task_binary_addrs(runtime);
 
     // a5-specific: probe the AICPU topology + compute ALLOWED_CPUS for the
     // filter-style gate (see src/common/platform/onboard/aicpu/

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -214,20 +214,13 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
 
 int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     apply_call_config(config);
-    int block_dim = config.block_dim;
+    // prepare_launch_shape() resolved block_dim before the graph was built, so
+    // the geometry this run launches with is already on the runner.
+    const int block_dim = block_dim_;
     const int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
-    if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
-        return -1;
-    }
-
-    if (block_dim == 0) {
-        block_dim = PLATFORM_MAX_BLOCKDIM;
-        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
-    }
-    if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
+    if (block_dim < 1) {
+        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
         return -1;
     }
 
@@ -245,19 +238,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         }
     }
 
-    block_dim_ = block_dim;
     int num_aicore = block_dim * cores_per_blockdim_;
-
-    if (num_aicore > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)", num_aicore, RUNTIME_MAX_WORKER);
-        return -1;
-    }
-
-    runtime.set_worker_count(num_aicore);
-    worker_count_ = num_aicore;
-    runtime.set_aicpu_thread_num(launch_aicpu_num);
-
-    int num_aic = block_dim;
     uint32_t enable_profiling_flag = SIMPLER_DFX_FLAG_NONE;
     if (enable_dump_args_) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
@@ -275,13 +256,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     }
 
-    Handshake *workers = runtime.get_workers();
-    for (int i = 0; i < num_aicore; i++) {
-        workers[i].aicpu_ready = 0;
-        workers[i].aicore_done = 0;
-        workers[i].task = 0;
-        workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-    }
     kernel_args_.enable_profiling_flag = enable_profiling_flag;
 
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -657,11 +657,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 // Fill ops / core counts (host can't resolve s_runtime_ops's
                 // device address nor know the SchedulerContext's core fan-out).
-                // Core counts come from cores_total_num_ (fixed 1 AIC : 2 AIV
-                // cluster ratio). On the decoupled path aic_count()/aiv_count() are
-                // not populated until after this SM reset, so they cannot be read here.
-                int32_t spike_total = sched_ctx_.cores_total_num();
-                runtime_finalize_after_wire(rt, spike_total / 3, (spike_total * 2) / 3);
+                // aic_count()/aiv_count() carry the handshake-derived cluster
+                // count: cores_total_num_/3 on the fixed 1:2 blocked layout, or
+                // the core-type-classified count post_handshake_init produces on
+                // the serial path.
+                runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
 
 #if SIMPLER_DFX
                 rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level();

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -87,6 +87,9 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
+    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    int32_t (*available_cluster_count)(PTO2Runtime *rt);
+
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
@@ -223,6 +226,12 @@ static inline void rt_scope_end() {
 static inline void rt_orchestration_done() {
     PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
+}
+
+/** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
+static inline int32_t rt_available_cluster_count() {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->available_cluster_count(rt);
 }
 
 static inline bool rt_is_fatal() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -87,8 +87,10 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
-    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
+    int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -232,6 +234,12 @@ static inline void rt_orchestration_done() {
 static inline int32_t rt_available_cluster_count() {
     PTO2Runtime *rt = current_runtime();
     return rt->ops->available_cluster_count(rt);
+}
+
+/** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
+static inline int32_t rt_available_aiv_count() {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -258,6 +258,8 @@ void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, cons
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
+static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
+
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
@@ -273,6 +275,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
     .submit_dummy_task = submit_dummy_task_impl,
+    .available_cluster_count = available_cluster_count_impl,
 #if SIMPLER_DFX
     .scope_set_site = scope_set_site_impl,
 #else

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -259,6 +259,7 @@ static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pe
 #endif
 
 static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
+static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
@@ -276,6 +277,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .alloc_tensors = alloc_tensors_impl,
     .submit_dummy_task = submit_dummy_task_impl,
     .available_cluster_count = available_cluster_count_impl,
+    .available_aiv_count = available_aiv_count_impl,
 #if SIMPLER_DFX
     .scope_set_site = scope_set_site_impl,
 #else

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -90,6 +90,9 @@ struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
+    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    int32_t (*available_cluster_count)(PTO2Runtime *rt);
+
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present to keep ops-table layout stable across
     // SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -90,8 +90,10 @@ struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
-    // This-run MIX cluster (= AIC) count from runtime_finalize_after_wire.
+    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
+    int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present to keep ops-table layout stable across

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1123,8 +1123,9 @@ int32_t SchedulerContext::pre_handshake_init(
     // ratio makes these exact pre-handshake, so scheduler threads can self-assign
     // their owned clusters (assign_own_clusters) without the post-handshake
     // discovery pass and its all-thread barrier.
-    aic_count_ = cores_total_num_ / 3;
-    aiv_count_ = (cores_total_num_ * 2) / 3;
+    const int32_t cluster_num = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
+    aic_count_ = cluster_num * PLATFORM_AIC_CORES_PER_BLOCKDIM;
+    aiv_count_ = cluster_num * PLATFORM_AIV_CORES_PER_BLOCKDIM;
     active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
     handshake_failed_.store(false, std::memory_order_release);
 

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -590,6 +590,17 @@ int simpler_run(
         // runtime state — the shared g_host_api table (built once at load time)
         // is passed explicitly into the runtime impls rather than stored on
         // `Runtime` or reassembled per run.
+        // Core geometry first: a host-side orchestrator runs to completion
+        // inside the bind below, and reads worker_count to size its cluster
+        // spreading. Resolving after the bind would hand it the zeros a fresh
+        // Runtime carries.
+        rc = runner->prepare_launch_shape(*r, *config);
+        if (rc != 0) {
+            r->set_gm_sm_ptr(nullptr);
+            int validation_rc = validate_runtime_impl(r, &g_host_api, rc);
+            return validation_rc != 0 ? validation_rc : rc;
+        }
+
         {
             STRACE("simpler_run.bind");
             // One-step bind: restore kernel addrs + active_callable_id and run

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -392,6 +392,16 @@ int DeviceRunnerBase::ensure_device_initialized() {
         LOG_INFO_V0("DeviceRunner: device=%d set, streams created", device_id_);
     }
 
+    // Latch the AICore stream's block_dim ceiling. resolve_block_dim() is then
+    // pure arithmetic and can run before any per-run stream work.
+    if (max_block_dim_ == 0) {
+        max_block_dim_ = query_max_block_dim(stream_aicore_, &max_cube_cores_, &max_vector_cores_);
+        LOG_INFO_V0(
+            "DeviceRunner: device=%d max_block_dim=%d (cube=%u, vector=%u)", device_id_, max_block_dim_,
+            max_cube_cores_, max_vector_cores_
+        );
+    }
+
     rc = ensure_binaries_loaded();
     if (rc != 0) return rc;
 
@@ -523,30 +533,6 @@ int DeviceRunnerBase::query_max_block_dim(rtStream_t stream, uint32_t *out_cube,
         return std::min(from_stream, PLATFORM_MAX_BLOCKDIM);
     }
     return PLATFORM_MAX_BLOCKDIM;
-}
-
-int DeviceRunnerBase::validate_block_dim(rtStream_t stream, int block_dim) {
-    if (block_dim < 1) {
-        LOG_ERROR("block_dim (%d) must be >= 1", block_dim);
-        return -1;
-    }
-    uint32_t cube_limit = 0, vector_limit = 0;
-    int max_bd = query_max_block_dim(stream, &cube_limit, &vector_limit);
-    if (block_dim > max_bd) {
-        if (cube_limit > 0 && vector_limit > 0) {
-            LOG_ERROR(
-                "block_dim (%d) exceeds available cores (max_block_dim=%d, cube=%u, vector=%u)", block_dim, max_bd,
-                cube_limit, vector_limit
-            );
-        } else {
-            LOG_ERROR(
-                "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
-                block_dim, PLATFORM_MAX_BLOCKDIM
-            );
-        }
-        return -1;
-    }
-    return 0;
 }
 
 void DeviceRunnerBase::print_handshake_results() {
@@ -1100,6 +1086,11 @@ int DeviceRunnerBase::finalize_common() {
 
     block_dim_ = 0;
     worker_count_ = 0;
+    // Tied to stream_aicore_, destroyed above: a re-provisioned runner
+    // re-queries rather than trusting the previous stream's limits.
+    max_block_dim_ = 0;
+    max_cube_cores_ = 0;
+    max_vector_cores_ = 0;
     aicore_kernel_binary_.clear();
     cached_gm_heap_size_ = 0;
     cached_gm_sm_size_ = 0;
@@ -1208,28 +1199,42 @@ void DeviceRunnerBase::ensure_device_wall_buffer() {
 }
 
 int DeviceRunnerBase::resolve_block_dim(int requested_block_dim) {
-    // Auto sentinel (block_dim == 0) is resolved directly from
-    // query_max_block_dim; explicit values still go through validate. The
-    // auto branch skips validate so we don't pay the ACL syscalls twice.
-    int resolved = requested_block_dim;
-    if (resolved == 0) {
-        resolved = query_max_block_dim(stream_aicore_);
+    if (max_block_dim_ < 1) {
+        LOG_ERROR("block_dim ceiling not resolved (ensure_device_initialized must run first)");
+        return -1;
+    }
+    // 0 is the CallConfig "auto" sentinel: take the whole device.
+    int resolved = (requested_block_dim == 0) ? max_block_dim_ : requested_block_dim;
+    if (resolved < 1 || resolved > max_block_dim_) {
+        if (max_cube_cores_ > 0 && max_vector_cores_ > 0) {
+            LOG_ERROR(
+                "block_dim (%d) outside [1, %d] available cores (cube=%u, vector=%u)", resolved, max_block_dim_,
+                max_cube_cores_, max_vector_cores_
+            );
+        } else {
+            LOG_ERROR(
+                "aclrtGetStreamResLimit unavailable; block_dim (%d) outside [1, %d] static cap PLATFORM_MAX_BLOCKDIM",
+                resolved, max_block_dim_
+            );
+        }
+        return -1;
+    }
+    if (requested_block_dim == 0) {
         LOG_INFO_V0("block_dim auto-resolved to %d", resolved);
-        if (resolved < 1) {
-            LOG_ERROR("block_dim auto-resolved to invalid value %d", resolved);
-            return -1;
-        }
-    } else {
-        int rc = validate_block_dim(stream_aicore_, resolved);
-        if (rc != 0) {
-            return -1;
-        }
     }
     block_dim_ = resolved;
     return resolved;
 }
 
-int DeviceRunnerBase::prepare_runtime_for_launch(Runtime &runtime, int block_dim, int launch_aicpu_num) {
+int DeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig &config) {
+    if (validate_launch_aicpu_num(config.aicpu_thread_num) != 0) {
+        return -1;
+    }
+    int block_dim = resolve_block_dim(config.block_dim);
+    if (block_dim < 0) {
+        return -1;
+    }
+
     int num_aicore = block_dim * cores_per_blockdim_;
     if (num_aicore > RUNTIME_MAX_WORKER) {
         LOG_ERROR("block_dim (%d) exceeds RUNTIME_MAX_WORKER (%d)", block_dim, RUNTIME_MAX_WORKER);
@@ -1238,7 +1243,7 @@ int DeviceRunnerBase::prepare_runtime_for_launch(Runtime &runtime, int block_dim
 
     runtime.set_worker_count(num_aicore);
     worker_count_ = num_aicore;  // Stored for print_handshake_results in destructor
-    runtime.set_aicpu_thread_num(launch_aicpu_num);
+    runtime.set_aicpu_thread_num(config.aicpu_thread_num);
 
     // First `block_dim` cores are AIC; remaining ~2/3 are AIV.
     int num_aic = block_dim;
@@ -1249,11 +1254,13 @@ int DeviceRunnerBase::prepare_runtime_for_launch(Runtime &runtime, int block_dim
         workers[i].task = 0;
         workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
     }
+    return 0;
+}
 
-    // Set function_bin_addr for all tasks: Runtime::func_id_to_addr_[] stores
-    // a CoreCallable device address; the binary code address is one
-    // compile-time offset further in. The dispatch path then reads
-    // resolved_addr_ from the on-device CoreCallable header.
+void DeviceRunnerBase::resolve_task_binary_addrs(Runtime &runtime) {
+    // Runtime::func_id_to_addr_[] stores a CoreCallable device address; the
+    // binary code address is one compile-time offset further in. The dispatch
+    // path then reads resolved_addr_ from the on-device CoreCallable header.
     LOG_DEBUG("Setting function_bin_addr for Tasks");
     for (int i = 0; i < runtime.get_task_count(); i++) {
         Task *task = runtime.get_task(i);
@@ -1264,7 +1271,6 @@ int DeviceRunnerBase::prepare_runtime_for_launch(Runtime &runtime, int block_dim
         }
     }
     LOG_DEBUG("");
-    return 0;
 }
 
 int DeviceRunnerBase::sync_run_streams() {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -23,7 +23,7 @@
  *     `configure_aicore_op_timeout`, `ensure_device_initialized`,
  *     `ensure_binaries_loaded`, persistent AICPU/AICore streams,
  *     dispatcher/executor bytes, `LoadAicpuOp`, `KernelArgsHelper`.
- *   - block_dim resolution: `query_max_block_dim`, `validate_block_dim`.
+ *   - block_dim resolution: `query_max_block_dim`, `resolve_block_dim`.
  *   - Debug: `print_handshake_results`, `create_thread`.
  *
  * Subclasses (`{a2a3,a5}::DeviceRunner`) add arch-specific state
@@ -366,6 +366,23 @@ public:
     uint64_t callable_hash(int32_t callable_id) const;
 
     /**
+     * Publish this run's core geometry onto `Runtime` before the graph is
+     * built: resolves `block_dim`, derives `num_aicore = block_dim *
+     * cores_per_blockdim_`, range-checks against `RUNTIME_MAX_WORKER`,
+     * publishes `worker_count` / `worker_count_` / `aicpu_thread_num`,
+     * and zero-initializes the handshake worker array with AIC/AIV core
+     * typing (first `block_dim` cores are AIC, remaining are AIV).
+     *
+     * Callers run this before `bind_callable_to_runtime` so a host-side
+     * orchestrator sees the real core count while it submits, rather than
+     * the zeros a freshly constructed `Runtime` carries. Needs
+     * `ensure_device_initialized()` to have latched `max_block_dim_`.
+     *
+     * Returns 0 on success, -1 on a bad `block_dim` / `aicpu_thread_num`.
+     */
+    int prepare_launch_shape(Runtime &runtime, const CallConfig &config);
+
+    /**
      * Replay a previously-registered callable's state onto a fresh Runtime and
      * complete the per-run binding in one step. Writes back kernel addrs and
      * active_callable_id, then calls the runtime's bind_callable_to_runtime_impl
@@ -608,13 +625,6 @@ protected:
      */
     int query_max_block_dim(rtStream_t stream, uint32_t *out_cube = nullptr, uint32_t *out_vector = nullptr);
 
-    /**
-     * Validate block_dim against the stream's CUBE/VECTOR core limits
-     * (via `query_max_block_dim`). Returns 0 if block_dim fits, -1
-     * otherwise (or if block_dim < 1).
-     */
-    int validate_block_dim(rtStream_t stream, int block_dim);
-
     // ---- run() sub-sequence helpers --------------------------------------
     //
     // Each arch's `run()` keeps the heavily-divergent middle (register
@@ -642,10 +652,12 @@ protected:
 
     /**
      * Resolve the caller's `requested_block_dim` into a concrete
-     * block_dim:
-     *  - `requested_block_dim == 0`: auto-resolve from
-     *    `query_max_block_dim(stream_aicore_)`.
-     *  - otherwise: pass through `validate_block_dim`.
+     * block_dim: 0 means "auto", i.e. this device's `max_block_dim_`;
+     * any other value is taken as an explicit request. Either way the
+     * result is range-checked against `max_block_dim_`.
+     *
+     * Pure arithmetic on the cached ceiling — no ACL call, so it is safe
+     * to run at bind time, before any stream work for the run.
      *
      * Returns the resolved block_dim on success, -1 on failure.
      * Updates `block_dim_` on success.
@@ -653,19 +665,12 @@ protected:
     int resolve_block_dim(int requested_block_dim);
 
     /**
-     * Per-run Runtime setup: derives `num_aicore = block_dim *
-     * cores_per_blockdim_`, range-checks against `RUNTIME_MAX_WORKER`,
-     * publishes `worker_count`, `worker_count_`,
-     * `aicpu_thread_num` (via the Runtime accessors), zero-initializes
-     * the handshake
-     * worker array with AIC/AIV core typing (first `block_dim` cores
-     * are AIC, remaining are AIV), and rewrites each task's
-     * `function_bin_addr` from `runtime.get_function_bin_addr(func_id)
-     * + CoreCallable::binary_data_offset()`.
-     *
-     * Returns 0 on success, -1 on `block_dim`-too-large error.
+     * Rewrites each task's `function_bin_addr` from
+     * `runtime.get_function_bin_addr(func_id) +
+     * CoreCallable::binary_data_offset()`. Runs inside `run()`, after the
+     * bind that populates the task table.
      */
-    int prepare_runtime_for_launch(Runtime &runtime, int block_dim, int launch_aicpu_num);
+    void resolve_task_binary_addrs(Runtime &runtime);
 
     /**
      * Wait for both per-Worker streams (AICPU first, then AICore) with
@@ -835,6 +840,15 @@ protected:
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results
+
+    // This device's block_dim ceiling and the raw ACL core limits behind it,
+    // resolved once against the persistent AICore stream in
+    // ensure_device_initialized(). Nothing in this codebase calls
+    // aclrtSetStreamResLimit, so the limits hold for that stream's lifetime;
+    // finalize_common() clears them along with the stream.
+    int max_block_dim_{0};
+    uint32_t max_cube_cores_{0};
+    uint32_t max_vector_cores_{0};
     HostRuntimeTimeoutConfig timeout_config_{PLATFORM_OP_EXECUTE_TIMEOUT_US, PLATFORM_STREAM_SYNC_TIMEOUT_MS};
 
     // Executor binaries — populated once via `set_executors()` during

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -538,7 +538,18 @@ int simpler_run(
         // runtime state — the shared g_host_api table (built once at load time)
         // is passed explicitly into the runtime impls rather than stored on
         // `Runtime` or reassembled per run.
-        int rc;
+        // Core geometry first: a host-side orchestrator runs to completion
+        // inside the bind below, and reads worker_count to size its cluster
+        // spreading. Resolving after the bind would hand it the zeros a fresh
+        // Runtime carries.
+        int rc = runner->prepare_launch_shape(*r, *config);
+        if (rc != 0) {
+            r->set_gm_sm_ptr(nullptr);
+            int validation_rc = validate_runtime_impl(r, &g_host_api, rc);
+            pthread_setspecific(g_runner_key, nullptr);
+            return validation_rc != 0 ? validation_rc : rc;
+        }
+
         {
             STRACE("simpler_run.bind");
             // One-step bind: replay CallableState + run the per-run binding. The

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -243,6 +243,47 @@ int SimDeviceRunnerBase::ensure_device_initialized() {
     return ensure_binaries_loaded();
 }
 
+int SimDeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig &config) {
+    if (config.aicpu_thread_num < 1 || config.aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "launch_aicpu_num (%d) must be in range [1, %d]", config.aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS
+        );
+        return -1;
+    }
+    // 0 is the CallConfig "auto" sentinel. Sim has no stream resource query, so
+    // auto takes SIM_AUTO_BLOCKDIM while an explicit request is bounded only by
+    // the modelled chip.
+    int block_dim = (config.block_dim == 0) ? SIM_AUTO_BLOCKDIM : config.block_dim;
+    if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
+        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
+        return -1;
+    }
+    if (config.block_dim == 0) {
+        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
+    }
+
+    int num_aicore = block_dim * cores_per_blockdim_;
+    if (num_aicore > RUNTIME_MAX_WORKER) {
+        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)", num_aicore, RUNTIME_MAX_WORKER);
+        return -1;
+    }
+
+    block_dim_ = block_dim;
+    runtime.set_worker_count(num_aicore);
+    worker_count_ = num_aicore;
+    runtime.set_aicpu_thread_num(config.aicpu_thread_num);
+
+    // First `block_dim` cores are AIC; remaining ~2/3 are AIV.
+    Handshake *workers = runtime.get_workers();
+    for (int i = 0; i < num_aicore; i++) {
+        workers[i].aicpu_ready = 0;
+        workers[i].aicore_done = 0;
+        workers[i].task = 0;
+        workers[i].core_type = (i < block_dim) ? CoreType::AIC : CoreType::AIV;
+    }
+    return 0;
+}
+
 void *SimDeviceRunnerBase::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
 void SimDeviceRunnerBase::free_tensor(void *dev_ptr) {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -55,6 +55,15 @@
 struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
 struct CallConfig;  // task_interface/call_config.h — per-run config threaded into run()
 
+// Width sim resolves the CallConfig "auto" sentinel to, deliberately below
+// PLATFORM_MAX_BLOCKDIM (24 on a2a3, 36 on a5). The simulator runs one OS
+// thread per AICore, so taking the whole modelled chip would be 72-108 threads
+// per case; under xdist that is several hundred threads for no added coverage.
+// It is not a ceiling: an explicit block_dim is still honoured up to
+// PLATFORM_MAX_BLOCKDIM. Onboard is unaffected — it auto-resolves from the real
+// per-stream core limits.
+constexpr int SIM_AUTO_BLOCKDIM = 8;
+
 class SimDeviceRunnerBase {
 public:
     SimDeviceRunnerBase() :
@@ -129,6 +138,15 @@ public:
         Runtime &runtime, int32_t callable_id, const HostApi *api, const void *orch_args,
         const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
     );
+
+    // Publish this run's core geometry onto `Runtime` before the graph is
+    // built: resolves block_dim (SIM_AUTO_BLOCKDIM on auto), derives num_aicore,
+    // and publishes worker_count / aicpu_thread_num plus the AIC/AIV-typed
+    // handshake array. Callers run this before bind_callable_to_runtime so a
+    // host-side orchestrator sees the real core count while it submits, rather
+    // than the zeros a freshly constructed Runtime carries. Returns 0 on
+    // success, -1 on a bad block_dim / aicpu_thread_num.
+    int prepare_launch_shape(Runtime &runtime, const CallConfig &config);
     uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
     int release_chip_callable_buffer(uint64_t hash);
     int launch_device_register(int32_t callable_id);

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -19,11 +19,13 @@
  * (`l2_swimlane_records.json` / `args_dump/` / `pmu.csv` / `deps.json` /
  * `scope_stats/scope_stats.jsonl`).
  *
- * `block_dim == 0` is a sentinel for "auto" — DeviceRunner resolves it at
- * run() time to the max block_dim the AICore stream allows
- * (aclrtGetStreamResLimit on onboard; PLATFORM_MAX_BLOCKDIM on sim).
- * Any positive value is taken as an explicit cap and validated against
- * the same stream-resource limits.
+ * `block_dim == 0` is a sentinel for "auto": onboard takes every cluster the
+ * AICore stream reports (aclrtGetStreamResLimit, capped by
+ * PLATFORM_MAX_BLOCKDIM); sim takes SIM_AUTO_BLOCKDIM, which is deliberately
+ * narrower than the modelled chip because sim runs one OS thread per AICore.
+ * Any positive value is taken as an explicit request and range-checked against
+ * the same ceiling. DeviceRunner::prepare_launch_shape() resolves this before
+ * the graph is built, so a host-side orchestrator sees the real core count.
  *
  * Lives here (rather than chip_worker.h) so distributed task slot state
  * can store it directly without pulling in the full ChipWorker header

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * available_aicore_counts: surface rt_available_cluster_count() to the host.
+ *
+ * The this-run MIX cluster (= AIC) count is an AICPU-side runtime query, so no
+ * AICore kernel computes it: orchestration reads it through the ops table and
+ * writes it into a single int32 output tensor. A dummy_task stands in as that
+ * tensor's producer so the run has a completable task graph and set_tensor_data
+ * has a producer to wait on; the host then compares the value directly.
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_out = orch_args.tensor(0).ref();
+
+    // dummy_task stands in as ext_out's producer so the run has a completable
+    // task graph and set_tensor_data has a producer to wait on.
+    {
+        L0TaskArgs args;
+        args.add_inout(ext_out);
+        rt_submit_dummy_task(args);
+    }
+
+    int32_t cluster_count = rt_available_cluster_count();
+    LOG_INFO_V0("[available_aicore_counts] rt_available_cluster_count=%d", cluster_count);
+    uint32_t idx[1] = {0};
+    set_tensor_data<int32_t>(ext_out, 1, idx, cluster_count);
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -10,43 +10,79 @@
  */
 
 /**
- * available_aicore_counts: surface rt_available_cluster_count() to the host.
+ * available_aicore_counts: spend the counts rt_available_*_count() reports.
  *
- * The this-run MIX cluster (= AIC) count is an AICPU-side runtime query, so no
- * AICore kernel computes it: orchestration reads it through the ops table and
- * writes it into a single int32 output tensor. A dummy_task stands in as that
- * tensor's producer so the run has a completable task graph and set_tensor_data
- * has a producer to wait on; the host then compares the value directly.
+ * The counts are an AICPU-side runtime query with no host-side equivalent, so
+ * the run is made self-describing rather than compared against a pinned number:
+ * `shape` carries the reported cluster / AIV counts, and a MIX cohort of
+ * exactly `cluster_count` blocks writes its block index into `blocks`. The host
+ * reads the width out of `shape` and checks that many block slots.
+ *
+ * require_sync_start on the cohort is what makes the count falsifiable: the
+ * cohort needs every block co-resident, so an over-reported cluster count trips
+ * the sync-start deadlock guard instead of silently passing.
  */
 
 #include <stdint.h>
 
 #include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
 
+#define FUNC_SPMD_MIX_AIC 0
+#define FUNC_SPMD_MIX_AIV0 1
+#define FUNC_SPMD_MIX_AIV1 2
+
+// PTO2LaunchSpec spells the SPMD block-count setter differently per arch
+// (a5: set_core_num, a2a3: set_block_num) for the same field. Bridge it so this
+// one fixture compiles on both; keyed off the arch's pto_types.h include guard,
+// which pto_orchestration_api.h pulls in transitively.
+static inline void set_block_count(L0TaskArgs &args, int16_t n) {
+#if defined(SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_)
+    args.launch_spec.set_core_num(n);
+#else
+    args.launch_spec.set_block_num(n);
+#endif
+}
+
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
-        .expected_arg_count = 1,
+        .expected_arg_count = 2,
     };
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
-    const Tensor &ext_out = orch_args.tensor(0).ref();
+    const Tensor &blocks = orch_args.tensor(0).ref();
+    const Tensor &shape = orch_args.tensor(1).ref();
 
-    // dummy_task stands in as ext_out's producer so the run has a completable
-    // task graph and set_tensor_data has a producer to wait on.
+    const int32_t cluster_count = rt_available_cluster_count();
+    const int32_t aiv_count = rt_available_aiv_count();
+    LOG_INFO_V0("[available_aicore_counts] clusters=%d aiv=%d", cluster_count, aiv_count);
+
+    MixedKernels mk;
+    mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
+    mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
+    mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
+
+    L0TaskArgs args;
+    args.add_inout(blocks);
+    args.add_scalar(static_cast<int64_t>(0));  // base cache line
+    set_block_count(args, static_cast<int16_t>(cluster_count));
+    args.launch_spec.set_require_sync_start(true);
+    rt_submit_task(mk, args);
+
+    // dummy_task stands in as shape's producer so set_tensor_data has a
+    // producer to wait on.
     {
-        L0TaskArgs args;
-        args.add_inout(ext_out);
-        rt_submit_dummy_task(args);
+        L0TaskArgs shape_args;
+        shape_args.add_inout(shape);
+        rt_submit_dummy_task(shape_args);
     }
-
-    int32_t cluster_count = rt_available_cluster_count();
-    LOG_INFO_V0("[available_aicore_counts] rt_available_cluster_count=%d", cluster_count);
     uint32_t idx[1] = {0};
-    set_tensor_data<int32_t>(ext_out, 1, idx, cluster_count);
+    set_tensor_data<int32_t>(shape, 1, idx, cluster_count);
+    idx[0] = 1;
+    set_tensor_data<int32_t>(shape, 1, idx, aiv_count);
 }
 
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""available_aicore_counts: rt_available_cluster_count() returns the run's AIC cluster count.
+
+The orchestration reads the this-run MIX cluster (= AIC) count through the ops
+table and writes it into a single int32 output tensor; the host compares it
+against the count the a2a3 sim platform exposes. A regression that returns the
+host placeholder, 0, or a stale ratio fails the comparison.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+# a2a3sim exposes a fixed AIC cluster count (cores_total_num / 3); pinned from
+# the value the orchestration surfaces on this platform.
+EXPECTED_AIC_COUNT = 1
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestAvailableAicoreCounts(SceneTestCase):
+    """rt_available_cluster_count() surfaces the this-run AIC cluster count."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/available_aicore_counts_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT],
+        },
+        "incores": [],
+    }
+
+    CASES = [
+        {
+            "name": "Default",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        out = torch.zeros((1,), dtype=torch.int32)
+        return TaskArgsBuilder(Tensor("out", out))
+
+    def compute_golden(self, args, params):
+        args.out[0] = EXPECTED_AIC_COUNT
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -7,12 +7,19 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""available_aicore_counts: rt_available_cluster_count() returns the run's AIC cluster count.
+"""available_aicore_counts: the runtime's core counts are real and spendable.
 
-The orchestration reads the this-run MIX cluster (= AIC) count through the ops
-table and writes it into a single int32 output tensor; the host compares it
-against the count the a2a3 sim platform exposes. A regression that returns the
-host placeholder, 0, or a stale ratio fails the comparison.
+The counts have no host-side equivalent — sim and onboard resolve different
+values, and onboard's comes from the driver — so there is no constant to pin.
+The orchestration instead reports what it saw in `shape` and spends it: a MIX
+cohort of exactly `cluster_count` blocks, each writing its block index into
+`blocks`. This test reads the width back out of `shape` and checks that many
+block slots, so it holds on every platform without knowing any of their numbers.
+
+What would fail: a count of 0 or one exceeding the platform ceiling (checked
+here), a count larger than the run really has (the cohort's require_sync_start
+needs every block co-resident, so the deadlock guard fires on device), and a
+count smaller than it should be (the untouched tail slots stay zero).
 """
 
 import torch
@@ -20,14 +27,17 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 
-# a2a3sim exposes a fixed AIC cluster count (cores_total_num / 3); pinned from
-# the value the orchestration surfaces on this platform.
-EXPECTED_AIC_COUNT = 1
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3
+# Cover the largest cohort the platform can launch (PLATFORM_MAX_BLOCKDIM).
+MAX_CLUSTERS = 24
+AIV_PER_CLUSTER = 2
+TOTAL_CL = MAX_CLUSTERS * SLOTS_PER_BLOCK
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestAvailableAicoreCounts(SceneTestCase):
-    """rt_available_cluster_count() surfaces the this-run AIC cluster count."""
+    """rt_available_cluster_count() / rt_available_aiv_count() report a spendable width."""
 
     RTOL = 0
     ATOL = 0
@@ -36,26 +46,68 @@ class TestAvailableAicoreCounts(SceneTestCase):
         "orchestration": {
             "source": "kernels/orchestration/available_aicore_counts_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
-            "signature": [D.INOUT],
+            "signature": [D.INOUT, D.INOUT],
         },
-        "incores": [],
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SPMD_MIX_AIC",
+                "source": "../spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SPMD_MIX_AIV0",
+                "source": "../spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "SPMD_MIX_AIV1",
+                "source": "../spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
     }
 
     CASES = [
         {
             "name": "Default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]
 
     def generate_args(self, params):
-        out = torch.zeros((1,), dtype=torch.int32)
-        return TaskArgsBuilder(Tensor("out", out))
+        return TaskArgsBuilder(
+            Tensor("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            Tensor("shape", torch.zeros(2, dtype=torch.int32)),
+        )
 
     def compute_golden(self, args, params):
-        args.out[0] = EXPECTED_AIC_COUNT
+        # Both outputs are checked against the reported width in
+        # compare_outputs; nothing here is host-computable.
+        pass
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        clusters = int(test_args.shape[0])
+        aivs = int(test_args.shape[1])
+        assert 1 <= clusters <= MAX_CLUSTERS, f"cluster_count {clusters} outside [1, {MAX_CLUSTERS}]"
+        assert aivs == clusters * AIV_PER_CLUSTER, f"aiv_count {aivs} != {clusters} * {AIV_PER_CLUSTER}"
+
+        blocks = test_args.blocks.reshape(TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        expected = torch.zeros(TOTAL_CL, dtype=torch.float32)
+        for block_idx in range(clusters):
+            for slot in range(SLOTS_PER_BLOCK):
+                expected[block_idx * SLOTS_PER_BLOCK + slot] = float(block_idx)
+        assert torch.equal(blocks, expected), (
+            f"block slots disagree with the reported cluster_count {clusters}: "
+            f"got {blocks.tolist()}, expected {expected.tolist()}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * available_aicore_counts: surface rt_available_cluster_count() to the host.
+ *
+ * The this-run MIX cluster (= AIC) count is an AICPU-side runtime query, so no
+ * AICore kernel computes it: orchestration reads it through the ops table and
+ * writes it into a single int32 output tensor. A dummy_task stands in as that
+ * tensor's producer so the run has a completable task graph and set_tensor_data
+ * has a producer to wait on; the host then compares the value directly.
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_out = orch_args.tensor(0).ref();
+
+    // dummy_task stands in as ext_out's producer so the run has a completable
+    // task graph and set_tensor_data has a producer to wait on.
+    {
+        L0TaskArgs args;
+        args.add_inout(ext_out);
+        rt_submit_dummy_task(args);
+    }
+
+    int32_t cluster_count = rt_available_cluster_count();
+    LOG_INFO_V0("[available_aicore_counts] rt_available_cluster_count=%d", cluster_count);
+    uint32_t idx[1] = {0};
+    set_tensor_data<int32_t>(ext_out, 1, idx, cluster_count);
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -10,43 +10,79 @@
  */
 
 /**
- * available_aicore_counts: surface rt_available_cluster_count() to the host.
+ * available_aicore_counts: spend the counts rt_available_*_count() reports.
  *
- * The this-run MIX cluster (= AIC) count is an AICPU-side runtime query, so no
- * AICore kernel computes it: orchestration reads it through the ops table and
- * writes it into a single int32 output tensor. A dummy_task stands in as that
- * tensor's producer so the run has a completable task graph and set_tensor_data
- * has a producer to wait on; the host then compares the value directly.
+ * The counts are an AICPU-side runtime query with no host-side equivalent, so
+ * the run is made self-describing rather than compared against a pinned number:
+ * `shape` carries the reported cluster / AIV counts, and a MIX cohort of
+ * exactly `cluster_count` blocks writes its block index into `blocks`. The host
+ * reads the width out of `shape` and checks that many block slots.
+ *
+ * require_sync_start on the cohort is what makes the count falsifiable: the
+ * cohort needs every block co-resident, so an over-reported cluster count trips
+ * the sync-start deadlock guard instead of silently passing.
  */
 
 #include <stdint.h>
 
 #include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
 
+#define FUNC_SPMD_MIX_AIC 0
+#define FUNC_SPMD_MIX_AIV0 1
+#define FUNC_SPMD_MIX_AIV1 2
+
+// PTO2LaunchSpec spells the SPMD block-count setter differently per arch
+// (a5: set_core_num, a2a3: set_block_num) for the same field. Bridge it so this
+// one fixture compiles on both; keyed off the arch's pto_types.h include guard,
+// which pto_orchestration_api.h pulls in transitively.
+static inline void set_block_count(L0TaskArgs &args, int16_t n) {
+#if defined(SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_)
+    args.launch_spec.set_core_num(n);
+#else
+    args.launch_spec.set_block_num(n);
+#endif
+}
+
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
-        .expected_arg_count = 1,
+        .expected_arg_count = 2,
     };
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
-    const Tensor &ext_out = orch_args.tensor(0).ref();
+    const Tensor &blocks = orch_args.tensor(0).ref();
+    const Tensor &shape = orch_args.tensor(1).ref();
 
-    // dummy_task stands in as ext_out's producer so the run has a completable
-    // task graph and set_tensor_data has a producer to wait on.
+    const int32_t cluster_count = rt_available_cluster_count();
+    const int32_t aiv_count = rt_available_aiv_count();
+    LOG_INFO_V0("[available_aicore_counts] clusters=%d aiv=%d", cluster_count, aiv_count);
+
+    MixedKernels mk;
+    mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
+    mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
+    mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
+
+    L0TaskArgs args;
+    args.add_inout(blocks);
+    args.add_scalar(static_cast<int64_t>(0));  // base cache line
+    set_block_count(args, static_cast<int16_t>(cluster_count));
+    args.launch_spec.set_require_sync_start(true);
+    rt_submit_task(mk, args);
+
+    // dummy_task stands in as shape's producer so set_tensor_data has a
+    // producer to wait on.
     {
-        L0TaskArgs args;
-        args.add_inout(ext_out);
-        rt_submit_dummy_task(args);
+        L0TaskArgs shape_args;
+        shape_args.add_inout(shape);
+        rt_submit_dummy_task(shape_args);
     }
-
-    int32_t cluster_count = rt_available_cluster_count();
-    LOG_INFO_V0("[available_aicore_counts] rt_available_cluster_count=%d", cluster_count);
     uint32_t idx[1] = {0};
-    set_tensor_data<int32_t>(ext_out, 1, idx, cluster_count);
+    set_tensor_data<int32_t>(shape, 1, idx, cluster_count);
+    idx[0] = 1;
+    set_tensor_data<int32_t>(shape, 1, idx, aiv_count);
 }
 
 }  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""available_aicore_counts: rt_available_cluster_count() returns the run's AIC cluster count.
+
+The orchestration reads the this-run MIX cluster (= AIC) count through the ops
+table and writes it into a single int32 output tensor; the host compares it
+against the count the a5 sim platform exposes. A regression that returns the
+host placeholder, 0, or a stale ratio fails the comparison.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+# a5sim exposes a fixed AIC cluster count (cores_total_num / 3); pinned from
+# the value the orchestration surfaces on this platform.
+EXPECTED_AIC_COUNT = 1
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestAvailableAicoreCounts(SceneTestCase):
+    """rt_available_cluster_count() surfaces the this-run AIC cluster count."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/available_aicore_counts_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT],
+        },
+        "incores": [],
+    }
+
+    CASES = [
+        {
+            "name": "Default",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        out = torch.zeros((1,), dtype=torch.int32)
+        return TaskArgsBuilder(Tensor("out", out))
+
+    def compute_golden(self, args, params):
+        args.out[0] = EXPECTED_AIC_COUNT
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -7,12 +7,19 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""available_aicore_counts: rt_available_cluster_count() returns the run's AIC cluster count.
+"""available_aicore_counts: the runtime's core counts are real and spendable.
 
-The orchestration reads the this-run MIX cluster (= AIC) count through the ops
-table and writes it into a single int32 output tensor; the host compares it
-against the count the a5 sim platform exposes. A regression that returns the
-host placeholder, 0, or a stale ratio fails the comparison.
+The counts have no host-side equivalent — sim and onboard resolve different
+values, and onboard's comes from the driver — so there is no constant to pin.
+The orchestration instead reports what it saw in `shape` and spends it: a MIX
+cohort of exactly `cluster_count` blocks, each writing its block index into
+`blocks`. This test reads the width back out of `shape` and checks that many
+block slots, so it holds on every platform without knowing any of their numbers.
+
+What would fail: a count of 0 or one exceeding the platform ceiling (checked
+here), a count larger than the run really has (the cohort's require_sync_start
+needs every block co-resident, so the deadlock guard fires on device), and a
+count smaller than it should be (the untouched tail slots stay zero).
 """
 
 import torch
@@ -20,14 +27,17 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 
-# a5sim exposes a fixed AIC cluster count (cores_total_num / 3); pinned from
-# the value the orchestration surfaces on this platform.
-EXPECTED_AIC_COUNT = 1
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3
+# Cover the largest cohort the platform can launch (PLATFORM_MAX_BLOCKDIM).
+MAX_CLUSTERS = 36
+AIV_PER_CLUSTER = 2
+TOTAL_CL = MAX_CLUSTERS * SLOTS_PER_BLOCK
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestAvailableAicoreCounts(SceneTestCase):
-    """rt_available_cluster_count() surfaces the this-run AIC cluster count."""
+    """rt_available_cluster_count() / rt_available_aiv_count() report a spendable width."""
 
     RTOL = 0
     ATOL = 0
@@ -36,26 +46,68 @@ class TestAvailableAicoreCounts(SceneTestCase):
         "orchestration": {
             "source": "kernels/orchestration/available_aicore_counts_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
-            "signature": [D.INOUT],
+            "signature": [D.INOUT, D.INOUT],
         },
-        "incores": [],
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SPMD_MIX_AIC",
+                "source": "../spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SPMD_MIX_AIV0",
+                "source": "../spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "SPMD_MIX_AIV1",
+                "source": "../spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
     }
 
     CASES = [
         {
             "name": "Default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]
 
     def generate_args(self, params):
-        out = torch.zeros((1,), dtype=torch.int32)
-        return TaskArgsBuilder(Tensor("out", out))
+        return TaskArgsBuilder(
+            Tensor("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            Tensor("shape", torch.zeros(2, dtype=torch.int32)),
+        )
 
     def compute_golden(self, args, params):
-        args.out[0] = EXPECTED_AIC_COUNT
+        # Both outputs are checked against the reported width in
+        # compare_outputs; nothing here is host-computable.
+        pass
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        clusters = int(test_args.shape[0])
+        aivs = int(test_args.shape[1])
+        assert 1 <= clusters <= MAX_CLUSTERS, f"cluster_count {clusters} outside [1, {MAX_CLUSTERS}]"
+        assert aivs == clusters * AIV_PER_CLUSTER, f"aiv_count {aivs} != {clusters} * {AIV_PER_CLUSTER}"
+
+        blocks = test_args.blocks.reshape(TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        expected = torch.zeros(TOTAL_CL, dtype=torch.float32)
+        for block_idx in range(clusters):
+            for slot in range(SLOTS_PER_BLOCK):
+                expected[block_idx * SLOTS_PER_BLOCK + slot] = float(block_idx)
+        assert torch.equal(blocks, expected), (
+            f"block slots disagree with the reported cluster_count {clusters}: "
+            f"got {blocks.tolist()}, expected {expected.tolist()}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Orchestration had no way to ask how many clusters the current run actually has,
so MIX / AIV cohorts hardcoded 24 or 36. This exposes the counts the runtime
already latches in `runtime_finalize_after_wire` through the ops table:

```cpp
int32_t clusters = rt_available_cluster_count();  // MIX clusters (one AIC each)
int32_t aivs     = rt_available_aiv_count();      // standalone AIV cores
```

Available on `tensormap_and_ringbuffer` (a2a3, a5) and `host_build_graph` (a2a3).

## Why the host path had to change first

`host_build_graph`'s orchestrator runs **on the host**, inside
`bind_callable_to_runtime`. But `worker_count` was not published until
`prepare_runtime_for_launch`, one step later in `run()`:

```text
new (runtime) Runtime()      → worker_count = 0
bind_callable_to_runtime()   → host orchestration runs here, reads worker_count ← 0
run()                        → resolve_block_dim() → set_worker_count()
```

So host orchestration read 0. That silently disabled the `require_sync_start`
`block_num` deadlock guard, whose only consumer treats a limit of 0 as
"unknown, skip" — no in-repo hbg case uses `require_sync_start` today, so CI
stayed green while the check was off.

The fix is to resolve the geometry before the graph is built. The expensive
part is the device query, so that gets cached once:

- `DeviceRunner` latches the AICore stream's block_dim ceiling in
  `ensure_device_initialized()`. Nothing in the codebase calls
  `aclrtSetStreamResLimit`, so the limits hold for that stream's lifetime;
  `finalize_common()` clears them alongside the stream.
- `resolve_block_dim()` becomes pure arithmetic on that ceiling, so the auto
  and explicit branches share one range check instead of the auto branch
  skipping validation to save an ACL round trip.
- The core-geometry half of `prepare_runtime_for_launch` splits out as
  `prepare_launch_shape()` and runs before the bind; the task-address half
  stays in `run()` as `resolve_task_binary_addrs()`, where the task table
  exists.

The move is a **no-op for `tensormap_and_ringbuffer`**:
`src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp` is the only
bind-time reader of `worker_count` in the tree.

## Also in this change

- **Sim auto width.** Sim resolves the `block_dim == 0` sentinel to
  `SIM_AUTO_BLOCKDIM` (8) instead of the modelled chip's full width. Sim runs
  one OS thread per AICore, so 24 / 36 clusters is 72-108 threads per case for
  no added coverage. It is **not** a ceiling — an explicit `block_dim` is still
  honoured up to `PLATFORM_MAX_BLOCKDIM`, so the 178 cases that pin a value
  today are unaffected.
- **No more `/3`.** Cluster counts derive from
  `PLATFORM_{AIC,AIV}_CORES_PER_BLOCKDIM` instead of open-coded `/ 3` and
  `* 2 / 3` in the two scheduler cold paths and on the host.

## Test

The scene test **spends** the counts rather than pinning them — there is no
constant to pin, since sim and onboard resolve different values and onboard's
comes from the driver. The orchestration reports what it saw in one tensor and
launches a MIX cohort of exactly `cluster_count` blocks, each writing its block
index into another; the host reads the width back out and checks that many
slots (via the `compare_outputs` hook from #1470).

What would fail:

| Defect | Caught by |
| ------ | --------- |
| count is 0 or exceeds the platform ceiling | host range check |
| count larger than the run really has | cohort's `require_sync_start` needs every block co-resident → deadlock guard fires on device |
| count smaller than it should be | untouched tail slots stay zero |

## Verification

| Suite | Result |
| ----- | ------ |
| `pytest examples tests/st --platform a2a3sim` | 58/58 cases |
| `pytest examples tests/st --platform a5sim` | 43/43 cases |
| `pytest examples tests/st --platform a2a3` (onboard, task-submit) | 54/54 cases |
| `pytest tests/ut -m "not requires_hardware"` | 803 passed |
| `ctest` C++ unit tests | 60/60 |
| pre-commit (all hooks) | passed |

Confirmed on a2a3sim that the sim auto width takes effect and is really spent:

```text
prepare_launch_shape: block_dim auto-resolved to 8
run: Launching 24 AICore thread(s)          # was 72
aicpu_orchestration_entry: [available_aicore_counts] clusters=8 aiv=16
```

One earlier onboard full-suite run had two `allreduce` L3 cases fail with an
AICore `ub address out of bounds`; it did not reproduce (10/10 in isolation,
54/54 on an immediate re-run) and cannot come from this change, since those
cases run on `tensormap_and_ringbuffer` whose bind path never reads
`worker_count`. Logged locally rather than dismissed.

## Follow-up

This is the groundwork for removing the user-specified `block_dim` entirely, so
runs always take the whole device and SPMD cohorts size themselves from
`rt_available_cluster_count()`. That flips the 178 pinned cases and reworks the
`require_sync_start` cases — see #1309.