### PR TITLE
Fix: initialise dep_gen on the orchestrator, not behind the handshake

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -695,9 +695,20 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if SIMPLER_DFX
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
-            // record the per-thread ready_queue index before any submit_task fires
-            // inside orch_func_.
+            // resolve its buffer state and record the per-thread ready_queue index
+            // before any submit_task fires inside orch_func_. The init belongs to
+            // this thread, not to the scheduler cold path: dep_gen needs nothing
+            // from the AICore handshake, while the orchestrator skips that
+            // handshake entirely on the decoupled path and starts submitting
+            // immediately. Initialising it behind the handshake makes the first
+            // submits race a barrier they never joined — and the wider the device,
+            // the longer that handshake, so the orchestrator wins more of the race
+            // the more clusters there are.
+            //
+            // The free_queue is SPSC: this must remain the only site that pops
+            // from it on the device side.
             if (is_dep_gen_enabled()) {
+                dep_gen_aicpu_init();
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
             }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -981,9 +981,7 @@ void SchedulerContext::post_handshake_profiling_init() {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
         LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
     }
-    if (is_dep_gen_enabled()) {
-        dep_gen_aicpu_init();
-    }
+    if (is_dep_gen_enabled()) {}
 #endif
 }
 
@@ -1224,9 +1222,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     // init() only pops the initial buffer from instance 0's free_queue; the
     // orchestrator thread still records its idx via
     // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
-    if (is_dep_gen_enabled()) {
-        dep_gen_aicpu_init();
-    }
+    if (is_dep_gen_enabled()) {}
 #endif
 
     // total_tasks_ is read in pre_handshake_init (before the orchestrator's early

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -696,9 +696,20 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             scope_stats_aicpu_set_orch_thread_idx(thread_idx);
 
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
-            // record the per-thread ready_queue index before any submit_task fires
-            // inside orch_func_.
+            // resolve its buffer state and record the per-thread ready_queue index
+            // before any submit_task fires inside orch_func_. The init belongs to
+            // this thread, not to the scheduler cold path: dep_gen needs nothing
+            // from the AICore handshake, while the orchestrator skips that
+            // handshake entirely on the decoupled path and starts submitting
+            // immediately. Initialising it behind the handshake makes the first
+            // submits race a barrier they never joined — and the wider the device,
+            // the longer that handshake, so the orchestrator wins more of the race
+            // the more clusters there are.
+            //
+            // The free_queue is SPSC: this must remain the only site that pops
+            // from it on the device side.
             if (is_dep_gen_enabled()) {
+                dep_gen_aicpu_init();
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -973,9 +973,7 @@ void SchedulerContext::post_handshake_profiling_init() {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
         LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
     }
-    if (is_dep_gen_enabled()) {
-        dep_gen_aicpu_init();
-    }
+    if (is_dep_gen_enabled()) {}
 #endif
 }
 
@@ -1220,9 +1218,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     // init() only pops the initial buffer from instance 0's free_queue; the
     // orchestrator thread still records its idx via
     // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
-    if (is_dep_gen_enabled()) {
-        dep_gen_aicpu_init();
-    }
+    if (is_dep_gen_enabled()) {}
 #endif
 
     // total_tasks_ is read in pre_handshake_init (before the orchestrator's early

--- a/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -42,6 +42,12 @@ static bool g_enable_dep_gen = false;
 static DepGenDataHeader *s_dep_gen_header = nullptr;
 static DepGenBufferState *s_dep_gen_state = nullptr;
 static int s_orch_thread_idx = -1;  // set via dep_gen_aicpu_set_orch_thread_idx
+// A record arriving before dep_gen_aicpu_init() cannot be accounted: the
+// counter reconcile_counters() reads lives in the very BufferState that is
+// still null, so the host would see total == collected == dropped == 0 and
+// call an empty deps.json clean. One-shot so a per-task path never floods the
+// AICPU log (see .claude/rules/codestyle.md).
+static bool s_pre_init_drop_reported = false;
 
 static constexpr uint64_t kDepGenQueueBackpressureWaitCycles = PLATFORM_DFX_BACKPRESSURE_TIMEOUT_CYCLES;
 
@@ -133,6 +139,7 @@ void dep_gen_aicpu_init() {
         LOG_ERROR("dep_gen_aicpu_init: dep_gen_data_base is NULL");
         return;
     }
+    s_pre_init_drop_reported = false;
     s_dep_gen_header = get_dep_gen_header(base);
     s_dep_gen_state = get_dep_gen_buffer_state(base, /*instance_index=*/0);
 
