### PR TITLE
Add: READMEs for the six undocumented L3 examples

### DIFF
--- a/examples/workers/l3/README.md
+++ b/examples/workers/l3/README.md
@@ -58,14 +58,36 @@ Two things to know before reading the example:
 
 ## What each example demonstrates
 
+Roughly in reading order — each row assumes the ones above it. Every directory
+has its own README with the run commands and what the golden check proves.
+
+### Start here
+
 | Directory | New concept |
 | --------- | ----------- |
-| [`multi_chip_dispatch/`](multi_chip_dispatch/) | Two chips + one SubWorker. An orchestration fn dispatches a `ChipCallable` to each chip, then submits a Python callable to collect/verify results. |
+| [`multi_chip_dispatch/`](multi_chip_dispatch/) | Two chips + one SubWorker. An orchestration fn dispatches a `ChipCallable` to each chip, then submits a Python callable to collect/verify results. The smallest correct L3 program. |
 | [`child_memory/`](child_memory/) | `orch.malloc` + `Tensor(child_memory=True)` to load a weight once and reuse it across multiple kernel invocations on the same chip. |
-| [`ffn_tp_parallel/`](ffn_tp_parallel/) | Local compute followed by one-domain cross-rank reduction through a domain scratch window. |
-| [`ep_dispatch_combine/`](ep_dispatch_combine/) | MoE-style dispatch/combine over a one-domain communication window. |
-| [`domain_rank_map/`](domain_rank_map/) | Small two-domain example showing domain-local ranks, missing-domain `KeyError`, separate window slices, and real per-domain allreduce. |
-| [`dual_domain_overlap/`](dual_domain_overlap/) | Two overlapping communication domains where worker 1 participates in both, each allocated inside the orchestration via `orch.allocate_domain` and indexed by domain-local rank. |
+| [`per_task_runtime_env/`](per_task_runtime_env/) | One L3 launch where each L2 task binds its own ring sizes through `CallConfig.runtime_env`. |
+
+### Communication domains and collectives
+
+| Directory | New concept |
+| --------- | ----------- |
+| [`allreduce/`](allreduce/) | The minimal collective: allocate a domain, submit one task per rank, golden-check the sum. |
+| [`ffn_tp_parallel/`](ffn_tp_parallel/) | Two dependent stages per rank — AIC matmul then AIV cross-rank reduce — with the producer/consumer edge inferred from a shared buffer address rather than declared. |
+| [`domain_rank_map/`](domain_rank_map/) | What `orch.allocate_domain` actually hands each chip: dense per-domain ranks, `KeyError` for non-members, distinct buffers for overlapping domains. |
+| [`dual_domain_overlap/`](dual_domain_overlap/) | Two overlapping domains where worker 1 holds a different rank in each, plus `submit_next_level_group`. |
+| [`ep_dispatch_combine/`](ep_dispatch_combine/) | Production-shape MoE dispatch/combine: three chained AIV kernels, a five-phase routing protocol, and a hand-laid-out window. The largest example here. |
+
+### Driving a task that is already running
+
+Both submit one long-lived L2 task and then exchange data with it in flight —
+a serving loop rather than a batch DAG. Each needs `aicpu_thread_num = 2`.
+
+| Directory | New concept |
+| --------- | ----------- |
+| [`l3_l2_message_queue/`](l3_l2_message_queue/) | Request/response streaming over the L3-L2 queue: input and output arenas, `peek`/`read_into`/`release`, cooperative `request_stop`. Responses are not paired one-to-one with requests. |
+| [`l3_l2_orch_comm_stream/`](l3_l2_orch_comm_stream/) | The raw form underneath: a shared payload region plus counters, driven by `notify` / `test` / `wait` on a monotonic sequence. |
 
 **Collective algorithm tests** (allreduce, allgather, reduce_scatter, broadcast, all_to_all) have moved to `tests/st/worker/collectives/`. See the scene tests there for the full algorithm corpus including multi-mode allreduce (onephase, twophase, ring, bidirectional_ring, ibing).
 

