### PR TITLE
Fix: size CoreTracker by the device's clusters, not by a uint64_t

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -144,19 +144,33 @@ static_assert(sizeof(CoreExecState) == 64, "CoreExecState must occupy exactly on
 
 class alignas(64) CoreTracker {
 public:
-    static inline int32_t MAX_CORE_PER_THREAD = 63;
-    static constexpr int32_t MAX_CLUSTERS = 63 / 3;
+    // The ceiling is the platform's cluster count, not the width of the backing
+    // word: a run takes the whole device, and aicpu_thread_num can leave a single
+    // scheduler thread owning all of it.
+    static constexpr int32_t MAX_CLUSTERS = PLATFORM_MAX_BLOCKDIM;
+    static constexpr int32_t MAX_CORE_PER_THREAD = MAX_CLUSTERS * PLATFORM_CORES_PER_BLOCKDIM;
 
 public:
     CoreTracker() = default;
 
     class BitStates {
     public:
+        // 3 state bits per cluster, so the backing word must hold
+        // MAX_CLUSTERS * 3 bits. 128 covers both arches (a2a3 72, a5 108) with
+        // room; a single uint64_t held only 21 clusters, fewer than either
+        // device has.
+        using Storage = unsigned __int128;
+
         BitStates() = default;
 
-        explicit BitStates(uint64_t states) :
+        explicit BitStates(Storage states) :
             states_(states) {}
         void init() { states_ = 0; }
+
+        // A mask with exactly `offset` set. The shift lives here so a caller
+        // cannot silently narrow it by writing `1ULL << offset`, which is
+        // undefined once offset reaches 64.
+        static BitStates bit(int32_t offset) { return BitStates(Storage(1) << offset); }
 
         BitStates operator~() const { return BitStates(~states_); }
         BitStates operator&(const BitStates &other) const { return BitStates(states_ & other.states_); }
@@ -169,36 +183,47 @@ public:
         void operator^=(const BitStates &other) { states_ ^= other.states_; }
 
         bool has_value() const { return states_ > 0; }
-        int32_t count() const { return __builtin_popcountll(states_); }
-        void clear_bit(int32_t offset) { states_ &= ~(1ULL << offset); }
+        int32_t count() const {
+            return __builtin_popcountll(static_cast<uint64_t>(states_)) +
+                   __builtin_popcountll(static_cast<uint64_t>(states_ >> 64));
+        }
+        void clear_bit(int32_t offset) { states_ &= ~(Storage(1) << offset); }
 
         // Extract the lowest set bit from mask, clear it, and return its position.
         // Returns -1 if mask is empty.
         int32_t pop_first() {
             if (states_ == 0) return -1;
-            int32_t pos = __builtin_ctzll(states_);
+            const uint64_t low = static_cast<uint64_t>(states_);
+            const int32_t pos =
+                (low != 0) ? __builtin_ctzll(low) : 64 + __builtin_ctzll(static_cast<uint64_t>(states_ >> 64));
             states_ &= states_ - 1;
             return pos;
         }
 
     private:
-        uint64_t states_{0};
+        Storage states_{0};
     };
 
 public:
+    static_assert(MAX_CORE_PER_THREAD <= 128, "CoreTracker state bits must fit BitStates::Storage");
+
     void init(int32_t cluster_count) {
+        always_assert(
+            cluster_count >= 0 && cluster_count <= MAX_CLUSTERS && "cluster_count outside CoreTracker capacity"
+        );
         cluster_count_ = cluster_count;
         aic_mask_.init();
         aiv_mask_.init();
         pending_occupied_.init();
         for (int32_t i = 0; i < cluster_count; i++) {
-            aic_mask_ |= BitStates(1ULL << (i * 3));
-            aiv_mask_ |= BitStates(6ULL << (i * 3));
+            aic_mask_ |= BitStates::bit(i * 3);
+            aiv_mask_ |= (BitStates::bit(i * 3 + 1) | BitStates::bit(i * 3 + 2));
         }
         core_states_ = aic_mask_ | aiv_mask_;
     }
 
     void set_cluster(int32_t cluster_idx, int32_t aic_wid, int32_t aiv0_wid, int32_t aiv1_wid) {
+        always_assert(cluster_idx >= 0 && cluster_idx < MAX_CLUSTERS && "cluster_idx outside CoreTracker capacity");
         core_id_map_[cluster_idx * 3] = aic_wid;
         core_id_map_[cluster_idx * 3 + 1] = aiv0_wid;
         core_id_map_[cluster_idx * 3 + 2] = aiv1_wid;
@@ -274,9 +299,9 @@ public:
         case PTO2ResourceShape::DUMMY:
             // DUMMY tasks never reach the core-tracker dispatch path; they are
             // completed inline by resolve_and_dispatch via dummy_ready_queue.
-            return BitStates(0ULL);
+            return {};
         }
-        return BitStates(0ULL);
+        return {};
     }
 
     int32_t get_aic_core_id(int32_t cluster_offset) const { return core_id_map_[cluster_offset]; }
@@ -288,27 +313,27 @@ public:
     int32_t get_aiv1_core_offset(int32_t cluster_offset) const { return cluster_offset + 2; }
 
     bool is_aic_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> cluster_offset) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> cluster_offset) & BitStates::bit(0)).has_value();
     }
     bool is_aiv0_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> (cluster_offset + 1)) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> (cluster_offset + 1)) & BitStates::bit(0)).has_value();
     }
     bool is_aiv1_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> (cluster_offset + 2)) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> (cluster_offset + 2)) & BitStates::bit(0)).has_value();
     }
 
     // --- State mutation ---
 
     // Toggle bit at the given bit offset (running <-> idle)
