### PR TITLE
Add FP8/FP4 MX dtype support in task_interface

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -587,7 +587,10 @@ NB_MODULE(_task_interface, m) {
         .value("INT64", DataType::INT64)
         .value("UINT64", DataType::UINT64)
         .value("UINT16", DataType::UINT16)
-        .value("UINT32", DataType::UINT32);
+        .value("UINT32", DataType::UINT32)
+        .value("FP8E4M3FN", DataType::FP8E4M3FN)  // A5 only
+        .value("FP8E8M0", DataType::FP8E8M0)      // A5 only
+        .value("FP4E2M1", DataType::FP4E2M1);     // A5 only
 
     // --- Free functions ---
     m.def(

--- a/simpler_setup/goldens/mx_fp_gemm.py
+++ b/simpler_setup/goldens/mx_fp_gemm.py
@@ -1,0 +1,259 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Golden helpers for a5 ``mx_fp_gemm`` ST / MX FP8/FP4 UT decode.
+
+MXFP8 matmul golden follows pto-isa ``tmatmul_mx/gen_data.py`` and pypto2
+``test_matmul_mx.py``: per-block E8M0 scales (factor 32 along K), ZZ/NN GM packing
+for ``TMATMUL_MX``, then FP32 matmul of dequantized A/B.
+
+Pure torch (no numpy) — CI torch CPU wheels do not pull numpy.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+
+def decode_e4m3fn(byte: int) -> float:
+    """Decode one IEEE-style E4M3FN byte (bias=7, no Inf; exp=15 → NaN)."""
+    b = int(byte) & 0xFF
+    sign = (b >> 7) & 1
+    exp = (b >> 3) & 0xF
+    mant = b & 0x7
+    if exp == 0:
+        val = 0.0 if mant == 0 else (mant / 8.0) * (2.0 ** (1 - 7))
+    elif exp == 0xF:
+        return math.nan
+    else:
+        val = (1.0 + mant / 8.0) * (2.0 ** (exp - 7))
+    return -val if sign else val
+
+
+def decode_e2m1(nibble: int) -> float:
+    """Decode one E2M1 nibble (OCP MXFP4; bias=1)."""
+    n = int(nibble) & 0xF
+    sign = (n >> 3) & 1
+    exp = (n >> 1) & 0x3
+    mant = n & 0x1
+    if exp == 0:
+        val = 0.0 if mant == 0 else 0.5
+    else:
+        val = (1.0 + 0.5 * mant) * (2.0 ** (exp - 1))
+    return -val if sign else val
+
+
+def decode_e8m0(byte: int) -> float:
+    """Decode one E8M0 shared-exponent byte as ``2**(x - 127)`` (OCP MX scale)."""
+    return math.ldexp(1.0, (int(byte) & 0xFF) - 127)
+
+
+def fp8_e4m3fn_to_float32(t: torch.Tensor) -> torch.Tensor:
+    """Bit-exact E4M3FN → float32 (matches ``t.to(torch.float32)`` for finite values)."""
+    bits = t.contiguous().view(torch.uint8).reshape(-1)
+    out = torch.empty(bits.numel(), dtype=torch.float32)
+    for i, b in enumerate(bits.tolist()):
+        out[i] = decode_e4m3fn(b)
+    return out.view(t.shape)
+
+
+def fp4_e2m1_x2_to_float32(t: torch.Tensor) -> torch.Tensor:
+    """Unpack ``float4_e2m1fn_x2`` → float32 with last dim expanded ×2 (lo nibble first)."""
+    bits = t.contiguous().view(torch.uint8)
+    flat = bits.reshape(-1)
+    out = torch.empty(flat.numel() * 2, dtype=torch.float32)
+    for i, b in enumerate(flat.tolist()):
+        out[2 * i] = decode_e2m1(b & 0xF)
+        out[2 * i + 1] = decode_e2m1((b >> 4) & 0xF)
+    shape = list(t.shape)
+    shape[-1] = shape[-1] * 2
+    return out.view(*shape)
+
+
+def convert_x1_scale_format(x1_mx_gm: torch.Tensor, block_size: int = 16, c0_size_mx: int = 2) -> torch.Tensor:
+    """Pack A-side E8M0 scales to MX_A_ZZ GM layout (pto-isa gen_data)."""
+    m, k = x1_mx_gm.shape
+    pad_m = (block_size - m % block_size) % block_size
+    pad_k = (c0_size_mx - k % c0_size_mx) % c0_size_mx
+    if pad_m > 0 or pad_k > 0:
+        # F.pad pads last dim first: (left, right, top, bottom)
+        padded = F.pad(x1_mx_gm, (0, pad_k, 0, pad_m), value=0)
+    else:
+        padded = x1_mx_gm
+    m_padded = m + pad_m
+    k_padded = k + pad_k
+    x1_scale_gm = padded.reshape(m_padded // block_size, block_size, k_padded // c0_size_mx, c0_size_mx)
+    x1_scale_gm = x1_scale_gm.permute(0, 2, 1, 3)
+    return x1_scale_gm.reshape(
+        x1_scale_gm.shape[0] * x1_scale_gm.shape[1],
+        x1_scale_gm.shape[2] * x1_scale_gm.shape[3],
+    )
+
+
+def convert_x2_scale_format(x2_mx_gm: torch.Tensor, block_size: int = 16, c0_size_mx: int = 2) -> torch.Tensor:
+    """Pack B-side E8M0 scales to MX_B_NN GM layout (pto-isa gen_data)."""
+    k, n = x2_mx_gm.shape
+    pad_n = (block_size - n % block_size) % block_size
+    pad_k = (c0_size_mx - k % c0_size_mx) % c0_size_mx
+    if pad_n > 0 or pad_k > 0:
+        padded = F.pad(x2_mx_gm, (0, pad_n, 0, pad_k), value=0)
+    else:
+        padded = x2_mx_gm
+    k_padded, n_padded = padded.shape
+    x2_scale_gm = padded.reshape(k_padded // c0_size_mx, c0_size_mx, n_padded // 16, 16).permute(2, 0, 3, 1)
+    return x2_scale_gm.reshape(
+        x2_scale_gm.shape[1] * x2_scale_gm.shape[3],
+        x2_scale_gm.shape[0] * x2_scale_gm.shape[2],
+    )
+
+
+def _u8_e8m0_to_torch(buf: torch.Tensor, logical_shape: tuple[int, int]) -> torch.Tensor:
+    """View ZZ/NN-packed uint8 E8M0 bytes as torch.float8_e8m0fnu with logical shape."""
+    flat = buf.contiguous().reshape(-1).to(torch.uint8)
+    assert flat.numel() == logical_shape[0] * logical_shape[1]
+    return flat.clone().view(torch.float8_e8m0fnu).reshape(logical_shape)
+
+
+def mx_fp8_matmul_golden(
+    a_fp8: torch.Tensor,
+    b_fp8: torch.Tensor,
+    a_scale_u8: torch.Tensor,
+    b_scale_u8: torch.Tensor,
+) -> torch.Tensor:
+    """Dequant A/B with block E8M0 scales (factor 32 along K), then FP32 matmul.
+
+    ``a_scale_u8`` is logical ``[M, ceil(K/32)]``, ``b_scale_u8`` is ``[ceil(K/32), N]``
+    (before ZZ/NN packing). Matches pto-isa ``gen_golden_data`` for MXFP8.
+    """
+    _m, k = a_fp8.shape
+    k2, _n = b_fp8.shape
+    assert k == k2
+    a_mx = torch.pow(2.0, a_scale_u8.to(torch.float64) - 127)  # [M, KMX]
+    b_mx = torch.pow(2.0, b_scale_u8.to(torch.float64) - 127)  # [KMX, N]
+    k_idx = torch.arange(k) // 32
+    a_scaled = a_fp8.to(torch.float64) * a_mx[:, k_idx]
+    b_scaled = b_fp8.to(torch.float64) * b_mx[k_idx, :]
+    return torch.matmul(a_scaled, b_scaled).to(torch.float32)
+
+
+def make_mx_fp8_case(m: int = 128, k: int = 64, n: int = 64, seed: int = 19):
+    """Build host-prequant MXFP8 tensors + golden for ``TMATMUL_MX`` ST.
+
+    Returns ``(a, a_s, b, b_s, c, expected)`` where ``a_s``/``b_s`` are ZZ/NN-packed
+    ``float8_e8m0fnu`` with logical shapes ``[M, K/32]`` / ``[K/32, N]``.
+    """
+    if not hasattr(torch, "float8_e4m3fn") or not hasattr(torch, "float8_e8m0fnu"):
+        raise RuntimeError("torch.float8_e4m3fn / float8_e8m0fnu required")
+    assert k % 64 == 0, "K must be multiple of 64 for single-tile MX sample"
+    kmx = k // 32
+    torch.manual_seed(seed)
+    a = torch.randint(-10, 10, (m, k), dtype=torch.int64).to(torch.float32).to(torch.float8_e4m3fn)
+    b = torch.randint(-10, 10, (k, n), dtype=torch.int64).to(torch.float32).to(torch.float8_e4m3fn)
+    a_scale_u8 = torch.randint(127, 130, (m, kmx), dtype=torch.int64).to(torch.uint8)
+    b_scale_u8 = torch.randint(127, 130, (kmx, n), dtype=torch.int64).to(torch.uint8)
+    expected = mx_fp8_matmul_golden(a, b, a_scale_u8, b_scale_u8)
+    a_s = _u8_e8m0_to_torch(convert_x1_scale_format(a_scale_u8), (m, kmx))
+    b_s = _u8_e8m0_to_torch(convert_x2_scale_format(b_scale_u8), (kmx, n))
+    c = torch.zeros((m, n), dtype=torch.float32)
+    return a, a_s, b, b_s, c, expected
+
+
+def pack_two_fp4(nibble_matrix: torch.Tensor) -> torch.Tensor:
+    """Pack adjacent E2M1 nibble codes along the last dim (pto-isa ``pack_two_fp4``).
+
+    Even index → lo nibble, odd → hi nibble. ``nibble_matrix`` is uint8 ``[R, C]``
+    with C even; returns uint8 ``[R, C/2]``.
+    """
+    rows, cols = nibble_matrix.shape
+    assert cols % 2 == 0
+    flat = nibble_matrix.contiguous().to(torch.uint8).reshape(-1)
+    high = flat[::2] & 0x0F
+    low = (flat[1::2] & 0x0F) << 4
+    return (low | high).reshape(rows, cols // 2)
+
+
+def _fp4_logical_to_torch_x2(logical_u8: torch.Tensor) -> torch.Tensor:
+    """``[R, C]`` nibble codes → torch ``float4_e2m1fn_x2`` with shape ``[R, C/2]``."""
+    packed = pack_two_fp4(logical_u8).contiguous()
+    return packed.view(torch.float4_e2m1fn_x2)
+
+
+def mx_fp4_matmul_golden(
+    a_fp4_x2: torch.Tensor,
+    b_fp4_x2: torch.Tensor,
+    a_scale_u8: torch.Tensor,
+    b_scale_u8: torch.Tensor,
+) -> torch.Tensor:
+    """Dequant packed MXFP4 A/B (pto-isa last-dim packing) with E8M0 scales, then FP32 matmul.
+
+    ``a_fp4_x2`` is ``[M, K/2]``, ``b_fp4_x2`` is ``[K, N/2]`` (pack along last dim).
+    Scales are logical ``[M, K/32]`` / ``[K/32, N]``.
+    """
+    a_f = fp4_e2m1_x2_to_float32(a_fp4_x2).to(torch.float64)  # [M, K]
+    b_f = fp4_e2m1_x2_to_float32(b_fp4_x2).to(torch.float64)  # [K, N]
+    _m, k = a_f.shape
+    k2, _n = b_f.shape
+    assert k == k2
+    a_mx = torch.pow(2.0, a_scale_u8.to(torch.float64) - 127)
+    b_mx = torch.pow(2.0, b_scale_u8.to(torch.float64) - 127)
+    k_idx = torch.arange(k) // 32
+    a_scaled = a_f * a_mx[:, k_idx]
+    b_scaled = b_f * b_mx[k_idx, :]
+    return torch.matmul(a_scaled, b_scaled).to(torch.float32)
+
+
+def make_mx_fp4_case(m: int = 128, k: int = 64, n: int = 64, seed: int = 19):
+    """Build host-prequant MXFP4 tensors + golden for ``TMATMUL_MX`` ST.
+
+    A/B follow pto-isa packing: logical ``[M,K]``/``[K,N]`` E2M1 → torch
+    ``float4_e2m1fn_x2`` of shapes ``[M, K/2]`` / ``[K, N/2]``.
+    """
+    if not hasattr(torch, "float4_e2m1fn_x2") or not hasattr(torch, "float8_e8m0fnu"):
+        raise RuntimeError("torch.float4_e2m1fn_x2 / float8_e8m0fnu required")
+    assert k % 64 == 0 and n % 64 == 0, "K/N must be multiples of 64 for MXFP4 sample"
+    kmx = k // 32
+    torch.manual_seed(seed)
+    # Logical nibble codes in a small finite set (matches pto-isa e2m1 range).
+    a_logical = torch.randint(0, 8, (m, k), dtype=torch.int64).to(torch.uint8)
+    b_logical = torch.randint(0, 8, (k, n), dtype=torch.int64).to(torch.uint8)
+    a = _fp4_logical_to_torch_x2(a_logical)
+    b = _fp4_logical_to_torch_x2(b_logical)
+    a_scale_u8 = torch.randint(127, 130, (m, kmx), dtype=torch.int64).to(torch.uint8)
+    b_scale_u8 = torch.randint(127, 130, (kmx, n), dtype=torch.int64).to(torch.uint8)
+    expected = mx_fp4_matmul_golden(a, b, a_scale_u8, b_scale_u8)
+    a_s = _u8_e8m0_to_torch(convert_x1_scale_format(a_scale_u8), (m, kmx))
+    b_s = _u8_e8m0_to_torch(convert_x2_scale_format(b_scale_u8), (kmx, n))
+    c = torch.zeros((m, n), dtype=torch.float32)
+    return a, a_s, b, b_s, c, expected
+
+
+def fp8_matmul_golden(a_fp8: torch.Tensor, b_fp8: torch.Tensor) -> torch.Tensor:
+    """``(A_fp8 → f32) @ (B_fp8 → f32)`` (no MX scales; UT helper)."""
+    return torch.matmul(a_fp8.to(torch.float32), b_fp8.to(torch.float32))
+
+
+def fp4_matmul_golden(a_fp4_x2: torch.Tensor, b_fp4_x2: torch.Tensor) -> torch.Tensor:
+    """Unpack packed FP4 A/B along the contracting dim, then matmul in float32.
+
+    ``a_fp4_x2`` has shape ``[M, K_pack]`` (each element = 2 E2M1 along K),
+    ``b_fp4_x2`` has shape ``[K_pack, N]`` (each element = 2 E2M1 along K).
+    Logical GEMM is ``[M, 2*K_pack] @ [2*K_pack, N]``.
+    """
+    a = fp4_e2m1_x2_to_float32(a_fp4_x2)  # [M, 2*K_pack]
+    b_bits = b_fp4_x2.contiguous().view(torch.uint8)
+    k_pack, n = b_bits.shape
+    b = torch.empty(k_pack * 2, n, dtype=torch.float32)
+    for kp in range(k_pack):
+        for j in range(n):
+            byte = int(b_bits[kp, j].item())
+            b[2 * kp, j] = decode_e2m1(byte & 0xF)
+            b[2 * kp + 1, j] = decode_e2m1((byte >> 4) & 0xF)
+    return torch.matmul(a, b)

--- a/simpler_setup/torch_interop.py
+++ b/simpler_setup/torch_interop.py
@@ -57,6 +57,19 @@ def _ensure_torch_map():
         torch.uint16: DataType.UINT16,
         torch.uint32: DataType.UINT32,
     }
+    # MX low-precision dtypes — A5 only (consumed by the A5-only pto.tquant.mx /
+    # tmatmul.mx ops). MX paths use E4M3FN (+ E8M0 scale) and packed E2M1;
+    # FP8E5M2 is not registered. float8_e4m3fn needs torch >= 2.1;
+    # float8_e8m0fnu needs >= 2.7; float4_e2m1fn_x2 needs a recent torch.
+    # Guard with getattr so an older torch silently skips the ones it lacks.
+    for _torch_dt_name, _sim_dt in (
+        ("float8_e4m3fn", DataType.FP8E4M3FN),  # A5 only
+        ("float8_e8m0fnu", DataType.FP8E8M0),  # A5 only
+        ("float4_e2m1fn_x2", DataType.FP4E2M1),  # A5 only
+    ):
+        _torch_dt = getattr(torch, _torch_dt_name, None)
+        if _torch_dt is not None:
+            _TORCH_DTYPE_MAP[_torch_dt] = _sim_dt
 
 
 def torch_dtype_to_datatype(dt) -> DataType:

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -44,6 +44,12 @@ enum class DataType : uint8_t {
     UINT16,    // 2 bytes
     UINT32,    // 4 bytes
     BOOL,      // 1 byte (stored as 1/0 in uint64_t slot)
+    // MX block-scale dtypes — A5 only (consumed by the A5-only pto.tquant.mx /
+    // tmatmul.mx ops). Host transfer itself is arch-agnostic (1 byte/element).
+    // FP8E5M2 is intentionally omitted: MX paths use E4M3FN (+ E8M0 scale), not E5M2.
+    FP8E4M3FN,  // 1 byte — MXFP8 E4M3FN (A5 only)
+    FP8E8M0,    // 1 byte — MXFP8 E8M0 shared exponent (A5 only)
+    FP4E2M1,    // 1 byte — MXFP4 E2M1, 2 values packed (torch float4_e2m1fn_x2) (A5 only)
     DATA_TYPE_NUM,
 };
 
@@ -70,6 +76,9 @@ inline uint64_t get_element_size(DataType dtype) {
         2,  // DataType::UINT16
         4,  // DataType::UINT32
         1,  // DataType::BOOL
+        1,  // DataType::FP8E4M3FN (A5 only)
+        1,  // DataType::FP8E8M0 (A5 only)
+        1,  // DataType::FP4E2M1 (A5 only)
     };
     return data_type_size[static_cast<int>(dtype)];
 }
@@ -106,6 +115,12 @@ inline const char *get_dtype_name(DataType dtype) {
         return "UINT32";
     case DataType::BOOL:
         return "BOOL";
+    case DataType::FP8E4M3FN:  // A5 only
+        return "FP8E4M3FN";
+    case DataType::FP8E8M0:  // A5 only
+        return "FP8E8M0";
+    case DataType::FP4E2M1:  // A5 only
+        return "FP4E2M1";
     default:
         return "UNKNOWN";
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/aic/kernel_fp_gemm.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/aic/kernel_fp_gemm.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * MXFP8 / MXFP4 matmul via pto-isa ``TMATMUL_MX`` (A5 Cube, onboard only).
+ *
+ * Fixed tile: M=128, K=64, N=64 (K aligned to 64; scale K = K/32 = 2).
+ * mode (args[5]):
+ *   0 — MXFP8: A/B float8_e4m3 [M,K]/[K,N]; As/Bs float8_e8m0 ZZ/NN
+ *   1 — MXFP4: A/B float4_e2m1x2 packed GM (logical [M,K]/[K,N]); same scales
+ *
+ * Pattern mirrors pto-isa ``tmatmul_mx_kernel.cpp`` RunTMATMULMX (no bias).
+ * a5sim is not supported: CPU stub TLOAD lacks MX_A_ZZ / MX_B_NN.
+ *
+ * Args: [A, As, B, Bs, C, mode]
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+#include <pto/npu/a5/utils.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#include "pipe_sync.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+template <typename T>
+AICORE constexpr inline T CeilDiv(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2;
+}
+
+template <typename AType, typename BType, int validM, int validK, int validN, bool isFp4>
+static __aicore__ void matmul_mx_impl(
+    __gm__ AType *src0, __gm__ float8_e8m0_t *src2, __gm__ BType *src1, __gm__ float8_e8m0_t *src3, __gm__ float *out
+) {
+    constexpr int blockAlign = isFp4 ? 64 : 32;
+    constexpr int M = CeilAlign<int>(validM, 16);
+    constexpr int kAlign = CeilAlign<int>(validK, 64);
+    constexpr int N = CeilAlign<int>(validN, blockAlign);
+    constexpr uint8_t kMX = CeilDiv(kAlign, 32);
+
+    using ScaleType = float8_e8m0_t;
+    using OutType = float;
+
+    using GlobalDataSrc0 = GlobalTensor<
+        AType, pto::Shape<1, 1, 1, validM, validK>,
+        pto::Stride<1 * validM * validK, 1 * validM * validK, validM * validK, validK, 1>>;
+    using GlobalDataSrc1 = GlobalTensor<
+        BType, pto::Shape<1, 1, 1, validK, validN>,
+        pto::Stride<1 * validK * validN, 1 * validK * validN, validK * validN, validN, 1>>;
+
+    using MxShapeA = TileShape2D<ScaleType, M, kMX, Layout::MX_A_ZZ>;
+    using MxStrideA = BaseShape2D<ScaleType, M, kMX, Layout::MX_A_ZZ>;
+    using GlobalDataSrc2 = GlobalTensor<ScaleType, MxShapeA, MxStrideA, Layout::MX_A_ZZ>;
+
+    using MxShapeB = TileShape2D<ScaleType, kMX, N, Layout::MX_B_NN>;
+    using MxStrideB = BaseShape2D<ScaleType, kMX, N, Layout::MX_B_NN>;
+    using GlobalDataSrc3 = GlobalTensor<ScaleType, MxShapeB, MxStrideB, Layout::MX_B_NN>;
+
+    using GlobalDataOut = GlobalTensor<
+        OutType, pto::Shape<1, 1, 1, validM, validN>,
+        pto::Stride<1 * validM * validN, 1 * validM * validN, validM * validN, validN, 1>>;
+
+    GlobalDataSrc0 src0Global(src0);
+    GlobalDataSrc1 src1Global(src1);
+    GlobalDataSrc2 src2Global(src2);
+    GlobalDataSrc3 src3Global(src3);
+    GlobalDataOut dstGlobal(out);
+
+    using TileMatAData =
+        Tile<TileType::Mat, AType, M, kAlign, BLayout::ColMajor, validM, validK, SLayout::RowMajor, 512>;
+    using TileMatBData =
+        Tile<TileType::Mat, BType, kAlign, N, BLayout::ColMajor, validK, validN, SLayout::RowMajor, 512>;
+    using TileScaleAData =
+        Tile<TileType::Mat, ScaleType, M, kMX, BLayout::RowMajor, validM, kMX, SLayout::RowMajor, 32>;
+    using TileScaleBData =
+        Tile<TileType::Mat, ScaleType, kMX, N, BLayout::ColMajor, kMX, validN, SLayout::ColMajor, 32>;
+
+    using LeftTile = TileLeft<AType, M, kAlign, validM, kAlign>;
+    using RightTile = TileRight<BType, kAlign, N, kAlign, validN>;
+    using LeftScaleTile = TileLeftScale<ScaleType, M, kMX, validM, kMX>;
+    using RightScaleTile = TileRightScale<ScaleType, kMX, N, kMX, validN>;
+    using AccTile = TileAcc<OutType, M, N, validM, validN>;
+
+    TileMatAData aMatTile;
+    TileMatBData bMatTile;
+    TileScaleAData aScaleMatTile;
+    TileScaleBData bScaleMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, M * kAlign);
+    TASSIGN(aScaleMatTile, M * kAlign + kAlign * N);
+    TASSIGN(bScaleMatTile, M * kAlign + kAlign * N + M * kMX);
+
+    LeftTile aTile;
+    RightTile bTile;
+    LeftScaleTile aScaleTile;
+    RightScaleTile bScaleTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    uint64_t scaleAAddr = pto::GetScaleAddr(aTile.data());
+    uint64_t scaleBAddr = pto::GetScaleAddr(bTile.data());
+    TASSIGN(aScaleTile, scaleAAddr);
+    TASSIGN(bScaleTile, scaleBAddr);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+    if constexpr (kAlign - validK >= blockAlign) {
+        TFILLPAD(aMatTile, aMatTile);
+    }
+    TFILLPAD(bMatTile, bMatTile);
+
+    TLOAD<TileScaleAData, GlobalDataSrc2>(aScaleMatTile, src2Global);
+    TLOAD<TileScaleBData, GlobalDataSrc3>(bScaleMatTile, src3Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+    TMOV(aScaleTile, aScaleMatTile);
+    TMOV(bScaleTile, bScaleMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL_MX(cTile, aTile, aScaleTile, bTile, bScaleTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+    pipe_sync();
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *a_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *as_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *b_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *bs_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *c_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    const int mode = static_cast<int>(args[5]);
+
+    __gm__ float8_e8m0_t *as =
+        reinterpret_cast<__gm__ float8_e8m0_t *>(as_tensor->buffer.addr) + as_tensor->start_offset;
+    __gm__ float8_e8m0_t *bs =
+        reinterpret_cast<__gm__ float8_e8m0_t *>(bs_tensor->buffer.addr) + bs_tensor->start_offset;
+    __gm__ float *c = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+
+    if (mode == 0) {
+        __gm__ float8_e4m3_t *a =
+            reinterpret_cast<__gm__ float8_e4m3_t *>(a_tensor->buffer.addr) + a_tensor->start_offset;
+        __gm__ float8_e4m3_t *b =
+            reinterpret_cast<__gm__ float8_e4m3_t *>(b_tensor->buffer.addr) + b_tensor->start_offset;
+        matmul_mx_impl<float8_e4m3_t, float8_e4m3_t, 128, 64, 64, false>(a, as, b, bs, c);
+    } else {
+        __gm__ float4_e2m1x2_t *a =
+            reinterpret_cast<__gm__ float4_e2m1x2_t *>(a_tensor->buffer.addr) + a_tensor->start_offset;
+        __gm__ float4_e2m1x2_t *b =
+            reinterpret_cast<__gm__ float4_e2m1x2_t *>(b_tensor->buffer.addr) + b_tensor->start_offset;
+        matmul_mx_impl<float4_e2m1x2_t, float4_e2m1x2_t, 128, 64, 64, true>(a, as, b, bs, c);
+    }
+}

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/orchestration/mx_fp_gemm_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/orchestration/mx_fp_gemm_orch.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * MXFP8 / MXFP4 ``TMATMUL_MX`` orchestration.
+ *
+ * L2 args: [A, As, B, Bs, C, mode]
+ *   mode 0 = MXFP8 (FP8E4M3FN + E8M0), mode 1 = MXFP4 (FP4E2M1x2 + E8M0)
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_MATMUL_MX 0
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 6,  // A, As, B, Bs, C, mode
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_a = orch_args.tensor(0).ref();
+    const Tensor &ext_as = orch_args.tensor(1).ref();
+    const Tensor &ext_b = orch_args.tensor(2).ref();
+    const Tensor &ext_bs = orch_args.tensor(3).ref();
+    const Tensor &ext_c = orch_args.tensor(4).ref();
+    const uint64_t mode = orch_args.scalar(0);
+
+    LOG_INFO_V0(
+        "[mx_fp_gemm_orch] TMATMUL_MX mode=%llu A=%s As=%s B=%s Bs=%s C=%s", static_cast<unsigned long long>(mode),
+        get_dtype_name(ext_a.dtype), get_dtype_name(ext_as.dtype), get_dtype_name(ext_b.dtype),
+        get_dtype_name(ext_bs.dtype), get_dtype_name(ext_c.dtype)
+    );
+
+    PTO2_SCOPE() {
+        L0TaskArgs args;
+        args.add_input(ext_a);
+        args.add_input(ext_as);
+        args.add_input(ext_b);
+        args.add_input(ext_bs);
+        args.add_output(ext_c);
+        args.add_scalar(mode);
+        rt_submit_aic_task(FUNC_MATMUL_MX, args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/test_mx_fp_gemm.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/test_mx_fp_gemm.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""mx_fp_gemm: A5 MXFP8/MXFP4 ``TMATMUL_MX`` ST via task interface (onboard only).
+
+Device AIC kernel calls pto-isa ``TMATMUL_MX`` (not scalar MAC). Host inputs +
+golden follow pto-isa ``tmatmul_mx`` host-prequant sample:
+  M=128, K=64, N=64; scales=FP8E8M0 (ZZ/NN); C=FP32
+  mode 0: A/B = FP8E4M3FN
+  mode 1: A/B = FP4E2M1x2 (last-dim packed; A [M,K/2], B [K,N/2])
+
+a5sim is omitted: CPU stub TLOAD does not support MX_A_ZZ / MX_B_NN layouts.
+"""
+
+import pytest
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.goldens.mx_fp_gemm import make_mx_fp4_case, make_mx_fp8_case
+
+M, K, N = 128, 64, 64
+RTOL = 1e-3
+ATOL = 1e-3
+
+
+def _cases():
+    cases = []
+    if hasattr(torch, "float8_e4m3fn") and hasattr(torch, "float8_e8m0fnu"):
+        cases.append(
+            {
+                "name": "MXFP8_TMATMUL_MX",
+                "platforms": ["a5"],
+                "config": {"aicpu_thread_num": 2, "block_dim": 1},
+                "params": {"mode": 0},
+            }
+        )
+    if hasattr(torch, "float4_e2m1fn_x2") and hasattr(torch, "float8_e8m0fnu"):
+        cases.append(
+            {
+                "name": "MXFP4_TMATMUL_MX",
+                "platforms": ["a5"],
+                "config": {"aicpu_thread_num": 2, "block_dim": 1},
+                "params": {"mode": 1},
+            }
+        )
+    return cases
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestMxFpGemm(SceneTestCase):
+    """Host-prequant MXFP8/MXFP4 → A5 ``TMATMUL_MX`` numerical check."""
+
+    RTOL = RTOL
+    ATOL = ATOL
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/mx_fp_gemm_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "MATMUL_MX",
+                "source": "kernels/aic/kernel_fp_gemm.cpp",
+                "core_type": "aic",
+            },
+        ],
+    }
+
+    CASES = _cases()
+
+    def generate_args(self, params):
+        mode = int(params["mode"])
+        if mode == 0:
+            if not (hasattr(torch, "float8_e4m3fn") and hasattr(torch, "float8_e8m0fnu")):
+                pytest.skip("torch.float8_e4m3fn / float8_e8m0fnu required")
+            a, a_s, b, b_s, c, _ = make_mx_fp8_case(M, K, N)
+        else:
+            if not (hasattr(torch, "float4_e2m1fn_x2") and hasattr(torch, "float8_e8m0fnu")):
+                pytest.skip("torch.float4_e2m1fn_x2 / float8_e8m0fnu required")
+            a, a_s, b, b_s, c, _ = make_mx_fp4_case(M, K, N)
+        return TaskArgsBuilder(
+            Tensor("A", a.reshape(-1)),
+            Tensor("As", a_s.reshape(-1)),
+            Tensor("B", b.reshape(-1)),
+            Tensor("Bs", b_s.reshape(-1)),
+            Tensor("C", c.reshape(-1)),
+            Scalar("mode", mode),
+        )
+
+    def compute_golden(self, args, params):
+        mode = int(params["mode"])
+        if mode == 0:
+            _a, _as, _b, _bs, _c, expected = make_mx_fp8_case(M, K, N)
+        else:
+            _a, _as, _b, _bs, _c, expected = make_mx_fp4_case(M, K, N)
+        args.C[:] = expected.reshape(-1)
+
+
+if __name__ == "__main__":
+    if not TestMxFpGemm.CASES:
+        raise SystemExit("Need torch MX dtypes (float8_e4m3fn/float4_e2m1fn_x2 + float8_e8m0fnu)")
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/py/test_mx_fp_numeric.py
+++ b/tests/ut/py/test_mx_fp_numeric.py
@@ -1,0 +1,200 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Unit tests: MX FP8/FP4 decode + small-matmul numerical correctness (host)."""
+
+import math
+
+import pytest
+import torch
+
+from simpler_setup.goldens.mx_fp_gemm import (
+    convert_x1_scale_format,
+    convert_x2_scale_format,
+    decode_e2m1,
+    decode_e4m3fn,
+    decode_e8m0,
+    fp4_e2m1_x2_to_float32,
+    fp4_matmul_golden,
+    fp8_e4m3fn_to_float32,
+    fp8_matmul_golden,
+    make_mx_fp4_case,
+    make_mx_fp8_case,
+    mx_fp4_matmul_golden,
+    mx_fp8_matmul_golden,
+    pack_two_fp4,
+)
+from simpler_setup.torch_interop import make_tensor_arg
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="torch.float8_e4m3fn required")
+class TestFp8E4m3Numeric:
+    def test_decode_matches_torch_cast(self):
+        torch.manual_seed(0)
+        src = torch.randn(64)
+        fp8 = src.to(torch.float8_e4m3fn)
+        ref = fp8.to(torch.float32)
+        got = fp8_e4m3fn_to_float32(fp8)
+        finite = torch.isfinite(ref) & torch.isfinite(got)
+        assert torch.allclose(ref[finite], got[finite], rtol=0, atol=0)
+        assert torch.equal(torch.isnan(ref), torch.isnan(got))
+
+    def test_all_bytes_finite_or_nan(self):
+        for b in range(256):
+            v = decode_e4m3fn(b)
+            assert math.isnan(v) or math.isfinite(v)
+
+    def test_matmul_matches_torch(self):
+        torch.manual_seed(1)
+        a = torch.randn(8, 8).to(torch.float8_e4m3fn)
+        b = torch.randn(8, 8).to(torch.float8_e4m3fn)
+        golden = fp8_matmul_golden(a, b)
+        ref = torch.matmul(a.to(torch.float32), b.to(torch.float32))
+        assert torch.allclose(golden, ref, rtol=0, atol=0)
+
+    def test_make_tensor_arg_preserves_bytes_for_matmul(self):
+        torch.manual_seed(2)
+        a = torch.randn(4, 4).to(torch.float8_e4m3fn).contiguous()
+        b = torch.randn(4, 4).to(torch.float8_e4m3fn).contiguous()
+        arg_a = make_tensor_arg(a)
+        arg_b = make_tensor_arg(b)
+        assert arg_a.nbytes() == a.nbytes
+        assert arg_b.nbytes() == b.nbytes
+        a_round = a.view(torch.uint8).clone().view(torch.float8_e4m3fn).reshape(a.shape)
+        b_round = b.view(torch.uint8).clone().view(torch.float8_e4m3fn).reshape(b.shape)
+        assert torch.allclose(fp8_matmul_golden(a, b), fp8_matmul_golden(a_round, b_round), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e8m0fnu"), reason="torch.float8_e8m0fnu required (torch>=2.7)")
+class TestFp8E8m0Numeric:
+    def test_decode_scale_pow2(self):
+        # 127 → 2^0 = 1; 128 → 2; 126 → 0.5
+        assert decode_e8m0(127) == 1.0
+        assert decode_e8m0(128) == 2.0
+        assert decode_e8m0(126) == 0.5
+
+    def test_scale_mul_matches_torch(self):
+        data = torch.tensor([1.0, -2.0, 0.5, 3.0], dtype=torch.float32)
+        scale_bytes = torch.tensor([127, 128, 126, 129], dtype=torch.uint8)
+        scales = torch.tensor([decode_e8m0(int(b)) for b in scale_bytes.tolist()])
+        # Mirror via torch E8M0 when available: 2**(x-127)
+        e8 = scale_bytes.view(torch.float8_e8m0fnu)
+        # torch may not implement mul for e8m0; use explicit decode.
+        out = data * scales
+        assert out.tolist() == pytest.approx([1.0, -4.0, 0.25, 12.0])
+        assert e8.numel() == 4
+
+    def test_zz_nn_pack_preserves_nbytes(self):
+        m, kmx, n = 128, 2, 64
+        a_s = torch.randint(127, 130, (m, kmx), dtype=torch.int64).to(torch.uint8)
+        b_s = torch.randint(127, 130, (kmx, n), dtype=torch.int64).to(torch.uint8)
+        assert convert_x1_scale_format(a_s).numel() == a_s.numel()
+        assert convert_x2_scale_format(b_s).numel() == b_s.numel()
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "float8_e4m3fn") and hasattr(torch, "float8_e8m0fnu")),
+    reason="torch float8_e4m3fn + float8_e8m0fnu required",
+)
+class TestMxFp8MatmulGolden:
+    def test_make_case_shapes_and_finite(self):
+        a, a_s, b, b_s, c, expected = make_mx_fp8_case(128, 64, 64)
+        assert a.shape == (128, 64) and a.dtype == torch.float8_e4m3fn
+        assert b.shape == (64, 64) and b.dtype == torch.float8_e4m3fn
+        assert a_s.shape == (128, 2) and a_s.dtype == torch.float8_e8m0fnu
+        assert b_s.shape == (2, 64) and b_s.dtype == torch.float8_e8m0fnu
+        assert c.shape == expected.shape == (128, 64)
+        assert torch.isfinite(expected).all()
+
+    def test_unit_scales_match_plain_fp8_matmul(self):
+        torch.manual_seed(0)
+        a = torch.randn(16, 64).clamp(-4, 4).to(torch.float8_e4m3fn)
+        b = torch.randn(64, 32).clamp(-4, 4).to(torch.float8_e4m3fn)
+        a_s = torch.full((16, 2), 127, dtype=torch.uint8)  # 2^0
+        b_s = torch.full((2, 32), 127, dtype=torch.uint8)
+        got = mx_fp8_matmul_golden(a, b, a_s, b_s)
+        ref = fp8_matmul_golden(a, b)
+        assert torch.allclose(got, ref, rtol=0, atol=0)
+
+    def test_make_tensor_arg_nbytes(self):
+        a, a_s, b, b_s, c, _ = make_mx_fp8_case(128, 64, 64)
+        assert make_tensor_arg(a).nbytes() == a.nbytes
+        assert make_tensor_arg(a_s).nbytes() == a_s.nbytes
+        assert make_tensor_arg(b).nbytes() == b.nbytes
+        assert make_tensor_arg(b_s).nbytes() == b_s.nbytes
+        assert make_tensor_arg(c).nbytes() == c.nbytes
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "float4_e2m1fn_x2") and hasattr(torch, "float8_e8m0fnu")),
+    reason="torch float4_e2m1fn_x2 + float8_e8m0fnu required",
+)
+class TestMxFp4MatmulGolden:
+    def test_pack_two_fp4_lo_hi(self):
+        # [0.5=0b0001, 1.0=0b0010] → byte 0x21
+        packed = pack_two_fp4(torch.tensor([[1, 2]], dtype=torch.uint8))
+        assert packed.shape == (1, 1)
+        assert int(packed[0, 0].item()) == 0x21
+
+    def test_make_case_shapes_and_finite(self):
+        a, a_s, b, b_s, c, expected = make_mx_fp4_case(128, 64, 64)
+        assert a.shape == (128, 32) and a.dtype == torch.float4_e2m1fn_x2
+        assert b.shape == (64, 32) and b.dtype == torch.float4_e2m1fn_x2
+        assert a_s.shape == (128, 2) and a_s.dtype == torch.float8_e8m0fnu
+        assert b_s.shape == (2, 64) and b_s.dtype == torch.float8_e8m0fnu
+        assert c.shape == expected.shape == (128, 64)
+        assert torch.isfinite(expected).all()
+
+    def test_unit_scales_match_unpacked_matmul(self):
+        a_logical = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 0]], dtype=torch.uint8)  # M=2,K=4
+        b_logical = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 0]], dtype=torch.uint8)  # K=4,N=2
+        a = pack_two_fp4(a_logical).contiguous().view(torch.float4_e2m1fn_x2)
+        b = pack_two_fp4(b_logical).contiguous().view(torch.float4_e2m1fn_x2)
+        a_s = torch.full((2, 1), 127, dtype=torch.uint8)
+        b_s = torch.full((1, 2), 127, dtype=torch.uint8)
+        got = mx_fp4_matmul_golden(a, b, a_s, b_s)
+        a_f = fp4_e2m1_x2_to_float32(a)
+        b_f = fp4_e2m1_x2_to_float32(b)
+        ref = torch.matmul(a_f, b_f)
+        assert torch.allclose(got, ref, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not hasattr(torch, "float4_e2m1fn_x2"), reason="torch.float4_e2m1fn_x2 required")
+class TestFp4E2m1Numeric:
+    def test_known_nibbles(self):
+        # lo=0b0001 (0.5), hi=0b0010 (1.0) → byte 0x21
+        t = torch.empty(1, dtype=torch.float4_e2m1fn_x2)
+        t.view(torch.uint8)[0] = 0x21
+        got = fp4_e2m1_x2_to_float32(t)
+        assert got.tolist() == pytest.approx([0.5, 1.0])
+
+    def test_decode_table_finite(self):
+        for n in range(16):
+            assert math.isfinite(decode_e2m1(n))
+
+    def test_matmul_unpack_consistency(self):
+        torch.manual_seed(3)
+        m, k_pack, n = 4, 4, 4  # logical K = 8
+        a = torch.empty(m, k_pack, dtype=torch.float4_e2m1fn_x2)
+        b = torch.empty(k_pack, n, dtype=torch.float4_e2m1fn_x2)
+        a.view(torch.uint8).reshape(-1)[:] = torch.randint(0, 256, (m * k_pack,), dtype=torch.uint8)
+        b.view(torch.uint8).reshape(-1)[:] = torch.randint(0, 256, (k_pack * n,), dtype=torch.uint8)
+        golden = fp4_matmul_golden(a, b)
+        assert golden.shape == (m, n)
+        assert torch.isfinite(golden).all()
+        # Re-run after byte clone (simulates host↔device payload preserve).
+        a2 = a.view(torch.uint8).clone().view(torch.float4_e2m1fn_x2).reshape(a.shape)
+        b2 = b.view(torch.uint8).clone().view(torch.float4_e2m1fn_x2).reshape(b.shape)
+        assert torch.allclose(golden, fp4_matmul_golden(a2, b2), rtol=0, atol=0)
+
+    def test_make_tensor_arg_nbytes(self):
+        t = torch.empty(2, 4, dtype=torch.float4_e2m1fn_x2)
+        t.view(torch.uint8)[:] = 0x13
+        arg = make_tensor_arg(t)
+        assert arg.nbytes() == 8

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -57,6 +57,11 @@ class TestDataType:
         assert DataType.UINT64 is not None
         assert DataType.UINT16 is not None
         assert DataType.UINT32 is not None
