### PR TITLE
Add: user-facing documentation for building on simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
 
 ## Documentation
 
-**[docs/README.md](docs/README.md) indexes every document**, grouped by task. The entry points:
+Building **on** simpler? Start at **[docs/user/](docs/user/README.md)** — how-to guides plus the Python and CLI reference. **[docs/README.md](docs/README.md) indexes every document**, grouped by task. The entry points:
 
 | Document | Description |
 | -------- | ----------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,15 @@ Add the row here in the same commit — an unlisted doc is invisible.
 
 ## Start here
 
+Two audiences use this tree. If you are **building on** simpler — writing
+kernels and orchestration, running and measuring them — start at
+**[user/](user/README.md)**, which routes you through install → first run →
+write a kernel → profile → debug. Everything else here is written for people
+changing simpler's own internals.
+
 | Document | What it covers |
 | -------- | -------------- |
+| [**Using simpler**](user/README.md) | The user-facing entry point: how-to guides and the Python / CLI reference |
 | [Getting Started](getting-started.md) | Prerequisites, PTO-ISA setup, first example run |
 | [Installation and Runtime Environment](install.md) | Install layout and the runtime environment variables |
 | [Developer Guide](developer-guide.md) | Directory structure, role ownership, when to rebuild |

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,62 @@
+# Using simpler
+
+Documentation for **building on** simpler — writing kernels and orchestration,
+running them on a device or the simulator, measuring them, and diagnosing
+failures. If you are changing simpler's own runtime internals, start from the
+[documentation index](../README.md) instead; the architecture and internals
+pages are written for that audience.
+
+## The path through
+
+| Step | Go to |
+| ---- | ----- |
+| 1. Install and get a device visible | [Getting Started](../getting-started.md), [Installation and Runtime Environment](../install.md) |
+| 2. Prove your setup works, no kernels involved | [`examples/workers/l2/hello_worker/`](../../examples/workers/l2/hello_worker/README.md) — constructs a `Worker`, `init()`, `malloc`/`free`, `close()` |
+| 3. Compile and run your first kernel | [How-to: write and run a kernel](how-to/write-and-run-a-kernel.md) |
+| 4. Spread work across chips | [How-to: run on multiple chips](how-to/run-on-multiple-chips.md) |
+| 5. Find out where the time goes | [How-to: profile a kernel](how-to/profile-a-kernel.md) |
+| 6. Something failed | [How-to: debug a failed run](how-to/debug-a-failed-run.md) |
+
+## Reference
+
+| Document | What it covers |
+| -------- | -------------- |
+| [Python API](reference/python-api.md) | The types and methods you call: `Worker`, callables, task args, `CallConfig` |
+| [Command-line flags and tools](reference/cli.md) | pytest flags for platform/device/diagnostics, and the analysis CLIs |
+
+## Which package do I import from?
+
+Both `simpler` and `simpler_setup` are part of the surface you write against:
+
+- **`simpler`** — the runtime itself. `Worker`, and the task/callable types in
+  `simpler.task_interface`.
+- **`simpler_setup`** — compilation and test scaffolding: `KernelCompiler`,
+  `SceneTestCase` / `scene_test`, `Tensor`, `TaskArgsBuilder`,
+  `ensure_pto_isa_root`, `make_tensor_arg`. Also the analysis CLIs under
+  `simpler_setup.tools`.
+
+You cannot compile a kernel without `simpler_setup`, so treat both as yours to
+use. Note that
+[`.claude/rules/project-layout.md`](../../.claude/rules/project-layout.md)
+describes `simpler_setup` as internal test framework — that boundary does not
+match how the examples import today, and neither does the claim that `simpler`
+is the whole user API: `simpler.__all__` currently exports only the logging
+helpers, so `Worker` must be imported as `from simpler.worker import Worker`
+rather than `from simpler import Worker`.
+
+## Where the worked examples live
+
+The example trees are the tutorial layer, and several carry their own
+walkthrough README:
+
+| Tree | What is in it |
+| ---- | ------------- |
+| [`examples/workers/l2/`](../../examples/workers/l2/README.md) | Single-chip Worker API: `hello_worker`, `vector_add`, `worker_malloc`, `per_task_runtime_env` |
+| [`examples/workers/l3/`](../../examples/workers/l3/README.md) | Host-level multi-chip: `allreduce`, `multi_chip_dispatch`, `child_memory` |
+| `examples/a2a3/`, `examples/a5/` | Per-arch, per-runtime scene tests — the `@scene_test` style you will most often copy |
+
+[`examples/workers/l2/vector_add/main.py`](../../examples/workers/l2/vector_add/main.py)
+is the most useful single file to read: it walks the whole pipeline explicitly
+(compile → wrap into callables → allocate → copy → run → verify) with a diagram
+in its module docstring, precisely because `@scene_test` normally hides those
+stages.