--- a/examples/workers/l3/domain_rank_map/README.md
+++ b/examples/workers/l3/domain_rank_map/README.md
@@ -1,0 +1,67 @@
+# domain_rank_map — what a communication domain hands each chip
+
+The reference for reading a `ChipDomainContext`. Three chips, two overlapping
+domains, and a first pass that submits **no tasks at all** — it allocates both
+domains and inspects the handles, so you can see exactly what
+`orch.allocate_domain` returns before any kernel muddies the picture.
+
+```text
+even = workers [0, 2]
+tail = workers [1, 2]        # chip 2 is in both
+```
+
+## What this exercises
+
+| Property of the domain handle | Asserted here |
+| ----------------------------- | ------------- |
+| **`domain_rank` is dense and follows `workers` order** | `even` gives chip 0 → rank 0 and chip 2 → rank 1; `tail` gives chip 1 → rank 0 and chip 2 → rank 1. A chip's rank is per domain, not global — chip 2 is rank 1 in both, chip 0 is rank 0 in one and absent from the other. |
+| **A non-member chip is absent, not zero-valued** | `tail[0]` raises `KeyError`. Indexing is the membership test. |
+| **Overlapping domains carve separate buffers** | `even[2].buffer_ptrs["scratch"] != tail[2].buffer_ptrs["scratch"]` — chip 2's two memberships do not alias. |
+| **`device_ctx` and buffer pointers are non-null** | Both must be set before a kernel can address the window. |
+| **Two lifetime styles** | The inspection pass allocates both domains and releases them in a `finally` via `handle.release()`; the reduce pass uses `with orch.allocate_domain(...) as handle`. |
+
+After the inspection pass, each domain runs its own small allreduce — in its
+**own `worker.run()`**, so chip 2 never juggles two collectives at once. That
+separation is deliberate; see `dual_domain_overlap` for the case where both
+domains are live across the same DAG.
+
+## Run
+
+```bash
+# Simulation (3 chips)
+python examples/workers/l3/domain_rank_map/main.py -p a2a3sim -d 0-2
+
+# Hardware (3 chips)
+python examples/workers/l3/domain_rank_map/main.py -p a2a3 -d 0-2
+```
+
+Or as a scene test — `a2a3sim`, `a2a3`, and `a5sim` are marked (the pytest
+path calls `run()` directly, so it is not limited by `main()`'s `--platform`
+choices):
+
+```bash
+pytest examples/workers/l3/domain_rank_map --platform a2a3sim
+```
+
+Exactly three devices are required. The kernels are borrowed from
+`../dual_domain_overlap/kernels/` rather than duplicated.
+
+## Verification
+
+Two independent checks, both required to pass:
+
+1. **Structural** — the rank map, the `KeyError`, and the distinct scratch
+   pointers described above.
+2. **Numerical** — each domain's allreduce output equals the sum of its own
+   members' inputs, within `1e-3`. This is what proves data moved *only*
+   among a domain's participants: chip 1's contribution must not appear in
+   `even`'s result.
+
+## File structure
+
+```text
+domain_rank_map/
+├── main.py
+├── test_domain_rank_map.py
+└── README.md
+```

