### PR TITLE
CI: skip st-onboard-a5 while the a5 runner is under repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -790,7 +790,8 @@ jobs:
 
   st-onboard-a5:
     needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a5_changed == 'true'
+    # The a5 self-hosted runner is under repair; drop the `false &&` to re-enable.
+    if: false && needs.detect-changes.outputs.a5_changed == 'true'
     runs-on: [self-hosted, a5]
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary

- Short-circuit the `st-onboard-a5` gate to `if: false && ...` so the job reports **skipped** instead of waiting on a runner that is out for repair.
- The original condition is kept inline; re-enabling is deleting `false && `.

The a5 self-hosted runner is under repair, so `st-onboard-a5` has no host to pick it up. Nothing declares `needs: st-onboard-a5` and `main` has no required status checks, so skipping it blocks no merge.

Coverage for a5 changes falls back to `st-sim-a5` (GitHub-hosted). `ut-a5` targets the same self-hosted runner and is deliberately left enabled — if the repair runs long it will need the same treatment.

## Testing

- [x] YAML parses and the job's `if` resolves as intended (`yaml.safe_load` → `false && needs.detect-changes.outputs.a5_changed == 'true'`)
- [ ] Simulation tests pass — n/a, CI config only
- [ ] Hardware tests pass — n/a (and a5 hardware is the thing under repair)