### PR TITLE
Fix: drop the stale N_UNROLL value from the unroll orchestration headers

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/README.md
@@ -34,8 +34,7 @@ Softmax becomes a two-pass over a wider buffer, which is why that kernel is
 rewritten rather than adjusted.
 
 `N_UNROLL` is a `#define` at the top of the orchestration source, currently
-**64**. (The file's header comment still says `N_UNROLL=8`; the `#define` is
-what takes effect.)
+**64**.
 
 Dependencies are declared explicitly inside
 `PTO2_SCOPE(PTO2ScopeMode::MANUAL)`, using the primitive

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
+ * Paged Attention Orchestration Function V2 - 4 Tasks Per Group
  *
  * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
  *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (q_tile, n_blocks * block_size)

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
+ * Paged Attention Orchestration Function V2 - 4 Tasks Per Group
  *
  * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
  *   1. QK matmul:  qi @ K^T for n_blocks -> sij_buf (q_tile, n_blocks * block_size)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
+ * Paged Attention Orchestration Function V2 - 4 Tasks Per Group
  *
  * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
  *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (q_tile, n_blocks * block_size)

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
+ * Paged Attention Orchestration Function V2 - 4 Tasks Per Group
  *
  * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
  *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (q_tile, n_blocks * block_size)


### PR DESCRIPTION
## Summary

Four copies of the unroll paged-attention orchestration open with

```c
 * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
```

while `#define N_UNROLL 64` sits twenty lines below. The comment has been wrong since the constant was raised, and it is the first line a reader sees.

**The value is dropped rather than corrected to 64.** The next line already reads "Batches up to N_UNROLL blocks per group" with no number, and the `#define` is the only place the value belongs — restating it in prose is exactly what let the two drift apart. Per [`.claude/rules/comments.md`](https://github.com/hw-native-sys/simpler/blob/main/.claude/rules/comments.md), a comment should state a fact that survives on its own.

All four copies land in one commit:

- `examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/`
- `examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/`
- `tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/`
- `tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/`

The `paged_attention_unroll_manual_scope` README (added in #1571) called out the discrepancy; that sentence goes with it, so the docs do not describe a state that no longer exists.

Found by scanning `examples/`, `tests/`, and `src/` for `#define NAME <int>` whose value disagrees with a `NAME = <int>` mention elsewhere in the same file. These four were the only true positives.

## Testing

- [x] `grep -rn "N_UNROLL=8"` returns nothing repo-wide
- [x] `#define N_UNROLL 64` unchanged in all four files
- [x] `clang-format --output-replacements-xml` clean on all four `.cpp`
- [x] Comment-only — no compiled token changes

Note for rebasing: #1475 touches two of these files and #1521 touches five paths under `paged_attention_unroll*`. The overlap here is a single comment line in each.