-    void change_core_state(int32_t bit_offset) { core_states_ ^= BitStates(1ULL << bit_offset); }
+    void change_core_state(int32_t bit_offset) { core_states_ ^= BitStates::bit(bit_offset); }
 
     // --- Pending-occupied tracking ---
     // Tracks whether a core's pending payload slot is occupied (awaiting hardware ACK).
     // SET on dispatch (both running-first and pending), CLEAR on idle or pending_freed.
 
-    void set_pending_occupied(int32_t bit_offset) { pending_occupied_ |= BitStates(1ULL << bit_offset); }
+    void set_pending_occupied(int32_t bit_offset) { pending_occupied_ |= BitStates::bit(bit_offset); }
     void clear_pending_occupied(int32_t bit_offset) {
-        pending_occupied_ ^= (pending_occupied_ & BitStates(1ULL << bit_offset));
+        pending_occupied_ ^= (pending_occupied_ & BitStates::bit(bit_offset));
     }
 
     // --- Two-phase dispatch queries ---
@@ -344,15 +369,15 @@ public:
     // task. REJECT only when a used core's pending slot is already occupied (no free
     // slot) or the mask is empty.
     MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used(0ULL);
+        BitStates used;
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
-            used |= BitStates(1ULL << cluster_offset);
+            used |= BitStates::bit(cluster_offset);
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
-            used |= BitStates(1ULL << (cluster_offset + 1));
+            used |= BitStates::bit(cluster_offset + 1);
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
-            used |= BitStates(1ULL << (cluster_offset + 2));
+            used |= BitStates::bit(cluster_offset + 2);
         }
         if (!used.has_value() || (pending_occupied_ & used).has_value()) {
             return MixPlacement::REJECT;
@@ -374,10 +399,10 @@ public:
 
     // Cores of `cluster_offset` named by core_mask.
     BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used(0ULL);
-        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates(1ULL << cluster_offset);
-        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates(1ULL << (cluster_offset + 1));
-        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates(1ULL << (cluster_offset + 2));
+        BitStates used;
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates::bit(cluster_offset);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates::bit(cluster_offset + 1);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates::bit(cluster_offset + 2);
         return used;
     }
 
@@ -397,12 +422,12 @@ public:
 
     // Clusters where every used core has a free slot (gated MIX split gate/iteration).
     BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result(0ULL);
+        BitStates result;
         BitStates candidates = get_cluster_offset_states();
         while (candidates.has_value()) {
             int32_t off = candidates.pop_first();
             if (mix_cluster_all_slots(off, core_mask)) {
-                result |= BitStates(1ULL << off);
+                result |= BitStates::bit(off);
             }
         }
         return result;
@@ -413,12 +438,12 @@ public:
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result(0ULL);
+        BitStates result;
         BitStates candidates = get_cluster_offset_states();
         while (candidates.has_value()) {
             int32_t cluster_offset = candidates.pop_first();
             if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
-                result |= BitStates(1ULL << cluster_offset);
+                result |= BitStates::bit(cluster_offset);
             }
         }
         return result;
