### PR TITLE
Fix: link incore objects before extracting the AICore .text payload

### DIFF
--- a/docs/aicore-kernel-programming.md
+++ b/docs/aicore-kernel-programming.md
@@ -219,55 +219,67 @@ thread `args` into a third-party library template.
 **Do not** bridge `get_subblockid()` with a file-scope cache:
 
 ```cpp
-// WRONG — the .o will not load. See §4.
+// WRONG — hides per-core state from the orchestrator.
 [[block_local]] static int32_t lane;   // per-core static
 #define get_subblockid() lane          // redirect the library's no-arg call
 // ... lane = get_sub_block_id(args); once in kernel_entry
 ```
 
-A `[[block_local]]` (or any non-const) static is read via a `.text` relocation
-that the AICore loader rejects (§4). If onboard `get_subblockid()` does not
-match `get_sub_block_id(args)`, prefer fixing platform/launch identity; until
-then add the lane split explicitly with `setEntryOffset` computed inline from
+The link step resolves the `.text` relocation such a static needs (§4), so this
+loads — but it is still the wrong shape: it hides per-core state the
+orchestrator cannot see, behind a macro that silently changes what a library
+template computes. If onboard `get_subblockid()` does not match
+`get_sub_block_id(args)`, prefer fixing platform/launch identity; until then add
+the lane split explicitly with `setEntryOffset` computed inline from
 `get_sub_block_id(args)` (see the `run_aiv` `setEntryOffset` call sites in
 [`spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp`](../tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp)).
 
 ---
 
-## 4. The AICore loader runs raw `.text` only
+## 4. The AICore loader runs a linked `.text`
 
-simpler loads a kernel by copying the **literal `.text` section bytes** out of
-the compiled `.o` and jumping to them
-([`simpler_setup/elf_parser.py`](../simpler_setup/elf_parser.py)). It does
-**not**:
+simpler loads a kernel by copying the **literal `.text` section bytes** and
+jumping to offset 0. To make those bytes self-contained,
+[`KernelCompiler.compile_incore`](../simpler_setup/kernel_compiler.py) links
+each compiled object with `ld.lld` (`-e kernel_entry`) before
+[`elf_parser.extract_text_section`](../simpler_setup/elf_parser.py) takes the
+payload. Linking is what:
 
-- apply ELF relocations (`.rela.text`), or
-- merge out-of-line template instantiations (`.text._Z*` COMDAT groups).
+- applies ELF relocations (`.rela.text`), and
+- folds out-of-line template instantiations (`.text._Z*` COMDAT groups) into
+  the single output `.text`.
 
