### PR TITLE
Fix empty ring heap rebase deadlock

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -225,6 +225,11 @@ The heap ring manages output buffer allocation from a circular GM heap.
 
 **Reclamation**: When `last_task_alive` advances past a task, its `packed_buffer_end` is used to advance `heap_tail`, freeing the memory region.
 
+When an empty ring is parked at a non-zero offset and neither free arc can hold a request that fits the full
+capacity, allocation restarts at offset zero: `heap_tail` resets to zero and `heap_top` advances past the new
+allocation. Reclaim markers from tasks in the preceding coordinate space are ignored until the first post-rebase
+allocation retires.
+
 ### 4.3 Dependency Representation (polling completion)
 
 There is no dependency-list pool or fanout adjacency. A task's dependencies are

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_ring_buffer.h
@@ -111,6 +111,7 @@ public:
         heap_top_ = 0;
         heap_tail_ = 0;
         last_alive_seen_ = 0;
+        heap_rebase_anchor_task_id_ = -1;
     }
 
     /**
@@ -232,6 +233,9 @@ public:
 
     uint64_t heap_available() const {
         uint64_t tail = heap_tail_;
+        if (heap_top_ == tail) {
+            return heap_size_;
+        }
         if (heap_top_ >= tail) {
             uint64_t at_end = heap_size_ - heap_top_;
             uint64_t at_begin = tail;
@@ -270,6 +274,9 @@ private:
     uint64_t heap_top_ = 0;        // Current heap allocation pointer
     uint64_t heap_tail_ = 0;       // Heap reclamation pointer (derived from consumed tasks)
     int32_t last_alive_seen_ = 0;  // last_task_alive at last heap_tail derivation
+    // While last_alive has not advanced past this task ID, the latest
+    // reclaimed descriptor still predates the empty-ring rebase.
+    int32_t heap_rebase_anchor_task_id_ = -1;
 
     // --- Shared ---
     std::atomic<int32_t> *error_code_ptr_ = nullptr;
@@ -298,6 +305,11 @@ private:
     void update_heap_tail(int32_t last_alive) {
         if (last_alive <= last_alive_seen_) return;
         last_alive_seen_ = last_alive;
+
+        if (heap_rebase_anchor_task_id_ >= 0 && last_alive <= heap_rebase_anchor_task_id_) {
+            return;
+        }
+        heap_rebase_anchor_task_id_ = -1;
 
         PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
         uint64_t old_tail = heap_tail_;
@@ -345,6 +357,17 @@ private:
                 // scope_stats can unroll the wrapping offset into a monotonic value.
                 // The collector attributes the wrap to the current scope's ring.
                 if (is_scope_stats_enabled()) scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+#endif
+            } else if (top == tail && alloc_size <= heap_size_) {
+                result = heap_base_;
+                heap_top_ = alloc_size;
+                heap_tail_ = 0;
+                heap_rebase_anchor_task_id_ = local_task_id_;
+#if SIMPLER_DFX
+                if (is_scope_stats_enabled()) {
+                    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+                    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+                }
 #endif
             } else {
                 LOG_DEBUG(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -224,6 +224,11 @@ The heap ring manages output buffer allocation from a circular GM heap.
 
 **Reclamation**: When `last_task_alive` advances past a task, its `packed_buffer_end` is used to advance `heap_tail`, freeing the memory region.
 
+When an empty ring is parked at a non-zero offset and neither free arc can hold a request that fits the full
+capacity, allocation restarts at offset zero: `heap_tail` resets to zero and `heap_top` advances past the new
+allocation. Reclaim markers from tasks in the preceding coordinate space are ignored until the first post-rebase
+allocation retires.
+
 ### 4.3 Dependency List Pool
 
 A simple bump allocator for `PTO2DepListEntry` nodes used in fanin/fanout linked lists.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -109,6 +109,7 @@ public:
         heap_top_ = 0;
         heap_tail_ = 0;
         last_alive_seen_ = 0;
+        heap_rebase_anchor_task_id_ = -1;
     }
 
     /**
@@ -231,6 +232,9 @@ public:
 
     uint64_t heap_available() const {
         uint64_t tail = heap_tail_;
+        if (heap_top_ == tail) {
+            return heap_size_;
+        }
         if (heap_top_ >= tail) {
             uint64_t at_end = heap_size_ - heap_top_;
             uint64_t at_begin = tail;
@@ -270,6 +274,9 @@ private:
     uint64_t heap_top_ = 0;        // Current heap allocation pointer
     uint64_t heap_tail_ = 0;       // Heap reclamation pointer (derived from consumed tasks)
     int32_t last_alive_seen_ = 0;  // last_task_alive at last heap_tail derivation
+    // While last_alive has not advanced past this task ID, the latest
+    // reclaimed descriptor still predates the empty-ring rebase.
+    int32_t heap_rebase_anchor_task_id_ = -1;
 
     // --- Shared ---
     std::atomic<int32_t> *error_code_ptr_ = nullptr;
@@ -298,6 +305,11 @@ private:
     void update_heap_tail(int32_t last_alive) {
         if (last_alive <= last_alive_seen_) return;
         last_alive_seen_ = last_alive;
+
+        if (heap_rebase_anchor_task_id_ >= 0 && last_alive <= heap_rebase_anchor_task_id_) {
+            return;
+        }
+        heap_rebase_anchor_task_id_ = -1;
 
         PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
         uint64_t old_tail = heap_tail_;
@@ -345,6 +357,17 @@ private:
                 // scope_stats can unroll the wrapping offset into a monotonic value.
                 // The collector attributes the wrap to the current scope's ring.
                 if (is_scope_stats_enabled()) scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+#endif
+            } else if (top == tail && alloc_size <= heap_size_) {
+                result = heap_base_;
+                heap_top_ = alloc_size;
+                heap_tail_ = 0;
+                heap_rebase_anchor_task_id_ = local_task_id_;
+#if SIMPLER_DFX
+                if (is_scope_stats_enabled()) {
+                    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+                    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+                }
 #endif
             } else {
                 LOG_DEBUG(

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -224,6 +224,11 @@ The heap ring manages output buffer allocation from a circular GM heap.
 
 **Reclamation**: When `last_task_alive` advances past a task, its `packed_buffer_end` is used to advance `heap_tail`, freeing the memory region.
 
+When an empty ring is parked at a non-zero offset and neither free arc can hold a request that fits the full
+capacity, allocation restarts at offset zero: `heap_tail` resets to zero and `heap_top` advances past the new
+allocation. Reclaim markers from tasks in the preceding coordinate space are ignored until the first post-rebase
+allocation retires.
+
 ### 4.3 Dependency List Pool
 
 A simple bump allocator for `PTO2DepListEntry` nodes used in fanin/fanout linked lists.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -109,6 +109,7 @@ public:
         heap_top_ = 0;
         heap_tail_ = 0;
         last_alive_seen_ = 0;
+        heap_rebase_anchor_task_id_ = -1;
     }
 
     /**
@@ -231,6 +232,9 @@ public:
 
     uint64_t heap_available() const {
         uint64_t tail = heap_tail_;
+        if (heap_top_ == tail) {
+            return heap_size_;
+        }
         if (heap_top_ >= tail) {
             uint64_t at_end = heap_size_ - heap_top_;
             uint64_t at_begin = tail;
@@ -270,6 +274,9 @@ private:
     uint64_t heap_top_ = 0;        // Current heap allocation pointer
     uint64_t heap_tail_ = 0;       // Heap reclamation pointer (derived from consumed tasks)
     int32_t last_alive_seen_ = 0;  // last_task_alive at last heap_tail derivation
+    // While last_alive has not advanced past this task ID, the latest
+    // reclaimed descriptor still predates the empty-ring rebase.
+    int32_t heap_rebase_anchor_task_id_ = -1;
 
     // --- Shared ---
     std::atomic<int32_t> *error_code_ptr_ = nullptr;
@@ -298,6 +305,11 @@ private:
     void update_heap_tail(int32_t last_alive) {
         if (last_alive <= last_alive_seen_) return;
         last_alive_seen_ = last_alive;
+
+        if (heap_rebase_anchor_task_id_ >= 0 && last_alive <= heap_rebase_anchor_task_id_) {
+            return;
+        }
+        heap_rebase_anchor_task_id_ = -1;
 
         PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
         uint64_t old_tail = heap_tail_;
@@ -345,6 +357,17 @@ private:
                 // scope_stats can unroll the wrapping offset into a monotonic value.
                 // The collector attributes the wrap to the current scope's ring.
                 if (is_scope_stats_enabled()) scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+#endif
+            } else if (top == tail && alloc_size <= heap_size_) {
+                result = heap_base_;
+                heap_top_ = alloc_size;
+                heap_tail_ = 0;
+                heap_rebase_anchor_task_id_ = local_task_id_;
+#if SIMPLER_DFX
+                if (is_scope_stats_enabled()) {
+                    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+                    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+                }
 #endif
             } else {
                 LOG_DEBUG(

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/aic/kernel_copy_first.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/aic/kernel_copy_first.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *in_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+
+    __gm__ float *in = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = in[0];
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/aic/kernel_write_const.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/aic/kernel_write_const.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 42.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Allocates one 1 MiB scratch in each of two consecutive scopes on ring 1.
+ * Ring 1 has 1.5 MiB of heap, so the second allocation requires the drained
+ * ring parked at offset 1 MiB to rebase to zero.
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_FILL_CONST 0
+#define FUNC_COPY_FIRST 1
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 2,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_Y1 = orch_args.tensor(0).ref();
+    const Tensor &ext_Y2 = orch_args.tensor(1).ref();
+
+    uint32_t scratch_shapes[2] = {1024, 256};
+    TensorCreateInfo scratch_ci(scratch_shapes, 2, DataType::FLOAT32);
+
+    PTO2_SCOPE() {
+        L0TaskArgs fill1;
+        fill1.add_output(scratch_ci);
+        TaskOutputTensors t1_outs = rt_submit_aic_task(FUNC_FILL_CONST, fill1);
+        const Tensor &t1 = t1_outs.get_ref(0);
+
+        L0TaskArgs copy1;
+        copy1.add_input(t1);
+        copy1.add_inout(ext_Y1);
+        rt_submit_aic_task(FUNC_COPY_FIRST, copy1);
+    }
+
+    PTO2_SCOPE() {
+        L0TaskArgs fill2;
+        fill2.add_output(scratch_ci);
+        TaskOutputTensors t2_outs = rt_submit_aic_task(FUNC_FILL_CONST, fill2);
+        const Tensor &t2 = t2_outs.get_ref(0);
+
+        L0TaskArgs copy2;
+        copy2.add_input(t2);
+        copy2.add_inout(ext_Y2);
+        rt_submit_aic_task(FUNC_COPY_FIRST, copy2);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Verify that a drained heap ring can reuse its full capacity.
+
+Each scope allocates a 1 MiB scratch on ring 1. The first scope drains the ring
+at offset 1 MiB; the second allocation therefore requires an empty-ring rebase
+when ring 1 is limited to 1.5 MiB.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+SENTINEL = 42.0
+INIT_VAL = -1.0
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestHeapEmptyRingRebase(SceneTestCase):
+    """A drained ring parked away from zero accepts a whole-span allocation."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/heap_empty_ring_rebase_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "FILL_CONST",
+                "source": "kernels/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+                "signature": [D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": "kernels/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "EmptyRingRebase",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {
+                "aicpu_thread_num": 2,
+                "runtime_env": {
+                    "ring_heap": [268435456, 1572864, 268435456, 268435456],
+                },
+            },
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        y1 = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        y2 = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        return TaskArgsBuilder(
+            Tensor("y1", y1),
+            Tensor("y2", y2),
+        )
+
+    def compute_golden(self, args, params):
+        args.y1[0] = SENTINEL
+        args.y2[0] = SENTINEL
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -119,6 +119,33 @@ function(add_a2a3_runtime_test name src)
     set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
 endfunction()
 
+function(add_a2a3_hbg_runtime_test name src)
+    add_executable(${name}
+        ${src}
+        ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/orchestration
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/runtime
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/common
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/aicpu
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common
+    )
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
+endfunction()
+
 function(add_a2a3_orchestrator_runtime_test name src)
     add_executable(${name}
         ${src}
@@ -612,6 +639,7 @@ add_a2a3_test(test_task_timing_slots a2a3/test_task_timing_slots.cpp)
 
 # PTO2 runtime-linked tests
 add_a2a3_runtime_test(test_task_allocator   a2a3/test_task_allocator.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_task_allocator a2a3/test_task_allocator.cpp)
 add_a2a3_runtime_test(test_dep_list_pool    a2a3/test_dep_list_pool.cpp)
 add_a2a3_runtime_test(test_scheduler_state  a2a3/test_scheduler_state.cpp)
 add_a2a3_runtime_test(test_task_state       a2a3/test_task_state.cpp)

--- a/tests/ut/cpp/a2a3/test_task_allocator.cpp
+++ b/tests/ut/cpp/a2a3/test_task_allocator.cpp
@@ -174,8 +174,8 @@ TEST_F(TaskAllocatorTest, UpdateHeapTailFromConsumedTask) {
     auto r2 = allocator.alloc(0);
     ASSERT_FALSE(r2.failed());
 
-    // top=256, tail=256: at_end = 4096-256=3840, at_begin = 256
-    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE - 256u);
+    // top=256, tail=256: the ring is empty despite both cursors being non-zero.
+    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE);
 }
 
 TEST_F(TaskAllocatorTest, UpdateHeapTailAtTask0) {
@@ -266,6 +266,64 @@ TEST_F(TaskAllocatorTest, HeapWrapAroundSuccess) {
     ASSERT_FALSE(r2.failed());
     EXPECT_EQ(r2.packed_base, static_cast<void *>(heap_buf));
     EXPECT_EQ(allocator.heap_top(), 64u);
+}
+
+TEST_F(TaskAllocatorTest, HeapEmptyRingRebasesForContiguousAlloc) {
+    constexpr uint64_t allocation_size = 3000;
+    auto r1 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r1.failed());
+    const uint64_t aligned_size = allocator.heap_top();
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 1, aligned_size);
+
+    auto r2 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r2.failed()) << "an empty ring must place an allocation that fits its full capacity";
+    EXPECT_EQ(r2.packed_base, static_cast<void *>(heap_buf));
+    EXPECT_EQ(allocator.heap_top(), aligned_size);
+    EXPECT_EQ(allocator.heap_tail(), 0u);
+}
+
+TEST_F(TaskAllocatorTest, HeapAvailableReportsCapacityForParkedEmptyRing) {
+    constexpr uint64_t allocation_size = 1024;
+    auto r1 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r1.failed());
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 1, allocation_size);
+    auto zero_size_probe = allocator.alloc(0);
+    ASSERT_FALSE(zero_size_probe.failed());
+
+    ASSERT_EQ(allocator.heap_top(), allocation_size);
+    ASSERT_EQ(allocator.heap_tail(), allocation_size);
+    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE);
+}
+
+TEST_F(TaskAllocatorTest, HeapRebaseKeepsNewAllocationLiveWhenOlderZeroSizeTaskRetires) {
+    constexpr uint64_t allocation_size = 3000;
+    auto r1 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r1.failed());
+    const uint64_t aligned_size = allocator.heap_top();
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 1, aligned_size);
+    auto old_zero_size = allocator.alloc(0);
+    ASSERT_FALSE(old_zero_size.failed());
+
+    auto rebased = allocator.alloc(allocation_size);
+    ASSERT_FALSE(rebased.failed());
+    descriptors[rebased.slot].packed_buffer_end = rebased.packed_end;
+    ASSERT_EQ(allocator.heap_tail(), 0u);
+    ASSERT_EQ(allocator.heap_used_bytes(), aligned_size);
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 2, aligned_size);
+    auto live_probe = allocator.alloc(0);
+    ASSERT_FALSE(live_probe.failed());
+    EXPECT_EQ(allocator.heap_tail(), 0u);
+    EXPECT_EQ(allocator.heap_used_bytes(), aligned_size);
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 3, aligned_size);
+    auto retired_probe = allocator.alloc(0);
+    ASSERT_FALSE(retired_probe.failed());
+    EXPECT_EQ(allocator.heap_tail(), aligned_size);
+    EXPECT_EQ(allocator.heap_used_bytes(), 0u);
 }
 
 // Linear-gap guard `tail - top > alloc_size` uses strict > for the same reason.

--- a/tests/ut/cpp/a5/test_task_allocator.cpp
+++ b/tests/ut/cpp/a5/test_task_allocator.cpp
@@ -174,8 +174,8 @@ TEST_F(TaskAllocatorTest, UpdateHeapTailFromConsumedTask) {
     auto r2 = allocator.alloc(0);
     ASSERT_FALSE(r2.failed());
 
-    // top=256, tail=256: at_end = 4096-256=3840, at_begin = 256
-    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE - 256u);
+    // top=256, tail=256: the ring is empty despite both cursors being non-zero.
+    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE);
 }
 
 TEST_F(TaskAllocatorTest, UpdateHeapTailAtTask0) {
@@ -266,6 +266,64 @@ TEST_F(TaskAllocatorTest, HeapWrapAroundSuccess) {
     ASSERT_FALSE(r2.failed());
     EXPECT_EQ(r2.packed_base, static_cast<void *>(heap_buf));
     EXPECT_EQ(allocator.heap_top(), 64u);
+}
+
+TEST_F(TaskAllocatorTest, HeapEmptyRingRebasesForContiguousAlloc) {
+    constexpr uint64_t allocation_size = 3000;
+    auto r1 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r1.failed());
+    const uint64_t aligned_size = allocator.heap_top();
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 1, aligned_size);
+
+    auto r2 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r2.failed()) << "an empty ring must place an allocation that fits its full capacity";
+    EXPECT_EQ(r2.packed_base, static_cast<void *>(heap_buf));
+    EXPECT_EQ(allocator.heap_top(), aligned_size);
+    EXPECT_EQ(allocator.heap_tail(), 0u);
+}
+
+TEST_F(TaskAllocatorTest, HeapAvailableReportsCapacityForParkedEmptyRing) {
+    constexpr uint64_t allocation_size = 1024;
+    auto r1 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r1.failed());
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 1, allocation_size);
+    auto zero_size_probe = allocator.alloc(0);
+    ASSERT_FALSE(zero_size_probe.failed());
+
+    ASSERT_EQ(allocator.heap_top(), allocation_size);
+    ASSERT_EQ(allocator.heap_tail(), allocation_size);
+    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE);
+}
+
+TEST_F(TaskAllocatorTest, HeapRebaseKeepsNewAllocationLiveWhenOlderZeroSizeTaskRetires) {
+    constexpr uint64_t allocation_size = 3000;
+    auto r1 = allocator.alloc(allocation_size);
+    ASSERT_FALSE(r1.failed());
+    const uint64_t aligned_size = allocator.heap_top();
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 1, aligned_size);
+    auto old_zero_size = allocator.alloc(0);
+    ASSERT_FALSE(old_zero_size.failed());
+
+    auto rebased = allocator.alloc(allocation_size);
+    ASSERT_FALSE(rebased.failed());
+    descriptors[rebased.slot].packed_buffer_end = rebased.packed_end;
+    ASSERT_EQ(allocator.heap_tail(), 0u);
+    ASSERT_EQ(allocator.heap_used_bytes(), aligned_size);
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 2, aligned_size);
+    auto live_probe = allocator.alloc(0);
+    ASSERT_FALSE(live_probe.failed());
+    EXPECT_EQ(allocator.heap_tail(), 0u);
+    EXPECT_EQ(allocator.heap_used_bytes(), aligned_size);
+
+    consume_up_to(descriptors, last_alive, heap_buf, WINDOW_SIZE, 3, aligned_size);
+    auto retired_probe = allocator.alloc(0);
+    ASSERT_FALSE(retired_probe.failed());
+    EXPECT_EQ(allocator.heap_tail(), aligned_size);
+    EXPECT_EQ(allocator.heap_used_bytes(), 0u);
 }
 
 // Linear-gap guard `tail - top > alloc_size` uses strict > for the same reason.


### PR DESCRIPTION
## Summary

- Fix an empty heap ring parked at a non-zero offset incorrectly reporting `HEAP_RING_DEADLOCK` for an allocation that fits the ring's full capacity.
- Apply the fix consistently to the a2a3 tensormap, a2a3 host-build-graph, and a5 allocators.
- Add allocator unit coverage, a stable issue #1469 scene regression, and a dedicated a2a3sim CI signal.

## Problem

After a heap ring drains, `heap_top_ == heap_tail_` can remain at a non-zero offset. For a request that fits the whole ring but neither free arc contiguously, the allocator rejects the request even though no live bytes remain.

The existing strict wrap guards are intentional: relaxing `>` to `>=` would reintroduce full/empty ambiguity when an allocation makes `top == tail`. The missing case is an explicit rebase for a genuinely empty ring.

## Solution

- Rebase an empty parked ring to `heap_base_` when the request fits the full heap capacity.
- Reset `heap_tail_` to zero and advance `heap_top_` past the new allocation.
- Report the full capacity from `heap_available()` whenever `heap_top_ == heap_tail_`.
- Track a post-rebase anchor task so reclaim markers from the previous coordinate space cannot reclaim the new allocation early.
- Preserve the strict wrap guards and update DFX wrap accounting and runtime documentation.

## Regression coverage

- Add allocator tests for:
  - contiguous allocation after an empty-ring rebase;
  - full capacity reporting for a parked empty ring;
  - delayed retirement of an older zero-output task after rebase.
- Run the allocator coverage for a2a3, a5, and a2a3 host-build-graph runtimes.
- Add a stable scene test using two consecutive scopes with 1 MiB scratch allocations on a 1.5 MiB ring. The first scope drains the ring at a non-zero offset; the second must rebase and complete with `Y1[0] == Y2[0] == 42.0`.
- Run that scene explicitly in CI before the general a2a3sim scene sweep so future regressions are directly attributable.

## Validation

- a2a3 allocator: 25/25 passed
- a5 allocator: 25/25 passed
- host-build-graph allocator: 25/25 passed
- Targeted allocator regressions: 5/5 passed on all three runtimes
- Full combined C++ test suite passed
- a2a3sim scene regression passed
- Real a2a3 hardware scene regression passed
- Pre-commit hooks passed

Fixes #1469