--- a/examples/workers/l3/dual_domain_overlap/README.md
+++ b/examples/workers/l3/dual_domain_overlap/README.md
@@ -1,0 +1,78 @@
+# dual_domain_overlap — one chip in two communication domains
+
+Three chips, two domains that share a member:
+
+```text
+left  = workers [0, 1]
+right = workers [1, 2]        # chip 1 is in both
+```
+
+Chip 1 receives **two independent `ChipDomainContext` objects**, one per
+domain, each with its own rank, its own scratch pointer, and its own peers.
+Nothing about being in one domain constrains its role in the other.
+
+Where `domain_rank_map` inspects the handles, this example runs real work
+through both and then computes on the results.
+
+## What this exercises
+
+| Concept | How |
+| ------- | --- |
+| **Per-domain identity** | Chip 1 is rank 1 in `left` and rank 0 in `right`. The `workers` list order defines the dense rank, so the same chip legitimately holds two different ranks at once. |
+| **Domains allocated inside the orch function** | `with orch.allocate_domain(name=..., workers=..., window_size=..., buffers=[CommBufferSpec(...)])` — created and released within one orchestration, not configured on the `Worker`. |
+| **`submit_next_level_group`** | The affine stage submits one `TaskArgs` per member in a single call, with `workers=worker_indices`, instead of a loop of `submit_next_level`. |
+| **Compute that depends only on its own domain's result** | Each affine task reads `reduce_out[domain][chip]`. The dependency is implicit — same `buffer.addr` as the reduce output — so `left`'s affine work can never consume `right`'s reduction. |
+
+## Run
+
+```bash
+# Simulation (3 chips)
+python examples/workers/l3/dual_domain_overlap/main.py -p a2a3sim -d 0-2
+
+# Hardware (3 chips)
+python examples/workers/l3/dual_domain_overlap/main.py -p a2a3 -d 0-2
+```
+
+Or as a scene test — `a2a3sim`, `a2a3`, and `a5sim` are marked (the pytest
+path calls `run()` directly, so it is not limited by `main()`'s `--platform`
+choices):
+
+```bash
+pytest examples/workers/l3/dual_domain_overlap --platform a2a3sim
+```
+
+Exactly three devices are required.
+
+## Verification
+
+Per domain and per member chip:
+
+1. `reduce_out` equals the sum of that **domain's** inputs — chip 2's data must
+   not reach `left`, nor chip 0's reach `right`.
+2. `affine_out` equals `reduce_out * scale[chip] + bias[chip]`, with per-chip
+   `scale` and `bias`, so a task that ran against the wrong chip's parameters
+   is caught.
+
+Both are checked to `1e-3`, and both tensors are additionally screened with
+`torch.isfinite` — a non-finite value means the window was read before the
+peer published, which a max-diff test alone can mask.
+
+## File structure
+
+```text
+dual_domain_overlap/
+├── kernels/
+│   ├── aiv/
+│   │   ├── affine_kernel.cpp
+│   │   └── domain_allreduce_sum.cpp
+│   └── orchestration/
+│       ├── affine_orch.cpp
+│       └── domain_allreduce_orch.cpp
+├── main.py
+├── test_dual_domain_overlap.py
+└── README.md
+```
+
+`domain_allreduce_sum.cpp` and `domain_allreduce_orch.cpp` are also compiled by
+`../domain_rank_map/`, which reaches into this directory rather than keeping a
+copy.

