### PR TITLE
Update: extend codestyle rules and sync commit-message guidance

### DIFF
--- a/.claude/rules/codestyle.md
+++ b/.claude/rules/codestyle.md
@@ -1,6 +1,17 @@
 # Codestyle Rules
 
-1. **Avoid plan specific comments** such as Phase 1, Step 1, or Gap #3 which reflect planning details but don't aid code comprehension.
+1. **Avoid plan-specific and process-narrative comments.** Do not write
+   comments that describe the planning or the editing process rather than
+   the code as it now stands — neither plan markers (`Phase 1`, `Step 1`,
+   `Gap #3`) nor narration of the change that produced the line (`now uses
+   the engine`, `removed the barrier`, `previously wmb'd`, `was 16384
+   before`). A comment must state a present-tense fact about the code; see
+   [comments.md](comments.md) for the full WHAT-not-history rule.
+
+   **The same applies to commit messages.** A commit message describes what
+   the change does and why it is correct — not the plan or step sequence
+   that produced it. No `Phase 1 / Step 2 / Gap #3` framing, no "first did
+   X, then changed to Y" working-process narration.
 2. Use `enum class` preferentially for basic enumeration usage. Use `enum` only when implementing bitmask patterns or when bitwise operations are required.
 
     **Good:**
@@ -40,3 +51,43 @@
    trying to observe* and looks like a runtime hang. Gate any diagnostic to a
    high-water-mark (log only on a new max), a sample interval, or the
    cold/stall path — never unconditionally per iteration.
+
+8. **Host code is C++; the host–device boundary is C/POD.** Host-side code
+   (everything running on the host CPU — `src/{arch}/**/host/`, host-side
+   runtime maker / orchestration, `simpler_setup/`, and the Python-adjacent
+   tooling) must be written in modern C++, not C style. Use the STL
+   (`std::vector`, `std::string`, `std::optional`, RAII, algorithms) to
+   express intent; do not hand-roll C idioms where a standard facility
+   exists. **Do not size fixed / static arrays to a worst case** — allocate
+   to the actual size with a container. A multi-MB global dimensioned by a
+   `MAX_*` constant is a defect, not a safety margin.
+
+   The host↔device boundary is the sole exception, and it goes the other
+   way: anything copied to the device, placed in shared memory, or uploaded
+   (task descriptors, graph/definition images, ring/SM structs) must use **C
+   data types in POD, contiguous storage** — trivially `memcpy`-able and
+   position-independent. **Intra-image references must be offsets or indices
+   from a block base, never raw pointers**: a wire struct has to survive a
+   single `memcpy` to the device with zero pointer fix-up, so a `T*` that
+   points inside the image is a defect even inside an otherwise trivially
+   copyable struct (an absolute device address is acceptable only as an
+   integer-typed field, not a host pointer). Back each wire struct with a
+   compile-time guard — `static_assert(std::is_trivially_copyable_v<T> &&
+   std::is_standard_layout_v<T>)` — as done for the device-copied structs in
+   `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h`. Keep the
+   rich C++/STL representation host-only and compact it into the POD wire
+   form at the boundary.
+
+9. **`PTO2` is a legacy prefix — do not propagate it.** New code must not
+   introduce the `PTO2` prefix on any identifier — types, functions,
+   variables, macros, or file names; it is historical and carries no
+   meaning. When you modify internal legacy code that uses it, remove the
+   prefix as part of the change (rename the variable / macro / type / file)
+   rather than leaving a mixed `PTO2Foo` / `Foo` surface behind, replacing
+   the disambiguation it provided with **clear names or a `namespace`**.
+   **Exempt externally-consumed names** where a blind rename would break a
+   contract — public API, ABI / linked symbols, serialized or on-wire names,
+   include paths, and host↔device struct layouts — unless you also ship a
+   compatibility alias or a full migration. The ban on *new* `PTO2`
+   identifiers is unconditional; removal of *existing* ones is scoped to
+   what can be renamed safely.

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -57,6 +57,12 @@ git diff --staged  # Review before committing
 
 Separate from subject by a blank line. Explain **what** changed and **why**. Use bullet points for multiple items. Wrap at 72 characters.
 
+Describe what the change does and why it is correct — **not** the plan or
+step sequence that produced it. No `Phase 1 / Step 2 / Gap #3` framing and no
+"first did X, then changed to Y" working-process narration (see
+[`codestyle.md`](../../rules/codestyle.md) §1, which applies the same ban to
+comments and commit messages).
+
 **When to include a body**:
 
 - Changes touch 3+ files
@@ -105,6 +111,11 @@ x  fix bug                         # Lowercase type
 x  WIP                             # Not descriptive
 x  Chore: update gitignore         # Invalid type
 x  Support: update stuff           # Vague, no body for multi-file change
+```
+
+```text
+x  Add: graph exec — Phase 1 record, Step 2 replay, Gap #3 fixed
+                                    # Plan/process framing: say what+why, not the steps
 ```
 
 ## Co-Author Policy


### PR DESCRIPTION
## Summary

Documentation-only change to `.claude/` conventions. No code touched.

- **codestyle §1** now forbids process-narrative comments (`now uses the
  engine`, `removed the barrier`, `was 16384 before`) in addition to plan
  markers (`Phase 1 / Step 1 / Gap #3`), and applies the same ban to commit
  messages. Cross-references `comments.md` for the full WHAT-not-history rule.
- **codestyle §8 (new)**: host-side code is modern C++/STL with no
  worst-case static arrays; the host↔device boundary is the sole exception
  and stays C/POD contiguous storage, preferring offsets over pointers so a
  single `memcpy` relocates an image with no pointer fix-up.
- **codestyle §9 (new)**: the legacy `PTO2` prefix must not be propagated to
  new identifiers; remove it when touching related legacy code.
- **git-commit skill**: mirrors the §1 commit-message ban with a bad example
  so it is visible at message-writing time.

## Why

These fill gaps the existing rules did not cover — host-side code style, the
POD-at-the-boundary contract, and prefix hygiene — and keep the comment /
commit-message guidance consistent across `comments.md`, `codestyle.md`, and
the `git-commit` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)