### PR TITLE
Add: automatic AICPU architecture defaults (a2a3/a5)

### DIFF
--- a/docs/capability-survey.md
+++ b/docs/capability-survey.md
@@ -63,10 +63,10 @@ shared across a device's AICPU/AICore tiers but exclusive per `device_id`.
 | Comm window | Fabric V2 handles, VMM-IPC fallback | VMM shareable handles only |
 
 Two numbers surprise readers who skip the arch docs: the default
-`aicpu_thread_num` is **3** (`src/common/task_interface/call_config.h:112`) —
-neither the per-arch max nor the launch bound — and AICore geometry is not
-selectable at all, because `resolve_block_dim()` unconditionally takes the
-device maximum (`src/common/platform/onboard/host/device_runner_base.cpp:1201-1212`).
+`aicpu_thread_num` is **0 (auto)** — each architecture resolves it against its
+usable AICPU topology — and AICore geometry is not selectable at all, because
+`resolve_block_dim()` unconditionally takes the device maximum
+(`src/common/platform/onboard/host/device_runner_base.cpp:1201-1212`).
 Each arch doc's "three views of how many cores" section explains why the spec
 count, the silicon count, and the runtime-visible count differ
 (`src/a2a3/docs/hardware.md:42-51`).

--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -148,7 +148,7 @@ worker.init(device_id=0, bins=bins)   # bins = RuntimeBuilder(platform).get_bina
 
 config = CallConfig()
 # A run always takes the whole device; there is no per-call width knob.
-config.aicpu_thread_num = 3
+config.aicpu_thread_num = 0  # auto
 config.enable_pmu = 0
 worker.run(callable, args, config)
 worker.finalize()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -214,7 +214,7 @@ Runtime behavior is configured via `kernel_config.py` in each example:
 ```python
 RUNTIME_CONFIG = {
     "runtime": "host_build_graph",    # Runtime to use
-    "aicpu_thread_num": 3,            # Number of AICPU scheduler threads
+    "aicpu_thread_num": 0,            # Auto-select AICPU threads
 }
 ```
 

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -210,7 +210,7 @@ View does **not** own memory. Valid for the duration of a single
 
 ```cpp
 struct CallConfig {
-    int32_t aicpu_thread_num = 3;
+    int32_t aicpu_thread_num = 0;  // auto
     int32_t enable_l2_swimlane = 0;  // perf_level 0–4 (0=off, 4=full)
     int32_t enable_dump_args = 0;
     int32_t enable_pmu = 0;           // 0 = disabled; >0 selects PMU event type
@@ -683,7 +683,7 @@ w3 = Worker(level=3, child_mode=PROCESS)
 w3.add_worker(NEXT_LEVEL, chip_worker_0)
 w3.init()    # fork chip_0 here
 
-w3.run(my_orch, args, CallConfig(aicpu_thread_num=3))
+w3.run(my_orch, args, CallConfig(aicpu_thread_num=0))
 ```
 
 Step-by-step (one chip worker):

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -120,7 +120,7 @@ takes a device pointer; `DataType` carries the element types.
 
 | Field | Default | Meaning |
 | ----- | ------- | ------- |
-| `aicpu_thread_num` | `3` | AICPU threads for this run |
+| `aicpu_thread_num` | `0` | AICPU threads for this run; `0` selects the architecture default |
 | `enable_l2_swimlane` | `0` | `0` off; `1`–`4` select detail. L2 only |
 | `enable_dump_args` | `0` | Capture per-task arguments |
 | `enable_pmu` | `0` | `0` off; `>0` selects the event type |

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
@@ -52,41 +52,35 @@ class TestBenchmarkBgemm(SceneTestCase):
         {
             "name": "Case0",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"matmul_add_task_num": 500, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
         },
         {
             "name": "Case1",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"matmul_add_task_num": 64, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
         },
         {
             "name": "Case2",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"matmul_add_task_num": 256, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
         },
         {
             "name": "Case3",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"matmul_add_task_num": 64, "incore_data_size": 128, "incore_loop": 16, "grid_k": 2},
         },
         {
             "name": "Case4",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"matmul_add_task_num": 64, "incore_data_size": 128, "incore_loop": 4, "grid_k": 4},
         },
         {
             "name": "Bgemm64",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"matmul_add_task_num": 32, "incore_data_size": 64, "incore_loop": 1, "grid_k": 4},
         },
     ]

--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
@@ -61,7 +61,6 @@ class TestMergePipelineBarrier(SceneTestCase):
             # per-task via launch_spec.set_block_num in merge_orch.cpp).
             "name": "merge",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/README.md
@@ -21,9 +21,9 @@ graph is a consequence of the data, not of the code.
 
 ## Cases
 
-Seven, all `platforms=["a2a3"]` with `aicpu_thread_num: 4`: `Case1`–`Case3` at
-production scale (up to batch 256, 16 heads, 8192 context), `CaseSmall1` /
-`CaseSmall2`, and `CaseVarSeq2` / `CaseVarSeq4` for ragged sequence lengths.
+Seven, all for `platforms=["a2a3"]` with automatic AICPU thread selection:
+`Case1`–`Case3` at production scale (up to batch 256, 16 heads, 8192 context),
+`CaseSmall1` / `CaseSmall2`, and `CaseVarSeq2` / `CaseVarSeq4` for ragged sequence lengths.
 The four kernels are registered as sub-callables named `QK`, `SF`, `PV`, `UP`.
 
 ## Run

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
@@ -64,7 +64,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -79,7 +78,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -95,7 +93,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -111,7 +108,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "CaseSmall1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -126,7 +122,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "CaseSmall2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,
@@ -142,7 +137,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "CaseVarSeq2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 2,
@@ -159,7 +153,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "CaseVarSeq4",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 4,

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
@@ -68,7 +68,7 @@ class TestPagedAttentionManualScope(SceneTestCase):
             # MANUAL scope; the default per-ring task window (16384) can fill
             # before the oldest task retires and wedge the orchestrator
             # (FLOW_CONTROL_DEADLOCK / code 3). Double the window for headroom.
