### PR TITLE
Refactor: stop duplicating the error-code tables the runtime already prints

### DIFF
--- a/docs/troubleshooting/device-error-codes.md
+++ b/docs/troubleshooting/device-error-codes.md
@@ -1,20 +1,38 @@
 # Device Error Codes
 
-What a failing run's error code means, and what is known about chasing each one
-down. The host log now names the code it prints, so this page is the long form of
-what the `error detail:` / `ACL error detail:` lines already tell you.
+The runtime names, describes and hints every code it latches, at the moment it
+fails. This page is what those lines cannot carry: which field to read, who the
+code usually blames, and how to chase each family down.
 
-## How an error reaches you
+## Start by reading the two lines you already have
 
-The `tensormap_and_ringbuffer` runtime runs orchestration and scheduling on the
-AICPU. On a fatal condition the runtime **latches** a code into the shared-memory
-header; the host reads it back in `validate_runtime_impl` and prints:
+The `error hint:` line that sent you here is the second of a pair:
 
 ```text
 [ERROR] PTO2 runtime failed: orch_error_code=1 sched_error_code=0 runtime_status=-1
 [ERROR] error detail: orch_error_code=1 SCOPE_DEADLOCK - tasks submitted in one scope ...
 [ERROR] error hint: raise ring_task_window (PTO2_RING_TASK_WINDOW) or split the scope ...
 ```
+
+`error detail:` gives the **name** and a full description of the mechanism.
+`error hint:` gives the **next action**, including the knob to turn. Host-side
+CANN failures print the same pair as `ACL error detail:` / `ACL error hint:`.
+
+So the code's meaning and its first remedy are already on your screen. Come here
+for the parts that are not: the triage columns below, and the chase procedures.
+
+**First move, always:**
+
+```bash
+grep -E "orch_error_code=|sched_error_code=|sub_class=|error detail:" <run log>
+```
+
+## How an error reaches you
+
+The `tensormap_and_ringbuffer` runtime runs orchestration and scheduling on the
+AICPU. On a fatal condition the runtime **latches** a code into the shared-memory
+header; the host reads it back in `validate_runtime_impl` and prints the lines
+above.
 
 At most one of `orch_error_code` (1-11) and `sched_error_code` (100+) is ever
 non-zero. `runtime_status` is just the latched code negated.
@@ -28,40 +46,37 @@ the same number:
 | **onboard** | Usually a CANN watchdog fires first and masks the code as a generic `507018`. **Do not read `<rc>` as the error code here.** |
 
 So on hardware the exception code is the *least* informative thing on screen. The
-failure lines above are printed either way — start there.
+`error detail:` / `error hint:` pair is printed either way — start there.
 
-**First move, always:**
+## Triage: who the code usually blames
 
-```bash
-grep -E "orch_error_code=|sched_error_code=|sub_class=|error detail:" <run log>
-```
-
-## 1. Code reference
+The description and remedy come from the log. What it cannot tell you is which
+layer to go looking in, which is what these columns are for.
 
 ### Orchestration errors (1-11)
 
-| Code | Name | Meaning | Whose bug, usually |
-| ---- | ---- | ------- | ------------------ |
-| 1 | SCOPE_DEADLOCK | Tasks in one scope hit the ring task-window cap; slots are not reclaimed until `scope_end` | orchestration |
-| 2 | HEAP_RING_DEADLOCK | Ring task slots *and* heap bytes both exhausted | orchestration / config |
-| 3 | FLOW_CONTROL_DEADLOCK | Task window blocked while heap is not full (classically: nesting on one ring) | orchestration |
-| 4 | DEP_POOL_OVERFLOW | A task's fanin edges overflowed the ring's dependency spill pool | orchestration / config |
-| 5 | INVALID_ARGS | An orchestration API rejected its arguments | orchestration |
-| 6 | *(retired)* | Was per-task fanin overflow; now reported as 4 | — |
-| 7 | REQUIRE_SYNC_START_INVALID | `require_sync_start()` asked for more blocks than the core type physically has | orchestration |
-| 8 | TENSOR_WAIT_TIMEOUT | Waiting for tensor data timed out | kernel / orchestration |
-| 9 | EXPLICIT_ORCH_FATAL | Orchestration called `rt_report_fatal()` itself | orchestration (deliberate) |
-| 10 | SCOPE_TASKS_OVERFLOW | Scope task-record buffer saturated | runtime-internal |
-| 11 | TENSORMAP_OVERFLOW | Tensormap entry pool wedged | runtime-internal / extreme scale |
+| Code | Name | Whose bug, usually |
+| ---- | ---- | ------------------ |
+| 1 | SCOPE_DEADLOCK | orchestration |
+| 2 | HEAP_RING_DEADLOCK | orchestration / config |
+| 3 | FLOW_CONTROL_DEADLOCK | orchestration |
+| 4 | DEP_POOL_OVERFLOW | orchestration / config |
+| 5 | INVALID_ARGS | orchestration |
+| 6 | *(retired — reported as 4)* | — |
+| 7 | REQUIRE_SYNC_START_INVALID | orchestration |
+| 8 | TENSOR_WAIT_TIMEOUT | kernel / orchestration |
+| 9 | EXPLICIT_ORCH_FATAL | orchestration (deliberate) |
+| 10 | SCOPE_TASKS_OVERFLOW | runtime-internal |
+| 11 | TENSORMAP_OVERFLOW | runtime-internal / extreme scale |
 
 ### Scheduler errors (100+)
 
