### PR TITLE
Fix: accept interior copy_to/copy_from ranges within a live allocation

### DIFF
--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -62,8 +62,8 @@ else raises. Remote-worker and remote-memory calls require `level >= 4`.
 | ------ | ----- |
 | `malloc(size, worker_id=0) -> int` | Returns a device pointer as an integer |
 | `free(ptr, worker_id=0)` | |
-| `copy_to(dst, src, size, worker_id=0)` | H2D; `dst` is a device pointer, `src` a host address |
-| `copy_from(dst, src, size, worker_id=0)` | D2H; `dst` is the host address |
+| `copy_to(dst, src, size, worker_id=0)` | H2D; `dst` is a device pointer, `src` a host address. `dst` may be a `base + offset` interior address as long as `[dst, dst + size)` lies within one live allocation (partial update of a persistent buffer) |
+| `copy_from(dst, src, size, worker_id=0)` | D2H; `dst` is the host address. `src` may be an interior address whose `[src, src + size)` lies within one live device allocation |
 | `create_host_buffer(nbytes) -> HostBuffer` / `free_host_buffer(handle)` | Host-side buffer the device can reach |
 | `remote_malloc` / `remote_free` / `remote_copy_to` / `remote_copy_from` / `remote_export` / `remote_import` / `remote_release_import` | L4 only |
 

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -491,7 +491,7 @@ class Orchestrator:
             return int(self._o.malloc(wid, sz))
         with self._worker._child_prov_lock:
             ptr = int(self._o.malloc(wid, sz))
-            self._worker._child_prov_record_malloc(wid, ptr)
+            self._worker._child_prov_record_malloc(wid, ptr, sz)
             return ptr
 
     def free(self, worker_id: int, ptr: int) -> None:
@@ -519,7 +519,7 @@ class Orchestrator:
             self._o.copy_to(wid, d, int(src), int(size))
             return
         with self._worker._child_prov_lock:
-            self._worker._child_prov_require_live(wid, d, api="copy_to")
+            self._worker._child_prov_require_live_range(wid, d, int(size), api="copy_to")
             self._o.copy_to(wid, d, int(src), int(size))
 
     def copy_from(self, worker_id: int, dst: int, src: int, size: int) -> None:
@@ -529,7 +529,7 @@ class Orchestrator:
             self._o.copy_from(wid, int(dst), s, int(size))
             return
         with self._worker._child_prov_lock:
-            self._worker._child_prov_require_live(wid, s, api="copy_from")
+            self._worker._child_prov_require_live_range(wid, s, int(size), api="copy_from")
             self._o.copy_from(wid, int(dst), s, int(size))
 
     def alloc(self, shape: Sequence[int], dtype: DataType) -> Tensor:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -450,22 +450,28 @@ _IdentitySnapshotEntry = tuple[bytes, Any, int, str, str]
 
 
 class _ChildProvEntry:
-    """Provenance record for one exact ``(worker_id, device_ptr)`` child pointer.
+    """Provenance record for one exact ``(worker_id, device_ptr)`` allocation base.
 
     Typed rather than a bare presence bit because the same ``(worker_id, ptr)``
     can carry more than one role at once: a ``malloc`` base and a CommDomain
     window / carved buffer pointer can legally alias the same device address.
     The key is live while ``malloc_owned or domain_allocation_ids``; only an
     exact ``malloc`` base is ``free``-able, while a domain pointer is revoked by
-    its domain's release. Interior pointers are never recorded, so a pointer
-    that merely lands inside a live allocation has no entry and is rejected.
+    its domain's release.
+
+    ``ptr`` is the allocation's base; each role also carries the allocation's
+    byte extent so a copy landing at ``base + offset`` can be validated against
+    ``[base, base + extent)``. ``malloc_size`` is the ``malloc`` extent (0 when
+    not malloc-owned); ``domain_allocation_ids`` maps each owning CommDomain
+    allocation id to the extent of the window / buffer recorded at this base.
     """
 
-    __slots__ = ("malloc_owned", "domain_allocation_ids")
+    __slots__ = ("malloc_owned", "malloc_size", "domain_allocation_ids")
 
     def __init__(self) -> None:
         self.malloc_owned: bool = False
-        self.domain_allocation_ids: set[int] = set()
+        self.malloc_size: int = 0
+        self.domain_allocation_ids: dict[int, int] = {}
 
     def is_live(self) -> bool:
         """True iff this entry still carries a role. A role-less entry is dead —
