### PR TITLE
Docs: make the testing skill mirror ci.yml's onboard quarantines

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -13,9 +13,31 @@ description: Testing guide and pre-commit testing strategy for simpler. Use when
 
 ## Running Tests
 
-**Important**: Always read `.github/workflows/ci.yml` first to extract the
-current `--pto-session-timeout` values. PTO-ISA reproducibility comes from the
-repo-root `pto_isa.pin`.
+**Important**: Always read `.github/workflows/ci.yml` first to extract both the
+current `--pto-session-timeout` values **and the `--ignore` sets the onboard
+sweep carries**. PTO-ISA reproducibility comes from the repo-root `pto_isa.pin`.
+
+**CI does not run one flat sweep.** Some tests are quarantined out of the
+general onboard sweep and run in their own step on their own devices, because
+they are only correct in isolation. Reproducing CI means reproducing that
+shape — a bare `pytest examples tests/st --platform a2a3` is *not* what CI runs
+and will report failures that CI never sees:
+
+| Quarantine | Excludes | Runs instead in |
+| ---------- | -------- | --------------- |
+| `SDMA_IGNORE` (`ci.yml:600`) | `sdma_async_completion_demo`, `prefetch_async_demo` | dedicated "SDMA pytest (a2a3)" step, `--device-num 2` (`ci.yml:628-643`) |
+| `HEAVY_IGNORE` (`ci.yml:605`) | `qwen3_14b_decode` | its own long-timeout step |
+
+The SDMA demos provision 48 device-only STARS streams, which makes an AICore
+fault take ~306 s to tear down instead of ~0.3 s — so they must not share a
+sweep with the `aicore_op_timeout` fault-injection test
+([investigations/2026-07-a2a3-sdma-fault-teardown.md](../../../docs/investigations/2026-07-a2a3-sdma-fault-teardown.md),
+issue #1425).
+
+When an onboard test fails, **run it alone before calling it a regression**.
+Alone-passes plus sweep-fails is an isolation requirement, not a defect: grep
+`ci.yml` for an `--ignore` naming it. Do not "fix" such a test by reordering it
+earlier — that only moves the pollution onto whatever now runs after it.
 
 ### Runtime rebuild decision
 
@@ -47,9 +69,15 @@ ctest --test-dir tests/ut/cpp/build -L "^requires_hardware(_a2a3)?$" --output-on
 pytest examples tests/st --platform a2a3sim \
     --pto-session-timeout <timeout>
 
-# All hardware scene tests (extract timeout from ci.yml; auto-detect idle devs)
-pytest examples tests/st --platform a2a3 --device <range> \
+# All hardware scene tests — mirror ci.yml: carry its --ignore sets, or the
+# quarantined tests fail here and nowhere else (extract both from ci.yml)
+pytest examples tests/st $SDMA_IGNORE $HEAVY_IGNORE --platform a2a3 --device <range> \
     --pto-session-timeout <timeout>
+
+# The quarantined tests, the way CI runs them — alone, on their own devices
+pytest examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo \
+       examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo \
+    --platform a2a3 --device <2 devs> --pto-session-timeout <timeout>
 
 # Single runtime
 pytest examples tests/st --platform a2a3sim --runtime host_build_graph


### PR DESCRIPTION
## Problem

The testing skill told the reader to read `ci.yml` only for `--pto-session-timeout`, then handed them this as the hardware sweep:

```bash
pytest examples tests/st --platform a2a3 --device <range> --pto-session-timeout <timeout>
```

That is **not what CI runs**. The onboard sweep carries `SDMA_IGNORE` (`ci.yml:600`) and `HEAVY_IGNORE` (`ci.yml:605`), and the excluded tests get their own step on their own devices because they are only correct in isolation.

So following the skill produces failures CI never sees. Measured on this box, on unmodified `main`:

- `sdma_async_completion_demo` fails **every** time it shares the general sweep (4/4 runs)
- and passes **alone** (1/1) — which is exactly how `ci.yml:628-643` runs it

That reads as a regression in whatever branch is being validated. It cost me a full investigation cycle on an unrelated PR before the baseline on `main` showed the same failures.

## Change

Docs only — one file.

- Say to extract the `--ignore` sets from `ci.yml`, not just the timeout.
- Add the quarantine table with `ci.yml` line anchors, and the measured reason (48 device-only STARS streams make an AICore fault take ~306 s to tear down instead of ~0.3 s, so the SDMA demos must not share a sweep with the `aicore_op_timeout` fault-injection test — [investigations/2026-07-a2a3-sdma-fault-teardown.md](docs/investigations/2026-07-a2a3-sdma-fault-teardown.md), #1425).
- Fix the recommended sweep command to carry the ignore sets, and add the command that runs the quarantined tests the way CI does.
- State the triage rule: **run a failing onboard test alone before calling it a regression.** Alone-passes + sweep-fails is an isolation requirement, not a defect.

## The last line is the one that matters

I also tried "fixing" the ordering so the fork-based demos run first. Measured result: `sdma` still failed **and** `test_l3_group` started failing on `aclrtSynchronizeStream ... 507015`, because moving a known-hazardous test earlier just relocates the pollution onto whatever now runs after it. The skill now says not to do that.

## Testing

`pre-commit run --files .claude/skills/testing/SKILL.md` — passes (`markdownlint-cli2`, `check-headers`, `check-english-only`). Relative link to the investigation doc verified to resolve. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)