--- a/examples/workers/l3/ep_dispatch_combine/README.md
+++ b/examples/workers/l3/ep_dispatch_combine/README.md
@@ -1,0 +1,116 @@
+# ep_dispatch_combine — MoE expert-parallel dispatch and combine
+
+The largest L3 example: a two-card run of the real DeepSeek-V4 FLASH MoE
+shapes, with three AIV kernels chained behind a single orchestration over a
+shared communication window.
+
+```text
+dispatch.cpp      route tokens to the owning rank's experts
+local_expert.cpp  recv_y[e, s, :] = recv_x[e, s, :] * recv_w[e, s]
+combine.cpp       scatter recv_y back by route id, reduce over TOPK
+```
+
+`local_expert` stands in for the production expert MLP — the point of the
+example is the **communication protocol around it**, not the arithmetic.
+
+## Shapes
+
+Production values, except for the rank count:
+
+| Constant | Value | Meaning |
+| -------- | ----- | ------- |
+| `T` | 128 | tokens (decode batch × seq) |
+| `TOPK` | 6 | experts per token |
+| `D` | 4096 | hidden size |
+| `L` | 16 | local experts per rank |
+| `R` | 192 | per-expert receive cap |
+| `N_RANKS` | 2 | **EP=2 here vs EP=16 in production** |
+
+Each rank keeps the same 16-expert load, so only the global expert count
+differs (32 vs 256). These must mirror the constants at the top of the
+kernels.
+
+## The dispatch protocol
+
+One kernel walks five phases, and this is the part worth reading:
+
+| Phase | What happens |
+| ----- | ------------ |
+| `histogram` | Scalar histogram of the routing indices, plus a `(dst, loc_e)`-sorted route table. |
+| `publish` | Push the full `send_counts` table to every peer with `TNOTIFY(AtomicAdd)`, then a `count_done` barrier. |
+| `prefix_sum` | Local prefix sums over the gathered `pub_counts` — no communication. This is what fixes each route's destination slot. |
+| `payload_push` | Per route, `TPUT` three independent tiles (`x` BF16, `weight` FP32, `idx` INT32) into the peer's receive windows, then a `data_done` barrier. |
+| `stage_out` | Copy the receive windows out to host-backed tensors. |
+
+**Why the weight and index tiles are padded to 8 elements:** 8 FP32 = 32 B is
+the minimum vector tile in the PTO ISA (one MTE burst). The host pre-packs each
+row as `[value, 0, …, 0]`; the kernel `TROWSUM`-compacts the receive side down
+to a dense `[L, R]` output. It wastes bandwidth and is still the cheapest legal
+transfer.
+
+`combine` relies on the communication window being **zero-initialised** — it
+scatters into `routed_y_buf` without clearing it first.
+
+## What this exercises
+
+| Concept | How |
+| ------- | --- |
+| **Three children under one `ChipCallable`** | `children=[(0, dispatch), (1, local_expert), (2, combine)]` — the integers are `func_id`s, matching the `rt_submit_aiv_task(0/1/2, …)` calls in the orchestration. Each child declares only the args it consumes; the orchestration signature is the union. |
+| **Ordering without dependencies** | The three tasks run back-to-back because `rt_submit_aiv_task` dispatches in submission order, not because any tensor edge forces it. |
+| **Chaining through host-backed tensors** | `recv_x_out` / `recv_w_out` / `recv_count_out` are `OUTPUT_EXISTING` for dispatch and inputs to `local_expert`; `recv_y` likewise feeds `combine`. |
+| **A hand-laid-out window** | `SCRATCH_NBYTES` sums every region — counts table, two signal areas, three receive windows, the combine push destination, a third signal — and must match the `kOff*` offsets in the kernels. |
+| **Mixed dtypes across one transfer** | BF16 payload, FP32 weights, INT32 indices, in three separate tiles per route. |
+
+## Run
+
+```bash
+# Simulation (2 ranks)
+python examples/workers/l3/ep_dispatch_combine/main.py -p a2a3sim -d 0-1
+
+# Hardware (2 ranks)
+python examples/workers/l3/ep_dispatch_combine/main.py -p a2a3 -d 0-1
+```
+
+Or as a scene test — `a2a3sim`, `a2a3`, and `a5sim` are marked:
+
+```bash
+pytest examples/workers/l3/ep_dispatch_combine --platform a2a3sim
+```
+
+Exactly two devices are required.
+
+## Verification
+
+The host replays the whole dispatch protocol to build the golden, then:
+
+- **`recv_x` is compared bit-exact.** The x channel is a pure copy, so BF16
+  meets BF16 with no cast in between — no tolerance is needed, and none is
+  granted, at any magnitude.
+- **`recv_y` and `routed_y` allow 2 BF16 ULPs** (`rtol = atol = 2**-6`). A
+  single BF16 cast can differ from torch's round-to-nearest-even by one ULP on
+  an exact tie; the FP32 accumulation over `TOPK` terms is itself exact.
+- **Failures print structure, not just a max-diff** — how many rows are bad,
+  the span of `d` they cover, and the got/expected ratio. A dropped `TOPK` term
+  shows up as a ratio of `(TOPK-1)/TOPK`; a lost tail shows as a bad-`d` span
+  at high `d`.
+
+**On the simulator, only `routed_y` is checked.** Sim keeps intermediate child
+outputs device-local when they feed a later child task, so `recv_y` is not
+host-visible there. Hardware runs both the dispatch-output and the reduce
+checks.
+
+## File structure
+
+```text
+ep_dispatch_combine/
+├── kernels/
+│   ├── aiv/
+│   │   ├── combine.cpp
+│   │   ├── dispatch.cpp
+│   │   └── local_expert.cpp
+│   └── orchestration/
+│       └── ep_dispatch_combine_orch.cpp
+├── main.py
+├── test_ep_dispatch_combine.py
+└── README.md
+```