@@ -472,7 +497,7 @@ private:
     BitStates aiv_mask_;
     BitStates core_states_;
     BitStates pending_occupied_;
-    int32_t core_id_map_[63];  // bit_position -> worker_id, max 21 clusters * 3
+    int32_t core_id_map_[MAX_CORE_PER_THREAD];  // bit position -> worker id
 };
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -903,6 +903,19 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     int32_t own_n = 0;
     for (int32_t ci = tidx; ci < aic_n; ci += active)
         own_n++;
+    // Mirrors the check assign_cores_to_threads() makes on the serial path. A
+    // thread owning more clusters than CoreTracker can hold used to write past
+    // core_id_map_ into the next tracker, which is the orchestrator's on the
+    // decoupled path: its cluster_count_ became garbage and shutdown() then
+    // sent AICORE_EXIT to a core the scheduler was still dispatching to.
+    if (own_n > CoreTracker::MAX_CLUSTERS) {
+        LOG_ERROR(
+            "Thread %d owns %d clusters, exceeding CoreTracker capacity %d (raise aicpu_thread_num)", tidx, own_n,
+            CoreTracker::MAX_CLUSTERS
+        );
+        handshake_failed_.store(true, std::memory_order_release);
+        return;
+    }
     tracker.init(own_n);
 
     int32_t local = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -133,19 +133,33 @@ static_assert(sizeof(CoreExecState) == 64, "CoreExecState must occupy exactly on
 
 class alignas(64) CoreTracker {
 public:
-    static inline int32_t MAX_CORE_PER_THREAD = 63;
-    static constexpr int32_t MAX_CLUSTERS = 63 / 3;
+    // The ceiling is the platform's cluster count, not the width of the backing
+    // word: a run takes the whole device, and aicpu_thread_num can leave a single
+    // scheduler thread owning all of it.
+    static constexpr int32_t MAX_CLUSTERS = PLATFORM_MAX_BLOCKDIM;
+    static constexpr int32_t MAX_CORE_PER_THREAD = MAX_CLUSTERS * PLATFORM_CORES_PER_BLOCKDIM;
 
 public:
     CoreTracker() = default;
 
     class BitStates {
     public:
+        // 3 state bits per cluster, so the backing word must hold
+        // MAX_CLUSTERS * 3 bits. 128 covers both arches (a2a3 72, a5 108) with
+        // room; a single uint64_t held only 21 clusters, fewer than either
+        // device has.
+        using Storage = unsigned __int128;
+
         BitStates() = default;
 
-        explicit BitStates(uint64_t states) :
+        explicit BitStates(Storage states) :
             states_(states) {}
         void init() { states_ = 0; }
+
+        // A mask with exactly `offset` set. The shift lives here so a caller
+        // cannot silently narrow it by writing `1ULL << offset`, which is
+        // undefined once offset reaches 64.
+        static BitStates bit(int32_t offset) { return BitStates(Storage(1) << offset); }
 
         BitStates operator~() const { return BitStates(~states_); }
         BitStates operator&(const BitStates &other) const { return BitStates(states_ & other.states_); }
@@ -158,36 +172,47 @@ public:
         void operator^=(const BitStates &other) { states_ ^= other.states_; }
 
         bool has_value() const { return states_ > 0; }
-        int32_t count() const { return __builtin_popcountll(states_); }
-        void clear_bit(int32_t offset) { states_ &= ~(1ULL << offset); }
+        int32_t count() const {
+            return __builtin_popcountll(static_cast<uint64_t>(states_)) +
+                   __builtin_popcountll(static_cast<uint64_t>(states_ >> 64));
+        }
+        void clear_bit(int32_t offset) { states_ &= ~(Storage(1) << offset); }
 
         // Extract the lowest set bit from mask, clear it, and return its position.
         // Returns -1 if mask is empty.
         int32_t pop_first() {
             if (states_ == 0) return -1;
-            int32_t pos = __builtin_ctzll(states_);
+            const uint64_t low = static_cast<uint64_t>(states_);
+            const int32_t pos =
+                (low != 0) ? __builtin_ctzll(low) : 64 + __builtin_ctzll(static_cast<uint64_t>(states_ >> 64));
             states_ &= states_ - 1;
             return pos;
         }
 
     private:
-        uint64_t states_{0};
+        Storage states_{0};
     };
 
 public:
+    static_assert(MAX_CORE_PER_THREAD <= 128, "CoreTracker state bits must fit BitStates::Storage");
+
     void init(int32_t cluster_count) {
+        always_assert(
+            cluster_count >= 0 && cluster_count <= MAX_CLUSTERS && "cluster_count outside CoreTracker capacity"
+        );
         cluster_count_ = cluster_count;
         aic_mask_.init();
         aiv_mask_.init();
         pending_occupied_.init();
         for (int32_t i = 0; i < cluster_count; i++) {
-            aic_mask_ |= BitStates(1ULL << (i * 3));
-            aiv_mask_ |= BitStates(6ULL << (i * 3));
+            aic_mask_ |= BitStates::bit(i * 3);
+            aiv_mask_ |= (BitStates::bit(i * 3 + 1) | BitStates::bit(i * 3 + 2));
         }
         core_states_ = aic_mask_ | aiv_mask_;
     }
 
     void set_cluster(int32_t cluster_idx, int32_t aic_wid, int32_t aiv0_wid, int32_t aiv1_wid) {
+        always_assert(cluster_idx >= 0 && cluster_idx < MAX_CLUSTERS && "cluster_idx outside CoreTracker capacity");
         core_id_map_[cluster_idx * 3] = aic_wid;
         core_id_map_[cluster_idx * 3 + 1] = aiv0_wid;
         core_id_map_[cluster_idx * 3 + 2] = aiv1_wid;
@@ -263,9 +288,9 @@ public:
         case PTO2ResourceShape::DUMMY:
             // DUMMY tasks never reach the core-tracker dispatch path; they are
             // completed inline by resolve_and_dispatch via dummy_ready_queue.
-            return BitStates(0ULL);
+            return {};
         }
-        return BitStates(0ULL);
+        return {};
     }
 
     int32_t get_aic_core_id(int32_t cluster_offset) const { return core_id_map_[cluster_offset]; }
@@ -277,27 +302,27 @@ public:
     int32_t get_aiv1_core_offset(int32_t cluster_offset) const { return cluster_offset + 2; }
 
     bool is_aic_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> cluster_offset) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> cluster_offset) & BitStates::bit(0)).has_value();
     }
     bool is_aiv0_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> (cluster_offset + 1)) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> (cluster_offset + 1)) & BitStates::bit(0)).has_value();
     }
     bool is_aiv1_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> (cluster_offset + 2)) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> (cluster_offset + 2)) & BitStates::bit(0)).has_value();
     }
 
     // --- State mutation ---
 
     // Toggle bit at the given bit offset (running <-> idle)
