### PR TITLE
Perf(a2a3): inline dispatch timestamp counter reads

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -18,6 +18,7 @@
 #include "common/l2_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "device_time_fast.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -601,7 +602,7 @@ SchedulerContext::drain_stage_cores(PTO2TaskSlotState *slot_state, int32_t block
 #if SIMPLER_DFX
             uint64_t pub_t0 = 0;
             if (sub_prof) {
-                pub_t0 = get_sys_cnt_aicpu();
+                pub_t0 = fast_sys_cnt_aicpu();
                 // DrainPrepare bar: cluster scan happened before this lambda, so this covers the
                 // build_payload work for `claim` blocks (handle_count subtasks).
                 l2_swimlane_aicpu_record_sched_phase(
@@ -610,7 +611,7 @@ SchedulerContext::drain_stage_cores(PTO2TaskSlotState *slot_state, int32_t block
                 );
             }
             if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
-                dispatch_ts = pub_t0 != 0 ? pub_t0 : get_sys_cnt_aicpu();
+                dispatch_ts = pub_t0 != 0 ? pub_t0 : fast_sys_cnt_aicpu();
             }
 #endif
             // Accumulate this batch's gated cores into a LOCAL mask and OR it into the shared

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -24,6 +24,7 @@
 #include "common/l2_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "device_time_fast.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -380,7 +381,7 @@ void SchedulerContext::dispatch_shape(
             uint64_t dispatch_ts = 0;
 #if SIMPLER_DFX
             if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
-                dispatch_ts = get_sys_cnt_aicpu();
+                dispatch_ts = fast_sys_cnt_aicpu();
             }
 #endif
             for (int i = 0; i < handle_count; i++) {
@@ -624,7 +625,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
     CoreTracker &tracker = core_trackers_[thread_idx];
     // Stamp the real pre-stage time (NOT 0) so the swimlane shows these blocks
     // dispatched during the producer's run, not at trace start.
-    uint64_t early_dispatch_ts = get_sys_cnt_aicpu();
+    uint64_t early_dispatch_ts = fast_sys_cnt_aicpu();
     uint64_t my_cores[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};  // cores gated by this staging pass
     int32_t staged = 0;
     int32_t block = start;

--- a/src/common/platform/onboard/aicpu/device_time_fast.h
+++ b/src/common/platform/onboard/aicpu/device_time_fast.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_COMMON_PLATFORM_ONBOARD_AICPU_DEVICE_TIME_FAST_H_
+#define SRC_COMMON_PLATFORM_ONBOARD_AICPU_DEVICE_TIME_FAST_H_
+
+#include <cstdint>
+
+static inline __attribute__((always_inline)) uint64_t fast_sys_cnt_aicpu() {
+    uint64_t ticks;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(ticks));
+    return ticks;
+}
+
+#endif  // SRC_COMMON_PLATFORM_ONBOARD_AICPU_DEVICE_TIME_FAST_H_

--- a/src/common/platform/sim/aicpu/device_time_fast.h
+++ b/src/common/platform/sim/aicpu/device_time_fast.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_COMMON_PLATFORM_SIM_AICPU_DEVICE_TIME_FAST_H_
+#define SRC_COMMON_PLATFORM_SIM_AICPU_DEVICE_TIME_FAST_H_
+
+#include <cstdint>
+
+#include "aicpu/device_time.h"
+
+static inline uint64_t fast_sys_cnt_aicpu() { return get_sys_cnt_aicpu(); }
+
+#endif  // SRC_COMMON_PLATFORM_SIM_AICPU_DEVICE_TIME_FAST_H_


### PR DESCRIPTION
## Summary

- add an onboard always-inline AICPU system-counter helper using `CNTVCT_EL0`
- keep simulation on the existing `get_sys_cnt_aicpu()` clock path
- use the fast helper only for a2a3 TMR dispatch-publication timestamps
- keep the change isolated from PR #1243's dispatch-buffer prefetch experiment

## Motivation

L2 swimlane profiling stamps dispatch events on scheduler hot paths. These
sites currently call the out-of-line `get_sys_cnt_aicpu()` implementation,
which also reads and rescales the counter frequency. This draft isolates the
counter-read part of PR #1243 so it can be reviewed independently.

## Impact

The a2a3 onboard AICPU binary changes from 232 to 225 calls to
`get_sys_cnt_aicpu()` and from 1 to 8 direct counter reads. Its `.text` size
does not grow in the controlled build (164,676 to 164,636 bytes).

No investigation documents, benchmark logs, or dispatch-buffer prefetch
changes are included.

## Validation

- a2a3 onboard and sim runtime builds passed
- pre-commit headers, formatting, clang-tidy, and cpplint checks passed
- Qwen3-14B `StressBatch16Seq3500` golden passed
- Qwen L2 swimlane level 4 retest: 8 baseline + 8 change samples on the same
  NPU, balanced across four ABBA/BAAB blocks

The retest measured device wall 2567.695 us to 2563.857 us (-0.15%), but the
four block deltas were +7.360, -11.980, -20.910, and +10.181 us. Scheduler
time moved +0.42%. The performance result is therefore inconclusive; this is
opened as a draft for implementation review rather than as a demonstrated
performance win.
