### PR TITLE
Add: MkDocs documentation site with a generated API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # Republish without a code change, and exercise the deploy path on demand.
+  workflow_dispatch:
+
+# Allow one deploy at a time; skip superseded runs rather than queueing them.
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      # Deliberately not `pip install .`: that runs scikit-build-core and builds
+      # the C++ runtime. mkdocstrings reads `python/simpler` through griffe, which
+      # parses statically, so the docs need neither a CANN toolkit nor the built
+      # nanobind extension — only the three tools below.
+      - name: Install docs toolchain
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site
+        env:
+          DOCS_REF: ${{ github.event_name == 'push' && 'main' || github.sha }}
+        # --strict fails on a dead intra-docs link, a page missing from nav, or a
+        # bad anchor. See docs/_hooks/griffe_filter.py for the one warning class
+        # that is deliberately not counted.
+        run: mkdocs build --strict --site-dir _site
+
+      - name: Upload artifact
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    # Only main publishes; a pull request builds to prove the docs still compile.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 build/
 .env
 .venv/
+.venv-docs/
 venv/
 .cache
 .ccache/
@@ -44,3 +45,7 @@ python/_task_interface*.dylib
 # Log files
 *.log
 profiling_logs_*/
+
+# mkdocs build output
+_site/
+site/

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,12 @@ Index of every document under `docs/`, grouped by what you are trying to do.
 The top-level [README](../README.md) links only the handful of entry-point docs;
 this page is the complete map.
 
+These pages are also published as a searchable site at
+<https://hw-native-sys.github.io/simpler/>, which adds a generated API reference
+for `simpler.worker`, `simpler.task_interface` and `simpler.orchestrator`. The
+site is built by `.github/workflows/docs.yml`; `mkdocs.yml` owns its navigation,
+so a new page needs a `nav` entry there as well as a row here.
+
 New docs belong in one of the groups below, and in a subdirectory when the group
 already has one (`dfx/`, `hardware/`, `troubleshooting/`, `investigations/`).
 Add the row here in the same commit — an unlisted doc is invisible.