-            "config": {"aicpu_thread_num": 4, "runtime_env": {"ring_task_window": 32768}},
+            "config": {"runtime_env": {"ring_task_window": 32768}},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -83,7 +83,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -99,7 +98,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -115,7 +113,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "CaseSmall1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -130,7 +127,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "CaseSmall2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,
@@ -146,7 +142,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "CaseVarSeq2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 2,
@@ -163,7 +158,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "CaseVarSeq4",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 4,

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -72,7 +72,6 @@ class TestPagedAttentionRingbuffer(SceneTestCase):
             # ring_heap is bytes per ring. Non power-of-2 sizes are accepted,
             # but 4 MiB keeps the small-ring stress intent compact.
             "config": {
-                "aicpu_thread_num": 4,
                 "runtime_env": {
                     "ring_task_window": 64,
                     "ring_heap": 4 * 1024 * 1024,

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/README.md
@@ -44,8 +44,8 @@ directory to read for that API on its own, against unchanged kernels.
 
 ## Cases
 
-Three — `Case1`–`Case3`, all `platforms=["a2a3"]` with
-`aicpu_thread_num: 4`. The baseline's small and variable-sequence cases have no
+Three — `Case1`–`Case3`, all for `platforms=["a2a3"]` with automatic AICPU
+thread selection. The baseline's small and variable-sequence cases have no
 counterpart here.
 
 ## Run

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -64,7 +64,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -79,7 +78,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -95,7 +93,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -427,7 +427,6 @@ class TestQwen314BDecode(SceneTestCase):
             "name": "StressBatch16Seq3500",
             "platforms": ["a2a3"],
             # A run takes the whole device, matching the lib default.
-            "config": {"aicpu_thread_num": 4},
             "params": {"seed": 1234, "seq_len": 3500},
         },
     ]

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
@@ -49,7 +49,8 @@ landing a value in `check[0..8]`:
 
 ## Cases
 
