### PR TITLE
Docs: keep the log-level split where both files say it is

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -250,6 +250,43 @@ The Python-side level snapshot is **one-shot** at `Worker.init()`. Calling
 `logger.setLevel(...)` afterwards has no effect on a live `ChipWorker` —
 recreate the worker if mid-run reconfiguration is needed.
 
+### Forked chip subprocesses
+
+L3 / L4 hierarchical workers fork chip subprocesses. The parent snapshots the
+same threshold **before** `fork()` and passes it explicitly to
+`_chip_process_loop`, so each subprocess runs its own `ChipWorker.init` with
+that value rather than re-reading a logger the child may not have configured.
+
+### Onboard AICPU severity is CANN-owned
+
+The onboard AICPU library reads severity from CANN's `dlog` (`CheckLogLevel`),
+**not** from `KernelArgs.log_level` — the one place where the single-threshold
+model does not reach directly. `simpler_init` bridges the gap: it issues
+`dlog_setlevel(-1, HostLogger.cann_level(), 0)` **unless
+`ASCEND_GLOBAL_LOG_LEVEL` is already set in the environment**, which therefore
+wins over the Python logger.
+
+| Simpler threshold | CANN level |
+| ----------------- | ---------- |
+| `debug` | DEBUG |
+| `info` | INFO |
+| `timing` | WARN |
+| `warn` | WARN |
+| `error` | ERROR |
+| `null` | NUL |
+
+CANN has no TIMING level, so TIMING and WARN both map to CANN WARN. The
+consequence is the one worth remembering: **the default TIMING threshold does
+not open CANN's INFO stream.**
+
+To configure onboard severity directly, set `ASCEND_GLOBAL_LOG_LEVEL=0..4` or
+call `dlog_setlevel(-1, level, 0)` — **before `Worker.init()`**. The AICPU
+reads CANN once, in `init_log_switch()` at the top of its init kernel, and
+latches the answer into `g_is_log_enable_*`; every later `LOG_*` tests those
+flags and never asks CANN again. Since that init kernel runs inside
+`Worker.init()`, anything set afterwards leaves device-side severity where it
+already was.
+
 ## Build orchestration
 
 `libsimpler_log.so` is built **once per `pip install`** (not per

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,46 +161,40 @@ rule; C++ and AICPU use the same single-axis rule.
 At the default TIMING threshold, `[STRACE]`, warnings, and errors are visible;
 ordinary INFO and DEBUG messages are silent.
 
-### Configuration sources
+### Setting it
 
-- **Single source of truth**: the Python `simpler` logger
-  (`logging.getLogger("simpler")`).
-- The simpler module sets this logger to TIMING at import unless the user has
-  already called `setLevel`. Inheritance from the root logger is intentionally
-  not used so `import simpler` keeps timing markers visible despite Python's
-  default `WARNING`.
-- `TIMING` and `NUL` are registered with `logging.addLevelName` at import, so
-  name-based callers and `%(levelname)s` formatters accept and emit them.
-- **Snapshot at `Worker.init()`, not per-run**: when a `Worker` is initialised
-  it reads the current `simpler` logger level once and forwards it through
-  `ChipWorker.init(..., log_level)`. ChipWorker then calls
-  libsimpler_log's `simpler_log_init` (which writes the value into the
-  process-wide `HostLogger` singleton) BEFORE `host_runtime.so` is dlopen'd;
-  the platform SO's `simpler_init` maps `HostLogger.cann_level()` to CANN `dlog`
-  onboard, and AICPU receives the threshold through `InitArgs`.
-  **Subsequent `logger.setLevel(...)`
-  calls are not re-pushed to that worker** — recreate the worker if you need
-  to change levels mid-run.
-- L3 / L4 hierarchical workers fork chip subprocesses; the parent snapshots
-  the same threshold before `fork()` and passes it explicitly
-  to `_chip_process_loop` so each subprocess starts its own `ChipWorker.init`
-  with the correct value.
+```bash
+pytest --platform a2a3sim --log-level debug
+python test_xxx.py -p a2a3sim --log-level debug
+```
 
-### Onboard AICPU severity is CANN-owned
+The `simpler` Python logger (`logging.getLogger("simpler")`) is the single
+source of truth; `--log-level` sets it. Importing `simpler` puts it at TIMING
+unless you have already called `setLevel` — root-logger inheritance is
+deliberately not used, so `import simpler` keeps timing markers visible despite
+Python's default `WARNING`. `TIMING` and `NUL` are registered with
+`logging.addLevelName` at import, so name-based callers and `%(levelname)s`
+formatters accept them.
 
