### PR TITLE
CI: re-enable st-onboard-a5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,8 +785,7 @@ jobs:
   # ---------- Unit tests (a5 hardware, Python + C++) ----------
   ut-a5:
     needs: [detect-changes, pre-commit]
-    # The a5 self-hosted runner is under repair; drop the `false &&` to re-enable.
-    if: false && needs.detect-changes.outputs.docs_only != 'true'
+    if: needs.detect-changes.outputs.docs_only != 'true'
     runs-on: [self-hosted, a5]
     timeout-minutes: 30
     env:
@@ -856,8 +855,7 @@ jobs:
 
   st-onboard-a5:
     needs: [detect-changes, pre-commit]
-    # The a5 self-hosted runner is under repair; drop the `false &&` to re-enable.
-    if: false && needs.detect-changes.outputs.a5_changed == 'true'
+    if: needs.detect-changes.outputs.a5_changed == 'true'
     runs-on: [self-hosted, a5]
     timeout-minutes: 60
     env:


### PR DESCRIPTION
The a5 self-hosted runner is back in service, so the job has a host to run on again. Restore its gate to the same shape as st-onboard-a2a3: gated solely by detect-changes' a5_changed flag, giving a5 changes silicon coverage rather than st-sim-a5 alone.

Drops the note about the repair along with the short-circuit it described — the condition it explained no longer exists.