### PR TITLE
Fix: make --strict catch broken anchors, and fix the six it was hiding

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -873,7 +873,7 @@ Per-thread arena =
 `BUFFERS_PER_THREAD × RECORDS_PER_BUFFER × AVG_TENSOR_BYTES`
 = `8 × 256 × 65536` = **128 MiB**.
 
-## 8. FAQ / Debug Guide
+## 8. FAQ and Debug Guide
 
 **No `args_dump/` directory in the output.** Check that
 `--dump-args` was passed; without it (level 0) the host does not

--- a/docs/dfx/l0-swimlane-profiling.md
+++ b/docs/dfx/l0-swimlane-profiling.md
@@ -53,7 +53,7 @@ captured args — zero hand-written shapes or scalars.
   "fake-fast" zero-filled control tensor — without distorting the
   per-iteration pipeline structure. Repeatable; default uses the real
   dump values. See
-  [§7.2](#72---set-arg-floor-for-a-loop-count-without-distortion).
+  [§7.2](#72-arg-floor-for-a-loop-count-without-distortion).
 - **Source-line attribution (`--debug-line` / `-g`)** — compile the
   kernel with `-g` (skipping the link strip) so the trace carries
   `debug_line` and Insight maps each instruction back to its kernel
@@ -67,7 +67,7 @@ captured args — zero hand-written shapes or scalars.
   idiom (e.g. a manual `prod.record()`) compiles only for the device.
 - **Two trace outputs** — a native Insight `trace.json` and an
   auto-generated Perfetto-friendly variant (sub-laned + atomic flags;
-  see [§3.4](#34-viewing--insight-vs-perfetto)).
+  see [§3.4](#34-viewing-insight-vs-perfetto)).
 
 Drive it in one line (`--func-id` is the task's member set):
 
@@ -144,7 +144,7 @@ reading the kernel source — names are not in the dump (only kind / shape
 
 A scalar slot holds the value directly (`--set-arg 4=4`); a tensor slot
 holds a pointer, so `--set-arg` fills its buffer (`--set-arg 4=512`). See
-[§7.2](#72---set-arg-floor-for-a-loop-count-without-distortion).
+[§7.2](#72-arg-floor-for-a-loop-count-without-distortion).
 
 ### 3.3 Key flags
 
@@ -170,7 +170,7 @@ Per-arch build parameters are fixed in the tool's `ARCH_CONFIG`:
 | a2a3 | `dav_2201` | `dav-c220` | `__CCE_AICORE__ 220` / `PTO_NPU_ARCH_A2A3` |
 | a5 | `dav_3510` | `dav-c310` | `__CCE_AICORE__ 310` / `PTO_NPU_ARCH_A5` |
 
-### 3.4 Viewing — Insight vs Perfetto
+### 3.4 Viewing: Insight vs Perfetto
 
 The workspace lands at
 `outputs/l0_swimlane_<label>_<ts>/`, where
@@ -220,7 +220,7 @@ sub-cores cooperating as they do in production.
 **What loop count to shrink** for a fast camodel is a scalar `n_blocks`,
 a control *tensor* (`context_lens`), or nothing — the slot is shown in
 the step-3 table and `4` is the prefetch floor (see
-[§7.2](#72---set-arg-floor-for-a-loop-count-without-distortion)). For
+[§7.2](#72-arg-floor-for-a-loop-count-without-distortion)). For
 the `mixed_example` matmul/add/mul kernels the loop count derives from
 the tensor **shape** (`shapes[0]`), which the dump captures truthfully,
 so **no `--set-arg` is needed** — the real count (one 128×128 tile) is
@@ -269,7 +269,7 @@ arch-precheck (the case must declare the `--platform` you pass — §3.1).
 | Mix 3-way 1C2V | `mixed_example` | `--func-id 0,1,2` | MATMUL@AIC + ADD@AIV0 + MUL@AIV1 |
 | SPMD single-source | `spmd_multiblock_aiv` | `--func-id 0` | single AIV reading `get_block_idx` (pass `--spmd-block-num`; replay traces block 0) |
 | SPMD mix, 2 AIV share a source | `spmd_multiblock_mix` | `--func-id 0,1,2` | func 1 & 2 are distinct ids but **both `kernel_spmd_mix.cpp`** → the 2 AIV collapse to one (both lanes run it). Routes by `get_sub_block_id` (slot 49) → in replay both lanes read `sub_block_id=0`; AIV0/AIV1 differ only by write offset, so the pipeline stays representative. (The same-source collapse also covers the duplicate-func_id `[0,1,1]` shape an SPMD mix produces when `aiv0 = aiv1`.) |
-| Paged-attn, loop = scalar | `paged_attention_unroll` | `--func-id 0 --set-arg 4=4` | QK stage; `n_blocks` scalar (slot 4) → shrink to 4 ([§7.2](#72---set-arg-floor-for-a-loop-count-without-distortion)) |
+| Paged-attn, loop = scalar | `paged_attention_unroll` | `--func-id 0 --set-arg 4=4` | QK stage; `n_blocks` scalar (slot 4) → shrink to 4 ([§7.2](#72-arg-floor-for-a-loop-count-without-distortion)) |
 | Paged-attn, loop = control tensor | `batch_paged_attention` | `--func-id 1 --set-arg 1=512 --case CaseSmall1` | SF reads `context_lens` (**slot 1**) content (`aiv_softmax_prepare.cpp`); `--set-arg 1=512` fills it uniformly → shrinks the derived per-batch block count |
 
 Runnable commands (one per category):
@@ -500,7 +500,7 @@ fewer ticks. Much of the cost is fixed setup, so shrinking a loop count
 helps only modestly. **Prefer a2a3 for logic validation; run a5 only
 when you specifically need the a5 pipeline.**
 
-### 7.2 `--set-arg` floor for a loop count (without distortion)
+### 7.2 Arg floor for a loop count (without distortion)
 
 Double-buffered prefetch kernels guard the prefetch + `pipe_barrier`
 with `if (i+1 < n_blocks)`:
@@ -621,7 +621,7 @@ Trace each AIV kernel as its own single-kernel task instead (e.g.
 
 **Perfetto shows overlapping / missing slices.** Open
 `<label>_trace_perfetto.json`, not the raw Insight `trace.json`
-(see [§3.4](#34-viewing--insight-vs-perfetto)).
+(see [§3.4](#34-viewing-insight-vs-perfetto)).
 
 **`MMAD` / `FIX` count < `n_blocks`.** The export truncated the tail
 (§7.4). Re-run or change `n_blocks`.

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -185,7 +185,7 @@ SubmitResult Orchestrator::submit_next_level(const CallableIdentity &callable,
 
 ### Step details
 
-**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-slot--per-scope-heap-allocator). Blocks the Orch thread
+**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-slot-and-per-scope-heap-allocator). Blocks the Orch thread
 if all slots are in-flight; this is the system's back-pressure mechanism.
 
 **Step 2 — store task data**: `TaskArgs` is moved (not copied). `config` is a
@@ -301,7 +301,7 @@ SubmitResult Orchestrator::submit_sub(const CallableIdentity &callable, TaskArgs
 
 ---
 
-## 5. Ring (slot + per-scope heap allocator)
+## 5. Ring (slot and per-scope heap allocator)
 
 `Ring` owns three correlated per-task resources:
 

--- a/docs/sanitizers.md
+++ b/docs/sanitizers.md
@@ -2,7 +2,7 @@
 
 Opt-in `-fsanitize` instrumentation of **host-compiled** code, driven by a
 single `--sanitizer` selection. This page is the design + usage reference. The
-nightly CI job lives in [ci.md](ci.md#sanitizer-sim); the *scoping* rationale
+nightly CI job lives in [ci.md](ci.md#nightly-sanitizer-sweep); the *scoping* rationale
 (why macOS is excluded, why TSAN is report-only, why LSan is off) lives in
 [investigations/2026-06-sanitizer-scope.md](investigations/2026-06-sanitizer-scope.md).
 
@@ -141,7 +141,7 @@ The nightly `Sanitizers` workflow does both and uploads the files as a
 
 ## See also
 
-- [ci.md](ci.md#sanitizer-sim) — the nightly `sanitizer-sim` job (matrix,
+- [ci.md](ci.md#nightly-sanitizer-sweep) — the nightly `sanitizer-sim` job (matrix,
   scope, gating).
 - [investigations/2026-06-sanitizer-scope.md](investigations/2026-06-sanitizer-scope.md)
   — why macOS is excluded, why TSAN is report-only, why LSan is off, and the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -698,7 +698,7 @@ Opt-in `-fsanitize` instrumentation of host-compiled code via `--sanitizer`
 (build with `SIMPLER_SANITIZER=...`, run with the matching runtime preloaded).
 The design, load-bearing invariants, usage, and presets now live in their own
 page — see **[sanitizers.md](sanitizers.md)**. The nightly CI job is in
-[ci.md](ci.md#sanitizer-sim); the scoping rationale (macOS / TSAN / LSan) is in
+[ci.md](ci.md#nightly-sanitizer-sweep); the scoping rationale (macOS / TSAN / LSan) is in
 [investigations/2026-06-sanitizer-scope.md](investigations/2026-06-sanitizer-scope.md).
 
 ## CI Pipeline

--- a/docs/troubleshooting/local-timeout-defaults.md
+++ b/docs/troubleshooting/local-timeout-defaults.md
@@ -29,5 +29,5 @@ stream-sync timeout > scheduler timeout + 1.5 s
 ```
 
 Invalid values or invalid onboard ordering are ignored with a warning and the
-compiled defaults are used instead. See [args-dump](../dfx/args-dump.md#8-faq--debug-guide)
+compiled defaults are used instead. See [args-dump](../dfx/args-dump.md#8-faq-and-debug-guide)
 for the timeout chain and dump-recovery details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,13 @@ validation:
   nav:
     omitted_files: warn
     not_found: warn
+  links:
+    # Defaults to `info`, which --strict ignores, so a link to a heading that
+    # was renamed or never existed builds clean and 404s in the reader's
+    # browser. Note the two slug dialects differ: GitHub keeps the doubled
+    # hyphen a heading like "FAQ / Debug Guide" produces, MkDocs collapses it.
+    # Headings here avoid the punctuation that splits them.
+    anchors: warn
 
 # Deliberate omissions: these are accumulating logs and design sets, reached
 # through their own index pages rather than the sidebar. Listing every entry in


### PR DESCRIPTION
## Summary

`validation.links.anchors` defaults to `info` in MkDocs 1.6, and `--strict` only fails on `warn` or above. A link to a heading that was renamed or never existed therefore **built clean and 404'd in the reader's browser**. Six were live on `main`:

| Link | Problem |
| ---- | ------- |
| `ci.md#sanitizer-sim` (3 call sites) | never existed — the heading is `### Nightly sanitizer sweep` |
| `orchestrator.md#5-ring-slot--per-scope-heap-allocator` | doubled hyphen |
| `l0-swimlane-profiling.md#34-viewing--insight-vs-perfetto` | doubled hyphen |
| `l0-swimlane-profiling.md#72---set-arg-floor-...` (4 call sites) | tripled hyphen |
| `args-dump.md#8-faq--debug-guide` | doubled hyphen |

### The last four were not typos

**GitHub and MkDocs slugify differently.** A heading like `## 8. FAQ / Debug Guide` drops the `/` and leaves two spaces; GitHub renders that as `8-faq--debug-guide`, MkDocs collapses it to `8-faq-debug-guide`. So those links were **correct in the GitHub view and broken on the published site** — which is why nobody noticed, and why simply repointing them would have moved the breakage rather than removed it.

The fix is to take the punctuation out of the four headings so both dialects agree:

| Was | Now |
| --- | --- |
| `## 5. Ring (slot + per-scope heap allocator)` | `## 5. Ring (slot and per-scope heap allocator)` |
| `### 3.4 Viewing — Insight vs Perfetto` | `### 3.4 Viewing: Insight vs Perfetto` |
| ``### 7.2 `--set-arg` floor for a loop count …`` | `### 7.2 Arg floor for a loop count …` |
| `## 8. FAQ / Debug Guide` | `## 8. FAQ and Debug Guide` |

Every referring link is updated with them.

### Then the guard goes on

```yaml
validation:
  links:
    anchors: warn
```

Verified it bites — pointing `sanitizers.md` at `ci.md#does-not-exist` gives:

```
WARNING - Doc file 'sanitizers.md' contains a link 'ci.md#does-not-exist',
          but the doc 'ci.md' does not contain an anchor '#does-not-exist'.
Aborted with 1 warnings in strict mode!
exit=1
```

### Correcting my own comment

`.github/workflows/docs.yml` has claimed since #1569 that `--strict` "fails on a dead intra-docs link, a page missing from nav, or **a bad anchor**". The first two were true; the third was not. This PR makes the sentence accurate rather than editing it down.

### Not fixed here

Five links point at directories with no index page — `hardware/`, `troubleshooting/`, `remote-l3-worker-design/`, `troubleshooting/device-error-codes/`. They resolve in the GitHub view and 404 on the site, and MkDocs reports them at INFO under `unrecognized_links`. Fixing them means **adding index pages**, not editing links, so it is a separate change; `unrecognized_links` is deliberately left at its default until then.

## Testing

- [x] `mkdocs build --strict` — exit 0, zero warnings
- [x] Negative test: deliberately broken anchor → exit 1 (output above), then reverted
- [x] Generated ids read out of the built HTML rather than guessed, e.g. `id="8-faq-and-debug-guide"`
- [x] All four reworded headings verified to produce the same slug under both dialects
- [x] `markdownlint-cli2 --config tests/lint/.markdownlint.yaml` — 0 errors on all six changed docs

Docs and docs-tooling only.