### PR TITLE
Refactor: separate A2/A3 device launch and reap

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -432,6 +432,24 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
 
+    rc = launch_run(runtime, num_aicore, launch_aicpu_num);
+    if (rc != 0) return rc;
+
+    rc = reap_run();
+    if (rc != 0) return rc;
+
+    // Print handshake results (reads from device memory, must be before free)
+    print_handshake_results();
+
+    return 0;
+}
+
+int DeviceRunner::launch_run(Runtime &runtime, int num_aicore, int launch_aicpu_num) {
+    // KernelLaunch is the pipeline boundary: this method clears the handshake
+    // consumed by the launch and submits exactly the AICore and AICPU kernels.
+    // It intentionally performs no stream synchronization or per-run cleanup.
+    int rc = 0;
+
     // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
     // so the two arches stay symmetric. First-launch latency optimization +
     // op-timeout-family defense-in-depth: with the AICPU Run task launched first
@@ -478,7 +496,11 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         return rc;
     }
 
-    rc = sync_run_streams();
+    return 0;
+}
+
+int DeviceRunner::reap_run() {
+    int rc = sync_run_streams();
     if (rc != 0) {
         // sync_run_streams surfaces the AICore op-timeout (STARS-reaped op ->
         // 507000/507018/507046 at AICPU/AICore stream sync). The op-timeout
@@ -516,9 +538,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
             }
         }
     }
-
-    // Print handshake results (reads from device memory, must be before free)
-    print_handshake_results();
 
     return 0;
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -97,8 +97,8 @@ public:
      * 1. Initializes device if not already done (lazy initialization)
      * 2. Initializes worker handshake buffers in the runtime based on block_dim
      * 3. Transfers runtime to device memory
-     * 4. Launches AICPU main kernel
-     * 5. Launches AICore kernel
+     * 4. Launches AICore kernel
+     * 5. Launches AICPU main kernel
      * 6. Synchronizes streams
      * 7. Cleans up runtime memory
      *
@@ -218,6 +218,11 @@ private:
     // force_reset_device()). This flag fails run() fast and drives that
     // recovery. See run() and recover_device_or_mark_unusable().
     bool device_unusable_{false};
+
+    // Keep the kernel submission boundary separate from stream synchronization
+    // and teardown. run() still invokes these back-to-back in this change.
+    int launch_run(Runtime &runtime, int num_aicore, int launch_aicpu_num);
+    int reap_run();
 
     // On an AICore launch/sync error, best-effort drain the device so a later
     // run() on the same DeviceRunner can recover in place; if the drain itself


### PR DESCRIPTION
## Summary

- split the A2/A3 onboard `DeviceRunner::run()` kernel submission boundary into `launch_run()`
- move stream synchronization, device-error recovery, profiling export, and timing collection into `reap_run()`
- keep `run()` strictly synchronous as `launch_run()` followed immediately by `reap_run()`
- correct the `run()` step list, which named the AICPU kernel before the AICore kernel while the launch has submitted AICore first
- do not add ACK states, resource banks, background reaping, or execution overlap

This is behavior-equivalent groundwork: the effective statement sequence, every
error return code, and every recovery action are unchanged — including the
collector teardown on the sync-failure path and `print_handshake_results()` on
the success path only. `reap_run()` deliberately takes no arguments and reads
only members, so a later change can defer it without re-splitting its inputs.

## Series context

Part of the worker async-preparation series, following #1459 (per-run identity
and completion fence) and #1460 (`Worker.submit` and run handles), both merged.
Asynchronous reaping, resource banks and device overlap come later.

## Validation

- changed-file pre-commit hooks: passed
- A2/A3 onboard `libhost_runtime.so` rebuilt for both `host_build_graph` and
  `tensormap_and_ringbuffer` — the real compile check, since this code is
  onboard-only
- C++ unit tests: 60/60 passed
- Python unit tests: 821 passed, 2 skipped

Neither unit-test suite exercises the onboard `DeviceRunner` path, so the
onboard CI job is the meaningful check. The A2/A3 hardware runs quoted in
earlier revisions were against a commit that is no longer in this branch's
history and have not been re-run.