@@ -473,6 +479,15 @@ class _ChildProvEntry:
         entry momentarily left empty (e.g. an interrupted revoke) never
         re-authorizes a freed pointer."""
         return self.malloc_owned or bool(self.domain_allocation_ids)
+
+    def live_extent(self) -> int:
+        """Byte extent of the largest live role recorded at this base. A copy
+        range is admitted iff it fits within ``[base, base + live_extent())``,
+        so aliased roles of differing sizes admit up to the widest of them."""
+        extent = self.malloc_size if self.malloc_owned else 0
+        if self.domain_allocation_ids:
+            extent = max(extent, *self.domain_allocation_ids.values())
+        return extent
 
 
 @dataclass
@@ -5338,11 +5353,14 @@ class Worker:
         # one of them is validated against its owning chip. Revoked by
         # _release_domain_now just before the backend free (a commit barrier),
         # not by the deferred marker — so the deferred window stays dispatchable.
+        buf_nbytes = {b.name: int(b.nbytes) for b in buffers}
         with self._child_prov_lock:
             for chip_idx, ctx in contexts.items():
-                self._child_prov_record_domain(chip_idx, int(ctx.local_window_base), allocation_id)
-                for buf_ptr in ctx.buffer_ptrs.values():
-                    self._child_prov_record_domain(chip_idx, int(buf_ptr), allocation_id)
+                self._child_prov_record_domain(
+                    chip_idx, int(ctx.local_window_base), allocation_id, int(ctx.actual_window_size)
+                )
+                for buf_name, buf_ptr in ctx.buffer_ptrs.items():
+                    self._child_prov_record_domain(chip_idx, int(buf_ptr), allocation_id, buf_nbytes[buf_name])
         return handle
 
     def _release_domain_handle(self, handle: CommDomainHandle, resources: _RunResources) -> None:
@@ -5605,17 +5623,20 @@ class Worker:
     # successful native alloc; revoke before the native free.
     # ------------------------------------------------------------------
 
-    def _child_prov_record_malloc(self, worker_id: int, ptr: int) -> None:
-        """Mark ``(worker_id, ptr)`` as a live malloc base (after a successful malloc)."""
+    def _child_prov_record_malloc(self, worker_id: int, ptr: int, size: int) -> None:
+        """Mark ``(worker_id, ptr)`` as a live malloc base spanning ``size`` bytes
+        (after a successful malloc)."""
         entry = self._child_alloc_prov.get((worker_id, ptr))
         if entry is None:
             # Fully initialise the role BEFORE inserting, so the dict never holds
             # a role-less (dead) entry even if an async unwind lands here.
             entry = _ChildProvEntry()
             entry.malloc_owned = True
+            entry.malloc_size = size
             self._child_alloc_prov[(worker_id, ptr)] = entry
         else:
             entry.malloc_owned = True
+            entry.malloc_size = size
 
     def _child_prov_require_malloc_base(self, worker_id: int, ptr: int, *, api: str) -> None:
         """Require ``(worker_id, ptr)`` to be an exact live malloc base (freeable).
@@ -5644,22 +5665,46 @@ class Worker:
         else:
             del self._child_alloc_prov[key]  # last role — delete directly, no empty state
 
