### PR TITLE
docs: fix scalar_data README to LOG_INFO after V-tier retirement

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
@@ -64,7 +64,7 @@ pytest examples/a2a3/tensormap_and_ringbuffer/scalar_data --platform a2a3 --devi
 
 Onboard only. Wrap in `task-submit` on a shared box.
 
-Each step also logs its observed-vs-expected value with `LOG_INFO_V0`, so a
+Each step also logs its observed-vs-expected value with `LOG_INFO`, so a
 failure tells you which step diverged before you look at `check`.
 
 ## See also


### PR DESCRIPTION
## Summary

Follow-up doc-consistency fix for #1475. That PR replaced the verbose `V0..V9` log tiers with severity levels and migrated `scalar_data_orch.cpp` from `LOG_INFO_V0` to `LOG_INFO`, but the example's `README.md` still named the removed `LOG_INFO_V0` macro. This aligns the doc with the code.

A full-tree grep after #1475 landed (`LOG_INFO_V[0-9] | log_info_v | set_log_info_v | _split_threshold | set_host_log_config | ...`) shows this README was the only remaining stale reference; everything else (interfaces, `docs/logging.md`, DFX/runtime docs, skills/rules) is already clean.

## Testing

Docs-only, single-word change. Verified `scalar_data_orch.cpp` uses `LOG_INFO` and that no other `LOG_INFO_V*` / `info_v` references remain in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)