-    void change_core_state(int32_t bit_offset) { core_states_ ^= BitStates(1ULL << bit_offset); }
+    void change_core_state(int32_t bit_offset) { core_states_ ^= BitStates::bit(bit_offset); }
 
     // --- Pending-occupied tracking ---
     // Tracks whether a core's pending payload slot is occupied (awaiting hardware ACK).
     // SET on dispatch (both running-first and pending), CLEAR on idle or pending_freed.
 
-    void set_pending_occupied(int32_t bit_offset) { pending_occupied_ |= BitStates(1ULL << bit_offset); }
+    void set_pending_occupied(int32_t bit_offset) { pending_occupied_ |= BitStates::bit(bit_offset); }
     void clear_pending_occupied(int32_t bit_offset) {
-        pending_occupied_ ^= (pending_occupied_ & BitStates(1ULL << bit_offset));
+        pending_occupied_ ^= (pending_occupied_ & BitStates::bit(bit_offset));
     }
 
     // --- Two-phase dispatch queries ---
@@ -333,15 +358,15 @@ public:
     // task. REJECT only when a used core's pending slot is already occupied (no free
     // slot) or the mask is empty.
     MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used(0ULL);
+        BitStates used;
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
-            used |= BitStates(1ULL << cluster_offset);
+            used |= BitStates::bit(cluster_offset);
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
-            used |= BitStates(1ULL << (cluster_offset + 1));
+            used |= BitStates::bit(cluster_offset + 1);
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
-            used |= BitStates(1ULL << (cluster_offset + 2));
+            used |= BitStates::bit(cluster_offset + 2);
         }
         if (!used.has_value() || (pending_occupied_ & used).has_value()) {
             return MixPlacement::REJECT;
@@ -363,10 +388,10 @@ public:
 
     // Cores of `cluster_offset` named by core_mask.
     BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used(0ULL);
-        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates(1ULL << cluster_offset);
-        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates(1ULL << (cluster_offset + 1));
-        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates(1ULL << (cluster_offset + 2));
+        BitStates used;
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates::bit(cluster_offset);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates::bit(cluster_offset + 1);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates::bit(cluster_offset + 2);
         return used;
     }
 
