### PR TITLE
CI: skip ut-a5 while the a5 runner is under repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,7 +785,8 @@ jobs:
   # ---------- Unit tests (a5 hardware, Python + C++) ----------
   ut-a5:
     needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.docs_only != 'true'
+    # The a5 self-hosted runner is under repair; drop the `false &&` to re-enable.
+    if: false && needs.detect-changes.outputs.docs_only != 'true'
     runs-on: [self-hosted, a5]
     timeout-minutes: 30
     env:


### PR DESCRIPTION
The a5 self-hosted runner is out for repair, so `ut-a5` has no host to run on and sits waiting for one instead of reporting a result. This short-circuits its existing gate with `false &&` so it reports **skipped**, mirroring exactly what #1481 already did for `st-onboard-a5` on the same runner.

Nothing declares `needs: ut-a5` and `main` has no required status checks, so the job's absence blocks no merge. Coverage for a5 changes falls back to `st-sim-a5`, which runs on GitHub-hosted runners.

To re-enable once the runner returns: drop the `false &&` from the `if:` gate (same as the note left on `st-onboard-a5`).