### PR TITLE
Fix: correct the MD013 claim in doc-consistency rule

### DIFF
--- a/.claude/rules/doc-consistency.md
+++ b/.claude/rules/doc-consistency.md
@@ -67,9 +67,11 @@ comment on the load-bearing line.
 
 ## 6. Keep docs maintainable — length and structure
 
-Line length is already enforced by `markdownlint-cli2` (MD013, 80 cols) via
-pre-commit. The rules below are the file-level counterparts that tooling
-cannot enforce for you.
+Markdown style is checked by `markdownlint-cli2` via pre-commit, configured in
+[`tests/lint/.markdownlint.yaml`](../../tests/lint/.markdownlint.yaml). Note
+that line length (MD013) is **disabled** there — keep lines readable by
+convention, but no tool will fail the commit for a long one. The rules below
+are the file-level counterparts that tooling cannot enforce for you.
 
 - **Soft size target.** Past roughly **300 lines** or **5 H2 sections**,
   the reader has to scroll to orient. Treat that as a trigger to split or


### PR DESCRIPTION
## Summary

`.claude/rules/doc-consistency.md` §6 opened with:

> Line length is already enforced by `markdownlint-cli2` (MD013, 80 cols) via pre-commit.

That is not true: `tests/lint/.markdownlint.yaml` — the config the pre-commit
hook is pointed at — sets `MD013: false`, so no hook fails a long line.

The text now names the config file, states that MD013 is disabled, and keeps
readable line length as a convention rather than a tool-enforced rule.

## Why

The stale claim is the exact failure mode §1 of this same rule warns about — a
doc that was true once and now disagrees with the config. It misleads anyone
sizing a docs change (it prompted a needless reflow while writing a design doc),
and it undersells the checks that *are* enforced (MD024 siblings-only, MD060
table style).

Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)