--- a/examples/workers/l3/ffn_tp_parallel/README.md
+++ b/examples/workers/l3/ffn_tp_parallel/README.md
@@ -1,0 +1,71 @@
+# ffn_tp_parallel — tensor-parallel FFN in two dependent stages
+
+**Two chip tasks per rank, chained by a dependency nothing in the Python
+declares.** Stage 2 must not start until stage 1 has produced its output, and
+the orch function contains no barrier, no event, and no ordering call — the
+edge is discovered from the fact that both tasks name the same buffer.
+
+Per rank:
+
+| Stage | Core | Computation |
+| ----- | ---- | ----------- |
+| 1 | AIC | `partial_local = x_shard @ w_shard` |
+| 2 | AIV | `y = sum over ranks of partial_local` |
+
+## What this exercises
+
+| Concept | How |
+| ------- | --- |
+| **Implicit producer/consumer edge** | `host_partial[i]` is `OUTPUT_EXISTING` on the stage-1 submit and `INPUT` on the stage-2 submit. Both carry the same `buffer.addr`, so TensorMap links the two tasks itself — there is no barrier, no event, and no ordering call in the orch function. |
+| **Mixed core types in one DAG** | Stage 1 compiles with `core_type="aic"` and its orchestration calls `rt_submit_aic_task`; stage 2 uses `core_type="aiv"` and `rt_submit_aiv_task`. One `Worker`, one `run()`. |
+| **`func_id`, not core id** | The integer in `children=[(0, core_callable)]` is the `func_id` the orchestration passes to `rt_submit_*_task(func_id, params)` — here `0` for the matmul and `1` for the reduce. It selects *which child kernel*, not which core type. |
+| **Cross-rank exchange through a domain buffer** | The stage-2 kernel reduces over a `scratch` buffer in the communication window: a mailbox of `nranks * M * N` floats followed by a signal tail of `nranks` int32 slots. |
+| **`config_name` on `ChipCallable.build`** | Both callables name an orchestration config symbol alongside the entry function. |
+
+Read the stage-2 kernel as the four-phase collective it is: publish into the
+peer's mailbox slot, notify, wait on the signal tail, accumulate.
+
+## Run
+
+```bash
+# Simulation (2 ranks)
+python examples/workers/l3/ffn_tp_parallel/main.py -p a2a3sim -d 0-1
+
+# Hardware (2 ranks)
+python examples/workers/l3/ffn_tp_parallel/main.py -p a2a3 -d 0-1
+```
+
+Or as a scene test — `a2a3sim`, `a2a3`, and `a5sim` are marked:
+
+```bash
+pytest examples/workers/l3/ffn_tp_parallel --platform a2a3sim
+```
+
+Exactly two devices are required — `parse_device_range` rejects any other
+count. `M = K = N = 64` here and must match `TILE` / `kRows` / `kCols` in the
+AIC and AIV kernels; changing one without the others silently corrupts the
+result.
+
+## Verification
+
+Every rank's `y` is compared against `sum over r of x_shard[r] @ w_shard[r]`
+computed in torch, with `rtol = atol = 1e-4` — the same tolerance
+`scene_test` applies. All ranks must match: an allreduce that only converged
+on rank 0 fails here.
+
+## File structure
+
+```text
+ffn_tp_parallel/
+├── kernels/
+│   ├── aic/
+│   │   └── kernel_local_linear.cpp
+│   ├── aiv/
+│   │   └── kernel_allreduce_sum.cpp
+│   └── orchestration/
+│       ├── allreduce_sum_orch.cpp
+│       └── ffn_local_orch.cpp
+├── main.py
+├── test_ffn_tp_parallel.py
+└── README.md
+```

