### PR TITLE
Fix: stage bgemm's C accumulator to the device (host_build_graph)

### DIFF
--- a/tests/st/a2a3/host_build_graph/bgemm/README.md
+++ b/tests/st/a2a3/host_build_graph/bgemm/README.md
@@ -5,8 +5,11 @@ Tiled matrix multiplication example demonstrating Cube (AIC) and Vector (AIV) co
 ## Computation
 
 ```text
-C = A @ B
+C = C_init + A @ B
 ```
+
+`C` is an INOUT accumulator: every output tile is read-modify-written by
+`tile_add`, starting from the host-supplied `C_init` staged to the device.
 
 Tiled computation with 4x4x4 grid:
 

--- a/tests/st/a2a3/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -11,7 +11,8 @@
 /**
  * BGEMM orchestration — submit_task / TensorMap form
  *
- * Tiled C = A @ B, tile 64x64, grid 4x4x4.  Per output tile (m,n), for each k:
+ * Tiled C = C_init + A @ B, tile 64x64, grid 4x4x4.  Per output tile (m,n),
+ * for each k:
  *   P_k = A[m,k] @ B[k,n]   (gemm_tile, AIC)  — fresh runtime-allocated buffer
  *   C[m,n] += P_k           (tile_add, AIV, INOUT C tile)
  *
@@ -20,9 +21,12 @@
  *   - add_{k-1} -> add_k via the C[m,n] tile (add_inout overlap).
  * Allocating a fresh P per k (instead of reusing one P buffer per tile) removes
  * the write-after-read hazard the explicit-edge version needed an extra edge
- * for. C arrives zero-initialized (pure OUTPUT), so the accumulation is exact.
+ * for.
  *
- * Arg layout: [A (IN), B (IN), C (OUT)] — flattened 1-D tile-first tensors.
+ * Arg layout: [A (IN), B (IN), C (INOUT)] — flattened 1-D tile-first tensors.
+ * C must be declared INOUT, not OUT: the k=0 tile_add reads C before any task
+ * has written it, and the runtime stages only IN/INOUT tensors to the device
+ * (a tensor declared OUT is handed to the kernel uninitialized).
  */
 
 #include <stdint.h>

--- a/tests/st/a2a3/host_build_graph/bgemm/test_bgemm.py
+++ b/tests/st/a2a3/host_build_graph/bgemm/test_bgemm.py
@@ -9,11 +9,10 @@
 # -----------------------------------------------------------------------------------------------------------
 """BGEMM — host_build_graph runtime with tiled matrix multiplication.
 
-Computation: C = A @ B (4x4x4 grid, 64x64 tiles).
+Computation: C = C_init + A @ B (4x4x4 grid, 64x64 tiles).
 Tests AIC (Cube) + AIV (Vector) cooperation with tile-first memory layout.
 """
 
-import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
@@ -26,15 +25,12 @@ GRID_M = 4
 GRID_K = 4
 GRID_N = 4
 BATCH = 1
+C_BASE = 0.25
 
 
-# The golden comparison reads memory this run never wrote: max_diff lands
-# between 1e25 and 1e36 on inputs of magnitude 1e-2, roughly one full-suite run
-# in two or three, and never when the case runs alone. Tracked in #1483.
-@pytest.mark.skip(reason="flaky: reads uninitialised device memory in full-suite runs (#1483)")
 @scene_test(level=2, runtime="host_build_graph")
 class TestBgemmHostBuildGraph(SceneTestCase):
-    """BGEMM: tiled C = A @ B with AIC gemm + AIV tile add."""
+    """BGEMM: tiled C = C_init + A @ B with AIC gemm + AIV tile add."""
 
     RTOL = 1e-3
     ATOL = 1e-3
@@ -43,7 +39,7 @@ class TestBgemmHostBuildGraph(SceneTestCase):
         "orchestration": {
             "source": "kernels/orchestration/bgemm_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
-            "signature": [D.IN, D.IN, D.OUT],
+            "signature": [D.IN, D.IN, D.INOUT],
         },
         "incores": [
             {
@@ -73,7 +69,10 @@ class TestBgemmHostBuildGraph(SceneTestCase):
     def generate_args(self, params):
         A = torch.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K, dtype=torch.float32) * 0.01
         B = torch.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N, dtype=torch.float32) * 0.01