@@ -156,7 +163,17 @@ void dep_gen_aicpu_record_submit(
     const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
     const int32_t kernel_ids[3]
 ) {
-    if (!g_enable_dep_gen || s_dep_gen_state == nullptr) {
+    if (!g_enable_dep_gen) {
+        return;
+    }
+    if (s_dep_gen_state == nullptr) {
+        if (!s_pre_init_drop_reported) {
+            s_pre_init_drop_reported = true;
+            LOG_ERROR(
+                "dep_gen: submit recorded before dep_gen_aicpu_init(); this and any further "
+                "pre-init records are lost and cannot be reconciled on the host"
+            );
+        }
         return;
     }
 


### PR DESCRIPTION
## The bug

The `dep_gen` DFX collector intermittently emits an **empty** `deps.json`:

```text
AssertionError: deps.json missing expected edges: {(0, 4294967297), ...} (got set())
```

`got set()` — no edges at all, rather than wrong edges. The records are never
recorded, not buffered-and-unread and not dropped at emit.

`dep_gen_aicpu_init()` resolves the collector's buffer state and pops its first
buffer, and it ran from the scheduler cold path **after the AICore handshake**,
next to `pmu_aicpu_init()`. pmu belongs there — it needs the `physical_core_ids_`
the handshake produces. dep_gen needs nothing from it: init only reads
`dep_gen_data_base`, which `kernel.cpp` publishes before `aicpu_execute()` even
starts.

The orchestrator, meanwhile, deliberately skips that handshake
(`aicpu_executor.cpp`):

```cpp
if (decouple_orch && is_orchestrator) {
    return 0;  // do NOT touch the handshake or hs_arrived_ barrier
}
```

so it goes straight to building the graph while the schedulers are still
handshaking cores. Every `submit_task` in that window reaches
`dep_gen_aicpu_record_submit()` with `s_dep_gen_state` still null and is dropped.

Instrumented device log, same binary, same card, only the width changed:

```text
block_dim=3   PASS  dep_gen_aicpu_flush: pre_init_misses=0 init_calls=1 state=0x12c0c00e8440
block_dim=24  FAIL  dep_gen_aicpu_flush: pre_init_misses=5 init_calls=0 state=(nil)
                    dep_gen_aicpu_init:  entering        <-- after the flush
```

## It is a race, not a capacity limit

Handshake wall time scales with core count, so the wider the device the more
often the orchestrator wins:

| block_dim | 2 | 3 | 4 | 6 | 8 | 12 | 20 | 24 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| pass rate | 2/2 | 5/5 | 2/2 | 1/2 | 3/4 | 0/5 | 1/5 | 1/5 |

There is no threshold and no 21/22 cliff — I looked for one, since #1477 had
just fixed a 21-cluster bound in `CoreTracker`, and this is not that. The
intermediate runs are the giveaway: several failed with `tasks[] missing
expected ids: {0}`, i.e. the graph captured **except its very first submit**. No
sizing or indexing bug loses exactly the first record and keeps the rest.

**This already reaches CI on `main`.** The CI runner loses the race even at
`block_dim: 3` — `st-onboard-a2a3` on #1478, which does not touch `block_dim` at
all, fails with exactly this assertion, and `main`'s own history has an
`st-onboard-a2a3` failure among recent runs.

## Why only dep_gen

`pmu` / `args_dump` / `l2_swimlane` are per-core subsystems whose producers are
downstream of the same handshake that gates their init, so they cannot race it.
`scope_stats` is orchestrator-side like dep_gen, but resolves its pointers inside
`set_platform_scope_stats_base()` — before `aicpu_execute()` — and pops its
buffer lazily. dep_gen was the only orchestrator-side subsystem with an eager
init parked behind the handshake. I ran all five per-feature smokes at full
width: only dep_gen failed.

## The fix

Initialise dep_gen on the thread that feeds it, immediately before the existing
`set_orch_thread_idx()` and before `orch_func_` runs. There is then nothing left
to order it against.

**Both** cold-path call sites go, not just one: the free_queue is SPSC and the
orchestrator must be its only device-side consumer. a5 carried the identical
arrangement and is fixed with it.

## The silence

The failure surfaced as an empty file rather than an error because the early
return skipped the accounting one line below it — the line whose comment reads
*"Account every attempted record so total == collected + dropped on host"*. The
host's `reconcile_counters()` saw `0/0/0`, called that consistent, and wrote
`{"tasks":[],"tensors":[],"edges":[]}`.

A pre-init record cannot be accounted — the counter lives in the `BufferState`
that is still null — so it now reports itself once instead. Once, because
`record_submit` is a per-task path and the AICPU log is not free
(`.claude/rules/codestyle.md` §7).

## Verification

| Check | Result |
| ----- | ------ |
| dep_gen smoke, widths 24/3/24/16/24/12/24/auto | **8/8 pass** (was ~80% failure at 24) |
| `pytest examples tests/st --platform a2a3sim` | 52 passed, 0 failed |
| `pytest examples tests/st --platform a5sim` | 39 passed, 0 failed |
| `pytest tests/ut -m "not requires_hardware"` | 816 passed |
| pre-commit (all hooks) | passed |

**Not run on this branch:** the full onboard a2a3 suite and the other four DFX
smokes. The dep_gen smoke is the one that reproduces this, and it was run across
eight widths; the rest is unverified here.

## Follow-up, not fixed here

`host_build_graph` calls `dep_gen_aicpu_init()`
(`src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp:899`)
but never calls `dep_gen_aicpu_set_orch_thread_idx()` or `..._flush()`, so
`s_orch_thread_idx` stays `-1` and an `enqueue_ready` would index `queues[-1]`.
Unreachable today — hbg has no dep_gen consumer path — but it is a separate bug
and wants its own change. Filing an issue.

Unblocks #1478 and #1309, both of which are red on this assertion.