### PR TITLE
Fix: prevent L2 swimlane records from crossing buffers

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -115,7 +115,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // first deref is safe here — off the dispatch→start critical path.
     __gm__ L2SwimlaneActiveHead *l2_swimlane_head = l2_swimlane_enabled ? get_l2_swimlane_aicore_head() : nullptr;
     // cached_buf_seq must start != AICPU's initial head.current_buf_seq (0)
-    // so the first record_task observes a mismatch and loads the buffer ptr.
+    // so the first reservation observes a mismatch and loads the buffer ptr.
     L2SwimlaneAicoreLocalState l2_swimlane_local = {nullptr, UINT32_MAX, 0};
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
@@ -233,6 +233,13 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 receive_time = get_sys_cnt_aicore();
             }
 
+            // Bind this task to the currently-published buffer generation
+            // before ACK makes progress visible to AICPU.
+            __gm__ L2SwimlaneAicoreTaskRecord *l2_swimlane_record = nullptr;
+            if (l2_swimlane_enabled) {
+                l2_swimlane_record = l2_swimlane_aicore_reserve_task_record(l2_swimlane_head, &l2_swimlane_local);
+            }
+
             write_reg(RegId::COND, MAKE_ACK_VALUE(task_id));
 
             // Performance profiling: record start time
@@ -245,6 +252,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             // Execute the task
             execute_task(exec_payload);
+
+            // Keep start_time -> end_time scoped to AICore execution.
+            uint64_t end_time = l2_swimlane_enabled ? get_sys_cnt_aicore() : 0;
 
             if (pmu_enabled) {
                 pmu_aicore_end();
@@ -271,16 +281,10 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             last_reg_val = reg_val;
             write_reg(RegId::COND, MAKE_FIN_VALUE(task_id));
 
-            // Sample end_time AFTER the FIN write so the op-event end marks the
-            // moment the AICPU can first observe completion — any compute-end ->
-            // FIN gap (epilogue / write-back) shows directly on the bar instead
-            // of being inferred. The record write itself stays off the critical
-            // path (it runs after FIN, so it no longer delays completion).
             if (l2_swimlane_enabled) {
-                uint64_t end_time = get_sys_cnt_aicore();
                 uint64_t task_token_raw = exec_payload->local_context.async_ctx.task_token.raw;
-                l2_swimlane_aicore_record_task(
-                    l2_swimlane_head, &l2_swimlane_local, task_token_raw, task_id, receive_time, start_time, end_time
+                l2_swimlane_aicore_commit_task_record(
+                    l2_swimlane_record, task_token_raw, task_id, receive_time, start_time, end_time
                 );
             }
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -113,7 +113,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // first deref is safe here — off the dispatch→start critical path.
     __gm__ L2SwimlaneActiveHead *l2_swimlane_head = l2_swimlane_enabled ? get_l2_swimlane_aicore_head() : nullptr;
     // cached_buf_seq must start != AICPU's initial head.current_buf_seq (0)
-    // so the first record_task observes a mismatch and loads the buffer ptr.
+    // so the first reservation observes a mismatch and loads the buffer ptr.
     L2SwimlaneAicoreLocalState l2_swimlane_local = {nullptr, UINT32_MAX, 0};
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
@@ -216,6 +216,13 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 }
             }
 
+            // Bind this task to the currently-published buffer generation
+            // before ACK makes progress visible to AICPU.
+            __gm__ L2SwimlaneAicoreTaskRecord *l2_swimlane_record = nullptr;
+            if (l2_swimlane_enabled) {
+                l2_swimlane_record = l2_swimlane_aicore_reserve_task_record(l2_swimlane_head, &l2_swimlane_local);
+            }
+
             write_reg(RegId::COND, MAKE_ACK_VALUE(task_id));
 
             // PMU window brackets kernel execution.
@@ -227,10 +234,11 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             execute_task(exec_payload);
 
+            // Keep start_time -> end_time scoped to AICore execution.
+            uint64_t end_time = l2_swimlane_enabled ? get_sys_cnt_aicore() : 0;
+
             last_reg_val = reg_val;
             write_reg(RegId::COND, MAKE_FIN_VALUE(task_id));