-        C = torch.zeros(BATCH, GRID_M, GRID_N, TILE_M, TILE_N, dtype=torch.float32)
+        # C is an INOUT accumulator: the k=0 tile_add reads it before anything
+        # writes it. A non-zero base makes the host->device staging of C
+        # observable — a zeroed or unstaged device buffer fails the compare.
+        C = torch.full((BATCH, GRID_M, GRID_N, TILE_M, TILE_N), C_BASE, dtype=torch.float32)
 
         return TaskArgsBuilder(
             Tensor("A", A.flatten()),
@@ -86,7 +85,6 @@ class TestBgemmHostBuildGraph(SceneTestCase):
         B = args.B.reshape(BATCH, GRID_K, GRID_N, TILE_K, TILE_N)
         C = args.C.reshape(BATCH, GRID_M, GRID_N, TILE_M, TILE_N)
 
-        C[:] = 0.0
         for batch in range(BATCH):
             for m_idx in range(GRID_M):
                 for n_idx in range(GRID_N):


### PR DESCRIPTION
## Summary

Fixes #1483 — `tests/st/a2a3/host_build_graph/bgemm` intermittently failed its golden compare with `max_diff` of 1e25–1e36, but only in full-suite sim runs, never in isolation.

## Root cause

`C` is declared `D.OUT` in the orchestration signature, but the task graph read-modify-writes it: `p_add.add_inout(c_view)` feeds `kernel_tile_add`, whose first `k` iteration `TLOAD`s `C` before any task has written it.

The runtime stages only IN/INOUT tensors host→device (`src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp` — *"pure write-only OUTPUT buffers are never read by the kernel"*), and since #1365 (`affb4612`) it no longer zero-fills OUT buffers either. So `C` accumulated onto whatever the device allocation happened to hold. On sim that allocation is a plain `malloc` block on a process-lifetime worker (`memory_allocator.cpp`): fresh zeros when the case runs alone, a previous case's bytes under the full suite. Same class as #1449.

Both sibling bgemm variants already tag their accumulator correctly — `examples/a5/tensormap_and_ringbuffer/bgemm` and `examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm` use `D.INOUT`. The hbg ST was the only one mislabelling it.

## Fix

- `signature`: `[D.IN, D.IN, D.OUT]` → `[D.IN, D.IN, D.INOUT]`.
- Seed `C` with a non-zero base (`0.25`) and drop `C[:] = 0.0` from `compute_golden`, so golden is `C_init + A @ B`. This makes the staging load-bearing: a zeroed or unstaged device buffer can no longer match, so a future regression fails deterministically instead of hiding behind a happens-to-be-zero allocation.
- Drop the `pytest.mark.skip` that quarantined the case — the defect it tracked is fixed, so the case runs in CI again.
- Orchestration header comment and README updated — the comment previously asserted *"C arrives zero-initialized (pure OUTPUT), so the accumulation is exact"*, which is no longer true.

## Verification

- **Failing repro first**: with the non-zero base applied but the signature still `D.OUT`, the case fails on the first attempt with `max_diff=8.0e+35` — the reported signature, now deterministic rather than one run in two or three.
- With the fix: passes in isolation on `a2a3sim` and onboard on `a2a3` under `task-submit`.
- `pytest examples tests/st --platform a2a3sim --device 0-15 --pto-session-timeout 600 --require-pto-isa` — green on 5/5 consecutive runs, 3 before and 2 after the rebase onto `23de96e0` (issue reported ~1-in-2-to-3 failures).
- `pre-commit` clean on all three changed files.

## Scope

I surveyed every other `add_inout` orchestration under `tests/st/a2a3/host_build_graph/`: `available_aicore_counts` and `predicated_dispatch` already declare their tensors INOUT, and `dump_args` / `matmul` / `vector_example` cover their OUT tensor with an `add_output` before any read. bgemm was the only offender, so no other test is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