-| Code | Name | Meaning | Whose bug, usually |
-| ---- | ---- | ------- | ------------------ |
-| 100 | SCHEDULER_TIMEOUT | No forward progress within the timeout. See the sub-class below | depends on sub-class |
-| 101 | ASYNC_COMPLETION_INVALID | Malformed async completion condition | kernel (async) |
-| 102 | ASYNC_WAIT_OVERFLOW | Async wait list full (in-flight completions over the 64 cap) | kernel (async) |
-| 103 | ASYNC_REGISTRATION_FAILED | Illegal async completion message kind | runtime-internal |
+| Code | Name | Whose bug, usually |
+| ---- | ---- | ------------------ |
+| 100 | SCHEDULER_TIMEOUT | depends on the sub-class below |
+| 101 | ASYNC_COMPLETION_INVALID | kernel (async) |
+| 102 | ASYNC_WAIT_OVERFLOW | kernel (async) |
+| 103 | ASYNC_REGISTRATION_FAILED | runtime-internal |
 
 ### SCHEDULER_TIMEOUT sub-classes
 
@@ -73,72 +88,56 @@ verdict plus locators, so you rarely need the device log:
         running=1 ready=0 waiting=0 orch_done=1 stuck_task_id=42 stuck_core=5
 ```
 
-| Sub-class | Meaning | Cause |
-| --------- | ------- | ----- |
-| **S1** running-stalled | A task is on a core and never completes | AICore kernel hang, or a kernel that is merely very slow |
-| **S3** ready-but-all-idle | Cores idle, a fanin-satisfied task exists, nothing dispatched | dispatch loop / sync-start gate |
-| **S4** dependency-deadlock | Only WAIT tasks remain, fanin never resolves | dependency wiring |
-| **S5** orchestrator-starvation | Submitted tasks all done, orchestration not finished | orchestration stuck upstream |
-| **unknown** | Bookkeeping invariant violated | runtime bug / memory corruption |
+| Sub-class | Cause |
+| --------- | ----- |
+| **S1** running-stalled | AICore kernel hang, or a kernel that is merely very slow |
+| **S3** ready-but-all-idle | dispatch loop / sync-start gate |
+| **S4** dependency-deadlock | dependency wiring |
+| **S5** orchestrator-starvation | orchestration stuck upstream |
+| **unknown** | runtime bug / memory corruption |
 
 The counters *are* the decision: priority is `running > ready > waiting > orch not
 done`. `running=1` is always S1; `running=0, ready>0` is S3.
 
 **Only S1 and S3 are reproducible in practice.** S4, S5 and unknown are defensive
-labels — see [5. Codes with no end-to-end test](#5-codes-with-no-end-to-end-test).
+labels — see [Codes with no end-to-end test](device-error-codes/untested.md).
 
 ### Host-side CANN codes
 
-These come from the driver, not from the runtime. Names are CANN's own
-(`acl/error_codes/rt_error_codes.h`).
+These come from the driver, not from the runtime. Unlike the codes above, a CANN
+number can reach you from output we do not wrap (a driver log, a raw ACL return),
+so the names are worth keeping here rather than only in
+`acl/error_codes/rt_error_codes.h`.
 
-| Code | Name | Meaning |
-| ---- | ---- | ------- |
-| 107022 | ACL_ERROR_RT_DEVICE_TASK_ABORT | Task aborted, usually collateral damage from an earlier fault |
-| 207001 | ACL_ERROR_RT_MEMORY_ALLOCATION | Device out of memory |
-| 507000 | ACL_ERROR_RT_INTERNAL_ERROR | Runtime internal error; on a5 this is how an AICPU op timeout surfaces |
-| 507014 | ACL_ERROR_RT_AICORE_TIMEOUT | AICore task exceeded its execution timeout |
-| 507015 | ACL_ERROR_RT_AICORE_EXCEPTION | AICore task faulted |
-| 507017 | ACL_ERROR_RT_AICPU_TIMEOUT | AICPU task exceeded its execution timeout |
-| 507018 | ACL_ERROR_RT_AICPU_EXCEPTION | AICPU task faulted — **the generic one** |
-| 507046 | ACL_ERROR_RT_STREAM_SYNC_TIMEOUT | Host timed out on a stream sync |
-| 507899 | ACL_ERROR_RT_DRV_INTERNAL_ERROR | Driver internal error; typically a *sticky* error on an already-poisoned context |
-| -1 | SIMPLER_DEVICE_UNUSABLE | Our own sentinel: the DeviceRunner had already marked the device unusable |
+| Code | Name |
+| ---- | ---- |
+| 107022 | ACL_ERROR_RT_DEVICE_TASK_ABORT |
+| 207001 | ACL_ERROR_RT_MEMORY_ALLOCATION |
+| 507000 | ACL_ERROR_RT_INTERNAL_ERROR |
+| 507014 | ACL_ERROR_RT_AICORE_TIMEOUT |
+| 507015 | ACL_ERROR_RT_AICORE_EXCEPTION |
+| 507017 | ACL_ERROR_RT_AICPU_TIMEOUT |
+| 507018 | ACL_ERROR_RT_AICPU_EXCEPTION — **the generic one** |
+| 507046 | ACL_ERROR_RT_STREAM_SYNC_TIMEOUT |
+| 507899 | ACL_ERROR_RT_DRV_INTERNAL_ERROR |
+| -1 | SIMPLER_DEVICE_UNUSABLE (our own sentinel: the DeviceRunner had already marked the device unusable) |
 
-`507018` is a **generic host-side code**: several unrelated device mechanisms all
-surface as it. Never conclude "deadlock" or "OOM" from it alone. `507899` and
-`107022` are almost always *fallout* — scroll up for the first failure on that
-device. For classifying `507018` against the device log, see the triage table in
-[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md).
+`507018` is **generic**: several unrelated device mechanisms all surface as it.
+Never conclude "deadlock" or "OOM" from it alone. `507899` and `107022` are almost
+always *fallout* — scroll up for the first failure on that device. For classifying
+`507018` against the device log, see the triage table in
+[`running-onboard.md`](../../.claude/rules/running-onboard.md).
 
-## 2. Chasing down a capacity code (1, 2, 4)
+## Chasing it down
 
-These three all say the same thing — "some resource ran out" — without saying
-*which* resource or *which* scope. Do not guess at the ring sizes. Turn on
-`scope_stats`, which records the high-water mark of all four resources (task-window
-slots, heap bytes, dep-pool entries, tensormap entries) per `PTO2_SCOPE`:
+| You have | Go to |
+| -------- | ----- |
+| a capacity code — 1, 2, 4 | [Capacity](device-error-codes/capacity.md) |
+| a stall — 100, or code 8 | [Stalls](device-error-codes/stall.md) |
+| a `VEC`/`CUBE` instruction error or UB out of bounds in the device log | [AICore faults](device-error-codes/aicore-fault.md) |
+| 10, 11, 103, S4, S5 or unknown | [Codes with no end-to-end test](device-error-codes/untested.md) — and it is a runtime bug |
 
-```python
-cfg = CallConfig()
-cfg.enable_scope_stats = True
-cfg.output_prefix = "outputs/my_run"
-worker.run(callable, args, cfg)
-```
-
-It works on a **failing** run: the metadata line is marked `"fatal": true` and
-everything written before the fatal is kept. So point it straight at the workload
-that trips the code.
-
-| Bottleneck resource | Code | Fix |
-| ------------------- | ---- | --- |
-| task window | 1 | raise `ring_task_window` (`PTO2_RING_TASK_WINDOW`), or split the scope |
-| heap | 2 | raise `ring_heap` (`PTO2_RING_HEAP`), or shrink per-task args / intermediate tensors |
-| dep pool | 4 | raise `ring_dep_pool` (`PTO2_RING_DEP_POOL`), or cut the fanin count |
-
-Report fields, the `Top Peaks` table and the plotting tool are documented in
-[`../dfx/scope-stats.md`](../dfx/scope-stats.md).
-
-### Minimal reproductions
+## Minimal reproductions
 
 Each code has a live, minimal trigger in `tests/st/runtime_fatal_codes/`. These are
 the fastest way to see what a code looks like, and the shape to copy when you
@@ -158,194 +157,29 @@ suspect one:
 | 101 | Kernel defers `PTO2_ERROR_ASYNC_COMPLETION_INVALID` into the slab directly | `kernels/aiv/kernel_async_completion_invalid.cpp` |
 | 102 | Kernel registers `MAX_COMPLETIONS_PER_TASK + 1` conditions | `kernels/aiv/kernel_async_wait_overflow.cpp` |
 
-## 3. Chasing down a stall (100, and code 8)
+## Adding or changing a code
 
-### The timeout race decides what you see
+The names, descriptions and hints live in switch statements, and the compiler
+enforces coverage. Edit those and the log carries the new code correctly:
 
-Three watchdogs compete, and whichever fires first determines whether you get a
-clean `-100` with a `sub_class`, or a masked `507018`:
+| What | Where |
+| ---- | ----- |
+| runtime code names / descriptions / hints | `src/common/runtime_status/error_names.h` |
+| host-side CANN names / descriptions / hints | `src/common/platform/include/host/acl_error_names.h` |
+| `SCHEDULER_TIMEOUT` sub-class labels | `src/{arch}/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h` |
+| completeness test | `tests/ut/cpp/common/test_error_code_names.cpp` |
 
-- the scheduler no-progress timeout (`PTO2_SCHEDULER_TIMEOUT_MS`),
-- the STARS op-execute timeout (`PTO2_OP_EXECUTE_TIMEOUT_US`, ~45 s, kills `aicpu-sd`),
-- the host stream-sync timeout (`PTO2_STREAM_SYNC_TIMEOUT_MS`).
-
-**A 45 s op-execute kill is not proof of a deadlock** — the kernel may simply be
-slow. To find out which, order the race deliberately. The STs do exactly this, and
-the technique transfers:
-
-- To make the **scheduler** win (get a `sub_class`), squeeze it below the others:
-  `SCHEDULER=2000ms < OP_EXECUTE=3s < STREAM_SYNC=4000ms` (`aicore_hang` case).
-- To let a **slow-but-alive** path finish, push the others out of the way:
-  `SCHEDULER=30000ms`, `OP_EXECUTE=30s`, `STREAM_SYNC=40000ms` — this is how the
-  `tensor_wait_timeout` case lets the 15 s tensor-data wait land code 8 instead of
-  being reaped first.
-
-**These three are read once, at `Worker.init()`.** Changing them between `run()`
-calls on the same Worker does nothing — you must rebuild the Worker (or use a
-separate process) per value. Defaults and the rationale are in
-[`local-timeout-defaults.md`](local-timeout-defaults.md).
-
-### S1: find the stuck kernel
-
-The `sub_class=` line gives you `stuck_task_id` and `stuck_core`. Map the task id
-back to your orchestration and look at that kernel for an infinite loop, a wait on
-a signal that never arrives, or simply too much work.
-
-When the task id is not enough, raise the log level to **V0** and the device log
-prints a task snapshot at the moment of the stall:
-
-```text
-[STALL thread=0 idle_iterations=...] TASK ring=1 task_id=42 state=RUNNING \
-    fanin_refcount=0/2 kernels=[aic:3 aiv0:7 aiv1:-1] \
-    running_on=[owner_thread=0 cores=[core=5(AIC) core=6(AIV0)]]
-```
-
-`kernels=[...]` are the kernel ids in the task's three sub-core slots and
-`cores=[...]` the physical cores running it — that maps "stuck task" to "which
-kernel, on which core".
-
-Setting the level:
-
-- **Worker directly**: `logging.getLogger("simpler").setLevel("V0")` **before**
-  `worker.init()` — the level is snapshotted at init and pushed to the device, so
-  setting it between `run()` calls has no effect.
-- **pytest / scene test**: `--log-level v0`.
-
-V0 is the most verbose level (V0 verbose … V9 terse, default V5). Device logs land
-in the shared `~/ascend/log/debug/device-<id>/` by default, where several processes
-interleave; redirect them per-run with `ASCEND_PROCESS_LOG_PATH` (the directory must
-exist) before reading. See the "Device logs" section of
-[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md).
-
-### Code 8, specifically
-
-The tensor-data wait defaults to 15 s (`PTO2_TENSOR_DATA_TIMEOUT_MS`,
-frequency-scaled). It means either the producer never completed, or a consumer never
-released its fanout reference. Check for a hung producer first (that is S1 above),
-then verify the consumer really declares the dependency and exits. If the kernel is
-merely slow, raising the timeout will prove it.
-
-## 4. Chasing down an AICore fault (UB out of bounds, VEC/CUBE instruction error)
-
-An AICore addressing fault reaches the host as the same generic `507018` a stall
-does, usually with a `SCHEDULER_TIMEOUT` tail, because the faulting core stops
-answering and a watchdog reaps the op afterwards. The device log is the only
-place the fault itself appears:
-
-```text
-VEC instruction error: the ub address out of bounds
-  core id 15, blk:1, errcode 0x4000000000000000
-→ aicpu exception → 507018 → sched_error_code=100 SCHEDULER_TIMEOUT
-```
-
-**Redirect the device log before the run that you expect to fail.** The harness
-does not do this for you: `outputs/<case>_<ts>/` is only created when a DFX flag
-is on, so a plain onboard run leaves its device log in the shared
-`~/ascend/log/debug/device-<id>/` among every other user's. A fault you cannot
-attribute to a file is a fault you cannot diagnose, and the evidence is gone
-once the run ends:
-
-```bash
-LOGDIR="$PWD/outputs/<label>/ascend"; mkdir -p "$LOGDIR"   # driver fopens; it will not mkdir
-export ASCEND_PROCESS_LOG_PATH="$LOGDIR"
-```
-
-See the "Device logs" section of
-[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md).
-
-### F1: is it the kernel's own addressing, or did the core jump somewhere else?
-
-These two look identical from the host and have nothing in common as bugs, so
-settle it before reading any kernel arithmetic:
-
-- **`PrintErrorInfoForDavinciTask`** — `fault kernel_name`, `hash`, and
-  `GetBinAndKernelNameExceptionArgs: binSize`. If `binSize` matches the
-  runtime's own `aicore_kernel.o` rather than your kernel, the report is naming
-  the **polling-dispatch executor**, and the faulting code is whatever it jumped
-  to — a dispatch-payload / `function_bin_addr` problem, not kernel arithmetic.
-- **`PrintCoreInfo`** — `pc current`. Whether that offset lands inside the
-  executor's binary size or far outside it tells you the same thing
-  independently.
-
-[#1036](https://github.com/hw-native-sys/simpler/issues/1036) has the worked
-example of making this distinction.
-
-### F2: rule the kernel's own addressing in or out statically
-
-Before instrumenting, check whether the kernel *can* compute an out-of-range UB
-address at all. Compile-time `TASSIGN` offsets and template-derived tile extents
-do not make that impossible — the constants themselves can overrun — but they
-make it **decidable on paper**, because runtime values that only shrink a tile
-(a per-rank chunk count, a shorter row) move no base and grow no extent.
-
-So compute it. Sum the highest byte each `TASSIGN` base plus its tile extent
-reaches and compare against the AIV UB size:
-
-- **Fits for every input the guards admit** → the address did not come from
-  here, and you are in F1's second case.
-- **Does not fit** → you have found the bug without touching the device.
-
-The allreduce collectives were cleared this way in
-[#1489](https://github.com/hw-native-sys/simpler/issues/1489): all five modes
-bind every tile to a constant base, `nranks` only divides the chunk count, and
-the whole footprint stays under 132 KiB of the 192 KiB UB at every rank count.
-
-That case is worth following to its end, because F2's verdict held. The fault
-was not in the kernels; it was almost certainly
-[#1477](https://github.com/hw-native-sys/simpler/pull/1477), a `CoreTracker`
-whose `uint64_t` state overran past 21 clusters while those cases ran at the
-device's full 24. Corrupted dispatch state, F1's second case — reached by
-believing F2 rather than re-reading the kernel arithmetic a second time.
-
-### F3: separate a real fault from a post-mortem register dump
-
-A core killed while spinning can produce a fault-looking line that describes the
-state it was reaped in rather than an instruction it executed. Count the
-detectors, per [`running-onboard.md`](../../.claude/rules/running-onboard.md):
-if `FATAL: Task Allocator Deadlock` and `Timeout (N cycles):
-producer/consumers` are both **zero** and only `HandleTaskTimeout` fired, then
-nothing on the device proved a fault or a deadlock — treat the wait that never
-completed as the primary object of the investigation, not the addressing line.
-
-## 5. Codes with no end-to-end test
-
-Three codes and three stall sub-classes have no ST — not from neglect, but because
-they cannot be provoked. Recording why, so the next person does not re-derive it
-(the argument lives in `tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py`):
-
-- **103 ASYNC_REGISTRATION_FAILED** is structurally pre-empted. The AICore side caps
-  at `MAX_COMPLETIONS_PER_TASK` (64) and latches **102** on the 65th condition, so
-  the scheduler-side "more than 64" check that would raise 103 never sees enough
-  messages. 103 is reachable only by corrupting the slab (UB) or a malformed message.
-- **10 SCOPE_TASKS_OVERFLOW** cannot be reached either. `scope_tasks_cap` is the sum
-  of the per-ring windows, but each ring physically holds only `window - 1` tasks, so
-  all rings together top out at `cap - PTO2_MAX_RING_DEPTH` — strictly below the cap.
-  The rings always fill first and latch 1 or 3. Shrinking the window shrinks both, so
-  the gap holds.
-- **11 TENSORMAP_OVERFLOW** needs the 65536-entry pool (`PTO2_TENSORMAP_POOL_SIZE`,
-  compile-time, not tunable via `runtime_env`) flooded *and* a stalled producer
-  holding entries.
-- **S4 / S5 / unknown**: not expressible through the public API. `set_dependencies()`
-  can only name already-submitted tasks, so a dependency cycle cannot be written; a
-  stuck producer is RUNNING (→ S1), never pure WAIT (S4). `total_tasks_` counts
-  *submitted* tasks, so once they retire `completed == total` and the S5 watchdog
-  never fires. They are kept as defensive labels: if a future bug produces the state,
-  it gets named instead of mislabelled.
-
-The name tables are held complete for these anyway
-(`tests/ut/cpp/common/test_error_code_names.cpp`) — an unreachable code is exactly
-the one that would otherwise print as a bare number on the day it finally fires.
-
-If you do hit 10, 11, 103, S4, S5 or unknown, it is a runtime bug. Keep the device
-log and report it.
+**This page does not need updating for a new code** — deliberately. The tables
+above carry only the triage column and the CANN names, neither of which the log
+can supply. Everything a reader would otherwise look up here is printed at failure
+time, so there is nothing to drift out of sync.
 
 ## References
 
 - Code definitions: `src/{arch}/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h`
-- Name/hint tables: `src/common/runtime_status/error_names.h`, `src/common/platform/include/host/acl_error_names.h`
 - Host print site: `.../host/runtime_maker.cpp` (`validate_runtime_impl`)
 - Sub-class logic: `.../runtime/scheduler/scheduler_cold_path.cpp` (`classify_stall_reason`)
 - End-to-end negative tests: `tests/st/runtime_fatal_codes/`
-- Onboard `507018` mechanism triage + device logs: [`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md)
+- Onboard `507018` mechanism triage + device logs: [`running-onboard.md`](../../.claude/rules/running-onboard.md)
 - Timeout defaults: [`local-timeout-defaults.md`](local-timeout-defaults.md)
 - Capacity DFX: [`../dfx/scope-stats.md`](../dfx/scope-stats.md)