@@ -386,12 +411,12 @@ public:
 
     // Clusters where every used core has a free slot (gated MIX split gate/iteration).
     BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result(0ULL);
+        BitStates result;
         BitStates candidates = get_cluster_offset_states();
         while (candidates.has_value()) {
             int32_t off = candidates.pop_first();
             if (mix_cluster_all_slots(off, core_mask)) {
-                result |= BitStates(1ULL << off);
+                result |= BitStates::bit(off);
             }
         }
         return result;
@@ -402,12 +427,12 @@ public:
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result(0ULL);
+        BitStates result;
         BitStates candidates = get_cluster_offset_states();
         while (candidates.has_value()) {
             int32_t cluster_offset = candidates.pop_first();
             if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
-                result |= BitStates(1ULL << cluster_offset);
+                result |= BitStates::bit(cluster_offset);
             }
         }
         return result;
@@ -461,7 +486,7 @@ private:
     BitStates aiv_mask_;
     BitStates core_states_;
     BitStates pending_occupied_;
-    int32_t core_id_map_[63];  // bit_position -> worker_id, max 21 clusters * 3
+    int32_t core_id_map_[MAX_CORE_PER_THREAD];  // bit position -> worker id
 };
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -907,6 +907,19 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     int32_t own_n = 0;
     for (int32_t ci = tidx; ci < aic_n; ci += active)
         own_n++;
