### PR TITLE
Docs: correct two claims left behind by the qwen3 re-harvest

### DIFF
--- a/docs/dfx/dfx-buffer-capacity-audit.md
+++ b/docs/dfx/dfx-buffer-capacity-audit.md
@@ -114,11 +114,19 @@ overwrite count.
 | benchmark_bgemm | 3/1 drop0 | 0/33 | 3/17 | 7/1 | 3/0 ovf0 |
 | paged_attention_ringbuffer | 3/1 drop0 | 0/25 | 3/12 | 7/1 | 3/1 ovf0 |
 
-`qwen3_14b_decode` was measured here too, but only as a 2-layer chunk; it now
-runs all 40 layers, so its peaks need re-measuring before they mean anything and
-the stale row was dropped. Expect dep_gen and l2_swimlane to overflow on the
-full graph. It was not the worst case in any column, so the margins below are
-unaffected.
+A sixth example, `qwen3_14b_decode`, was measured for this audit as well. It has
+since been re-harvested from a 2-layer chunk to all 40 decode layers
+(simpler#1484), so its row was removed rather than left showing numbers from a
+workload roughly 20x smaller than the one now under that name. It was not the
+worst case in any column, so nothing below changes.
+
+Re-adding it is not a prerequisite for anything here: this table is the
+measurement behind the right-sizing that #977 landed, not a live dashboard. Note
+also that pypto-lib warns the full 40-layer graph can overflow the per-run SHM
+record buffer under `--enable-dep-gen` (`models/qwen3/14b/decode_fwd.py`,
+`--enable-dep-gen` help text), which is an expected consequence of a 20x larger
+graph rather than a capacity regression — but that is upstream's observation,
+not a measurement taken here.
 
 Converted to worst-case margins (`free = lowest/cap`, `ready = 1 − peak/cap`,
 verdict reads the weaker dimension):

--- a/docs/dfx/l0-swimlane-profiling.md
+++ b/docs/dfx/l0-swimlane-profiling.md
@@ -305,10 +305,25 @@ task-submit --device auto --max-time 1800 --run "$L0a --func-id 0 --set-arg 4=4 
 
 `qwen3_14b_decode` used to serve as the "real SPMD workload" row here, driving
 its generated `fa_fused` mix with `--set-arg 0=96` on the `fa_total` work-item
-count. Its attention is now a CANN `FusedInferAttentionScore` extern whose work
-distribution comes from tiling metadata that `paged_attention_tiling_cce` builds
-at runtime, not from a replayable scalar, so there is no `--set-arg` that shrinks
-it — it is no longer an l0 target.
+count. That kernel is gone: its attention is now a CANN
+`FusedInferAttentionScore` extern, so the row was dropped.
+
+Being an extern is not what blocks it — the replay feeds `kernel_entry` and does
+not care whether the source was generated or hand-written. The blocker is that
+this one takes its work distribution from a `FAInferTilingData` **struct**, in a
+`UINT8 metadata` buffer that `paged_attention_tiling_cce` fills at runtime.
+`--set-arg` writes one integer into *every* element, so it cannot synthesize a
+coherent struct (it is not even refused — `UINT8` passes the integer-dtype
+check), and this tool dumps at level 3, which captures metadata but no payload
+([args-dump](args-dump.md) §levels). With a zeroed `metadata`,
+`fai_body.hpp` reads `tiling->needCoreNum == 0` and takes the degenerate branch,
+so the trace would be unrepresentative rather than absent.
+
+That gap is in the tooling, not the kernel: `--dump-args 2` does capture the
+buffer's real bytes. Restoring payloads for control tensors — rather than only
+uniform-filling them — would make this and any other metadata-driven extern
+replayable. Until then the "real SPMD workload" category has no representative
+here.
 
 **Not l0 targets (excluded).** Runtime-mechanics tests (`orch_so_cache`,
 `prepared_callable`, `dynamic_register`, `l3_group`, `l3_dependency`,


### PR DESCRIPTION
Both claims are mine, from #1484, and both say more than was established.

## 1. "no longer an l0 target" was too broad

`docs/dfx/l0-swimlane-profiling.md` explained the removal of the "real SPMD
workload" row as: attention became a CANN extern, therefore not an l0 target.

Being an extern is not the blocker. The replay feeds `kernel_entry` and does not
care whether the source was generated or hand-written. What actually blocks it:

- its work distribution lives in a **`FAInferTilingData` struct** inside a
  `UINT8 metadata` buffer that `paged_attention_tiling_cce` fills at runtime;
- `--set-arg` writes **one integer into every element**, so it cannot synthesize
  a coherent struct — and `UINT8` passes the integer-dtype check, so it is not
  even refused, just useless;
- `l0_swimlane` dumps at **level 3**, which captures metadata and no payload.

With a zeroed `metadata`, `fai_body.hpp` reads `tiling->needCoreNum == 0` and
takes the degenerate branch, so the trace would be *unrepresentative* rather than
absent — a worse failure than an empty one, and worth naming.

The gap is in the tooling: **`--dump-args 2` does capture those bytes**.
Restoring payloads for control tensors, instead of only uniform-filling them,
would make this and any other metadata-driven extern replayable. Written that
way the category is a known gap with a route out, rather than a property of the
kernel that reads as permanent.

## 2. A dangling TODO and an unearned measurement

`docs/dfx/dfx-buffer-capacity-audit.md` said the qwen3 row's "peaks need
re-measuring", and asserted dep_gen and l2_swimlane would overflow on the full
graph.

- That table is the evidence behind the right-sizing #977 landed — a snapshot,
  not a live dashboard. A row from a workload ~20x smaller was removed rather
  than refreshed; re-adding it is not a prerequisite for anything in the doc, and
  the "needs re-measuring" phrasing left a task nobody owns.
- The overflow claim is **pypto-lib's** documented warning on `--enable-dep-gen`
  (`models/qwen3/14b/decode_fwd.py`, verified against upstream), not something
  measured here. Now attributed instead of presented as a local result.

Docs only, so per #1522 this runs pre-commit and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)