### PR TITLE
Fix: never leave a RunHandle un-terminal when finalize is interrupted

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -229,6 +229,12 @@ _ROLLBACK_GRACEFUL_TIMEOUT_S = 10.0
 # joiner still re-observes `done` within this interval instead of blocking
 # forever.
 _CLOSE_JOIN_RECHECK_S = 1.0
+# Bounded re-check interval for a RunHandle waiter parked behind the elected
+# waiter. Same backstop role as _CLOSE_JOIN_RECHECK_S: if the elected waiter's
+# notify_all() is skipped (an async BaseException landing between publishing the
+# terminal state and notifying), a parked waiter re-observes that state within
+# this interval instead of blocking forever.
+_RUN_HANDLE_WAIT_RECHECK_S = 1.0
 
 # Control sub-commands (written at _OFF_CALLABLE as uint64)
 _CTRL_MALLOC = 0
@@ -1936,13 +1942,28 @@ class RunHandle:
 
     def wait(self, timeout: float | None = None) -> None:
         """Wait for completion, raising ``TimeoutError`` or the run's error."""
+        # Exactly one waiter is elected to cross the native fence; the rest park
+        # on the CV until it publishes. That election is unrecoverable if it is
+        # abandoned silently — no other path clears `_wait_in_progress`, and
+        # Worker.close() drains the handle with an untimed wait() — so every
+        # publication below (both abandonment paths and the terminal one) is a
+        # resilient publish in the shape close() uses for its _CloseAttempt:
+        # plain attribute assigns land BEFORE the CV acquire, whose only
+        # remaining work is notify_all(). An async BaseException in that
+        # interruptible acquire therefore cannot strand the handle, and a parked
+        # waiter's bounded re-check recovers the skipped notify. The only
+        # irreducible window is an async exception landing between the `_error`
+        # and `_terminal` assigns.
         deadline = self._deadline(timeout)
         with self._cv:
             while not self._terminal and self._wait_in_progress:
                 remaining = None if deadline is None else deadline - time.monotonic()
                 if remaining is not None and remaining <= 0:
                     raise TimeoutError("RunHandle.wait() timed out")
-                self._cv.wait(timeout=remaining)
+                recheck = (
+                    _RUN_HANDLE_WAIT_RECHECK_S if remaining is None else min(remaining, _RUN_HANDLE_WAIT_RECHECK_S)
+                )
+                self._cv.wait(timeout=recheck)
             if self._terminal:
                 error = self._error
                 if error is not None:
@@ -1960,24 +1981,30 @@ class RunHandle:
             completed = True
             native_error = exc
         except BaseException:
+            self._wait_in_progress = False
             with self._cv:
-                self._wait_in_progress = False
                 self._cv.notify_all()
             raise
 
         if not completed:
+            self._wait_in_progress = False
             with self._cv:
-                self._wait_in_progress = False
                 self._cv.notify_all()
             raise TimeoutError("RunHandle.wait() timed out")
 
-        error = self._worker._finalize_run_handle(self, run_id, native_error)
+        # Cleanup runs exactly once, on this waiter, and its outcome IS the
+        # handle's result: an interruption mid-finalize is cached like any other
+        # error rather than lost, so the publication below is unconditional.
+        try:
+            error = self._worker._finalize_run_handle(self, run_id, native_error)
+        except BaseException as exc:  # noqa: BLE001
+            error = exc
+        self._error = error
+        self._run_id = None
+        self._keepalive = None
+        self._terminal = True
+        self._wait_in_progress = False
         with self._cv:
-            self._error = error
-            self._run_id = None
-            self._keepalive = None
-            self._terminal = True
-            self._wait_in_progress = False
             self._cv.notify_all()
         if error is not None:
             raise error
@@ -5888,9 +5915,21 @@ class Worker:
                 result = RuntimeError("RunHandle cleanup lost its native Orchestrator")
         else:
             _step(lambda: orch._release_run(run_id))
-        with self._hierarchical_start_cv:
-            self._accepted_run_handles.discard(handle)
-            self._hierarchical_start_cv.notify_all()
+        # Retirement is not optional: a handle left in the accepted set keeps
+        # every later close() from completing its drain, and the lock is
+        # mandatory (the drain and the submit serializer both snapshot the set
+        # under it). An async BaseException in the interruptible acquire is
+        # delivered to this frame once, so one retry always retires the handle.
+        try:
+            with self._hierarchical_start_cv:
+                self._accepted_run_handles.discard(handle)
+                self._hierarchical_start_cv.notify_all()
+        except BaseException as exc:  # noqa: BLE001
+            if result is None:
+                result = exc
+            with self._hierarchical_start_cv:
+                self._accepted_run_handles.discard(handle)
+                self._hierarchical_start_cv.notify_all()
         return result
 
     @property

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -1632,6 +1632,93 @@ class TestRunHandle:
         assert observed == [True]
         assert wait_entered.is_set()
 