-If a kernel `.o` carries either, the loader refuses it with
-"AICore loader cannot extract a runnable payload …" rather than load a binary
-whose `BL`/`B` targets are left as `imm26 = 0` — those would branch to garbage
-on device, producing CANN 507018 watchdog timeouts or silently-wrong partial
-output (the failure modes behind issue #900, PR #830 / issue #831). The loader
-is strict **by design**; it is not relaxed to let "benign" relocations through.
+The linked image is position-independent — `--image-base` does not change the
+emitted `.text` — so the loader can place it anywhere.
 
-Two things produce a rejected `.o`:
+`extract_text_section` still refuses an image that carries either, and also one
+whose `kernel_entry` is not at the start of `.text` (the loader would enter the
+wrong function). Reaching one of those now means the **link** left the image
+incomplete — an undefined symbol kept as a relocation, or out-of-line code the
+linker placed ahead of the entry point — not that a kernel merely needs
+inlining. The alternative, loading a binary whose `BL`/`B` targets are left as
+`imm26 = 0`, branches to garbage on device: CANN 507018 watchdog timeouts or
+silently-wrong partial output (issue #900, PR #830 / issue #831).
 
-| Cause | Why it relocates | Fix |
-| ----- | ---------------- | --- |
-| Out-of-line call to another function (a non-inlined `static` helper, or a template instantiation emitted to its own section) | `BL <fn>` needs an `R_AARCH64_CALL26` relocation the loader can't apply | Mark every function in the call chain `__attribute__((always_inline))` so the compiler folds them into one `.text` |
-| Reading a non-const global / `static` / `[[block_local]]` variable | The address load needs a relocation against the data symbol | Don't use module-level mutable data on AICore — pass the value as a function argument down from `kernel_entry` |
+What linking does and does not rescue:
 
-Verify a kernel object before chasing a device hang:
+| Cause | Why it relocates | Status |
+| ----- | ---------------- | ------ |
+| Out-of-line call to another function (a non-inlined `static` helper, or a template instantiation emitted to its own section) | `BL <fn>` needs an `R_AARCH64_CALL26` relocation | Resolved by the link, provided the linker keeps `kernel_entry` first. `__attribute__((always_inline))` on the call chain still avoids the question entirely and keeps the payload smaller |
+| Reading a non-const global / `static` / `[[block_local]]` variable | The address load needs a relocation against the data symbol | Resolved by the link: block-locals merge into one `.bl_uninit` region and each reference gets its true offset. Still prefer passing the value as an argument down from `kernel_entry` — a per-core global is state the orchestrator cannot see |
+
+That second row is why CANN AscendC kernels load at all: AscendC declares
+`g_vecTPipePtr` / `g_cubeTPipePtr` and `g_kfcClient` as block-local globals in
+separate `.bl.uninit.*` sections, and they cannot all sit at offset 0. Without
+the link, whichever one is not first silently aliases onto another's slot.
+
+Verify a kernel image before chasing a device hang:
 
 ```bash
-readelf -SW kernel.o | grep -E '\.text'  # want only ".text"; ".text._Z*" or ".rela.text" = reject
-readelf -r  kernel.o                      # want: no relocation entries
+readelf -SW kernel.elf | grep -E '\.text'   # want only ".text"
+readelf -rW kernel.elf                      # want: no relocation entries
+readelf -sW kernel.elf | grep kernel_entry  # want: value == .text address
 ```
-
-This is exactly why §3 rejects a cached `[[block_local]]` static to redirect
-`get_subblockid()`: the static would reintroduce a `.rela.text` the loader
-rejects.
 
 ---
 

--- a/simpler_setup/elf_parser.py
+++ b/simpler_setup/elf_parser.py
@@ -12,17 +12,18 @@ Object File Parser for AICore Kernel Binaries
 Pure Python implementation for extracting the ``.text`` section from
 ELF64 or Mach-O ``.o`` files for direct execution on AICore.
 
-The loader extracts only the literal ``.text`` section bytes; it does
-NOT apply ELF relocations or merge ``.text._Z*`` COMDAT group sections
-(out-of-line template instantiations). If a kernel ``.o`` contains
-either, the loader rejects it with an actionable diagnostic — see
-issue #900 and PR #830 / issue #831 for the failure modes that motivate
-this check (CANN 507018 watchdog timeouts and silently-wrong partial
-output, both caused by BL instructions in ``.text`` left with imm26=0).
+The loader extracts only the literal ``.text`` section bytes and jumps to
+offset 0, so the payload must already be complete: no unapplied relocations,
+no code stranded outside ``.text``, and ``kernel_entry`` first.
 
-The workaround on the kernel side is to mark every templated AICore
-function in the call chain with ``__attribute__((always_inline))`` so
-the compiler folds the call graph into a single ``.text`` section.
+``KernelCompiler.compile_incore`` links each object with ``ld.lld`` before it
+reaches this parser, which is what makes those properties hold — the linker
+applies ``.rela.text`` and folds ``.text.*`` COMDAT groups into the output
+``.text``. The checks below therefore run *after* linking: reaching one means
+the link did not produce a self-contained image, not that a kernel merely
+needs inlining. Returning the raw bytes anyway is what issue #900 and
+PR #830 / issue #831 record — CANN 507018 watchdog timeouts and
+silently-wrong partial output from BL instructions left with imm26=0.
 """
 
 import logging
@@ -45,7 +46,15 @@ _RELA_SIZE = 24
 
 # ELF section types
 _SHT_PROGBITS = 1
+_SHT_SYMTAB = 2
 _SHT_RELA = 4
+
+# Elf64_Sym: st_name(4) st_info(1) st_other(1) st_shndx(2) st_value(8) st_size(8)
+_SYM_SIZE = 24
+
+# The AICore loader jumps to offset 0 of the payload, so this symbol must be
+# the first thing in .text.
+_ENTRY_SYMBOL = "kernel_entry"
 
 # Mach-O Magic Numbers
 MH_MAGIC_64 = 0xFEEDFACF
@@ -129,6 +138,8 @@ def _extract_text_elf64(elf_data: bytes, source_name: str) -> bytes:
     # produce broken code on device.
     text_data: Union[bytes, None] = None
     text_size = 0
+    text_index = -1
+    text_addr = 0
     out_of_line: list[tuple[str, int]] = []
     text_relocs: list[tuple[str, int]] = []
 
@@ -147,6 +158,8 @@ def _extract_text_elf64(elf_data: bytes, source_name: str) -> bytes:
                 raise ValueError(f"Invalid ELF: .text section data is out of bounds in {source_name}")
             text_data = elf_data[sh_offset : sh_offset + sh_size]
             text_size = sh_size
+            text_index = i
+            text_addr = struct.unpack("<Q", elf_data[section_offset + 16 : section_offset + 24])[0]
         elif sh_type == _SHT_PROGBITS and section_name.startswith(".text."):
             # `.text._Z*` group sections hold out-of-line template instantiations
             # (and similar inline-but-not-inlined emissions). `.text.startup`
@@ -161,8 +174,65 @@ def _extract_text_elf64(elf_data: bytes, source_name: str) -> bytes:
     if text_data is None:
         raise ValueError(f".text section not found in: {source_name}")
 
+    _check_entry_is_first(elf_data, source_name, e_shoff, e_shnum, text_index, text_addr)
+
     logger.debug(f"Loaded .text section from {source_name} (size: {text_size} bytes)")
     return text_data
+
+
+def _check_entry_is_first(
+    elf_data: bytes,
+    source_name: str,
+    e_shoff: int,
+    e_shnum: int,
+    text_index: int,
+    text_addr: int,
+) -> None:
+    """Reject an image whose ``kernel_entry`` is not at the start of ``.text``.
+
+    The loader jumps to offset 0 of the extracted payload. In an unlinked object
+    that is ``kernel_entry`` by construction, but linking merges ``.text.*``
+    COMDAT groups into ``.text`` and is free to order them, so a kernel with
+    out-of-line code can end up with another function first. Objects carrying no
+    symbol table, or none naming ``kernel_entry``, are left alone — orchestration
+    and hand-built test fixtures both take that path.
+    """
+    for i in range(e_shnum):
+        section_offset = e_shoff + i * _SHDR_SIZE
+        if struct.unpack("<I", elf_data[section_offset + 4 : section_offset + 8])[0] != _SHT_SYMTAB:
+            continue
+        sym_offset = struct.unpack("<Q", elf_data[section_offset + 24 : section_offset + 32])[0]
+        sym_size = struct.unpack("<Q", elf_data[section_offset + 32 : section_offset + 40])[0]
+        link = struct.unpack("<I", elf_data[section_offset + 40 : section_offset + 44])[0]
+        if link >= e_shnum or sym_size > len(elf_data) or sym_offset > len(elf_data) - sym_size:
+            continue
+
+        str_header = e_shoff + link * _SHDR_SIZE
+        str_offset = struct.unpack("<Q", elf_data[str_header + 24 : str_header + 32])[0]
+        str_size = struct.unpack("<Q", elf_data[str_header + 32 : str_header + 40])[0]
+        if str_size > len(elf_data) or str_offset > len(elf_data) - str_size:
+            continue
+        symstr = elf_data[str_offset : str_offset + str_size]
+
+        for s in range(sym_size // _SYM_SIZE):
+            entry = sym_offset + s * _SYM_SIZE
+            st_name = struct.unpack("<I", elf_data[entry : entry + 4])[0]
+            if st_name >= len(symstr) or _extract_cstring(symstr, st_name) != _ENTRY_SYMBOL:
+                continue
+            st_shndx = struct.unpack("<H", elf_data[entry + 6 : entry + 8])[0]
+            st_value = struct.unpack("<Q", elf_data[entry + 8 : entry + 16])[0]
+            if st_shndx != text_index or st_value != text_addr:
+                raise ValueError(
+                    f"AICore loader cannot extract a runnable payload from {source_name}: "
+                    f"{_ENTRY_SYMBOL} is not at the start of .text (symbol is at section "
+                    f"{st_shndx} offset {st_value:#x}, .text is section {text_index} at "
+                    f"{text_addr:#x}). The loader jumps to offset 0 of the payload, so it "
+                    f"would enter the wrong function. This means the link placed out-of-line "
+                    f"code ahead of the entry point. Inspect with:\n"
+                    f"  readelf -SW <file> | grep '\\.text'\n"
+                    f"  readelf -sW <file> | grep {_ENTRY_SYMBOL}"
+                )
+            return
 
 
 def _raise_unresolved_text_error(
@@ -172,11 +242,12 @@ def _raise_unresolved_text_error(
 ) -> None:
     """Raise with an actionable diagnostic naming the offending sections.
 
-    See issue #900 for context: the loader does not yet merge `.text._Z*`
-    sections or apply `.rela.text*` relocations. Silently returning the
-    raw `.text` bytes in that situation produces BL/B instructions with
-    imm26=0, which on AICore manifests as CANN 507018 watchdog timeouts
-    or silently-wrong partial output (e.g. PR #830 / issue #831).
+    `KernelCompiler.compile_incore` links before extraction, so a linked image
+    reaching here still has code outside `.text` or relocations `ld.lld` could
+    not apply. Silently returning the raw `.text` bytes in that situation
+    produces BL/B instructions with imm26=0, which on AICore manifests as CANN
+    507018 watchdog timeouts or silently-wrong partial output (issue #900,
+    PR #830 / issue #831).
     """
     detail_lines = []
     if out_of_line:
@@ -189,17 +260,19 @@ def _raise_unresolved_text_error(
             detail_lines.append(f"  {name}  ({count} entries)")
     detail = "\n".join(detail_lines)
     raise ValueError(
-        f"AICore loader cannot extract a runnable payload from {source_name}: the .o file contains "
-        f"out-of-line code or unresolved .text relocations that this loader does not yet apply "
+        f"AICore loader cannot extract a runnable payload from {source_name}: it contains "
+        f"out-of-line code or relocations against .text that linking did not resolve "
         f"(see issue #900). On device the BL/B targets in .text would branch to garbage, "
         f"producing CANN 507018 watchdog timeouts or silently-wrong partial output "
         f"(historically PR #830 / issue #831).\n\n"
         f"{detail}\n\n"
-        f"Workaround until the loader applies relocations: annotate every templated AICore "
-        f"function in the call chain with __attribute__((always_inline)) so the compiler folds "
-        f"the call graph into a single .text section. Verify with:\n"
-        f"  readelf -S <file.o> | grep '\\.text'\n"
-        f"  readelf -r <file.o>"
+        f"Incore objects are linked with ld.lld before extraction, so this is a link that "
+        f"left the image incomplete — an undefined symbol the linker kept as a relocation, "
+        f"or a section it could not place. Annotating the AICore call chain with "
+        f"__attribute__((always_inline)) folds it into a single .text and sidesteps both. "
+        f"Verify with:\n"
+        f"  readelf -SW <file> | grep '\\.text'\n"
+        f"  readelf -rW <file>"
     )
 
 

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -320,7 +320,7 @@ class KernelCompiler:
     ) -> bytes:
         """
         Compile a kernel source file. Dispatches based on platform:
-        - a2a3: Uses ccec compiler (requires pto_isa_root)
+        - a2a3: Uses ccec compiler (requires pto_isa_root), then links
         - a2a3sim: Uses compile_incore_sim (g++-15)
 
         Args:
@@ -330,7 +330,9 @@ class KernelCompiler:
             extra_include_dirs: Additional include directories
 
         Returns:
-            Binary contents of the compiled .o file
+            On hardware platforms, the linked AICore image (see
+            :meth:`_link_incore`) that ``elf_parser.extract_text_section``
+            takes the loadable payload from; on sim, the compiled shared object.
 
         Raises:
             FileNotFoundError: If source file or PTO-ISA headers not found
@@ -391,11 +393,45 @@ class KernelCompiler:
         logger.info(f"[Incore] Compiling ({core_type_name}): {source_path}")
         logger.debug(f"  Command: {' '.join(cmd)}")
 
-        return self._compile_to_bytes(
+        self._compile_to_bytes(
             cmd,
             output_path,
             "Incore",
             error_hint=f"ccec compiler not found at {self.ccec.cxx_path}",
+            delete_output=False,
+        )
+        try:
+            return self._link_incore(output_path, build_dir=build_dir)
+        finally:
+            if build_dir is None:
+                os.remove(output_path)
+
+    def _link_incore(self, object_path: str, build_dir: Optional[str] = None) -> bytes:
+        """Link a compiled incore object into a self-contained AICore image.
+
+        The AICore loader copies the literal ``.text`` bytes and jumps to offset
+        0 (``simpler_setup/elf_parser.py``), so the payload must carry no
+        unapplied relocations and must begin at ``kernel_entry``. ``ld.lld``
+        resolves ``.rela.text`` — notably the ``.bl.uninit.*`` block-local
+        globals CANN AscendC headers declare, such as ``g_vecTPipePtr`` and
+        ``g_kfcClient``, which share one merged block-local region and so cannot
+        all sit at offset 0 — and folds ``.text.*`` COMDAT groups holding
+        out-of-line template instantiations into the single output ``.text``.
+
+        The linked image is position-independent: ``--image-base`` does not
+        change the emitted ``.text`` bytes.
+        """
+        assert self.ccec is not None, "incore linking is only available for hardware platforms"
+        linked_path = self._make_temp_path(
+            prefix=f"{os.path.basename(object_path)}.linked_", suffix=".elf", build_dir=build_dir
+        )
+        cmd = [self.ccec.linker_path, "-e", "kernel_entry", "-o", linked_path, object_path]
+        logger.debug(f"  Link command: {' '.join(cmd)}")
+        return self._compile_to_bytes(
+            cmd,
+            linked_path,
+            "Incore-link",
+            error_hint=f"ccec linker not found at {self.ccec.linker_path}",
             delete_output=build_dir is None,
         )
 

--- a/tests/ut/py/test_elf_parser.py
+++ b/tests/ut/py/test_elf_parser.py
@@ -8,14 +8,17 @@
 # -----------------------------------------------------------------------------------------------------------
 """Tests for ``simpler_setup.elf_parser.extract_text_section``.
 
-The loader only knows how to return a literal ``.text`` section. When
-the compiler emits out-of-line template instantiations into
-``.text._Z*`` group sections (with matching relocations in
-``.rela.text``), the loader cannot produce correct bytes — and silently
-returning the raw ``.text`` causes CANN 507018 timeouts or
-silently-wrong partial output on device (issue #900, PR #830 /
-issue #831). These tests pin down the detect-and-reject behavior using
-synthetic ELF64 buffers that don't depend on the CCEC toolchain.
+The loader returns a literal ``.text`` section and jumps to offset 0, so the
+image it is handed must be complete. ``KernelCompiler.compile_incore`` links
+each object with ``ld.lld`` first, which applies ``.rela.text`` and folds
+``.text._Z*`` group sections in; these tests cover what the parser must still
+reject when that link leaves something behind — out-of-line code, surviving
+relocations, or a ``kernel_entry`` that is not first. Returning such bytes
+anyway causes CANN 507018 timeouts or silently-wrong partial output on device
+(issue #900, PR #830 / issue #831).
+
+The buffers are synthetic ELF64 so the tests don't depend on the CCEC
+toolchain.
 """
 
 import struct
@@ -28,6 +31,7 @@ _EHDR_SIZE = 64
 _SHDR_SIZE = 64
 _SHT_NULL = 0
 _SHT_PROGBITS = 1
+_SHT_SYMTAB = 2
 _SHT_STRTAB = 3
 _SHT_RELA = 4
 _SHF_ALLOC = 2
@@ -59,6 +63,7 @@ def _pack_shdr(
     sh_name: int,
     sh_type: int,
     sh_flags: int = 0,
+    sh_addr: int = 0,
     sh_offset: int = 0,
     sh_size: int = 0,
     sh_link: int = 0,
@@ -71,7 +76,7 @@ def _pack_shdr(
         sh_name,
         sh_type,
         sh_flags,
-        0,  # sh_addr
+        sh_addr,
         sh_offset,
         sh_size,
         sh_link,
@@ -79,6 +84,11 @@ def _pack_shdr(
         sh_addralign,
         sh_entsize,
     )
+
+
+def _pack_sym(*, st_name: int, st_shndx: int, st_value: int, st_size: int = 0) -> bytes:
+    """Elf64_Sym: st_name(4) st_info(1) st_other(1) st_shndx(2) st_value(8) st_size(8)."""
+    return struct.pack("<IBBHQQ", st_name, 0x12, 0, st_shndx, st_value, st_size)
 
 
 def _strtab(strings: list[str]) -> tuple[bytes, list[int]]:
@@ -142,6 +152,34 @@ class TestRejectsTextRelocations:
         with pytest.raises(ValueError) as excinfo:
             extract_text_section(elf)
         assert "2 entries" in str(excinfo.value)
+
+
+class TestEntryPointMustBeFirst:
+    """The loader jumps to offset 0 of the payload. Linking merges ``.text.*``
+    into ``.text`` and is free to order the pieces, so a kernel with out-of-line
+    code can end up with another function ahead of ``kernel_entry`` — which
+    would silently enter the wrong function."""
+
+    def test_entry_at_start_of_text_loads(self):
+        text_bytes = b"\xd6\x5f\x03\xc0" * 4
+        elf = _build_elf_with_symtab(text_bytes, text_addr=0x1000, entry_value=0x1000, entry_shndx=1)
+        assert extract_text_section(elf) == text_bytes
+
+    def test_entry_offset_into_text_raises(self):
+        elf = _build_elf_with_symtab(b"\x00" * 16, text_addr=0x1000, entry_value=0x1008, entry_shndx=1)
+        with pytest.raises(ValueError, match=r"kernel_entry is not at the start of \.text"):
+            extract_text_section(elf)
+
+    def test_entry_in_another_section_raises(self):
+        elf = _build_elf_with_symtab(b"\x00" * 16, text_addr=0x1000, entry_value=0x1000, entry_shndx=2)
+        with pytest.raises(ValueError, match=r"kernel_entry is not at the start of \.text"):
+            extract_text_section(elf)
+
+    def test_object_without_symtab_is_left_alone(self):
+        """Orchestration objects and hand-built fixtures carry no symbol table;
+        the check must not turn those into failures."""
+        text_bytes = b"\xd6\x5f\x03\xc0"
+        assert extract_text_section(_build_single_text_elf(text_bytes)) == text_bytes
 
 
 class TestMissingText:
@@ -268,6 +306,70 @@ def _build_elf_with_extra_text_section(*, extra_name: str, extra_size: int) -> b
         ]
     )
     return ehdr + shdrs + text_bytes + extra_bytes + shstr_bytes
+
+
+def _build_elf_with_symtab(text_bytes: bytes, *, text_addr: int, entry_value: int, entry_shndx: int) -> bytes:
+    """A linked-image shape: ``.text`` at a load address plus a symbol table
+    naming ``kernel_entry``."""
+    sym_bytes, [entry_name] = _strtab(["kernel_entry"])
+    symtab_bytes = _pack_sym(st_name=0, st_shndx=0, st_value=0) + _pack_sym(
+        st_name=entry_name, st_shndx=entry_shndx, st_value=entry_value, st_size=len(text_bytes)
+    )
+    shstr_bytes, [text_name, symtab_name, strtab_name, shstr_name] = _strtab(
+        [".text", ".symtab", ".strtab", ".shstrtab"]
+    )
+
+    shdr_count = 5
+    e_shoff = _EHDR_SIZE
+    cursor = e_shoff + shdr_count * _SHDR_SIZE
+
+    def place(b: bytes) -> int:
+        nonlocal cursor
+        off = cursor
+        cursor += len(b)
+        return off
+
+    text_off = place(text_bytes)
+    symtab_off = place(symtab_bytes)
+    sym_str_off = place(sym_bytes)
+    shstr_off = place(shstr_bytes)
+
+    ehdr = _pack_ehdr(e_shoff=e_shoff, e_shnum=shdr_count, e_shstrndx=4)
+    shdrs = b"".join(
+        [
+            _pack_shdr(sh_name=0, sh_type=_SHT_NULL),
+            _pack_shdr(
+                sh_name=text_name,
+                sh_type=_SHT_PROGBITS,
+                sh_flags=_SHF_ALLOC | _SHF_EXECINSTR,
+                sh_addr=text_addr,
+                sh_offset=text_off,
+                sh_size=len(text_bytes),
+                sh_addralign=4,
+            ),
+            _pack_shdr(
+                sh_name=symtab_name,
+                sh_type=_SHT_SYMTAB,
+                sh_offset=symtab_off,
+                sh_size=len(symtab_bytes),
+                sh_link=3,
+                sh_entsize=24,
+            ),
+            _pack_shdr(
+                sh_name=strtab_name,
+                sh_type=_SHT_STRTAB,
+                sh_offset=sym_str_off,
+                sh_size=len(sym_bytes),
+            ),
+            _pack_shdr(
+                sh_name=shstr_name,
+                sh_type=_SHT_STRTAB,
+                sh_offset=shstr_off,
+                sh_size=len(shstr_bytes),
+            ),
+        ]
+    )
+    return ehdr + shdrs + text_bytes + symtab_bytes + sym_bytes + shstr_bytes
 
 
 def _build_elf_with_rela_text(*, reloc_count: int) -> bytes:


### PR DESCRIPTION
## What

`KernelCompiler.compile_incore` now links each compiled AICore object with
`ld.lld -e kernel_entry` before `elf_parser.extract_text_section` takes the
payload. The parser's existing checks become post-link assertions, and it gains
one more: `kernel_entry` must be at the start of `.text`.

## Why

The loader copies literal `.text` bytes and jumps to offset 0, so the payload
must be self-contained. Nothing made it so — the loader just rejected any object
with `.rela.text` or `.text._Z*` and pointed at `__attribute__((always_inline))`.

That workaround does not cover data relocations. CANN AscendC declares
`g_vecTPipePtr` / `g_cubeTPipePtr` and `g_kfcClient` as **block-local globals**,
each in its own `.bl.uninit.*` section, so every AscendC-based kernel carries
relocations no amount of inlining removes. That currently makes the whole
`FusedInferAttentionScore` family — including pypto-lib's current qwen3 decode
attention — unloadable by simpler.

**This is a correctness fix, not a relaxation.** pypto's forked copy of the
parser has no guard and uploads the raw `.text`. For the qwen3 attention extern,
linking changes exactly two words:

| `.text` offset | uploaded raw | correct (post-link) |
| -------------- | ------------ | ------------------- |
| `0x3014` | `0x08000000` | `0x08000008` |
| `0x7908` | `0x08000000` | `0x08000008` |

Both block-locals merge into one 16-byte `.bl_uninit` region: `g_vecTPipePtr` at
offset 0 (so its 16 sites are already right at imm=0) and `g_kfcClient` at
offset 8. Unrelocated, **`g_kfcClient` aliases onto `g_vecTPipePtr`'s slot**. It
survives today only because that kernel synchronizes via `AscendC::SyncAll<false>()`
and never touches the KFC mailbox — the two mis-addressed instructions are
unreachable. A kernel where that global is live would corrupt silently.

Linking also folds `.text.*` COMDAT groups in, which closes the other half of
#900. The new `kernel_entry`-first assertion exists because that merge lets the
linker place another function ahead of the entry point.

## Verification

- **No payload changes anywhere.** All **202** incore kernels in the repo
  (121 a2a3, 55 a5, 26 under `examples/workers/` and the non-arch `tests/st/`
  dirs) produce byte-identical `.text` before and after.
- **The capability is real.** A kernel with a `noinline` template that the
  loader previously rejected now loads: `.text` 80 B + `.text._Z4bumpIlET_S0_`
  8 B → linked 88 B, `kernel_entry` still first. The three pypto-lib
  `paged_attention_cce` externs now load (1 980 / 21 316 / 55 168 B).
- **a2a3 onboard sweep** (CI-equivalent, `examples tests/st`, 4 devices):
  52 PASS groups, 0 FAIL, exit 0.
- **a2a3sim sweep**: 60 PASS groups, 0 FAIL, exit 0.
- **Python UTs**: 828 passed, 2 skipped. `tests/ut/py/test_elf_parser.py` gains
  4 cases for the entry-point check (13 total).

## Notes for review

- `compile_incore` now returns a **linked image** rather than a `.o` on hardware
  platforms; docstring updated. Every in-repo caller feeds it straight to
  `extract_text_section`, so the change is contained.
- `docs/aicore-kernel-programming.md` §4 previously said the loader "is strict
  **by design**; it is not relaxed to let 'benign' relocations through." That
  still holds — the guard is unchanged, it just runs after the linker. §3's
  claim that a `[[block_local]]` static "will not load" is now inaccurate and is
  reworded; the advice against per-core mutable state stands on its own merits.
- Worth reporting upstream: pypto's `runtime/elf_parser.py` is an older fork of
  this file without the guard, so it ships the unrelocated payload described
  above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