--- a/examples/workers/l3/l3_l2_message_queue/README.md
+++ b/examples/workers/l3/l3_l2_message_queue/README.md
@@ -1,0 +1,69 @@
+# l3_l2_message_queue — stream requests into a running L2 task
+
+A different shape from every other L3 example. Elsewhere the host builds a DAG,
+submits it, and waits. Here the host submits **one long-lived L2 task** and then
+feeds it a stream of requests while it runs, reading results back as they
+appear — a serving loop, not a batch.
+
+The transport is the L3-L2 message queue: two arenas (input and output) plus a
+descriptor the L2 orchestration receives as plain scalars. See
+[`docs/l3-l2-message-queue.md`](../../../../docs/l3-l2-message-queue.md) for
+the channel's design.
+
+## What this exercises
+
+| Concept | How |
+| ------- | --- |
+| **Creating the channel** | `orch.create_l3_l2_queue(worker_id=0, depth=8, input_arena_bytes=..., output_arena_bytes=...)`. |
+| **Handing it to L2** | `queue.l2_task_arg_scalars()` packs the descriptor into `TaskArgs` as scalars — the L2 side needs no other setup. |
+| **Full-duplex, decoupled** | The host enqueues two requests, drains **three** responses, then enqueues two more. Requests and responses are not paired one-to-one. |
+| **Zero-copy reads** | `queue.output.peek(timeout)` → `read_into(message, buf)` → `release(message)`. `release` is what returns arena space; skipping it stalls the producer once the queue fills. |
+| **Cooperative shutdown** | `queue.request_stop(timeout)` lets the L2 side finish work already accepted. Responses queued before the stop are still drained afterwards. |
+| **Application-level correlation** | The queue's `seq` is transport ordering only. This example carries its own 64-byte headers — `request_id` in, `(request_id, kind, aux)` out — because responses may arrive out of request order and one request may produce several. |
+
+The mode field in each request drives the L2 kernel:
+
+| Request | Mode | Produces |
+| ------- | ---- | -------- |
+| 101 | 1 | two responses (kinds 10 and 11) |
+| 102 | 2 | one response (kind 20) |
+| 103 + 104 | 3 | one response combining both tiles (kind 30, `aux = 104`) |
+
+Note the expected output order: `102`'s response comes back before `101`'s two.
+That is the point — a queue, not a call stack.
+
+## Run
+
+Single device, and unlike the collective examples it runs on all four
+platforms:
+
+```bash
+pytest examples/workers/l3/l3_l2_message_queue --platform a2a3sim
+pytest examples/workers/l3/l3_l2_message_queue --platform a2a3 --device 0
+```
+
+The test file is also the example — `run_l3_l2_message_queue_example(platform,
+device_id)` is importable directly.
+
+`config.aicpu_thread_num = 2` is required: one AICPU thread drains the queue
+while the other runs the transform kernel.
+
+## Verification
+
+Each of the four expected responses is matched **byte-for-byte** against a
+host-packed golden — header and payload — and in the exact order given above.
+An out-of-order or duplicated response fails, as does a payload whose header
+metadata is right but whose tile is wrong.
+
+## File structure
+
+```text
+l3_l2_message_queue/
+├── kernels/
+│   ├── aiv/
+│   │   └── kernel_queue_transform.cpp
+│   └── orchestration/
+│       └── l3_l2_message_queue_orch.cpp
+├── test_l3_l2_message_queue.py
+└── README.md
+```