--- a/docs/user/how-to/debug-a-failed-run.md
+++ b/docs/user/how-to/debug-a-failed-run.md
@@ -1,0 +1,113 @@
+# How-to: debug a failed run
+
+Work outward from the symptom. Most confusion here comes from treating a
+host-side error code as if it named the cause — it usually does not.
+
+## First, classify the symptom
+
+| Symptom | Most likely cause | Go to |
+| ------- | ----------------- | ----- |
+| `507018`, `507014`, `507899`, `507046` at `run()` | a generic host-side code masking a device-side event | [Reading a 5xxxxx code](#reading-a-5xxxxx-code) below |
+| Error at `init()`, not `run()` | wrong platform, missing runtime binaries, or a busy device | [Failures at init()](#failures-at-init) below |
+| Golden mismatch, run itself succeeded | kernel logic, tile geometry, or arg order | [Wrong results](#wrong-results) below |
+| Hangs forever in simulation | more simulated cores than the host can schedule | [sim oversubscription hang](../../troubleshooting/sim-oversubscription-hang.md) |
+| Build or import failure on macOS | toolchain / OpenMP collision | [macos-build](../../troubleshooting/macos-build.md), [macos-libomp-collision](../../troubleshooting/macos-libomp-collision.md) |
+
+## Reading a 5xxxxx code
+
+A `507018` means "the stream did not finish in time", **not** "deadlock". Several
+distinct device-side mechanisms surface as the same host code, so name the
+mechanism before you theorize:
+
+1. **Read the host log first.** It names the code and the device-side error class
+   it masks — look for `error detail:`, `orch_error_code=`, `sched_error_code=`,
+   `sub_class=`.
+2. **Then look up the code** in
+   [device-error-codes](../../troubleshooting/device-error-codes.md), the repo's
+   own table, with per-mechanism notes in
+   [`device-error-codes/`](../../troubleshooting/device-error-codes/):
+   [aicore-fault](../../troubleshooting/device-error-codes/aicore-fault.md),
+   [capacity](../../troubleshooting/device-error-codes/capacity.md),
+   [stall](../../troubleshooting/device-error-codes/stall.md).
+3. **Only then open the device log**, which is the ground truth for what the
+   AICPU was doing.
+
+The decisive distinction: if no capacity or deadlock detector fired and only an
+op-execute timeout did, the op was **slow or stalled, not deadlocked**. A real
+capacity exhaustion trips its own detector; silence means look for a race or for
+"just too slow" instead of enlarging a ring.
+
+### Get your own device log
+
+The device log defaults to a directory shared with every other user and process
+on the machine, so finding your run's file means guessing by pid and timestamp.
+Redirect it into your run's own output directory instead — the directory must
+exist first, because the driver opens the file without creating the path:
+
+```bash
+LOGDIR="$PWD/outputs/my_run/ascend"
+mkdir -p "$LOGDIR"
+export ASCEND_PROCESS_LOG_PATH="$LOGDIR"
+# run; the log is then at $LOGDIR/device-<id>/device-*.log
+```
+
+### If it is merely slow, not stuck
+
+The timeouts are compile-time defaults — op-execute 45 s, stream-sync 50 s,
+scheduler 10 s — and all three are environment-overridable, with the ordering
+between them validated at startup. Raising them is how you tell "genuinely
+hung" from "legitimately long":
+
+```bash
+export SIMPLER_SCHEDULER_TIMEOUT_MS=5000
+export SIMPLER_OP_EXECUTE_TIMEOUT_US=3000000
+export SIMPLER_STREAM_SYNC_TIMEOUT_MS=4000
+```
+
+See [local-timeout-defaults](../../troubleshooting/local-timeout-defaults.md).
+Note CI runs deliberately short timeouts, so a CI failure should be read against
+the CI values rather than the header defaults.
+
+## Failures at init()
+
+`init()` is where runtime binaries are resolved and the device is opened, so it
+is the first place setup problems appear:
+
+- **Wrong `--platform` for this machine's silicon.** An `a2a3` invocation on a5
+  hardware (or the reverse) produces failures that look like genuine runtime
+  bugs. Confirm which platform this box can actually run before blaming the code.
+- **Missing runtime binaries.** They are loaded from `build/lib/<platform>/<runtime>/`,
+  not rebuilt on import. After changing runtime or platform C++, re-run
+  `pip install --no-build-isolation -e .`; see
+  [Developer Guide](../../developer-guide.md#when-to-rebuild).
+- **A stale install after a struct-layout change.** If a whole suite fails with
+  something like a zeroed `launch_aicpu_num`, the installed `_task_interface`
+  predates a `CallConfig` layout change — reinstall rather than bisect.
+- **Device busy.** A previous run that skipped `close()` still holds it.
+
+## Wrong results
+
+The run completed, so this is your kernel or your arg wiring:
+
+- **Arg order is positional** and must match the callable `signature`. A swapped
+  input pair produces plausible-looking wrong numbers, not an error.
+- **`func_id` must match** the id the orchestration submits, and
+  `function_name` the exported orchestration symbol — a mismatch can run the
+  wrong kernel body.
+- **Tile geometry.** Example kernels frequently hard-code a shape with no
+  boundary handling; feeding a different shape silently reads out of range.
+- Capture what a task actually received with `--dump-args` and inspect it —
+  see [Args Dump](../../dfx/args-dump.md) and
+  [How-to: profile a kernel](profile-a-kernel.md).
+
+## Before concluding "simpler is broken"
+
+If the failing workload lives in another repo (pypto, pypto-lib,
+pypto-serving), first confirm which simpler is actually loaded and whether the
+workload is covered by that repo's CI — a script that no workflow runs may be an
+experimental draft that was never expected to pass. The repo map and the
+import chain are in the [top-level README](../../../README.md#where-simpler-sits-in-the-stack).
+
+If the mechanism you depend on may simply not be wired up on your arch, check
+the [Capability Survey](../../capability-survey.md) — several communication
+engines are declared but unreachable, and it records which.

--- a/docs/user/how-to/profile-a-kernel.md
+++ b/docs/user/how-to/profile-a-kernel.md
@@ -1,0 +1,88 @@
+# How-to: profile a kernel
+
+Diagnostics are **off by default** and are enabled per run. Turn on the one that
+answers your question — each writes its artifacts under the run's output
+directory, and each has an analysis CLI that reads them.
+
+Start by asking which question you have:
+
+| Question | Enable | Then read |
+| -------- | ------ | --------- |
+| Where did wall-clock go, host vs device? | nothing — `[STRACE]` markers are always emitted | [L2 Timing](../../dfx/l2-timing.md), [host trace](../../dfx/host-trace.md) |
+| Which task ran when, on which core? | `--enable-l2-swimlane` | [L2 Swimlane Profiling](../../dfx/l2-swimlane-profiling.md) |
+| Is the scheduler the bottleneck, or starved? | `--enable-l2-swimlane --enable-dep-gen --enable-swimlane-overhead` | [Scheduler-Overhead Model](../../dfx/sched-overhead-model.md) |
+| Why is *one* task slow inside the core? | `--dump-args`, then the L0 tool | [L0 Swimlane Profiling](../../dfx/l0-swimlane-profiling.md) |
+| What do the AICore hardware counters say? | `--enable-pmu` | [PMU Profiling](../../dfx/pmu-profiling.md) |
+| What does the dependency graph actually look like? | `--enable-dep-gen` | [dep_gen](../../dfx/dep_gen.md) |
+| Am I near a ring / dep-pool capacity limit? | `--enable-scope-stats` | [Scope Stats](../../dfx/scope-stats.md) |
+| What arguments did a task really receive? | `--dump-args` | [Args Dump](../../dfx/args-dump.md) |
+
+## Enabling from pytest
+
+```bash
+# per-task timing across cores (bare flag = level 4, full detail)
+pytest examples/my_example --platform a2a3 --device 4 --enable-l2-swimlane
+
+# scheduler overhead: needs the swimlane AND a dependency graph
+pytest examples/my_example --platform a2a3 --device 4 \
+    --enable-l2-swimlane --enable-dep-gen --enable-swimlane-overhead
+
+# hardware counters, and captured per-task arguments
+pytest examples/my_example --platform a2a3 --device 4 --enable-pmu
+pytest examples/my_example --platform a2a3 --device 4 --dump-args
+```
+
+`--enable-swimlane-overhead` requires `--enable-l2-swimlane` plus a `deps.json`;
+if it is absent, re-run adding `--enable-dep-gen`.
+
+**`--enable-l2-swimlane` is L2-only.** Asking for it on an L3 test is rejected
+up front — scope to a single chip with `--level 2`, or drop the flag.
+
+Use `--rounds N` when you want several iterations, so first-run effects (binary
+load, cold arena) do not dominate what you measure.
+
+## Enabling from your own code
+
+The same switches are `CallConfig` fields, so a direct-`Worker` program sets
+them itself. Any enabled diagnostic requires `output_prefix` to be set —
+`CallConfig::validate()` rejects the config otherwise.
+
+```python
+cfg = CallConfig()
+cfg.enable_l2_swimlane = 4      # 0 = off; 1..4 select detail
+cfg.enable_pmu = 1              # 0 = off; >0 selects the event type
+cfg.output_prefix = "outputs/my_run"    # required once any diagnostic is on
+worker.run(handle, args, cfg)
+```
+
+In a `@scene_test`, per-case knobs live under `"config"`, including
+`aicpu_thread_num` and — on `tensormap_and_ringbuffer` — `runtime_env` ring
+sizing (`ring_task_window`, `ring_heap`, `ring_dep_pool`).
+
+## Reading the results
+
+The analysis CLIs ship in the wheel under `simpler_setup.tools`; run them with
+`python -m`. Full flag documentation is in
+[`simpler_setup/tools/README.md`](../../../simpler_setup/tools/README.md).
+
+| Tool | Consumes | Gives you |
+| ---- | -------- | --------- |
+| `strace_timing` | the run log | host/device wall-clock breakdown, per-round table |
+| `swimlane_converter` | `l2_swimlane_records_*.json` | a Perfetto trace plus a per-function task summary; `--overhead` overlays the scheduler-overhead counters |
+| `sched_overhead_analysis` | swimlane + deps | whether the scheduler is the bottleneck or starved |
+| `l0_swimlane` | an args dump | intra-core pipeline trace for one task |
+| `deps_viewer`, `critical_path` | `deps.json` | the dependency graph, and its critical path |
+| `dump_viewer` | an args dump | the captured per-task arguments |
+| `scope_stats_plot` | `scope_stats.jsonl` | per-scope resource peaks |
+
+```bash
+python -m simpler_setup.tools.strace_timing <run.log> --rounds-table
+python -m simpler_setup.tools.swimlane_converter <l2_swimlane_records_*.json>
+```
+
+## Before optimizing anything
+
+Check [`docs/investigations/`](../../investigations/README.md) first. It records
+proposals that were measured and dropped — several plausible-sounding
+optimizations on the profiling and dispatch paths are already shut down there
+with numbers, and re-deriving them costs a hardware round-trip.

--- a/docs/user/how-to/run-on-multiple-chips.md
+++ b/docs/user/how-to/run-on-multiple-chips.md
@@ -1,0 +1,113 @@
+# How-to: run on multiple chips
+
+One host driving several chips is **L3**. The single-chip API you already know
+still applies; L3 adds a host-side orchestration function that submits one task
+per chip, plus optional Python "sub worker" callables for post-processing.
+
+Worked examples live in
+[`examples/workers/l3/`](../../../examples/workers/l3/README.md), whose README
+enumerates what each one demonstrates.
+
+## The lifecycle
+
+```python
+from simpler.worker import Worker
+
+worker = Worker(
+    level=3,
+    platform="a2a3sim",
+    runtime="tensormap_and_ringbuffer",
+    device_ids=[0, 1],        # one chip child process per entry
+    num_sub_workers=1,        # optional host-side Python callables
+)
+
+# Register everything BEFORE init(): chip callables and any sub-worker callable.
+chip_handle = worker.register(chip_callable)
+postprocess = worker.register(lambda args: print("post-process got", args))
+
+worker.init()                 # forks the chip children and sub children, starts the scheduler
+
+def my_orch(orch, args, cfg):
+    # Plain Python, running in the host process — not a C++ kernel.
+    orch.submit_next_level(chip_handle, chip_args, worker=0)   # target a specific chip
+    orch.submit_sub(postprocess, sub_args)                     # schedule host-side work
+
+try:
+    worker.run(my_orch, args, config)
+finally:
+    worker.close()            # shuts the children down and releases shared memory
+```
+
+Three differences from L2 that trip people up:
+
+- **`device_ids` (plural), not `device_id`.** Each entry becomes its own forked
+  child process holding its own chip.
+- **The orchestration function is Python and runs on the host.** At L2 the
+  orchestration is a compiled `.cpp`; at L3 the top-level orchestration is a
+  Python callable that hands compiled `ChipCallable`s down to the children.
+- **Register before `init()`.** `init()` is the fork point, so registration
+  afterwards does not reach children that already exist.
+
+To direct a task at one specific child rather than any free one, see
+[Directed NEXT_LEVEL Scheduling](../../directed-next-level-scheduling.md).
+
+## Collectives across chips
+
+Cross-chip collectives run through a **communication domain**: a symmetric
+memory window that every participating rank can address. Allocate it inside the
+orchestration function, as a context manager, and index it by *domain-local*
+rank:
+
+```python
+def orch_fn(orch, _args, cfg):
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(nranks)),
+        window_size=window_size,
+        buffers=[CommBufferSpec(name="scratch", dtype="float32",
+                                count=elems, nbytes=scratch_nbytes)],
+    ) as handle:
+        for i in range(nranks):
+            domain = handle[i]          # domain-local rank i
+            ...                         # build per-rank args, submit per chip
+```
+
+A worker can belong to more than one domain, and each domain gets its own window
+slice. Full semantics — allocation, lifetime, the rank map, and what happens
+when you ask for a domain a worker is not in — are in
+[Communication Domains](../../comm-domain.md).
+
+The shipped collectives are hand-written AIV kernels that compute peer pointers
+from the window, not HCCL collective calls; HCCL is used only to bootstrap the
+domain. The algorithm corpus (allreduce in several modes, allgather,
+reduce_scatter, broadcast, all_to_all) lives in
+`tests/st/worker/collectives/` — read those scene tests for the real
+implementations.
+
+## Scope limits worth knowing up front
+
+- **Collectives are single-host, multi-card.** Both backends state this
+  explicitly; there is no cross-node collective path today.
+- **`--enable-l2-swimlane` does not work on L3.** It is rejected up front. To
+  get a swimlane, scope the run to one chip with `--level 2`.
+- **Multi-host (L4) is not usable for data movement yet.** The control plane is
+  real — you can register a remote worker, and the remote side builds a genuine
+  L3 subtree — but the transport is simulation-backed, and the daemon rejects
+  any other setting. The RoCE / HCCS / UB profiles are documented contracts, not
+  working paths. See [Remote L3 Worker Design](../../remote-l3-worker-design.md)
+  and the [Capability Survey](../../capability-survey.md) before designing
+  against it.
+
+## Running
+
+```bash
+# simulation, two virtual chips
+python examples/workers/l3/multi_chip_dispatch/main.py -p a2a3sim -d 0,1
+
+# hardware
+pytest tests/st/worker/collectives --platform a2a3 --device 4-7
+```
+
+On shared machines, hardware runs should hold the devices they use rather than
+racing other users for them; see [Testing](../../testing.md) for how the suites
+are invoked.

--- a/docs/user/how-to/write-and-run-a-kernel.md
+++ b/docs/user/how-to/write-and-run-a-kernel.md
@@ -1,0 +1,184 @@
+# How-to: write and run a kernel
+
+Two ways to get a kernel onto a device. Pick by what you are doing:
+
+| You want | Use | Why |
+| -------- | --- | --- |
+| A test or example that CI will run | **`@scene_test`** | Compilation, arg building, golden comparison and per-platform cases are handled for you |
+| To see or control every stage yourself | **The `Worker` API directly** | Nothing is hidden; you own compile, malloc, copy, run |
+
+Both need the same three source pieces:
+
+```text
+my_example/
+  kernels/orchestration/my_orch.cpp   # runs on AICPU (or host) — submits tasks
+  kernels/aiv/my_kernel.cpp           # runs on an AICore vector unit
+  test_my_example.py                  # or main.py for the direct-API style
+```
+
+The orchestration source is what builds the task graph; the in-core sources are
+the per-task kernels it submits. See
+[AICore Kernel Programming](../../aicore-kernel-programming.md) for what may go
+inside a kernel body.
+
+## Option A — `@scene_test` (recommended)
+
+Declare the sources and the per-case matrix; the framework compiles and runs
+them. Copy
+[`examples/a2a3/tensormap_and_ringbuffer/vector_example/`](../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/)
+as your starting point.
+
+```python
+from simpler.task_interface import ArgDirection as D
+from simpler_setup import SceneTestCase, scene_test
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestMyExample(SceneTestCase):
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/my_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",   # must match the exported symbol
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,                                # matches rt_submit_aiv_task(0, ...)
+                "source": "kernels/aiv/my_kernel.cpp",
+                "core_type": "aiv",                          # "aiv" or "aic"
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a2a3sim", "a2a3"],                # sim needs no hardware
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        ...        # build the input tensors
+
+    def compute_golden(self, args, params):
+        ...        # return the expected output; the framework compares for you
+```
+
+Two things to get right, because both fail confusingly:
+
+- **`function_name` must match the symbol** your orchestration `.cpp` exports
+  with `__attribute__((visibility("default")))`.
+- **`func_id` must match the id** the orchestration passes to its submit call.
+  `func_id=0` corresponds to the first `rt_submit_aiv_task(0, ...)`.
+
+Run it:
+
+```bash
+# simulation — no device needed
+pytest examples/my_example --platform a2a3sim
+
+# hardware
+pytest examples/my_example --platform a2a3 --device 4-7
+```
+
+Standalone (same file, no pytest):
+
+```bash
+python examples/my_example/test_my_example.py -p a2a3sim
+```
+
+`level` and `runtime` are decorator arguments; **platforms are declared per case
+in `CASES`**, not on the decorator. Per-case knobs go under `"config"` —
+`aicpu_thread_num`, and `runtime_env` for ring sizing on
+`tensormap_and_ringbuffer`. See the [Python API reference](../reference/python-api.md)
+for the full `CallConfig` field list.
+
+## Option B — the `Worker` API directly
+
+Use this when you need to see the stages, or when your program is not a test.
+The canonical worked example is
+[`examples/workers/l2/vector_add/main.py`](../../../examples/workers/l2/vector_add/main.py);
+the shape is:
+
+```python
+from simpler.task_interface import (
+    ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
+    CoreCallable, DataType, Tensor,
+)
+from simpler.worker import Worker
+
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+# 1. Compile. pto_isa_root is the managed sibling header checkout.
+kc = KernelCompiler(platform=platform)
+kernel_bytes = kc.compile_incore(
+    source_path=".../kernels/aiv/my_kernel.cpp",
+    core_type="aiv",
+    pto_isa_root=ensure_pto_isa_root(),
+    extra_include_dirs=kc.get_orchestration_include_dirs("tensormap_and_ringbuffer"),
+)
+# On real hardware only, extract .text before wrapping:
+if not platform.endswith("sim"):
+    from simpler_setup.elf_parser import extract_text_section
+    kernel_bytes = extract_text_section(kernel_bytes)
+
+orch_bytes = kc.compile_orchestration(
+    runtime_name="tensormap_and_ringbuffer",
+    source_path=".../kernels/orchestration/my_orch.cpp",
+)
+
+# 2. Wrap into callables. children maps func_id -> CoreCallable.
+core = CoreCallable.build(
+    signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+    binary=kernel_bytes,
+)
+chip = ChipCallable.build(
+    signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+    func_name="my_orchestration",
+    binary=orch_bytes,
+    children=[(0, core)],
+)
+
+# 3. Register BEFORE init(), then init.
+worker = Worker(level=2, platform=platform,
+                runtime="tensormap_and_ringbuffer", device_id=device_id)
+handle = worker.register(chip)
+worker.init()
+try:
+    # 4. Device memory + H2D.
+    dev_a, dev_out = worker.malloc(nbytes), worker.malloc(nbytes)
+    worker.copy_to(dev_a, host_a.data_ptr(), nbytes)
+
+    # 5. Task args, in the same order as the signature.
+    args = ChipStorageTaskArgs()
+    args.add_tensor(Tensor.make(dev_a, (rows, cols), DataType.FLOAT32))
+    args.add_tensor(Tensor.make(dev_out, (rows, cols), DataType.FLOAT32))
+
+    # 6. Run, then D2H.
+    worker.run(handle, args, CallConfig())
+    worker.copy_from(host_out.data_ptr(), dev_out, nbytes)
+    worker.free(dev_a); worker.free(dev_out)
+finally:
+    worker.close()          # always; a leaked device stays locked
+```
+
+Ordering rules that are not optional:
+
+- **`register()` happens before `init()`.** Construction only stashes config;
+  `init()` is where runtime binaries are resolved and the device is opened.
+- **`close()` belongs in a `finally`.** Skipping it leaves the device held, and
+  the next job on that device hangs.
+- **Task-arg order must match the callable `signature`**, positionally.
+
+`run()` blocks and returns `None`. For a non-blocking submit use `submit()`,
+which returns a handle with `done()` / `wait(timeout)` / `result(timeout)`.
+
+## After it runs
+
+- Timing: [How-to: profile a kernel](profile-a-kernel.md)
+- A failure or a hang: [How-to: debug a failed run](debug-a-failed-run.md)
+- Multiple chips: [How-to: run on multiple chips](run-on-multiple-chips.md)

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -1,0 +1,85 @@
+# Command-line flags and tools
+
+How you select what runs, turn diagnostics on, and read the artifacts back.
+
+## Running tests and examples
+
+```bash
+pytest examples tests/st --platform a2a3sim            # simulation, no device
+pytest examples tests/st --platform a2a3 --device 4-7  # hardware
+python examples/my_example/test_my_example.py -p a2a3sim   # standalone, no pytest
+```
+
+### Selecting what runs
+
+| Flag | Meaning |
+| ---- | ------- |
+| `--platform` | Target platform: `a2a3sim`, `a2a3`, `a5sim`, `a5`. Required |
+| `--device` | Device id or range, e.g. `0` or `4-7`. Default `0` |
+| `--runtime` | Restrict to one runtime (`tensormap_and_ringbuffer`, `host_build_graph`) |
+| `--level` | Restrict to one level, e.g. `--level 2` |
+| `--case` | Case selector, repeatable: `Foo`, `ClassA::Foo`, or `ClassA::` for a whole class |
+| `--manual` | Manual-case handling: `exclude` (default), `include`, `only` |
+| `--rounds` | Run each case N times. Default `1`; use this so first-run effects do not dominate a measurement |
+| `--skip-golden` | Skip golden comparison — benchmark mode |
+| `--require-pto-isa` | Fail the session immediately if PTO-ISA cannot be resolved, instead of deferring to the per-test lazy path |
+| `--sanitizer` | Run against a sanitizer build; see [Compiler Sanitizers](../../sanitizers.md) |
+
+### Diagnostics
+
+All off by default. Each also exists as a `CallConfig` field for direct-`Worker`
+programs — see the [Python API reference](python-api.md).
+
+| Flag | Meaning |
+| ---- | ------- |
+| `--enable-l2-swimlane` | Per-task timing. Bare flag = level 4 (full); `1` AICore timing, `2` + dispatch/fanout, `3` + scheduler phases, `4` + orchestration. **L2 only** |
+| `--enable-swimlane-overhead` | Adds the 8 Overhead Analysis counter tracks. Requires `--enable-l2-swimlane` **and** a `deps.json` — add `--enable-dep-gen` if absent |
+| `--enable-pmu` | AICore hardware counters. Bare flag = `PIPE_UTILIZATION` (2); pass an event type to override, e.g. `--enable-pmu 4` |
+| `--dump-args` | Capture per-task arguments. `0` off, `1` partial (only args marked via `Arg::dump(...)`) |
+| `--enable-dep-gen` | Capture the dependency graph (first round only) |
+| `--enable-scope-stats` | Per-scope peaks to `<output_prefix>/scope_stats.jsonl` |
+
+Which flag answers which question is tabulated in
+[How-to: profile a kernel](../how-to/profile-a-kernel.md).
+
+## Analysis tools
+
+Shipped in the wheel under `simpler_setup.tools`, run with `python -m`. Full
+flags in [`simpler_setup/tools/README.md`](../../../simpler_setup/tools/README.md).
+
+| Tool | Input | Output |
+| ---- | ----- | ------ |
+| `strace_timing` | run log | host/device wall-clock breakdown; `--rounds-table` for per-round |
+| `swimlane_converter` | `l2_swimlane_records_*.json` | Perfetto trace + per-function task summary; `--overhead` adds the scheduler-overhead counters (needs `deps.json`) |
+| `sched_overhead_analysis` | swimlane + deps | scheduler bottleneck vs starvation verdict |
+| `l0_swimlane` | args dump | intra-core pipeline trace for one task |
+| `deps_viewer` | `deps.json` | the dependency graph |
+| `critical_path` | `deps.json` | critical path through the graph |
+| `dump_viewer` | args dump | captured per-task arguments |
+| `scope_stats_plot` | `scope_stats.jsonl` | per-scope resource peaks |
+
+```bash
+python -m simpler_setup.tools.strace_timing <run.log> --rounds-table
+python -m simpler_setup.tools.swimlane_converter <l2_swimlane_records_*.json>
+```
+
+## Environment variables
+
+| Variable | Effect |
+| -------- | ------ |
+| `SIMPLER_OP_EXECUTE_TIMEOUT_US` | Overrides the op-execute timeout (default 45 s) |
+| `SIMPLER_STREAM_SYNC_TIMEOUT_MS` | Overrides the stream-sync timeout (default 50 s) |
+| `SIMPLER_SCHEDULER_TIMEOUT_MS` | Overrides the scheduler timeout (default 10 s) |
+| `ASCEND_PROCESS_LOG_PATH` | Redirects the device log into a directory you own; the directory must already exist |
+| `ASCEND_HOME_PATH` | CANN toolkit location; required for hardware platforms |
+
+The three timeouts are validated against each other at startup, and CI runs
+deliberately shorter values than the defaults — read a CI timeout against the CI
+values. Details in
+[local-timeout-defaults](../../troubleshooting/local-timeout-defaults.md).
+
+## See also
+
+- [Testing](../../testing.md) — the full testing guide, including how the suites are composed
+- [CI Pipeline](../../ci.md) — what each pipeline stage runs
+- [How-to: debug a failed run](../how-to/debug-a-failed-run.md)

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -1,0 +1,151 @@
+# Python API reference
+
+The surface you write against, hand-maintained. There is no generated API
+reference in this repo, so treat the source as authoritative when the two
+disagree and fix this page in the same change.
+
+Import paths matter: `simpler.__all__` currently exports only the logging
+helpers, so the runtime types are imported from their submodules.
+
+```python
+from simpler.worker import Worker
+from simpler.task_interface import (
+    ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
+    CoreCallable, DataType, Tensor,
+)
+from simpler_setup import KernelCompiler, SceneTestCase, scene_test
+```
+
+## `Worker`
+
+```python
+Worker(level: int, **config)
+```
+
+`level` is the only declared parameter; everything else is a keyword collected
+into `**config` and validated later. The recognized keys:
+
+| Key | Applies to | Meaning |
+| --- | ---------- | ------- |
+| `platform` | all | `a2a3`, `a2a3sim`, `a5`, `a5sim` |
+| `runtime` | all | `tensormap_and_ringbuffer` or `host_build_graph` |
+| `device_id` | L2 | the single chip this worker drives |
+| `device_ids` | L3+ | one chip child process per entry |
+| `num_sub_workers` | L3+ | host-side Python callables to fork |
+| `enable_sdma` | a2a3 | provisions the SDMA workspace; defaults to `False` |
+| `heap_ring_size` | all | heap ring sizing |
+| `remote_heap_ring_size`, `remote_session_timeout_s` | L4 | remote-session sizing and timeout |
+
+`level` selects the topology: `2` is one chip, `>= 3` is hierarchical. Anything
+else raises. Remote-worker and remote-memory calls require `level >= 4`.
+
+### Lifecycle
+
+| Method | Notes |
+| ------ | ----- |
+| `register(target, *, workers=None) -> CallableHandle` | **Before `init()`.** Accepts a `ChipCallable` or, at L3+, a Python callable |
+| `unregister(handle_or_slot)` | Releases a registration |
+| `add_worker(worker) -> int` | Attaches a child worker; returns its id |
+| `add_remote_worker(spec: RemoteWorkerSpec) -> int` | L4; see the remote-L3 design doc |
+| `init(prewarm_config=None)` | Resolves runtime binaries, opens the device, forks children. First place setup errors appear |
+| `close()` | Releases the device and reaps children. Put it in a `finally` — a skipped `close()` leaves the device held |
+
+### Memory
+
+| Method | Notes |
+| ------ | ----- |
+| `malloc(size, worker_id=0) -> int` | Returns a device pointer as an integer |
+| `free(ptr, worker_id=0)` | |
+| `copy_to(dst, src, size, worker_id=0)` | H2D; `dst` is a device pointer, `src` a host address |
+| `copy_from(dst, src, size, worker_id=0)` | D2H; `dst` is the host address |
+| `create_host_buffer(nbytes) -> HostBuffer` / `free_host_buffer(handle)` | Host-side buffer the device can reach |
+| `remote_malloc` / `remote_free` / `remote_copy_to` / `remote_copy_from` / `remote_export` / `remote_import` / `remote_release_import` | L4 only |
+
+### Execution
+
+| Method | Notes |
+| ------ | ----- |
+| `run(callable, args=None, config=None) -> None` | Blocks until the run completes |
+| `submit(callable, args=None, config=None) -> RunHandle` | Non-blocking |
+| `live_domains() -> dict[str, CommDomainHandle]` | Currently allocated communication domains |
+
+`RunHandle` exposes `done() -> bool`, `wait(timeout=None)`, and
+`result(timeout=None)`.
+
+At L2 the `callable` is a registered `ChipCallable` handle. At L3+ the top-level
+callable is a **Python orchestration function** `f(orch, args, cfg)`, where
+`orch` is the `Orchestrator`:
+
+| Method | Notes |
+| ------ | ----- |
+| `submit_next_level(callable_handle, args, config=None, *, worker: int)` | Hands a `ChipCallable` to one chip child. `worker` is keyword-only |
+| `submit_sub(callable_handle, args=None)` | Schedules a registered host-side Python callable |
+| `allocate_domain(name, workers, window_size, buffers=[...])` | Context manager returning a handle indexed by domain-local rank |
+| `malloc(worker_id, size) -> int` | **Argument order is `(worker_id, size)`** — the reverse of `Worker.malloc(size, worker_id=0)` |
+
+## Callables and task args
+
+```python
+CoreCallable.build(signature=[ArgDirection...], binary=kernel_bytes)
+
+ChipCallable.build(
+    signature=[ArgDirection...],
+    func_name="my_orchestration",     # the exported orchestration symbol
+    binary=orch_bytes,
+    children=[(func_id, core_callable), ...],
+)
+```
+
+`ArgDirection` is `SCALAR`, `IN`, `OUT`, or `INOUT`. The signature list is
+positional and defines the task-arg order. `func_id` must match the id the
+orchestration submits. `ChipCallable` exposes `binary_size`.
+
+```python
+args = ChipStorageTaskArgs()
+args.add_tensor(Tensor.make(dev_ptr, (rows, cols), DataType.FLOAT32))
+```
+
+Tensors are added **in signature order**. `Tensor.make(data_ptr, shape, dtype)`
+takes a device pointer; `DataType` carries the element types.
+
+## `CallConfig`
+
+`CallConfig()` defaults are fine for an ordinary run.
+
+| Field | Default | Meaning |
+| ----- | ------- | ------- |
+| `aicpu_thread_num` | `3` | AICPU threads for this run |
+| `enable_l2_swimlane` | `0` | `0` off; `1`–`4` select detail. L2 only |
+| `enable_dump_args` | `0` | Capture per-task arguments |
+| `enable_pmu` | `0` | `0` off; `>0` selects the event type |
+| `enable_dep_gen` | `0` | Emit the dependency graph |
+| `enable_scope_stats` | `0` | Writes `<output_prefix>/scope_stats/scope_stats.jsonl` |
+| `output_prefix` | `""` | **Required whenever any diagnostic is enabled** |
+| `runtime_env` | — | `ring_task_window`, `ring_heap`, `ring_dep_pool`; `tensormap_and_ringbuffer` only |
+
+`validate()` runs at every submit/run entry point and throws if a diagnostic is
+on without `output_prefix`, or if a ring override breaks the ring's constraints.
+
+## `simpler_setup`
+
+Compilation and test scaffolding. Exported from the package root:
+
+| Name | Use |
+| ---- | --- |
+| `KernelCompiler` | `compile_incore(source_path, core_type, pto_isa_root, extra_include_dirs)`, `compile_orchestration(runtime_name, source_path)`, `get_orchestration_include_dirs(runtime)` |
+| `ensure_pto_isa_root()` | Clones/updates the pinned pto-isa checkout and returns its path |
+| `extract_text_section(binary)` | Required on hardware platforms before wrapping a kernel `.o` |
+| `scene_test(level, runtime)` / `SceneTestCase` | The decorator and base class for declarative examples and tests |
+| `Tensor`, `Scalar`, `TaskArgsBuilder`, `CallableNamespace` | Scene-test arg construction |
+| `make_tensor_arg`, `torch_dtype_to_datatype` | torch interop |
+| `parse_platform` | Platform string parsing |
+| `RuntimeBuilder` | Runtime build orchestration |
+
+Analysis CLIs live under `simpler_setup.tools`; see
+[command-line flags and tools](cli.md).
+
+## See also
+
+- [How-to: write and run a kernel](../how-to/write-and-run-a-kernel.md)
+- [Task Flow](../../task-flow.md) — how these handles travel through the runtime
+- [Communication Domains](../../comm-domain.md) — `allocate_domain` semantics


### PR DESCRIPTION
## Summary

`docs/` is written almost entirely for people changing simpler's internals. Classified by use, roughly **18 of the 46 pages** under `docs/` and `docs/dfx/` serve someone *building on* simpler and **28** serve someone *modifying* it — and the user-serving pages are all reference material, with no task-oriented layer above them.

There was also **no API reference of any kind**. The repo has no doc generator (no sphinx/mkdocs/doxygen), and `simpler.__all__` exports only the logging helpers, so even the entry point — `from simpler.worker import Worker` — was undocumented anywhere.

This PR adds `docs/user/`, routed by the reader's task rather than by subsystem:

| Page | Covers |
| ---- | ------ |
| `user/README.md` | install → prove the setup works → write a kernel → multiple chips → profile → debug |
| `how-to/write-and-run-a-kernel.md` | the `@scene_test` path and the direct `Worker` path side by side |
| `how-to/profile-a-kernel.md` | question→flag table over the existing `dfx/` references, and which CLI reads which artifact |
| `how-to/run-on-multiple-chips.md` | L3 lifecycle, communication domains, and the real scope limits |
| `how-to/debug-a-failed-run.md` | classify the symptom before theorizing; getting a private device log |
| `reference/python-api.md`, `reference/cli.md` | the API surface and the flags/tools, hand-maintained |

## Design choices worth reviewing

**It links the examples instead of duplicating them.** `examples/workers/**/README.md` is already the tutorial layer, and `hello_worker/README.md` is genuinely good ("what it does" / "why each line matters" / expected output). The user pages route there rather than re-teaching, per `doc-consistency.md` §2.

**The reference is hand-written, not generated.** Docstring coverage on the user API is **54% (`worker.py`) / 57% (`task_interface.py`)**, so a generated reference would be mostly holes today. Raising docstring coverage and then adding a generator is the better sequencing, and is not attempted here.

**The `simpler` / `simpler_setup` boundary is documented as it actually is.** `.claude/rules/project-layout.md` calls `simpler` the "stable user API" and `simpler_setup` an internal test framework, but the examples import `simpler_setup` *more* than `simpler` (`KernelCompiler` ×15, `pto_isa` ×15, `torch_interop` ×11, `SceneTestCase` group ×7) — you cannot compile a kernel without it. The user pages say so plainly. **Aligning the packages themselves is a code change and is deliberately not in this documentation-only PR**; happy to follow up if maintainers want `python/simpler/__init__.py` to export the real surface.

## Every fact was read from the source

Not recalled. Three cases where checking changed the text:

- `Worker.__init__(self, level, **config)` — only `level` is declared; the reference lists the 9 keys actually read from `**config`.
- `ArgDirection` has **four** values (`SCALAR`, `IN`, `OUT`, `INOUT`) — an earlier draft said two.
- `Orchestrator.malloc(worker_id, size)` takes its arguments in the **opposite order** to `Worker.malloc(size, worker_id=0)`. Documented explicitly as a footgun.

## Testing

Documentation only (`.md`); no code, build, or config files changed, so the sim/hardware suites do not apply per the git-commit skill's test matrix.

- [x] `markdownlint-cli2` clean on all 9 touched files, using **v0.20.0** — the version `.pre-commit-config.yaml:83` pins, i.e. what CI runs
- [x] Repo-wide relative-link validation: **no new broken links** (5 pre-existing remain, all in files this PR does not touch)
- [x] All 23 API names cited in the new pages verified to exist in `python/`, `simpler_setup/`, or `src/common/task_interface/`
- [ ] Simulation tests — not applicable (no code changed)
- [ ] Hardware tests — not applicable (no code changed)