### PR TITLE
Add: skip everything but pre-commit when a PR only touches markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
   # build artifacts cannot mask a regression in the next mode. Slow but reliable.
   # See docs/python-packaging.md and tools/verify_packaging.sh.
   packaging-matrix:
-    needs: pre-commit
+    needs: [detect-changes, pre-commit]
+    if: needs.detect-changes.outputs.docs_only != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -105,7 +106,8 @@ jobs:
 
   # ---------- Unit tests (no hardware, Python + C++) ----------
   ut:
-    needs: pre-commit
+    needs: [detect-changes, pre-commit]
+    if: needs.detect-changes.outputs.docs_only != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -470,7 +472,8 @@ jobs:
 
   # ---------- Unit tests (a2a3 hardware, Python + C++) ----------
   ut-a2a3:
-    needs: pre-commit
+    needs: [detect-changes, pre-commit]
+    if: needs.detect-changes.outputs.docs_only != 'true'
     runs-on: [self-hosted, a2a3]
     timeout-minutes: 30
     env:
@@ -729,6 +732,7 @@ jobs:
     outputs:
       a2a3_changed: ${{ steps.check.outputs.a2a3_changed }}
       a5_changed: ${{ steps.check.outputs.a5_changed }}
+      docs_only: ${{ steps.check.outputs.docs_only }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -740,6 +744,17 @@ jobs:
           FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
 
           NON_CODE='^(docs/|\.docs/|\.claude/|\.gitignore$|\.pre-commit-config\.yaml$)|\.md$'
+
+          # Markdown-only: nothing here can change what the code does, and
+          # markdownlint (in pre-commit) is the only check that inspects it. An
+          # empty FILES leaves this false, so an unexpected diff runs everything.
+          NON_MD=$(echo "$FILES" | grep -v '\.md$' || true)
+          if [ -n "$FILES" ] && [ -z "$NON_MD" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Only .md changed; pre-commit is the whole gate"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
           # a2a3: skip only when ALL changed files are a5-only or non-code
           A5_ONLY='^(src/a5/|examples/a5/|tests/(st|ut/cpp)/a5/)'
@@ -769,7 +784,8 @@ jobs:
 
   # ---------- Unit tests (a5 hardware, Python + C++) ----------
   ut-a5:
-    needs: pre-commit
+    needs: [detect-changes, pre-commit]
+    if: needs.detect-changes.outputs.docs_only != 'true'
     runs-on: [self-hosted, a5]
     timeout-minutes: 30
     env:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,7 +10,8 @@ Design principles:
 2. **Runner matches hardware tier** — no-hardware tests run on `ubuntu-latest`; platform-specific tests run on self-hosted runners with the matching label (`a2a3`, `a5`).
 3. **`--platform` is the only filter** — pytest uses `--platform` + the `requires_hardware` marker; ctest uses label `-LE` exclusion. No `-m st`, no `-m "not requires_hardware"`.
 4. **sim = no hardware** — `a2a3sim`/`a5sim` jobs run on github-hosted runners alongside unit tests.
-5. **Skip irrelevant platforms for scene tests** — `detect-changes` gates `st-sim-*` and `st-onboard-*` so pure-a5 PRs skip a2a3 scene-test runs and vice versa. **UT jobs (`ut`, `ut-a2a3`, `ut-a5`) are unconditional** — unit tests cover shared contracts and the cost of a falsely-skipped regression outweighs the savings.
+5. **Skip irrelevant platforms for scene tests** — `detect-changes` gates `st-sim-*` and `st-onboard-*` so pure-a5 PRs skip a2a3 scene-test runs and vice versa. **UT jobs (`ut`, `ut-a2a3`, `ut-a5`) are not gated by platform** — unit tests cover shared contracts and the cost of a falsely-skipped regression outweighs the savings.
+6. **Markdown-only PRs run pre-commit and nothing else** — `detect-changes` sets `docs_only` when *every* changed file ends in `.md`. That is the one case where skipping the UT jobs carries no risk: there is no code delta to regress, and markdownlint inside pre-commit is the only check that reads the files at all.
 
 ## Full Job Matrix
 
@@ -26,14 +27,14 @@ The complete test-type × hardware-tier matrix. Empty cells have no tests yet; o
 ```text
 PullRequest
   ├── pre-commit             (ubuntu-latest)
-  ├── packaging-matrix       (ubuntu + macOS)
-  ├── ut                     (ubuntu + macOS)        — Python + C++ UT, no hardware [always]
-  ├── detect-changes         (ubuntu-latest)         — outputs a{2a3,5}_changed flags
+  ├── packaging-matrix       (ubuntu + macOS)        — [skipped iff docs_only]
+  ├── ut                     (ubuntu + macOS)        — Python + C++ UT, no hardware [skipped iff docs_only]
+  ├── detect-changes         (ubuntu-latest)         — outputs a{2a3,5}_changed + docs_only
   ├── st-sim-a2a3            (ubuntu + macOS)        — gated by a2a3_changed
   ├── st-sim-a5              (ubuntu + macOS)        — gated by a5_changed
-  ├── ut-a2a3                (a2a3 self-hosted)      — Python + C++ UT, a2a3 hardware [always]
+  ├── ut-a2a3                (a2a3 self-hosted)      — Python + C++ UT, a2a3 hardware [skipped iff docs_only]
   ├── st-onboard-a2a3        (a2a3 self-hosted)      — gated by a2a3_changed
-  ├── ut-a5                  (a5 self-hosted)        — Python + C++ UT, a5 hardware [always]
+  ├── ut-a5                  (a5 self-hosted)        — Python + C++ UT, a5 hardware [skipped iff docs_only]
   └── st-onboard-a5          (a5 self-hosted)        — gated by a5_changed
 ```
 
@@ -127,9 +128,10 @@ not need `--max-parallel` manually.
 ### Scheduling constraints
 
 - Sim scene tests and no-hardware unit tests run on github-hosted runners (no hardware).
-- `detect-changes` computes two flags (`a2a3_changed`, `a5_changed`) from the PR diff. Each flag is `false` only when *every* changed file is in the opposite platform's tree (`src/{arch}/`, `examples/{arch}/`, `tests/{st,ut/cpp}/{arch}/`) or in the `NON_CODE` set (`docs/`, `.docs/`, `.claude/`, `.gitignore`, `.pre-commit-config.yaml`, and any `*.md` file anywhere). Anything else — shared C++ (`src/common/`), Python (`python/`, `simpler_setup/`), build files (`CMakeLists.txt`, `pyproject.toml`), shared test infra (`tests/ut/py/`, `tests/lint/`), tooling (`tools/`), or workflow files (`.github/`) — flips both flags to `true`.
+- `detect-changes` computes three flags (`a2a3_changed`, `a5_changed`, `docs_only`) from the PR diff. Each flag is `false` only when *every* changed file is in the opposite platform's tree (`src/{arch}/`, `examples/{arch}/`, `tests/{st,ut/cpp}/{arch}/`) or in the `NON_CODE` set (`docs/`, `.docs/`, `.claude/`, `.gitignore`, `.pre-commit-config.yaml`, and any `*.md` file anywhere). Anything else — shared C++ (`src/common/`), Python (`python/`, `simpler_setup/`), build files (`CMakeLists.txt`, `pyproject.toml`), shared test infra (`tests/ut/py/`, `tests/lint/`), tooling (`tools/`), or workflow files (`.github/`) — flips both flags to `true`.
 - **Gated jobs (scene tests only):** `st-sim-{a2a3,a5}`, `st-onboard-{a2a3,a5}` run iff their platform's flag is `true`.
-- **Unconditional jobs (all UT):** `ut`, `ut-a2a3`, `ut-a5` always run regardless of the flags — unit tests exercise shared contracts (nanobind bindings, RuntimeBuilder, ring buffers, etc.) and the risk of silently skipping a regression outweighs the CI minutes saved. The `tests/ut/cpp/{arch}/` entry in the gating regex only *attributes* an arch-specific C++ UT change to that platform (so it does not spuriously flip the other arch's scene-test flag); it does not gate the UT jobs themselves. A consequence: self-hosted runners (`a2a3`, `a5`) are always busy for at least the UT job, even on doc-only PRs that skip all scene tests.
+- **Platform-independent jobs (all UT + packaging):** `ut`, `ut-a2a3`, `ut-a5`, `packaging-matrix` ignore the platform flags — unit tests exercise shared contracts (nanobind bindings, RuntimeBuilder, ring buffers, etc.) and the risk of silently skipping a regression outweighs the CI minutes saved. The `tests/ut/cpp/{arch}/` entry in the gating regex only *attributes* an arch-specific C++ UT change to that platform (so it does not spuriously flip the other arch's scene-test flag); it does not gate the UT jobs themselves.
+- **`docs_only` is the one exception**, and it is narrower than the `NON_CODE` set on purpose. `NON_CODE` is about *platform attribution* and covers whole trees (`docs/`, `.claude/`, `.gitignore`, `.pre-commit-config.yaml`) — a change to `.pre-commit-config.yaml` or a `.claude/` script can still change what CI does, so it must not skip the UT jobs. `docs_only` is true only when every changed path ends in `.md`, which no test can execute. An empty diff leaves it `false`, so an unexpected result runs the full matrix rather than nothing.
 
 ## Hardware Classification
 


### PR DESCRIPTION
## What

`detect-changes` gains a `docs_only` output — true only when **every** changed
path ends in `.md`. `packaging-matrix`, `ut`, `ut-a2a3` and `ut-a5` now skip on
it.

## Why

Those four jobs never consulted `detect-changes` at all; only the scene-test jobs
did. So a markdown-only PR still ran packaging on two runners, `ut` on two more,
and occupied **both self-hosted hardware boxes** for a unit-test pass over a tree
that had not changed. The scene-test jobs already skipped, since `NON_CODE`
covers `*.md`.

| job | before | after |
| --- | --- | --- |
| `pre-commit` | runs | runs |
| `packaging-matrix`, `ut`, `ut-a2a3`, `ut-a5` | **always ran** | skipped iff `docs_only` |
| `st-sim-*`, `st-onboard-*`, `profiling-flags-smoke` | already skipped (`NON_CODE`) | unchanged |

## Why `.md` and not the whole `NON_CODE` set

Deliberately narrower. `NON_CODE` answers *platform attribution* and covers whole
trees — `.pre-commit-config.yaml` and `.claude/` are both in it, and both can
change what CI itself does, so neither may skip the UT jobs. `docs_only` answers
the stricter question "can this diff change what any test executes", and for
`.md` the answer is no: markdownlint inside pre-commit is the only check that
reads them.

## On the documented decision this touches

`docs/ci.md` stated UT jobs are unconditional because "the risk of silently
skipping a regression outweighs the CI minutes saved". That reasoning is about
*platform* gating, where a shared-code change can look arch-specific and still
break the other arch. It does not reach a diff containing no code. Rather than
contradict it silently, `docs/ci.md` is updated in the same commit to say where
the rule still holds and where `docs_only` is the exception.

## Verification

Logic exercised against the boundary cases:

| changed files | `docs_only` |
| --- | --- |
| `README.md` | true |
| `docs/a.md` + `.claude/b.md` | true |
| `docs/a.md` + `simpler_setup/x.py` | false |
| `.github/workflows/ci.yml` | false |
| `docs/a.md` + `tests/lint/.markdownlint.yaml` | false |
| *(empty diff)* | false — unexpected input runs the full matrix, not nothing |

YAML parses; scoped pre-commit clean. This PR is not itself markdown-only (it
edits `ci.yml`), so it still runs the full matrix — the next docs PR is the real
demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)