--- a/examples/workers/l3/l3_l2_orch_comm_stream/README.md
+++ b/examples/workers/l3/l3_l2_orch_comm_stream/README.md
@@ -1,0 +1,64 @@
+# l3_l2_orch_comm_stream — closed-loop host/L2 handshake over a shared region
+
+The lower-level counterpart to [`l3_l2_message_queue`](../l3_l2_message_queue/).
+Same idea — the host drives a task that is already running — but instead of a
+queue with arenas and opcodes, the host and the L2 orchestration share a raw
+**region**: one payload area plus a small counter area they signal through.
+
+Three rounds of a strict ping-pong, then a stop:
+
+```text
+host: write input  ->  bump data_ready  ->  wait completion  ->  read output
+L2:   wait data_ready  ->  transform  ->  bump completion
+```
+
+See [`docs/l3-l2-orch-comm.md`](../../../../docs/l3-l2-orch-comm.md) for the
+mechanism.
+
+## What this exercises
+
+| Concept | How |
+| ------- | --- |
+| **Creating the region** | `orch.create_l3_l2_region(worker_id=0, payload_bytes=..., counter_bytes=...)`, described to L2 via `region.descriptor_scalars()`. |
+| **Named counters at fixed offsets** | `region.counter(0)` is `data_ready`, `region.counter(64)` is `completion`. The offsets are passed to the kernel as scalars — both sides must agree. |
+| **Notify / test / wait** | `counter.notify(seq, NotifyOp.Set)` publishes; `counter.test(seq, WaitCmp.GE)` polls without blocking and returns a snapshot; `counter.wait(seq, WaitCmp.GE, timeout=...)` blocks. The example calls `test` first and only falls back to `wait` when it did not already match — the fast path costs no block. |
+| **Explicit payload transfer** | `region.payload_write(offset, tensor, nbytes)` and `payload_read(...)`, at offsets the host lays out itself: header at 0, input at 64, output after the input. |
+| **A monotonic sequence as the protocol** | Round *n* sets `data_ready` to *n* and waits for `completion >= n`. `GE`, not `EQ`, so a host that fell behind still makes progress. |
+| **In-band shutdown** | The stop is round `_ROUNDS + 1` with opcode 2 in the header — the same notify path as a data round, no separate channel. |
+| **Passing a typed scalar** | `scalar_to_uint64(ctypes.c_float(7.0))` reinterprets a float's bits for `add_scalar`. |
+
+## Run
+
+Single device, all four platforms:
+
+```bash
+pytest examples/workers/l3/l3_l2_orch_comm_stream --platform a2a3sim
+pytest examples/workers/l3/l3_l2_orch_comm_stream --platform a2a3 --device 0
+```
+
+The test file is also the example — `run_closed_loop_stream(platform,
+device_id)` is importable directly.
+
+`config.aicpu_thread_num = 2` is required: one AICPU thread polls the counter
+while the other runs the transform kernel.
+
+## Verification
+
+After each round the host reads the output area and asserts every one of the
+16,384 elements equals `input + 7.0` within `1e-5`. Because the check runs
+**inside the loop**, a round that returned the previous round's data is caught
+immediately — the inputs differ per round by construction (`round_idx * 1000 +
+(i % 251)`), so a stale buffer cannot pass.
+
+## File structure
+
+```text
+l3_l2_orch_comm_stream/
+├── kernels/
+│   ├── aiv/
+│   │   └── kernel_l3_l2_transform.cpp
+│   └── orchestration/
+│       └── l3_l2_orch_comm_orch.cpp
+├── test_l3_l2_orch_comm_stream.py
+└── README.md
+```


### PR DESCRIPTION
## Summary

`examples/workers/l3/` documented 4 of its 10 examples. The other six were reachable only by reading `main.py`, and two — `l3_l2_message_queue` and `l3_l2_orch_comm_stream` — were absent from the directory index, so nothing in the tree pointed at them.

Adds a README to each, following the shape of the existing ones: what the example demonstrates that its predecessors do not, how to run it (both the `main.py` CLI and the scene test, with the device count each requires), and what the golden check actually proves.

| Example | Covers |
| ------- | ------ |
| `ffn_tp_parallel/` | Two dependent stages per rank, with the producer/consumer edge inferred from a shared buffer address |
| `domain_rank_map/` | What `orch.allocate_domain` hands each chip: dense per-domain ranks, `KeyError` for non-members, distinct buffers for overlapping domains |
| `dual_domain_overlap/` | One chip holding a different rank in each of two domains; `submit_next_level_group` |
| `ep_dispatch_combine/` | Production-shape MoE dispatch/combine — three chained AIV kernels, the five-phase routing protocol, the hand-laid-out window |
| `l3_l2_message_queue/` | Request/response streaming into a task that is already running |
| `l3_l2_orch_comm_stream/` | The raw region + counters underneath that queue |

Two facts are stated explicitly because neither is guessable from the call site:

- The integer in `children=[(id, core_callable)]` is the `func_id` the orchestration passes to `rt_submit_aic_task` / `rt_submit_aiv_task`. It selects **which child kernel**, not which core type — core type comes from `core_type=` at compile time and from which `rt_submit_*` the orchestration calls.
- `ep_dispatch_combine` verifies only `routed_y` on the simulator, because sim keeps intermediate child outputs device-local when they feed a later child task, so `recv_y` is not host-visible there.

The directory index is regrouped into reading order and gains rows for `allreduce`, `per_task_runtime_env`, and the two L3-L2 examples that were missing.

## Testing

- [x] `markdownlint-cli2 --config tests/lint/.markdownlint.yaml` — 0 errors across all 11 files in the directory
- [x] Every relative link in the new and edited files resolves to an existing path
- [x] Every run command matches the module's own docstring, `argparse` defaults/choices, and `pytest.mark.device_count` / `platforms`
- [ ] Examples not executed locally — this worktree has no built project venv, and the change is documentation only

Docs only; no code, test, or build files touched.