### PR TITLE
Add: AICore fault triage to the device error code guide

### DIFF
--- a/docs/troubleshooting/device-error-codes.md
+++ b/docs/troubleshooting/device-error-codes.md
@@ -85,7 +85,7 @@ The counters *are* the decision: priority is `running > ready > waiting > orch n
 done`. `running=1` is always S1; `running=0, ready>0` is S3.
 
 **Only S1 and S3 are reproducible in practice.** S4, S5 and unknown are defensive
-labels — see [4. Codes with no end-to-end test](#4-codes-with-no-end-to-end-test).
+labels — see [5. Codes with no end-to-end test](#5-codes-with-no-end-to-end-test).
 
 ### Host-side CANN codes
 
@@ -225,7 +225,89 @@ released its fanout reference. Check for a hung producer first (that is S1 above
 then verify the consumer really declares the dependency and exits. If the kernel is
 merely slow, raising the timeout will prove it.
 
-## 4. Codes with no end-to-end test
+## 4. Chasing down an AICore fault (UB out of bounds, VEC/CUBE instruction error)
+
+An AICore addressing fault reaches the host as the same generic `507018` a stall
+does, usually with a `SCHEDULER_TIMEOUT` tail, because the faulting core stops
+answering and a watchdog reaps the op afterwards. The device log is the only
+place the fault itself appears:
+
+```text
+VEC instruction error: the ub address out of bounds
+  core id 15, blk:1, errcode 0x4000000000000000
+→ aicpu exception → 507018 → sched_error_code=100 SCHEDULER_TIMEOUT
+```
+
+**Redirect the device log before the run that you expect to fail.** The harness
+does not do this for you: `outputs/<case>_<ts>/` is only created when a DFX flag
+is on, so a plain onboard run leaves its device log in the shared
+`~/ascend/log/debug/device-<id>/` among every other user's. A fault you cannot
+attribute to a file is a fault you cannot diagnose, and the evidence is gone
+once the run ends:
+
+```bash
+LOGDIR="$PWD/outputs/<label>/ascend"; mkdir -p "$LOGDIR"   # driver fopens; it will not mkdir
+export ASCEND_PROCESS_LOG_PATH="$LOGDIR"
+```
+
+See the "Device logs" section of
+[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md).
+
+### F1: is it the kernel's own addressing, or did the core jump somewhere else?
+
+These two look identical from the host and have nothing in common as bugs, so
+settle it before reading any kernel arithmetic:
+
+- **`PrintErrorInfoForDavinciTask`** — `fault kernel_name`, `hash`, and
+  `GetBinAndKernelNameExceptionArgs: binSize`. If `binSize` matches the
+  runtime's own `aicore_kernel.o` rather than your kernel, the report is naming
+  the **polling-dispatch executor**, and the faulting code is whatever it jumped
+  to — a dispatch-payload / `function_bin_addr` problem, not kernel arithmetic.
+- **`PrintCoreInfo`** — `pc current`. Whether that offset lands inside the
+  executor's binary size or far outside it tells you the same thing
+  independently.
+
+[#1036](https://github.com/hw-native-sys/simpler/issues/1036) has the worked
+example of making this distinction.
+
+### F2: rule the kernel's own addressing in or out statically
+
+Before instrumenting, check whether the kernel *can* compute an out-of-range UB
+address at all. Compile-time `TASSIGN` offsets and template-derived tile extents
+do not make that impossible — the constants themselves can overrun — but they
+make it **decidable on paper**, because runtime values that only shrink a tile
+(a per-rank chunk count, a shorter row) move no base and grow no extent.
+
+So compute it. Sum the highest byte each `TASSIGN` base plus its tile extent
+reaches and compare against the AIV UB size:
+
+- **Fits for every input the guards admit** → the address did not come from
+  here, and you are in F1's second case.
+- **Does not fit** → you have found the bug without touching the device.
+
+The allreduce collectives were cleared this way in
+[#1489](https://github.com/hw-native-sys/simpler/issues/1489): all five modes
+bind every tile to a constant base, `nranks` only divides the chunk count, and
+the whole footprint stays under 132 KiB of the 192 KiB UB at every rank count.
+
+That case is worth following to its end, because F2's verdict held. The fault
+was not in the kernels; it was almost certainly
+[#1477](https://github.com/hw-native-sys/simpler/pull/1477), a `CoreTracker`
+whose `uint64_t` state overran past 21 clusters while those cases ran at the
+device's full 24. Corrupted dispatch state, F1's second case — reached by
+believing F2 rather than re-reading the kernel arithmetic a second time.
+
+### F3: separate a real fault from a post-mortem register dump
+
+A core killed while spinning can produce a fault-looking line that describes the
+state it was reaped in rather than an instruction it executed. Count the
+detectors, per [`running-onboard.md`](../../.claude/rules/running-onboard.md):
+if `FATAL: Task Allocator Deadlock` and `Timeout (N cycles):
+producer/consumers` are both **zero** and only `HandleTaskTimeout` fired, then
+nothing on the device proved a fault or a deadlock — treat the wait that never
+completed as the primary object of the investigation, not the addressing line.
+
+## 5. Codes with no end-to-end test
 
 Three codes and three stall sub-classes have no ST — not from neglect, but because
 they cannot be provoked. Recording why, so the next person does not re-derive it


### PR DESCRIPTION
## Why

`docs/troubleshooting/device-error-codes.md` covers **capacity codes** (§2) and **stalls** (§3), but an AICore addressing fault is the third way a run reaches the same generic `507018` — and it had no section. #1489 re-derived the procedure from scratch over a full investigation and still could not close, so this records what that investigation established.

## What

A new §4 with three steps, ordered so the cheap disqualifications come first:

**F1 — is it the kernel's addressing, or did the core jump elsewhere?** These look identical from the host and have nothing in common as bugs. If `GetBinAndKernelNameExceptionArgs: binSize` matches the runtime's own `aicore_kernel.o` rather than your kernel, the report is naming the **polling-dispatch executor** and the fault is a dispatch-payload / `function_bin_addr` problem — no amount of reading kernel arithmetic will find it. #1036 is the worked example.

**F2 — rule the kernel in or out statically, before instrumenting.** A kernel whose `TASSIGN` bases are compile-time constants and whose extents come from a template cannot compute an out-of-range UB address; runtime values that only *shrink* a tile move nothing. Summing the highest byte reached against the UB size settles it on paper. This is what cleared all five allreduce modes in #1489 (constant bases, `nranks` only divides the chunk count, ≤132 KiB of 192 KiB at every rank count).

**F3 — real fault vs post-mortem register dump.** A core reaped mid-spin can produce a fault-looking line describing the state it died in. If the deadlock and SPIN detectors are both zero and only `HandleTaskTimeout` fired, nothing on the device proved a fault — the wait that never completed is the investigation, not the addressing line.

## The part that matters most

The section states plainly that **the harness will not isolate your device log**: `outputs/<case>_<ts>/` is created only when a DFX flag is on, so a plain onboard run leaves its log in the shared `~/ascend/log/debug/` among every other user's on the box.

That is not hypothetical — it is why #1489 is still open. Its one real occurrence produced exactly the artifact that would have decided F1, and it was unattributable by the time anyone looked.

`.claude/rules/running-onboard.md` already says to export `ASCEND_PROCESS_LOG_PATH`; what was missing is *what to read once you have the log*, which is the substance here.

## Notes for review

- Renumbers the trailing "Codes with no end-to-end test" §4 → §5 and fixes the in-page link that pointed at the old number (markdownlint MD051 caught it).
- The doc is now 339 lines / 7 H2 sections, past the 300-line, 5-H2 soft target in `doc-consistency.md` §6 — it was already over before this change. The natural split is a landing page plus `device-error-codes/{capacity,stall,aicore-fault,untested}.md`. I did not bundle that restructure into a content-only change; flagging it instead, per that rule's "flag it to the user" clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)