### PR TITLE
Fix: zero a comm-domain window before its handle is published

### DIFF
--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -110,11 +110,19 @@ symmetric window is realized:
 | ------ | --- | -------------- |
 | Window memory | POSIX shm + `ftruncate`, mmap'd per rank | VMM physical allocation + shareable-handle import; peer access via `aclrtDeviceEnablePeerAccess` |
 | Subset barrier | shm-header atomic, `allocation_id`-scoped | file barriers, `allocation_id`-scoped |
-| Window init | window zeroed after handshake (`memset`) | window zeroed after handshake (`aclrtMemset`) |
+| Window init | window zeroed before the subset barrier (`memset`) | window zeroed before the handle is announced (`aclrtMemset`) |
 | Async-DMA workspace | n/a | a2a3: opt-in per Worker (`enable_sdma`); a5: optional communication overlay, gated off by default |
 
 The window is zero-initialized on both backends so scratch/signal protocols see
 a known starting state (matching the historical static-path contract).
+
+The wipe happens before the window becomes reachable by any peer — before the
+shareable handle is announced on HCCL, before the `ready_count` barrier on sim.
+A peer that clears the subset barrier can return, launch its kernel and store a
+barrier signal into this rank's window immediately; a wipe issued after that
+point can erase a signal the owner has not yet waited on, and the owner then
+waits on it forever. The rank skew that opens that window grows with host load,
+so the resulting hang shows up only under a loaded box.
 
 On a2a3, async-DMA resources are a Worker-level opt-in, not a
 communication-domain property. Construct the Worker with `enable_sdma=True` and

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -937,6 +937,16 @@ static bool domain_read_announce(
     return false;
 }
 
+// Wipes a window before its shareable handle is published. Publication is the
+// point from which a peer may import the window and store into it — a barrier
+// signal lands there as soon as that peer's kernel runs — so a wipe issued any
+// later can erase a signal the owner has not yet waited on. Kernels take the
+// zeroed tail as the initial value of their barrier-signal slots.
+// The full granularity-aligned mapped range is zeroed to match ctx.winSize.
+static aclError zero_local_window(const VmmWindow &window) {
+    return aclrtMemset(window.base, window.size, 0, window.size);
+}
+
 // Tag helper for allocation-scoped file barriers.  Tag is fed straight into
 // `file_barrier`, which already namespaces the marker filename by
 // rootinfo prefix + run_token + rank, so adding allocation_id to `tag` is
@@ -977,6 +987,12 @@ static int domain_alloc_via_ipc(
     status = export_ipc_window(local_window, &shareable_handle);
     if (status != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain ipc: ExportToShareableHandle -> %d", h->rank, static_cast<int>(status));
+        return -1;
+    }
+
+    status = zero_local_window(local_window);
+    if (status != ACL_SUCCESS) {
+        LOG_ERROR("[comm rank %d] alloc_domain ipc: aclrtMemset -> %d", h->rank, static_cast<int>(status));
         return -1;
     }
 
@@ -1174,6 +1190,13 @@ static FabricAttempt domain_alloc_via_fabric(
             return FabricAttempt::kUnsupported;
         }
         LOG_ERROR("[comm rank %d] alloc_domain: ExportToShareableHandleV2 -> %d", h->rank, static_cast<int>(aret));
+        release_domain_windows(out);
+        return FabricAttempt::kError;
+    }
+
+    aret = zero_local_window(out->local_window);
+    if (aret != ACL_SUCCESS) {
+        LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
         release_domain_windows(out);
         return FabricAttempt::kError;
     }
