### PR TITLE
fix(toolchain): disable cce-simd-vf-fusion by default on A5

### DIFF
--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -167,7 +167,7 @@ class CCECToolchain(Toolchain):
         else:
             raise ValueError(f"Unknown platform: {self.platform}. Supported: a2a3, a2a3sim, a5, a5sim")
 
-        return [
+        flags = [
             "-c",
             "-O3",
             "-g",
@@ -189,6 +189,17 @@ class CCECToolchain(Toolchain):
             "-cce-aicore-dcci-insert-for-scalar=false",
             "-DMEMORY_BASE",
         ]
+        # A5: VF fusion can reorder same-V ops across expand/abs/sinkhorn and
+        # break DeepSeek-V4 correctness; keep it off by default for a5/a5sim.
+        #
+        # Scope: per-kernel incore compilation only. Do NOT mirror this into the
+        # platform AICore build (src/a5/platform/onboard/aicore/CMakeLists.txt) --
+        # its only VF construct is the __simd_vf__ meta anchor in simt_anchor.h,
+        # whose fusion behaviour is what makes bisheng tag the entry
+        # SIMD_SIMT_MIX_VF(4); disabling fusion there breaks that classification.
+        if self.platform in ("a5", "a5sim"):
+            flags.append("--cce-simd-vf-fusion=false")
+        return flags
 
     def get_cmake_args(self) -> list[str]:
         return [

--- a/tests/ut/py/test_toolchain.py
+++ b/tests/ut/py/test_toolchain.py
@@ -185,3 +185,41 @@ class TestShlexJoinSafety:
         flags_arg = next(a for a in args if a.startswith("-DCMAKE_C_FLAGS="))
         # shlex.join must re-quote the path so CMake re-parses it as one token.
         assert "'/opt/my compilers/compat'" in flags_arg
+
+
+class TestCCECToolchainCompileFlags:
+    """A5 must disable SIMD VF fusion; A2/A3 must be left untouched.
+
+    VF fusion can reorder same-V vector ops (expand/abs/sinkhorn) and silently
+    break DeepSeek-V4 numerics on Ascend950. The failure mode is a wrong result
+    rather than a compile error, so guard the flag explicitly.
+    """
+
+    @pytest.fixture
+    def ccec(self, monkeypatch):
+        """Build a CCECToolchain without needing a real CANN install."""
+
+        def _make(platform):
+            # Constructor probes ASCEND_HOME_PATH and the ccec/ld.lld binaries.
+            monkeypatch.setattr(
+                "simpler_setup.toolchain.env_manager.get", lambda _k: "/nonexistent/ascend"
+            )
+            monkeypatch.setattr("simpler_setup.toolchain.os.path.isfile", lambda _p: True)
+            from simpler_setup.toolchain import CCECToolchain  # noqa: PLC0415
+
+            return CCECToolchain(platform)
+
+        return _make
+
+    @pytest.mark.parametrize("platform", ["a5", "a5sim"])
+    def test_a5_disables_vf_fusion(self, ccec, platform):
+        assert "--cce-simd-vf-fusion=false" in ccec(platform).get_compile_flags()
+
+    @pytest.mark.parametrize("platform", ["a2a3", "a2a3sim"])
+    def test_a2a3_keeps_vf_fusion(self, ccec, platform):
+        assert "--cce-simd-vf-fusion=false" not in ccec(platform).get_compile_flags()
+
+    def test_a5_flag_applies_to_both_core_types(self, ccec):
+        toolchain = ccec("a5")
+        for core_type in ("aiv", "aic"):
+            assert "--cce-simd-vf-fusion=false" in toolchain.get_compile_flags(core_type)


### PR DESCRIPTION
## Summary

Append `--cce-simd-vf-fusion=false` to the `ccec` compile flags for `a5` / `a5sim`.
VF fusion can reorder same-V vector ops (expand / abs / sinkhorn) and breaks
DeepSeek-V4 correctness on Ascend950.

This restores the fix from `41fc8ba8`, which was only ever on a side branch and
never reached `main` (`git merge-base --is-ancestor 41fc8ba8 main` → no).

## Why it matters

Measured on a real Ascend 950 host, sweeping all 27 single-card DeepSeek V4-Pro
kernels in `pypto-lib/models/deepseek/v4-pro/` serially:

| | kernels passing |
|---|---|
| without this flag | 10 / 27 |
| with this flag | 26 / 27 |

(Everything else held fixed: same pypto, same pto-isa, same CANN, ptoas 0.48,
run serially on one locked card.)

The ~15 affected kernels **compile and run cleanly** — they just produce wrong
numbers. `hc_pre`'s `comb` output, for example, comes back all-NaN. There is no
compile error and no runtime error, which is what makes this worth pinning down
with a test.

## Scope

Deliberately limited to per-kernel incore compilation
(`KernelCompiler.compile_incore` → `CCECToolchain.get_compile_flags`).

It is **not** mirrored into the platform AICore build
(`src/a5/platform/onboard/aicore/CMakeLists.txt`), and should not be: the only VF
construct there is the `__simd_vf__` meta anchor in `simt_anchor.h`, whose fusion
behaviour is exactly what makes bisheng tag the entry `SIMD_SIMT_MIX_VF(4)`
rather than `SIMT_VF_ONLY(3)`. That file records that getting the classification
wrong produced "107000 param-invalid across the whole a5 ST suite". A comment now
says so at the flag site, so the asymmetry does not read as an oversight.

`a2a3` / `a2a3sim` are untouched — the flag is behind a platform guard, and
`CCECToolchain` is only ever constructed with one of the four known platform
strings.

## Tests

`tests/ut/py/test_toolchain.py` had no coverage of
`CCECToolchain.get_compile_flags` at all, and `simd-vf-fusion` appeared exactly
once in the repo. Added `TestCCECToolchainCompileFlags` asserting the flag is
present for `a5`/`a5sim`, absent for `a2a3`/`a2a3sim`, and present for both
`aiv` and `aic` core types. The constructor's `ASCEND_HOME_PATH` and compiler
existence probes are monkeypatched so the test needs no CANN install.

`python -m pytest tests/ut/py/test_toolchain.py` → 20 passed.

## Note for anyone re-measuring

Compiled kernel binaries are **not** cached by compile flags — the non-external
branch of `kernel_binary_cache_path` keys on
`incore_{func_id}_{core_type}_{stem}_{platform}.bin`, and `device_runner` also
reuses a `source.with_suffix('.o')` sidecar. Reusing a `build_output/` produced
before this change will silently re-run the VF-fused binary. Wipe `build_output/`
before comparing.

## Open question for reviewers

`--cce-simd-vf-fusion=false` is a bare driver flag (same family as
`--cce-aicore-only`), not an `-mllvm` pass-through, so a `ccec` that does not
recognise it would hard-fail every A5 kernel compile with no way to opt out.
Worth gating on an env var following the existing
`SIMPLER_ENABLE_PTO_SDMA_WORKSPACE` idiom (default off = flag emitted)? Left out
here to keep the diff minimal and faithful to `41fc8ba8`; happy to add it.