+    // Mirrors the check assign_cores_to_threads() makes on the serial path. A
+    // thread owning more clusters than CoreTracker can hold used to write past
+    // core_id_map_ into the next tracker, which is the orchestrator's on the
+    // decoupled path: its cluster_count_ became garbage and shutdown() then
+    // sent AICORE_EXIT to a core the scheduler was still dispatching to.
+    if (own_n > CoreTracker::MAX_CLUSTERS) {
+        LOG_ERROR(
+            "Thread %d owns %d clusters, exceeding CoreTracker capacity %d (raise aicpu_thread_num)", tidx, own_n,
+            CoreTracker::MAX_CLUSTERS
+        );
+        handshake_failed_.store(true, std::memory_order_release);
+        return;
+    }
     tracker.init(own_n);
 
     int32_t local = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -134,19 +134,33 @@ static_assert(sizeof(CoreExecState) == 64, "CoreExecState must occupy exactly on
 
 class alignas(64) CoreTracker {
 public:
-    static inline int32_t MAX_CORE_PER_THREAD = 63;
-    static constexpr int32_t MAX_CLUSTERS = 63 / 3;
+    // The ceiling is the platform's cluster count, not the width of the backing
+    // word: a run takes the whole device, and aicpu_thread_num can leave a single
+    // scheduler thread owning all of it.
+    static constexpr int32_t MAX_CLUSTERS = PLATFORM_MAX_BLOCKDIM;
+    static constexpr int32_t MAX_CORE_PER_THREAD = MAX_CLUSTERS * PLATFORM_CORES_PER_BLOCKDIM;
 
 public:
     CoreTracker() = default;
 
     class BitStates {
     public:
+        // 3 state bits per cluster, so the backing word must hold
+        // MAX_CLUSTERS * 3 bits. 128 covers both arches (a2a3 72, a5 108) with
+        // room; a single uint64_t held only 21 clusters, fewer than either
+        // device has.
+        using Storage = unsigned __int128;
+
         BitStates() = default;
 
-        explicit BitStates(uint64_t states) :
+        explicit BitStates(Storage states) :
             states_(states) {}
         void init() { states_ = 0; }
+
+        // A mask with exactly `offset` set. The shift lives here so a caller
+        // cannot silently narrow it by writing `1ULL << offset`, which is
+        // undefined once offset reaches 64.
+        static BitStates bit(int32_t offset) { return BitStates(Storage(1) << offset); }
 
         BitStates operator~() const { return BitStates(~states_); }
         BitStates operator&(const BitStates &other) const { return BitStates(states_ & other.states_); }
@@ -159,36 +173,47 @@ public:
         void operator^=(const BitStates &other) { states_ ^= other.states_; }
 
         bool has_value() const { return states_ > 0; }
-        int32_t count() const { return __builtin_popcountll(states_); }
-        void clear_bit(int32_t offset) { states_ &= ~(1ULL << offset); }
+        int32_t count() const {
+            return __builtin_popcountll(static_cast<uint64_t>(states_)) +
+                   __builtin_popcountll(static_cast<uint64_t>(states_ >> 64));
+        }
+        void clear_bit(int32_t offset) { states_ &= ~(Storage(1) << offset); }
 
         // Extract the lowest set bit from mask, clear it, and return its position.
         // Returns -1 if mask is empty.
         int32_t pop_first() {
             if (states_ == 0) return -1;
-            int32_t pos = __builtin_ctzll(states_);
+            const uint64_t low = static_cast<uint64_t>(states_);
+            const int32_t pos =
+                (low != 0) ? __builtin_ctzll(low) : 64 + __builtin_ctzll(static_cast<uint64_t>(states_ >> 64));
             states_ &= states_ - 1;
             return pos;
         }
 
     private:
-        uint64_t states_{0};
+        Storage states_{0};
     };
 
 public:
+    static_assert(MAX_CORE_PER_THREAD <= 128, "CoreTracker state bits must fit BitStates::Storage");
+
     void init(int32_t cluster_count) {
+        always_assert(
+            cluster_count >= 0 && cluster_count <= MAX_CLUSTERS && "cluster_count outside CoreTracker capacity"
+        );
         cluster_count_ = cluster_count;
         aic_mask_.init();
         aiv_mask_.init();
         pending_occupied_.init();
         for (int32_t i = 0; i < cluster_count; i++) {
-            aic_mask_ |= BitStates(1ULL << (i * 3));
-            aiv_mask_ |= BitStates(6ULL << (i * 3));
+            aic_mask_ |= BitStates::bit(i * 3);
+            aiv_mask_ |= (BitStates::bit(i * 3 + 1) | BitStates::bit(i * 3 + 2));
         }
         core_states_ = aic_mask_ | aiv_mask_;
     }
 
     void set_cluster(int32_t cluster_idx, int32_t aic_wid, int32_t aiv0_wid, int32_t aiv1_wid) {
+        always_assert(cluster_idx >= 0 && cluster_idx < MAX_CLUSTERS && "cluster_idx outside CoreTracker capacity");
         core_id_map_[cluster_idx * 3] = aic_wid;
         core_id_map_[cluster_idx * 3 + 1] = aiv0_wid;
         core_id_map_[cluster_idx * 3 + 2] = aiv1_wid;
@@ -251,9 +276,9 @@ public:
         case PTO2ResourceShape::DUMMY:
             // DUMMY tasks never reach the core-tracker dispatch path; they are
             // completed inline by resolve_and_dispatch via dummy_ready_queue.
-            return BitStates(0ULL);
+            return {};
         }
-        return BitStates(0ULL);
+        return {};
     }
 
     int32_t get_aic_core_id(int32_t cluster_offset) const { return core_id_map_[cluster_offset]; }
@@ -265,27 +290,27 @@ public:
     int32_t get_aiv1_core_offset(int32_t cluster_offset) const { return cluster_offset + 2; }
 
     bool is_aic_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> cluster_offset) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> cluster_offset) & BitStates::bit(0)).has_value();
     }
     bool is_aiv0_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> (cluster_offset + 1)) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> (cluster_offset + 1)) & BitStates::bit(0)).has_value();
     }
     bool is_aiv1_core_idle(int32_t cluster_offset) const {
-        return ((core_states_ >> (cluster_offset + 2)) & BitStates(1ULL)).has_value();
+        return ((core_states_ >> (cluster_offset + 2)) & BitStates::bit(0)).has_value();
     }
 
     // --- State mutation ---
 
     // Toggle bit at the given bit offset (running <-> idle)
