### PR TITLE
Add: READMEs for merge_pipeline_barrier, scalar_data, benchmark_bgemm

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/README.md
@@ -18,13 +18,13 @@ For the `Worker` API underneath the framework, see
 | Example | What it teaches |
 | ------- | --------------- |
 | [`vector_example/`](vector_example/) | The smallest complete kernel: `f = (a+b+1)*(a+b+2) + (a+b)`. Runs on sim. |
-| [`scalar_data/`](scalar_data/) | Orchestration-level data manipulation — `GetTensorData` / `SetTensorData` round-trips, `add_inout`, and automatic WAW / WAR waits including on external tensors. |
+| [`scalar_data/`](scalar_data/) | Orchestration-level data manipulation — `get_tensor_data` / `set_tensor_data` round-trips, runtime-created outputs with initial values, and automatic WAW / WAR waits. Also the reference for the one case where they **don't** fire: `add_input` on an external tensor registers no TensorMap entry, so a later `set_tensor_data` races the reader. |
 
 ## Compute
 
 | Example | What it teaches |
 | ------- | --------------- |
-| [`benchmark_bgemm/`](benchmark_bgemm/) | Runtime-configurable tiled matmul `C = sum(k) A[k] @ B[k]`, shaped for measurement. Runs on sim. |
+| [`benchmark_bgemm/`](benchmark_bgemm/) | Runtime-configurable tiled matmul `C = sum(k) A[k] @ B[k]`, laid out as single-axis moves over task count, tile size, work per task, and accumulation depth. Runs on sim. Four of its six cases are `"manual": True` and need `--manual include`. |
 | [`paged_attention/`](paged_attention/) | Online softmax with AIC/AIV subgraph splitting, bfloat16. The baseline the three variants below are compared against. |
 | [`paged_attention_manual_scope/`](paged_attention_manual_scope/) | The same computation with explicit scope control — kernels byte-identical to the baseline's, only the orchestration differs. See [`docs/manual-scope.md`](../../../docs/manual-scope.md). |
 | [`paged_attention_unroll_manual_scope/`](paged_attention_unroll_manual_scope/) | A second implementation, not a patch on the baseline: KV blocks batched into groups of `N_UNROLL`, four tasks per group instead of per block, with the kernels rewritten to match. |

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/README.md
@@ -1,0 +1,81 @@
+# benchmark_bgemm — a shape sweep, not a kernel demo
+
+Tiled batched matmul `C = sum over k of A[k] @ B[k]`, with every dimension that
+matters driven from `params`. The arithmetic is ordinary; the directory exists
+so you can move one axis at a time and watch what it costs.
+
+| Task | Core | Work |
+| ---- | ---- | ---- |
+| `GEMM` | AIC | one `tile_size × tile_size` matmul |
+| `ADD` | AIV | accumulate that tile into `C` |
+
+## The four axes
+
+| Param | Moves | Effect |
+| ----- | ----- | ------ |
+| `matmul_add_task_num` | task count | more, smaller units of scheduling — the dispatch-overhead axis |
+| `incore_data_size` | tile edge | arithmetic per task, quadratically |
+| `incore_loop` | tiles per task | arithmetic per task, linearly, with no extra dispatch |
+| `grid_k` | accumulation depth | how many partial products land in the same `C` tile — the dependency-chain axis |
+
+The cases are laid out as single-axis moves from `Case1`, which is what makes
+them comparable:
+
+| Case | Default run? | `task_num` | `data_size` | `loop` | `grid_k` | Reads as |
+| ---- | ------------ | ---------- | ----------- | ------ | -------- | -------- |
+| `Case1` | no | 64 | 128 | 4 | 2 | the reference point |
+| `Case2` | no | 256 | 128 | 4 | 2 | 4× the tasks |
+| `Case0` | **yes** | 500 | 128 | 4 | 2 | ~8× the tasks |
+| `Case3` | no | 64 | 128 | 16 | 2 | 4× the work per task, same task count |
+| `Case4` | no | 64 | 128 | 4 | 4 | twice the accumulation depth |
+| `Bgemm64` | **yes** | 32 | 64 | 1 | 4 | small tiles, minimal per-task work |
+
+`Case2` against `Case3` is the interesting pair: both quadruple the total
+matmul work relative to `Case1`, one by adding tasks and one by making each
+task bigger.
+
+## Only two cases run by default
+
+`Case1`–`Case4` are marked `"manual": True`, and `_select_cases` drops manual
+cases unless you ask for them (`simpler_setup/scene_test.py`). A plain run
+executes `Case0` and `Bgemm64` only:
+
+```bash
+# default — 2 of 6 cases
+pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3sim
+
+# all six
+pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3sim --manual include
+
+# only the sweep
+pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3sim --manual only
+```
+
+If a `--case` selector matches nothing, the error names this as the likely
+cause — the selected case is manual and the default mode is `exclude`.
+
+All six run on `a2a3sim` as well as `a2a3`, which makes this one of the few
+places you can move these axes without holding a die.
+
+## `C` is INOUT, not OUT
+
+Worth knowing before you copy the `CALLABLE` block. `C` is a zero-initialised
+accumulator: the AIV kernel reads it from GM, adds the matmul result, and
+stores it back, once per `grid_k` iteration. The host-provided zeros therefore
+have to be staged host-to-device, which makes `C` **read-before-write** — an
+`INOUT`, not a pure `OUT`. Declaring it `OUT` would skip the H2D stage and
+accumulate onto whatever the buffer held.
+
+## Run
+
+```bash
+pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3 --device 0 --manual include
+```
+
+Tolerances are `RTOL = ATOL = 1e-3`, with inputs scaled by `0.01` to keep the
+`grid_k`-deep float32 accumulation inside them.
+
+For turning a run into numbers rather than pass/fail, see
+[`docs/dfx/README.md`](../../../../docs/dfx/README.md) — in particular the
+scheduler-overhead model, which is the thing the task-count axis here is built
+to probe.

