### PR TITLE
Docs: add the copyright header to the two sim CMakeLists

### DIFF
--- a/src/a2a3/platform/sim/CMakeLists.txt
+++ b/src/a2a3/platform/sim/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 # a2a3sim Platform - Thread-Based Simulation
 #
 # This platform simulates the Ascend AICPU/AICore execution model using threads.

--- a/src/a5/platform/sim/CMakeLists.txt
+++ b/src/a5/platform/sim/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 # a5sim Platform - Thread-Based Simulation
 #
 # This platform simulates the Ascend AICPU/AICore execution model using threads.


### PR DESCRIPTION
`src/a2a3/platform/sim/CMakeLists.txt` and `src/a5/platform/sim/CMakeLists.txt`
were the only two files in the repo missing the header that
`tests/lint/check_headers.py` requires on `CMakeLists.txt`.

Before / after, full-repo scan:

```
Results: 1026 passed, 2 failed   →   Results: 1028 passed, 0 failed
```

They survived because pre-commit passes only the filenames a commit touches, so
the full-repo scan that finds them never runs in CI — you see it only by
invoking `check_headers.py` with no arguments.

The header text is taken from `check_headers.PY_HEADER` programmatically rather
than retyped, so it matches the validator exactly. Nothing else changes: it is
comment lines prepended to the existing content.

Verified beyond the linter, since these are live build scripts rather than docs:
rebuilt with `pip install --no-build-isolation -e .` and ran a sim scene test
(`spmd_basic --platform a2a3sim`) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)