### PR TITLE
Fix: give each process its own counter slot in test_l4_sub_and_l3_dispatch

### DIFF
--- a/tests/ut/py/test_worker/test_l4_recursive.py
+++ b/tests/ut/py/test_worker/test_l4_recursive.py
@@ -28,22 +28,30 @@ from simpler.worker import Worker
 # ---------------------------------------------------------------------------
 
 
-def _make_shared_counter():
-    """Allocate a 4-byte shared counter accessible from forked subprocesses."""
-    shm = SharedMemory(create=True, size=4)
+def _make_shared_counter(slots: int = 1):
+    """Allocate `slots` 4-byte shared counters accessible from forked subprocesses.
+
+    `_increment_counter` is a non-atomic read-modify-write, so a slot tolerates
+    at most one writing process: two processes that read before either writes
+    both store the same value and one increment is lost. A test whose
+    increments come from more than one process must give each process its own
+    slot.
+    """
+    shm = SharedMemory(create=True, size=4 * slots)
     buf = shm.buf
     assert buf is not None
-    struct.pack_into("i", buf, 0, 0)
+    for slot in range(slots):
+        struct.pack_into("i", buf, 4 * slot, 0)
     return shm, buf
 
 
-def _read_counter(buf) -> int:
-    return struct.unpack_from("i", buf, 0)[0]
+def _read_counter(buf, slot: int = 0) -> int:
+    return struct.unpack_from("i", buf, 4 * slot)[0]
 
 
-def _increment_counter(buf) -> None:
-    v = struct.unpack_from("i", buf, 0)[0]
-    struct.pack_into("i", buf, 0, v + 1)
+def _increment_counter(buf, slot: int = 0) -> None:
+    v = struct.unpack_from("i", buf, 4 * slot)[0]
+    struct.pack_into("i", buf, 4 * slot, v + 1)
 
 
 def _slot_for(worker: Worker, handle: CallableHandle) -> int:
@@ -309,15 +317,20 @@ class TestL4WithOwnSubs:
     def test_l4_sub_and_l3_dispatch(self):
         """L4 has its own sub workers AND dispatches to an L3 child.
 
-        Both L4's sub callable and L3's sub callable increment the same
-        shared counter. Verifies both paths execute.
+        L4's sub callable and L3's sub callable each increment a counter, and
+        both paths must execute. They are the only two increments in this file
+        that run in *different* processes — L4's own SubWorker and the L3
+        child's SubWorker — dispatched from independent WorkerThreads with no
+        ordering between them, so each gets its own slot. Sharing one slot
+        would make the pair a cross-process non-atomic read-modify-write.
         """
-        counter_shm, counter_buf = _make_shared_counter()
+        counter_shm, counter_buf = _make_shared_counter(slots=2)
+        L3_SLOT, L4_SLOT = 0, 1
 
         try:
             # L3 child: sub worker increments counter
             l3 = Worker(level=3, num_sub_workers=1)
-            l3_sub_handle = l3.register(lambda args: _increment_counter(counter_buf))
+            l3_sub_handle = l3.register(lambda args: _increment_counter(counter_buf, L3_SLOT))
 
             def l3_orch(orch, args, config):
                 orch.submit_sub(l3_sub_handle)
@@ -325,7 +338,7 @@ class TestL4WithOwnSubs:
             # L4: own sub worker + L3 child
             w4 = Worker(level=4, num_sub_workers=1)
             l3_handle = w4.register(l3_orch)
-            l4_verify_handle = w4.register(lambda args: _increment_counter(counter_buf))
+            l4_verify_handle = w4.register(lambda args: _increment_counter(counter_buf, L4_SLOT))
             l3_worker_id = w4.add_worker(l3)
             w4.init()
 
@@ -336,8 +349,8 @@ class TestL4WithOwnSubs:
             w4.run(l4_orch)
             w4.close()
 
-            # L3 sub + L4 sub = 2
-            assert _read_counter(counter_buf) == 2
+            assert _read_counter(counter_buf, L3_SLOT) == 1, "L3 sub callable did not run"
+            assert _read_counter(counter_buf, L4_SLOT) == 1, "L4 sub callable did not run"
         finally:
             counter_shm.close()
             counter_shm.unlink()


### PR DESCRIPTION
## Summary

Fixes the macOS-only `ut` flake where `TestL4WithOwnSubs::test_l4_sub_and_l3_dispatch` fails with `assert 1 == 2`.

**2 failures in 218 sampled `ut (macos-latest, 3.10)` jobs (~0.9%); 0 in 101 Ubuntu jobs**, over Jul 20-26.

## Root cause

`_increment_counter` is a non-atomic read-modify-write on one shared 4-byte cell:

```python
v = struct.unpack_from("i", buf, 0)[0]   # read
struct.pack_into("i", buf, 0, v + 1)     # write
```

`test_l4_sub_and_l3_dispatch` is the only case in the file whose L4 parent has **both** its own sub worker (`num_sub_workers=1`) and an L3 child, and whose orch submits to both in one run. L4's SubWorker and the L3 child's SubWorker are **distinct forked processes**, dispatched from independent `WorkerThread`s with no ordering between them. If both read the cell before either writes, both store `1` and one increment is lost.

Every other counter test funnels its increments through a single `num_sub_workers=1` process. `TestL4L3WithMultipleSubs` already documents that workaround in its docstring — it just cannot apply here, because the two incrementers belong to two different workers by construction.

**This is a lost update, not a dropped dispatch.** `Worker.run()` is `submit(...).wait()`, whose fence is `RunState::active_tasks == 0` with submission closed, and the wait is untimed. A task that never ran would **hang**, not under-count. The NEXT_LEVEL ack is likewise written only after the L3 child's own nested `submit().wait()` drains. So both increments provably execute, and the observed total of 1 can only be a lost write.

### Why macOS

Not `spawn` vs `fork` — this path uses raw `os.fork()`, so the start method is `fork` on both platforms. The macOS runner's narrower core count widens the window between the read and the write. The race is real on Linux too; it just loses far less often.

## Fix

Give the three counter helpers an optional slot index (default `0`, so the six single-writer call sites are untouched) and give each path its own slot.

Asserting the two slots separately also **names which path was lost** on failure — the previous `assert 1 == 2` said nothing about which one.

A per-slot counter is preferred over a pre-fork `multiprocessing.Lock()`: it needs no cross-process primitive, and each slot then has exactly one writer, so the RMW is correct by construction rather than by mutual exclusion.

## Verification

- `pytest tests/ut/py -q` -> **824 passed, 2 skipped** (Linux aarch64).
- `pre-commit` clean.

I cannot reproduce the macOS failure without a macOS runner, so the fix rests on the code-level proof above rather than on a red-to-green local run. **The change doubles as the discriminating experiment**: a lost update is now impossible by construction, so if the test ever fails again with a slot reading `0`, the cause is a product dispatch bug rather than this race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)