--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/README.md
@@ -1,0 +1,80 @@
+# merge_pipeline_barrier — three stages, one task, a barrier instead of a scheduler
+
+Everywhere else in this tree, ordering between pipeline stages is what the
+runtime is *for*: submit three tasks, let TensorMap chain them. This example
+does the opposite — it merges all three stages into **one** `block_num=8` AIV
+task and orders them with a cross-core barrier inside the kernel.
+
+```text
+stage A: x + 1        stage B: × 2        stage C: + 1        →  out = 2x + 3
+```
+
+The computation is trivial on purpose. What is under test is the barrier.
+
+## Why a barrier at all
+
+The three stages have deliberately mismatched shapes, so the barrier has to
+work when the cores are unevenly loaded:
+
+| Stage | Work | Blocks doing it |
+| ----- | ---- | --------------- |
+| A | 8 tiles | block 0 only |
+| B | 2 tiles each | blocks 0–3 |
+| C | 1 tile each | all 8 |
+
+**Every block arrives at every barrier, including the idle ones**, so each
+barrier waits for all `block_num` arrivals. Blocks 4–7 do nothing until stage
+C, and still have to show up twice before it.
+
+## Two barrier implementations, chosen at compile time
+
+`MERGE_BARRIER_COUNTER` in `kernels/aiv/merge_pipeline.cpp` selects between
+them (default `1`):
+
+| Value | Mechanism | Reads per barrier |
+| ----- | --------- | ----------------- |
+| `0` | **Per-slot.** Each block writes its own slot with `st_dev`, single-writer so no atomic needed; the reader polls all `n` slots with `ld_dev`. | **O(n)** non-cacheable |
+| `1` | **Single counter.** Arrival is a scalar hardware `st_atomic` add, bracketed by `dcci` so the line is written out atomically; every block then polls that one counter with `ld_dev` until it reaches `epoch * n`. | **O(1)** |
+
+The slot version needs no atomic and no cache maintenance; the counter version
+trades one atomic-add on arrival for a single-address poll. Both use
+`ld_dev`/`st_dev` — non-cacheable device accesses — rather than ordinary loads,
+and the `epoch` argument advances monotonically so a slot or counter is never
+mistaken for a previous barrier's.
+
+Note where the `dcci` calls sit in the counter version: around the *arrival*
+write, not in the poll loop. The reader's `ld_dev` bypasses cache, so the hot
+path carries no cache maintenance at all.
+
+## Measurement is built in
+
+The kernel records each block's per-barrier gap with `get_sys_cnt` into a
+`timing` output — `NBLK × 32` int32, one 32-int stride per block, first 6
+entries used. `compare_outputs` is overridden to print those (ticks at 50 MHz,
+so ÷50 gives µs) and then **drop `timing` from the golden comparison**, since
+it has no expected value.
+
+That override is the pattern to copy whenever a scene test needs a diagnostic
+output alongside checked ones:
+
+```python
+def compare_outputs(self, test_args, golden_args, output_names, params):
+    ...  # print the diagnostic
+    super().compare_outputs(
+        test_args, golden_args, [n for n in output_names if n != "timing"], params
+    )
+```
+
+## Run
+
+```bash
+pytest examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier --platform a2a3 --device 0
+```
+
+**Onboard only, and it cannot be otherwise.** The barrier is a busy-wait, so
+all `block_num` logical blocks must be co-resident — if a block is not running,
+the ones waiting on it never proceed. The case runs with config `block_dim` 24
+against `block_num` 8 (set per task via `launch_spec.set_block_num` in
+`merge_orch.cpp`) to guarantee that.
+
+Wrap in `task-submit` on a shared box.

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
@@ -1,0 +1,73 @@
+# scalar_data — the orchestration reads and writes tensor data itself
+
+Every other example here treats the orchestration as a *scheduler*: it submits
+kernels and touches no data. This one has the orchestration poke individual
+tensor elements with `get_tensor_data` / `set_tensor_data`, interleaved with
+kernel submits, and checks that the runtime orders the two correctly.
+
+Read it for one question: **when the orchestration writes a tensor a kernel is
+using, who waits?**
+
+## The answer, and the trap
+
+`set_tensor_data` auto-waits — but only for tensors TensorMap knows about.
+
+| Tensor kind | Added as | Does `set_tensor_data` wait? |
+| ----------- | -------- | ---------------------------- |
+| runtime-created | anything | **Yes.** TensorMap holds a producer entry, so it waits for the producer to complete (WAW) and for `fanout_refcount` to drain (WAR). |
+| external | `add_output` / `add_inout` | **Yes.** These create a TensorMap entry, so the same lookup works. |
+| external | `add_input` | **No — and this is a data race.** `add_input` on an external tensor creates no TensorMap entry. `set_tensor_data` finds no producer, so it writes immediately, while the reader kernel may still be running. |
+
+That last row is the whole reason this example exists. There is no error and no
+warning; the value is simply overwritten under a running kernel. **On an
+external tensor, use `add_inout` when a later `set_tensor_data` must not race
+the reader**, even though `add_input` describes the kernel's access accurately.
+
+Step 12 in the orchestration demonstrates the safe form: submit `noop` with
+`ext_b` as an output (`noop` reads nothing), then `set_tensor_data(ext_b, 55.0)`
+— which now waits, because the output registered an entry.
+
+## The thirteen steps
+
+`kernels/orchestration/scalar_data_orch.cpp` walks through them in order, each
+landing a value in `check[0..8]`:
+
+| Steps | What is exercised | Lands in |
+| ----- | ----------------- | -------- |
+| 1–3 | `get_tensor_data` on a runtime-created tensor at two indices | `check[0]` = 2.0, `check[1]` = 102.0 |
+| 4–5 | `add_output(TensorCreateInfo, 77.0f)` — a runtime-created output with an **initial value** | `check[2]` = 77.0 |
+| 6–7 | `add_inout` on the same tensor: the buffer already exists, so the submit only registers a dependency; the value survives | `check[3]` = 77.0 |
+| 8 | Plain arithmetic in the orchestration on a value it read back | `check[4]` = 79.0 |
+| 9 | `set_tensor_data` → `get_tensor_data` round-trip | `check[5]` = 42.0 |
+| 10 | Orchestration → AICore RAW: write 10.0, then a kernel reads it | `check[6]` = 12.0 |
+| 11 | WAW + WAR on a runtime-created tensor — `set_tensor_data` waits for both the producer and the consumer | `check[7]` = 88.0 |
+| 12 | External WAR done correctly, via `add_inout` | `check[8]` = 55.0 |
+| 13 | `result = a + b`, external output through `add_inout` | `result` |
+
+`kernel_noop` exists precisely because several steps need a task that
+*registers a dependency* without touching data.
+
+## Cases
+
+One, `default`, `platforms=["a2a3"]`, `aicpu_thread_num: 4`.
+
+Note the comment on the `check` tensor in `generate_args`: it is **exactly 9
+slots**, matching `check[0..8]`. Output-tensor slots are not seeded from the
+host, so a tenth slot would read undefined device memory and the golden
+comparison would fail nondeterministically.
+
+## Run
+
+```bash
+pytest examples/a2a3/tensormap_and_ringbuffer/scalar_data --platform a2a3 --device 0
+```
+
+Onboard only. Wrap in `task-submit` on a shared box.
+
+Each step also logs its observed-vs-expected value with `LOG_INFO_V0`, so a
+failure tells you which step diverged before you look at `check`.
+
+## See also
+
+- [`docs/war-anti-dependency.md`](../../../../docs/war-anti-dependency.md) — write-after-read hazards and how the runtime orders them
+- [`docs/orchestrator.md`](../../../../docs/orchestrator.md) — TensorMap, producer/consumer entries, `fanout_refcount`