@@ -1443,18 +1466,6 @@ extern "C" int comm_alloc_domain_windows(
         const int rc =
             domain_alloc_via_ipc(h, allocation_id, rank_ids, rank_count, domain_rank, window_size, alloc.get());
         if (rc != 0) return rc;
-    }
-
-    // Zero the freshly-allocated local pool so kernels do not observe stale
-    // bytes (parity with the sim backend's memset). The full granularity-aligned
-    // mapped range is zeroed to match ctx.winSize.
-    aclError aret = aclrtMemset(alloc->local_window.base, alloc->local_window.size, 0, alloc->local_window.size);
-    if (aret != ACL_SUCCESS) {
-        LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
-        aclrtFree(alloc->device_ctx);
-        alloc->device_ctx = nullptr;
-        release_domain_windows(alloc.get());
-        return -1;
     }
 
     *device_ctx_out = reinterpret_cast<uint64_t>(alloc->device_ctx);

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -79,7 +79,6 @@ struct DomainAllocation {
     int rank = 0;                            // this rank's index within the subset (domain_rank)
     int nranks = 0;                          // subset size
     void *local_buf = nullptr;               // VMM-mapped device VA
-    uint64_t alloc_size = 0;                 // granularity-aligned byte size
     aclrtDrvMemHandle own_handle = nullptr;  // physical handle backing local_buf
     // Per-peer imports: (mapped VA, imported physical handle).  allocate_domain
     // can cycle repeatedly within one comm handle before any device reset, so
@@ -877,8 +876,7 @@ static int domain_alloc_via_ipc(
     }
 
     // VMM own-window allocation; see alloc_windows_via_ipc for step-by-step
-    // rationale. aligned_size is also stored in the DomainAllocation so the
-    // caller can zero the full mapped range.
+    // rationale.
     aclrtPhysicalMemProp prop{};
     prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
     prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
@@ -930,6 +928,19 @@ static int domain_alloc_via_ipc(
     );
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ExportToShareableHandle -> %d", h->rank, static_cast<int>(aret));
+        release_own_vmm_window(localBuf, handle);
+        return -1;
+    }
+
+    // Wipe before the handle is published. Publication is the point from which
+    // a peer may import this window and store into it — a barrier signal lands
+    // there as soon as that peer's kernel runs — so a wipe issued any later can
+    // erase a signal the owner has not yet waited on. Kernels take the zeroed
+    // tail as the initial value of their barrier-signal slots. The full
+    // granularity-aligned mapped range is zeroed to match ctx.winSize.
+    aret = aclrtMemset(localBuf, aligned_size, 0, aligned_size);
+    if (aret != ACL_SUCCESS) {
+        LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
         release_own_vmm_window(localBuf, handle);
         return -1;
     }
