### PR TITLE
Remove the dead dep_gen guards left in the scheduler cold path

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -15,7 +15,6 @@
 
 #include "common/unified_log.h"
 #include "aicpu/aicpu_device_config.h"
-#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
@@ -979,7 +978,6 @@ void SchedulerContext::post_handshake_profiling_init() {
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
     }
-    if (is_dep_gen_enabled()) {}
 #endif
 }
 
@@ -1213,12 +1211,6 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
     }
-    // dep_gen is host-driven (SubmitTrace) — runtime-gated by the host flag —
-    // and compiles out with the other profiling subsystems at SIMPLER_DFX=0.
-    // init() only pops the initial buffer from instance 0's free_queue; the
-    // orchestrator thread still records its idx via
-    // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
-    if (is_dep_gen_enabled()) {}
 #endif
 
     // total_tasks_ is read in pre_handshake_init (before the orchestrator's early

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -15,7 +15,6 @@
 
 #include "common/unified_log.h"
 #include "aicpu/aicpu_device_config.h"
-#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
@@ -971,7 +970,6 @@ void SchedulerContext::post_handshake_profiling_init() {
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
     }
-    if (is_dep_gen_enabled()) {}
 #endif
 }
 
@@ -1209,12 +1207,6 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
     }
-    // dep_gen is host-driven (SubmitTrace) — runtime-gated by the host flag —
-    // and compiles out with the other profiling subsystems at SIMPLER_DFX=0.
-    // init() only pops the initial buffer from instance 0's free_queue; the
-    // orchestrator thread still records its idx via
-    // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
-    if (is_dep_gen_enabled()) {}
 #endif
 
     // total_tasks_ is read in pre_handshake_init (before the orchestrator's early


### PR DESCRIPTION
## Summary

PR #1486 moved `dep_gen_aicpu_init()` off the scheduler cold path and onto the orchestrator thread (`aicpu_executor.cpp`), but left the two cold-path call sites as empty `if (is_dep_gen_enabled()) {}` shells instead of removing them. This cleans up the vestiges:

- Drop both empty `if (is_dep_gen_enabled()) {}` guards in `post_handshake_profiling_init()` and `post_handshake_init()`.
- Remove the now-stale comment above `post_handshake_init()` that still described the `init()` popping the initial free_queue buffer here — that no longer runs in this file.
- Remove the now-unused `#include "aicpu/dep_gen_collector_aicpu.h"`; no `dep_gen` symbol remains in either `scheduler_cold_path.cpp`.

a2a3 and a5 carried the identical arrangement and are cleaned together. Pure deletion, `SIMPLER_DFX`-gated device code only — no behaviour change.

## Testing

- [ ] Simulation tests pass
- [ ] Hardware tests pass (if applicable)