### PR DESCRIPTION
## Summary

The three remaining a2a3 examples whose point is not guessable from the directory listing. Each inverts something the rest of the tree takes for granted.

### `merge_pipeline_barrier` — the scheduler replaced by a barrier

Three stages merged into **one** `block_num=8` SPMD task, ordered by an intra-task cross-core barrier instead of by three scheduled tasks. The stages are deliberately unbalanced (stage A on block 0 alone, C on all eight) and **idle blocks still arrive at every barrier**, so each waits for the full block count.

Two implementations sit behind `MERGE_BARRIER_COUNTER`:

| Value | Mechanism | Reads per barrier |
| ----- | --------- | ----------------- |
| `0` | per-slot `st_dev` write, single-writer, reader polls all slots | O(n) non-cacheable |
| `1` (default) | `st_atomic` arrival bracketed by `dcci`, all blocks poll one counter with `ld_dev` | O(1) |

Its `compare_outputs` override is also the pattern for carrying a diagnostic output that has no golden — it prints the per-block barrier gaps (`get_sys_cnt` ticks at 50 MHz) and drops `timing` from the comparison.

### `scalar_data` — where the automatic waits stop

The orchestration reads and writes tensor elements directly, interleaved with submits. The load-bearing fact:

> **`add_input` on an *external* tensor registers no TensorMap entry.** A following `set_tensor_data` finds no producer and writes immediately — under a still-running reader. No error, no warning.