@@ -1017,7 +1028,6 @@ static int domain_alloc_via_ipc(
     out->rank = my_dr;
     out->nranks = subset_n;
     out->local_buf = localBuf;
-    out->alloc_size = aligned_size;
     out->own_handle = handle;
     // Build a host-side CommContext for the subset and upload it as device_ctx.
     // PTO-ISA async SDMA ops (SdmaTget) read the scratch workspace off
@@ -1319,19 +1329,6 @@ extern "C" int comm_alloc_domain_windows(
     auto alloc = std::make_unique<DomainAllocation>();
     int rc = domain_alloc_via_ipc(h, allocation_id, rank_ids, rank_count, domain_rank, window_size, alloc.get());
     if (rc != 0) return rc;
-
-    // Zero the freshly-allocated local pool so kernels do not observe stale
-    // bytes (parity with the sim backend's memset). The full granularity-aligned
-    // mapped range is zeroed to match ctx.winSize.
-    aclError aret = aclrtMemset(alloc->local_buf, alloc->alloc_size, 0, alloc->alloc_size);
-    if (aret != ACL_SUCCESS) {
-        LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
-        aclrtFree(alloc->device_ctx);
-        reset_domain_urma_workspace(*alloc);
-        release_domain_peer_windows(*alloc);
-        release_own_vmm_window(alloc->local_buf, alloc->own_handle);
-        return -1;
-    }
 
     *device_ctx_out = reinterpret_cast<uint64_t>(alloc->device_ctx);
     *local_window_base_out = reinterpret_cast<uint64_t>(alloc->local_buf);

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -586,6 +586,16 @@ extern "C" int comm_alloc_domain_windows(
         ctx.windowsOut[i] = addr;
     }
 
+    // Zero this rank's local window so scratch/signal protocols see a known
+    // initial state — matches the static-bootstrap contract (which zeroed
+    // the base window after alloc).  Kernels on HCCL must not observe
+    // stale aclrtMalloc bytes; same contract on sim for parity.
+    // The wipe precedes the ready barrier below: once a peer clears that
+    // barrier it may store a barrier signal into this window, and a later
+    // wipe would erase a signal this rank has not yet waited on.
+    uint8_t *local_window = win_base + domain_rank * window_size;
+    std::memset(local_window, 0, window_size);
+
     // ready_count barrier on the subset so all participants finish mapping
     // before any of them returns and starts using the windows.
     __atomic_add_fetch(&hdr->ready_count, 1, __ATOMIC_ACQ_REL);
@@ -600,13 +610,6 @@ extern "C" int comm_alloc_domain_windows(
         munmap(alloc->mmap_base, alloc->mmap_size);
         return -1;
     }
-
-    // Zero this rank's local window so scratch/signal protocols see a known
-    // initial state — matches the static-bootstrap contract (which zeroed
-    // the base window after alloc).  Kernels on HCCL must not observe
-    // stale aclrtMalloc bytes; same contract on sim for parity.
-    uint8_t *local_window = win_base + domain_rank * window_size;
-    std::memset(local_window, 0, window_size);
 
     *device_ctx_out = reinterpret_cast<uint64_t>(alloc->host_ctx.get());
     *local_window_base_out = reinterpret_cast<uint64_t>(local_window);


### PR DESCRIPTION
## What

`comm_alloc_domain_windows` wiped a rank's freshly allocated domain window
*after* the alloc path's subset barrier — on HCCL after the file barrier that
gates the peer imports (`ipc_p2p_ready` / `fabric_ready`), on sim after the
`ready_count` barrier. This moves the wipe ahead of the point where the window
becomes reachable by a peer, on all three backends.

## Why it is a bug

Publication is the point from which a peer may reach the window. A peer that
clears the subset barrier can return from `allocate_domain`, launch its kernel
and store a barrier signal into this rank's window immediately — the collective
kernels under `tests/st/worker/collectives/` do exactly that, `TNOTIFY` into a
peer's signal slot as their first cross-rank act. A wipe issued after that
erases a signal the owner has not yet waited on, and the owner's `TWAIT` then
spins forever.

The kernels' "fresh-window zero init" comments are the contract this restores:
they read the zeroed window tail as the initial value of their barrier-signal
slots, which only holds if the zeroing is ordered before any peer can write.

## Reachability — this is hardening, not a live failure

`Orchestrator.allocate_domain` joins every rank's chip child before any kernel
is submitted (`python/simpler/worker.py`, "Joins all threads"), so under today's
callers no kernel can write into a peer's window before that peer's wipe. The
ordering hazard is real in the backend but currently masked by that join. I
found it while investigating #1489 and it is **not** the cause of that issue —
this PR references #1489 for context only and does not close it.

## Change

- a2a3: new `zero_local_window` helper, called before `domain_write_announce`
  (Fabric V2) and before `write_ipc_announce` (VMM IPC fallback).
- a5: `aclrtMemset` before `domain_write_announce`. `DomainAllocation::alloc_size`
  loses its only reader with the caller-side wipe and is removed.
- sim: `memset` moved above the `ready_count` barrier.
- `docs/comm-domain.md`: the backend table stated the old ordering as the
  contract ("window zeroed after handshake"); updated, with the ordering
  requirement spelled out.

No extra synchronization is added — the existing barriers now order the wipe.

## Test

- `pytest tests/st/worker/collectives --platform a2a3sim --device 0-3` — 18/18 pass.
- `pytest tests/st/worker/collectives --platform a2a3 --device <4 devices>` — 18/18 pass (onboard, under `task-submit`).
- `pytest examples tests/st --platform a2a3 --device <8 devices>` — full onboard suite green.

No new regression test: the race is a timing window that no deterministic test
can pin without a fault-injection knob in the alloc path, and it is unreachable
through the public API today. The collectives suite is the behavioural coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)