+        # A5-only MX block-scale dtypes (no FP8E5M2 — MX uses E4M3FN).
+        assert DataType.FP8E4M3FN is not None  # A5 only
+        assert DataType.FP8E8M0 is not None  # A5 only
+        assert DataType.FP4E2M1 is not None  # A5 only
+        assert not hasattr(DataType, "FP8E5M2")
 
     def test_enum_int_values(self):
         assert DataType.FLOAT32.value == 0
@@ -70,6 +75,9 @@ class TestDataType:
         assert DataType.UINT64.value == 8
         assert DataType.UINT16.value == 9
         assert DataType.UINT32.value == 10
+        assert DataType.FP8E4M3FN.value == 12  # A5 only (11 is BOOL)
+        assert DataType.FP8E8M0.value == 13  # A5 only
+        assert DataType.FP4E2M1.value == 14  # A5 only
 
 
 class TestTaskState:
@@ -94,6 +102,9 @@ class TestGetElementSize:
             (DataType.UINT64, 8),
             (DataType.UINT16, 2),
             (DataType.UINT32, 4),
+            (DataType.FP8E4M3FN, 1),  # A5 only
+            (DataType.FP8E8M0, 1),  # A5 only
+            (DataType.FP4E2M1, 1),  # A5 only
         ],
     )
     def test_element_sizes(self, dtype, expected):