-    void change_core_state(int32_t bit_offset) { core_states_ ^= BitStates(1ULL << bit_offset); }
+    void change_core_state(int32_t bit_offset) { core_states_ ^= BitStates::bit(bit_offset); }
 
     // --- Pending-occupied tracking ---
     // Tracks whether a core's pending payload slot is occupied (awaiting hardware ACK).
     // SET on dispatch (both running-first and pending), CLEAR on idle or pending_freed.
 
-    void set_pending_occupied(int32_t bit_offset) { pending_occupied_ |= BitStates(1ULL << bit_offset); }
+    void set_pending_occupied(int32_t bit_offset) { pending_occupied_ |= BitStates::bit(bit_offset); }
     void clear_pending_occupied(int32_t bit_offset) {
-        pending_occupied_ ^= (pending_occupied_ & BitStates(1ULL << bit_offset));
+        pending_occupied_ ^= (pending_occupied_ & BitStates::bit(bit_offset));
     }
 
     // --- Two-phase dispatch queries ---
@@ -321,15 +346,15 @@ public:
     // task. REJECT only when a used core's pending slot is already occupied (no free
     // slot) or the mask is empty.
     MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used(0ULL);
+        BitStates used;
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
-            used |= BitStates(1ULL << cluster_offset);
+            used |= BitStates::bit(cluster_offset);
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
-            used |= BitStates(1ULL << (cluster_offset + 1));
+            used |= BitStates::bit(cluster_offset + 1);
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
-            used |= BitStates(1ULL << (cluster_offset + 2));
+            used |= BitStates::bit(cluster_offset + 2);
         }
         if (!used.has_value() || (pending_occupied_ & used).has_value()) {
             return MixPlacement::REJECT;
@@ -343,12 +368,12 @@ public:
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result(0ULL);
+        BitStates result;
         BitStates candidates = get_cluster_offset_states();
         while (candidates.has_value()) {
             int32_t cluster_offset = candidates.pop_first();
             if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
-                result |= BitStates(1ULL << cluster_offset);
+                result |= BitStates::bit(cluster_offset);
             }
         }
         return result;
@@ -361,10 +386,10 @@ public:
     // Gated MIX split placement (#1304): each used core independently takes
     // running-if-idle / pending-if-busy while every used core waits on the doorbell.
     BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used(0ULL);
-        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates(1ULL << cluster_offset);
-        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates(1ULL << (cluster_offset + 1));
-        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates(1ULL << (cluster_offset + 2));
+        BitStates used;
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates::bit(cluster_offset);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates::bit(cluster_offset + 1);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates::bit(cluster_offset + 2);
         return used;
     }
 
@@ -380,12 +405,12 @@ public:
     }
 
     BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result(0ULL);
+        BitStates result;
         BitStates candidates = get_cluster_offset_states();
         while (candidates.has_value()) {
             int32_t off = candidates.pop_first();
             if (mix_cluster_all_slots(off, core_mask)) {
-                result |= BitStates(1ULL << off);
+                result |= BitStates::bit(off);
             }
         }
         return result;
@@ -439,7 +464,7 @@ private:
     BitStates aiv_mask_;
     BitStates core_states_;
     BitStates pending_occupied_;
-    int32_t core_id_map_[63];  // bit_position -> worker_id, max 21 clusters * 3
+    int32_t core_id_map_[MAX_CORE_PER_THREAD];  // bit position -> worker id
 };
 
 // =============================================================================


### PR DESCRIPTION
## The bug

`CoreTracker` packs three state bits per cluster (AIC, AIV0, AIV1) into a single
`uint64_t`, so it holds `floor(64/3) = 21` clusters. The two literals that
encoded that came from the width of the backing word, not from any device:

```cpp
static inline int32_t MAX_CORE_PER_THREAD = 63;
static constexpr int32_t MAX_CLUSTERS = 63 / 3;
uint64_t states_{0};
int32_t core_id_map_[63];  // bit_position -> worker_id, max 21 clusters * 3
```

a2a3 has **24** clusters and a5 has **36**. Neither fits.

`assign_cores_to_threads()` checks the ceiling (`scheduler_cold_path.cpp:990`).
`assign_own_clusters()` — the barrier-free path the decoupled scheduler actually
takes — **does not**. Give one scheduler thread more than 21 clusters and
`set_cluster()` writes past `core_id_map_` into the next `CoreTracker`, which on
that path is the orchestrator's.