-
-            uint64_t end_time = l2_swimlane_enabled ? get_sys_cnt_aicore() : 0;
 
             if (pmu_enabled) {
                 pmu_aicore_end();
@@ -255,8 +263,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             //     task_token_raw.
             if (l2_swimlane_enabled) {
                 uint64_t task_token_raw = exec_payload->local_context.async_ctx.task_token.raw;
-                l2_swimlane_aicore_record_task(
-                    l2_swimlane_head, &l2_swimlane_local, task_token_raw, task_id, receive_time, start_time, end_time
+                l2_swimlane_aicore_commit_task_record(
+                    l2_swimlane_record, task_token_raw, task_id, receive_time, start_time, end_time
                 );
             }
         }

--- a/src/common/platform/include/aicore/l2_swimlane_collector_aicore.h
+++ b/src/common/platform/include/aicore/l2_swimlane_collector_aicore.h
@@ -33,86 +33,27 @@
 
 /**
  * AICore-local rotation state. Tracks which buffer this core is currently
- * writing into and which slot is next. Reset by `l2_swimlane_aicore_record_task`
+ * writing into and which slot is next. Reset by `l2_swimlane_aicore_reserve_task_record`
  * when it observes a `current_buf_seq` bump on the shared `L2SwimlaneActiveHead`
- * cache line (AICPU rotates by writing `current_buf_ptr` + bumping
- * `current_buf_seq`, so the AICore-local state self-recovers without any
- * AICore-side spin-wait).
+ * cache line.
  */
 struct L2SwimlaneAicoreLocalState {
     __gm__ L2SwimlaneAicoreTaskBuffer *cached_buf = nullptr;
     // Must start != AICPU's initial head.current_buf_seq (0) so the first
-    // record_task call observes a mismatch and loads the buffer pointer.
+    // reservation observes a mismatch and loads the buffer pointer.
     uint32_t cached_buf_seq = UINT32_MAX;
     uint32_t slot_within_buf = 0;
 };
 
 /**
- * Record task execution performance data.
+ * Reserve the record slot for one task.
  *
- * AICore writes a slim L2SwimlaneAicoreTaskRecord into its currently-published
- * per-core L2SwimlaneAicoreTaskBuffer at `records[slot_within_buf++]`. The
- * publication channel is an L2SwimlaneActiveHead cache line addressed via
- * `KernelArgs::l2_swimlane_aicore_rotation_table[block_idx]` (points to the
- * AICore pool's `head`, not directly to a buffer). AICPU updates
- * `head->current_buf_ptr` and bumps `head->current_buf_seq` at dispatch
- * boundaries; AICore detects the change by `dcci`-ing the head line per task
- * and comparing the sequence to its locally cached copy.
- *
- * AICPU and AICore never read each other's data on the hot path. The host
- * post-processor joins the AICore stream (multi-buffer per core, in order)
- * with the AICPU stream by `reg_task_id` at flush time. See
- * `docs/dfx/l2-swimlane-profiling.md`.
- *
- * Race avoidance: AICPU rotates strictly before `write_reg(DATA_MAIN_BASE)`
- * for the first task of a new BUFFER_SIZE batch — driven by AICPU's own
- * per-core dispatch count (no AICore-side signal). Rotation publishes the new
- * active buffer to AICore; safe release of the old buffer to the host is owned
- * by the AICPU collector and may be ACK-gated or deferred to a backstop,
- * depending on the runtime's FIN-vs-record ordering.
- *
- * @param head            Per-core L2SwimlaneActiveHead channel — lazy-resolved on
- *                        the executor's first-task branch via
- *                        get_l2_swimlane_aicore_head(), which deref's the slot
- *                        the kernel entry stashed from
- *                        KernelArgs::l2_swimlane_aicore_rotation_table[block_idx].
- *                        (Kernel entry can't deref directly — AICPU init runs
- *                        concurrently with kernel entry, so the slot may not yet
- *                        hold a valid address at that point.)
- * @param local           Per-core AICore-local state (caller-owned static)
- * @param task_token_raw  Full task identity (PTO2 encoding for tensormap_and_ringbuffer
- *                        runtime: `(ring_id << 32) | local_id`; plain task index
- *                        zero-extended for host_build_graph). The caller in the
- *                        ringbuffer runtime reads this from
- *                        `exec_payload->local_context.async_ctx.task_token.raw`
- *                        which is already in AICore cache (it was just dcci'd for
- *                        the kernel call), so no extra GM load.
- * @param reg_task_id     Per-core dispatch token (low 32 bits of the per-core
- *                        monotonic dispatch_seq). Per-dispatch unique within
- *                        a core; serves as the host-side join key against the
- *                        AICPU record stream. Required because SPMD with
- *                        `block_num > num_cores` (and MIX cluster spread)
- *                        dispatch the same `task_token_raw` multiple times to
- *                        the same core — each dispatch needs its own AICore
- *                        record matched to its own AICPU record, which
- *                        task_token_raw alone cannot disambiguate.
- * @param receive_time    Timestamp captured immediately after `read_reg(DATA_MAIN_BASE)`
- *                        returns the new task_id (before dcci+ack). Stored as a
- *                        32-bit delta `start_time - receive_time` in the record;
- *                        host recovers `receive_time = start_time - delta`.
- *                        Lets DFX split head_OH into the unfixable
- *                        AICPU→AICore NoC propagation (dispatch_ts → receive_time)
- *                        and the AICore-local dcci+ack cost (receive_time → start_time).
- * @param start_time      Start timestamp (get_sys_cnt) — post-dcci+ack, just
- *                        before kernel `execute_task`.
- * @param end_time        End timestamp
+ * AICore reserves from the currently-published per-core buffer before ACK.
+ * The returned record pointer remains the task's write target after FIN even
+ * if AICPU has published the next buffer by then.
  */
-__aicore__ __attribute__((always_inline)) static inline void l2_swimlane_aicore_record_task(
-    __gm__ L2SwimlaneActiveHead *head, L2SwimlaneAicoreLocalState *local, uint64_t task_token_raw, uint32_t reg_task_id,
-    uint64_t receive_time, uint64_t start_time, uint64_t end_time
-) {
-    // Re-fetch head channel each task; cheap relative to the
-    // baseline `dcci(payload, ENTIRE_DATA_CACHE)` we already pay per task.
+__aicore__ __attribute__((always_inline)) static inline __gm__ L2SwimlaneAicoreTaskRecord *
+l2_swimlane_aicore_reserve_task_record(__gm__ L2SwimlaneActiveHead *head, L2SwimlaneAicoreLocalState *local) {
     dcci(head, SINGLE_CACHE_LINE);
     if (head->current_buf_seq != local->cached_buf_seq) {
         local->cached_buf_seq = head->current_buf_seq;
@@ -120,38 +61,53 @@ __aicore__ __attribute__((always_inline)) static inline void l2_swimlane_aicore_
         local->slot_within_buf = 0;
     }
     if (local->cached_buf == nullptr) {
-        // Rotation channel published a null pointer (AICPU couldn't pop a
-        // fresh buffer from free_queue). Drop silently — AICPU side already
-        // bumped dropped_record_count.
-        return;
+        return nullptr;
     }
 
     uint32_t slot = local->slot_within_buf;
     if (slot >= PLATFORM_AICORE_BUFFER_SIZE) {
-        // Defensive: AICPU should rotate before this can happen. If it
-        // didn't, refuse to write past the end rather than corrupt adjacent
-        // memory.
+        // Refuse to write past the end if AICPU failed to rotate.
+        return nullptr;
+    }
+
+    local->slot_within_buf = slot + 1;
+    return &local->cached_buf->records[slot];
+}
+
+/**
+ * Commit one task's timestamps and identity to its pre-ACK reservation.
+ *
+ * `end_time` is captured immediately after execute_task and before FIN. The
+ * commit itself runs after FIN and never reads the possibly-rotated head.
+ */
+__aicore__ __attribute__((always_inline)) static inline void l2_swimlane_aicore_commit_task_record(
+    __gm__ L2SwimlaneAicoreTaskRecord *record, uint64_t task_token_raw, uint32_t reg_task_id, uint64_t receive_time,
+    uint64_t start_time, uint64_t end_time
+) {
+    if (record == nullptr) {
         return;
     }
 
-    __gm__ L2SwimlaneAicoreTaskRecord *record = &local->cached_buf->records[slot];
     record->start_time = start_time;
     record->end_time = end_time;
     record->task_token_raw = task_token_raw;
     record->reg_task_id = reg_task_id;
-    // 32-bit delta; receive_time always precedes start_time on the same core
-    // (sys_cnt is monotonic per AICore), so the subtraction can never wrap.
+    // 32-bit delta; receive_time always precedes start_time on the same core.
     record->receive_to_start_cycles = static_cast<uint32_t>(start_time - receive_time);
-    local->slot_within_buf = slot + 1;
 
-    // Flush record to GM so host can read it after the buffer is enqueued.
-    // No buffer-full signal is needed: AICPU drives rotation from its own
-    // per-core dispatch count (it knows how many DATA_MAIN_BASE writes it has
-    // sent to this core, and rotates before crossing a BUFFER_SIZE boundary).
-    // The completion-before-dispatch invariant guarantees this dcci has hit
-    // GM before AICPU enqueues the buffer.
     dcci(record, SINGLE_CACHE_LINE, CACHELINE_OUT);
     dsb((mem_dsb_t)0);
+}
+
+/**
+ * Compatibility wrapper for platforms that have not moved reservation before ACK.
+ */
+__aicore__ __attribute__((always_inline)) static inline void l2_swimlane_aicore_record_task(
+    __gm__ L2SwimlaneActiveHead *head, L2SwimlaneAicoreLocalState *local, uint64_t task_token_raw, uint32_t reg_task_id,
+    uint64_t receive_time, uint64_t start_time, uint64_t end_time
+) {
+    __gm__ L2SwimlaneAicoreTaskRecord *record = l2_swimlane_aicore_reserve_task_record(head, local);
+    l2_swimlane_aicore_commit_task_record(record, task_token_raw, reg_task_id, receive_time, start_time, end_time);
 }
 
 #endif  // SRC_COMMON_PLATFORM_INCLUDE_AICORE_L2_SWIMLANE_COLLECTOR_AICORE_H_


### PR DESCRIPTION
Reserve each AICore record slot before ACK so an AICPU buffer rotation after FIN cannot redirect the completed task into the next buffer generation. Commit timestamps and task identity to the reserved address after FIN without reading the active head again.

Capture end_time immediately after task execution and before FIN. Keep the existing ACK gate responsible only for old-buffer lifetime and host collection.

Validated with the Qwen3-14B warmup-only serving workload: 860265 Prefill and 19264 Decode AICPU/AICore records matched one-to-one, with no zero start times, duplicate keys, join gaps, sequence breaks, or invalid buffer boundaries.