+    def test_interrupted_finalize_still_publishes_terminal_state(self):
+        interrupt = KeyboardInterrupt()
+
+        class FakeWorker:
+            def _wait_run_handle(self, run_id, timeout):
+                return True
+
+            def _finalize_run_handle(self, handle, run_id, error):
+                raise interrupt
+
+        handle = RunHandle(cast(Worker, FakeWorker.__new__(FakeWorker)), 1, ())
+        with pytest.raises(KeyboardInterrupt) as first:
+            handle.wait()
+        assert first.value is interrupt
+        assert handle.done
+        # The handle is terminal, so this must resolve from the cached result
+        # instead of re-electing a waiter that blocks on the native fence.
+        with pytest.raises(KeyboardInterrupt) as second:
+            handle.wait(5.0)
+        assert second.value is interrupt
+
+    def test_waiter_is_not_stranded_when_finalize_is_interrupted(self):
+        finalize_entered = threading.Event()
+        finalize_release = threading.Event()
+
+        class FakeWorker:
+            def _wait_run_handle(self, run_id, timeout):
+                return True
+
+            def _finalize_run_handle(self, handle, run_id, error):
+                finalize_entered.set()
+                assert finalize_release.wait(5.0)
+                raise KeyboardInterrupt
+
+        handle = RunHandle(cast(Worker, FakeWorker.__new__(FakeWorker)), 1, ())
+        elected: list[BaseException] = []
+        parked: list[BaseException] = []
+
+        def run(sink, timeout):
+            try:
+                handle.wait(timeout)
+            except BaseException as exc:  # noqa: BLE001
+                sink.append(exc)
+
+        elected_thread = threading.Thread(target=run, args=(elected, None))
+        elected_thread.start()
+        assert finalize_entered.wait(3.0)
+        parked_thread = threading.Thread(target=run, args=(parked, 5.0))
+        parked_thread.start()
+        finalize_release.set()
+        elected_thread.join(5.0)
+        parked_thread.join(5.0)
+        assert not elected_thread.is_alive()
+        assert not parked_thread.is_alive()
+        assert [type(exc) for exc in elected] == [KeyboardInterrupt]
+        assert [type(exc) for exc in parked] == [KeyboardInterrupt]
+        assert handle.done
+
+    def test_finalize_retires_handle_when_its_cv_acquire_is_interrupted(self):
+        interrupt = KeyboardInterrupt()
+
+        class OnceInterruptingCV:
+            def __init__(self, cv):
+                self._cv = cv
+                self._armed = True
+
+            def __enter__(self):
+                if self._armed:
+                    self._armed = False
+                    raise interrupt
+                return self._cv.__enter__()
+
+            def __exit__(self, *exc_info):
+                return self._cv.__exit__(*exc_info)
+
+            def notify_all(self):
+                self._cv.notify_all()
+
+        hw = Worker(level=3, num_sub_workers=0)
+        handle = RunHandle(hw, 1, ())
+        hw._accepted_run_handles.add(handle)
+        hw._orch = cast(object, type("FakeOrch", (), {"_release_run": lambda self, run_id: None})())
+        hw._hierarchical_start_cv = cast(threading.Condition, OnceInterruptingCV(hw._hierarchical_start_cv))
+
+        assert hw._finalize_run_handle(handle, 1, None) is interrupt
+        assert not hw._accepted_run_handles
+
 
 # ---------------------------------------------------------------------------
 # Test: multiple SUB workers execute in parallel


### PR DESCRIPTION
## Summary

`RunHandle.wait()` elects one waiter to cross the native fence and publish cleanup. That waiter claimed the election with `_wait_in_progress`, then called `Worker._finalize_run_handle()` **unguarded**, and only afterwards marked the handle terminal. An asynchronous exception (`KeyboardInterrupt` / `SystemExit`) landing anywhere in that window propagated out with the election still claimed and the handle still un-terminal — a state nothing else ever clears. Every later `wait()` then blocked or timed out forever, `done` reported `False` permanently, and the handle was never retired from `_accepted_run_handles`, so `Worker.close()` (which drains accepted handles with an *untimed* `wait()`) could never complete.

`Worker.close()` already defends against this exact hazard class for its own joiners; `RunHandle` never got the same treatment. This applies it:

- An exception out of `_finalize_run_handle()` is cached as the handle's error instead of being lost, and still propagates out of `wait()`.
- Terminal state is published with plain attribute assigns (`_error` before `_terminal`) **before** acquiring the CV, whose only remaining work is `notify_all()`. Both election-abandonment paths (native interrupt, timeout) publish the same way, so an async exception in the interruptible acquire cannot strand the handle.
- A parked waiter re-checks on a bounded interval (`_RUN_HANDLE_WAIT_RECHECK_S`, mirroring `_CLOSE_JOIN_RECHECK_S`), so a skipped `notify_all()` is recovered rather than blocking forever. `wait(timeout)` semantics are unchanged — `TimeoutError` still fires only once the caller's own deadline passes.
- `_finalize_run_handle()` retries its trailing `discard`/`notify_all` once, so an interrupt during that acquire cannot skip retiring the handle from `_accepted_run_handles`. The lock stays held for the discard — both `close()`'s drain and the submit serializer snapshot that set under it.

The only irreducible window left (documented in a comment, same as `close()`) is an async exception landing between the `_error` and `_terminal` plain assigns.

Python-only; no behavior change on any non-interrupted path, and the `docs/orchestrator.md` contract ("repeated waits replay the same terminal result") is unchanged — this makes it hold under interruption too.

## Testing

Three regression tests in `TestRunHandle`, each confirmed failing before the fix:
- `test_interrupted_finalize_still_publishes_terminal_state` — elected waiter propagates the interrupt, handle becomes terminal, second `wait()` replays the cached error instead of blocking.
- `test_waiter_is_not_stranded_when_finalize_is_interrupted` — a second waiter parked behind the elected one observes the terminal result (pre-fix it got `TimeoutError`).
- `test_finalize_retires_handle_when_its_cv_acquire_is_interrupted` — handle is retired from `_accepted_run_handles` even when the finalize CV acquire itself is interrupted.

- [x] `pytest tests/ut/py` — 824 passed, 2 skipped
- [x] Simulation: `examples/a2a3/tensormap_and_ringbuffer/async_notify_demo --platform a2a3sim` passes
- [x] Hardware (a2a3, under `task-submit`): `tensormap_and_ringbuffer/{dummy_task,mixed_example}` + `host_build_graph/vector_example` pass
- [x] ruff check / ruff format / pyright / check-headers / check-english-only clean

Fixes #1479