Use `add_inout` (or `add_output`) on external tensors whose later writes must not race. Step 12 of the orchestration is the correct form; the note at step 11 explains why `ext_a` would *not* be safe.

### `benchmark_bgemm` — a shape sweep, not a kernel demo

Cases are single-axis moves from `Case1` over task count, tile size, work per task, and accumulation depth, which is what makes `Case2` (4× the tasks) and `Case3` (4× the work per task) comparable — both quadruple total matmul work by different means.

**Four of the six cases are `"manual": True`**, so a default run executes only `Case0` and `Bgemm64`; `--manual include` gets the rest. And `C` is `INOUT` rather than `OUT` because the zero-initialised accumulator is read before it is written, so its host zeros must be staged H2D.

### Index

The `scalar_data` and `benchmark_bgemm` rows in `examples/a2a3/tensormap_and_ringbuffer/README.md` are sharpened to match — the first previously implied the WAW/WAR waits were universal including on external tensors, which is the opposite of the point.

## Testing

- [x] `markdownlint-cli2 --config tests/lint/.markdownlint.yaml` — 0 errors on all four files
- [x] Every relative link resolves
- [x] `--manual` choices/default confirmed at `conftest.py:110-115`; filtering at `simpler_setup/scene_test.py:666-670`
- [x] Per-case `manual` flags and params read directly from each `CASES` entry; barrier mechanics from `kernels/aiv/merge_pipeline.cpp`; the external-tensor WAR rule from the step 11/12 comments in `scalar_data_orch.cpp`
- [ ] Examples not executed — no built project venv in this worktree; documentation only

Docs only; no code, test, or build files touched.