At 24 clusters the store lands exactly on `core_trackers_[1].cluster_count_`
(`sizeof(CoreTracker)==320`, `offsetof(core_id_map_)==40`, so
`core_id_map_[70]` → byte 320). The orchestrator's tracker is never assigned and
its `shutdown()` documents the assumption it breaks:

```cpp
// Orchestrator threads have core_trackers_[thread_idx].core_num() == 0 -> no-op.
```

It instead reports 210 cores, walks a zeroed id map, and sends `AICORE_EXIT` to
core 0 two hundred times. If the scheduler still has a task dispatched there it
polls that core's COND for a `FIN` that can never arrive:

```text
Thread 1: Orchestrator completed
Thread 1: Shutting down 210 cores          <-- must be 0
[STALL thread=0] CLUSTER cluster_id=0 aic=core0(busy ... ANOMALY cond_tok=2147483646 ...)
```

`cond_tok=2147483646` = `0x7FFFFFFE` = `AICORE_EXIT_TASK_ID`. Surfaces as
`sched_error_code=100 SCHEDULER_TIMEOUT` → host `507018`. No deadlock or
capacity detector fires — counts of `Task Allocator Deadlock`, SPIN
`Timeout (N cycles)` and `HandleTaskTimeout` are all 0 — which is why this reads
as a mystery stall rather than an overflow.

Bisected onboard by clamping the resolved width:

| clusters | result |
| --- | --- |
| 21 | pass |
| 22 | pass |
| 23 | pass |
| **24** | **fail** |

Exactly the byte-offset prediction: only `cluster_idx == 23` reaches
`core_id_map_[70]`. **22 and 23 are already corrupt** — the bitmask aliases once
past 63 bits (`1ULL << 66` becomes `LSL #2` on aarch64) — the write just lands
in tail padding and survives.

Nothing reaches this today because every scene test pins `block_dim` low enough
to stay under 21 clusters per thread. The bound is a property of the hardware,
not of the test suite, so any caller passing `aicpu_thread_num: 2` on a
24-cluster device hits it.

## The fix

- **`MAX_CLUSTERS` derives from `PLATFORM_MAX_BLOCKDIM`** and
  `MAX_CORE_PER_THREAD` from it, so one scheduler thread can own a whole device
  on either arch. A `static_assert` ties the pair to the storage width.
  (`MAX_CORE_PER_THREAD` was also a mutable `static inline` used as a constant —
  now `constexpr`.)
- **`BitStates` is backed by `unsigned __int128`** (a2a3 needs 72 bits, a5 108).
  The hot path shifts the whole mask by 1 and 2 to test cluster co-residency
  (`scheduler_types.h:260/262/427/432`); letting the compiler generate those
  crossings is what keeps the widening honest. Only `popcount` and `ctz` split by
  hand. `__uint128_t` is already used on this target in
  `src/common/platform/include/aicpu/device_time.h`.
- **Callers can no longer build a mask with `1ULL << offset`**, undefined once
  offset reaches 64 — there were 13 such sites and the widening would have made
  every one of them UB. `BitStates::bit()` owns the shift.
- **`assign_own_clusters()` gets the guard its serial sibling already had**
  (a2a3 + a5), and `init()` / `set_cluster()` assert the bound, so exceeding it
  fails by name instead of corrupting a neighbour.

## Verification

Repro before the fix: `dummy_task`, `predicated_dispatch` (tmr **and** hbg),
`dep_gen_chain` at `aicpu_thread_num: 2` with the width auto-resolved to 24 —
100% reproducible. After: 5/5 pass, and `Shutting down 210 cores` is gone from
the device log.

| Suite | Result |
| ----- | ------ |
| `pytest examples tests/st --platform a2a3` (onboard) | 60 passed, 0 failed |
| `pytest examples tests/st --platform a2a3sim` | 51 passed, 0 failed |
| `pytest examples tests/st --platform a5sim` | 39 passed, 0 failed |
| `pytest tests/ut -m "not requires_hardware"` | 813 passed |
| `ctest` C++ unit tests | 60/60 |
| pre-commit (all hooks) | passed |

hbg reaches the same ceiling through the guarded path, so it fails cleanly today
(`Can't assign more then 64 cores in per scheduler`) rather than corrupting —
the widening lifts that limit too.