### PR TITLE
Fix: keep a newer same-run TensorMap entry when its predecessor is consumed

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -503,7 +503,7 @@ class TensorMap {
 public:
     TaskSlot lookup(RunId run_id, TensorKey key) const;
     void insert(RunId run_id, TensorKey key, TaskSlot sid);
-    void erase_task_outputs(RunId run_id,
+    void erase_task_outputs(RunId run_id, TaskSlot owner,
                             const std::vector<TensorKey> &keys);
 private:
     std::mutex mu_;
@@ -517,7 +517,11 @@ private:
   entry → fanin edge recorded.
 - **WAW (write-after-write)**: a new `OUTPUT` on the same address replaces
   the entry. The previous producer remains live (still has wire references
-  from any prior consumers); new consumers depend only on the latest.
+  from any prior consumers); new consumers depend only on the latest. The two
+  writers carry no edge between them, so the earlier one can reach CONSUMED
+  first — `erase_task_outputs` therefore drops a key only while it still maps
+  to the consumed slot, leaving the later writer's entry for new consumers to
+  find.
 - **WAR (write-after-read)** is not tracked directly. Read tasks don't
   register in TensorMap; write tasks only look up current producer. If a
   consumer reads `X` (recording fanin on producer P1) and then a later task

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -879,7 +879,7 @@ bool Orchestrator::on_consumed(TaskSlot slot) {
     }
 
     RunId run_id = s.run_id;
-    tensormap_->erase_task_outputs(run_id, s.output_keys);
+    tensormap_->erase_task_outputs(run_id, slot, s.output_keys);
 
     // HeapRing-owned OUTPUT slabs are reclaimed implicitly when the allocator
     // advances last_alive past this slot — no per-slot munmap needed.

--- a/src/common/hierarchical/tensormap.cpp
+++ b/src/common/hierarchical/tensormap.cpp
@@ -23,10 +23,12 @@ void TensorMap::insert(RunId run_id, TensorKey key, TaskSlot producer) {
     map_[RunTensorKey{run_id, key}] = producer;
 }
 
-void TensorMap::erase_task_outputs(RunId run_id, const std::vector<TensorKey> &keys) {
+void TensorMap::erase_task_outputs(RunId run_id, TaskSlot owner, const std::vector<TensorKey> &keys) {
     std::lock_guard<std::mutex> lk(mu_);
-    for (const auto &key : keys)
-        map_.erase(RunTensorKey{run_id, key});
+    for (const auto &key : keys) {
+        auto it = map_.find(RunTensorKey{run_id, key});
+        if (it != map_.end() && it->second == owner) map_.erase(it);
+    }
 }
 
 int32_t TensorMap::size() const {

--- a/src/common/hierarchical/tensormap.h
+++ b/src/common/hierarchical/tensormap.h
@@ -21,7 +21,8 @@
  * Unlike the L2 PTO2TensorMap, this implementation:
  *   - Uses std::unordered_map (no ring buffer entry pool)
  *   - Does not perform overlap detection (each key maps to one producer)
- *   - Cleans up entries actively when a task is CONSUMED
+ *   - Cleans up a task's entries when it is CONSUMED, skipping the keys a
+ *     newer same-run producer has taken over
  *
  * Owned exclusively by the Orchestrator (main thread); no locking required.
  */
@@ -44,9 +45,11 @@ public:
     // Overwrites any existing entry (re-use of the same buffer by a new producer).
     void insert(RunId run_id, TensorKey key, TaskSlot producer);
 
-    // Remove all entries whose key appears in 'keys'.
-    // Called when a producer task transitions to CONSUMED.
-    void erase_task_outputs(RunId run_id, const std::vector<TensorKey> &keys);
+    // Remove the entries in 'keys' that still map to 'owner'.
+    // Called when a producer task transitions to CONSUMED. A key that a newer
+    // same-run producer has since re-registered belongs to that producer and
+    // is left intact.
+    void erase_task_outputs(RunId run_id, TaskSlot owner, const std::vector<TensorKey> &keys);
 
     // Number of entries currently tracked.
     int32_t size() const;

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -186,6 +186,36 @@ TEST_F(OrchestratorFixture, OnConsumedCleansUpTensorMap) {
     EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 }
 
+TEST_F(OrchestratorFixture, ConsumingASupersededProducerKeepsTheNewerMapping) {
+    // Two OUTPUT writers of one key carry no edge between them (insert-only,
+    // see OutputAndOutputExistingAreInsertOnly), so the first can reach
+    // CONSUMED while the second is still running. Its cleanup must leave the
+    // second's mapping intact -- otherwise a later INPUT reader looks up an
+    // empty slot, infers no dependency, and can be dispatched before the
+    // second writer has written the buffer.
+    auto args_a = single_tensor_args(0x5150, TensorArgType::OUTPUT);
+    auto a = orch.submit_next_level(C(42), args_a, cfg, 0);
+    TaskSlot drain;
+    ASSERT_TRUE(rq.try_pop(drain));
+
+    auto args_b = single_tensor_args(0x5150, TensorArgType::OUTPUT);
+    auto b = orch.submit_next_level(C(43), args_b, cfg, 0);
+    ASSERT_TRUE(rq.try_pop(drain));
+    ASSERT_EQ(tm.lookup(run_id, TensorKey{0x5150, -1}), b.task_slot);
+
+    S(a.task_slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+    ASSERT_TRUE(orch.on_consumed(a.task_slot));
+
+    EXPECT_EQ(tm.lookup(run_id, TensorKey{0x5150, -1}), b.task_slot);
+
+    auto args_c = single_tensor_args(0x5150, TensorArgType::INPUT);
+    auto c = orch.submit_next_level(C(44), args_c, cfg, 0);
+    EXPECT_EQ(S(c.task_slot).state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(c.task_slot).fanin_count, 1);
+    ASSERT_EQ(S(c.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(c.task_slot).fanin_producers[0], b.task_slot);
+}
+
 TEST_F(OrchestratorFixture, ScopeRegistersAndReleasesRef) {
     orch.scope_begin();
     auto args_a = single_tensor_args(0x77, TensorArgType::OUTPUT);

--- a/tests/ut/cpp/hierarchical/test_tensormap.cpp
+++ b/tests/ut/cpp/hierarchical/test_tensormap.cpp
@@ -48,7 +48,7 @@ TEST(TensorMap, EraseTaskOutputs) {
     tm.insert(RUN1, hk(0x2000), 0);
     tm.insert(RUN1, hk(0x3000), 1);
 
-    tm.erase_task_outputs(RUN1, {hk(0x1000), hk(0x2000)});
+    tm.erase_task_outputs(RUN1, 0, {hk(0x1000), hk(0x2000)});
 
     EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), INVALID_SLOT);
     EXPECT_EQ(tm.lookup(RUN1, hk(0x2000)), INVALID_SLOT);
@@ -59,7 +59,7 @@ TEST(TensorMap, EraseTaskOutputs) {
 TEST(TensorMap, EraseWithEmptyKeyList) {
     TensorMap tm;
     tm.insert(RUN1, hk(0x1000), 2);
-    tm.erase_task_outputs(RUN1, {});
+    tm.erase_task_outputs(RUN1, 2, {});
     EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 2);
 }
 
@@ -96,7 +96,7 @@ TEST(TensorMap, EraseChildKeyLeavesHostKey) {
     TensorMap tm;
     tm.insert(RUN1, hk(0x1000), 5);
     tm.insert(RUN1, ck(0x1000, 0), 6);
-    tm.erase_task_outputs(RUN1, {ck(0x1000, 0)});
+    tm.erase_task_outputs(RUN1, 6, {ck(0x1000, 0)});
     EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 5);
     EXPECT_EQ(tm.lookup(RUN1, ck(0x1000, 0)), INVALID_SLOT);
     EXPECT_EQ(tm.size(), 1);
@@ -111,7 +111,22 @@ TEST(TensorMap, SameAddressIsNamespacedByRun) {
     EXPECT_EQ(tm.lookup(RUN2, hk(0x1000)), 9);
     EXPECT_EQ(tm.size(), 2);
 
-    tm.erase_task_outputs(RUN1, {hk(0x1000)});
+    tm.erase_task_outputs(RUN1, 5, {hk(0x1000)});
     EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), INVALID_SLOT);
     EXPECT_EQ(tm.lookup(RUN2, hk(0x1000)), 9);
+}
+
+TEST(TensorMap, EraseKeepsNewerSameRunProducer) {
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), 3);
+    tm.insert(RUN1, hk(0x1000), 7);  // unordered second writer of the same key
+
+    // Slot 3 no longer owns the key; its cleanup must not evict slot 7.
+    tm.erase_task_outputs(RUN1, 3, {hk(0x1000)});
+    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 7);
+    EXPECT_EQ(tm.size(), 1);
+
+    tm.erase_task_outputs(RUN1, 7, {hk(0x1000)});
+    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), INVALID_SLOT);
+    EXPECT_EQ(tm.size(), 0);
 }