--- a/docs/_hooks/griffe_filter.py
+++ b/docs/_hooks/griffe_filter.py
@@ -1,0 +1,45 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Stop griffe's missing-annotation notices from failing ``--strict``.
+
+``--strict`` is what makes the build fail on a dead link, a page missing from
+``nav``, or an anchor that does not exist — the checks worth gating on. It counts
+warnings through ``mkdocs.utils.CountHandler`` on the root logger, which also
+picks up griffe's "No type or annotation for parameter". That one reports a
+*source* typing gap — a parameter the docstring describes but the signature does
+not annotate — not a documentation defect, and it cannot be fixed from here
+without inventing a type for a parameter whose accepted values have to be
+established first.
+
+The filter is attached to the counting handler only, so the warning still prints
+and stays visible; it just does not abort the build. Every other griffe or MkDocs
+warning is still counted and still fails ``--strict``. Remove this hook once the
+annotations land.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from mkdocs.utils import CountHandler
+
+_SUPPRESSED = "No type or annotation for parameter"
+
+
+class _UncountMissingAnnotation(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return _SUPPRESSED not in record.getMessage()
+
+
+def on_pre_build(config) -> None:  # noqa: ANN001, ARG001 -- MkDocs hook signature
+    # Not on_startup: `build()` attaches the counter to the `mkdocs` logger at its
+    # own entry, which is after startup but before this event fires.
+    for handler in logging.getLogger("mkdocs").handlers:
+        if isinstance(handler, CountHandler):
+            handler.addFilter(_UncountMissingAnnotation())

--- a/docs/_hooks/repo_links.py
+++ b/docs/_hooks/repo_links.py
@@ -1,0 +1,65 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Rewrite doc links that point outside ``docs/`` to absolute repository URLs.
+
+The docs are written to be read on GitHub, where a relative link like
+``../../src/common/hierarchical/worker.cpp`` resolves. MkDocs only serves
+``docs_dir``, so those links would 404 on the built site — roughly a quarter of
+all relative links in ``docs/`` leave the tree, most of them citing source files
+as evidence for a claim.
+
+This hook resolves each relative link against the page's own directory and, when
+the target escapes ``docs/``, replaces it with a permalink into the repository at
+the ref being built. Links that stay inside ``docs/`` are untouched, so MkDocs
+still validates them and ``--strict`` still catches a genuinely dead one.
+"""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+
+REPO_URL = "https://github.com/hw-native-sys/simpler"
+
+# Ref to point at. CI sets DOCS_REF; a local build falls back to main.
+REF = os.environ.get("DOCS_REF", "main")
+
+# ](target) or ](target#anchor) — skips images, absolute URLs and pure anchors.
+_LINK = re.compile(r"(?<!!)\]\((?!https?://|mailto:|#)([^)\s]+?)(#[^)]*)?\)")
+
+# Directories serve as tree/ URLs; files as blob/. A trailing slash means a dir.
+_TREE_SUFFIX = ("/",)
+
+
+def _repo_url(target: str) -> str:
+    kind = "tree" if target.endswith(_TREE_SUFFIX) else "blob"
+    return f"{REPO_URL}/{kind}/{REF}/{target.rstrip('/')}"
+
+
+def on_page_markdown(markdown: str, page, config, files) -> str:  # noqa: ARG001 -- MkDocs hook signature
+    page_dir = posixpath.dirname(page.file.src_uri)
+
+    def replace(match: re.Match[str]) -> str:
+        target, anchor = match.group(1), match.group(2) or ""
+        resolved = posixpath.normpath(posixpath.join(page_dir, target))
+        # normpath drops a trailing slash; keep it so directories stay tree/ URLs.
+        if target.endswith("/"):
+            resolved += "/"
+        if not resolved.startswith(".."):
+            return match.group(0)  # still inside docs/ — leave for MkDocs to check
+        # Strip only the leading ../ hops that took us out of docs_dir. Not
+        # lstrip("./"), which would also eat the dot of a dotfile path such as
+        # ../.claude/rules/codestyle.md and yield claude/rules/....
+        repo_path = resolved
+        while repo_path.startswith("../"):
+            repo_path = repo_path[3:]
+        return f"]({_repo_url(repo_path)}{anchor})"
+
+    return _LINK.sub(replace, markdown)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,8 @@
+# Documentation site toolchain, deliberately separate from the project's own
+# dependencies: installing the project would run scikit-build-core and compile
+# the C++ runtime, which the docs build does not need. mkdocstrings reads
+# `python/simpler` through griffe, which parses the source statically — nothing
+# is imported, so no CANN toolkit and no built extension are required.
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.26

--- a/docs/user/reference/api/orchestrator.md
+++ b/docs/user/reference/api/orchestrator.md
@@ -1,0 +1,7 @@
+# `simpler.orchestrator`
+
+Generated from the source. For the curated view — which `**config` keys
+`Worker` accepts, `CallConfig` defaults, and the argument-order footguns — see
+[Python API](../python-api.md).
+
+::: simpler.orchestrator

--- a/docs/user/reference/api/task_interface.md
+++ b/docs/user/reference/api/task_interface.md
@@ -1,0 +1,7 @@
+# `simpler.task_interface`
+
+Generated from the source. For the curated view — which `**config` keys
+`Worker` accepts, `CallConfig` defaults, and the argument-order footguns — see
+[Python API](../python-api.md).
+
+::: simpler.task_interface

--- a/docs/user/reference/api/worker.md
+++ b/docs/user/reference/api/worker.md
@@ -1,0 +1,7 @@
+# `simpler.worker`
+
+Generated from the source. For the curated view — which `**config` keys
+`Worker` accepts, `CallConfig` defaults, and the argument-order footguns — see
+[Python API](../python-api.md).
+
+::: simpler.worker

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -1,8 +1,12 @@
 # Python API reference
 
-The surface you write against, hand-maintained. There is no generated API
-reference in this repo, so treat the source as authoritative when the two
-disagree and fix this page in the same change.
+The surface you write against, hand-maintained: what `**config` keys `Worker`
+accepts, `CallConfig` defaults, and the argument-order footguns a generator
+cannot state. For the complete generated listing of every public symbol and
+signature, see the API pages on the
+[documentation site](https://hw-native-sys.github.io/simpler/user/reference/api/worker/).
+Treat the source as authoritative when the two disagree, and fix this page in the
+same change.
 
 `Worker` is available from the package root; the remaining task and callable
 types live in `simpler.task_interface`. Both resolve on first access, so

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,141 @@
+site_name: simpler
+site_description: "Simple Runtime — make writing runtime simpler"
+site_url: https://hw-native-sys.github.io/simpler/
+repo_url: https://github.com/hw-native-sys/simpler
+repo_name: hw-native-sys/simpler
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+# Build inputs that live under docs/ but are not content.
+exclude_docs: |
+  _hooks/
+  requirements.txt
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle: { icon: material/weather-night, name: Switch to dark mode }
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle: { icon: material/weather-sunny, name: Switch to light mode }
+
+hooks:
+  - docs/_hooks/repo_links.py
+  - docs/_hooks/griffe_filter.py
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [python]
+          options:
+            docstring_style: google
+            show_source: false
+            show_root_heading: true
+            members_order: source
+            filters: ["!^_"]
+            separate_signature: true
+            show_signature_annotations: true
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - tables
+  - toc: { permalink: true }
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight: { anchor_linenums: true }
+
+nav:
+  - Home: README.md
+  - Using simpler:
+      - Overview: user/README.md
+      - Getting Started: getting-started.md
+      - Installation: install.md
+      - Capability Survey: capability-survey.md
+      - How-to:
+          - Write and run a kernel: user/how-to/write-and-run-a-kernel.md
+          - Run on multiple chips: user/how-to/run-on-multiple-chips.md
+          - Profile a kernel: user/how-to/profile-a-kernel.md
+          - Debug a failed run: user/how-to/debug-a-failed-run.md
+      - Reference:
+          - Python API: user/reference/python-api.md
+          - Command line and tools: user/reference/cli.md
+          - Generated API:
+              - simpler.worker: user/reference/api/worker.md
+              - simpler.task_interface: user/reference/api/task_interface.md
+              - simpler.orchestrator: user/reference/api/orchestrator.md
+  - Architecture:
+      - Chip-Level Architecture: chip-level-arch.md
+      - Hierarchical Level Runtime: hierarchical-level-runtime.md
+      - Task Flow: task-flow.md
+      - Orchestrator: orchestrator.md
+      - Scheduler: scheduler.md
+      - Worker Manager: worker-manager.md
+      - Hardware:
+          - Chip architecture: hardware/chip-architecture.md
+          - Cache coherency: hardware/cache-coherency.md
+          - MMIO performance: hardware/mmio-performance.md
+          - CANN source references: hardware/cann-source-references.md
+  - Kernels:
+      - AICore Kernel Programming: aicore-kernel-programming.md
+      - a5 SIMT Launch: simt-launch.md
+      - Manual Scope: manual-scope.md
+      - WAR Anti-Dependencies: war-anti-dependency.md
+      - TPUSH/TPOP: tpush-tpop.md
+  - Launch and linking:
+      - AICPU Kernel Launch: aicpu-kernel-launch-mechanisms.md
+      - Dynamic Linking: dynamic-linking.md
+      - Callable Identity: callable-identity-registration.md
+      - Callable IPC Registration: callable-ipc-dynamic-register.md
+      - Python Callable Serialization: python-callable-serialization.md
+  - Multi-chip and comm:
+      - Communication Domains: comm-domain.md
+      - a5 SDMA Overlay: a5-sdma-overlay.md
+      - L3-L2 Orchestrator Comm: l3-l2-orch-comm.md
+      - L3-L2 Message Queue: l3-l2-message-queue.md
+      - Directed NEXT_LEVEL Scheduling: directed-next-level-scheduling.md
+      - Remote L3 Worker Design: remote-l3-worker-design.md
+  - Profiling and DFX:
+      - Overview: dfx/README.md
+      - Profiling Framework: dfx/profiling-framework.md
+      - Config naming rules: dfx/profiling-config-naming.md
+      - Name map: dfx/profiling-name-map.md
+      - Log System: logging.md
+      - L2 Timing: dfx/l2-timing.md
+      - Host trace: dfx/host-trace.md
+      - Device phases: dfx/device-phases.md
+      - Scheduler-overhead model: dfx/sched-overhead-model.md
+      - L2 Swimlane: dfx/l2-swimlane-profiling.md
+      - L0 Swimlane: dfx/l0-swimlane-profiling.md
+      - PMU: dfx/pmu-profiling.md
+      - Args dump: dfx/args-dump.md
+      - dep_gen: dfx/dep-gen.md
+      - Scope stats: dfx/scope-stats.md
+      - Global backpressure: dfx/global-backpressure-design.md
+      - Buffer capacity audit: dfx/dfx-buffer-capacity-audit.md
+  - Build and test:
+      - Developer Guide: developer-guide.md
+      - Testing: testing.md
+      - CI Pipeline: ci.md
+      - Python Packaging: python-packaging.md
+      - Sanitizers: sanitizers.md
+      - Sim Multi-Device Isolation: sim-multi-device-isolation.md
+  - Troubleshooting:
+      - Device error codes: troubleshooting/device-error-codes.md
+      - Local timeout defaults: troubleshooting/local-timeout-defaults.md
+      - a2a3 507899 AICPU shared-SO fault: troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
+      - Sim oversubscription hang: troubleshooting/sim-oversubscription-hang.md
+      - macOS build: troubleshooting/macos-build.md
+      - macOS libomp collision: troubleshooting/macos-libomp-collision.md
+      - cpput gtest ABI: troubleshooting/ut-cpp-gtest-abi.md
+  - Investigations: investigations/README.md


### PR DESCRIPTION
## Summary

Builds `docs/` into a searchable site (MkDocs + Material) and adds a **generated** API reference for `simpler.worker`, `simpler.task_interface` and `simpler.orchestrator` via mkdocstrings — 98 pages, `--strict` clean.

The generated pages sit **alongside** the hand-written `python-api.md`, not instead of it. The curated page keeps what a generator cannot state: which `**config` keys `Worker` accepts, `CallConfig` defaults, and the argument-order footguns (`Orchestrator.malloc(worker_id, size)` vs `Worker.malloc(size, worker_id)`).

**Relationship to #1542:** that PR adds the docstrings this reference renders. The two are independent — I verified this site builds `--strict` clean on plain `main` without it — but the generated pages are noticeably thinner until it lands. Either order works.

## The two build details that carry the design

**Out-of-tree links.** A quarter of the relative links in `docs/` leave the tree — **132 of 523**, mostly citing a source file as evidence for a claim — and MkDocs only serves `docs_dir`, so every one would 404 on the site. `docs/_hooks/repo_links.py` resolves each link against its own page and rewrites only the ones that escape, into permalinks at the ref being built. Intra-docs links are left alone so `--strict` still validates them. **The docs stay readable on GitHub**, where those relative paths resolve, with no rewriting of the prose.

Validated: all 75 unique rewritten targets exist in the repo, directories get `tree/` and files `blob/`, and no `../src/`-style link survives in the output.

**Strictness.** `--strict` makes a dead intra-docs link, a page missing from `nav`, or a bad anchor fail CI. griffe additionally warns about parameters a docstring describes but the signature does not annotate — a *source typing* gap, not a doc defect, and not fixable here without first establishing what e.g. `ChipWorker.init`'s `bins` accepts. `docs/_hooks/griffe_filter.py` attaches a filter to **the strict counter alone**, so that one message still prints and stays visible but does not abort; every other warning still fails the build. Nine such gaps exist today and are worth a follow-up.

## The workflow does not build the project

`pip install -r docs/requirements.txt`, deliberately **not** `pip install .` — the latter runs scikit-build-core and compiles the C++ runtime. mkdocstrings reads the API through griffe, which parses statically, so the docs job needs **neither a CANN toolkit nor the built nanobind extension**.

I proved this rather than assuming: the site builds with full API docs in an environment where `simpler` is **not installed at all**. An earlier draft of this PR did use a `[docs]` extra in `pyproject.toml`; I dropped it because installing the project unavoidably triggers the cmake build, which would have contradicted the workflow's own comment.

A pull request builds the site to prove it compiles; only `main` deploys.

## GitHub Pages — now enabled

Pages is **enabled** with **GitHub Actions** as the source (`build_type: workflow`, `https_enforced: true`, no custom domain), and the `github-pages` environment exists. The site will be at:

**<https://hw-native-sys.github.io/simpler/>**

It returns 404 until this PR merges, because `deploy` only runs off `main`. `workflow_dispatch` is now also accepted, so the site can be republished — or the deploy path exercised — without a code change.

**The one step not yet end-to-end verified is `deploy` itself**, since it is skipped on pull requests by design. Repo-level `default_workflow_permissions` is `read`, which does not block us — the job declares `pages: write` and `id-token: write` explicitly, and that setting only governs the default when a workflow declares nothing. I could not read the **org-level** Actions policy (403, needs `admin:org`), so if the first deploy fails on permissions that is where to look.

Rebased onto `main` after #1542 merged, and re-verified the generated pages now render those docstrings — `numeric IPv4`, `HOST_INLINE`, the payload-vs-allocation `nbytes` note, and both retryable `close()` drain paths all appear in the built HTML.

## Verification

- [x] `mkdocs build --strict` exits 0 — 98 pages, 12M
- [x] Builds clean on plain `main` too, i.e. independent of #1542
- [x] All 75 rewritten repo links resolve to files/dirs that exist; `tree/` vs `blob/` correct
- [x] `docs/_hooks/` and `docs/requirements.txt` excluded from the published output
- [x] `ruff check` / `ruff format --check` clean on both hooks; `markdownlint-cli2` clean on the changed markdown
- [x] Site content spot-checked to contain real docstring text, not just signatures

One bug worth recording, caught by validating rather than eyeballing: the first version of the link hook used `lstrip("./")`, which also ate the leading dot of dotfile paths and turned `.claude/rules/codestyle.md` into `claude/rules/codestyle.md`. That would have shipped 24 silently broken links.