-One, `default`, `platforms=["a2a3"]`, `aicpu_thread_num: 4`.
+One, `default`, for `platforms=["a2a3"]`. The default AICPU configuration uses
+auto selection.
 
 Note the comment on the `check` tensor in `generate_args`: it is **exactly 9
 slots**, matching `check[0..8]`. Output-tensor slots are not seeded from the

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
@@ -49,7 +49,6 @@ class TestScalarData(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py
@@ -51,7 +51,6 @@ class TestVectorExample(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py
@@ -64,7 +64,6 @@ class TestBgemm(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
@@ -70,7 +70,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -85,7 +84,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -101,7 +99,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -117,7 +114,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "SmallCase1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -132,7 +128,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "SmallCase2",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,
@@ -148,7 +143,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "SmallCaseVarSeq2",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 2,
@@ -165,7 +159,6 @@ class TestPagedAttention(SceneTestCase):
         {
             "name": "SmallCaseVarSeq4",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 4,

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
@@ -66,7 +66,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "SmallCase1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -81,7 +80,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "SmallCase2",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,
@@ -97,7 +95,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "SmallCaseVarSeq2",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 2,
@@ -114,7 +111,6 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "SmallCaseVarSeq4",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 4,

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -66,7 +66,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -81,7 +80,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -97,7 +95,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -113,7 +110,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "SmallCase1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -128,7 +124,6 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         {
             "name": "SmallCase2",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/test_vector_example.py
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/test_vector_example.py
@@ -51,7 +51,6 @@ class TestVectorExample(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -76,7 +76,7 @@ def _assert_bindings_match_source_tree() -> None:
     Nothing then rebuilds, and a changed struct layout — `CallConfig` losing a
     field, say — makes attributes read as 0 with no error at all. That surfaces
     much later as a plausible-looking runtime rejection
-    (``launch_aicpu_num (0) must be in range [1, 4]``) and reads as a product
+    (``launch_aicpu_num (1) must be 0 (auto) or in range [2, 4]``) and reads as a product
     bug, so it is worth one git call at import to stop.
 
     Only source-tree installs are checked: a wheel has no ``.git`` to compare
@@ -1322,7 +1322,7 @@ class ChipWorker:
             args: ChipStorageTaskArgs for this invocation.
             config: Optional CallConfig. If None, a default is created.
             **kwargs: Overrides applied to config (e.g.
-                ``aicpu_thread_num=4``). A run always takes the whole device;
+                ``aicpu_thread_num=2``). A run always takes the whole device;
                 orchestration reads the resulting width back through
                 ``rt_available_cluster_count()``.
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1182,7 +1182,8 @@ class SceneTestCase:
         from simpler.task_interface import CallConfig  # noqa: PLC0415
 
         config = CallConfig()
-        config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 3)
+        # 0 = auto: DeviceRunner uses the architecture default.
+        config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 0)
         # Per-task ring sizing (tensormap_and_ringbuffer only; 0 = unset),
         # nested under the "runtime_env" key. Takes precedence over the
         # PTO2_RING_* env vars / RUNTIME_ENV. Each value is either a scalar

--- a/src/a2a3/docs/hardware.md
+++ b/src/a2a3/docs/hardware.md
@@ -145,11 +145,11 @@ correctness, prefer ACL or CANN ini.
 
 | You are doing… | Use |
 | -------------- | --- |
-| Configuring runtime `aicpu_thread_num` (per-case config) | **user-accessible** (6 — never request more) |
+| Configuring runtime `aicpu_thread_num` (per-case config) | **0 = auto** → architecture default 4; explicit values must be in `[2, 4]`; the effective count is capped by the usable AICPU pool |
 | Setting kernel `block_dim` for AICore launch | **user-accessible** (24 — runtime rejects > 24) |
 | Reading the spec sheet / product datasheet | **spec / user-accessible** (24 AIC, 6 AICPU) |
 | Asking "what is in silicon" | **HAL physical** (25 AIC, 8 AICPU slots) — 1 PG-disabled + 1 OS-reserved on AICPU; 1 PG-disabled on AICore |
-| Debugging "I set `aicpu_thread_num=8`, got error" | gap is **cpu_id 0 (AICPU OS) + cpu_id 1 (PG)** — both unreachable from runtime; cap is 6 |
+| Debugging "I set `aicpu_thread_num=8`, got error" | active cap is **4** (`PLATFORM_MAX_AICPU_THREADS`); 6 is the launch pool (popcount OCCUPY). Gap to 8 AICPU slots = **cpu_id 0 (OS) + cpu_id 1 (PG)**, both unreachable from runtime |
 | Debugging "I set `block_dim=25`, got error" | runtime cap is **24**; the +1 slot is PG fab-disabled |
 | Building a chip-management dashboard | use HAL OCCUPY + OS_SCHED to expose the split; cite `tools/cann-examples/aicpu-device-query/` for the OS_SCHED query |
 

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -52,6 +52,14 @@ constexpr int PLATFORM_AIV_CORES_PER_BLOCKDIM = 2;
 constexpr int PLATFORM_MAX_AICPU_THREADS = 4;
 
 /**
+ * Default active AICPU thread count when aicpu_thread_num is left at 0 (auto):
+ * 1 orchestrator + 3 schedulers. DeviceRunner clamps it to the probed usable
+ * count (PG/OS cores are absent from the AICPU OCCUPY bitmap), runs with fewer
+ * schedulers if usable < default, and errors if fewer than 2 AICPU are usable.
+ */
+constexpr int PLATFORM_DEFAULT_AICPU_THREAD_NUM = 4;  // 1 orch + 3 sched
+
+/**
  * Maximum AICPU launch threads (physical)
  * Upper bound for the number of AICPU threads that can be launched by Host.
  * Can be larger than PLATFORM_MAX_AICPU_THREADS to allow threads to be dropped

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -241,7 +241,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // prepare_launch_shape() resolved block_dim before the graph was built, so
     // the geometry this run launches with is already on the runner.
     const int block_dim = block_dim_;
-    const int launch_aicpu_num = config.aicpu_thread_num;
+    int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade into
     // rtMalloc 507899 / halResMap rc=62 (init_aicore_register_addresses). A soft
@@ -358,13 +358,18 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
             LOG_ERROR("A2A3 AICPU topology probe failed; cannot configure affinity gate");
             return -1;
         }
-        if (!pto::a2a3::compute_allowed_cpus(user_cpus, runtime.get_aicpu_thread_num(), allowed)) {
+        int resolved_aicpu = resolve_aicpu_thread_num(
+            runtime.get_aicpu_thread_num(), static_cast<int>(user_cpus.size()), PLATFORM_DEFAULT_AICPU_THREAD_NUM
+        );
+        if (resolved_aicpu < 0) return -1;
+        if (!pto::a2a3::compute_allowed_cpus(user_cpus, resolved_aicpu, allowed)) {
             LOG_ERROR(
-                "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(),
-                runtime.get_aicpu_thread_num()
+                "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(), resolved_aicpu
             );
             return -1;
         }
+        runtime.set_aicpu_thread_num(resolved_aicpu);
+        launch_aicpu_num = resolved_aicpu;
         const size_t cap = runtime.aicpu_allowed_cpus_capacity();
         if (allowed.size() > cap) {
             LOG_ERROR("A2A3 compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -254,8 +254,13 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // prepare_launch_shape() resolved block_dim before the graph was built, so
     // the geometry this run launches with is already on the runner.
     const int block_dim = block_dim_;
-    const int launch_aicpu_num = config.aicpu_thread_num;
+    int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
+    // Sim has no hardware topology to probe, so auto uses the architecture
+    // default directly. Publish the effective count so AICPU init and DFX
+    // setup match the launch gate.
+    if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
+    runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
         LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
         return -1;

--- a/src/a5/docs/hardware.md
+++ b/src/a5/docs/hardware.md
@@ -139,12 +139,12 @@ report what user code can address.
 
 | You are doing… | Use |
 | -------------- | --- |
-| Configuring runtime `aicpu_thread_num` | **user-visible** (6) |
+| Configuring runtime `aicpu_thread_num` | **0 = auto** → architecture default 5; explicit values pass configuration validation in `[2, 7]`, while the observed onboard device-visible pool limits the effective maximum to 6 |
 | Setting kernel `block_dim` for AICore | **user-visible** (per CANN ini for your specific SKU) |
 | Counting cores in a multi-die a5 device | **per-device** HAL CORE_NUM (= 2 × per-die) |
 | Reasoning about hyperthreading on AICPU | **DSMI CPU_TOPO** (only it shows the hyperthread pair on cpu_id 1+2) |
 | Writing code expected to also work on a3 | **ACL or CANN ini only** — HAL semantics differ |
-| Debugging "I requested N AICPU, only 6 ran" | gap is **1 AICPU OS scheduler (cpu_id 0) + 2 SMT-pair (cpu_id 1, 2) withheld by AICPU OS**; cap is 6 |
+| Debugging "I requested N AICPU, only 6 ran" | active cap is **7** (`PLATFORM_MAX_AICPU_THREADS`); 6 are device-usable (gap = 1 OS cpu_id 0 + 2 SMT-pair withheld by AICPU OS). Host-side OCCUPY reports 8, so the default 5 stays <= 6 |
 
 For cross-generation portable code: **always go through ACL or CANN
 ini, never HAL**. HAL's CORE_NUM semantics shift between a3 and a5 in

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -52,6 +52,13 @@ constexpr int PLATFORM_AIV_CORES_PER_BLOCKDIM = 2;
 constexpr int PLATFORM_MAX_AICPU_THREADS = 7;
 
 /**
+ * Default active AICPU thread count when aicpu_thread_num is left at 0 (auto):
+ * 1 orchestrator + 4 schedulers. Onboard topology probing assigns those
+ * threads to device-visible CPUs; simulation uses the value directly.
+ */
+constexpr int PLATFORM_DEFAULT_AICPU_THREAD_NUM = 5;  // 1 orch + 4 sched
+
+/**
  * Compile-time upper bound on the number of AICPU threads CANN may
  * start per launch. The actual launch count is runtime-derived:
  * the host topology probe sets runtime.aicpu_launch_count =

--- a/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
+++ b/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
@@ -173,6 +173,10 @@ bool probe_aicpu_topology_uncached(uint32_t device_id, std::vector<AicpuLogicalC
         return derive_topology_from_occupy(soc_name, occupy, out_user_cpus);
     }
 
+    // Host-side OCCUPY includes the SMT pair reserved by the AICPU OS on a5,
+    // whereas device-side user kernels cannot run on either sibling. Identify
+    // shared physical cores from CPU_TOPO and exclude the whole pair so this
+    // host-side reconstruction matches the device-visible dispatch pool.
     for (uint32_t i = 0; i < topo.total_nums; ++i) {
         const DsmiSingleCpu &c = topo.cpus[i];
         // Skip any cpu_id not in the device-side OCCUPY pool. Guard the
@@ -180,6 +184,14 @@ bool probe_aicpu_topology_uncached(uint32_t device_id, std::vector<AicpuLogicalC
         // to expose more than 64 logical AICPU cpus, but a driver bug or
         // future SKU change shouldn't trip undefined behavior here.
         if (c.cpu_id >= 64 || ((occupy >> c.cpu_id) & 1ULL) == 0) continue;
+        bool has_smt_sibling = false;
+        for (uint32_t j = 0; j < topo.total_nums; ++j) {
+            if (i != j && topo.cpus[j].phy_cpu_id == c.phy_cpu_id) {
+                has_smt_sibling = true;
+                break;
+            }
+        }
+        if (has_smt_sibling) continue;
         AicpuLogicalCpu e{};
         e.cpu_id = static_cast<int32_t>(c.cpu_id);
         e.phy_cpu_id = static_cast<int32_t>(c.phy_cpu_id);

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -144,7 +144,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // prepare_launch_shape() resolved block_dim before the graph was built, so
     // the geometry this run launches with is already on the runner.
     const int block_dim = block_dim_;
-    const int launch_aicpu_num = config.aicpu_thread_num;
+    int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade
     // into halResMap rc=62 (init_aicore_register_addresses) or rtMalloc
@@ -163,6 +163,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         return -1;
     }
     if (validate_launch_aicpu_num(launch_aicpu_num) != 0) return -1;
+    if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
+    runtime.set_aicpu_thread_num(launch_aicpu_num);
 
     int rc = ensure_device_initialized();
     if (rc != 0) {
@@ -199,9 +201,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // filter-style gate (see src/common/platform/onboard/aicpu/
     // platform_aicpu_affinity.cpp::platform_aicpu_affinity_gate_filter).
     // Convention: indices 0..n_sched-1 = sched slots, last = orch slot.
-    // n_sched = launch_aicpu_num - 1 (one orch + the rest sched). When
-    // launch_aicpu_num == 1 (init-only path) we leave allowed_cpus empty —
-    // the gate is a no-op for a single thread.
+    // n_sched = launch_aicpu_num - 1 (one orch + the rest sched).
     {
         std::vector<pto::a5::AicpuLogicalCpu> user_cpus;
         std::vector<int32_t> allowed;
@@ -390,10 +390,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // launch_count = popcount(OCCUPY) from the topology probe — one thread
     // per user-schedulable cpu_id. The filter gate barriers exactly this
     // many threads (runtime.aicpu_launch_count is read on the device side
-    // by kernel.cpp). Fall back to the caller-requested active count when
-    // the probe was skipped (single-thread init / launch_aicpu_num == 1)
-    // — over-launching to the compile-time bound on that path would
-    // start 14 threads to do a 1-thread job and deadlock the device.
+    // by kernel.cpp). The fallback is defensive; normal runs always publish
+    // the topology-derived launch count above.
     int aicpu_launch_n = (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
     if (rc != 0) {

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -218,8 +218,13 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // prepare_launch_shape() resolved block_dim before the graph was built, so
     // the geometry this run launches with is already on the runner.
     const int block_dim = block_dim_;
-    const int launch_aicpu_num = config.aicpu_thread_num;
+    int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
+    // Sim has no hardware topology to probe, so auto uses the architecture
+    // default directly. Publish the effective count so AICPU init and DFX
+    // setup match the launch gate.
+    if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
+    runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
         LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
         return -1;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1210,11 +1210,29 @@ int DeviceRunnerBase::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args
 // =============================================================================
 
 int DeviceRunnerBase::validate_launch_aicpu_num(int launch_aicpu_num) {
-    if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
+    if (launch_aicpu_num == 1 || launch_aicpu_num < 0 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "launch_aicpu_num (%d) must be 0 (auto) or in range [2, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS
+        );
         return -1;
     }
     return 0;
+}
+
+int DeviceRunnerBase::resolve_aicpu_thread_num(int requested, int usable, int arch_default) {
+    if (usable < 2) {
+        LOG_ERROR("AICPU usable count %d < 2 (need >=1 orchestrator + >=1 scheduler)", usable);
+        return -1;
+    }
+    int desired = (requested > 0) ? requested : arch_default;
+    int total = std::min(desired, usable);
+    if (total < desired) {
+        LOG_WARN(
+            "AICPU: requested %d active threads, only %d usable on this die — running 1 orch + %d sched", desired,
+            usable, total - 1
+        );
+    }
+    return total;
 }
 
 void DeviceRunnerBase::ensure_device_wall_buffer() {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -699,6 +699,16 @@ protected:
     int validate_launch_aicpu_num(int launch_aicpu_num);
 
     /**
+     * Resolve the active AICPU thread count for partial-good tolerance.
+     * requested == 0 means auto (use arch_default = 1 orch + N sched); the
+     * result is clamped to `usable` (the probed AICPU count — PG/OS cores are
+     * absent from OCCUPY) so a degraded die runs with fewer schedulers, and
+     * returns <0 if usable < 2 (need >=1 orch + >=1 sched). Returns the active
+     * total otherwise.
+     */
+    int resolve_aicpu_thread_num(int requested, int usable, int arch_default);
+
+    /**
      * Lazy-allocate the 8-byte device-resident buffer that AICPU writes
      * the run wall (ns) into and that `read_device_wall_ns()` pulls
      * back after stream sync. Idempotent: a no-op once

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -319,9 +319,11 @@ int SimDeviceRunnerBase::ensure_device_initialized() {
 }
 
 int SimDeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig &config) {
-    if (config.aicpu_thread_num < 1 || config.aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
+    if (config.aicpu_thread_num == 1 || config.aicpu_thread_num < 0 ||
+        config.aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
-            "launch_aicpu_num (%d) must be in range [1, %d]", config.aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS
+            "launch_aicpu_num (%d) must be 0 (auto) or in range [2, %d]", config.aicpu_thread_num,
+            PLATFORM_MAX_AICPU_THREADS
         );
         return -1;
     }

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -109,7 +109,9 @@ struct RuntimeEnv {
 };
 
 struct CallConfig {
-    int32_t aicpu_thread_num = 3;
+    // 0 = auto: use the architecture default (a2a3: 4; a5: 5).
+    // Explicit normal-run values must be at least 2.
+    int32_t aicpu_thread_num = 0;
     int32_t enable_l2_swimlane = 0;
     int32_t enable_dump_args = 0;
     int32_t enable_pmu = 0;  // 0 = disabled; >0 = enabled, value selects event type

--- a/tests/st/a2a3/host_build_graph/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a2a3/host_build_graph/available_aicore_counts/test_available_aicore_counts.py
@@ -86,7 +86,6 @@ class TestAvailableAicoreCounts(SceneTestCase):
         {
             "name": "Default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/bgemm/test_bgemm.py
+++ b/tests/st/a2a3/host_build_graph/bgemm/test_bgemm.py
@@ -61,7 +61,6 @@ class TestBgemmHostBuildGraph(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py
@@ -124,7 +124,6 @@ class TestDepGenHostBuildGraph(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/dump_args/test_dump_args_example.py
+++ b/tests/st/a2a3/host_build_graph/dump_args/test_dump_args_example.py
@@ -50,7 +50,6 @@ class TestDumpArgsExample(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/matmul/test_matmul.py
+++ b/tests/st/a2a3/host_build_graph/matmul/test_matmul.py
@@ -58,7 +58,6 @@ class TestMatmulHostBuildGraph(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py
@@ -76,7 +76,6 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
             # a large PTO2_RING_TASK_WINDOW / PTO2_RING_HEAP if needed.
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 256,
@@ -92,7 +91,6 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -108,7 +106,6 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
         {
             "name": "small1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -123,7 +120,6 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
         {
             "name": "small2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,

--- a/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -84,14 +84,12 @@ class TestPreparedCallableHbg(SceneTestCase):
         ],
     }
 
-    _COMMON_CONFIG = {"aicpu_thread_num": 4}
     _PLATFORMS = ["a2a3sim", "a2a3"]
 
     CASES = [
         {
             "name": "prepare_run_twice",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"a": 2.0, "b": 3.0},
         },
     ]
@@ -171,7 +169,7 @@ class TestPreparedCallableHbg(SceneTestCase):
     def _setup_dlopen_count_test(self, st_worker, st_platform):
         case = self.CASES[0]
         callable_obj = self.build_callable(st_platform)
-        config = self._build_config(case["config"])
+        config = self._build_config(case.get("config", {}))
         return callable_obj, config, case
 
     def _run_one(self, worker, slot, config, case):

--- a/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
+++ b/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
@@ -106,7 +106,7 @@ class TestRunStreamReuseHbg(SceneTestCase):
         {
             "name": "repeated_runs",
             "platforms": ["a2a3", "a2a3sim"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "config": {"block_dim": 3},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py
+++ b/tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py
@@ -58,7 +58,6 @@ class TestVectorExampleHostBuildGraph(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py
@@ -54,20 +54,17 @@ class TestAlternatingMatmulAdd(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"batch": 1, "M": 1, "N": 1, "matmul_batch": 1, "add_batch": 1},
         },
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"batch": 500, "M": 4, "N": 4, "matmul_batch": 4, "add_batch": 4},
             "manual": True,
         },
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"batch": 512, "M": 2, "N": 5, "matmul_batch": 4, "add_batch": 5},
             "manual": True,
         },

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -79,7 +79,6 @@ class TestAvailableAicoreCounts(SceneTestCase):
         {
             "name": "Default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
@@ -64,7 +64,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -79,7 +78,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -95,7 +93,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -111,7 +108,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "CaseSmall1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -126,7 +122,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "CaseSmall2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,
@@ -142,7 +137,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "CaseSmall3",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 1,
@@ -158,7 +152,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "CaseVarSeq2",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 2,
@@ -175,7 +168,6 @@ class TestBatchPagedAttention(SceneTestCase):
         {
             "name": "CaseVarSeq4",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 4,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -83,7 +83,6 @@ class TestArgsDump(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -88,7 +88,6 @@ class TestDepGen(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -76,7 +76,6 @@ class TestL2Swimlane(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
         {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
@@ -88,7 +88,6 @@ class TestL2SwimlaneMixed(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
@@ -69,7 +69,6 @@ class TestPmu(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -88,7 +88,6 @@ class TestScopeStats(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
         {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -155,7 +155,6 @@ def test_prepare_new_identity_after_start_then_run(st_platform, st_device_ids):
     worker.init()
     try:
         config = CallConfig()
-        config.aicpu_thread_num = 4
 
         # 1. Run pre_handle once against the snapshot-prepared chip callable.
         #    init() already forked the chip children and prepared the startup
@@ -227,7 +226,6 @@ def test_prepare_new_identity_after_start_parallel_broadcast(st_platform, st_dev
     worker.init()
     try:
         config = CallConfig()
-        config.aicpu_thread_num = 4
 
         def orch_pre(o, _a, _c):
             o.submit_next_level(pre_handle, chip_args_pre, config, worker=0)
@@ -283,7 +281,6 @@ def test_prepare_capacity_overflow_post_start(st_platform, st_device_ids):
     worker.init()
     try:
         config = CallConfig()
-        config.aicpu_thread_num = 4
 
         def orch_pre(o, _a, _c):
             o.submit_next_level(chip_handle, chip_args_pre, config, worker=0)
@@ -332,7 +329,6 @@ def test_duplicate_prepare_same_hashid_survives_one_unregister(st_platform, st_d
     worker.init()
     try:
         config = CallConfig()
-        config.aicpu_thread_num = 4
 
         # 1. Trigger fork via pre_handle to put the chip child into the main loop.
         def orch_one(o, _args, _cfg):
@@ -402,7 +398,6 @@ def test_unregister_last_handle_allows_reprepare_same_hashid(st_platform, st_dev
     worker.init()
     try:
         config = CallConfig()
-        config.aicpu_thread_num = 4
 
         def orch_one(o, _args, _cfg):
             o.submit_next_level(pre_handle, chip_args_one, config, worker=0)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -49,13 +49,11 @@ class TestFaninLookupPerf(SceneTestCase):
         {
             "name": "LookupOnlyProducers64Consumers64",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 0},
         },
         {
             "name": "SwimlaneProducers64Consumers64",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 1},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
@@ -98,14 +98,12 @@ class TestMixedExample(SceneTestCase):
         {
             "name": "case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"num_iters": 4},
         },
         {
             "name": "case2",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"num_iters": 1},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
@@ -69,7 +69,6 @@ class TestMultiRoundPagedAttention(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -85,7 +84,6 @@ class TestMultiRoundPagedAttention(SceneTestCase):
             "name": "Case2",
             "platforms": ["a2a3sim", "a2a3"],
             "manual": True,
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 16,
@@ -101,7 +99,6 @@ class TestMultiRoundPagedAttention(SceneTestCase):
             "name": "CaseVarSeq2",
             "platforms": ["a2a3sim", "a2a3"],
             "manual": True,
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 2,
                 "num_heads": 16,
@@ -118,7 +115,6 @@ class TestMultiRoundPagedAttention(SceneTestCase):
             "name": "CaseVarSeq4",
             "platforms": ["a2a3sim", "a2a3"],
             "manual": True,
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 4,
                 "num_heads": 16,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
@@ -72,7 +72,6 @@ class TestOrchSoCache(SceneTestCase):
     # Three cases sharing one callable. The framework iterates them on a
     # single Worker; cases after the first land on cache-hit. Sizes vary so
     # a stale handle would manifest as wrong output, not "happens to pass".
-    _COMMON_CONFIG = {"aicpu_thread_num": 4}
     _PLATFORMS = ["a2a3sim", "a2a3"]
 
     # All cases use the same size (128*128) because the AIV kernels have
@@ -84,19 +83,16 @@ class TestOrchSoCache(SceneTestCase):
         {
             "name": "first_miss",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"size": 128 * 128, "a": 2.0, "b": 3.0},
         },
         {
             "name": "second_hit",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"size": 128 * 128, "a": 1.0, "b": 4.0},
         },
         {
             "name": "third_hit",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"size": 128 * 128, "a": 0.5, "b": 0.5},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -64,7 +64,6 @@ class TestPagedAttentionUnroll(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -79,7 +78,6 @@ class TestPagedAttentionUnroll(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -95,7 +93,6 @@ class TestPagedAttentionUnroll(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
@@ -67,7 +67,6 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -82,7 +81,6 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 64,
                 "num_heads": 64,
@@ -98,7 +96,6 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 64,
                 "num_heads": 64,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -71,14 +71,12 @@ class TestPreparedCallable(SceneTestCase):
         ],
     }
 
-    _COMMON_CONFIG = {"aicpu_thread_num": 4}
     _PLATFORMS = ["a2a3sim", "a2a3"]
 
     CASES = [
         {
             "name": "prepare_run_twice",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"a": 2.0, "b": 3.0},
         },
     ]
@@ -163,7 +161,7 @@ class TestPreparedCallable(SceneTestCase):
         """Common fixture: build callable + config, return (callable, config, case)."""
         case = self.CASES[0]
         callable_obj = self.build_callable(st_platform)
-        config = self._build_config(case["config"])
+        config = self._build_config(case.get("config", {}))
         return callable_obj, config, case
 
     def _run_one(self, worker, slot, config, case):
@@ -279,7 +277,7 @@ class TestPreparedCallable(SceneTestCase):
 
         MissingEntryCallable.CALLABLE["orchestration"]["function_name"] = "missing_aicpu_orchestration_entry"
         bad_callable = MissingEntryCallable().build_callable(st_platform)
-        config = self._build_config(self.CASES[0]["config"])
+        config = self._build_config(self.CASES[0].get("config", {}))
         case = self.CASES[0]
         baseline = st_worker.aicpu_dlopen_count
         chip_worker = self._chip_worker(st_worker)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -68,7 +68,6 @@ class TestSpmdBasic(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
@@ -67,7 +67,6 @@ class TestSpmdBatchDispatchOob(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
@@ -50,7 +50,6 @@ class TestSpmdMultiblockAiv(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
@@ -68,7 +68,6 @@ class TestSpmdMultiblockMix(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -57,7 +57,6 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -72,7 +71,6 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -94,7 +92,6 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
             "name": "SmallCase1",
             "platforms": ["a2a3"],
             "manual": True,
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 24,
                 "num_heads": 16,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
@@ -174,7 +174,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             # producer-side DdrBarrierBeforeFfts cross-core DDR fence, validated
             # over 19 st-onboard-a2a3 rounds.
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 32,
@@ -190,7 +189,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b4_h32_kv8_s512_bs128_fp16",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 4,
                 "num_heads": 32,
@@ -206,7 +204,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b1_h32_kv8_s16384_bs128_fp16",
             "manual": True,
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 32,
@@ -222,7 +219,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b1_h32_kv8_s4096_bs128_fp16",
             "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 32,
@@ -238,7 +234,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b1_h32_kv8_s6144_bs128_fp16",
             "manual": True,
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 32,
@@ -254,7 +249,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b1_h32_kv8_s8192_bs128_fp16",
             # enabled in CI to guard the long-sequence fix onboard.
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 1,
                 "num_heads": 32,
@@ -270,7 +264,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b2_h32_kv8_s4096_bs128_fp16",
             "manual": True,
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 2,
                 "num_heads": 32,
@@ -286,7 +279,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
             "name": "b2_h32_kv8_s8192_bs128_fp16",
             "manual": True,
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 2,
                 "num_heads": 32,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
@@ -85,7 +85,6 @@ class TestSpmdStarvation(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
@@ -70,7 +70,6 @@ class TestSpmdSyncStart(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
@@ -54,7 +54,6 @@ class TestSpmdSyncStartAiv(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
@@ -78,7 +78,6 @@ class TestSpmdSyncStartEarlyDispatch(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
@@ -68,7 +68,6 @@ class TestSpmdSyncStartEdge(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
@@ -100,7 +100,6 @@ class TestSpmdSyncStartStress(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
@@ -85,7 +85,7 @@ class TestL3Dependency(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"device_count": 1, "num_sub_workers": 1, "aicpu_thread_num": 4},
+            "config": {"device_count": 1, "num_sub_workers": 1},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
@@ -95,7 +95,7 @@ class TestL3Group(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"device_count": 2, "num_sub_workers": 1, "aicpu_thread_num": 4},
+            "config": {"device_count": 2, "num_sub_workers": 1},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -79,7 +79,6 @@ class TestAvailableAicoreCounts(SceneTestCase):
         {
             "name": "Default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -83,7 +83,6 @@ class TestArgsDump(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -88,7 +88,6 @@ class TestDepGen(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -76,7 +76,6 @@ class TestL2Swimlane(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
         {

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
@@ -88,7 +88,6 @@ class TestL2SwimlaneMixed(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
@@ -69,7 +69,6 @@ class TestPmu(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -88,7 +88,6 @@ class TestScopeStats(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
         {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
@@ -95,14 +95,12 @@ class TestMixedExample(SceneTestCase):
         {
             "name": "case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"num_iters": 4},
         },
         {
             "name": "case2",
             "manual": True,
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"num_iters": 1},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
@@ -72,7 +72,6 @@ class TestOrchSoCache(SceneTestCase):
     # Three cases sharing one callable. The framework iterates them on a
     # single Worker; cases after the first land on cache-hit. Sizes vary so
     # a stale handle would manifest as wrong output, not "happens to pass".
-    _COMMON_CONFIG = {"aicpu_thread_num": 4}
     _PLATFORMS = ["a5sim", "a5"]
 
     # All cases use the same size (128*128) because the AIV kernels have
@@ -84,19 +83,16 @@ class TestOrchSoCache(SceneTestCase):
         {
             "name": "first_miss",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"size": 128 * 128, "a": 2.0, "b": 3.0},
         },
         {
             "name": "second_hit",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"size": 128 * 128, "a": 1.0, "b": 4.0},
         },
         {
             "name": "third_hit",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"size": 128 * 128, "a": 0.5, "b": 0.5},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -64,7 +64,6 @@ class TestPagedAttentionUnroll(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -79,7 +78,6 @@ class TestPagedAttentionUnroll(SceneTestCase):
         {
             "name": "Case2",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,
@@ -95,7 +93,6 @@ class TestPagedAttentionUnroll(SceneTestCase):
         {
             "name": "Case3",
             "platforms": ["a5"],
-            "config": {"aicpu_thread_num": 4},
             "manual": True,
             "params": {
                 "batch": 64,

--- a/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -72,14 +72,12 @@ class TestPreparedCallable(SceneTestCase):
         ],
     }
 
-    _COMMON_CONFIG = {"aicpu_thread_num": 4}
     _PLATFORMS = ["a5sim", "a5"]
 
     CASES = [
         {
             "name": "prepare_run_twice",
             "platforms": _PLATFORMS,
-            "config": _COMMON_CONFIG,
             "params": {"a": 2.0, "b": 3.0},
         },
     ]
@@ -164,7 +162,7 @@ class TestPreparedCallable(SceneTestCase):
         """Common fixture: build callable + config, return (callable, config, case)."""
         case = self.CASES[0]
         callable_obj = self.build_callable(st_platform)
-        config = self._build_config(case["config"])
+        config = self._build_config(case.get("config", {}))
         return callable_obj, config, case
 
     def _run_one(self, worker, slot, config, case):
@@ -248,7 +246,7 @@ class TestPreparedCallable(SceneTestCase):
 
         MissingEntryCallable.CALLABLE["orchestration"]["function_name"] = "missing_aicpu_orchestration_entry"
         bad_callable = MissingEntryCallable().build_callable(st_platform)
-        config = self._build_config(self.CASES[0]["config"])
+        config = self._build_config(self.CASES[0].get("config", {}))
         case = self.CASES[0]
         baseline = st_worker.aicpu_dlopen_count
         chip_worker = self._chip_worker(st_worker)

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/test_simt_basic.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/test_simt_basic.py
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """SIMT basic element-scatter: minimal AIV scatter kernel that exercises the SIMT launch path.
 
-Config: aicpu_thread_num=4, sequential identity indices.
+Config: default aicpu_thread_num (auto), sequential identity indices.
 Identity indices keep the golden trivially src-equals-out so a failure
 here points at the SIMT launch path itself (TLV injection, localMemorySize
 budget, sync) rather than at the scatter index semantics.
@@ -52,7 +52,6 @@ class TestSimtBasic(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5", "a5sim"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -68,7 +68,6 @@ class TestSpmdBasic(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
@@ -43,7 +43,6 @@ class TestSpmdMultiblockAiv(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
@@ -64,7 +64,6 @@ class TestSpmdMultiblockMix(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
@@ -85,7 +85,6 @@ class TestSpmdStarvation(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
@@ -70,7 +70,6 @@ class TestSpmdSyncStart(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
@@ -52,7 +52,6 @@ class TestSpmdSyncStartAiv(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
@@ -78,13 +78,11 @@ class TestSpmdSyncStartEarlyDispatch(SceneTestCase):
         {
             "name": "EarlyOn",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"early_on": 1},
         },
         {
             "name": "EarlyOff",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"early_on": 0},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
@@ -68,7 +68,6 @@ class TestSpmdSyncStartEdge(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
@@ -81,13 +81,11 @@ class TestSpmdSyncStartMixSpill(SceneTestCase):
         {
             "name": "EarlyOn",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"early_on": 1},
         },
         {
             "name": "EarlyOff",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"early_on": 0},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
@@ -100,7 +100,6 @@ class TestSpmdSyncStartStress(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         }
     ]

--- a/tests/st/task_timing/task_timing_slots/test_task_timing_e2e.py
+++ b/tests/st/task_timing/task_timing_slots/test_task_timing_e2e.py
@@ -314,7 +314,6 @@ def test_mix_task_aggregates_across_subtasks(st_platform, st_device_ids, capfd):
         platform=st_platform,
         runtime="tensormap_and_ringbuffer",
         device_id=int(st_device_ids[0]),
-        aicpu_thread_num=4,
     )
     chip_handle = worker.register(_build_mix_chip_callable(st_platform))
     worker.init()

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -19,9 +19,8 @@ from _task_interface import CallConfig, RuntimeEnv, _ChipWorker  # pyright: igno
 class TestCallConfig:
     def test_defaults(self):
         config = CallConfig()
-        # 0 is the "auto" sentinel — DeviceRunner resolves it at run() time
-        # to the max the AICore stream allows.
-        assert config.aicpu_thread_num == 3
+        # 0 is the "auto" sentinel for the per-architecture runtime default.
+        assert config.aicpu_thread_num == 0
         assert config.enable_l2_swimlane == 0
         assert config.enable_dump_args == 0
         assert config.enable_pmu == 0
@@ -296,7 +295,7 @@ class TestChipWorkerPython:
 
         worker = ChipWorker()
         with pytest.raises(TypeError, match="CallableHandle returned by ChipWorker.register_callable"):
-            worker.run(0, ChipStorageTaskArgs(), CallConfig())
+            worker.run(0, ChipStorageTaskArgs(), CallConfig())  # pyright: ignore[reportArgumentType]
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`aicpu_thread_num` no longer needs to be specified by default. A value of `0`
is the automatic sentinel, while explicit per-run values remain supported.

- a2a3 resolves auto to 4 active AICPU threads.
- a5 resolves auto to 5 active AICPU threads.
- Onboard runners keep affinity, launch, Runtime, and DFX counts consistent
  with the selected architecture default or explicit override, and require at
  least one orchestration thread plus one scheduler thread.
- Simulation does not probe hardware topology; it resolves auto directly to
  the architecture default.
- a5 host topology reconstruction excludes the SMT physical core reserved by
  the AICPU OS so its launch pool matches device-visible availability.
- Scene tests and examples no longer need fixed `aicpu_thread_num` entries;
  callers can still provide an explicit value in `[2, PLATFORM_MAX]`.

## Validation

- `python -m pytest tests/ut/py/test_chip_worker.py -q` — 26 passed
- C++ no-hardware unit tests — 74 passed
- a2a3sim vector example — passed
- a5sim vector example — passed
- `pre-commit run --hook-stage commit` — passed