-    def _child_prov_require_live(self, worker_id: int, ptr: int, *, api: str) -> None:
-        """Require ``(worker_id, ptr)`` to be a live child pointer (malloc or domain)."""
-        entry = self._child_alloc_prov.get((worker_id, ptr))
-        if entry is None or not entry.is_live():
-            raise ValueError(
-                f"Worker.{api}: device pointer 0x{ptr:x} is not a live allocation on worker "
-                f"{worker_id} (wrong worker, freed/stale, or an interior pointer)"
-            )
+    def _child_prov_require_live_range(self, worker_id: int, ptr: int, nbytes: int, *, api: str) -> None:
+        """Require ``[ptr, ptr + nbytes)`` to lie wholly within one live allocation
+        (malloc or domain) on ``worker_id``.
 
-    def _child_prov_record_domain(self, worker_id: int, ptr: int, allocation_id: int) -> None:
-        """Record a CommDomain window / buffer pointer at exact ``(worker_id, ptr)``."""
+        Accepts an interior range of a live allocation — ``base + offset`` up to
+        the allocation's extent — so a partial update of a persistent buffer is
+        valid. Still rejects a wrong-worker pointer, a freed/stale pointer, and a
+        range that overruns its allocation. Python ints are unbounded, so the
+        ``ptr + nbytes`` bound is exact with no wraparound.
+
+        A copy to the exact base is the common case and resolves in O(1); only an
+        interior address falls back to scanning the worker's live allocations.
+        """
+        if nbytes < 0:
+            raise ValueError(f"Worker.{api}: nbytes must be non-negative, got {nbytes}")
+        exact = self._child_alloc_prov.get((worker_id, ptr))
+        if exact is not None and exact.is_live() and nbytes <= exact.live_extent():
+            return
+        end = ptr + nbytes
+        for (wid, base), entry in self._child_alloc_prov.items():
+            if wid != worker_id or base >= ptr or not entry.is_live():
+                continue
+            if end <= base + entry.live_extent():
+                return
+        raise ValueError(
+            f"Worker.{api}: device range [0x{ptr:x}, 0x{ptr:x}+{nbytes}) is not contained in a live "
+            f"allocation on worker {worker_id} (wrong worker, freed/stale, or out of allocation range)"
+        )
+
+    def _child_prov_record_domain(self, worker_id: int, ptr: int, allocation_id: int, extent: int) -> None:
+        """Record a CommDomain window / buffer pointer at exact ``(worker_id, ptr)``,
+        spanning ``extent`` bytes from that base. A carved buffer at offset 0
+        aliases its window's base under the same allocation id; keep the widest
+        extent so recording the smaller buffer never narrows the window's range."""
         entry = self._child_alloc_prov.get((worker_id, ptr))
         if entry is None:
             entry = _ChildProvEntry()
             self._child_alloc_prov[(worker_id, ptr)] = entry
-        entry.domain_allocation_ids.add(allocation_id)
+        prior = entry.domain_allocation_ids.get(allocation_id, 0)
+        entry.domain_allocation_ids[allocation_id] = max(prior, extent)
 
     def _child_prov_drop_domain(self, allocation_id: int) -> None:
         """Drop every pointer recorded by a CommDomain allocation (at the start of
@@ -5669,7 +5714,7 @@ class Worker:
             if allocation_id not in entry.domain_allocation_ids:
                 continue
             if entry.malloc_owned or len(entry.domain_allocation_ids) > 1:
-                entry.domain_allocation_ids.discard(allocation_id)  # other roles remain
+                del entry.domain_allocation_ids[allocation_id]  # other roles remain
             else:
                 del self._child_alloc_prov[key]  # last role — delete directly, no empty state
 
@@ -5738,7 +5783,7 @@ class Worker:
                 # provenance is keyed on the canonical worker 0.
                 with self._child_prov_lock:
                     ptr = self._chip_worker.malloc(size)
-                    self._child_prov_record_malloc(0, int(ptr))
+                    self._child_prov_record_malloc(0, int(ptr), int(size))
                     return ptr
             self._check_chip_worker_id(worker_id)
             assert self._orch is not None
@@ -5767,7 +5812,7 @@ class Worker:
             if self.level == 2:
                 assert self._chip_worker is not None
                 with self._child_prov_lock:
-                    self._child_prov_require_live(0, int(dst), api="copy_to")
+                    self._child_prov_require_live_range(0, int(dst), int(size), api="copy_to")
                     self._chip_worker.copy_to(dst, src, size)
                 return
             self._check_chip_worker_id(worker_id)
@@ -5780,7 +5825,7 @@ class Worker:
             if self.level == 2:
                 assert self._chip_worker is not None
                 with self._child_prov_lock:
-                    self._child_prov_require_live(0, int(src), api="copy_from")
+                    self._child_prov_require_live_range(0, int(src), int(size), api="copy_from")
                     self._chip_worker.copy_from(dst, src, size)
                 return
             self._check_chip_worker_id(worker_id)

--- a/tests/ut/py/test_worker/test_child_addr_guard.py
+++ b/tests/ut/py/test_worker/test_child_addr_guard.py
@@ -8,13 +8,15 @@
 # -----------------------------------------------------------------------------------------------------------
 """G2 — device-address guard ②: kind4 (child_memory) pointer provenance.
 