### PR DESCRIPTION
Fixes #1480

## Problem

`TensorMap::erase_task_outputs(run_id, keys)` erased every key unconditionally.
`Orchestrator::on_consumed` calls it with the consumed task's `output_keys`, so
the cleanup could drop a mapping that a *later* task in the same run already
owns.

Two `OUTPUT` / `OUTPUT_EXISTING` writers of one key carry no edge between them —
that path inserts without looking up — so the first can reach `CONSUMED` while
the second is still running:

1. A: `OUTPUT` K → `insert(run, K, A)`
2. B: `OUTPUT` K → `insert(run, K, B)` (overwrites; A and B unordered)
3. A consumed → `erase_task_outputs(run, [K])` removes the entry pointing at **B**
4. C: `INPUT` K → `lookup` returns `INVALID_SLOT` → **no dependency on B**

C can then be dispatched and read K before B has written it.

`INOUT` is unaffected: it looks up before inserting, so B depends on A and A
cannot reach `CONSUMED` until B has released its reference.

## Fix

`erase_task_outputs` takes the consumed slot and drops a key only while it still
maps to that slot. This mirrors how the L2 TensorMap reclaims a retired task's
entries — `pto_tensormap.h::cleanup_retired`, "Only remove if this entry belongs
to the retiring task (slot may have been reused by a newer task)".

## Tests

- `OrchestratorFixture.ConsumingASupersededProducerKeepsTheNewerMapping` — the
  end-to-end repro. Verified failing on the pre-fix code: C came back with
  `fanin_producers.size() == 0` and `fanin_count == 0`.
- `TensorMap.EraseKeepsNewerSameRunProducer` — same-run WAW at the map level,
  alongside the existing cross-run isolation test. Also asserts the *owning*
  slot's erase still removes the entry.

Existing `erase_task_outputs` call sites in `test_tensormap.cpp` take the owner
slot argument.

## Verification

- `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — **60/60 passed**
- `pytest tests/ut/py` — **824 passed, 2 skipped**
- `pytest tests/st/worker --platform a2a3sim --device 0-3` (level-3 collectives,
  the hierarchical orchestrator's ST coverage) — **18/18 passed**
- `pre-commit run` on the touched files — all hooks pass

Host-only change; no hardware run required.

## Left open

Whether two unordered `OUTPUT` writers of one key should be a *diagnosed error*
rather than a silently unordered WAW — raised in the issue, deliberately not
decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)