### PR TITLE
Fix: drop the docs workflow's reference to a deleted hook

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,8 @@ jobs:
       - name: Build site
         env:
           DOCS_REF: ${{ github.event_name == 'push' && 'main' || github.sha }}
-        # --strict fails on a dead intra-docs link, a page missing from nav, or a
-        # bad anchor. See docs/_hooks/griffe_filter.py for the one warning class
-        # that is deliberately not counted.
+        # --strict fails on a dead intra-docs link, a page missing from nav, or
+        # a bad anchor. No warning class is exempt.
         run: mkdocs build --strict --site-dir _site
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

`.github/workflows/docs.yml` told readers to see `docs/_hooks/griffe_filter.py` for "the one warning class that is deliberately not counted" by `mkdocs build --strict`.

That hook no longer exists — it was removed in #1546 once the type annotations it worked around landed. `docs/_hooks/` now holds only `repo_links.py`, and `mkdocs.yml` registers only that one. The strict build has no exempt warning class at all, so the comment both pointed at a missing file and understated the guarantee.

```diff
-        # --strict fails on a dead intra-docs link, a page missing from nav, or a
-        # bad anchor. See docs/_hooks/griffe_filter.py for the one warning class
-        # that is deliberately not counted.
+        # --strict fails on a dead intra-docs link, a page missing from nav, or
+        # a bad anchor. No warning class is exempt.
```

Comment only — no behavior change.

## Testing

- [x] `grep -rIn griffe_filter .` returns no remaining references
- [x] `docs/_hooks/` contains only `repo_links.py`; `mkdocs.yml` `hooks:` lists only that file
- [x] The `docs` workflow's own build job exercises the line this comment describes