-Device-free tests that pin the guard's contract: a child device pointer is
-tracked by its exact ``(worker_id, ptr)`` provenance so it is never freed,
-copied, or dispatched to the wrong next-level worker, and a stale (freed)
-pointer is rejected before reuse. Covers every real entry — ``Worker.malloc``
-(L2), ``orch.malloc/copy/free`` (L3, the path that bypasses ``Worker.malloc``),
-``submit_next_level`` / ``submit_next_level_group`` dispatch, and CommDomain
-window pointers — plus the explicit boundary that strict ABA is NOT covered.
+Device-free tests that pin the guard's contract: a child device allocation is
+tracked by its ``(worker_id, base)`` provenance and byte extent. ``free`` and
+kind4 dispatch require the exact base; ``copy_to`` / ``copy_from`` accept any
+range wholly within a live allocation (a ``base + offset`` partial update), but
+still reject a wrong-worker, stale, or out-of-range address. Covers every real
+entry — ``Worker.malloc`` (L2), ``orch.malloc/copy/free`` (L3, the path that
+bypasses ``Worker.malloc``), ``submit_next_level`` /
+``submit_next_level_group`` dispatch, and CommDomain window pointers — plus the
+explicit boundary that strict ABA is NOT covered.
 """
 
 from __future__ import annotations
@@ -40,9 +42,9 @@ def _child_args(ptr: int, *, n: int = 16) -> TaskArgs:
     return args
 
 
-def _record_malloc(w: Worker, worker_id: int, ptr: int) -> None:
+def _record_malloc(w: Worker, worker_id: int, ptr: int, size: int = 64) -> None:
     with w._child_prov_lock:
-        w._child_prov_record_malloc(worker_id, ptr)
+        w._child_prov_record_malloc(worker_id, ptr, size)
 
 
 # ----------------------------------------------------------------------------
@@ -54,12 +56,12 @@ class TestProvenanceTable:
     def test_malloc_base_is_live_then_freed(self):
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_malloc(0, 0x1000)
-            w._child_prov_require_live(0, 0x1000, api="copy_to")  # no raise
+            w._child_prov_record_malloc(0, 0x1000, 64)
+            w._child_prov_require_live_range(0, 0x1000, 64, api="copy_to")  # no raise
             w._child_prov_require_malloc_base(0, 0x1000, api="free")  # no raise
             w._child_prov_clear_malloc(0, 0x1000)
-            with pytest.raises(ValueError, match="not a live allocation"):
-                w._child_prov_require_live(0, 0x1000, api="copy_to")
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x1000, 64, api="copy_to")
 
     def test_free_of_unknown_pointer_rejected(self):
         w = _l3()
@@ -69,43 +71,57 @@ class TestProvenanceTable:
     def test_double_free_stale_before_reuse_rejected(self):
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_malloc(0, 0x1000)
+            w._child_prov_record_malloc(0, 0x1000, 64)
             w._child_prov_clear_malloc(0, 0x1000)
             with pytest.raises(ValueError, match="already-freed/stale"):
                 w._child_prov_require_malloc_base(0, 0x1000, api="free")
 
-    def test_interior_pointer_is_not_a_live_entry(self):
+    def test_interior_range_is_accepted_edges_rejected(self):
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_malloc(0, 0x1000)
-            # A pointer physically inside the allocation has no exact entry.
-            with pytest.raises(ValueError, match="interior"):
-                w._child_prov_require_live(0, 0x1008, api="copy_to")
+            w._child_prov_record_malloc(0, 0x1000, 64)
+            # A range wholly inside the allocation is a valid partial update.
+            w._child_prov_require_live_range(0, 0x1020, 16, api="copy_to")
+            w._child_prov_require_live_range(0, 0x1000, 64, api="copy_to")  # exact fill
+            # One byte past the end overruns the allocation.
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x103F, 2, api="copy_to")
+            # A base below the allocation is out of range too.
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x0FFF, 4, api="copy_to")
+
+    def test_free_still_requires_exact_base_not_interior(self):
+        # copy accepts interior ranges, but free must still hit the exact base.
+        w = _l3()
+        with w._child_prov_lock:
+            w._child_prov_record_malloc(0, 0x1000, 64)
+            with pytest.raises(ValueError, match="not a live malloc base"):
+                w._child_prov_require_malloc_base(0, 0x1020, api="free")
 
     def test_same_numeric_va_on_two_workers_is_independent(self):
         # A raw device VA is not globally unique; the composite key keeps two
         # chips' identical numeric addresses independent.
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_malloc(0, 0x4000)
-            w._child_prov_record_malloc(1, 0x4000)
+            w._child_prov_record_malloc(0, 0x4000, 64)
+            w._child_prov_record_malloc(1, 0x4000, 64)
             w._child_prov_clear_malloc(0, 0x4000)
-            with pytest.raises(ValueError, match="not a live allocation"):
-                w._child_prov_require_live(0, 0x4000, api="copy_to")
-            w._child_prov_require_live(1, 0x4000, api="copy_to")  # survives
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x4000, 64, api="copy_to")
+            w._child_prov_require_live_range(1, 0x4000, 64, api="copy_to")  # survives
 
     def test_domain_pointer_is_not_freeable_but_is_dispatchable(self):
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_domain(0, 0x8000, allocation_id=7)
+            w._child_prov_record_domain(0, 0x8000, allocation_id=7, extent=64)
             # usable for copy / dispatch
-            w._child_prov_require_live(0, 0x8000, api="copy_to")
+            w._child_prov_require_live_range(0, 0x8000, 64, api="copy_to")
             # but not free-able — domains are revoked by release, not free()
             with pytest.raises(ValueError, match="CommDomain buffer"):
                 w._child_prov_require_malloc_base(0, 0x8000, api="free")
             w._child_prov_drop_domain(7)
-            with pytest.raises(ValueError, match="not a live allocation"):
-                w._child_prov_require_live(0, 0x8000, api="copy_to")
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x8000, 64, api="copy_to")
 
     def test_malloc_and_domain_alias_same_pointer(self):
         # A malloc base and a domain buffer can alias the same (worker, ptr).
@@ -113,13 +129,13 @@ class TestProvenanceTable:
         # the domain removes it.
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_malloc(0, 0x9000)
-            w._child_prov_record_domain(0, 0x9000, allocation_id=3)
+            w._child_prov_record_malloc(0, 0x9000, 64)
+            w._child_prov_record_domain(0, 0x9000, allocation_id=3, extent=64)
             w._child_prov_clear_malloc(0, 0x9000)
-            w._child_prov_require_live(0, 0x9000, api="copy_to")  # still live via domain
+            w._child_prov_require_live_range(0, 0x9000, 64, api="copy_to")  # still live via domain
             w._child_prov_drop_domain(3)
-            with pytest.raises(ValueError, match="not a live allocation"):
-                w._child_prov_require_live(0, 0x9000, api="copy_to")
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x9000, 64, api="copy_to")
 
     def test_empty_entry_is_not_live_fail_closed(self):
         # A role-less entry (e.g. one left by an interrupted revoke) must never be
@@ -128,8 +144,8 @@ class TestProvenanceTable:
         w = _l3()
         w._child_alloc_prov[(0, 0x1000)] = _ChildProvEntry()  # both roles empty
         with w._child_prov_lock:
-            with pytest.raises(ValueError, match="not a live allocation"):
-                w._child_prov_require_live(0, 0x1000, api="copy_to")
+            with pytest.raises(ValueError, match="not contained in a live allocation"):
+                w._child_prov_require_live_range(0, 0x1000, 64, api="copy_to")
             with pytest.raises(ValueError, match="not a live malloc base"):
                 w._child_prov_require_malloc_base(0, 0x1000, api="free")
             with pytest.raises(ValueError, match="not a live allocation on target worker 0"):
@@ -141,10 +157,10 @@ class TestProvenanceTable:
         # live one without the fail-closed guard).
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_domain(0, 0x5000, allocation_id=1)
+            w._child_prov_record_domain(0, 0x5000, allocation_id=1, extent=64)
             w._child_prov_drop_domain(1)
             assert (0, 0x5000) not in w._child_alloc_prov
-            w._child_prov_record_malloc(0, 0x6000)
+            w._child_prov_record_malloc(0, 0x6000, 64)
             w._child_prov_clear_malloc(0, 0x6000)
             assert (0, 0x6000) not in w._child_alloc_prov
 
@@ -155,10 +171,10 @@ class TestProvenanceTable:
         # handles; this guard only catches stale-BEFORE-reuse.
         w = _l3()
         with w._child_prov_lock:
-            w._child_prov_record_malloc(0, 0x1000)
+            w._child_prov_record_malloc(0, 0x1000, 64)
             w._child_prov_clear_malloc(0, 0x1000)
-            w._child_prov_record_malloc(0, 0x1000)  # device handed back the same VA
-            w._child_prov_require_live(0, 0x1000, api="copy_to")  # NOT rejected — by design
+            w._child_prov_record_malloc(0, 0x1000, 64)  # device handed back the same VA
+            w._child_prov_require_live_range(0, 0x1000, 64, api="copy_to")  # NOT rejected — by design
 
 
 # ----------------------------------------------------------------------------
@@ -213,19 +229,55 @@ class TestOrchestratorMemoryOps:
         fake = MagicMock()
         fake.malloc.return_value = 0x2000
         o = Orchestrator(fake, w)
-        with pytest.raises(ValueError, match="not a live allocation"):
+        with pytest.raises(ValueError, match="not contained in a live allocation"):
             o.copy_to(0, 0x2000, 0xABCD, 64)
         fake.copy_to.assert_not_called()
         o.malloc(0, 64)
         o.copy_to(0, 0x2000, 0xABCD, 64)
         fake.copy_to.assert_called_once()
 
+    def test_copy_to_interior_range_within_allocation_passes(self):
+        # A partial update wholly inside a live allocation is valid (issue #1537).
+        w = _l3()
+        fake = MagicMock()
+        fake.malloc.return_value = 0x2000
+        o = Orchestrator(fake, w)
+        o.malloc(0, 64)
+        o.copy_to(0, 0x2020, 0xABCD, 16)  # base + 32, 16 bytes — inside [0x2000, 0x2040)
+        fake.copy_to.assert_called_once_with(0, 0x2020, 0xABCD, 16)
+
+    def test_copy_to_range_overrunning_allocation_rejected(self):
+        w = _l3()
+        fake = MagicMock()
+        fake.malloc.return_value = 0x2000
+        o = Orchestrator(fake, w)
+        o.malloc(0, 64)
+        with pytest.raises(ValueError, match="not contained in a live allocation"):
+            o.copy_to(0, 0x203F, 0xABCD, 2)  # last byte at 0x2040 == base + size
+        fake.copy_to.assert_not_called()
+
+    def test_copy_to_domain_window_chunk_not_narrowed_by_aliasing_buffer(self):
+        # A carved buffer at offset 0 aliases the window base under the same
+        # allocation id; recording its smaller extent must not shrink the
+        # window's copy range (a large chunk into the window must still pass).
+        w = _l3()
+        fake = MagicMock()
+        o = Orchestrator(fake, w)
+        with w._child_prov_lock:
+            w._child_prov_record_domain(0, 0x4000, allocation_id=7, extent=2 << 20)
+            w._child_prov_record_domain(0, 0x4000, allocation_id=7, extent=4)  # buffer #0 aliases the base
+        o.copy_to(0, 0x4000, 0xABCD, 1 << 20)  # 1 MiB into a 2 MiB window
+        fake.copy_to.assert_called_once_with(0, 0x4000, 0xABCD, 1 << 20)
+        with pytest.raises(ValueError, match="not contained in a live allocation"):
+            o.copy_to(0, 0x4000, 0xABCD, (2 << 20) + 1)  # one byte past the window
+        assert fake.copy_to.call_count == 1
+
     def test_copy_from_requires_live_device_src(self):
         w = _l3()
         fake = MagicMock()
         fake.malloc.return_value = 0x3000
         o = Orchestrator(fake, w)
-        with pytest.raises(ValueError, match="not a live allocation"):
+        with pytest.raises(ValueError, match="not contained in a live allocation"):
             o.copy_from(0, 0xABCD, 0x3000, 64)
         fake.copy_from.assert_not_called()
 
@@ -349,7 +401,7 @@ class TestSubmitDispatchGuard:
         w = _l3()
         w._chip_shms = [object(), object()]
         with w._child_prov_lock:
-            w._child_prov_record_domain(0, 0x5000, allocation_id=42)
+            w._child_prov_record_domain(0, 0x5000, allocation_id=42, extent=64)
         fake = MagicMock()
         o = Orchestrator(fake, w)
         o.submit_next_level(object(), _child_args(0x5000), None, worker=0)
@@ -406,12 +458,26 @@ class TestL2WorkerPath:
 
     def test_l2_copy_to_requires_live_dst(self):
         w, chip = self._l2()
-        with pytest.raises(ValueError, match="not a live allocation"):
+        with pytest.raises(ValueError, match="not contained in a live allocation"):
             w.copy_to(0x2000, 0xABCD, 64)
         chip.copy_to.assert_not_called()
         w.malloc(64)
         w.copy_to(0x2000, 0xABCD, 64)
         chip.copy_to.assert_called_once()
+
+    def test_l2_copy_to_interior_range_passes(self):
+        # base + offset partial update on the single chip (issue #1537).
+        w, chip = self._l2()
+        w.malloc(64)  # chip.malloc returns 0x2000
+        w.copy_to(0x2020, 0xABCD, 16)
+        chip.copy_to.assert_called_once_with(0x2020, 0xABCD, 16)
+
+    def test_l2_free_of_interior_pointer_rejected(self):
+        w, chip = self._l2()
+        w.malloc(64)
+        with pytest.raises(ValueError, match="not a live malloc base"):
+            w.free(0x2020)
+        chip.free.assert_not_called()
 
 
 # ----------------------------------------------------------------------------
@@ -518,8 +584,8 @@ class TestDomainReleaseOrdering:
         w = _l3()
         w._worker = MagicMock()  # non-None so _release_domain_now proceeds
         with w._child_prov_lock:
-            w._child_prov_record_domain(0, 0x5000, allocation_id=9)
-            w._child_prov_record_domain(1, 0x6000, allocation_id=9)
+            w._child_prov_record_domain(0, 0x5000, allocation_id=9, extent=64)
+            w._child_prov_record_domain(1, 0x6000, allocation_id=9, extent=64)
         handle = SimpleNamespace(name="d", workers=(0, 1), allocation_id=9)
         return w, handle
 


### PR DESCRIPTION
## Problem

Issue #1537: the child-pointer provenance guard keyed every allocation by its exact `(worker_id, base)` and admitted a copy only when the address hit that base. A partial update of a persistent device buffer — `copy_to(base + offset)` into one page of a resident cache (e.g. the DeepSeek V4 decode KV cache) — was rejected as though the interior address were unknown, because the guard stored no allocation extent to range-check against.

```python
base = orch.malloc(worker_id=0, size=64)
orch.copy_to(worker_id=0, dst=base + 32, src=host_ptr, size=16)
# before: ValueError: device pointer ... is not a live allocation
```

## Fix

Record each allocation's byte extent in provenance and validate copies by **containment** instead of exact base:

```
base <= ptr && ptr + nbytes <= base + extent
```

- `_ChildProvEntry` now carries `malloc_size` and maps each CommDomain allocation id to the extent of the window / buffer recorded at that base; `live_extent()` returns the widest live role.
- `copy_to` / `copy_from` (Worker L2 path and Orchestrator L3 path) call the new `_child_prov_require_live_range`, which scans the worker's live allocations and admits any range wholly contained in one. Python ints are unbounded, so the `ptr + nbytes` bound is exact (no wraparound).
- CommDomain windows / carved buffers carry their live extent so interior copies into them are validated too.

`free()` and kind4 dispatch are **unchanged** — they still require the exact base, since they act on the whole allocation, not an interior slice.

## Behavior

| Operation | Before | After |
| --------- | ------ | ----- |
| `copy_to(base + 32, ..., 16)` within a `malloc(64)` | rejected | **accepted** |
| `copy_to(base + 63, ..., 2)` (overruns) | accepted (guard blind to size) | **rejected** — out of range |
| same address on another worker | rejected | rejected |
| copy after `free(base)` | rejected | rejected |
| `free(base + 32)` | rejected | rejected |

## Tests

Device-free, mocked-orchestrator regression coverage in `tests/ut/py/test_worker/test_child_addr_guard.py` for all five cases in the issue, at both the L3 orchestrator and L2 worker entry points. `tests/ut/py/test_worker/` — 349 passed, 2 skipped (pre-existing).

close #1537 