-The onboard AICPU library reads severity from CANN's `dlog` (CheckLogLevel),
-not from `KernelArgs.log_level`. Configure it via
-`ASCEND_GLOBAL_LOG_LEVEL=0..4` or `dlog_setlevel(-1, level, 0)`.
-`simpler_init` (called from `ChipWorker::init` in the platform SO) issues
-`dlog_setlevel(-1, HostLogger.cann_level(), 0)` automatically — unless
-`ASCEND_GLOBAL_LOG_LEVEL` is already set in the environment. The mapping is
-`debug→DEBUG`, `info→INFO`, `timing/warn→WARN`, `error→ERROR`, and
-`null→NUL`. Therefore the default TIMING threshold does not open CANN INFO.
+Two consequences for test authors:
 
-### Output destinations
+- **The threshold is snapshotted once, at `Worker.init()`.** Calling
+  `logger.setLevel(...)` afterwards does not reach a live worker — recreate the
+  worker to change levels mid-run.
+- **Onboard AICPU severity comes from CANN, not from this threshold.**
+  `simpler_init` maps the snapshot onto `dlog_setlevel` for you, but an
+  `ASCEND_GLOBAL_LOG_LEVEL` already in the environment wins. Since CANN has no
+  TIMING level, the default threshold does not open CANN's INFO stream. If you
+  set it yourself, set it **before `Worker.init()`** — the AICPU latches CANN's
+  answer during that call and never re-reads it.
 
-- All log output goes to **stderr** (host + sim AICPU). Onboard AICPU still
-  routes through CANN dlog and lands wherever CANN is configured to write.
+All output goes to **stderr** for host and sim AICPU; onboard AICPU lands
+wherever CANN is configured to write.
+
+For the mechanism behind all of the above — the `HostLogger` singleton, the
+`simpler_log_init` → `dlopen` ordering, the CANN mapping table, and how forked
+chip subprocesses inherit the threshold — see
+[logging.md § Configuration flow](logging.md#configuration-flow).
 
 ## CLI Design Principles
 


### PR DESCRIPTION
## Summary

`docs/logging.md` opens with

> For the **user-facing model** — one Python knob and the CLI flags — see [testing.md § Log levels](testing.md#log-levels). This file documents the implementation.

and `docs/testing.md § Log levels` points back for implementation details. The split is declared in both directions. Neither file held it:

- **testing.md** carried the `simpler_log_init` / `HostLogger` / `InitArgs` chain, the `cann_level()` → CANN mapping, and the fork-time threshold propagation — all mechanism, in the file that says it is not about mechanism.
- **logging.md** restated the one-shot snapshot semantics that testing.md also spelled out.

That is the shape that produces a doc which silently lies: #1475 retired the verbose V-tiers and had two places to land.

### After

**testing.md** answers only what a test author needs — the integer layout, the macro→level table, how to set the threshold, and the two consequences:

- the threshold is snapshotted once at `Worker.init()`, so `logger.setLevel(...)` afterwards does not reach a live worker;
- onboard AICPU severity comes from CANN, and a pre-set `ASCEND_GLOBAL_LOG_LEVEL` wins over the Python logger.

**logging.md** gains what moved, under `## Configuration flow`:

- the CANN mapping as a table (`timing` and `warn` both → CANN WARN, which is *why* the default threshold does not open CANN's INFO stream);
- the `ASCEND_GLOBAL_LOG_LEVEL`-wins rule;
- **forked chip subprocesses**, which were documented nowhere else: L3/L4 parents snapshot the threshold *before* `fork()` and pass it explicitly to `_chip_process_loop`, rather than letting the child re-read a logger it never configured.

### Not a size reduction

testing.md loses 8 lines (788 → 780); logging.md gains 30 (282 → 312). The gain is that one topic now has one owner per aspect. testing.md is still 780 lines / 16 H2 and well past the soft target in [`.claude/rules/doc-consistency.md`](https://github.com/hw-native-sys/simpler/blob/main/.claude/rules/doc-consistency.md) §6 — splitting it is a separate decision, not folded in here.

## Testing

- [x] `mkdocs build --strict` passes
- [x] `markdownlint-cli2 --config tests/lint/.markdownlint.yaml` — 0 errors on both files
- [x] Both cross-links still resolve: `logging.md#configuration-flow` and `testing.md#log-levels` (neither heading renamed)
- [x] Every moved claim checked against source — `dlog_setlevel` / `cann_level()` in `src/common/platform/*/host/c_api_shared.cpp`, the `--log-level` choices in `conftest.py`

Docs only.