--- a/docs/troubleshooting/device-error-codes/aicore-fault.md
+++ b/docs/troubleshooting/device-error-codes/aicore-fault.md
@@ -1,0 +1,83 @@
+# Chasing down an AICore fault (UB out of bounds, VEC/CUBE instruction error)
+
+← [Device Error Codes](../device-error-codes.md)
+
+An AICore addressing fault reaches the host as the same generic `507018` a stall
+does, usually with a `SCHEDULER_TIMEOUT` tail, because the faulting core stops
+answering and a watchdog reaps the op afterwards. The device log is the only
+place the fault itself appears:
+
+```text
+VEC instruction error: the ub address out of bounds
+  core id 15, blk:1, errcode 0x4000000000000000
+→ aicpu exception → 507018 → sched_error_code=100 SCHEDULER_TIMEOUT
+```
+
+**Redirect the device log before the run that you expect to fail.** The harness
+does not do this for you: `outputs/<case>_<ts>/` is only created when a DFX flag
+is on, so a plain onboard run leaves its device log in the shared
+`~/ascend/log/debug/device-<id>/` among every other user's. A fault you cannot
+attribute to a file is a fault you cannot diagnose, and the evidence is gone
+once the run ends:
+
+```bash
+LOGDIR="$PWD/outputs/<label>/ascend"; mkdir -p "$LOGDIR"   # driver fopens; it will not mkdir
+export ASCEND_PROCESS_LOG_PATH="$LOGDIR"
+```
+
+See the "Device logs" section of
+[`running-onboard.md`](../../../.claude/rules/running-onboard.md).
+
+## F1: is it the kernel's own addressing, or did the core jump somewhere else?
+
+These two look identical from the host and have nothing in common as bugs, so
+settle it before reading any kernel arithmetic:
+
+- **`PrintErrorInfoForDavinciTask`** — `fault kernel_name`, `hash`, and
+  `GetBinAndKernelNameExceptionArgs: binSize`. If `binSize` matches the
+  runtime's own `aicore_kernel.o` rather than your kernel, the report is naming
+  the **polling-dispatch executor**, and the faulting code is whatever it jumped
+  to — a dispatch-payload / `function_bin_addr` problem, not kernel arithmetic.
+- **`PrintCoreInfo`** — `pc current`. Whether that offset lands inside the
+  executor's binary size or far outside it tells you the same thing
+  independently.
+
+[#1036](https://github.com/hw-native-sys/simpler/issues/1036) has the worked
+example of making this distinction.
+
+## F2: rule the kernel's own addressing in or out statically
+
+Before instrumenting, check whether the kernel *can* compute an out-of-range UB
+address at all. Compile-time `TASSIGN` offsets and template-derived tile extents
+do not make that impossible — the constants themselves can overrun — but they
+make it **decidable on paper**, because runtime values that only shrink a tile
+(a per-rank chunk count, a shorter row) move no base and grow no extent.
+
+So compute it. Sum the highest byte each `TASSIGN` base plus its tile extent
+reaches and compare against the AIV UB size:
+
+- **Fits for every input the guards admit** → the address did not come from
+  here, and you are in F1's second case.
+- **Does not fit** → you have found the bug without touching the device.
+
+The allreduce collectives were cleared this way in
+[#1489](https://github.com/hw-native-sys/simpler/issues/1489): all five modes
+bind every tile to a constant base, `nranks` only divides the chunk count, and
+the whole footprint stays under 132 KiB of the 192 KiB UB at every rank count.
+
+That case is worth following to its end, because F2's verdict held. The fault
+was not in the kernels; it was almost certainly
+[#1477](https://github.com/hw-native-sys/simpler/pull/1477), a `CoreTracker`
+whose `uint64_t` state overran past 21 clusters while those cases ran at the
+device's full 24. Corrupted dispatch state, F1's second case — reached by
+believing F2 rather than re-reading the kernel arithmetic a second time.
+
+## F3: separate a real fault from a post-mortem register dump
+
+A core killed while spinning can produce a fault-looking line that describes the
+state it was reaped in rather than an instruction it executed. Count the
+detectors, per [`running-onboard.md`](../../../.claude/rules/running-onboard.md):
+if `FATAL: Task Allocator Deadlock` and `Timeout (N cycles):
+producer/consumers` are both **zero** and only `HandleTaskTimeout` fired, then
+nothing on the device proved a fault or a deadlock — treat the wait that never
+completed as the primary object of the investigation, not the addressing line.

--- a/docs/troubleshooting/device-error-codes/capacity.md
+++ b/docs/troubleshooting/device-error-codes/capacity.md
@@ -1,0 +1,33 @@
+# Chasing down a capacity code (1, 2, 4)
+
+← [Device Error Codes](../device-error-codes.md)
+
+SCOPE_DEADLOCK, HEAP_RING_DEADLOCK and DEP_POOL_OVERFLOW all say the same thing —
+"some resource ran out" — without saying *which* resource or *which* scope. Do not
+guess at the ring sizes. Turn on `scope_stats`, which records the high-water mark of
+all four resources (task-window slots, heap bytes, dep-pool entries, tensormap
+entries) per `PTO2_SCOPE`:
+
+```python
+cfg = CallConfig()
+cfg.enable_scope_stats = True
+cfg.output_prefix = "outputs/my_run"
+worker.run(callable, args, cfg)
+```
+
+It works on a **failing** run: the metadata line is marked `"fatal": true` and
+everything written before the fatal is kept. So point it straight at the workload
+that trips the code.
+
+| Bottleneck resource | Code | Fix |
+| ------------------- | ---- | --- |
+| task window | 1 | raise `ring_task_window` (`PTO2_RING_TASK_WINDOW`), or split the scope |
+| heap | 2 | raise `ring_heap` (`PTO2_RING_HEAP`), or shrink per-task args / intermediate tensors |
+| dep pool | 4 | raise `ring_dep_pool` (`PTO2_RING_DEP_POOL`), or cut the fanin count |
+
+The runtime's own `error hint:` line already names the knob for the code it
+latched; this table is for when you have `scope_stats` output and want to read the
+peak back to a knob.
+
+Report fields, the `Top Peaks` table and the plotting tool are documented in
+[`../../dfx/scope-stats.md`](../../dfx/scope-stats.md).

--- a/docs/troubleshooting/device-error-codes/stall.md
+++ b/docs/troubleshooting/device-error-codes/stall.md
@@ -1,0 +1,75 @@
+# Chasing down a stall (100, and code 8)
+
+← [Device Error Codes](../device-error-codes.md)
+
+## The timeout race decides what you see
+
+Three watchdogs compete, and whichever fires first determines whether you get a
+clean `-100` with a `sub_class`, or a masked `507018`:
+
+- the scheduler no-progress timeout (`PTO2_SCHEDULER_TIMEOUT_MS`),
+- the STARS op-execute timeout (`PTO2_OP_EXECUTE_TIMEOUT_US`, ~45 s, kills `aicpu-sd`),
+- the host stream-sync timeout (`PTO2_STREAM_SYNC_TIMEOUT_MS`).
+
+**A 45 s op-execute kill is not proof of a deadlock** — the kernel may simply be
+slow. To find out which, order the race deliberately. The STs do exactly this, and
+the technique transfers:
+
+- To make the **scheduler** win (get a `sub_class`), squeeze it below the others:
+  `SCHEDULER=2000ms < OP_EXECUTE=3s < STREAM_SYNC=4000ms` (`aicore_hang` case).
+- To let a **slow-but-alive** path finish, push the others out of the way:
+  `SCHEDULER=30000ms`, `OP_EXECUTE=30s`, `STREAM_SYNC=40000ms` — this is how the
+  `tensor_wait_timeout` case lets the 15 s tensor-data wait land code 8 instead of
+  being reaped first.
+
+**These three are read once, at `Worker.init()`.** Changing them between `run()`
+calls on the same Worker does nothing — you must rebuild the Worker (or use a
+separate process) per value. Defaults and the rationale are in
+[`../local-timeout-defaults.md`](../local-timeout-defaults.md).
+
+## S1: find the stuck kernel
+
+The `sub_class=` line gives you `stuck_task_id` and `stuck_core`. Map the task id
+back to your orchestration and look at that kernel for an infinite loop, a wait on
+a signal that never arrives, or simply too much work.
+
+When the task id is not enough, raise the log level to **V0** and the device log
+prints a task snapshot at the moment of the stall:
+
+```text
+[STALL thread=0 idle_iterations=...] TASK ring=1 task_id=42 state=RUNNING \
+    fanin_refcount=0/2 kernels=[aic:3 aiv0:7 aiv1:-1] \
+    running_on=[owner_thread=0 cores=[core=5(AIC) core=6(AIV0)]]
+```
+
+`kernels=[...]` are the kernel ids in the task's three sub-core slots and
+`cores=[...]` the physical cores running it — that maps "stuck task" to "which
+kernel, on which core".
+
+Setting the level:
+
+- **Worker directly**: `logging.getLogger("simpler").setLevel("V0")` **before**
+  `worker.init()` — the level is snapshotted at init and pushed to the device, so
+  setting it between `run()` calls has no effect.
+- **pytest / scene test**: `--log-level v0`.
+
+V0 is the most verbose level (V0 verbose … V9 terse, default V5). Device logs land
+in the shared `~/ascend/log/debug/device-<id>/` by default, where several processes
+interleave; redirect them per-run with `ASCEND_PROCESS_LOG_PATH` (the directory must
+exist) before reading. See the "Device logs" section of
+[`running-onboard.md`](../../../.claude/rules/running-onboard.md).
+
+## Code 8, specifically
+
+The tensor-data wait defaults to 15 s (`PTO2_TENSOR_DATA_TIMEOUT_MS`,
+frequency-scaled). It means either the producer never completed, or a consumer never
+released its fanout reference. Check for a hung producer first (that is S1 above),
+then verify the consumer really declares the dependency and exits. If the kernel is
+merely slow, raising the timeout will prove it.
+
+## If the fault line is an addressing error, not a stall
+
+A core that faults stops answering, so a watchdog reaps the op afterwards and the
+tail looks identical to a stall. If the device log carries a `VEC`/`CUBE`
+instruction error rather than only a timeout, you are in
+[Chasing down an AICore fault](aicore-fault.md), not here.

--- a/docs/troubleshooting/device-error-codes/untested.md
+++ b/docs/troubleshooting/device-error-codes/untested.md
@@ -1,0 +1,33 @@
+# Codes with no end-to-end test
+
+← [Device Error Codes](../device-error-codes.md)
+
+Three codes and three stall sub-classes have no ST — not from neglect, but because
+they cannot be provoked. Recording why, so the next person does not re-derive it
+(the argument lives in `tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py`):
+
+- **103 ASYNC_REGISTRATION_FAILED** is structurally pre-empted. The AICore side caps
+  at `MAX_COMPLETIONS_PER_TASK` (64) and latches **102** on the 65th condition, so
+  the scheduler-side "more than 64" check that would raise 103 never sees enough
+  messages. 103 is reachable only by corrupting the slab (UB) or a malformed message.
+- **10 SCOPE_TASKS_OVERFLOW** cannot be reached either. `scope_tasks_cap` is the sum
+  of the per-ring windows, but each ring physically holds only `window - 1` tasks, so
+  all rings together top out at `cap - PTO2_MAX_RING_DEPTH` — strictly below the cap.
+  The rings always fill first and latch 1 or 3. Shrinking the window shrinks both, so
+  the gap holds.
+- **11 TENSORMAP_OVERFLOW** needs the 65536-entry pool (`PTO2_TENSORMAP_POOL_SIZE`,
+  compile-time, not tunable via `runtime_env`) flooded *and* a stalled producer
+  holding entries.
+- **S4 / S5 / unknown**: not expressible through the public API. `set_dependencies()`
+  can only name already-submitted tasks, so a dependency cycle cannot be written; a
+  stuck producer is RUNNING (→ S1), never pure WAIT (S4). `total_tasks_` counts
+  *submitted* tasks, so once they retire `completed == total` and the S5 watchdog
+  never fires. They are kept as defensive labels: if a future bug produces the state,
+  it gets named instead of mislabelled.
+
+The name tables are held complete for these anyway
+(`tests/ut/cpp/common/test_error_code_names.cpp`) — an unreachable code is exactly
+the one that would otherwise print as a bare number on the day it finally fires.
+
+If you do hit 10, 11, 103, S4, S5 or unknown, it is a runtime bug. Keep the device
+log and report it.


### PR DESCRIPTION
## The length was the symptom; duplication was the disease

The guide had reached 351 lines and 7 H2 sections, past the soft target in `doc-consistency.md` §6. But splitting it for size alone would have preserved the actual problem: **four of its reference tables restated switch statements that live in code and are printed at the moment of failure.**

```text
[ERROR] error detail: orch_error_code=1 SCOPE_DEADLOCK - tasks submitted in one scope
                      reached the ring task-window cap; their fanout references are
                      only released at scope_end, so no slot can be reclaimed
[ERROR] error hint:   raise ring_task_window (PTO2_RING_TASK_WINDOW) or split the scope;
                      enable CallConfig.enable_scope_stats to see which scope peaked
```

Compare what the doc carried for the same code:

> Tasks in one scope hit the ring task-window cap; slots are not reclaimed until `scope_end`

Near-verbatim, and **less complete than the log**. `error_name()` / `error_desc()` / `error_hint()` supply name, mechanism and next action; `acl_error_*` does the same for CANN codes; `pto_runtime_status.h` owns the stall sub-class labels.

The rot vector matters more than the redundancy: adding a code **must** update the switch (the compiler enforces it) and **silently leaves the doc table wrong**. That is exactly the "documentation that lies" `doc-consistency.md` opens with.

## What was dropped, and what was deliberately kept

Dropped: the `Meaning` columns from the orchestration, scheduler and CANN tables.

Kept, because the log cannot supply it:

- **"Whose bug, usually"** — orchestration / config / kernel / runtime-internal. Which layer to go looking in.
- **The CANN names.** Unlike our own codes, a CANN number can reach you from output we do not wrap — a driver log, a raw ACL return — so a bare number still has to be decodable here. This asymmetry is why the two tables are treated differently.
- **The sub-class causes and the counter priority rule** (`running > ready > waiting > orch not done`).
- **The minimal-reproduction table** (code → ST fixture), which exists nowhere else.

Verified before dropping anything: `error_desc`/`error_hint` cover all 15 runtime codes and `acl_error_desc`/`acl_error_hint` cover all 10 CANN codes including the `-1` sentinel. Nothing the removed columns carried is actually lost.

## Reframed opening

The runtime prints this page's path in **every** `error hint:` line, so a reader arriving here already has the name, the description and the remedy on screen. The page now opens by saying so and teaching the two-line format, rather than inviting a lookup of what they are already holding.

## Split

One page per reader intent, per `doc-consistency.md` §6:

| | lines |
| --- | --- |
| `device-error-codes.md` (landing: read the lines, triage, index, repros) | 351 → **185** |
| `device-error-codes/capacity.md` | 33 |
| `device-error-codes/stall.md` | 75 |
| `device-error-codes/aicore-fault.md` | 83 |
| `device-error-codes/untested.md` | 33 |

**No inbound reference breaks.** All six — two log call sites (`error_log.h`, `acl_error_log.h`), two header comments, `conftest.py`, and `running-onboard.md` — target the landing page, which is still there.

## The drift guard

A new "Adding or changing a code" section names the four files to edit and states that **this page needs no update for a new code**. That is not a request for discipline; it is a property of what the page now contains. Everything a reader would otherwise look up here is printed at failure time, so there is nothing left to fall out of sync.

## Verification

- `pre-commit` clean (markdownlint-cli2, check-headers, check-english-only).
- Every relative link in all five files resolves — checked programmatically, including the `../../../.claude/rules/` hops from the subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)