@@ -115,6 +126,9 @@ class TestGetDtypeName:
             (DataType.UINT64, "UINT64"),
             (DataType.UINT16, "UINT16"),
             (DataType.UINT32, "UINT32"),
+            (DataType.FP8E4M3FN, "FP8E4M3FN"),  # A5 only
+            (DataType.FP8E8M0, "FP8E8M0"),  # A5 only
+            (DataType.FP4E2M1, "FP4E2M1"),  # A5 only
         ],
     )
     def test_dtype_names(self, dtype, expected):
@@ -164,6 +178,39 @@ class TestTorchInterop:
         assert arg.shapes == (4, 8)
         assert arg.dtype == DataType.FLOAT32
         assert arg.nbytes() == 4 * 8 * 4
+
+    def test_torch_dtype_fp8_fp4_and_make_tensor_arg(self):
+        import torch  # pyright: ignore[reportMissingImports]
+
+        from simpler_setup.torch_interop import make_tensor_arg, torch_dtype_to_datatype
+
+        # A5-only MX dtypes (no float8_e5m2). float8_e4m3fn needs torch >= 2.1;
+        # float8_e8m0fnu >= 2.7; float4_e2m1fn_x2 (MXFP4 packed) needs a recent
+        # torch too. Collect available attrs; skip the whole test if none exist
+        # so a silent empty pass cannot hide missing coverage.
+        cases = [
+            ("float8_e4m3fn", DataType.FP8E4M3FN),  # A5 only
+            ("float8_e8m0fnu", DataType.FP8E8M0),  # A5 only
+            ("float4_e2m1fn_x2", DataType.FP4E2M1),  # A5 only
+        ]
+        available = [
+            (attr, expected, getattr(torch, attr)) for attr, expected in cases if getattr(torch, attr, None) is not None
+        ]
+        if not available:
+            pytest.skip(
+                "torch lacks float8_e4m3fn / float8_e8m0fnu / float4_e2m1fn_x2 "
+                "(need a recent torch, ideally >= 2.7 for E8M0/FP4)"
+            )
+        for attr, expected, torch_dt in available:
+            assert torch_dtype_to_datatype(torch_dt) == expected
+            # Regression: make_tensor_arg used to raise
+            # "Unsupported tensor dtype for Tensor: torch.<attr>".
+            t = torch.zeros(2, 4, dtype=torch_dt)
+            arg = make_tensor_arg(t)
+            assert arg.dtype == expected
+            # Each of these dtypes is 1 byte per torch element (FP4 packs 2
+            # E2M1 values per byte), so a [2, 4] tensor is 8 bytes.
+            assert arg.nbytes() == 2 * 4
 
 
 class TestScalarToUint64:


### PR DESCRIPTION
Register the MX block-scale host dtypes so torch FP8/FP4 tensors can flow through the task interface (host↔device transfer **and** native MX matmul).

### Changes
- `DataType::FP8E4M3FN / FP8E8M0` (1 byte each) and `FP4E2M1` (packed E2M1 ×2 / byte, matches `torch.float4_e2m1fn_x2`) — **A5 only**.
- **`FP8E5M2` intentionally omitted** (MX paths use E4M3FN + E8M0 scale, not E5M2).
- `get_element_size` / `get_dtype_name` + nanobind bindings.
- `torch_interop` maps `float8_e4m3fn / float8_e8m0fnu / float4_e2m1fn_x2` (getattr-guarded).
- **UT**
  - `test_task_interface.py`: enum / sizes / names / `make_tensor_arg` (skip only when **none** of the optional torch dtypes exist).
  - `test_mx_fp_numeric.py` + `simpler_setup/mx_fp_numeric.py`: E4M3/E2M1/E8M0 decode, MXFP8/MXFP4 golden with E8M0 block scales and ZZ/NN packing helpers.
- **ST** `tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/` (**a5 only**): AIC kernel calls pto-isa `TMATMUL_MX` for host-prequant MXFP8 / MXFP4 (E8M0 scales, `MX_A_ZZ` / `MX_B_NN`) and checks FP32 output against the host golden.

### a5sim leftover
CPU stub has no `GetScaleAddr`, and `TLOAD` does not support `MX_A_ZZ` / `MX_B_NN`, so this ST is **onboard-a5 only** for now. Unifying the sim path belongs in pto-isa (or a dual kernel), not this PR.

### Verified (torch 2.13.0 ≥ 2.7)
- Related UT passed (E8M0/FP4 mappings **executed**, not skipped).
- `mx_fp_gemm` **a5** (device 0): `MXFP8_TMATMUL_MX` / `MXFP4_TMATMUL_MX` **PASSED**