### PR TITLE
Add: generation-safe two-frame local endpoint

### DIFF
--- a/docs/callable-identity-registration.md
+++ b/docs/callable-identity-registration.md
@@ -45,12 +45,14 @@ dispatch. For chip targets, the local implementation also prewarms executable
 state before first use when startup or dynamic register control reaches the
 child before dispatch.
 
-The chip child loop requires a prepared slot at dispatch: a TASK_READY only
-consumes a slot already staged via `_CTRL_PREPARE` (dynamic register) or via the
-startup snapshot (initial callables, prepared before INIT_READY). Reaching
-TASK_READY for an unprepared slot is a control-flow error and fails loudly
-rather than lazily preparing in the dispatch path. The child never fetches
-missing callable bytes from the parent.
+The chip child loop requires a prewarmed callable slot at dispatch:
+`TASK_READY` and `PREPARE_READY` consume only a slot staged via `_CTRL_PREPARE`
+(dynamic register) or via the startup snapshot (initial callables, prepared
+before `INIT_READY`). Reaching either task state for an unprepared callable slot
+is a control-flow error and fails loudly rather than lazily materializing the
+callable in the dispatch path. This registration prewarm is distinct from
+two-frame endpoint `FRAME_STAGED` and from runtime-native run preparation. The
+child never fetches missing callable bytes from the parent.
 
 ### Chip Executable Prewarm
 
@@ -439,14 +441,22 @@ when the refcount reaches zero.
 Current local slot reuse rule:
 
 - A child resolves `hashid -> local_slot` immediately before execution.
-- Each endpoint has one local mailbox operation in flight at a time.
-- Parent-side dispatch and control operations to the same endpoint are
-  serialized by the per-WorkerThread mailbox lock.
-- Final unregister removes the hashid from resolution and releases the private
-  slot only after the current mailbox operation has completed.
+- A two-frame chip child may retain two resolved task snapshots while one
+  native run is active: the FIFO-head task and one staged successor. Both remain
+  users of the callable registration until their runs retire.
+- The base control frame is separate from the two task frames. Control commands
+  serialize with other control commands. Device-registry mutation waits until
+  the current native run is finalized, and final unregister also waits until no
+  published task frame still references that digest. Other controls may be
+  serviced while a task frame is active or staged.
+- Callers must not unregister a handle while any run may submit or use it. This
+  run-lifetime rule ensures final unregister cannot release a private slot still
+  retained by an active or staged frame.
+- A single-frame compatibility endpoint reuses the base frame for both task and
+  control traffic and therefore serializes those operations.
 
 This rule prevents stale slot reuse without exposing any extra public field.
-A future remote or multi-flight control channel must add explicit
+A future multi-flight control channel must add explicit
 `INSTALLED` / `TOMBSTONED` / `FAILED` target states, sequence numbers, and
 in-flight user draining before it can reuse private slots safely.
 
@@ -502,6 +512,21 @@ callable kind and target namespace. It never stores a child-local slot, `cid`,
 local handle id, or any other integer callable identity. Local mailbox task
 frames carry the fixed `sha256` digest.
 
+On a two-frame endpoint, the parent also binds the payload to a
+generation-safe dispatch identity:
+
+```text
+WorkerDispatch: task_slot, group_index, dispatch_id, prepare_only
+task-frame trailer: protocol, run_id, pipeline_slot, generation, dispatch_id
+```
+
+`WorkerThread` assigns `dispatch_id` only after its queue insertion succeeds.
+The callable digest remains part of the immutable payload, while the trailer
+lets both sides reject a stale activation, acceptance, or completion from an
+older use of the same pipeline frame. `FRAME_STAGED` confirms that this exact
+payload has been validated and retained; it does not resolve to a different
+callable identity and does not mean a native run has been prepared.
+
 The target child loop owns the final execution resolve:
 
 ```text
@@ -531,9 +556,10 @@ UNREGISTER_TOMBSTONE_ACTIVE
 ```
 
 Error messages should include worker id, namespace, `hashid`, and operation.
-The current local mailbox has one outstanding operation per endpoint and does
-not carry a separate sequence field; a future multi-flight control channel must
-add one. Messages must not include user-specific local absolute paths.
+Two-frame task traffic carries `dispatch_id`, but the base control protocol has
+no separate sequence field and remains single-flight under its control mutex. A
+future multi-flight control channel must add an explicit sequence. Messages
+must not include user-specific local absolute paths.
 
 ### Local Control Contract
 
@@ -567,7 +593,8 @@ Rules:
   and decrements the target-local `ref_count`.
 - A reply that returns a different `hashid` than requested is invalid.
 
-Local mailbox task callable reference:
+Local mailbox task callable reference (offsets are relative to the selected
+task frame):
 
 ```text
 MAILBOX_OFF_CALLABLE:
@@ -576,12 +603,26 @@ MAILBOX_OFF_CALLABLE:
 MAILBOX_OFF_ARGS:
   callable_hash_digest: uint8[32]
   task_args_blob: bytes
+
+task-frame trailer:
+  protocol, run_id, pipeline_slot, generation, dispatch_id
 ```
 
 The local mailbox task frame is fixed to `sha256` and carries only the raw
 32-byte digest. It does not carry `target_namespace`; the receiving child
 mailbox determines the target namespace and resolves the digest in its own
-`identity_table`.
+`identity_table`. On a two-frame endpoint the shared region has a separate base
+control frame followed by task frames for pipeline lease slots 0 and 1. The
+frame index and the serialized lease slot must agree. Only the real native
+launch writes the task frame's sticky acceptance word; successful callable
+resolution and `FRAME_STAGED` do not satisfy the launch fence.
+
+Single-frame endpoints retain the blocking compatibility layout: task and
+control operations alternate on the base frame and the two reserved task-frame
+regions are unused. The current facade enables the two-frame task protocol only
+for direct A2/A3 onboard chip children with a published pipeline depth of at
+least two; this contract does not imply support on A5, simulation, SUB, nested
+Worker, or remote endpoints.
 
 This task frame layout is a clean-break wire-format change from the prior
 integer callable-id layout where `MAILBOX_OFF_CALLABLE` carried the callable
@@ -600,15 +641,17 @@ Target unregister sequence:
 
 1. Decrement the target-local refcount for `hashid`.
 2. If the refcount remains nonzero, keep the mapping installed.
-3. If the refcount reaches zero, stop new local resolutions from `hashid` to
-   private slot.
-4. Clear executable state.
-5. Release the private slot for reuse.
-6. Remove or archive the `hashid` entry.
+3. If the refcount reaches zero, wait for any active native run and published
+   task frame using `hashid` to retire.
+4. Clear executable state. If this fails, retain the resolver and prepared-slot
+   bookkeeping unchanged.
+5. Remove the local `hashid -> private slot` resolver.
+6. Release the private slot for reuse.
 
-This sequence is the concrete unregister form of the target-local slot reuse
-rule for the current single-flight local mailbox. A future multi-flight target
-must insert a tombstone/drain phase before clearing executable state.
+The public rule still forbids unregister racing a run that may newly submit the
+handle. The local two-frame endpoint additionally protects already-published
+active and staged frames, so a concurrent final unregister cannot invalidate
+their resolved callable before launch or completion.
 
 If failed-register cleanup cannot be confirmed, the parent must not dispatch
 that hashid to the uncertain target again during the current Worker lifetime.
@@ -654,6 +697,11 @@ Local mailbox task frames are hashid-based:
 - The existing `TaskArgs` blob follows the digest prefix.
 - Chip and sub child loops resolve `hashid -> local_slot` immediately before
   execution.
+- A two-frame chip loop retains the resolved slot and immutable payload at
+  `FRAME_STAGED`; runtime-native prepare waits for activation and native-run
+  availability.
+- Protocol/run/lease-generation/dispatch identity guards task-frame reuse, and
+  a separate sticky word records only real native launch acceptance.
 - `ChipWorker.run(local_slot)` remains private to the child process.
 
 Register failure cleanup is conservative:
@@ -675,6 +723,8 @@ Required tests:
 | L3 run unchanged | `Worker.run(raw_orch_fn, ...)` still works at L3+. |
 | Submit handle only | Submit rejects bare strings and raw callables. |
 | Task frame digest | Local mailbox task frames carry the raw 32-byte digest. |
+| Staged-frame digest | A staged successor retains the digest resolution and cannot be activated under a reused frame identity. |
+| Real launch ACK | `FRAME_STAGED` never sets the sticky native-launch marker. |
 | Private slot resolve | Child loop resolves hashid to private slot. |
 | Slot independence | Same hashid runs with different private slots. |
 | Duplicate register | Repeated register returns independent handles. |

--- a/docs/hierarchical-level-runtime.md
+++ b/docs/hierarchical-level-runtime.md
@@ -115,9 +115,12 @@ See [scheduler.md](scheduler.md) for the dispatch loop and coordination.
 
 The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`s
 (next-level pool and sub pool). Each `WorkerThread` owns one std::thread that
-encodes `(callable, config, args_blob)` into a `MAILBOX_SIZE`-byte shared
-memory region, signals the pre-forked Python child, and spin-polls
-  `TASK_DONE`, returning an explicit completion outcome to the Scheduler.
+owns one shared-memory mailbox region and returns explicit progress/completion
+events to the Scheduler. Compatibility endpoints encode one task in the base
+frame and wait for `TASK_DONE`. Direct A2/A3 onboard chip endpoints instead
+multiplex two task frames: the same progress owner can poll the active native
+run while validating a staged successor, then activate that successor only
+after the predecessor's native finalization fence.
 
 - Next-level (chip) children run `_chip_process_loop`, which constructs a
   `ChipWorker` and dispatches each kernel through it.
@@ -150,8 +153,9 @@ what flows through `ChipWorker::run`.
                  │                                 │ pop directed/shared queue
                  │                                 │ resolve target (NL) or idle SUB
                  │                                 │ wt.dispatch(slot_id) ──────► WorkerThread
-                 │                                 │                              encode mailbox → spin-poll TASK_DONE
-                 │                                 │                              (blocking; child runs the kernel)
+                 │                                 │                              publish mailbox frame → drive progress
+                 │                                 │                              (compat: wait TASK_DONE;
+                 │                                 │                               A2/A3 chip: active + staged lanes)
                  │                                 │◄── completion_queue ────── on_complete_(completion)
                  │                                 │ on_task_complete:
                  │                                 │   success → COMPLETED

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -58,15 +58,20 @@ to C++:
 
 | Context | Namespace | How it's consumed |
 | ------- | --------- | ----------------- |
-| `w3.submit_next_level(handle, …)` dispatched to a chip child | `LOCAL_CHIP` | child resolves digest to its private chip slot, then calls `ChipWorker::run(local_slot, …)` |
+| `w3.submit_next_level(handle, …)` dispatched to a chip child | `LOCAL_CHIP` | child resolves digest to its private chip slot, then uses blocking `ChipWorker::run` on the compatibility path or the prepare/launch/poll/finalize native lifecycle on a two-frame endpoint |
 | `w4.submit_next_level(handle, …)` dispatched to an L3 `Worker` child | `LOCAL_PYTHON` | child resolves digest to an orchestration function and calls `inner_worker.run(orch_fn, …)` |
 | remote `w4.submit_next_level(handle, …)` dispatched to remote L3 | `REMOTE_TASK_DISPATCHER` | remote endpoint resolves digest in its dispatcher registry and calls its embedded L3 Worker |
 | `w3.submit_sub(handle, …)` dispatched to a SUB child | `LOCAL_PYTHON` | child resolves digest to a Python callable and calls `fn(args)` |
 
-All three paths share one mailbox wire format: `MAILBOX_OFF_CALLABLE` is
-reserved, the run's generation-safe pipeline lease follows `CallConfig`, and
-the 32-byte digest prefixes the args blob. The receiving child does the
-digest-to-slot resolve in its own address space.
+All three paths share the same logical task-frame payload:
+`MAILBOX_OFF_CALLABLE` is reserved, the run's generation-safe pipeline lease
+follows `CallConfig`, and the 32-byte digest prefixes the args blob. SUB,
+nested/remote L3, simulation, A5, and depth-one fallbacks carry that payload in
+the base compatibility frame. A direct A2/A3 onboard chip child can instead
+use either of two task frames after the base control frame, with
+`PREPARE_READY -> FRAME_STAGED -> ACTIVATE` separating validation from native
+launch. The receiving child resolves the digest in its own address space in
+both forms.
 
 The proposed remote L3 path keeps the same callable identity contract, but
 sends it in a versioned TASK frame. The remote endpoint resolves the digest
@@ -334,27 +339,55 @@ depth-one serial behavior instead of receiving an invalid slot-1 lease.
 
 Whole-run admission decides when a slot may be leased and carries the lease
 from `TaskSlot` through the chip mailbox into the runtime slot, so a production
-run now executes under the lease its run holds rather than unconditionally on
-slot 0. What this contract still does not enable is a second mailbox frame, a
-second device execution, or cross-run publication overlap: the endpoint remains
-a single synchronous round trip, and the scheduler dispatches only the run that
-holds the FIFO head and still owns its lease.
+run executes under the lease its run holds rather than unconditionally on slot
+0. The scheduler dispatches device work only for the run that holds the FIFO
+head and still owns its lease.
 
-The L2 host-runtime boundary is nevertheless progressable. Its opaque native
-run storage supports `prepare -> launch -> poll/wait -> finalize`, and the
-existing `simpler_run` / `ChipWorker.run` surface is the blocking composition
-of those phases. `prepare` constructs and binds the per-run `Runtime` without
-crossing the device launch fence; `launch` returns after the backend has
-actually submitted its execution; `finalize` owns validation, copy-back, DFX,
-and Runtime destruction. Until execution-only `DeviceRunner` state is made
-per-run, the backend admits only one prepared or launched native run at a time.
-The single-frame child intentionally continues to use the blocking composition;
-the phase split is the B3a ownership seam, not a claim of mailbox overlap.
+The L2 host-runtime boundary exposes `prepare -> launch -> poll/wait ->
+finalize`, and the existing `simpler_run` / `ChipWorker.run` surface is the
+blocking composition of those phases. `prepare` constructs and binds the
+per-run `Runtime` without crossing the device launch fence; `launch` returns
+after the backend has actually submitted its execution; `finalize` owns
+validation, copy-back, DFX, and Runtime destruction. One runner still permits
+only one unfinished native run, including a prepared-but-not-launched run.
 
-Simulation implements the same depth, so the contract means the same thing on
-both platforms: its runner owns one arena bank and one retained temporary
-buffer per slot, and its single-entry prebuilt-arena cache stays owned by
-bank 0 exactly as onboard's does.
+#### Two-frame endpoint staging lane
+
+A direct A2/A3 chip endpoint with a negotiated depth of at least two uses two
+task frames and advertises `supports_frame_staging`. One `WorkerThread` owns
+both frames and drives them through a non-blocking progress interface; the
+child process likewise has one loop that services control traffic, both task
+frames, and the single native-run lifecycle. There is no thread per frame.
+
+The active and successor paths are:
+
+```text
+IDLE -> TASK_READY    -> FRAME_STAGED -> TASK_LAUNCHED -> TASK_DONE | TASK_FAILED
+IDLE -> PREPARE_READY -> FRAME_STAGED -> ACTIVATE -> TASK_LAUNCHED
+                                               -> TASK_DONE | TASK_FAILED
+```
+
+`FRAME_STAGED` means only that the child validated and owns an immutable frame
+snapshot. It is distinct from both an L3 run in `RunPhase::PREPARED` and a
+runtime-specific `ChipWorkerNativeRun` in its prepared phase. While an active
+native run exists, the successor remains at `FRAME_STAGED`; native prepare is
+deferred until the predecessor has polled complete and finalized.
+
+The scheduler stages only the first eligible single NEXT_LEVEL task from the
+prepared FIFO successor. Tasks from the active run use only the active lane, so
+the second frame cannot create same-device execution overlap. Prepared groups
+remain on their normal queue and dispatch synchronously after FIFO promotion.
+Remote, SUB, A5, simulation, nested-worker, and single-frame endpoints retain
+the blocking compatibility path.
+
+Every task frame carries protocol, run, lease slot, generation, dispatch, and
+callable identity. Its sticky acceptance word is separate from the state word
+and is set only by the real native launch marker. `FRAME_STAGED` never satisfies
+the launch fence. A terminal pre-launch failure may conservatively retire the
+run-level acceptance waiter, but it does not set the frame's acceptance word.
+The parent clears that word only immediately before reusing an `IDLE` frame.
+Control commands continue to use a separate base frame, so they cannot
+overwrite either staged task frame.
 
 #### TRB temporary buffer
 
@@ -466,7 +499,8 @@ Local mailbox path:
 ```text
 slot.callable.digest ─┐
 slot.config          ─┼─► memcpy into shm mailbox ─► child resolves digest
-slot.task_args       ─┘    (dispatch_process)         and runs local slot
+slot.pipeline_lease  ─┤    (dispatch_process)         and runs local slot
+slot.task_args       ─┘
 ```
 
 For SUB children the same mailbox layout is reused; the Python child
@@ -609,7 +643,7 @@ L4 parent process
 | 1 | L4 parent Python | `w4.run(my_l4_orch)` → `scope_begin` → `my_l4_orch(orch4, ...)` |
 | 2 | L4 `Orchestrator.submit_next_level` | the L3 callable handle digest is stored in the slot's callable identity; slot pushed to L4's ready queue |
 | 3 | L4 Scheduler | pop the target worker's FIFO → that L3 child's mailbox |
-| 4 | L4 WorkerThread (PROCESS) | encode `(callable digest, config, args_blob)` into mailbox; write `TASK_READY`; spin-poll |
+| 4 | L4 WorkerThread (PROCESS compatibility endpoint) | encode `(callable digest, config, args_blob)` into the base frame; write `TASK_READY`; wait for terminal state |
 | 5 | L3 child `_child_worker_loop` | wake on `TASK_READY`; read digest → child-local slot → `my_l3_orch` |
 | 6 | L3 child | `inner_worker.run(my_l3_orch, args, cfg)` → `scope_begin` → `my_l3_orch(orch3, ...)` |
 | 7 | L3 `Orchestrator.submit_sub` | `l3_sub_handle` digest dispatched to L3's own sub worker child |
@@ -660,12 +694,12 @@ Step-by-step (one chip worker):
 | 2 | `Worker::run` | `scope_begin` → call `my_orch(&orch_, args.view(), cfg)` |
 | 3 | `Orchestrator::submit_next_level` | `slot = ring.alloc()`; move `chip_args` into `slot.task_args`; walk tags → `tensormap.lookup(a.data)`, `tensormap.lookup(b.data)`, `tensormap.insert(c.data, slot)`; push ready |
 | 4 | Scheduler thread | pop `slot` from worker 0's FIFO; resolve stable worker ID 0 to WT_chip_0; dispatch |
-| 5 | WT_chip_0 parent side | encode mailbox: write reserved callable field, `config`, digest prefix, `write_blob` of task_args; set `TASK_READY`; spin-poll |
-| 6 | chip_0 child process | wake on `TASK_READY`; resolve digest to local slot; `read_blob` → `view`; call `ChipWorker::run(local_slot, view, cfg)` |
-| 7 | `ChipWorker::run` | assemble `ChipStorageTaskArgs` POD (memcpy view); call `pto2_run_runtime(local_slot, &chip_storage, &cfg)` |
+| 5 | WT_chip_0 parent side | encode one leased task frame: write `config`, digest prefix, and the args blob; publish `TASK_READY` for the active lane or `PREPARE_READY` for a staged successor |
+| 6 | chip_0 child process | validate the frame and resolve its digest, then publish `FRAME_STAGED`; a successor waits for `ACTIVATE`, while the active frame may proceed immediately |
+| 7 | chip_0 native-run path | after activation, prepare and launch the native run; poll it to completion and finalize it before another staged frame may launch. Compatibility endpoints perform the equivalent operation through blocking `ChipWorker::run` |
 | 8 | runtime.so | translate host ptrs → device ptrs; dispatch AICPU / AICore; write output into `c`'s shm |
-| 9 | chip_0 child | `run` returns; write `TASK_DONE` |
-| 10 | WT_chip_0 parent | see `TASK_DONE`; push success completion |
+| 9 | chip_0 child | native finalization returns; write `TASK_DONE` |
+| 10 | WT_chip_0 parent | observe `TASK_DONE`; push success completion |
 | 11 | Scheduler | mark slot COMPLETED; fanout release (none in this DAG); scope_end will release scope ref |
 | 12 | `Worker::run` returns | user's `w3.run(...)` returns; `c` contains result in shm, visible to user |
 
@@ -694,8 +728,9 @@ runtime: `ChipStorageTaskArgs` (`task_args.h:157`) is already declared with
 
 `ChipWorker::run` takes `(local_slot, TaskArgsView, const CallConfig&)`
 directly. Wrapping them in a struct added no value and made mailbox serialization
-indirect. Task identity (slot_id) is held by the parent's WorkerThread
-for the completion callback, not passed into the child.
+indirect. The scheduler's parent-private `TaskSlot` is held by WorkerThread for
+the completion callback and is not passed into the child. The distinct,
+generation-safe `PipelineSlotLease.slot_id` does cross the mailbox boundary.
 
 ### Why slots on heap, mailbox on shm
 
@@ -703,7 +738,10 @@ Slots carry scheduler-only state (atomics, mutex, `std::vector` of fanout
 consumers) that is parent-private. Putting them in shm would force cross-
 process atomics and shm-safe containers. The only data that needs to cross
 the fork boundary is per-task: callable, config, args — and that fits in a
-~2 KB mailbox with a one-time memcpy per dispatch.
+fixed 32 KiB task frame with a one-time memcpy per dispatch. A two-frame-capable
+local mailbox reserves a separate 32 KiB control base plus two such task frames;
+single-frame compatibility endpoints use the base frame and leave the reserved
+task frames unused.
 
 ### Why TaskArgs in slot (not encoded blob in slot)
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -1,9 +1,8 @@
 # Worker Manager — Pool, Threading, and Dispatch
 
-Callable identity update: WorkerThread task frames now carry the submitted
-callable's 32-byte digest; the child resolves that digest to its private local
-slot. Older callable-id snippets below are historical shorthand for
-target-local internals. See
+Local task frames carry the submitted callable's 32-byte digest. The child
+resolves that digest to its private execution slot; no child-local slot crosses
+the mailbox boundary. See
 [callable-identity-registration.md](callable-identity-registration.md).
 
 `WorkerManager`, `WorkerThread`, and `WorkerEndpoint` together implement the
@@ -37,17 +36,20 @@ For where dispatched tasks come from, see [scheduler.md](scheduler.md).
 ```cpp
 class WorkerManager {
 public:
-    // Registration (before init). `mailbox` is a MAILBOX_SIZE-byte
-    // MAP_SHARED region; the real worker (a `ChipWorker` for NEXT_LEVEL,
-    // a Python callable for SUB) lives in the forked child.
-    void add_next_level(void *mailbox);
-    void add_next_level_at(int32_t worker_id, void *mailbox);
+    // Registration (before init). `task_frame_count` selects the blocking
+    // compatibility path (1) or the two-frame progress path (2).
+    void add_next_level(void *mailbox, int child_pid = -1,
+                        uint32_t task_frame_count = 1);
+    void add_next_level_at(int32_t worker_id, void *mailbox,
+                           int child_pid = -1,
+                           uint32_t task_frame_count = 1);
     void add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint);
-    void add_sub       (void *mailbox);
+    void add_sub(void *mailbox, int child_pid = -1);
 
     // Lifecycle
     void start(Ring *ring, OnCompleteFn on_complete,
                OnAcceptFn on_accept);              // starts all WorkerThreads
+    void stop_workers();                            // joins, retains pool entries
     void stop();
 
     // Scheduler API
@@ -60,9 +62,15 @@ private:
     struct LocalNextLevelEntry {
         int32_t worker_id;
         void *mailbox;
+        int child_pid;
+        uint32_t task_frame_count;
+    };
+    struct LocalSubEntry {
+        void *mailbox;
+        int child_pid;
     };
     std::vector<LocalNextLevelEntry> next_level_entries_;
-    std::vector<void *> sub_entries_;
+    std::vector<LocalSubEntry> sub_entries_;
     std::vector<std::unique_ptr<WorkerThread>> next_level_threads_;
     std::vector<std::unique_ptr<WorkerThread>> sub_threads_;
 };
@@ -82,6 +90,9 @@ the public worker id from the local worker vector index.
   another NEXT_LEVEL worker
 - **SUB-only idle selection**: `pick_idle_sub_excluding` chooses an idle SUB
   worker not already used by the same SUB group
+- **Two-step stop**: `stop_workers()` joins the execution threads while
+  retaining their pool entries, so Scheduler completion callbacks still see
+  stable worker objects; `stop()` then clears the pools
 
 Callable and remote-buffer eligibility is validated against the exact target
 during Orchestrator submission. It is not scheduling metadata and is not
@@ -91,12 +102,17 @@ stored on the task slot.
 
 ## 2. `WorkerThread`
 
-One WorkerThread per registered mailbox (i.e. per forked child worker).
+There is one `WorkerThread` and one `std::thread` per endpoint (for a local
+endpoint, per forked child). A two-frame endpoint does not add a thread per
+frame: the same thread owns its dispatch queue, both frame records, activation,
+acceptance, and completion progress.
 
 ```cpp
 struct WorkerDispatch {
     TaskSlot task_slot;
     int32_t  group_index = 0;    // 0 for non-group; 0..N-1 for group members
+    uint64_t dispatch_id = 0;    // assigned by WorkerThread after queue commit
+    bool prepare_only = false;   // stage for the FIFO successor
 };
 
 class WorkerThread {
@@ -106,8 +122,12 @@ public:
                const std::function<void(WorkerDispatch)> &on_accept,
                std::unique_ptr<WorkerEndpoint> endpoint);
     void stop();
-    void dispatch(WorkerDispatch d);       // slot id + group sub-index
-    bool idle() const;
+    void dispatch(WorkerDispatch d);          // reserve the active lane
+    void dispatch_prepared(WorkerDispatch d); // reserve the staged lane
+    bool activate_prepared(RunId run_id);
+    bool idle() const;                        // active lane is free
+    bool can_stage() const;                   // staged lane is free
+    bool busy() const;                        // either lane owns work
     const WorkerEndpointCaps &caps() const;
     int32_t worker_id() const;
 
@@ -119,28 +139,43 @@ private:
     std::mutex mu_;
     std::condition_variable cv_;
 
-    void loop();
+    void loop();  // the sole progress owner for this endpoint
     WorkerCompletion dispatch_process(WorkerDispatch d,
                                       const std::function<void()> &on_accept);
 };
 ```
 
-The WorkerThread's `std::thread` pumps the internal queue and calls
-`endpoint->run_with_accept(...)` once per dispatch. `LocalMailboxEndpoint`
-drives the shm handshake — one mailbox round trip per dispatch. The forked child loop
-that consumes the mailbox lives in Python (`_chip_process_loop` /
-`_sub_worker_loop` in `python/simpler/worker.py`); the parent does not fork
-children.
+For a blocking endpoint the thread pumps its queue and calls
+`endpoint->run_with_accept(...)` once per dispatch. For a progressable endpoint
+it publishes queued frames, forwards a latched activation, and polls monotonic
+`FRAME_STAGED`, `ACCEPTED`, and `COMPLETED` events. The forked child loop lives
+in Python (`_chip_process_loop`, `_child_worker_loop`, or `_sub_worker_loop` in
+`python/simpler/worker.py`); the parent does not fork children.
 
-`WorkerDispatch` carries only `{slot_id, group_index}`; the thread reads
-`slot.callable` / `slot.task_args` / `slot.config` on each dispatch via
-`ring->slot_state(slot_id)`. For a group slot with `group_size() == N`,
-the Scheduler pushes N `WorkerDispatch` entries (one per member) onto N
-exact target threads for NEXT_LEVEL, or N freely selected SUB threads. Each
-thread's `group_index` selects which
-`task_args_list[i]` view to hand to the worker. There is no
-`WorkerPayload` — the per-dispatch carrier is just the slot id plus the
-group sub-index.
+`WorkerDispatch` begins with `{task_slot, group_index}`. `WorkerThread` assigns
+`dispatch_id` under the queue lock only after the queue insertion succeeds, so
+a failed insertion consumes neither capacity nor identity. It also sets
+`prepare_only` for the one staged successor. The endpoint combines this carrier
+with `slot.run_id`, `slot.pipeline_lease`, `slot.callable`, `slot.task_args`,
+and `slot.config` read from `ring->slot_state(task_slot)`. The task frame's
+protocol/run/slot/generation/dispatch trailer makes frame reuse and late child
+publication detectable.
+
+The two capacity lanes have different meanings:
+
+- The **active lane** accepts ordinary tasks from the FIFO-head run. `idle()`
+  refers only to this lane, so an active run cannot use the second frame to run
+  two tasks on one device.
+- The **staged-successor lane** accepts at most the first eligible single
+  NEXT_LEVEL task from the prepared FIFO successor. It remains staged until
+  that run becomes the FIFO head and `activate_prepared(run_id)` succeeds.
+- Prepared groups retain the blocking path after FIFO promotion; they are not
+  split across staged lanes.
+
+For a group slot with `group_size() == N`, the Scheduler pushes N ordinary
+`WorkerDispatch` entries onto N exact NEXT_LEVEL targets, or N distinct idle
+SUB workers. `group_index` selects `task_args_list[i]`. There is no
+`WorkerPayload` wrapper.
 
 ---
 
@@ -152,126 +187,149 @@ The Python facade forks one child per mailbox **before**
 fork runs, avoiding the classical "fork in a multi-threaded process" hazard)
 and the child polls the mailbox for the lifetime of the worker.
 
-### 3.1 Parent-side dispatch
+The region currently consists of three equal `MAILBOX_FRAME_SIZE` frames:
 
-```cpp
-// `run(ring, d)` forwards here with an empty hook; the acceptance-aware
-// overload is what WorkerThread calls.
-WorkerCompletion LocalMailboxEndpoint::run_with_accept(
-    Ring *ring, const WorkerDispatch &d, const std::function<void()> &on_accept
-) {
-    TaskSlotState &s = *ring->slot_state(d.task_slot);
-    char *m = static_cast<char *>(mailbox_);
+| Frame | Two-frame chip endpoint | Single-frame compatibility endpoint |
+| ----- | ----------------------- | ----------------------------------- |
+| Base (0) | Startup and control state only | Startup, control, and the one blocking task round trip |
+| Task 0 (1) | Pipeline lease slot 0 | Unused |
+| Task 1 (2) | Pipeline lease slot 1 | Unused |
 
-    // Write task data: reserved callable field, config, digest prefix, then
-    // length-prefixed TaskArgs blob. Tags are stripped; only
-    // [digest][T][S][tensors][scalars] crosses the fork boundary.
-    uint64_t reserved = 0;
-    memcpy(m + MAILBOX_OFF_CALLABLE, &reserved, sizeof(reserved));
-    memcpy(m + MAILBOX_OFF_CONFIG, &s.config, sizeof(CallConfig));
-    memcpy(m + MAILBOX_OFF_TASK_CALLABLE_HASH, s.callable.digest.data(), 32);
-    const TaskArgs &args = s.is_group() ? s.task_args_list[d.group_index] : s.task_args;
-    write_blob(m + MAILBOX_OFF_TASK_ARGS_BLOB, args);
+`task_frame_count` is an endpoint contract, not a count inferred from the
+allocation size. Parent registration uses each direct chip child's own
+published depth, while whole-run admission uses the minimum depth across the
+chip set. The current Python facade selects two frames only for a direct A2/A3
+onboard chip child whose published pipeline depth is at least two. SUB,
+nested-Worker, remote, A5, simulation, and depth-one local endpoints use the
+single-frame blocking contract.
 
-    // Signal child
-    write_state(mailbox_, MailboxState::TASK_READY);
+### 3.1 Single-frame compatibility path
 
-    // Spin-poll for completion. The task's latency runs through this wait, so
-    // it never sleeps (codestyle rule 5). A child that dies without publishing
-    // TASK_DONE would spin here forever, so its liveness is sampled on a
-    // kChildLivenessPollPeriod steady-clock period rather than an iteration
-    // count, which no longer maps to a bounded time at spin speed.
-    auto next_liveness_check = steady_clock::now() + kChildLivenessPollPeriod;
-    bool acceptance_observed = false;
-    while (true) {
-        MailboxState state = read_state(mailbox_);
-        // Launch acceptance is a sticky word, not a state: the child sets it
-        // before TASK_DONE and nothing clears it until the next TASK_READY, so
-        // a task that finishes between two polls cannot lose the ACK. Read
-        // after the state so a TASK_DONE observation implies it is visible.
-        if (!acceptance_observed && read_accepted(mailbox_)) {
-            acceptance_observed = true;
-            if (on_accept) on_accept();
-        }
-        if (state == MailboxState::TASK_DONE) break;
-        auto now = steady_clock::now();
-        if (now >= next_liveness_check) {
-            next_liveness_check = now + kChildLivenessPollPeriod;
-            std::string death = check_child_death();
-            if (!death.empty()) {
-                completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-                completion.error_message = "LocalMailboxEndpoint::run: " + death;
-                return completion;
-            }
-        }
-    }
+`LocalMailboxEndpoint::run_with_accept` serializes task and control use of the
+base frame. It copies `CallConfig`, `PipelineSlotLease`, the 32-byte callable
+digest, and the length-prefixed `TaskArgs` blob, publishes `TASK_READY`, then
+spin-polls the base state to `TASK_DONE`. This dispatch wait never sleeps because
+task latency passes through it. A steady-clock liveness sample turns a child
+that exits before completion into `ENDPOINT_FAILURE`.
 
-    int err = read_error(mailbox_);
-    write_state(mailbox_, MailboxState::IDLE);
-    return err == 0
-        ? WorkerCompletion{d.task_slot, d.group_index, EndpointOutcome::SUCCESS, ""}
-        : WorkerCompletion{d.task_slot, d.group_index, EndpointOutcome::TASK_FAILURE,
-                           read_error_msg(mailbox_)};
-}
+The child uses `_run_mailbox_loop`, resolves the digest to a private local slot,
+executes the task synchronously, writes its error tuple, and then publishes
+`TASK_DONE`. This path retains the established behavior for endpoints that do
+not advertise `supports_frame_staging`.
+
+### 3.2 Two-frame progress path
+
+A two-frame `LocalMailboxEndpoint` advertises `supports_frame_staging` and is
+driven through `submit_progress`, `activate_progress`, and `poll_progress`.
+The owning `WorkerThread` is the only parent-side progress owner. The child also
+uses one `run_two_frame_loop`; it services the separate control base, stages
+both task frames, and owns the one native-run lifecycle.
+
+The ordinary active dispatch and the staged successor use distinct initial
+states:
+
+```text
+active:    IDLE -> TASK_READY    -> FRAME_STAGED -> TASK_LAUNCHED
+                                                   -> TASK_DONE | TASK_FAILED
+successor: IDLE -> PREPARE_READY -> FRAME_STAGED -> ACTIVATE
+                                                   -> TASK_LAUNCHED
+                                                   -> TASK_DONE | TASK_FAILED
 ```
 
-Parent-side cost per dispatch:
+`FRAME_STAGED` means the child validated the frame identity and arguments,
+resolved the callable digest, rewrote any mapped host addresses, and retained
+an immutable snapshot. It does **not** mean that the runtime-specific native
+run is prepared. While one native run is active, the successor remains at
+`FRAME_STAGED`. Only after activation and after the predecessor is polled and
+finalized does the child call native `prepare`, `launch`, `poll`, and
+`finalize` for the successor. This preserves the current one-unfinished-native-
+run contract.
 
-- One reserved `uint64`, one `CallConfig`, one 32-byte digest, and one
-  TaskArgs blob
-- One signal (`write_state`)
-- Spin-poll loop, never a sleep — a task's latency passes through this wait
-  ([codestyle](../.claude/rules/codestyle.md) rule 5). Child liveness is sampled
-  on a steady-clock period, so a dead child ends the wait with
-  `ENDPOINT_FAILURE` instead of spinning the parent forever
-- A sticky launch-acceptance word, observed before completion and cleared only
-  when the parent publishes the next `TASK_READY`
-- One explicit completion outcome: success, task failure, or endpoint failure
+Activation is sticky on the parent side: FIFO promotion may be observed before
+the child reaches `FRAME_STAGED`. The endpoint records that permission and
+publishes `ACTIVATE` only by a compare/exchange from the matching
+`FRAME_STAGED` state. The child chooses activated frames by `dispatch_id`, so a
+later frame cannot bypass an earlier eligible dispatch.
 
-Total ~nanoseconds overhead; the wait is dominated by actual kernel execution.
+Task-frame publication briefly shares the base control mutex so it has a
+defined order relative to a control request. Once published, ordinary controls
+may run while the device task is active. Registry-mutating controls are
+deferred until the active native run is finalized; final unregister also waits
+for every published frame using that digest to retire.
 
-### 3.2 Child loop
+Each task frame is bound to its pipeline lease slot and carries a protocol
+trailer with `{run_id, slot_id, generation, dispatch_id}`. Parent and child
+recheck that identity at staging, activation, acceptance, and completion. A
+stale identity, invalid state, unresolved control timeout, or dead child poisons
+the endpoint; the parent returns an endpoint-failure completion for every frame
+it still owns instead of reusing uncertain bytes. Those completions are withheld
+until the child process has exited (or a non-waitable test endpoint has marked
+every owned frame terminal), so releasing a run lease can never race native
+cleanup.
 
-The child loop lives in Python — see `_chip_process_loop` and
-`_sub_worker_loop` in `python/simpler/worker.py`. Each child polls
-`MAILBOX_OFF_STATE`, decodes the digest-prefixed args blob on `TASK_READY`,
-resolves the digest to its private local slot/callable, writes back any error,
-and publishes `TASK_DONE`. An A2A3 onboard chip child also exposes its mailbox
-state word to the native runner, which publishes `TASK_ACCEPTED` after both
-kernel launches succeed. SUB, remote, A5, and failure paths use WorkerThread's
-completion-time acceptance fallback.
+### 3.3 Launch acceptance
+
+Launch acceptance is a sticky per-frame word, separate from `MailboxState`.
+The parent clears it only immediately before publishing a new task into an
+`IDLE` frame. The native launch call receives the word's address and sets it
+only when the real launch boundary is crossed. `FRAME_STAGED`, `ACTIVATE`, and
+the parent-side progress bookkeeping never manufacture an ACK.
+
+The parent reports `ACCEPTED` at most once per `dispatch_id`, before its terminal
+completion when the real word is observed. A task that fails before launch
+still advances the run-level acceptance waiter at terminal completion so the
+waiter cannot hang, but that conservative fallback does not set the mailbox
+word. Blocking chip dispatch uses the same sticky marker. Endpoint paths with
+no earlier native marker retain completion-time acceptance.
+
 The child inherits the parent's full address space at fork time, so:
 
 - ChipCallable objects (pre-fork allocated) are COW-visible at the same VA
 - The Python callable registry is COW-visible
 - Tensor data in `torch.share_memory_()` regions is fully shared (MAP_SHARED)
 
-### 3.3 Mailbox layout
+### 3.4 Frame layout
 
 ```text
-offset 0:                         int32   state
-offset 4:                         int32   error
-offset 8:                         uint64  reserved task callable field
-                                          or control sub-command
-offset 16:                        CallConfig config
+frame + 0:                        int32   state
+frame + 4:                        int32   error
+frame + 8:                        uint64  reserved task field
+                                          or base-frame control sub-command
+frame + 16:                       CallConfig config / control args
+MAILBOX_OFF_PIPELINE_LEASE:       PipelineSlotLease
 MAILBOX_OFF_TASK_CALLABLE_HASH:   uint8[32] callable digest
 MAILBOX_OFF_TASK_ARGS_BLOB:       bytes [int32 T][int32 S]
                                         [Tensor x T][uint64_t x S]
-tail:                             fixed-size NUL-terminated error message
+task-frame trailer:               protocol, run id, lease slot,
+                                  lease generation, dispatch id
+MAILBOX_OFF_ACCEPTED:             int32 sticky native-launch marker
+frame tail:                       fixed-size NUL-terminated error message
 ```
 
-The current mailbox size is the C++ `MAILBOX_SIZE` constant exported through
-the nanobind module; Python derives its offsets from the same binding where
-possible so the two sides cannot drift silently.
+The C++ `MAILBOX_FRAME_SIZE` and `MAILBOX_SIZE` constants are exported through
+the nanobind module. Python derives frame slicing and offsets from those
+bindings where possible. `MAILBOX_ARGS_CAPACITY` ends before the protocol
+trailer, acceptance word, and error-message tail.
 
-### 3.4 Shutdown
+### 3.5 Stop and child shutdown
 
-`WorkerManager::shutdown_children()` writes `SHUTDOWN` to every registered
-endpoint; for `LocalMailboxEndpoint` this writes `SHUTDOWN` to the mailbox.
-Each child loop sees it on its next poll and exits. The Python facade owns the
-child PIDs and calls `waitpid()` after writing `SHUTDOWN` to its own mailbox
-copy. The parent's `WorkerThread::stop()` only joins the C++ dispatcher thread
-— it does not own the child process.
+`Worker::close()` first asks the Scheduler to stop admitting dispatch, then
+calls `WorkerManager::stop_workers()` while Scheduler callbacks and worker pool
+entries are still valid. A progressable `WorkerThread` repeatedly publishes
+`SHUTDOWN` on the control base until its frames terminalize; repetition prevents
+a concurrently finishing control handler's `CONTROL_DONE` from losing the stop
+request. The child finalizes any active native run and marks every
+active or staged task frame failed before leaving; the parent drains those
+terminal events, brings its in-flight count to zero, and joins the one progress
+thread. The Scheduler is joined only after worker threads can no longer invoke
+completion callbacks, and `WorkerManager::stop()` then clears the pools.
+
+A single-frame endpoint has no staged frame to cancel; its blocking round trip
+finishes before its dispatcher thread joins. The Python facade owns every child
+PID. After native worker teardown it broadcasts `SHUTDOWN` to all child base
+frames, reaps them under one shared deadline, and closes their shared-memory
+objects. C++ endpoint code may observe or reap an early child exit for liveness
+diagnostics, but it does not own the normal `waitpid()` lifecycle.
 
 ---
 

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -417,10 +417,12 @@ inline void bind_worker(nb::module_ &m) {
 
         .def(
             "add_next_level_worker",
-            [](Worker &self, uint64_t mailbox_ptr, int child_pid) {
-                self.add_worker(WorkerType::NEXT_LEVEL, reinterpret_cast<void *>(mailbox_ptr), child_pid);
+            [](Worker &self, uint64_t mailbox_ptr, int child_pid, uint32_t task_frame_count) {
+                self.add_worker(
+                    WorkerType::NEXT_LEVEL, reinterpret_cast<void *>(mailbox_ptr), child_pid, task_frame_count
+                );
             },
-            nb::arg("mailbox_ptr"), nb::arg("child_pid") = -1,
+            nb::arg("mailbox_ptr"), nb::arg("child_pid") = -1, nb::arg("task_frame_count") = 1,
             "Add a NEXT_LEVEL sub-worker. `mailbox_ptr` is the address of a "
             "MAILBOX_SIZE-byte MAP_SHARED region; the child process loop is "
             "Python-managed (fork + _chip_process_loop). `child_pid` is that "
@@ -428,10 +430,12 @@ inline void bind_worker(nb::module_ &m) {
         )
         .def(
             "add_next_level_worker_at",
-            [](Worker &self, int32_t worker_id, uint64_t mailbox_ptr, int child_pid) {
-                self.add_next_level_worker(worker_id, reinterpret_cast<void *>(mailbox_ptr), child_pid);
+            [](Worker &self, int32_t worker_id, uint64_t mailbox_ptr, int child_pid, uint32_t task_frame_count) {
+                self.add_next_level_worker(
+                    worker_id, reinterpret_cast<void *>(mailbox_ptr), child_pid, task_frame_count
+                );
             },
-            nb::arg("worker_id"), nb::arg("mailbox_ptr"), nb::arg("child_pid") = -1,
+            nb::arg("worker_id"), nb::arg("mailbox_ptr"), nb::arg("child_pid") = -1, nb::arg("task_frame_count") = 1,
             "Add a NEXT_LEVEL sub-worker with an explicit worker id."
         )
         .def(
@@ -792,6 +796,7 @@ inline void bind_worker(nb::module_ &m) {
 
     m.attr("DEFAULT_HEAP_RING_SIZE") = static_cast<uint64_t>(DEFAULT_HEAP_RING_SIZE);
     m.attr("MAILBOX_SIZE") = static_cast<int>(MAILBOX_SIZE);
+    m.attr("MAILBOX_FRAME_SIZE") = static_cast<int>(MAILBOX_FRAME_SIZE);
     m.attr("MAILBOX_OFF_ERROR_MSG") = static_cast<int>(MAILBOX_OFF_ERROR_MSG);
     m.attr("MAILBOX_ERROR_MSG_SIZE") = static_cast<int>(MAILBOX_ERROR_MSG_SIZE);
     m.attr("PTO_PIPELINE_MAX_DEPTH") = static_cast<uint32_t>(PTO_PIPELINE_MAX_DEPTH);

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 import _task_interface as _ti_module  # pyright: ignore[reportMissingImports]
 from _task_interface import (  # pyright: ignore[reportMissingImports]
     MAILBOX_ERROR_MSG_SIZE,
+    MAILBOX_FRAME_SIZE,
     MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
     MAX_REGISTERED_CALLABLE_IDS,
@@ -156,6 +157,7 @@ __all__ = [
     "TaskState",
     "_Worker",
     "MAILBOX_SIZE",
+    "MAILBOX_FRAME_SIZE",
     "MAILBOX_OFF_ERROR_MSG",
     "MAILBOX_ERROR_MSG_SIZE",
     "read_args_from_blob",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -133,6 +133,7 @@ from .l3_l2_orch_comm import (
 from .orchestrator import Orchestrator, _callback_run, direct_control
 from .task_interface import (
     MAILBOX_ERROR_MSG_SIZE,
+    MAILBOX_FRAME_SIZE,
     MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
     CallConfig,
@@ -197,10 +198,16 @@ _OFF_TASK_ARGS_BLOB = _OFF_TASK_CALLABLE_HASH + CALLABLE_HASH_DIGEST_BYTES
 # Mirrors MAILBOX_OFF_ACCEPTED / MAILBOX_TASK_ACCEPTED: launch acceptance is a
 # sticky word rather than a MailboxState, because a state carrying it is lost
 # whenever the child reaches TASK_DONE between two parent polls. The parent
-# clears it when it publishes the next TASK_READY.
-_OFF_ACCEPTED = MAILBOX_SIZE - MAILBOX_ERROR_MSG_SIZE - 8
+# clears it when it publishes the next task frame.
+_OFF_ACCEPTED = MAILBOX_FRAME_SIZE - MAILBOX_ERROR_MSG_SIZE - 8
 _TASK_ACCEPTED = 1
-_MAILBOX_ARGS_CAPACITY = MAILBOX_SIZE - _OFF_TASK_ARGS_BLOB - MAILBOX_ERROR_MSG_SIZE - 8
+_OFF_FRAME_PROTOCOL = _OFF_ACCEPTED - 40
+_OFF_FRAME_RUN_ID = _OFF_ACCEPTED - 32
+_OFF_FRAME_SLOT_ID = _OFF_ACCEPTED - 24
+_OFF_FRAME_GENERATION = _OFF_ACCEPTED - 16
+_OFF_FRAME_DISPATCH_ID = _OFF_ACCEPTED - 8
+_TASK_PROTOCOL_VERSION = 2
+_MAILBOX_ARGS_CAPACITY = _OFF_FRAME_PROTOCOL - _OFF_TASK_ARGS_BLOB
 _OFF_CONTROL_CALLABLE_HASH = _OFF_ARGS + 32
 # MAILBOX_OFF_ERROR_MSG / MAILBOX_ERROR_MSG_SIZE come from the C++
 # nanobind module so the two sides cannot drift.
@@ -220,6 +227,19 @@ _CONTROL_DONE = 5
 # deadline aborts startup with a bounded error instead of an unbounded spin.
 _INIT_READY = 6
 _INIT_FAILED = 7
+_FRAME_STAGED = 8
+_TASK_LAUNCHED = 9
+_TASK_FAILED = 10
+_ACTIVATE = 11
+_PREPARE_READY = 12
+_TASK_FRAME_COUNT = 2
+
+
+def _local_task_frame_count(platform: str, _runtime: str, pipeline_depth: int) -> int:
+    if platform == "a2a3" and pipeline_depth >= 2:
+        return _TASK_FRAME_COUNT
+    return 1
+
 
 # Startup readiness bound. A child that neither reports INIT_READY/INIT_FAILED
 # nor exits within this window is treated as hung and startup is aborted.
@@ -2156,21 +2176,22 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     chip_runtime: str = "",
     on_task_done_success=None,
     prepared: set[int] | None = None,
+    task_frame_count: int = 1,
 ) -> None:
     """Chip-process handlers for `_run_mailbox_loop`.
 
-    `on_task_done_success`, if provided, is invoked after a successful
-    ``run_from_blob`` and before publishing TASK_DONE. It must
-    return ``(code, msg)`` — typically ``(0, "")`` on success, or an
-    error tuple if the hook itself failed (e.g. D2H staging error).
-    Returning a non-zero code overrides the kernel's success.
+    `on_task_done_success`, if provided, is invoked after a successful chip task
+    and before publishing TASK_DONE. It must return ``(code, msg)`` — typically
+    ``(0, "")`` on success, or an error tuple if the hook itself failed (e.g.
+    D2H staging error). Returning a non-zero code overrides the kernel's
+    success.
 
-    TASK_READY carries a callable digest. The child resolves it to a
+    Published task frames carry a callable digest. The child resolves it to a
     target-local slot and runs it. The slot must already be prepared: initial
-    startup-snapshot ChipCallables are prepared before INIT_READY (carried in via
-    ``prepared``), and callables registered dynamically after startup arrive via
-    ``_CTRL_PREPARE``. A TASK_READY for an unprepared slot is a control-flow
-    error and fails the task rather than lazily preparing it.
+    startup-snapshot ChipCallables are prepared before INIT_READY (carried in
+    via ``prepared``), and callables registered dynamically after startup
+    arrive via ``_CTRL_PREPARE``. A task frame for an unprepared slot is a
+    control-flow error and fails rather than lazily preparing it.
     """
     prepared = prepared if prepared is not None else set()
     l3_l2_region_store = _L2HostL3L2RegionStore()
@@ -2316,10 +2337,20 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                     shm.close()
             elif sub_cmd == _CTRL_UNREGISTER:
                 digest = _read_control_digest(buf)
-                cid, removed = _remove_local_identity(registry, identity_table, identity_refs, digest)
-                if removed and cid is not None:
-                    cw._unregister_slot(int(cid))
-                    prepared.discard(int(cid))
+                cid = identity_table.get(digest)
+                if cid is not None:
+                    refs = identity_refs.get(digest, 1)
+                    if refs > 1:
+                        identity_refs[digest] = refs - 1
+                    else:
+                        # Mutate the resolver only after native unregister
+                        # succeeds. A device error must not leave the digest
+                        # absent locally while its prepared slot remains live.
+                        cw._unregister_slot(int(cid))
+                        identity_refs.pop(digest, None)
+                        identity_table.pop(digest, None)
+                        registry.pop(int(cid), None)
+                        prepared.discard(int(cid))
             elif sub_cmd == _CTRL_ALLOC_DOMAIN:
                 _handle_ctrl_alloc_domain(cw, buf)
             elif sub_cmd == _CTRL_RELEASE_DOMAIN:
@@ -2347,8 +2378,295 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
         return code, msg
 
+    def run_two_frame_loop() -> None:  # noqa: PLR0912, PLR0915 -- one progress owner drives control and both task frames
+        frame_bufs = [
+            buf[(1 + index) * MAILBOX_FRAME_SIZE : (2 + index) * MAILBOX_FRAME_SIZE]
+            for index in range(_TASK_FRAME_COUNT)
+        ]
+        frame_addrs = [mailbox_addr + (1 + index) * MAILBOX_FRAME_SIZE for index in range(_TASK_FRAME_COUNT)]
+
+        @dataclass
+        class _StagedFrame:
+            index: int
+            frame_buf: memoryview
+            frame_addr: int
+            identity: tuple[int, int, int, int, int]
+            cid: int
+            config: CallConfig
+            activated: bool
+
+        def read_identity(frame_buf: memoryview) -> tuple[int, int, int, int, int]:
+            return (
+                struct.unpack_from("=Q", frame_buf, _OFF_FRAME_PROTOCOL)[0],
+                struct.unpack_from("=Q", frame_buf, _OFF_FRAME_RUN_ID)[0],
+                struct.unpack_from("=Q", frame_buf, _OFF_FRAME_SLOT_ID)[0],
+                struct.unpack_from("=Q", frame_buf, _OFF_FRAME_GENERATION)[0],
+                struct.unpack_from("=Q", frame_buf, _OFF_FRAME_DISPATCH_ID)[0],
+            )
+
+        def task_frame_references_digest(digest: bytes) -> bool:
+            live_states = (_TASK_READY, _PREPARE_READY, _ACTIVATE, _FRAME_STAGED, _TASK_LAUNCHED)
+            for index, frame_buf in enumerate(frame_bufs):
+                if _mailbox_load_i32(frame_addrs[index] + _OFF_STATE) not in live_states:
+                    continue
+                if _read_task_digest(frame_buf) == digest:
+                    return True
+            return False
+
+        def fail_frame(frame: _StagedFrame, message: str) -> None:
+            _write_error(frame.frame_buf, 1, message)
+            _mailbox_store_i32(frame.frame_addr + _OFF_STATE, _TASK_FAILED)
+
+        def stage_frame(index: int, initial_state: int) -> _StagedFrame | None:
+            frame_buf = frame_bufs[index]
+            frame_addr = frame_addrs[index]
+            try:
+                identity = read_identity(frame_buf)
+                protocol, run_id, slot_id, generation, dispatch_id = identity
+                pipeline_slot, pipeline_reserved, pipeline_generation = _PIPELINE_LEASE_FMT.unpack_from(
+                    frame_buf, _OFF_PIPELINE_LEASE
+                )
+                if protocol != _TASK_PROTOCOL_VERSION:
+                    raise RuntimeError(f"unsupported task frame protocol {protocol}")
+                if run_id == 0 or generation == 0 or dispatch_id == 0:
+                    raise RuntimeError(f"invalid task frame identity {identity}")
+                if slot_id != index or pipeline_slot != index:
+                    raise RuntimeError(
+                        f"task frame {index} does not own pipeline slot (identity={slot_id}, lease={pipeline_slot})"
+                    )
+                if pipeline_reserved != 0 or pipeline_generation != generation:
+                    raise RuntimeError(
+                        "task frame pipeline lease does not match its identity "
+                        f"(reserved={pipeline_reserved}, lease_generation={pipeline_generation}, "
+                        f"identity_generation={generation})"
+                    )
+
+                tensor_count, scalar_count = struct.unpack_from("=ii", frame_buf, _OFF_TASK_ARGS_BLOB)
+                if tensor_count < 0 or scalar_count < 0:
+                    raise RuntimeError(
+                        f"task args has negative counts (tensors={tensor_count}, scalars={scalar_count})"
+                    )
+                args_bytes = (
+                    _BLOB_HEADER_BYTES + tensor_count * _BLOB_TENSOR_STRIDE + scalar_count * struct.calcsize("=Q")
+                )
+                if args_bytes > _MAILBOX_ARGS_CAPACITY:
+                    raise RuntimeError(
+                        f"task args needs {args_bytes} bytes but frame capacity is {_MAILBOX_ARGS_CAPACITY}"
+                    )
+
+                digest = _read_task_digest(frame_buf)
+                cid = identity_table.get(digest)
+                if cid is None:
+                    raise RuntimeError(f"callable hash {_format_digest(digest)} not registered")
+                if cid not in prepared:
+                    raise RuntimeError(
+                        f"cid {cid} not prepared before task frame publication (register via _CTRL_PREPARE first)"
+                    )
+                if host_buf_ranges:
+                    _rewrite_blob_host_addrs(frame_buf, _OFF_TASK_ARGS_BLOB, host_buf_ranges)
+                config = _read_config_from_mailbox(frame_buf)
+                activation_required = initial_state != _TASK_READY
+                staged = _StagedFrame(
+                    index=index,
+                    frame_buf=frame_buf,
+                    frame_addr=frame_addr,
+                    identity=identity,
+                    cid=int(cid),
+                    config=config,
+                    activated=not activation_required or initial_state == _ACTIVATE,
+                )
+                _write_error(frame_buf, 0, "")
+                _mailbox_store_i32(frame_addr + _OFF_STATE, _FRAME_STAGED)
+                return staged
+            except Exception as e:  # noqa: BLE001
+                _write_error(frame_buf, 1, _format_exc(f"chip_process dev={device_id} frame={index}", e))
+                _mailbox_store_i32(frame_addr + _OFF_STATE, _TASK_FAILED)
+                return None
+
+        staged_frames: dict[int, _StagedFrame] = {}
+        active_frame: _StagedFrame | None = None
+        active_run: Any = None
+        parent_pid = os.getppid()
+        liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
+        shutdown_message = f"chip_process dev={device_id}: task loop shut down"
+        try:
+            while True:
+                control_state = _mailbox_load_i32(state_addr)
+                if control_state == _SHUTDOWN:
+                    break
+                if control_state == _CONTROL_REQUEST:
+                    sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
+                    registry_control = sub_cmd in (_CTRL_PREPARE, _CTRL_REGISTER, _CTRL_UNREGISTER)
+                    defer_control = registry_control and active_frame is not None
+                    if sub_cmd == _CTRL_UNREGISTER:
+                        defer_control = defer_control or task_frame_references_digest(_read_control_digest(buf))
+                    if not defer_control:
+                        code, msg = handle_control(int(sub_cmd))
+                        _write_error(buf, code, msg)
+                        _mailbox_store_i32(state_addr, _CONTROL_DONE)
+
+                for index in range(_TASK_FRAME_COUNT):
+                    frame_state = _mailbox_load_i32(frame_addrs[index] + _OFF_STATE)
+                    staged = staged_frames.get(index)
+                    if staged is None:
+                        if frame_state in (_TASK_READY, _PREPARE_READY, _ACTIVATE):
+                            staged = stage_frame(index, frame_state)
+                            if staged is not None:
+                                staged_frames[index] = staged
+                        continue
+                    if frame_state == _ACTIVATE:
+                        if read_identity(staged.frame_buf) != staged.identity:
+                            fail_frame(staged, f"chip_process dev={device_id}: stale activation identity")
+                            if active_frame is not staged:
+                                staged_frames.pop(index, None)
+                            continue
+                        staged.activated = True
+
+                if active_frame is not None:
+                    try:
+                        run_complete = bool(cw._impl._poll_native_run(active_run))
+                    except Exception as e:  # noqa: BLE001
+                        poll_message = _format_exc(f"chip_process dev={device_id}: native poll", e)
+                        try:
+                            cw._impl._finalize_native_run(active_run)
+                        except Exception as finalize_error:  # noqa: BLE001
+                            poll_message += "; " + _format_exc("native finalize", finalize_error)
+                        fail_frame(active_frame, poll_message)
+                        staged_frames.pop(active_frame.index, None)
+                        active_frame = None
+                        active_run = None
+                        # A failed native progress/finalize fence cannot prove
+                        # that device state is reusable. Stop this endpoint so
+                        # an already-staged successor is failed, never launched
+                        # into potentially poisoned native state.
+                        shutdown_message = poll_message
+                        break
+                    else:
+                        if run_complete:
+                            completed_frame = active_frame
+                            code = 0
+                            msg = ""
+                            finalize_failed = False
+                            try:
+                                cw._impl._finalize_native_run(active_run)
+                            except Exception as e:  # noqa: BLE001
+                                code = 1
+                                finalize_failed = True
+                                msg = _format_exc(f"chip_process dev={device_id}: native finalize", e)
+                            active_frame = None
+                            active_run = None
+                            if code == 0 and on_task_done_success is not None:
+                                try:
+                                    code, msg = on_task_done_success()
+                                except Exception as e:  # noqa: BLE001
+                                    code = 1
+                                    msg = _format_exc(f"chip_process dev={device_id}: task completion hook", e)
+                            _write_error(completed_frame.frame_buf, code, msg)
+                            _mailbox_store_i32(
+                                completed_frame.frame_addr + _OFF_STATE,
+                                _TASK_DONE if code == 0 else _TASK_FAILED,
+                            )
+                            staged_frames.pop(completed_frame.index, None)
+                            if finalize_failed:
+                                # Finalization is the native reuse fence. Its
+                                # failure terminalizes the endpoint before a
+                                # staged successor can cross the launch fence.
+                                shutdown_message = msg
+                                break
+
+                if active_frame is None:
+                    eligible = sorted(
+                        (frame for frame in staged_frames.values() if frame.activated),
+                        key=lambda frame: frame.identity[4],
+                    )
+                    if eligible:
+                        next_frame = eligible[0]
+                        frame_state = _mailbox_load_i32(next_frame.frame_addr + _OFF_STATE)
+                        expected_states = (_FRAME_STAGED, _ACTIVATE)
+                        if (
+                            read_identity(next_frame.frame_buf) != next_frame.identity
+                            or frame_state not in expected_states
+                        ):
+                            fail_frame(
+                                next_frame,
+                                f"chip_process dev={device_id}: staged task frame changed before launch",
+                            )
+                            staged_frames.pop(next_frame.index, None)
+                        else:
+                            _protocol, _run_id, slot_id, generation, _dispatch_id = next_frame.identity
+                            native_run = None
+                            try:
+                                native_run = cw._impl._prepare_native_run_from_blob(
+                                    next_frame.cid,
+                                    next_frame.frame_addr + _OFF_TASK_ARGS_BLOB,
+                                    _MAILBOX_ARGS_CAPACITY,
+                                    next_frame.config,
+                                    slot_id,
+                                    generation,
+                                )
+                                cw._impl._launch_native_run(
+                                    native_run,
+                                    next_frame.frame_addr + _OFF_ACCEPTED,
+                                    _TASK_ACCEPTED,
+                                )
+                            except Exception as e:  # noqa: BLE001
+                                launch_message = _format_exc(f"chip_process dev={device_id}: native launch", e)
+                                finalize_failed = False
+                                if native_run is not None:
+                                    try:
+                                        cw._impl._finalize_native_run(native_run)
+                                    except Exception as finalize_error:  # noqa: BLE001
+                                        finalize_failed = True
+                                        launch_message += "; " + _format_exc("native finalize", finalize_error)
+                                fail_frame(next_frame, launch_message)
+                                staged_frames.pop(next_frame.index, None)
+                                if finalize_failed:
+                                    # The launch cleanup did not establish the
+                                    # native reuse fence. Stop before any other
+                                    # staged frame can enter poisoned state.
+                                    shutdown_message = launch_message
+                                    break
+                            else:
+                                active_frame = next_frame
+                                active_run = native_run
+                                _mailbox_store_i32(next_frame.frame_addr + _OFF_STATE, _TASK_LAUNCHED)
+
+                liveness_countdown -= 1
+                if liveness_countdown <= 0:
+                    liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
+                    if os.getppid() != parent_pid:
+                        shutdown_message = f"chip_process dev={device_id}: parent exited"
+                        break
+        finally:
+            if active_frame is not None:
+                active_message = shutdown_message
+                try:
+                    cw._impl._finalize_native_run(active_run)
+                except Exception as e:  # noqa: BLE001
+                    active_message += "; " + _format_exc("native finalize", e)
+                fail_frame(active_frame, active_message)
+                staged_frames.pop(active_frame.index, None)
+            for staged in staged_frames.values():
+                fail_frame(staged, shutdown_message)
+            for index, frame_buf in enumerate(frame_bufs):
+                frame_state_addr = frame_addrs[index] + _OFF_STATE
+                if _mailbox_load_i32(frame_state_addr) in (
+                    _TASK_READY,
+                    _PREPARE_READY,
+                    _ACTIVATE,
+                    _FRAME_STAGED,
+                    _TASK_LAUNCHED,
+                ):
+                    _write_error(frame_buf, 1, shutdown_message)
+                    _mailbox_store_i32(frame_state_addr, _TASK_FAILED)
+            for frame_buf in frame_bufs:
+                frame_buf.release()
+
     try:
-        _run_mailbox_loop(buf, state_addr, handle_task=handle_task, handle_control=handle_control)
+        if task_frame_count >= 2:
+            run_two_frame_loop()
+        else:
+            _run_mailbox_loop(buf, state_addr, handle_task=handle_task, handle_control=handle_control)
     finally:
         _sweep_l2_host_l3_l2_regions(l3_l2_region_store)
         for host_shm, _lo, _hi, _base in host_buf_table.values():
@@ -2424,6 +2742,9 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
     # child to reach _INIT_READY before dispatching the first task, so the
     # per-rank host-side stream sync budget only covers actual op execution
     # rather than absorbing peer-rank init skew.
+    # Before the first task, the lease word is startup metadata: slot_id carries
+    # the backend's supported admission depth. Dispatches later overwrite the
+    # same fixed wire region with the run-owned slot/generation lease.
     _PIPELINE_LEASE_FMT.pack_into(buf, _OFF_PIPELINE_LEASE, int(cw.pipeline_depth), 0, 0)
     _mailbox_store_i32(state_addr, _INIT_READY)
     sys.stderr.write(f"[chip_process pid={os.getpid()} dev={device_id}] ready\n")
@@ -2442,6 +2763,7 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
             chip_platform=platform,
             chip_runtime=runtime,
             prepared=prepared,
+            task_frame_count=_local_task_frame_count(platform, runtime, int(cw.pipeline_depth)),
         )
     finally:
         cw.finalize()
@@ -5809,6 +6131,7 @@ class Worker:
         n_sub = self._config.get("num_sub_workers", 0)
         deadline = self._startup_deadline
         direct_chip_pipeline_depth = PTO_PIPELINE_MAX_DEPTH
+        chip_depths: list[int] = []
 
         # Freeze the startup registry snapshot. init() already holds the epoch in
         # the INITIALIZING state, so a concurrent register/unregister is blocked
@@ -5914,10 +6237,11 @@ class Worker:
             # documented in issue #897.  A chip that fails or dies during init
             # raises here rather than spinning forever.
             self._await_children_ready(self._chip_shms, self._chip_pids, "chip", deadline)
-            chip_depths = []
             for shm in self._chip_shms:
                 buf = shm.buf
                 assert buf is not None
+                # INIT_READY repurposes the lease slot_id as the child's depth
+                # advertisement; task dispatch restores normal lease semantics.
                 chip_depths.append(_PIPELINE_LEASE_FMT.unpack_from(buf, _OFF_PIPELINE_LEASE)[0])
             if any(depth <= 0 or depth > PTO_PIPELINE_MAX_DEPTH for depth in chip_depths):
                 raise RuntimeError(f"chip worker published invalid pipeline depths: {chip_depths}")
@@ -5992,8 +6316,11 @@ class Worker:
         # mailbox that can no longer be completed.
         if device_ids:
             _require_matching_pids(self._chip_shms, self._chip_pids, "chip")
-            for shm, pid in zip(self._chip_shms, self._chip_pids):
-                dw.add_next_level_worker(_mailbox_addr(shm), pid)
+            for shm, pid, chip_depth in zip(self._chip_shms, self._chip_pids, chip_depths):
+                task_frame_count = _local_task_frame_count(
+                    str(self._config["platform"]), str(self._config["runtime"]), chip_depth
+                )
+                dw.add_next_level_worker(_mailbox_addr(shm), pid, task_frame_count)
 
         # Register Worker children as NEXT_LEVEL (L4+)
         if self._next_level_shms and not hasattr(dw, "add_next_level_worker_at"):

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -25,19 +25,18 @@
 #include "pto_runtime_c_api.h"
 
 #include "common/unified_log.h"
+#include "host/file_marker_handshake.h"
 
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
-#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -154,25 +153,11 @@ static uint64_t make_run_token(int rank) {
 
 static std::string
 barrier_marker_path(const std::string &rootinfo_path, uint64_t run_token, const std::string &tag, int rank) {
-    return handshake_dir(rootinfo_path) + "/barrier_" + handshake_prefix(rootinfo_path) + "_" + tag + "_" +
-           run_token_hex(run_token) + "_" + std::to_string(rank) + ".ready";
+    return file_marker_handshake::marker_path(rootinfo_path, run_token, tag, rank);
 }
 
 static void cleanup_handshake_files(const std::string &rootinfo_path) {
-    std::error_code ec;
-    std::filesystem::remove(rootinfo_path, ec);
-
-    const std::string prefix = "barrier_" + handshake_prefix(rootinfo_path) + "_";
-    const std::string dir = handshake_dir(rootinfo_path);
-    for (const auto &entry : std::filesystem::directory_iterator(dir, ec)) {
-        if (ec) break;
-        if (!entry.is_regular_file(ec)) continue;
-        const std::string name = entry.path().filename().string();
-        if (name.rfind(prefix, 0) != 0) continue;
-        if (name.size() < 6 || name.substr(name.size() - 6) != ".ready") continue;
-        std::filesystem::remove(entry.path(), ec);
-        ec.clear();
-    }
+    (void)file_marker_handshake::cleanup(rootinfo_path);
 }
 
 static bool
@@ -1539,8 +1524,13 @@ extern "C" int comm_destroy(CommHandle h) try {
     // Final barrier is best-effort: if a peer already crashed we still need to
     // release the local resources we own, so timeout just logs and proceeds.
     int rc = 0;
-    if (!file_barrier(h->rootinfo_path, h->rank, h->nranks, "destroy", h->run_token)) {
-        LOG_WARN("[comm rank %d] comm_destroy: final barrier timed out; releasing local state anyway", h->rank);
+    const auto destroy_handshake =
+        file_marker_handshake::destroy_barrier(h->rootinfo_path, h->rank, h->nranks, h->run_token);
+    if (!destroy_handshake.ok()) {
+        LOG_WARN(
+            "[comm rank %d] comm_destroy: final barrier failed during %s for rank %d; releasing local state anyway",
+            h->rank, file_marker_handshake::stage_name(destroy_handshake.stage), destroy_handshake.rank
+        );
         rc = -1;
     }
 
@@ -1579,13 +1569,23 @@ extern "C" int comm_destroy(CommHandle h) try {
     // lifecycle belongs to DeviceRunner, whose finalize() releases all
     // device memory before resetting the device and running aclFinalize.
 
-    // Only rank 0 sweeps the on-disk handshake markers, and only if the
-    // final barrier succeeded.  Deleting them after a timeout would strand
-    // any peer that hasn't observed our marker yet, and leak that peer
-    // into the next run with no rootinfo to discover.  Letting cleanup
-    // ride on the next rank-0 init is the safer recovery path.
-    if (h->rank == 0 && rc == 0) {
-        cleanup_handshake_files(h->rootinfo_path);
+    // Do not let a faster follower return and reuse this path while rank 0
+    // can still sweep the old generation. Rank 0 first retires rootinfo and
+    // best-effort sweeps its token-scoped barrier markers, then publishes a
+    // per-follower release outside the sweep namespace; each follower
+    // consumes its own release before return.
+    // This post phase runs after HcclCommDestroy, so waiting cannot hold a
+    // communicator resource needed by rank 0's teardown.
+    if (destroy_handshake.ok()) {
+        const auto destroy_release =
+            file_marker_handshake::release_after_cleanup(h->rootinfo_path, h->rank, h->nranks, h->run_token);
+        if (!destroy_release.ok()) {
+            LOG_WARN(
+                "[comm rank %d] comm_destroy: final release failed during %s for rank %d", h->rank,
+                file_marker_handshake::stage_name(destroy_release.stage), destroy_release.rank
+            );
+            rc = -1;
+        }
     }
 
     delete h;

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -26,17 +26,16 @@
 #include "platform_comm/comm_context.h"
 
 #include "common/unified_log.h"
+#include "host/file_marker_handshake.h"
 
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>
 #include <string>
-#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -158,25 +157,11 @@ static uint64_t make_run_token(int rank) {
 
 static std::string
 barrier_marker_path(const std::string &rootinfo_path, uint64_t run_token, const std::string &tag, int rank) {
-    return handshake_dir(rootinfo_path) + "/barrier_" + handshake_prefix(rootinfo_path) + "_" + tag + "_" +
-           run_token_hex(run_token) + "_" + std::to_string(rank) + ".ready";
+    return file_marker_handshake::marker_path(rootinfo_path, run_token, tag, rank);
 }
 
 static void cleanup_handshake_files(const std::string &rootinfo_path) {
-    std::error_code ec;
-    std::filesystem::remove(rootinfo_path, ec);
-
-    const std::string prefix = "barrier_" + handshake_prefix(rootinfo_path) + "_";
-    const std::string dir = handshake_dir(rootinfo_path);
-    for (const auto &entry : std::filesystem::directory_iterator(dir, ec)) {
-        if (ec) break;
-        if (!entry.is_regular_file(ec)) continue;
-        const std::string name = entry.path().filename().string();
-        if (name.rfind(prefix, 0) != 0) continue;
-        if (name.size() < 6 || name.substr(name.size() - 6) != ".ready") continue;
-        std::filesystem::remove(entry.path(), ec);
-        ec.clear();
-    }
+    (void)file_marker_handshake::cleanup(rootinfo_path);
 }
 
 static bool
@@ -1402,8 +1387,13 @@ extern "C" int comm_destroy(CommHandle h) try {
     // Final barrier is best-effort: if a peer already crashed we still need to
     // release the local resources we own, so timeout just logs and proceeds.
     int rc = 0;
-    if (!file_barrier(h->rootinfo_path, h->rank, h->nranks, "destroy", h->run_token)) {
-        LOG_WARN("[comm rank %d] comm_destroy: final barrier timed out; releasing local state anyway", h->rank);
+    const auto destroy_handshake =
+        file_marker_handshake::destroy_barrier(h->rootinfo_path, h->rank, h->nranks, h->run_token);
+    if (!destroy_handshake.ok()) {
+        LOG_WARN(
+            "[comm rank %d] comm_destroy: final barrier failed during %s for rank %d; releasing local state anyway",
+            h->rank, file_marker_handshake::stage_name(destroy_handshake.stage), destroy_handshake.rank
+        );
         rc = -1;
     }
 
@@ -1441,13 +1431,23 @@ extern "C" int comm_destroy(CommHandle h) try {
     // lifecycle belongs to DeviceRunner, whose finalize() releases all
     // device memory before resetting the device and running aclFinalize.
 
-    // Only rank 0 sweeps the on-disk handshake markers, and only if the
-    // final barrier succeeded.  Deleting them after a timeout would strand
-    // any peer that hasn't observed our marker yet, and leak that peer
-    // into the next run with no rootinfo to discover.  Letting cleanup
-    // ride on the next rank-0 init is the safer recovery path.
-    if (h->rank == 0 && rc == 0) {
-        cleanup_handshake_files(h->rootinfo_path);
+    // Do not let a faster follower return and reuse this path while rank 0
+    // can still sweep the old generation. Rank 0 first retires rootinfo and
+    // best-effort sweeps its token-scoped barrier markers, then publishes a
+    // per-follower release outside the sweep namespace; each follower
+    // consumes its own release before return.
+    // This post phase runs after HcclCommDestroy, so waiting cannot hold a
+    // communicator resource needed by rank 0's teardown.
+    if (destroy_handshake.ok()) {
+        const auto destroy_release =
+            file_marker_handshake::release_after_cleanup(h->rootinfo_path, h->rank, h->nranks, h->run_token);
+        if (!destroy_release.ok()) {
+            LOG_WARN(
+                "[comm rank %d] comm_destroy: final release failed during %s for rank %d", h->rank,
+                file_marker_handshake::stage_name(destroy_release.stage), destroy_release.rank
+            );
+            rc = -1;
+        }
     }
 
     delete h;

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -207,6 +207,7 @@ void Orchestrator::close_run_submission(RunId run_id) {
         }
     }
     run->completion_cv.notify_all();
+    if (ready_notify_cb_) ready_notify_cb_();
     activate_fifo_head();
     finish_run_if_ready(run);
 }
@@ -321,6 +322,19 @@ RunId Orchestrator::dispatchable_run_id() const {
 RunId Orchestrator::active_run_id() const {
     std::lock_guard<std::mutex> lk(runs_mu_);
     return active_run_id_;
+}
+
+RunId Orchestrator::preparable_run_id() const {
+    std::lock_guard<std::mutex> lk(runs_mu_);
+    if (!dispatchable_locked(active_run_id_) || run_fifo_.size() < 2 || run_fifo_.front() != active_run_id_) {
+        return INVALID_RUN_ID;
+    }
+    auto it = runs_.find(run_fifo_[1]);
+    if (it == runs_.end() || it->second->phase.load(std::memory_order_acquire) != RunPhase::PREPARED ||
+        !pipeline_slots_.owns(it->second->lease)) {
+        return INVALID_RUN_ID;
+    }
+    return it->first;
 }
 
 bool Orchestrator::quiescent_locked() const { return runs_.empty() && building_run_id_ == INVALID_RUN_ID; }

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -167,6 +167,7 @@ public:
      */
     void await_run_admission(RunId run_id);
     RunId active_run_id() const;
+    RunId preparable_run_id() const;
     void release_run(RunId run_id);
 
     // Open a nested scope. Every task submitted between this call and the

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -108,9 +108,13 @@ void Scheduler::start(const Config &cfg) {
     sched_thread_ = std::thread(&Scheduler::run, this);
 }
 
-void Scheduler::stop() {
+void Scheduler::request_stop() {
     stop_requested_.store(true, std::memory_order_release);
     completion_cv_.notify_all();
+}
+
+void Scheduler::stop() {
+    request_stop();
 
     if (sched_thread_.joinable()) sched_thread_.join();
 
@@ -216,6 +220,20 @@ void Scheduler::notify_ready() {
     completion_cv_.notify_one();
 }
 
+bool stageable_successor_ready(const NextLevelReadyQueues &ready_queues, const WorkerManager &manager, RunId run_id) {
+    // B3b stages singles only. If the successor has a group head, retain the
+    // established all-or-nothing group priority instead of letting a staged
+    // single occupy one of its reserved workers after FIFO promotion.
+    if (!ready_queues.groups_empty(run_id)) return false;
+    for (int32_t worker_id : ready_queues.worker_ids()) {
+        WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
+        if (worker != nullptr && worker->can_stage() && !ready_queues.single_empty(worker_id, run_id)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // =============================================================================
 // Scheduler loop
 // =============================================================================
@@ -230,7 +248,13 @@ void Scheduler::run() {
                 if (cfg_.active_run_cb) {
                     RunId active = cfg_.active_run_cb();
                     ready = active != INVALID_RUN_ID &&
-                            (!cfg_.ready_next_level_queues->empty(active) || !cfg_.ready_sub_queue->empty(active));
+                            (!cfg_.ready_next_level_queues->empty(active) || !cfg_.ready_sub_queue->empty(active) ||
+                             cfg_.manager->needs_activation(active));
+                    if (!ready && cfg_.preparable_run_cb) {
+                        RunId preparable = cfg_.preparable_run_cb();
+                        ready = preparable != INVALID_RUN_ID && !cfg_.manager->has_staged_run(preparable) &&
+                                stageable_successor_ready(*cfg_.ready_next_level_queues, *cfg_.manager, preparable);
+                    }
                 } else {
                     ready = !cfg_.ready_next_level_queues->empty() || !cfg_.ready_sub_queue->empty();
                 }
@@ -255,8 +279,9 @@ void Scheduler::run() {
             on_task_complete(completion);
         }
 
-        // Phase 2: dispatch ready tasks
-        dispatch_ready();
+        // Phase 2: dispatch ready tasks. Once teardown publishes stop, the
+        // existing endpoint-owned work drains but no new slot enters a worker.
+        if (!stop_requested_.load(std::memory_order_acquire)) dispatch_ready();
 
         // Exit when stop requested and all workers idle
         if (stop_requested_.load(std::memory_order_acquire)) {
@@ -272,7 +297,6 @@ void Scheduler::run() {
                     }
                     on_task_complete(completion);
                 }
-                dispatch_ready();
                 break;  // loop_lk released on scope exit before exiting run()
             }
         }
@@ -398,7 +422,10 @@ void Scheduler::dispatch_ready() {
         RunId active_run = cfg_.active_run_cb();
         if (active_run == INVALID_RUN_ID) return;
         run_snapshot = active_run;
+        cfg_.manager->activate_prepared_run(active_run);
     }
+
+    dispatch_preparable_next_level_singles();
 
     // Group reservations and every queue pop in one pass belong to the same
     // whole-run FIFO head, even if a completion advances the head mid-pass.
@@ -412,6 +439,49 @@ bool claim_for_dispatch(TaskSlotState &s) {
     return s.state.compare_exchange_strong(
         expected, TaskState::RUNNING, std::memory_order_acq_rel, std::memory_order_acquire
     );
+}
+
+void Scheduler::dispatch_claimed(WorkerThread *worker, WorkerDispatch dispatch, bool prepared) {
+    try {
+        if (prepared) {
+            worker->dispatch_prepared(dispatch);
+        } else {
+            worker->dispatch(dispatch);
+        }
+    } catch (const std::exception &e) {
+        worker->complete_unpublished(
+            dispatch, std::string("Scheduler failed to publish a claimed dispatch: ") + e.what()
+        );
+    } catch (...) {
+        worker->complete_unpublished(dispatch, "Scheduler failed to publish a claimed dispatch");
+    }
+}
+
+void Scheduler::dispatch_preparable_next_level_singles() {
+    if (!cfg_.preparable_run_cb) return;
+    RunId run_id = cfg_.preparable_run_cb();
+    if (run_id == INVALID_RUN_ID || cfg_.manager->has_staged_run(run_id) ||
+        !cfg_.ready_next_level_queues->groups_empty(run_id)) {
+        return;
+    }
+
+    for (int32_t worker_id : cfg_.ready_next_level_queues->worker_ids()) {
+        WorkerThread *worker = cfg_.manager->get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
+        if (worker == nullptr || !worker->can_stage()) continue;
+        TaskSlot slot;
+        if (!cfg_.ready_next_level_queues->try_pop_single(worker_id, run_id, slot)) continue;
+        TaskSlotState &state = *cfg_.ring->slot_state(slot);
+        if (state.state.load(std::memory_order_acquire) != TaskState::READY) continue;
+        if (state.run_id != run_id || state.worker_type != WorkerType::NEXT_LEVEL || state.is_group() ||
+            state.target_worker_id(0) != worker_id) {
+            cfg_.enqueue_ready_cb(slot);
+            continue;
+        }
+        if (cfg_.before_claim_cb) cfg_.before_claim_cb(slot);
+        if (!claim_for_dispatch(state)) continue;
+        dispatch_claimed(worker, WorkerDispatch{slot, 0}, /*prepared=*/true);
+        return;
+    }
 }
 
 void Scheduler::dispatch_sub_ready(const std::optional<RunId> &run_snapshot) {
@@ -470,7 +540,7 @@ void Scheduler::dispatch_sub_ready(const std::optional<RunId> &run_snapshot) {
                 if (member_state != GroupMemberState::NOT_DISPATCHED || s.group_failed) continue;
                 member_state = GroupMemberState::RUNNING;
             }
-            workers[static_cast<size_t>(i)]->dispatch(WorkerDispatch{slot, i});
+            dispatch_claimed(workers[static_cast<size_t>(i)], WorkerDispatch{slot, i}, /*prepared=*/false);
         }
     }
 }
@@ -544,7 +614,7 @@ std::unordered_set<int32_t> Scheduler::dispatch_next_level_group(const std::opti
             reset_group_state_locked(s, GroupMemberState::RUNNING);
         }
         for (int32_t i = 0; i < group_size; ++i) {
-            workers[static_cast<size_t>(i)]->dispatch(WorkerDispatch{slot, i});
+            dispatch_claimed(workers[static_cast<size_t>(i)], WorkerDispatch{slot, i}, /*prepared=*/false);
         }
     }
     return {};
@@ -578,7 +648,7 @@ void Scheduler::dispatch_next_level_singles(
             }
             if (cfg_.before_claim_cb) cfg_.before_claim_cb(slot);
             if (!claim_for_dispatch(s)) continue;
-            worker->dispatch(WorkerDispatch{slot, 0});
+            dispatch_claimed(worker, WorkerDispatch{slot, 0}, /*prepared=*/false);
             break;
         }
     }

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -46,7 +46,9 @@
 #include "types.h"
 
 class WorkerManager;  // forward decl
+class WorkerThread;   // forward decl
 class Ring;           // forward decl
+struct WorkerDispatch;
 
 // =============================================================================
 // Scheduler — DAG engine (no worker pool ownership)
@@ -67,6 +69,7 @@ class Ring;           // forward decl
  * window this closes is exactly the code between the queue pop and the launch.
  */
 bool claim_for_dispatch(TaskSlotState &s);
+bool stageable_successor_ready(const NextLevelReadyQueues &ready_queues, const WorkerManager &manager, RunId run_id);
 
 class Scheduler {
 public:
@@ -80,6 +83,7 @@ public:
         // Production workers expose exactly one whole-run FIFO head. Tests
         // that omit this callback retain the legacy unpartitioned queue path.
         std::function<RunId()> active_run_cb;
+        std::function<RunId()> preparable_run_cb;
         // Called when a task reaches CONSUMED (TensorMap cleanup + ring release).
         std::function<void(TaskSlot)> on_consumed_cb;
         // Called as soon as an endpoint reports failure so the error is
@@ -95,6 +99,7 @@ public:
     };
 
     void start(const Config &cfg);
+    void request_stop();
     void stop();
 
     bool running() const { return running_.load(std::memory_order_acquire); }
@@ -131,6 +136,8 @@ private:
     void poison_task(TaskSlot slot, const std::string &root_message);
     void try_consume(TaskSlot slot);
     void dispatch_ready();
+    void dispatch_claimed(WorkerThread *worker, WorkerDispatch dispatch, bool prepared);
+    void dispatch_preparable_next_level_singles();
     std::unordered_set<int32_t> dispatch_next_level_group(const std::optional<RunId> &run_snapshot);
     void dispatch_next_level_singles(
         const std::unordered_set<int32_t> &reserved_worker_ids, const std::optional<RunId> &run_snapshot

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -289,6 +289,19 @@ bool NextLevelReadyQueues::empty(RunId run_id) const {
     return true;
 }
 
+bool NextLevelReadyQueues::groups_empty(RunId run_id) const { return group_queue_.empty(run_id); }
+
+bool NextLevelReadyQueues::single_empty(int32_t worker_id, RunId run_id) const {
+    return queues_[index_for(worker_id)]->empty(run_id);
+}
+
+bool NextLevelReadyQueues::singles_empty(RunId run_id) const {
+    for (const auto &queue : queues_) {
+        if (!queue->empty(run_id)) return false;
+    }
+    return true;
+}
+
 void NextLevelReadyQueues::erase_run(RunId run_id) {
     group_queue_.erase_run(run_id);
     for (const auto &queue : queues_)

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -126,6 +126,7 @@ static constexpr int32_t INVALID_SLOT = -1;
 
 using RunId = uint64_t;
 static constexpr RunId INVALID_RUN_ID = 0;
+using TaskSlot = int32_t;
 
 // Admission reserves a generation-safe pipeline slot before graph construction.
 // Closing the graph publishes PREPARED; only the whole-run FIFO head may enter
@@ -152,7 +153,7 @@ struct RunState {
     mutable std::mutex completion_mu;
     std::condition_variable completion_cv;
     std::exception_ptr first_error;
-    std::vector<int32_t> task_slots;
+    std::vector<TaskSlot> task_slots;
     bool submission_closed{false};
     bool submission_failed{false};
     bool lease_released{false};
@@ -161,8 +162,6 @@ struct RunState {
 // =============================================================================
 // Task slot index type
 // =============================================================================
-
-using TaskSlot = int32_t;
 
 static constexpr size_t CALLABLE_HASH_DIGEST_SIZE = 32;
 
@@ -546,6 +545,9 @@ public:
     bool try_pop_group(RunId run_id, TaskSlot &out);
     bool empty() const;
     bool empty(RunId run_id) const;
+    bool groups_empty(RunId run_id) const;
+    bool single_empty(int32_t worker_id, RunId run_id) const;
+    bool singles_empty(RunId run_id) const;
     void erase_run(RunId run_id);
     const std::vector<int32_t> &worker_ids() const { return worker_ids_; }
 

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -68,15 +68,16 @@ Worker::~Worker() {
     if (initialized_) close();
 }
 
-void Worker::add_worker(WorkerType type, void *mailbox, int child_pid) {
+void Worker::add_worker(WorkerType type, void *mailbox, int child_pid, uint32_t task_frame_count) {
     if (initialized_) throw std::runtime_error("Worker: add_worker after init");
-    if (type == WorkerType::NEXT_LEVEL) manager_.add_next_level(mailbox, child_pid);
-    else manager_.add_sub(mailbox, child_pid);
+    if (type == WorkerType::NEXT_LEVEL) {
+        manager_.add_next_level(mailbox, child_pid, task_frame_count);
+    } else manager_.add_sub(mailbox, child_pid);
 }
 
-void Worker::add_next_level_worker(int32_t worker_id, void *mailbox, int child_pid) {
+void Worker::add_next_level_worker(int32_t worker_id, void *mailbox, int child_pid, uint32_t task_frame_count) {
     if (initialized_) throw std::runtime_error("Worker: add_next_level_worker after init");
-    manager_.add_next_level_at(worker_id, mailbox, child_pid);
+    manager_.add_next_level_at(worker_id, mailbox, child_pid, task_frame_count);
 }
 
 void Worker::add_remote_l3_socket(
@@ -125,6 +126,9 @@ void Worker::init() {
     cfg.active_run_cb = [this] {
         return orchestrator_.dispatchable_run_id();
     };
+    cfg.preparable_run_cb = [this] {
+        return orchestrator_.preparable_run_id();
+    };
     cfg.on_consumed_cb = [this](TaskSlot slot) {
         orchestrator_.on_consumed(slot);
     };
@@ -140,6 +144,8 @@ void Worker::init() {
 
 void Worker::close() {
     if (!initialized_) return;
+    scheduler_.request_stop();
+    manager_.stop_workers();
     scheduler_.stop();
     manager_.stop();
     allocator_.shutdown();

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -76,8 +76,8 @@ public:
     // child and consumes the mailbox via the Python child loop.
     // `child_pid` is the forked child servicing `mailbox`, or -1 when the
     // caller owns no waitable child.
-    void add_worker(WorkerType type, void *mailbox, int child_pid = -1);
-    void add_next_level_worker(int32_t worker_id, void *mailbox, int child_pid = -1);
+    void add_worker(WorkerType type, void *mailbox, int child_pid = -1, uint32_t task_frame_count = 1);
+    void add_next_level_worker(int32_t worker_id, void *mailbox, int child_pid = -1, uint32_t task_frame_count = 1);
 
     // Register a REMOTE_L3 endpoint only after its session runner completed
     // prestart and reported HELLO READY on the command lane.

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -149,18 +149,34 @@ WorkerEndpoint::run_with_accept(Ring *ring, const WorkerDispatch &dispatch, cons
     return completion;
 }
 
+void WorkerEndpoint::submit_progress(Ring *, const WorkerDispatch &) {
+    throw std::runtime_error("progress submission is not supported by this WorkerEndpoint");
+}
+bool WorkerEndpoint::poll_progress(WorkerEndpointProgress &) { return false; }
+bool WorkerEndpoint::activate_progress(RunId) { return false; }
+void WorkerEndpoint::request_progress_stop() noexcept {}
+void WorkerEndpoint::report_progress_error(const std::string &) { request_progress_stop(); }
+
 // =============================================================================
 // LocalMailboxEndpoint — mailbox helpers
 // =============================================================================
 
-LocalMailboxEndpoint::LocalMailboxEndpoint(int32_t worker_id, void *mailbox, int child_pid) :
+LocalMailboxEndpoint::LocalMailboxEndpoint(int32_t worker_id, void *mailbox, int child_pid, uint32_t task_frame_count) :
     mailbox_(mailbox),
+    task_frame_count_(task_frame_count),
     child_pid_(child_pid) {
     if (mailbox == nullptr) throw std::invalid_argument("LocalMailboxEndpoint: null mailbox");
+    if (task_frame_count == 0 || task_frame_count > MAILBOX_TASK_FRAME_COUNT) {
+        throw std::invalid_argument("LocalMailboxEndpoint: invalid task frame count");
+    }
     caps_.worker_id = worker_id;
+    caps_.max_inflight_tasks = task_frame_count;
+    caps_.supports_frame_staging = task_frame_count > 1;
+    next_liveness_check_ = std::chrono::steady_clock::now() + kChildLivenessPollPeriod;
 }
 
 std::string LocalMailboxEndpoint::check_child_death() {
+    std::lock_guard<std::mutex> child_lk(child_mu_);
     if (child_dead_) return child_death_reason_;
     if (child_pid_ <= 0) return {};
 
@@ -188,8 +204,9 @@ std::string LocalMailboxEndpoint::check_child_death() {
     return child_death_reason_;
 }
 
-MailboxState LocalMailboxEndpoint::read_mailbox_state() const {
-    volatile int32_t *ptr = reinterpret_cast<volatile int32_t *>(mbox() + MAILBOX_OFF_STATE);
+MailboxState LocalMailboxEndpoint::read_mailbox_state(const char *frame) const {
+    const char *base = frame == nullptr ? mbox() : frame;
+    volatile int32_t *ptr = reinterpret_cast<volatile int32_t *>(const_cast<char *>(base) + MAILBOX_OFF_STATE);
     int32_t v;
 #if defined(__aarch64__)
     __asm__ volatile("ldar %w0, [%1]" : "=r"(v) : "r"(ptr) : "memory");
@@ -202,8 +219,9 @@ MailboxState LocalMailboxEndpoint::read_mailbox_state() const {
     return static_cast<MailboxState>(v);
 }
 
-void LocalMailboxEndpoint::write_mailbox_state(MailboxState s) {
-    volatile int32_t *ptr = reinterpret_cast<volatile int32_t *>(mbox() + MAILBOX_OFF_STATE);
+void LocalMailboxEndpoint::write_mailbox_state(MailboxState s, char *frame) {
+    char *base = frame == nullptr ? mbox() : frame;
+    volatile int32_t *ptr = reinterpret_cast<volatile int32_t *>(base + MAILBOX_OFF_STATE);
     int32_t v = static_cast<int32_t>(s);
 #if defined(__aarch64__)
     __asm__ volatile("stlr %w0, [%1]" : : "r"(v), "r"(ptr) : "memory");
@@ -215,20 +233,35 @@ void LocalMailboxEndpoint::write_mailbox_state(MailboxState s) {
 #endif
 }
 
-bool LocalMailboxEndpoint::read_task_accepted() const {
-    const int32_t *ptr = reinterpret_cast<const int32_t *>(mbox() + MAILBOX_OFF_ACCEPTED);
+bool mailbox_compare_exchange_state(char *frame, MailboxState expected, MailboxState desired) noexcept {
+    auto *ptr = reinterpret_cast<int32_t *>(frame + MAILBOX_OFF_STATE);
+    int32_t expected_value = static_cast<int32_t>(expected);
+    return __atomic_compare_exchange_n(
+        ptr, &expected_value, static_cast<int32_t>(desired), false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE
+    );
+}
+
+bool LocalMailboxEndpoint::read_task_accepted(const char *frame) const {
+    const char *base = frame == nullptr ? mbox() : frame;
+    const int32_t *ptr = reinterpret_cast<const int32_t *>(base + MAILBOX_OFF_ACCEPTED);
     int32_t v = 0;
     __atomic_load(ptr, &v, __ATOMIC_ACQUIRE);
     return v == MAILBOX_TASK_ACCEPTED;
 }
 
-void LocalMailboxEndpoint::clear_task_accepted() {
-    int32_t *ptr = reinterpret_cast<int32_t *>(mbox() + MAILBOX_OFF_ACCEPTED);
+void LocalMailboxEndpoint::clear_task_accepted(char *frame) {
+    char *base = frame == nullptr ? mbox() : frame;
+    int32_t *ptr = reinterpret_cast<int32_t *>(base + MAILBOX_OFF_ACCEPTED);
     int32_t v = 0;
     __atomic_store(ptr, &v, __ATOMIC_RELEASE);
 }
 
 void LocalMailboxEndpoint::shutdown_child() { write_mailbox_state(MailboxState::SHUTDOWN); }
+
+char *LocalMailboxEndpoint::task_frame(size_t index) const {
+    return mbox() +
+           static_cast<ptrdiff_t>(MAILBOX_FIRST_TASK_FRAME + index) * static_cast<ptrdiff_t>(MAILBOX_FRAME_SIZE);
+}
 
 // =============================================================================
 // WorkerThread — lifecycle
@@ -244,15 +277,142 @@ void WorkerThread::start(
     on_accept_ = on_accept;
     endpoint_ = std::move(endpoint);
     shutdown_ = false;
-    idle_.store(true, std::memory_order_relaxed);
+    if (endpoint_->caps().max_inflight_tasks == 0) {
+        throw std::invalid_argument("WorkerThread::start: endpoint capacity is zero");
+    }
+    inflight_.store(0, std::memory_order_relaxed);
+    active_inflight_.store(false, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
+        staged_dispatch_id_ = 0;
+        activated_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
+        activated_dispatch_id_ = 0;
+    }
     thread_ = std::thread(&WorkerThread::loop, this);
 }
 
 void WorkerThread::dispatch(WorkerDispatch d) {
-    idle_.store(false, std::memory_order_release);
+    d.prepare_only = false;
+    bool expected = false;
+    if (!active_inflight_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        throw std::logic_error("WorkerThread::dispatch: active lane is occupied");
+    }
+    try {
+        enqueue_dispatch(d);
+    } catch (...) {
+        active_inflight_.store(false, std::memory_order_release);
+        throw;
+    }
+}
+
+void WorkerThread::dispatch_prepared(WorkerDispatch d) {
+    if (!caps().supports_frame_staging) {
+        throw std::logic_error("WorkerThread::dispatch_prepared: endpoint does not support frame staging");
+    }
+    if (ring_ == nullptr) throw std::logic_error("WorkerThread::dispatch_prepared: null ring");
+    TaskSlotState *slot = ring_->slot_state(d.task_slot);
+    if (slot == nullptr || slot->run_id == INVALID_RUN_ID) {
+        throw std::logic_error("WorkerThread::dispatch_prepared: dispatch has no run identity");
+    }
+    {
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        if (staged_run_id_.load(std::memory_order_relaxed) != INVALID_RUN_ID) {
+            throw std::logic_error("WorkerThread::dispatch_prepared: worker already owns a staged run");
+        }
+        staged_run_id_.store(slot->run_id, std::memory_order_relaxed);
+        staged_dispatch_id_ = 0;
+    }
+    d.prepare_only = true;
+    try {
+        enqueue_dispatch(d, slot->run_id);
+    } catch (...) {
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        if (staged_run_id_.load(std::memory_order_relaxed) == slot->run_id) {
+            staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
+            staged_dispatch_id_ = 0;
+        }
+        throw;
+    }
+}
+
+void WorkerThread::enqueue_dispatch(WorkerDispatch d, RunId staged_run_id) {
     std::lock_guard<std::mutex> lk(mu_);
-    queue_.push(d);
+    if (shutdown_.load(std::memory_order_acquire)) {
+        throw std::logic_error("WorkerThread::dispatch: worker is stopping");
+    }
+    if (inflight_.load(std::memory_order_acquire) >= endpoint_->caps().max_inflight_tasks) {
+        throw std::logic_error("WorkerThread::dispatch: endpoint capacity exceeded");
+    }
+    d.dispatch_id = next_dispatch_id_;
+    if (staged_run_id != INVALID_RUN_ID) {
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        if (staged_run_id_.load(std::memory_order_relaxed) != staged_run_id || staged_dispatch_id_ != 0) {
+            throw std::logic_error("WorkerThread::dispatch_prepared: staged lane identity changed before enqueue");
+        }
+        staged_dispatch_id_ = d.dispatch_id;
+    }
+    try {
+        queue_.push(d);  // A failed allocation consumes neither capacity nor dispatch identity.
+    } catch (...) {
+        if (staged_run_id != INVALID_RUN_ID) {
+            std::lock_guard<std::mutex> lane_lk(lane_mu_);
+            if (staged_run_id_.load(std::memory_order_relaxed) == staged_run_id &&
+                staged_dispatch_id_ == d.dispatch_id) {
+                staged_dispatch_id_ = 0;
+            }
+        }
+        throw;
+    }
+    ++next_dispatch_id_;
+    inflight_.fetch_add(1, std::memory_order_release);
     cv_.notify_one();
+}
+
+bool WorkerThread::activate_prepared(RunId run_id) {
+    if (run_id == INVALID_RUN_ID) return false;
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    if (staged_run_id_.load(std::memory_order_relaxed) != run_id || staged_dispatch_id_ == 0 ||
+        activated_run_id_.load(std::memory_order_relaxed) == run_id) {
+        return false;
+    }
+    bool expected = false;
+    if (!active_inflight_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        return false;
+    }
+    activated_run_id_.store(run_id, std::memory_order_release);
+    activated_dispatch_id_ = staged_dispatch_id_;
+    staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
+    staged_dispatch_id_ = 0;
+    cv_.notify_one();
+    return true;
+}
+
+bool WorkerThread::has_staged_run(RunId run_id) const {
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    return staged_run_id_.load(std::memory_order_relaxed) == run_id;
+}
+
+bool WorkerThread::needs_activation(RunId run_id) const {
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    return staged_run_id_.load(std::memory_order_relaxed) == run_id &&
+           activated_run_id_.load(std::memory_order_relaxed) != run_id;
+}
+
+bool WorkerThread::can_stage() const {
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    return caps().supports_frame_staging && staged_run_id_.load(std::memory_order_relaxed) == INVALID_RUN_ID;
+}
+
+void WorkerThread::complete_unpublished(WorkerDispatch dispatch, const std::string &error_message) {
+    try {
+        if (on_accept_) on_accept_(dispatch);
+    } catch (...) {
+        // The endpoint-publication error remains the primary task failure.
+    }
+    on_complete_(
+        WorkerCompletion{dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE, error_message}
+    );
 }
 
 void WorkerThread::stop() {
@@ -280,12 +440,99 @@ int32_t WorkerThread::worker_id() const { return caps().worker_id; }
 // =============================================================================
 
 void WorkerThread::loop() {
+    if (endpoint_->progressable()) {
+        while (true) {
+            WorkerDispatch dispatch;
+            bool have_dispatch = false;
+            {
+                std::unique_lock<std::mutex> lk(mu_);
+                if (queue_.empty() && inflight_.load(std::memory_order_acquire) == 0 &&
+                    !shutdown_.load(std::memory_order_acquire)) {
+                    cv_.wait(lk, [this] {
+                        return !queue_.empty() || shutdown_.load(std::memory_order_acquire);
+                    });
+                }
+                if (!queue_.empty()) {
+                    dispatch = queue_.front();
+                    queue_.pop();
+                    have_dispatch = true;
+                } else if (shutdown_.load(std::memory_order_acquire) &&
+                           inflight_.load(std::memory_order_acquire) == 0) {
+                    break;
+                }
+            }
+
+            if (shutdown_.load(std::memory_order_acquire)) {
+                // Repeat until every frame terminalizes. A child finishing a
+                // control handler may publish CONTROL_DONE after an earlier
+                // SHUTDOWN store; the next pass restores the stop request.
+                endpoint_->request_progress_stop();
+            }
+
+            if (have_dispatch) {
+                if (shutdown_.load(std::memory_order_acquire)) {
+                    WorkerEndpointProgress progress;
+                    progress.kind = WorkerProgressKind::COMPLETED;
+                    progress.dispatch = dispatch;
+                    progress.completion = WorkerCompletion{
+                        dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+                        "WorkerThread endpoint stopped before frame publication"
+                    };
+                    finish_progress_dispatch(progress);
+                } else {
+                    try {
+                        endpoint_->submit_progress(ring_, dispatch);
+                    } catch (const std::exception &e) {
+                        WorkerEndpointProgress progress;
+                        progress.kind = WorkerProgressKind::COMPLETED;
+                        progress.dispatch = dispatch;
+                        progress.completion = WorkerCompletion{
+                            dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+                            std::string("WorkerThread endpoint failed before frame publication: ") + e.what()
+                        };
+                        finish_progress_dispatch(progress);
+                    } catch (...) {
+                        WorkerEndpointProgress progress;
+                        progress.kind = WorkerProgressKind::COMPLETED;
+                        progress.dispatch = dispatch;
+                        progress.completion = WorkerCompletion{
+                            dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+                            "WorkerThread endpoint failed before frame publication with unknown exception"
+                        };
+                        finish_progress_dispatch(progress);
+                    }
+                }
+            }
+
+            RunId activated = activated_run_id_.load(std::memory_order_acquire);
+            if (activated != INVALID_RUN_ID) {
+                try {
+                    (void)endpoint_->activate_progress(activated);
+                } catch (const std::exception &e) {
+                    fail_progress_driver(std::string("activate_progress failed: ") + e.what());
+                } catch (...) {
+                    fail_progress_driver("activate_progress failed with unknown exception");
+                }
+            }
+
+            WorkerEndpointProgress progress;
+            try {
+                if (endpoint_->poll_progress(progress)) finish_progress_dispatch(progress);
+            } catch (const std::exception &e) {
+                fail_progress_driver(std::string("poll_progress failed: ") + e.what());
+            } catch (...) {
+                fail_progress_driver("poll_progress failed with unknown exception");
+            }
+        }
+        return;
+    }
+
     while (true) {
         WorkerDispatch d;
         {
             std::unique_lock<std::mutex> lk(mu_);
             cv_.wait(lk, [this] {
-                return !queue_.empty() || shutdown_;
+                return !queue_.empty() || shutdown_.load(std::memory_order_acquire);
             });
             if (queue_.empty()) break;
             d = queue_.front();
@@ -331,13 +578,82 @@ void WorkerThread::loop() {
             }
         }
 
-        idle_.store(true, std::memory_order_release);
         on_complete_(std::move(completion));
+        active_inflight_.store(false, std::memory_order_release);
+        inflight_.fetch_sub(1, std::memory_order_acq_rel);
+        cv_.notify_one();
     }
+}
+
+void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progress) {
+    const WorkerDispatch &dispatch = progress.dispatch;
+    if (progress.kind == WorkerProgressKind::FRAME_STAGED) return;
+
+    if (progress.kind == WorkerProgressKind::ACCEPTED) {
+        if (!accepted_dispatch_ids_.insert(dispatch.dispatch_id).second) return;
+        try {
+            if (on_accept_) on_accept_(dispatch);
+        } catch (const std::exception &e) {
+            accept_errors_[dispatch.dispatch_id] = std::string("WorkerThread accept fence failed: ") + e.what();
+        } catch (...) {
+            accept_errors_[dispatch.dispatch_id] = "WorkerThread accept fence failed with unknown exception";
+        }
+        return;
+    }
+
+    WorkerCompletion completion = progress.completion;
+    if (accepted_dispatch_ids_.erase(dispatch.dispatch_id) == 0) {
+        // This advances only the run-level waiter after a terminal endpoint
+        // result. It does not manufacture the per-frame launch marker: that
+        // sticky word is published exclusively by the native launch path.
+        try {
+            if (on_accept_) on_accept_(dispatch);
+        } catch (const std::exception &e) {
+            accept_errors_[dispatch.dispatch_id] = std::string("WorkerThread accept fence failed: ") + e.what();
+        } catch (...) {
+            accept_errors_[dispatch.dispatch_id] = "WorkerThread accept fence failed with unknown exception";
+        }
+    }
+    auto accept_error = accept_errors_.find(dispatch.dispatch_id);
+    if (accept_error != accept_errors_.end()) {
+        if (completion.outcome == EndpointOutcome::SUCCESS) {
+            completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+            completion.error_message = accept_error->second;
+        }
+        accept_errors_.erase(accept_error);
+    }
+
+    on_complete_(std::move(completion));
+    if (dispatch.prepare_only) {
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        if (dispatch.dispatch_id == staged_dispatch_id_) {
+            staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
+            staged_dispatch_id_ = 0;
+        } else if (dispatch.dispatch_id == activated_dispatch_id_) {
+            activated_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
+            activated_dispatch_id_ = 0;
+            active_inflight_.store(false, std::memory_order_release);
+        }
+    } else {
+        active_inflight_.store(false, std::memory_order_release);
+    }
+    inflight_.fetch_sub(1, std::memory_order_acq_rel);
+    cv_.notify_one();
+}
+
+void WorkerThread::fail_progress_driver(const std::string &reason) noexcept {
+    shutdown_.store(true, std::memory_order_release);
+    try {
+        endpoint_->report_progress_error(reason);
+    } catch (...) {
+        endpoint_->request_progress_stop();
+    }
+    cv_.notify_all();
 }
 
 WorkerCompletion WorkerThread::dispatch_process(WorkerDispatch d, const std::function<void()> &on_accept) {
     if (!endpoint_) throw std::runtime_error("WorkerThread::dispatch_process: null endpoint");
+    if (d.prepare_only) throw std::logic_error("prepared dispatch requires a progressable endpoint");
     return endpoint_->run_with_accept(ring_, d, on_accept);
 }
 
@@ -348,6 +664,9 @@ WorkerCompletion LocalMailboxEndpoint::run(Ring *ring, const WorkerDispatch &dis
 WorkerCompletion LocalMailboxEndpoint::run_with_accept(
     Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept
 ) {
+    if (task_frame_count_ > 1) {
+        throw std::logic_error("LocalMailboxEndpoint::run_with_accept: two-frame endpoints require progress driving");
+    }
     if (ring == nullptr) throw std::invalid_argument("LocalMailboxEndpoint::run: null ring");
     TaskSlotState &s = *ring->slot_state(dispatch.task_slot);
     int32_t group_index = dispatch.group_index;
@@ -363,7 +682,6 @@ WorkerCompletion LocalMailboxEndpoint::run_with_accept(
     WorkerCompletion completion;
     completion.task_slot = dispatch.task_slot;
     completion.group_index = group_index;
-
     // Hold mailbox_mu_ for the entire round trip (write payload + state +
     // spin-poll TASK_DONE + reset to IDLE). Any control_* request from the
     // orch thread waits for the dispatch to finish before claiming the
@@ -475,17 +793,299 @@ WorkerCompletion LocalMailboxEndpoint::run_with_accept(
     return completion;
 }
 
+void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dispatch) {
+    if (!progressable()) throw std::logic_error("LocalMailboxEndpoint::submit_progress: endpoint is not progressable");
+    if (ring == nullptr) throw std::invalid_argument("LocalMailboxEndpoint::submit_progress: null ring");
+    TaskSlotState *slot_state = ring->slot_state(dispatch.task_slot);
+    if (slot_state == nullptr) throw std::out_of_range("LocalMailboxEndpoint::submit_progress: invalid task slot");
+    TaskSlotState &state = *slot_state;
+    const TaskArgsView view = state.args_view(dispatch.group_index);
+    if (!state.remote_sidecar_for(dispatch.group_index).empty()) {
+        throw std::runtime_error("remote task sidecar is not supported by local mailbox");
+    }
+    if (state.run_id == INVALID_RUN_ID || state.pipeline_lease.reserved != 0 || state.pipeline_lease.generation == 0 ||
+        state.pipeline_lease.slot_id >= task_frame_count_) {
+        throw std::runtime_error("task frame has an invalid pipeline lease identity");
+    }
+    const size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(Tensor) +
+                              static_cast<size_t>(view.scalar_count) * sizeof(uint64_t);
+    if (blob_bytes > MAILBOX_ARGS_CAPACITY) {
+        throw std::runtime_error(
+            "args blob exceeds mailbox capacity: need " + std::to_string(blob_bytes) + ", capacity " +
+            std::to_string(MAILBOX_ARGS_CAPACITY)
+        );
+    }
+
+    const size_t frame_index = state.pipeline_lease.slot_id;
+    // Linearize task-frame publication against base-frame controls. The
+    // control mutex is released immediately after the task state release-store;
+    // controls may still execute while the native run is active, subject to
+    // the child-side registry lifetime gate.
+    std::lock_guard<std::mutex> mailbox_lk(mailbox_mu_);
+    std::lock_guard<std::mutex> lk(progress_mu_);
+    if (endpoint_poisoned_) {
+        throw std::runtime_error("endpoint is poisoned: " + endpoint_poison_reason_);
+    }
+    FrameRecord &record = frames_[frame_index];
+    char *frame = task_frame(frame_index);
+    if (record.occupied || read_mailbox_state(frame) != MailboxState::IDLE) {
+        poison_progress("pipeline-slot task frame is not reusable");
+        throw std::runtime_error("pipeline-slot task frame is not reusable");
+    }
+
+    int32_t zero_err = 0;
+    std::memcpy(frame + MAILBOX_OFF_ERROR, &zero_err, sizeof(zero_err));
+    std::memset(frame + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+    clear_task_accepted(frame);
+    uint64_t reserved_callable = 0;
+    std::memcpy(frame + MAILBOX_OFF_CALLABLE, &reserved_callable, sizeof(reserved_callable));
+    std::memcpy(frame + MAILBOX_OFF_CONFIG, &state.config, sizeof(CallConfig));
+    std::memcpy(frame + MAILBOX_OFF_PIPELINE_LEASE, &state.pipeline_lease, sizeof(PipelineSlotLease));
+    std::memcpy(
+        frame + MAILBOX_OFF_TASK_CALLABLE_HASH, state.callable.digest.data(),
+        static_cast<size_t>(CALLABLE_HASH_DIGEST_SIZE)
+    );
+
+    uint8_t *blob = reinterpret_cast<uint8_t *>(frame + MAILBOX_OFF_TASK_ARGS_BLOB);
+    std::memcpy(blob, &view.tensor_count, sizeof(int32_t));
+    std::memcpy(blob + sizeof(int32_t), &view.scalar_count, sizeof(int32_t));
+    if (view.tensor_count > 0) {
+        std::memcpy(
+            blob + TASK_ARGS_BLOB_HEADER_SIZE, view.tensor_bytes,
+            static_cast<size_t>(view.tensor_count) * sizeof(Tensor)
+        );
+    }
+    if (view.scalar_count > 0) {
+        std::memcpy(
+            blob + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(Tensor), view.scalars,
+            static_cast<size_t>(view.scalar_count) * sizeof(uint64_t)
+        );
+    }
+
+    const uint64_t protocol = MAILBOX_TASK_PROTOCOL_VERSION;
+    const uint64_t slot_id = state.pipeline_lease.slot_id;
+    std::memcpy(frame + MAILBOX_OFF_FRAME_PROTOCOL, &protocol, sizeof(protocol));
+    std::memcpy(frame + MAILBOX_OFF_FRAME_RUN_ID, &state.run_id, sizeof(state.run_id));
+    std::memcpy(frame + MAILBOX_OFF_FRAME_SLOT_ID, &slot_id, sizeof(slot_id));
+    std::memcpy(frame + MAILBOX_OFF_FRAME_GENERATION, &state.pipeline_lease.generation, sizeof(uint64_t));
+    std::memcpy(frame + MAILBOX_OFF_FRAME_DISPATCH_ID, &dispatch.dispatch_id, sizeof(dispatch.dispatch_id));
+
+    record.occupied = true;
+    record.dispatch = dispatch;
+    record.run_id = state.run_id;
+    record.slot_id = slot_id;
+    record.generation = state.pipeline_lease.generation;
+    write_mailbox_state(dispatch.prepare_only ? MailboxState::PREPARE_READY : MailboxState::TASK_READY, frame);
+}
+
+bool LocalMailboxEndpoint::frame_identity_matches(const FrameRecord &record, const char *frame) const {
+    uint64_t protocol = 0;
+    RunId run_id = INVALID_RUN_ID;
+    uint64_t slot_id = 0;
+    uint64_t generation = 0;
+    uint64_t dispatch_id = 0;
+    PipelineSlotLease lease{};
+    std::memcpy(&protocol, frame + MAILBOX_OFF_FRAME_PROTOCOL, sizeof(protocol));
+    std::memcpy(&run_id, frame + MAILBOX_OFF_FRAME_RUN_ID, sizeof(run_id));
+    std::memcpy(&slot_id, frame + MAILBOX_OFF_FRAME_SLOT_ID, sizeof(slot_id));
+    std::memcpy(&generation, frame + MAILBOX_OFF_FRAME_GENERATION, sizeof(generation));
+    std::memcpy(&dispatch_id, frame + MAILBOX_OFF_FRAME_DISPATCH_ID, sizeof(dispatch_id));
+    std::memcpy(&lease, frame + MAILBOX_OFF_PIPELINE_LEASE, sizeof(lease));
+    return protocol == MAILBOX_TASK_PROTOCOL_VERSION && run_id == record.run_id && slot_id == record.slot_id &&
+           generation == record.generation && dispatch_id == record.dispatch.dispatch_id &&
+           lease.slot_id == record.slot_id && lease.reserved == 0 && lease.generation == record.generation;
+}
+
+bool LocalMailboxEndpoint::try_publish_activation(FrameRecord &record, char *frame) {
+    if (!record.activation_requested || record.activation_published) return record.activation_published;
+    if (!frame_identity_matches(record, frame)) {
+        poison_progress("stale staged frame identity before activation");
+        return false;
+    }
+    if (mailbox_compare_exchange_state(frame, MailboxState::FRAME_STAGED, MailboxState::ACTIVATE)) {
+        record.activation_published = true;
+    }
+    return record.activation_published;
+}
+
+void LocalMailboxEndpoint::poison_progress(const std::string &reason) {
+    if (endpoint_poisoned_) return;
+    endpoint_poisoned_ = true;
+    endpoint_poison_reason_ = reason;
+}
+
+bool LocalMailboxEndpoint::poisoned_progress_quiesced() {
+    // SHUTDOWN is deliberately repeated. A child already inside a control
+    // handler may publish CONTROL_DONE after the first store; the next store
+    // restores the stop request and prevents a live native run from being
+    // mistaken for a terminal parent completion.
+    shutdown_child();
+    if (child_pid_ > 0) return !check_child_death().empty();
+    for (size_t index = 0; index < task_frame_count_; ++index) {
+        if (!frames_[index].occupied) continue;
+        MailboxState state = read_mailbox_state(task_frame(index));
+        if (state != MailboxState::TASK_DONE && state != MailboxState::TASK_FAILED) return false;
+    }
+    return true;
+}
+
+WorkerCompletion LocalMailboxEndpoint::poisoned_completion(const FrameRecord &record) const {
+    return WorkerCompletion{
+        record.dispatch.task_slot, record.dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+        "LocalMailboxEndpoint progress failed: " + endpoint_poison_reason_
+    };
+}
+
+bool LocalMailboxEndpoint::poll_progress(WorkerEndpointProgress &progress) {
+    std::lock_guard<std::mutex> lk(progress_mu_);
+    bool any_occupied = false;
+    for (const FrameRecord &record : frames_)
+        any_occupied = any_occupied || record.occupied;
+    if (!any_occupied) return false;
+
+    if (!endpoint_poisoned_ && mailbox_control_timed_out_.load(std::memory_order_acquire)) {
+        poison_progress("mailbox has an unresolved timed-out control command");
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (!endpoint_poisoned_ && now >= next_liveness_check_) {
+        next_liveness_check_ = now + kChildLivenessPollPeriod;
+        std::string death = check_child_death();
+        if (!death.empty()) poison_progress(death);
+    }
+
+    if (endpoint_poisoned_) {
+        if (!poisoned_progress_quiesced()) return false;
+        for (size_t offset = 0; offset < task_frame_count_; ++offset) {
+            size_t index = (poll_cursor_ + offset) % task_frame_count_;
+            FrameRecord &record = frames_[index];
+            if (!record.occupied) continue;
+            progress.kind = WorkerProgressKind::COMPLETED;
+            progress.dispatch = record.dispatch;
+            progress.completion = poisoned_completion(record);
+            record = FrameRecord{};
+            poll_cursor_ = (index + 1) % task_frame_count_;
+            return true;
+        }
+        return false;
+    }
+
+    for (size_t offset = 0; offset < task_frame_count_; ++offset) {
+        size_t index = (poll_cursor_ + offset) % task_frame_count_;
+        FrameRecord &record = frames_[index];
+        if (!record.occupied) continue;
+        char *frame = task_frame(index);
+        MailboxState state = read_mailbox_state(frame);
+
+        if (!record.accepted_reported && read_task_accepted(frame)) {
+            if (!frame_identity_matches(record, frame)) {
+                poison_progress("stale frame identity at launch acceptance");
+                break;
+            }
+            record.accepted_reported = true;
+            progress.kind = WorkerProgressKind::ACCEPTED;
+            progress.dispatch = record.dispatch;
+            poll_cursor_ = (index + 1) % task_frame_count_;
+            return true;
+        }
+
+        if (state == MailboxState::FRAME_STAGED) {
+            if (!frame_identity_matches(record, frame)) {
+                poison_progress("stale frame identity at endpoint staging");
+                break;
+            }
+            if (record.activation_requested) {
+                (void)try_publish_activation(record, frame);
+                if (endpoint_poisoned_) break;
+            }
+            if (!record.staged_reported) {
+                record.staged_reported = true;
+                progress.kind = WorkerProgressKind::FRAME_STAGED;
+                progress.dispatch = record.dispatch;
+                poll_cursor_ = (index + 1) % task_frame_count_;
+                return true;
+            }
+            continue;
+        }
+
+        if (state == MailboxState::TASK_DONE || state == MailboxState::TASK_FAILED) {
+            if (!frame_identity_matches(record, frame)) {
+                poison_progress("stale frame identity at terminal completion");
+                break;
+            }
+            int32_t error_code = 0;
+            std::memcpy(&error_code, frame + MAILBOX_OFF_ERROR, sizeof(error_code));
+            progress.kind = WorkerProgressKind::COMPLETED;
+            progress.dispatch = record.dispatch;
+            progress.completion.task_slot = record.dispatch.task_slot;
+            progress.completion.group_index = record.dispatch.group_index;
+            if (state == MailboxState::TASK_FAILED || error_code != 0) {
+                progress.completion.outcome = EndpointOutcome::TASK_FAILURE;
+                progress.completion.error_message =
+                    "LocalMailboxEndpoint child failed (worker_id=" + std::to_string(caps_.worker_id) +
+                    ", code=" + std::to_string(error_code) + "): " + read_error_msg(frame);
+            } else {
+                progress.completion.outcome = EndpointOutcome::SUCCESS;
+            }
+            write_mailbox_state(MailboxState::IDLE, frame);
+            record = FrameRecord{};
+            poll_cursor_ = (index + 1) % task_frame_count_;
+            return true;
+        }
+
+        if (state != MailboxState::TASK_READY && state != MailboxState::PREPARE_READY &&
+            state != MailboxState::ACTIVATE && state != MailboxState::TASK_LAUNCHED) {
+            poison_progress("task frame entered an invalid state " + std::to_string(static_cast<int32_t>(state)));
+            break;
+        }
+    }
+
+    if (!endpoint_poisoned_) return false;
+    if (!poisoned_progress_quiesced()) return false;
+    for (size_t index = 0; index < task_frame_count_; ++index) {
+        FrameRecord &record = frames_[index];
+        if (!record.occupied) continue;
+        progress.kind = WorkerProgressKind::COMPLETED;
+        progress.dispatch = record.dispatch;
+        progress.completion = poisoned_completion(record);
+        record = FrameRecord{};
+        poll_cursor_ = (index + 1) % task_frame_count_;
+        return true;
+    }
+    return false;
+}
+
+bool LocalMailboxEndpoint::activate_progress(RunId run_id) {
+    std::lock_guard<std::mutex> lk(progress_mu_);
+    if (endpoint_poisoned_) return false;
+    for (size_t index = 0; index < task_frame_count_; ++index) {
+        FrameRecord &record = frames_[index];
+        if (!record.occupied || !record.dispatch.prepare_only || record.run_id != run_id) continue;
+        record.activation_requested = true;
+        char *frame = task_frame(index);
+        (void)try_publish_activation(record, frame);
+        return true;
+    }
+    return false;
+}
+
+void LocalMailboxEndpoint::request_progress_stop() noexcept { shutdown_child(); }
+
+void LocalMailboxEndpoint::report_progress_error(const std::string &reason) {
+    std::lock_guard<std::mutex> lk(progress_mu_);
+    poison_progress("endpoint progress driver failed: " + reason);
+}
+
 // =============================================================================
 // WorkerManager
 // =============================================================================
 
-void WorkerManager::add_next_level(void *mailbox, int child_pid) {
-    add_next_level_at(static_cast<int32_t>(next_level_entries_.size()), mailbox, child_pid);
+void WorkerManager::add_next_level(void *mailbox, int child_pid, uint32_t task_frame_count) {
+    add_next_level_at(static_cast<int32_t>(next_level_entries_.size()), mailbox, child_pid, task_frame_count);
 }
 
-void WorkerManager::add_next_level_at(int32_t worker_id, void *mailbox, int child_pid) {
+void WorkerManager::add_next_level_at(int32_t worker_id, void *mailbox, int child_pid, uint32_t task_frame_count) {
     if (worker_id < 0) throw std::invalid_argument("WorkerManager::add_next_level_at: negative worker_id");
-    next_level_entries_.push_back(LocalNextLevelEntry{worker_id, mailbox, child_pid});
+    next_level_entries_.push_back(LocalNextLevelEntry{worker_id, mailbox, child_pid, task_frame_count});
 }
 
 void WorkerManager::add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint) {
@@ -522,7 +1122,9 @@ void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete, const OnA
     auto make_next_level_threads = [&]() {
         for (const auto &entry : next_level_entries_) {
             auto wt = std::make_unique<WorkerThread>();
-            auto endpoint = std::make_unique<LocalMailboxEndpoint>(entry.worker_id, entry.mailbox, entry.child_pid);
+            auto endpoint = std::make_unique<LocalMailboxEndpoint>(
+                entry.worker_id, entry.mailbox, entry.child_pid, entry.task_frame_count
+            );
             wt->start(ring, on_complete, on_accept, std::move(endpoint));
             next_level_threads_.push_back(std::move(wt));
         }
@@ -548,11 +1150,15 @@ void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete, const OnA
     make_sub_threads(sub_entries_, sub_threads_);
 }
 
-void WorkerManager::stop() {
+void WorkerManager::stop_workers() {
     for (auto &wt : next_level_threads_)
         wt->stop();
     for (auto &wt : sub_threads_)
         wt->stop();
+}
+
+void WorkerManager::stop() {
+    stop_workers();
     next_level_threads_.clear();
     sub_threads_.clear();
 }
@@ -637,7 +1243,11 @@ void LocalMailboxEndpoint::run_control_command(const char *op_name, double timeo
     while (read_mailbox_state() != MailboxState::CONTROL_DONE) {
         auto now = std::chrono::steady_clock::now();
         if (now >= deadline) {
-            mailbox_control_timed_out_ = true;
+            mailbox_control_timed_out_.store(true, std::memory_order_release);
+            {
+                std::lock_guard<std::mutex> progress_lk(progress_mu_);
+                poison_progress(std::string(op_name) + " timed out waiting for CONTROL_DONE");
+            }
             throw std::runtime_error(std::string(op_name) + " timed out waiting for CONTROL_DONE");
         }
         if (now >= next_liveness_check) {
@@ -647,7 +1257,11 @@ void LocalMailboxEndpoint::run_control_command(const char *op_name, double timeo
                 // The mailbox is poisoned rather than reset to IDLE: with the
                 // child gone no later command can complete, so admitting one
                 // would restore the hang this check exists to break.
-                mailbox_control_timed_out_ = true;
+                mailbox_control_timed_out_.store(true, std::memory_order_release);
+                {
+                    std::lock_guard<std::mutex> progress_lk(progress_mu_);
+                    poison_progress(death);
+                }
                 throw std::runtime_error(std::string(op_name) + ": " + death);
             }
         }
@@ -1010,10 +1624,29 @@ void WorkerThread::control_l3_l2_region_release(uint64_t region_id) {
 
 bool WorkerManager::any_busy() const {
     for (auto &wt : next_level_threads_)
-        if (!wt->idle()) return true;
+        if (wt->busy()) return true;
     for (auto &wt : sub_threads_)
-        if (!wt->idle()) return true;
+        if (wt->busy()) return true;
     return false;
+}
+
+bool WorkerManager::has_staged_run(RunId run_id) const {
+    for (const auto &worker : next_level_threads_)
+        if (worker->has_staged_run(run_id)) return true;
+    return false;
+}
+
+bool WorkerManager::needs_activation(RunId run_id) const {
+    for (const auto &worker : next_level_threads_)
+        if (worker->needs_activation(run_id)) return true;
+    return false;
+}
+
+bool WorkerManager::activate_prepared_run(RunId run_id) {
+    bool activated = false;
+    for (const auto &worker : next_level_threads_)
+        activated = worker->activate_prepared(run_id) || activated;
+    return activated;
 }
 
 // =============================================================================

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -16,17 +16,19 @@
  * Provides idle-worker selection and dispatch to the Scheduler.
  * The Scheduler drives the DAG; the Manager drives the workers.
  *
- * Each WorkerThread encodes `(callable digest, config, args_blob)` into a
- * pre-forked child's shared-memory mailbox, signals TASK_READY, and
- * spin-polls TASK_DONE. The child process loop (Python) reads the
- * digest, resolves it to a child-local slot, and runs that slot on its
- * `ChipWorker` (NEXT_LEVEL) or registered Python callable (SUB) in its
- * own address space.
+ * Each WorkerThread owns one endpoint-progress loop. Compatibility endpoints
+ * serialize a blocking TASK_READY -> TASK_DONE exchange. A two-frame local
+ * endpoint may additionally publish one PREPARE_READY successor while the
+ * active frame runs; FIFO promotion changes it to ACTIVATE. The Python child
+ * resolves each frame's callable digest to a child-local slot and executes it
+ * on its `ChipWorker` (NEXT_LEVEL). SUB and unsupported platform/runtime paths
+ * retain the serialized exchange.
  */
 
 #pragma once
 
 #include <atomic>
+#include <array>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -38,6 +40,8 @@
 #include <queue>
 #include <string>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "../task_interface/call_config.h"
@@ -72,7 +76,14 @@ enum class MailboxState : int32_t {
     // PLATFORM_STREAM_SYNC_TIMEOUT_MS budget (issue #897).
     INIT_READY = 6,
     INIT_FAILED = 7,
+    FRAME_STAGED = 8,
+    TASK_LAUNCHED = 9,
+    TASK_FAILED = 10,
+    ACTIVATE = 11,
+    PREPARE_READY = 12,
 };
+
+bool mailbox_compare_exchange_state(char *frame, MailboxState expected, MailboxState desired) noexcept;
 
 // Sized so the args region can hold any TaskArgs the runtime itself accepts
 // (CHIP_MAX_TENSOR_ARGS tensors + CHIP_MAX_SCALAR_ARGS scalars; see the
@@ -82,7 +93,12 @@ enum class MailboxState : int32_t {
 // to the unified 128 B Tensor: the worst-case blob (CHIP_MAX_TENSOR_ARGS tensors)
 // grew ~3x, and 128*128 B = 16 KB alone exceeded the old mailbox (see the
 // capacity static_assert after MAILBOX_ARGS_CAPACITY).
-static constexpr size_t MAILBOX_SIZE = 32768;
+static constexpr size_t MAILBOX_FRAME_SIZE = 32768;
+static constexpr size_t MAILBOX_TASK_FRAME_COUNT = 2;
+static constexpr size_t MAILBOX_CONTROL_FRAME = 0;
+static constexpr size_t MAILBOX_FIRST_TASK_FRAME = 1;
+static constexpr size_t MAILBOX_SIZE = MAILBOX_FRAME_SIZE * (1 + MAILBOX_TASK_FRAME_COUNT);
+static constexpr uint32_t MAILBOX_TASK_PROTOCOL_VERSION = 2;
 
 // Error message region lives at the mailbox tail. 256 B of headroom is
 // enough for `<ExceptionType>: <short message>` produced by the child-side
@@ -96,9 +112,8 @@ static constexpr size_t MAILBOX_ERROR_MSG_SIZE = 256;
 // derived by rounding up the lease's end so the
 // args blob's first Tensor field (buffer.addr, a uint64_t at OFF_ARGS+8) is
 // 8-byte aligned, avoiding SIGBUS on strict-alignment platforms (aarch64
-// atomics, some ARM cores). The control region (CTRL_OFF_ARG0..CTRL_OFF_RESULT) lives
-// inside the CallConfig byte range — that's safe because control commands
-// and task dispatch are mutually exclusive in time.
+// atomics, some ARM cores). The base frame carries control commands; task
+// frames use the same relative layout without sharing those bytes.
 static constexpr ptrdiff_t MAILBOX_OFF_STATE = 0;
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR = 4;
 static constexpr ptrdiff_t MAILBOX_OFF_CALLABLE = 8;  // also: control sub-command (uint64)
@@ -117,22 +132,31 @@ static_assert(
     "PipelineSlotLease overflows reserved lease region"
 );
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR_MSG =
-    static_cast<ptrdiff_t>(MAILBOX_SIZE) - static_cast<ptrdiff_t>(MAILBOX_ERROR_MSG_SIZE);
+    static_cast<ptrdiff_t>(MAILBOX_FRAME_SIZE) - static_cast<ptrdiff_t>(MAILBOX_ERROR_MSG_SIZE);
 // Launch acceptance is sticky, not a MailboxState: a state word carrying it
 // loses the ACK whenever the child reaches TASK_DONE between two parent polls,
 // which is exactly the short-task case the fence exists to pipeline. The child
-// sets it after both launches; the parent clears it when it publishes the next
-// TASK_READY, so nothing else can overwrite it in between.
+// sets it only after a real native launch; the parent clears it before reusing
+// that task frame, so nothing else can overwrite it in between.
 static constexpr int32_t MAILBOX_TASK_ACCEPTED = 1;
 static constexpr ptrdiff_t MAILBOX_OFF_ACCEPTED = MAILBOX_OFF_ERROR_MSG - 8;
+static constexpr ptrdiff_t MAILBOX_OFF_FRAME_PROTOCOL = MAILBOX_OFF_ACCEPTED - 40;
+static constexpr ptrdiff_t MAILBOX_OFF_FRAME_RUN_ID = MAILBOX_OFF_ACCEPTED - 32;
+static constexpr ptrdiff_t MAILBOX_OFF_FRAME_SLOT_ID = MAILBOX_OFF_ACCEPTED - 24;
+static constexpr ptrdiff_t MAILBOX_OFF_FRAME_GENERATION = MAILBOX_OFF_ACCEPTED - 16;
+static constexpr ptrdiff_t MAILBOX_OFF_FRAME_DISPATCH_ID = MAILBOX_OFF_ACCEPTED - 8;
 static constexpr ptrdiff_t MAILBOX_OFF_TASK_CALLABLE_HASH = MAILBOX_OFF_ARGS;
 static constexpr ptrdiff_t MAILBOX_OFF_TASK_ARGS_BLOB =
     MAILBOX_OFF_TASK_CALLABLE_HASH + static_cast<ptrdiff_t>(CALLABLE_HASH_DIGEST_SIZE);
 static constexpr size_t CTRL_SHM_NAME_BYTES = 32;
 static constexpr ptrdiff_t MAILBOX_OFF_CONTROL_CALLABLE_HASH =
     MAILBOX_OFF_ARGS + static_cast<ptrdiff_t>(CTRL_SHM_NAME_BYTES);
+static_assert(
+    MAILBOX_OFF_TASK_ARGS_BLOB < MAILBOX_OFF_FRAME_PROTOCOL,
+    "mailbox task-args region must precede the frame protocol trailer"
+);
 static constexpr size_t MAILBOX_ARGS_CAPACITY =
-    MAILBOX_SIZE - static_cast<size_t>(MAILBOX_OFF_TASK_ARGS_BLOB) - MAILBOX_ERROR_MSG_SIZE - 8;
+    static_cast<size_t>(MAILBOX_OFF_FRAME_PROTOCOL) - static_cast<size_t>(MAILBOX_OFF_TASK_ARGS_BLOB);
 static_assert(
     MAILBOX_ARGS_CAPACITY >= TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(CHIP_MAX_TENSOR_ARGS) * sizeof(Tensor) +
                                  static_cast<size_t>(CHIP_MAX_SCALAR_ARGS) * sizeof(uint64_t),
@@ -174,7 +198,7 @@ static constexpr uint64_t CTRL_L3_L2_REGION_RELEASE = 17;
 // the value to CTRL_OFF_RESULT; the parent sums across children for L3.
 static constexpr uint64_t CTRL_COMMITTED_DEVICE_MEMORY = 18;
 
-// Control args reuse the task mailbox region (mutually exclusive with task dispatch):
+// Control args occupy the base frame's config-sized region:
 //   offset 16: uint64 arg0 (size for malloc/register; ptr for free; dst for copy)
 //   offset 24: uint64 arg1 (src for copy)
 //   offset 32: uint64 arg2 (nbytes for copy)
@@ -197,7 +221,32 @@ struct ControlResult {
     std::string error_message;
 };
 
-struct WorkerDispatch;
+// =============================================================================
+// WorkerDispatch — per-dispatch handle handed to a WorkerThread.
+// =============================================================================
+//
+// `task_slot` is the slot id; `group_index` is 0 for single tasks and
+// 0..group_size-1 for group members. The thread resolves callable / args /
+// config by reading `ring->slot_state(task_slot)`.
+
+struct WorkerDispatch {
+    TaskSlot task_slot{INVALID_SLOT};
+    int32_t group_index{0};
+    uint64_t dispatch_id{0};
+    bool prepare_only{false};
+};
+
+enum class WorkerProgressKind : int32_t {
+    FRAME_STAGED = 0,
+    ACCEPTED = 1,
+    COMPLETED = 2,
+};
+
+struct WorkerEndpointProgress {
+    WorkerProgressKind kind{WorkerProgressKind::FRAME_STAGED};
+    WorkerDispatch dispatch{};
+    WorkerCompletion completion{};
+};
 
 enum class WorkerEndpointKind : int32_t {
     LOCAL_MAILBOX = 0,
@@ -210,6 +259,8 @@ struct WorkerEndpointCaps {
     bool remote{false};
     bool supports_task_dispatch{true};
     bool supports_control{true};
+    uint32_t max_inflight_tasks{1};
+    bool supports_frame_staging{false};
     std::string transport{"local-mailbox"};
 };
 
@@ -223,6 +274,20 @@ public:
     // conservative completion-time acceptance for remote, SUB and A5 paths.
     virtual WorkerCompletion
     run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept);
+
+    // Progressable endpoints are driven by the owning WorkerThread without a
+    // blocking call per frame. submit_progress publishes one complete frame;
+    // poll_progress reports monotonic events; activate_progress is a sticky
+    // FIFO-launch permission that may arrive before the child stages the frame.
+    virtual bool progressable() const { return false; }
+    virtual void submit_progress(Ring *ring, const WorkerDispatch &dispatch);
+    virtual bool poll_progress(WorkerEndpointProgress &progress);
+    virtual bool activate_progress(RunId run_id);
+    virtual void request_progress_stop() noexcept;
+    // Called when the owning progress driver catches an endpoint exception.
+    // Implementations must turn already-published work into terminal progress
+    // only after their child/device resources are quiescent.
+    virtual void report_progress_error(const std::string &reason);
 
     virtual void shutdown_child() {}
     virtual uint64_t control_malloc(size_t size);
@@ -275,12 +340,18 @@ public:
     // caller does not own a waitable child. A valid pid enables liveness
     // checks that turn a child that dies before publishing TASK_DONE /
     // CONTROL_DONE into a reported failure instead of an endless spin-poll.
-    LocalMailboxEndpoint(int32_t worker_id, void *mailbox, int child_pid = -1);
+    LocalMailboxEndpoint(int32_t worker_id, void *mailbox, int child_pid = -1, uint32_t task_frame_count = 1);
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
     WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
     WorkerCompletion
     run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept) override;
+    bool progressable() const override { return task_frame_count_ > 1; }
+    void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override;
+    bool poll_progress(WorkerEndpointProgress &progress) override;
+    bool activate_progress(RunId run_id) override;
+    void request_progress_stop() noexcept override;
+    void report_progress_error(const std::string &reason) override;
 
     void shutdown_child() override;
     uint64_t control_malloc(size_t size) override;
@@ -330,7 +401,14 @@ private:
     WorkerEndpointCaps caps_;
     void *mailbox_{nullptr};
     std::mutex mailbox_mu_;
-    bool mailbox_control_timed_out_{false};
+    std::mutex child_mu_;
+    std::mutex progress_mu_;
+    uint32_t task_frame_count_{1};
+    bool endpoint_poisoned_{false};
+    std::string endpoint_poison_reason_;
+    size_t poll_cursor_{0};
+    std::chrono::steady_clock::time_point next_liveness_check_{};
+    std::atomic<bool> mailbox_control_timed_out_{false};
     int child_pid_{-1};
     // Set once the child has been reaped or observed unwaitable; the exit
     // status is only available from the reaping waitpid(), so it is retained
@@ -339,31 +417,38 @@ private:
     std::string child_death_reason_;
 
     char *mbox() const { return static_cast<char *>(mailbox_); }
-    MailboxState read_mailbox_state() const;
-    void write_mailbox_state(MailboxState s);
-    // Sticky launch acceptance, cleared only when this endpoint publishes the
-    // next TASK_READY. See MAILBOX_OFF_ACCEPTED.
-    bool read_task_accepted() const;
-    void clear_task_accepted();
+    MailboxState read_mailbox_state(const char *frame = nullptr) const;
+    void write_mailbox_state(MailboxState s, char *frame = nullptr);
+    // Sticky launch acceptance, cleared before this endpoint reuses a task
+    // frame. See MAILBOX_OFF_ACCEPTED.
+    bool read_task_accepted(const char *frame = nullptr) const;
+    void clear_task_accepted(char *frame = nullptr);
+    char *task_frame(size_t index) const;
     void run_control_command(const char *op_name, double timeout_s = -1.0);
+
+    struct FrameRecord {
+        bool occupied{false};
+        bool staged_reported{false};
+        bool accepted_reported{false};
+        bool activation_requested{false};
+        bool activation_published{false};
+        WorkerDispatch dispatch{};
+        RunId run_id{INVALID_RUN_ID};
+        uint64_t slot_id{0};
+        uint64_t generation{0};
+    };
+    std::array<FrameRecord, MAILBOX_TASK_FRAME_COUNT> frames_{};
+
+    bool frame_identity_matches(const FrameRecord &record, const char *frame) const;
+    bool try_publish_activation(FrameRecord &record, char *frame);
+    void poison_progress(const std::string &reason);
+    bool poisoned_progress_quiesced();
+    WorkerCompletion poisoned_completion(const FrameRecord &record) const;
 
     // Returns a description of the child's death, or an empty string while it
     // is still running. Never throws: callers decide whether a dead child is
     // reported as a completion outcome or an exception.
     std::string check_child_death();
-};
-
-// =============================================================================
-// WorkerDispatch — per-dispatch handle handed to a WorkerThread.
-// =============================================================================
-//
-// `task_slot` is the slot id; `group_index` is 0 for single tasks and
-// 0..group_size-1 for group members. The thread resolves callable / args /
-// config by reading `ring->slot_state(task_slot)`.
-
-struct WorkerDispatch {
-    TaskSlot task_slot{INVALID_SLOT};
-    int32_t group_index{0};
 };
 
 // =============================================================================
@@ -396,9 +481,21 @@ public:
 
     // Enqueue a dispatch for the worker. Non-blocking.
     void dispatch(WorkerDispatch d);
+    void dispatch_prepared(WorkerDispatch d);
+    // Complete a slot the scheduler already claimed when publication throws.
+    // No endpoint capacity was consumed, but the run-level acceptance waiter
+    // still needs its conservative terminal fallback.
+    void complete_unpublished(WorkerDispatch d, const std::string &error_message);
+    bool has_staged_run(RunId run_id) const;
+    bool needs_activation(RunId run_id) const;
+    bool activate_prepared(RunId run_id);
 
-    // True if the worker has no active task.
-    bool idle() const { return idle_.load(std::memory_order_acquire); }
+    // The active lane and staged-successor lane are intentionally distinct.
+    // A staged successor must not make a second task from the active run
+    // dispatchable on the same device.
+    bool idle() const { return !active_inflight_.load(std::memory_order_acquire); }
+    bool can_stage() const;
+    bool busy() const { return inflight_.load(std::memory_order_acquire) != 0; }
     const WorkerEndpointCaps &caps() const;
     int32_t worker_id() const;
 
@@ -408,14 +505,12 @@ public:
     // Does NOT waitpid — the Python facade owns the child PID.
     void shutdown_child();
 
-    // Memory control — callable from the orch thread while the worker
-    // thread may be running a task. Issues a control command via the
-    // mailbox and blocks until the child responds.
-    //
-    // The mailbox is a single shared region; dispatch_process and the
-    // control_* methods both write its state field. They serialize on
-    // `mailbox_mu_` so a control request issued mid-dispatch waits for
-    // TASK_DONE before claiming the mailbox.
+    // Memory control — callable from the orch thread while the worker thread
+    // may be running a task. Commands serialize with each other on
+    // `mailbox_mu_`. A compatibility endpoint also serializes task dispatch on
+    // that mutex; a two-frame endpoint has a separate base control frame, so
+    // its single child progress owner may service control while a native run is
+    // active.
     uint64_t control_malloc(size_t size);
     uint64_t control_committed_device_memory();
     void control_free(uint64_t ptr);
@@ -429,9 +524,9 @@ public:
     // Dynamic post-init register/unregister of a ChipCallable identity.
     // `shm_name` is the (NUL-terminated, ≤ CTRL_SHM_NAME_BYTES-1) POSIX shm
     // name where the ChipCallable bytes are staged; `blob_size` is the exact
-    // byte span to read from that shm. Both methods hold mailbox_mu_, so a
-    // CTRL_REGISTER concurrent with dispatch_process waits for the in-flight
-    // TASK_DONE before claiming the mailbox.
+    // byte span to read from that shm. Both methods hold mailbox_mu_; on a
+    // two-frame endpoint the child additionally preserves any callable still
+    // referenced by an outstanding task frame.
     void control_register(const char *shm_name, size_t blob_size, const uint8_t *digest);
     void control_unregister(const uint8_t *digest);
     void control_remote_prepare_register(
@@ -467,8 +562,8 @@ public:
     // request payload (header + rank_ids + buffer_nbytes); for alloc the child
     // writes its (device_ctx, local_window_base, buffer_ptrs) into
     // `reply_shm_name`.  Both names are NUL-terminated and ≤
-    // CTRL_SHM_NAME_BYTES-1.  Holds mailbox_mu_ so it serialises with task
-    // dispatch on the same chip mailbox.
+    // CTRL_SHM_NAME_BYTES-1. Holds mailbox_mu_ so control commands serialize;
+    // two-frame task dispatch uses distinct frame state.
     void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name);
     void control_release_domain(const char *request_shm_name);
 
@@ -488,11 +583,23 @@ private:
     std::queue<WorkerDispatch> queue_;
     std::mutex mu_;
     std::condition_variable cv_;
-    bool shutdown_{false};
-    std::atomic<bool> idle_{true};
+    std::atomic<bool> shutdown_{false};
+    std::atomic<uint32_t> inflight_{0};
+    std::atomic<bool> active_inflight_{false};
+    uint64_t next_dispatch_id_{1};
+    mutable std::mutex lane_mu_;
+    std::atomic<RunId> staged_run_id_{INVALID_RUN_ID};
+    uint64_t staged_dispatch_id_{0};
+    std::atomic<RunId> activated_run_id_{INVALID_RUN_ID};
+    uint64_t activated_dispatch_id_{0};
+    std::unordered_set<uint64_t> accepted_dispatch_ids_;
+    std::unordered_map<uint64_t, std::string> accept_errors_;
 
     void loop();
     WorkerCompletion dispatch_process(WorkerDispatch d, const std::function<void()> &on_accept);
+    void enqueue_dispatch(WorkerDispatch d, RunId staged_run_id = INVALID_RUN_ID);
+    void finish_progress_dispatch(const WorkerEndpointProgress &progress);
+    void fail_progress_driver(const std::string &reason) noexcept;
 };
 
 // =============================================================================
@@ -509,8 +616,8 @@ public:
     // callable for SUB) lives in the forked child.
     // `child_pid` is the forked child servicing `mailbox`; pass -1 when the
     // caller owns no waitable child.
-    void add_next_level(void *mailbox, int child_pid = -1);
-    void add_next_level_at(int32_t worker_id, void *mailbox, int child_pid = -1);
+    void add_next_level(void *mailbox, int child_pid = -1, uint32_t task_frame_count = 1);
+    void add_next_level_at(int32_t worker_id, void *mailbox, int child_pid = -1, uint32_t task_frame_count = 1);
     void add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint);
     void add_sub(void *mailbox, int child_pid = -1);
 
@@ -518,6 +625,7 @@ public:
     // when nothing waits on that fence, since an omitted callback leaves
     // pending_accepts non-zero forever. No default: the choice is the caller's.
     void start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept);
+    void stop_workers();
     void stop();
 
     WorkerThread *get_worker_by_id(WorkerType type, int32_t worker_id) const;
@@ -528,6 +636,9 @@ public:
     WorkerThread *pick_idle_sub_excluding(const std::vector<WorkerThread *> &exclude) const;
 
     bool any_busy() const;
+    bool has_staged_run(RunId run_id) const;
+    bool needs_activation(RunId run_id) const;
+    bool activate_prepared_run(RunId run_id);
 
     // Forward CTRL_PREPARE to a specific NEXT_LEVEL worker. Thin wrapper
     // over WorkerThread::control_prepare; exposed at manager level so the
@@ -596,6 +707,7 @@ private:
         int32_t worker_id{-1};
         void *mailbox{nullptr};
         int child_pid{-1};
+        uint32_t task_frame_count{1};
     };
     struct LocalSubEntry {
         void *mailbox{nullptr};

--- a/src/common/platform/include/host/file_marker_handshake.h
+++ b/src/common/platform/include/host/file_marker_handshake.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SIMPLER_COMMON_PLATFORM_INCLUDE_HOST_FILE_MARKER_HANDSHAKE_H
+#define SIMPLER_COMMON_PLATFORM_INCLUDE_HOST_FILE_MARKER_HANDSHAKE_H
+
+#include <chrono>
+#include <cstdio>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <thread>
+
+namespace file_marker_handshake {
+
+enum class Stage {
+    COMPLETE,
+    ARRIVAL_PUBLISH,
+    ARRIVAL_WAIT,
+    DEPARTURE_PUBLISH,
+    DEPARTURE_WAIT,
+    CLEANUP,
+    RELEASE_PUBLISH,
+    RELEASE_WAIT,
+    RELEASE_REMOVE,
+};
+
+enum class Error {
+    NONE,
+    MARKER_WRITE_FAILED,
+    MARKER_REMOVE_FAILED,
+    CLEANUP_FAILED,
+    TIMED_OUT,
+};
+
+struct Result {
+    Error error{Error::NONE};
+    Stage stage{Stage::COMPLETE};
+    int rank{-1};
+
+    bool ok() const { return error == Error::NONE; }
+};
+
+struct WaitOptions {
+    std::chrono::milliseconds timeout{std::chrono::seconds(120)};
+    std::chrono::milliseconds poll_interval{std::chrono::milliseconds(50)};
+};
+
+inline const char *stage_name(Stage stage) {
+    switch (stage) {
+    case Stage::COMPLETE:
+        return "complete";
+    case Stage::ARRIVAL_PUBLISH:
+        return "arrival publish";
+    case Stage::ARRIVAL_WAIT:
+        return "arrival wait";
+    case Stage::DEPARTURE_PUBLISH:
+        return "departure publish";
+    case Stage::DEPARTURE_WAIT:
+        return "departure wait";
+    case Stage::CLEANUP:
+        return "cleanup";
+    case Stage::RELEASE_PUBLISH:
+        return "release publish";
+    case Stage::RELEASE_WAIT:
+        return "release wait";
+    case Stage::RELEASE_REMOVE:
+        return "release remove";
+    }
+    return "unknown";
+}
+
+inline std::string handshake_dir(const std::string &rootinfo_path) {
+    const auto last_slash = rootinfo_path.rfind('/');
+    if (last_slash == std::string::npos) return ".";
+    return rootinfo_path.substr(0, last_slash);
+}
+
+inline std::string handshake_prefix(const std::string &rootinfo_path) {
+    const auto last_slash = rootinfo_path.rfind('/');
+    return last_slash == std::string::npos ? rootinfo_path : rootinfo_path.substr(last_slash + 1);
+}
+
+inline std::string run_token_hex(uint64_t run_token) {
+    std::ostringstream oss;
+    oss << std::hex << run_token;
+    return oss.str();
+}
+
+inline std::string marker_path(const std::string &rootinfo_path, uint64_t run_token, const std::string &tag, int rank) {
+    return handshake_dir(rootinfo_path) + "/barrier_" + handshake_prefix(rootinfo_path) + "_" + tag + "_" +
+           run_token_hex(run_token) + "_" + std::to_string(rank) + ".ready";
+}
+
+inline bool publish_marker(const std::string &path) {
+    // Waiters treat visibility as publication, so never expose a partial
+    // marker. Each token/tag/rank path has exactly one serialized writer.
+    const std::string tmp_path = path + ".tmp";
+    std::ofstream marker(tmp_path, std::ios::trunc);
+    marker << "1";
+    marker.close();
+    if (!marker.good() || std::rename(tmp_path.c_str(), path.c_str()) != 0) {
+        std::remove(tmp_path.c_str());
+        return false;
+    }
+    return true;
+}
+
+inline Result cleanup(const std::string &rootinfo_path) {
+    // Retiring rootinfo is the generation-safety fence: followers must not be
+    // released while they could still consume its old token. Barrier markers
+    // are token-scoped, so their sweep remains best-effort; unrelated entries
+    // in a shared directory such as /tmp must not hold every follower hostage.
+    std::error_code rootinfo_ec;
+    std::filesystem::remove(rootinfo_path, rootinfo_ec);
+
+    const std::string prefix = "barrier_" + handshake_prefix(rootinfo_path) + "_";
+    const std::string dir = handshake_dir(rootinfo_path);
+    std::error_code ec;
+    std::filesystem::directory_iterator entry(dir, ec);
+    const std::filesystem::directory_iterator end;
+    while (!ec && entry != end) {
+        std::error_code entry_ec;
+        if (entry->is_regular_file(entry_ec)) {
+            const std::string name = entry->path().filename().string();
+            if (name.rfind(prefix, 0) == 0 && name.size() >= 6 && name.substr(name.size() - 6) == ".ready") {
+                std::filesystem::remove(entry->path(), entry_ec);
+            }
+        }
+        entry.increment(ec);
+    }
+    return rootinfo_ec ? Result{Error::CLEANUP_FAILED, Stage::CLEANUP, -1} : Result{};
+}
+
+inline Result wait_for_path(
+    const std::string &path, Stage stage, int rank, std::chrono::steady_clock::time_point deadline,
+    std::chrono::milliseconds poll_interval
+) {
+    while (true) {
+        std::ifstream marker(path);
+        if (marker.good()) return {};
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return {Error::TIMED_OUT, stage, rank};
+        }
+        std::this_thread::sleep_for(poll_interval);
+    }
+}
+
+inline Result wait_for_marker(
+    const std::string &rootinfo_path, uint64_t run_token, const char *tag, int rank, Stage stage,
+    std::chrono::steady_clock::time_point deadline, std::chrono::milliseconds poll_interval
+) {
+    return wait_for_path(marker_path(rootinfo_path, run_token, tag, rank), stage, rank, deadline, poll_interval);
+}
+
+inline std::string release_path(const std::string &rootinfo_path, uint64_t run_token, int rank) {
+    // Deliberately outside cleanup()'s barrier_<rootinfo>_*.ready namespace.
+    // A subsequent rank-0 init must not remove this file before its follower
+    // has observed and unlinked it. A crashed follower can leave one small,
+    // token-scoped file; it may only be swept after every rank has joined a
+    // newer generation, never by the init-entry cleanup.
+    return rootinfo_path + ".destroy_released." + run_token_hex(run_token) + "." + std::to_string(rank);
+}
+
+inline Result
+destroy_barrier(const std::string &rootinfo_path, int rank, int nranks, uint64_t run_token, WaitOptions options = {}) {
+    constexpr const char *kArrivalTag = "destroy";
+    constexpr const char *kDepartureTag = "destroy_departed";
+    const auto deadline = std::chrono::steady_clock::now() + options.timeout;
+
+    if (!publish_marker(marker_path(rootinfo_path, run_token, kArrivalTag, rank))) {
+        return {Error::MARKER_WRITE_FAILED, Stage::ARRIVAL_PUBLISH, rank};
+    }
+    for (int peer_rank = 0; peer_rank < nranks; ++peer_rank) {
+        Result result = wait_for_marker(
+            rootinfo_path, run_token, kArrivalTag, peer_rank, Stage::ARRIVAL_WAIT, deadline, options.poll_interval
+        );
+        if (!result.ok()) return result;
+    }
+
+    if (!publish_marker(marker_path(rootinfo_path, run_token, kDepartureTag, rank))) {
+        return {Error::MARKER_WRITE_FAILED, Stage::DEPARTURE_PUBLISH, rank};
+    }
+    if (rank != 0) return {};
+
+    // A departure marker proves its follower has observed every arrival
+    // marker. Successful rank-0 return makes a later marker sweep safe.
+    for (int follower_rank = 1; follower_rank < nranks; ++follower_rank) {
+        Result result = wait_for_marker(
+            rootinfo_path, run_token, kDepartureTag, follower_rank, Stage::DEPARTURE_WAIT, deadline,
+            options.poll_interval
+        );
+        if (!result.ok()) return result;
+    }
+    return {};
+}
+
+inline Result release_after_cleanup(
+    const std::string &rootinfo_path, int rank, int nranks, uint64_t run_token, WaitOptions options = {}
+) {
+    if (rank == 0) {
+        Result cleanup_result = cleanup(rootinfo_path);
+        if (!cleanup_result.ok()) return cleanup_result;
+
+        Result first_error;
+        for (int follower_rank = 1; follower_rank < nranks; ++follower_rank) {
+            if (!publish_marker(release_path(rootinfo_path, run_token, follower_rank)) && first_error.ok()) {
+                first_error = {Error::MARKER_WRITE_FAILED, Stage::RELEASE_PUBLISH, follower_rank};
+            }
+        }
+        return first_error;
+    }
+
+    const std::string path = release_path(rootinfo_path, run_token, rank);
+    Result wait_result = wait_for_path(
+        path, Stage::RELEASE_WAIT, rank, std::chrono::steady_clock::now() + options.timeout, options.poll_interval
+    );
+    if (!wait_result.ok()) return wait_result;
+
+    std::error_code ec;
+    const bool removed = std::filesystem::remove(path, ec);
+    if (ec || !removed) return {Error::MARKER_REMOVE_FAILED, Stage::RELEASE_REMOVE, rank};
+    return {};
+}
+
+}  // namespace file_marker_handshake
+
+#endif  // SIMPLER_COMMON_PLATFORM_INCLUDE_HOST_FILE_MARKER_HANDSHAKE_H

--- a/tests/st/a2a3/host_build_graph/worker_async_endpoint/kernels/orchestration/long_vector_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/worker_async_endpoint/kernels/orchestration/long_vector_orch.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+namespace {
+
+constexpr uint64_t kAdd = 0;
+constexpr uint64_t kAddScalar = 1;
+constexpr int kChainLength = 64;
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &args) {
+    (void)args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 3};
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &args) {
+    const Tensor &a = args.tensor(0).ref();
+    const Tensor &b = args.tensor(1).ref();
+    const Tensor &out = args.tensor(2).ref();
+    uint32_t shape[1] = {a.shapes[0]};
+    TensorCreateInfo temporary(shape, 1, DataType::FLOAT32);
+
+    L0TaskArgs add_args;
+    add_args.add_input(a);
+    add_args.add_input(b);
+    add_args.add_output(temporary);
+    TaskOutputTensors add_outputs = rt_submit_aiv_task(kAdd, add_args);
+    Tensor current = add_outputs.get_ref(0);
+
+    union {
+        float f32;
+        uint64_t u64;
+    } scalar{};
+    scalar.f32 = 1.0F;
+    for (int i = 0; i < kChainLength; ++i) {
+        L0TaskArgs step_args;
+        step_args.add_input(current);
+        if (i + 1 == kChainLength) {
+            step_args.add_output(out);
+            step_args.add_scalar(scalar.u64);
+            rt_submit_aiv_task(kAddScalar, step_args);
+        } else {
+            step_args.add_output(temporary);
+            step_args.add_scalar(scalar.u64);
+            TaskOutputTensors step_outputs = rt_submit_aiv_task(kAddScalar, step_args);
+            current = step_outputs.get_ref(0);
+        }
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/host_build_graph/worker_async_endpoint/test_worker_async_endpoint.py
+++ b/tests/st/a2a3/host_build_graph/worker_async_endpoint/test_worker_async_endpoint.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Onboard validation for the generation-safe two-frame local endpoint."""
+
+import atexit
+import ctypes
+import tempfile
+import time
+import uuid
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+import torch
+from simpler.task_interface import ArgDirection as D
+from simpler.worker import (
+    _FRAME_STAGED,
+    _OFF_ACCEPTED,
+    _OFF_STATE,
+    _TASK_LAUNCHED,
+    MAILBOX_FRAME_SIZE,
+    _mailbox_load_i32,
+)
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _build_l3_task_args
+
+_VECTOR_KERNELS = "../vector_example/kernels/aiv"
+_SIZE = 128 * 128
+_CHAIN_LENGTH = 64
+
+
+class _FileSignal:
+    """Pickle-safe parent/child signal for the standalone scene runner."""
+
+    def __init__(self, label: str):
+        token = uuid.uuid4().hex
+        self._path = Path(tempfile.gettempdir()) / f"simpler-worker-async-endpoint-{label}-{token}"
+
+    def clear(self) -> None:
+        with suppress(FileNotFoundError):
+            self._path.unlink()
+
+    def set(self) -> None:
+        self._path.touch(exist_ok=True)
+
+    def wait(self, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._path.exists():
+                return True
+            time.sleep(0.001)
+        return self._path.exists()
+
+
+_SUB_ENTERED = _FileSignal("entered")
+_SUB_RELEASE = _FileSignal("release")
+
+
+def _clear_signals() -> None:
+    _SUB_ENTERED.clear()
+    _SUB_RELEASE.clear()
+
+
+atexit.register(_clear_signals)
+
+
+def _wait_for_release(_args) -> None:
+    _SUB_ENTERED.set()
+    if not _SUB_RELEASE.wait(30.0):
+        raise RuntimeError("two-frame endpoint test timed out waiting for the release fence")
+
+
+@scene_test(level=3, runtime="host_build_graph")
+class TestWorkerAsyncEndpoint(SceneTestCase):
+    CALLABLE = {
+        "callables": [
+            {
+                "name": "long_vector",
+                "orchestration": {
+                    "source": "kernels/orchestration/long_vector_orch.cpp",
+                    "function_name": "aicpu_orchestration_entry",
+                    "signature": [D.IN, D.IN, D.OUT],
+                },
+                "incores": [
+                    {
+                        "func_id": 0,
+                        "source": f"{_VECTOR_KERNELS}/kernel_add.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.IN, D.OUT],
+                    },
+                    {
+                        "func_id": 1,
+                        "source": f"{_VECTOR_KERNELS}/kernel_add_scalar.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT],
+                    },
+                ],
+            },
+            {"name": "wait_for_release", "callable": _wait_for_release},
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "two_frame_sequential_execution",
+            "platforms": ["a2a3"],
+            "config": {"device_count": 1, "num_sub_workers": 1, "aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    @staticmethod
+    def _tensor_from_host_buffer(worker, value):
+        buffer = worker.create_host_buffer(_SIZE * torch.float32.itemsize)
+        tensor = torch.frombuffer(buffer.buffer, dtype=torch.float32, count=_SIZE)
+        tensor.fill_(value)
+        return buffer, tensor
+
+    def _run_and_validate_l3(  # noqa: PLR0913 -- mirror the scene-test runner hook
+        self,
+        worker,
+        compiled_callables,
+        sub_handles,
+        case,
+        rounds=1,
+        skip_golden=False,
+        enable_l2_swimlane=0,
+        enable_dump_args=False,
+        enable_pmu=0,
+        enable_dep_gen=False,
+        enable_scope_stats=False,
+        output_prefix="",
+    ):
+        """Run the custom protocol assertions from the standalone scene runner."""
+        del (
+            rounds,
+            skip_golden,
+            enable_l2_swimlane,
+            enable_dump_args,
+            enable_pmu,
+            enable_dep_gen,
+            enable_scope_stats,
+            output_prefix,
+        )
+        type(self)._st_chip_handles = compiled_callables
+        type(self)._st_sub_handles = sub_handles
+        platform = str(worker._config["platform"])  # noqa: SLF001 -- scene-test white-box validation
+        assert platform in case["platforms"], f"worker platform {platform!r} is not enabled for this case"
+        self._run_protocol_assertions(platform, worker)
+
+    def _run_protocol_assertions(self, st_platform, st_worker):
+        if st_platform != "a2a3":
+            pytest.skip("the two-frame local endpoint is enabled on a2a3 onboard workers")
+
+        _SUB_ENTERED.clear()
+        _SUB_RELEASE.clear()
+        buffers = []
+        tensors = []
+        first = None
+        second = None
+        try:
+            for value in (2.0, 3.0, 0.0, 5.0, 7.0, 0.0):
+                buffer, tensor = self._tensor_from_host_buffer(st_worker, value)
+                buffers.append(buffer)
+                tensors.append(tensor)
+            first_a, first_b, first_out, second_a, second_b, second_out = tensors
+            handle = type(self)._st_chip_handles["long_vector"]
+            signature = type(self)._st_chip_handles["long_vector_sig"]
+            sub_handle = type(self)._st_sub_handles["wait_for_release"]
+            cfg = self._build_config(self.CASES[0]["config"])
+
+            def submit_vector(orch, a, b, out, *, hold_open=False):
+                builder = TaskArgsBuilder(Tensor("a", a), Tensor("b", b), Tensor("out", out))
+                chip_args, _ = _build_l3_task_args(builder, signature)
+                orch.submit_next_level(handle, chip_args, cfg, worker=0)
+                if hold_open:
+                    orch.submit_sub(sub_handle)
+
+            def first_graph(orch, _args, _cfg):
+                submit_vector(orch, first_a, first_b, first_out, hold_open=True)
+
+            first = st_worker.submit(first_graph)
+            assert _SUB_ENTERED.wait(30.0), "the predecessor never reached its SubTask fence"
+
+            def second_graph(orch, _args, _cfg):
+                submit_vector(orch, second_a, second_b, second_out)
+
+            second = st_worker.submit(second_graph)
+
+            shm_buf = st_worker._chip_shms[0].buf
+            assert shm_buf is not None
+            mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(shm_buf))
+            predecessor_frame_addr = mailbox_addr + MAILBOX_FRAME_SIZE
+            predecessor_state_addr = predecessor_frame_addr + _OFF_STATE
+            successor_frame_addr = mailbox_addr + 2 * MAILBOX_FRAME_SIZE
+            successor_state_addr = successor_frame_addr + _OFF_STATE
+            successor_accepted_addr = successor_frame_addr + _OFF_ACCEPTED
+
+            saw_staged = False
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                state = _mailbox_load_i32(successor_state_addr)
+                accepted = _mailbox_load_i32(successor_accepted_addr)
+                if state == _FRAME_STAGED:
+                    assert accepted == 0, "the successor crossed its launch fence before activation"
+                    assert _mailbox_load_i32(predecessor_state_addr) == _TASK_LAUNCHED, (
+                        "the successor staged only after the predecessor native run had already terminalized"
+                    )
+                    saw_staged = True
+                    break
+                assert accepted == 0, "the successor launched while its predecessor was still active"
+                time.sleep(0.001)
+
+            assert saw_staged, "the successor did not reach FRAME_STAGED behind its predecessor"
+            assert not first.done, "the predecessor escaped its SubTask fence"
+
+            _SUB_RELEASE.set()
+            first.wait(30.0)
+            second.wait(30.0)
+            first_expected = first_a + first_b + _CHAIN_LENGTH
+            second_expected = second_a + second_b + _CHAIN_LENGTH
+            assert torch.allclose(first_out, first_expected), (
+                f"first output mismatch: got={first_out[0].item()} expected={first_expected[0].item()}"
+            )
+            assert torch.allclose(second_out, second_expected), (
+                f"second output mismatch: got={second_out[0].item()} expected={second_expected[0].item()}"
+            )
+        finally:
+            _SUB_RELEASE.set()
+            handles = [first, second]
+            for run in handles:
+                if run is not None:
+                    with suppress(Exception):
+                        run.wait(30.0)
+            tensors.clear()
+            tensor = None
+            first_a = first_b = first_out = second_a = second_b = second_out = None
+            submit_vector = first_graph = second_graph = None
+            if all(run is None or run.done for run in handles):
+                for buffer in buffers:
+                    st_worker.free_host_buffer(buffer)
+                _clear_signals()
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -473,6 +473,7 @@ target_include_directories(test_profiler_device_engine PRIVATE
 )
 
 add_common_utils_test(test_l3_l2_orch_comm common/test_l3_l2_orch_comm.cpp)
+add_common_utils_test(test_file_marker_handshake common/test_file_marker_handshake.cpp)
 
 add_executable(test_trb_runtime_temp_buffer
     common/test_trb_runtime_temp_buffer.cpp

--- a/tests/ut/cpp/common/test_file_marker_handshake.cpp
+++ b/tests/ut/cpp/common/test_file_marker_handshake.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <string>
+#include <thread>
+#include <unistd.h>
+
+#include "host/file_marker_handshake.h"
+
+namespace {
+
+class HandshakeDirectory {
+public:
+    HandshakeDirectory() {
+        path_ = std::filesystem::temp_directory_path() /
+                ("simpler_file_marker_handshake_" + std::to_string(static_cast<long long>(getpid())));
+        std::filesystem::remove_all(path_);
+        std::filesystem::create_directories(path_);
+    }
+    ~HandshakeDirectory() { std::filesystem::remove_all(path_); }
+
+    std::string rootinfo_path() const { return (path_ / "rootinfo.bin").string(); }
+
+private:
+    std::filesystem::path path_;
+};
+
+bool wait_for_path(const std::string &path, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!std::filesystem::exists(path)) {
+        if (std::chrono::steady_clock::now() >= deadline) return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return true;
+}
+
+}  // namespace
+
+TEST(FileMarkerHandshakeTest, RankZeroWaitsForFollowerDepartureBeforeCleanup) {
+    HandshakeDirectory directory;
+    constexpr uint64_t kRunToken = 0xA5A3;
+    const std::string rootinfo_path = directory.rootinfo_path();
+    const std::string rank_zero_arrival = file_marker_handshake::marker_path(rootinfo_path, kRunToken, "destroy", 0);
+    const std::string follower_arrival = file_marker_handshake::marker_path(rootinfo_path, kRunToken, "destroy", 1);
+    const std::string rank_zero_departure =
+        file_marker_handshake::marker_path(rootinfo_path, kRunToken, "destroy_departed", 0);
+    const std::string follower_departure =
+        file_marker_handshake::marker_path(rootinfo_path, kRunToken, "destroy_departed", 1);
+
+    auto rank_zero = std::async(std::launch::async, [&]() {
+        auto result = file_marker_handshake::destroy_barrier(
+            rootinfo_path, 0, 2, kRunToken, {std::chrono::seconds(2), std::chrono::milliseconds(1)}
+        );
+        if (result.ok()) (void)file_marker_handshake::cleanup(rootinfo_path);
+        return result;
+    });
+
+    EXPECT_TRUE(wait_for_path(rank_zero_arrival, std::chrono::seconds(1)));
+    EXPECT_TRUE(file_marker_handshake::publish_marker(follower_arrival));
+    EXPECT_TRUE(wait_for_path(rank_zero_departure, std::chrono::seconds(1)));
+
+    EXPECT_EQ(rank_zero.wait_for(std::chrono::milliseconds(20)), std::future_status::timeout);
+    EXPECT_TRUE(std::filesystem::exists(rank_zero_arrival));
+    EXPECT_TRUE(std::filesystem::exists(follower_arrival));
+
+    const auto follower_result = file_marker_handshake::destroy_barrier(
+        rootinfo_path, 1, 2, kRunToken, {std::chrono::seconds(2), std::chrono::milliseconds(1)}
+    );
+    const auto result = rank_zero.get();
+
+    EXPECT_TRUE(follower_result.ok());
+    EXPECT_TRUE(result.ok());
+    EXPECT_FALSE(std::filesystem::exists(rank_zero_arrival));
+    EXPECT_FALSE(std::filesystem::exists(follower_arrival));
+    EXPECT_FALSE(std::filesystem::exists(rank_zero_departure));
+    EXPECT_FALSE(std::filesystem::exists(follower_departure));
+}
+
+TEST(FileMarkerHandshakeTest, FollowerReturnsOnlyAfterRootinfoRetirement) {
+    HandshakeDirectory directory;
+    constexpr uint64_t kRunToken = 0x1234;
+    const std::string rootinfo_path = directory.rootinfo_path();
+    { std::ofstream(rootinfo_path) << "old generation"; }
+
+    auto follower = std::async(std::launch::async, [&]() {
+        return file_marker_handshake::release_after_cleanup(
+            rootinfo_path, 1, 2, kRunToken, {std::chrono::seconds(2), std::chrono::milliseconds(1)}
+        );
+    });
+
+    EXPECT_EQ(follower.wait_for(std::chrono::milliseconds(20)), std::future_status::timeout);
+    EXPECT_TRUE(std::filesystem::exists(rootinfo_path));
+
+    const auto root_result = file_marker_handshake::release_after_cleanup(
+        rootinfo_path, 0, 2, kRunToken, {std::chrono::seconds(2), std::chrono::milliseconds(1)}
+    );
+    const auto follower_result = follower.get();
+
+    EXPECT_TRUE(root_result.ok());
+    EXPECT_TRUE(follower_result.ok());
+    EXPECT_FALSE(std::filesystem::exists(rootinfo_path));
+    EXPECT_FALSE(std::filesystem::exists(file_marker_handshake::release_path(rootinfo_path, kRunToken, 1)));
+}
+
+TEST(FileMarkerHandshakeTest, FollowerReleaseSurvivesNextGenerationSweep) {
+    HandshakeDirectory directory;
+    constexpr uint64_t kOldRunToken = 0x1234;
+    constexpr uint64_t kNextRunToken = 0x5678;
+    const std::string rootinfo_path = directory.rootinfo_path();
+    const std::string old_marker = file_marker_handshake::marker_path(rootinfo_path, kOldRunToken, "destroy", 0);
+    const std::string release = file_marker_handshake::release_path(rootinfo_path, kOldRunToken, 1);
+    { std::ofstream(rootinfo_path) << "old generation"; }
+    ASSERT_TRUE(file_marker_handshake::publish_marker(old_marker));
+
+    const auto root_result = file_marker_handshake::release_after_cleanup(
+        rootinfo_path, 0, 2, kOldRunToken, {std::chrono::seconds(2), std::chrono::milliseconds(1)}
+    );
+    ASSERT_TRUE(root_result.ok());
+    ASSERT_TRUE(std::filesystem::exists(release));
+
+    // A sequential rank-0 init performs the same broad sweep before writing
+    // its new rootinfo. The old follower's private release must survive it.
+    ASSERT_TRUE(file_marker_handshake::cleanup(rootinfo_path).ok());
+    ASSERT_TRUE(std::filesystem::exists(release));
+
+    const std::string next_marker =
+        file_marker_handshake::marker_path(rootinfo_path, kNextRunToken, "rootinfo_ready", 0);
+    { std::ofstream(rootinfo_path) << "next generation"; }
+    ASSERT_TRUE(file_marker_handshake::publish_marker(next_marker));
+
+    const auto follower_result = file_marker_handshake::release_after_cleanup(
+        rootinfo_path, 1, 2, kOldRunToken, {std::chrono::seconds(2), std::chrono::milliseconds(1)}
+    );
+    EXPECT_TRUE(follower_result.ok());
+    EXPECT_FALSE(std::filesystem::exists(release));
+    EXPECT_TRUE(std::filesystem::exists(rootinfo_path));
+    EXPECT_TRUE(std::filesystem::exists(next_marker));
+}
+
+TEST(FileMarkerHandshakeTest, CleanupFailureDoesNotReleaseFollowers) {
+    HandshakeDirectory directory;
+    constexpr uint64_t kRunToken = 0x1234;
+    const std::string rootinfo_path = directory.rootinfo_path();
+    std::filesystem::create_directory(rootinfo_path);
+    { std::ofstream(std::filesystem::path(rootinfo_path) / "keep") << "not empty"; }
+
+    const auto result = file_marker_handshake::release_after_cleanup(
+        rootinfo_path, 0, 2, kRunToken, {std::chrono::milliseconds(20), std::chrono::milliseconds(1)}
+    );
+
+    EXPECT_EQ(result.error, file_marker_handshake::Error::CLEANUP_FAILED);
+    EXPECT_EQ(result.stage, file_marker_handshake::Stage::CLEANUP);
+    EXPECT_FALSE(std::filesystem::exists(file_marker_handshake::release_path(rootinfo_path, kRunToken, 1)));
+}
+
+TEST(FileMarkerHandshakeTest, UnrelatedEntryErrorDoesNotBlockRelease) {
+    HandshakeDirectory directory;
+    constexpr uint64_t kRunToken = 0x1234;
+    const std::string rootinfo_path = directory.rootinfo_path();
+    const auto loop = std::filesystem::path(rootinfo_path).parent_path() / "status_loop";
+    { std::ofstream(rootinfo_path) << "old generation"; }
+    std::filesystem::create_symlink(loop.filename(), loop);
+
+    const auto result = file_marker_handshake::release_after_cleanup(
+        rootinfo_path, 0, 2, kRunToken, {std::chrono::milliseconds(20), std::chrono::milliseconds(1)}
+    );
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(std::filesystem::exists(file_marker_handshake::release_path(rootinfo_path, kRunToken, 1)));
+}
+
+TEST(FileMarkerHandshakeTest, FailedAtomicPublishLeavesNoVisibleMarker) {
+    HandshakeDirectory directory;
+    const std::string path = directory.rootinfo_path() + "/missing/marker";
+
+    EXPECT_FALSE(file_marker_handshake::publish_marker(path));
+    EXPECT_FALSE(std::filesystem::exists(path));
+    EXPECT_FALSE(std::filesystem::exists(path + ".tmp"));
+}

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -10,20 +10,28 @@
  */
 
 #include <gtest/gtest.h>
+#include <poll.h>
+#include <signal.h>
 #include <sys/mman.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
+#include <deque>
 #include <future>
 #include <iterator>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -257,6 +265,290 @@ private:
     WorkerEndpointCaps caps_;
     std::atomic<int> *prepare_count_{nullptr};
 };
+
+class DeterministicProgressEndpoint final : public WorkerEndpoint {
+public:
+    explicit DeterministicProgressEndpoint(int32_t worker_id = 0, uint32_t max_inflight_tasks = 2) {
+        caps_.worker_id = worker_id;
+        caps_.max_inflight_tasks = max_inflight_tasks;
+        caps_.supports_frame_staging = true;
+    }
+
+    const WorkerEndpointCaps &caps() const override { return caps_; }
+    bool progressable() const override { return true; }
+
+    WorkerCompletion run(Ring *, const WorkerDispatch &) override {
+        throw std::logic_error("progress endpoint must not use blocking run");
+    }
+
+    void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override {
+        ProgressCall call(*this);
+        RunId run_id = INVALID_RUN_ID;
+        if (ring != nullptr) {
+            TaskSlotState *slot = ring->slot_state(dispatch.task_slot);
+            if (slot != nullptr) run_id = slot->run_id;
+        }
+        std::lock_guard<std::mutex> lk(mu_);
+        submitted_.push_back(dispatch);
+        outstanding_.emplace(dispatch.dispatch_id, Outstanding{dispatch, run_id});
+        cv_.notify_all();
+    }
+
+    bool poll_progress(WorkerEndpointProgress &progress) override {
+        ProgressCall call(*this);
+        std::lock_guard<std::mutex> lk(mu_);
+        if (throw_poll_once_) {
+            throw_poll_once_ = false;
+            throw std::runtime_error("injected poll failure");
+        }
+        if (events_.empty()) return false;
+        progress = std::move(events_.front());
+        events_.pop_front();
+        if (progress.kind == WorkerProgressKind::COMPLETED) {
+            outstanding_.erase(progress.dispatch.dispatch_id);
+        }
+        return true;
+    }
+
+    bool activate_progress(RunId run_id) override {
+        ProgressCall call(*this);
+        std::lock_guard<std::mutex> lk(mu_);
+        for (const auto &[dispatch_id, outstanding] : outstanding_) {
+            (void)dispatch_id;
+            if (outstanding.dispatch.prepare_only && outstanding.run_id == run_id) {
+                activated_runs_.insert(run_id);
+                cv_.notify_all();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void request_progress_stop() noexcept override {
+        ProgressCall call(*this);
+        std::lock_guard<std::mutex> lk(mu_);
+        stop_requested_ = true;
+        ++stop_request_count_;
+        if (stop_request_count_ >= stop_terminalization_request_) terminalize_outstanding_locked();
+        cv_.notify_all();
+    }
+
+    void report_progress_error(const std::string &reason) override {
+        ProgressCall call(*this);
+        std::lock_guard<std::mutex> lk(mu_);
+        progress_error_ = reason;
+        terminalize_outstanding_locked();
+        cv_.notify_all();
+    }
+
+    bool wait_submitted(size_t count, std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
+        std::unique_lock<std::mutex> lk(mu_);
+        return cv_.wait_for(lk, timeout, [this, count] {
+            return submitted_.size() >= count;
+        });
+    }
+
+    bool wait_activated(RunId run_id, std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
+        std::unique_lock<std::mutex> lk(mu_);
+        return cv_.wait_for(lk, timeout, [this, run_id] {
+            return activated_runs_.count(run_id) != 0;
+        });
+    }
+
+    bool wait_stop_requested(std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
+        std::unique_lock<std::mutex> lk(mu_);
+        return cv_.wait_for(lk, timeout, [this] {
+            return stop_requested_;
+        });
+    }
+
+    void terminalize_after_stop_request(size_t request_count) {
+        std::lock_guard<std::mutex> lk(mu_);
+        stop_terminalization_request_ = request_count;
+    }
+
+    void throw_on_next_poll() {
+        std::lock_guard<std::mutex> lk(mu_);
+        throw_poll_once_ = true;
+    }
+
+    bool wait_progress_error(std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
+        std::unique_lock<std::mutex> lk(mu_);
+        return cv_.wait_for(lk, timeout, [this] {
+            return !progress_error_.empty();
+        });
+    }
+
+    std::string progress_error() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return progress_error_;
+    }
+
+    size_t stop_request_count() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return stop_request_count_;
+    }
+
+    void force_stop_terminalization() {
+        std::lock_guard<std::mutex> lk(mu_);
+        terminalize_outstanding_locked();
+        cv_.notify_all();
+    }
+
+    std::vector<WorkerDispatch> submitted() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return submitted_;
+    }
+
+    void emit(WorkerProgressKind kind, const WorkerDispatch &dispatch) {
+        std::lock_guard<std::mutex> lk(mu_);
+        WorkerEndpointProgress progress;
+        progress.kind = kind;
+        progress.dispatch = dispatch;
+        if (kind == WorkerProgressKind::COMPLETED) {
+            progress.completion =
+                WorkerCompletion{dispatch.task_slot, dispatch.group_index, EndpointOutcome::SUCCESS, {}};
+        }
+        events_.push_back(std::move(progress));
+        cv_.notify_all();
+    }
+
+    int max_concurrent_progress_calls() const { return max_concurrent_calls_.load(std::memory_order_acquire); }
+    bool progress_owner_changed() const {
+        std::lock_guard<std::mutex> lk(owner_mu_);
+        return progress_owner_changed_;
+    }
+
+private:
+    struct Outstanding {
+        WorkerDispatch dispatch;
+        RunId run_id{INVALID_RUN_ID};
+    };
+
+    class ProgressCall {
+    public:
+        explicit ProgressCall(DeterministicProgressEndpoint &endpoint) :
+            endpoint_(endpoint) {
+            endpoint_.enter_progress_call();
+        }
+        ~ProgressCall() { endpoint_.leave_progress_call(); }
+
+    private:
+        DeterministicProgressEndpoint &endpoint_;
+    };
+
+    void enter_progress_call() {
+        int current = concurrent_calls_.fetch_add(1, std::memory_order_acq_rel) + 1;
+        int observed = max_concurrent_calls_.load(std::memory_order_acquire);
+        while (current > observed &&
+               !max_concurrent_calls_.compare_exchange_weak(observed, current, std::memory_order_acq_rel)) {}
+        std::lock_guard<std::mutex> lk(owner_mu_);
+        if (progress_owner_ == std::thread::id{}) {
+            progress_owner_ = std::this_thread::get_id();
+        } else if (progress_owner_ != std::this_thread::get_id()) {
+            progress_owner_changed_ = true;
+        }
+    }
+
+    void leave_progress_call() { concurrent_calls_.fetch_sub(1, std::memory_order_acq_rel); }
+
+    void terminalize_outstanding_locked() {
+        if (stop_terminalized_) return;
+        stop_terminalized_ = true;
+        for (const auto &[dispatch_id, outstanding] : outstanding_) {
+            (void)dispatch_id;
+            WorkerEndpointProgress progress;
+            progress.kind = WorkerProgressKind::COMPLETED;
+            progress.dispatch = outstanding.dispatch;
+            progress.completion = WorkerCompletion{
+                outstanding.dispatch.task_slot, outstanding.dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+                "test endpoint stopped"
+            };
+            events_.push_back(std::move(progress));
+        }
+    }
+
+    WorkerEndpointCaps caps_;
+    mutable std::mutex mu_;
+    std::condition_variable cv_;
+    std::vector<WorkerDispatch> submitted_;
+    std::unordered_map<uint64_t, Outstanding> outstanding_;
+    std::deque<WorkerEndpointProgress> events_;
+    std::set<RunId> activated_runs_;
+    bool stop_requested_{false};
+    bool stop_terminalized_{false};
+    size_t stop_request_count_{0};
+    size_t stop_terminalization_request_{1};
+    bool throw_poll_once_{false};
+    std::string progress_error_;
+    std::atomic<int> concurrent_calls_{0};
+    std::atomic<int> max_concurrent_calls_{0};
+    mutable std::mutex owner_mu_;
+    std::thread::id progress_owner_{};
+    bool progress_owner_changed_{false};
+};
+
+static char *test_task_frame(std::array<char, MAILBOX_SIZE> &mailbox, size_t index) {
+    return mailbox.data() + (MAILBOX_FIRST_TASK_FRAME + index) * MAILBOX_FRAME_SIZE;
+}
+
+static MailboxState test_frame_state(const char *frame) {
+    const auto *state = reinterpret_cast<const int32_t *>(frame + MAILBOX_OFF_STATE);
+    return static_cast<MailboxState>(__atomic_load_n(state, __ATOMIC_ACQUIRE));
+}
+
+static void set_test_frame_state(char *frame, MailboxState state) {
+    auto *wire_state = reinterpret_cast<int32_t *>(frame + MAILBOX_OFF_STATE);
+    __atomic_store_n(wire_state, static_cast<int32_t>(state), __ATOMIC_RELEASE);
+}
+
+static void set_test_frame_accepted(char *frame) {
+    auto *accepted = reinterpret_cast<int32_t *>(frame + MAILBOX_OFF_ACCEPTED);
+    __atomic_store_n(accepted, MAILBOX_TASK_ACCEPTED, __ATOMIC_RELEASE);
+}
+
+static uint64_t test_frame_dispatch_id(const char *frame) {
+    uint64_t dispatch_id = 0;
+    std::memcpy(&dispatch_id, frame + MAILBOX_OFF_FRAME_DISPATCH_ID, sizeof(dispatch_id));
+    return dispatch_id;
+}
+
+class ScopedChildProcess {
+public:
+    explicit ScopedChildProcess(pid_t pid) :
+        pid_(pid) {}
+    ScopedChildProcess(const ScopedChildProcess &) = delete;
+    ScopedChildProcess &operator=(const ScopedChildProcess &) = delete;
+
+    ~ScopedChildProcess() {
+        if (pid_ <= 0) return;
+        int status = 0;
+        pid_t result = 0;
+        do {
+            result = waitpid(pid_, &status, WNOHANG);
+        } while (result < 0 && errno == EINTR);
+        if (result != 0) return;
+
+        (void)kill(pid_, SIGKILL);
+        do {
+            result = waitpid(pid_, &status, 0);
+        } while (result < 0 && errno == EINTR);
+    }
+
+private:
+    pid_t pid_{-1};
+};
+
+static TaskSlot make_progress_slot(Ring &ring, RunId run_id, uint32_t pipeline_slot, uint64_t generation) {
+    AllocResult allocation = ring.alloc(/*heap_bytes=*/0, /*depth=*/0);
+    if (allocation.slot == INVALID_SLOT) return INVALID_SLOT;
+    TaskSlotState *slot = ring.slot_state(allocation.slot);
+    if (slot == nullptr) return INVALID_SLOT;
+    slot->reset();
+    slot->run_id = run_id;
+    slot->pipeline_lease = PipelineSlotLease{pipeline_slot, 0, generation};
+    return allocation.slot;
+}
 
 // ---------------------------------------------------------------------------
 // Helper: build a TaskArgs whose only tensor has the given (data, tag).
@@ -559,6 +851,892 @@ TEST(WorkerManagerTest, StartRejectsDuplicateNextLevelWorkerId) {
     EXPECT_TRUE(threw);
 }
 
+TEST(WorkerManagerTest, SingleFrameSuccessorIsNotReportedAsStageable) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    WorkerManager manager;
+    manager.add_next_level_endpoint(std::make_unique<FakeEndpoint>(0));
+    manager.start(&allocator, [](WorkerCompletion) {}, [](WorkerDispatch) {});
+    NextLevelReadyQueues ready;
+    ready.reset(manager.next_level_worker_ids());
+    constexpr RunId successor_run = 17;
+    ready.push_single(/*worker_id=*/0, successor_run, /*slot=*/3);
+
+    EXPECT_FALSE(ready.singles_empty(successor_run));
+    EXPECT_FALSE(stageable_successor_ready(ready, manager, successor_run));
+
+    manager.stop();
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, WorkerThreadUsesOneProgressOwnerForActiveAndStagedLanes) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot active_slot = make_progress_slot(allocator, /*run_id=*/11, /*pipeline_slot=*/0, /*generation=*/1);
+    TaskSlot staged_slot = make_progress_slot(allocator, /*run_id=*/12, /*pipeline_slot=*/1, /*generation=*/1);
+    ASSERT_NE(active_slot, INVALID_SLOT);
+    ASSERT_NE(staged_slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    std::mutex callback_mu;
+    std::condition_variable callback_cv;
+    std::vector<WorkerDispatch> accepted;
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            std::lock_guard<std::mutex> lk(callback_mu);
+            completed.push_back(std::move(completion));
+            callback_cv.notify_all();
+        },
+        [&](WorkerDispatch dispatch) {
+            std::lock_guard<std::mutex> lk(callback_mu);
+            accepted.push_back(dispatch);
+            callback_cv.notify_all();
+        },
+        std::move(endpoint)
+    );
+
+    worker.dispatch(WorkerDispatch{active_slot, 0});
+    worker.dispatch_prepared(WorkerDispatch{staged_slot, 0});
+    EXPECT_TRUE(endpoint_ptr->wait_submitted(2));
+    std::vector<WorkerDispatch> submitted = endpoint_ptr->submitted();
+    ASSERT_EQ(submitted.size(), 2u);
+    EXPECT_FALSE(submitted[0].prepare_only);
+    EXPECT_TRUE(submitted[1].prepare_only);
+    EXPECT_FALSE(worker.idle());
+    EXPECT_FALSE(worker.can_stage());
+    EXPECT_TRUE(worker.busy());
+
+    endpoint_ptr->emit(WorkerProgressKind::ACCEPTED, submitted[0]);
+    endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted[0]);
+    {
+        std::unique_lock<std::mutex> lk(callback_mu);
+        EXPECT_TRUE(callback_cv.wait_for(lk, std::chrono::seconds(3), [&] {
+            return completed.size() >= 1;
+        }));
+    }
+    EXPECT_TRUE(worker.idle());
+    EXPECT_TRUE(worker.busy());
+    EXPECT_TRUE(worker.activate_prepared(/*run_id=*/12));
+    EXPECT_TRUE(endpoint_ptr->wait_activated(/*run_id=*/12));
+
+    endpoint_ptr->emit(WorkerProgressKind::ACCEPTED, submitted[1]);
+    endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted[1]);
+    {
+        std::unique_lock<std::mutex> lk(callback_mu);
+        EXPECT_TRUE(callback_cv.wait_for(lk, std::chrono::seconds(3), [&] {
+            return accepted.size() == 2 && completed.size() == 2;
+        }));
+    }
+    EXPECT_TRUE(worker.idle());
+    EXPECT_FALSE(worker.busy());
+    EXPECT_EQ(endpoint_ptr->max_concurrent_progress_calls(), 1);
+    EXPECT_FALSE(endpoint_ptr->progress_owner_changed());
+    worker.stop();
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, TwoFrameLeaseSlotsDoNotDefineFifoOrAcceptance) {
+    alignas(8) std::array<char, MAILBOX_SIZE> mailbox{};
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot active_slot = make_progress_slot(allocator, /*run_id=*/21, /*pipeline_slot=*/1, /*generation=*/7);
+    TaskSlot staged_slot = make_progress_slot(allocator, /*run_id=*/22, /*pipeline_slot=*/0, /*generation=*/9);
+    ASSERT_NE(active_slot, INVALID_SLOT);
+    ASSERT_NE(staged_slot, INVALID_SLOT);
+
+    LocalMailboxEndpoint endpoint(/*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/2);
+    WorkerDispatch active{active_slot, 0, /*dispatch_id=*/41, /*prepare_only=*/false};
+    WorkerDispatch staged{staged_slot, 0, /*dispatch_id=*/42, /*prepare_only=*/true};
+    endpoint.submit_progress(&allocator, active);
+    endpoint.submit_progress(&allocator, staged);
+
+    char *lower_frame = test_task_frame(mailbox, 0);
+    char *upper_frame = test_task_frame(mailbox, 1);
+    EXPECT_EQ(test_frame_state(lower_frame), MailboxState::PREPARE_READY);
+    EXPECT_EQ(test_frame_state(upper_frame), MailboxState::TASK_READY);
+    EXPECT_EQ(test_frame_dispatch_id(lower_frame), 42u);
+    EXPECT_EQ(test_frame_dispatch_id(upper_frame), 41u);
+
+    EXPECT_TRUE(endpoint.activate_progress(/*run_id=*/22));
+    EXPECT_EQ(test_frame_state(lower_frame), MailboxState::PREPARE_READY);
+    WorkerEndpointProgress progress;
+    EXPECT_FALSE(endpoint.poll_progress(progress));
+
+    set_test_frame_state(lower_frame, MailboxState::FRAME_STAGED);
+    ASSERT_TRUE(endpoint.poll_progress(progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::FRAME_STAGED);
+    EXPECT_EQ(progress.dispatch.dispatch_id, 42u);
+    EXPECT_EQ(test_frame_state(lower_frame), MailboxState::ACTIVATE);
+
+    set_test_frame_state(lower_frame, MailboxState::TASK_LAUNCHED);
+    EXPECT_FALSE(endpoint.poll_progress(progress));
+    set_test_frame_accepted(lower_frame);
+    ASSERT_TRUE(endpoint.poll_progress(progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::ACCEPTED);
+    EXPECT_EQ(progress.dispatch.dispatch_id, 42u);
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, StaleActivationObservationCannotOverwriteTerminalState) {
+    alignas(8) std::array<char, MAILBOX_FRAME_SIZE> frame{};
+    set_test_frame_state(frame.data(), MailboxState::FRAME_STAGED);
+    MailboxState stale_observation = test_frame_state(frame.data());
+    ASSERT_EQ(stale_observation, MailboxState::FRAME_STAGED);
+
+    set_test_frame_state(frame.data(), MailboxState::TASK_DONE);
+    EXPECT_FALSE(mailbox_compare_exchange_state(frame.data(), stale_observation, MailboxState::ACTIVATE));
+    EXPECT_EQ(test_frame_state(frame.data()), MailboxState::TASK_DONE);
+}
+
+TEST(WorkerManagerTest, ThirdDispatchCannotMutateTwoOccupiedFrames) {
+    alignas(8) std::array<char, MAILBOX_SIZE> mailbox{};
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot active_slot = make_progress_slot(allocator, /*run_id=*/31, /*pipeline_slot=*/0, /*generation=*/1);
+    TaskSlot staged_slot = make_progress_slot(allocator, /*run_id=*/32, /*pipeline_slot=*/1, /*generation=*/1);
+    TaskSlot third_slot = make_progress_slot(allocator, /*run_id=*/33, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(active_slot, INVALID_SLOT);
+    ASSERT_NE(staged_slot, INVALID_SLOT);
+    ASSERT_NE(third_slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    std::mutex completion_mu;
+    std::condition_variable completion_cv;
+    int completion_count = 0;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion) {
+            std::lock_guard<std::mutex> lk(completion_mu);
+            ++completion_count;
+            completion_cv.notify_all();
+        },
+        [](WorkerDispatch) {},
+        std::make_unique<LocalMailboxEndpoint>(
+            /*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/2
+        )
+    );
+    worker.dispatch(WorkerDispatch{active_slot, 0});
+    worker.dispatch_prepared(WorkerDispatch{staged_slot, 0});
+
+    char *frame0 = test_task_frame(mailbox, 0);
+    char *frame1 = test_task_frame(mailbox, 1);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while ((test_frame_state(frame0) != MailboxState::TASK_READY ||
+            test_frame_state(frame1) != MailboxState::PREPARE_READY) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(test_frame_state(frame0), MailboxState::TASK_READY);
+    EXPECT_EQ(test_frame_state(frame1), MailboxState::PREPARE_READY);
+    const uint64_t first_dispatch_id = test_frame_dispatch_id(frame0);
+    const uint64_t second_dispatch_id = test_frame_dispatch_id(frame1);
+
+    EXPECT_THROW(worker.dispatch(WorkerDispatch{third_slot, 0}), std::logic_error);
+    EXPECT_THROW(worker.dispatch_prepared(WorkerDispatch{third_slot, 0}), std::logic_error);
+    EXPECT_EQ(test_frame_state(frame0), MailboxState::TASK_READY);
+    EXPECT_EQ(test_frame_state(frame1), MailboxState::PREPARE_READY);
+    EXPECT_EQ(test_frame_dispatch_id(frame0), first_dispatch_id);
+    EXPECT_EQ(test_frame_dispatch_id(frame1), second_dispatch_id);
+
+    set_test_frame_accepted(frame0);
+    set_test_frame_accepted(frame1);
+    set_test_frame_state(frame0, MailboxState::TASK_DONE);
+    set_test_frame_state(frame1, MailboxState::TASK_DONE);
+    {
+        std::unique_lock<std::mutex> lk(completion_mu);
+        EXPECT_TRUE(completion_cv.wait_for(lk, std::chrono::seconds(3), [&] {
+            return completion_count == 2;
+        }));
+    }
+    worker.stop();
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, StaleFrameIdentityWithholdsCompletionUntilChildQuiesces) {
+    alignas(8) std::array<char, MAILBOX_SIZE> mailbox{};
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot0 = make_progress_slot(allocator, /*run_id=*/41, /*pipeline_slot=*/0, /*generation=*/3);
+    TaskSlot slot1 = make_progress_slot(allocator, /*run_id=*/42, /*pipeline_slot=*/1, /*generation=*/4);
+    ASSERT_NE(slot0, INVALID_SLOT);
+    ASSERT_NE(slot1, INVALID_SLOT);
+
+    LocalMailboxEndpoint endpoint(/*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/2);
+    endpoint.submit_progress(&allocator, WorkerDispatch{slot0, 0, /*dispatch_id=*/51, /*prepare_only=*/false});
+    endpoint.submit_progress(&allocator, WorkerDispatch{slot1, 0, /*dispatch_id=*/52, /*prepare_only=*/true});
+
+    char *frame1 = test_task_frame(mailbox, 1);
+    uint64_t stale_generation = 99;
+    std::memcpy(frame1 + MAILBOX_OFF_FRAME_GENERATION, &stale_generation, sizeof(stale_generation));
+    set_test_frame_accepted(frame1);
+    set_test_frame_state(frame1, MailboxState::TASK_LAUNCHED);
+
+    WorkerEndpointProgress first;
+    WorkerEndpointProgress second;
+    EXPECT_FALSE(endpoint.poll_progress(first));
+    EXPECT_EQ(test_frame_state(frame1), MailboxState::TASK_LAUNCHED);
+
+    // Endpoint poison requests child shutdown, but parent-side completion must
+    // not release the run lease until every native task has terminalized. A
+    // real child publishes these states from its shutdown/finalize path.
+    set_test_frame_state(test_task_frame(mailbox, 0), MailboxState::TASK_FAILED);
+    set_test_frame_state(frame1, MailboxState::TASK_FAILED);
+
+    ASSERT_TRUE(endpoint.poll_progress(first));
+    ASSERT_TRUE(endpoint.poll_progress(second));
+    EXPECT_EQ(first.kind, WorkerProgressKind::COMPLETED);
+    EXPECT_EQ(second.kind, WorkerProgressKind::COMPLETED);
+    EXPECT_EQ(first.completion.outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    EXPECT_EQ(second.completion.outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    EXPECT_NE(first.completion.error_message.find("stale frame identity"), std::string::npos);
+    EXPECT_NE(second.completion.error_message.find("stale frame identity"), std::string::npos);
+    EXPECT_EQ(
+        std::set<TaskSlot>({first.dispatch.task_slot, second.dispatch.task_slot}), std::set<TaskSlot>({slot0, slot1})
+    );
+    EXPECT_THROW(
+        endpoint.submit_progress(&allocator, WorkerDispatch{slot0, 0, /*dispatch_id=*/53, false}), std::runtime_error
+    );
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, PoisonedProgressWithholdsCompletionUntilTheChildExits) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot0 = make_progress_slot(allocator, /*run_id=*/43, /*pipeline_slot=*/0, /*generation=*/5);
+    TaskSlot slot1 = make_progress_slot(allocator, /*run_id=*/44, /*pipeline_slot=*/1, /*generation=*/6);
+    ASSERT_NE(slot0, INVALID_SLOT);
+    ASSERT_NE(slot1, INVALID_SLOT);
+
+    void *mailbox =
+        mmap(nullptr, MAILBOX_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, /*fd=*/-1, /*offset=*/0);
+    ASSERT_NE(mailbox, MAP_FAILED);
+    std::memset(mailbox, 0, MAILBOX_SIZE);
+
+    int terminal_pipe[2] = {-1, -1};
+    int release_pipe[2] = {-1, -1};
+    ASSERT_EQ(pipe(terminal_pipe), 0);
+    ASSERT_EQ(pipe(release_pipe), 0);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(terminal_pipe[0]);
+        close(release_pipe[1]);
+        alarm(15);
+
+        auto *base_state = reinterpret_cast<int32_t *>(static_cast<char *>(mailbox) + MAILBOX_OFF_STATE);
+        while (static_cast<MailboxState>(__atomic_load_n(base_state, __ATOMIC_ACQUIRE)) != MailboxState::SHUTDOWN) {
+            usleep(100);
+        }
+
+        char *frame0 = static_cast<char *>(mailbox) + MAILBOX_FIRST_TASK_FRAME * MAILBOX_FRAME_SIZE;
+        char *frame1 = frame0 + MAILBOX_FRAME_SIZE;
+        set_test_frame_state(frame0, MailboxState::TASK_FAILED);
+        set_test_frame_state(frame1, MailboxState::TASK_FAILED);
+
+        char terminal = 1;
+        ssize_t written = 0;
+        do {
+            written = write(terminal_pipe[1], &terminal, sizeof(terminal));
+        } while (written < 0 && errno == EINTR);
+        if (written != sizeof(terminal)) _exit(2);
+
+        char release = 0;
+        ssize_t received = 0;
+        do {
+            received = read(release_pipe[0], &release, sizeof(release));
+        } while (received < 0 && errno == EINTR);
+        _exit(received == sizeof(release) ? 0 : 3);
+    }
+
+    ScopedChildProcess child_guard(child);
+    close(terminal_pipe[1]);
+    close(release_pipe[0]);
+
+    {
+        LocalMailboxEndpoint endpoint(/*worker_id=*/0, mailbox, static_cast<int>(child), /*task_frame_count=*/2);
+        endpoint.submit_progress(&allocator, WorkerDispatch{slot0, 0, /*dispatch_id=*/53, /*prepare_only=*/false});
+        endpoint.submit_progress(&allocator, WorkerDispatch{slot1, 0, /*dispatch_id=*/54, /*prepare_only=*/true});
+
+        char *frame0 = static_cast<char *>(mailbox) + MAILBOX_FIRST_TASK_FRAME * MAILBOX_FRAME_SIZE;
+        char *frame1 = frame0 + MAILBOX_FRAME_SIZE;
+        uint64_t stale_generation = 100;
+        std::memcpy(frame1 + MAILBOX_OFF_FRAME_GENERATION, &stale_generation, sizeof(stale_generation));
+        set_test_frame_accepted(frame1);
+        set_test_frame_state(frame1, MailboxState::TASK_LAUNCHED);
+
+        WorkerEndpointProgress progress;
+        EXPECT_FALSE(endpoint.poll_progress(progress));
+
+        pollfd terminal_ready{terminal_pipe[0], POLLIN, 0};
+        int poll_result = 0;
+        do {
+            poll_result = poll(&terminal_ready, 1, 3000);
+        } while (poll_result < 0 && errno == EINTR);
+        EXPECT_EQ(poll_result, 1) << "child did not terminalize both task frames after SHUTDOWN";
+        char terminal = 0;
+        ssize_t received = 0;
+        if (poll_result == 1) {
+            do {
+                received = read(terminal_pipe[0], &terminal, sizeof(terminal));
+            } while (received < 0 && errno == EINTR);
+        }
+        EXPECT_EQ(received, sizeof(terminal));
+        EXPECT_EQ(test_frame_state(frame0), MailboxState::TASK_FAILED);
+        EXPECT_EQ(test_frame_state(frame1), MailboxState::TASK_FAILED);
+        EXPECT_FALSE(endpoint.poll_progress(progress))
+            << "terminal frame states are insufficient while the native child remains alive";
+
+        char release = 1;
+        ssize_t written = 0;
+        do {
+            written = write(release_pipe[1], &release, sizeof(release));
+        } while (written < 0 && errno == EINTR);
+        EXPECT_EQ(written, sizeof(release));
+        close(release_pipe[1]);
+        release_pipe[1] = -1;
+
+        std::vector<WorkerEndpointProgress> completions;
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+        while (completions.size() < 2 && std::chrono::steady_clock::now() < deadline) {
+            if (endpoint.poll_progress(progress)) {
+                completions.push_back(progress);
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+        ASSERT_EQ(completions.size(), 2u);
+        EXPECT_EQ(completions[0].kind, WorkerProgressKind::COMPLETED);
+        EXPECT_EQ(completions[1].kind, WorkerProgressKind::COMPLETED);
+        EXPECT_EQ(completions[0].completion.outcome, EndpointOutcome::ENDPOINT_FAILURE);
+        EXPECT_EQ(completions[1].completion.outcome, EndpointOutcome::ENDPOINT_FAILURE);
+        EXPECT_EQ(
+            std::set<TaskSlot>({completions[0].dispatch.task_slot, completions[1].dispatch.task_slot}),
+            std::set<TaskSlot>({slot0, slot1})
+        );
+    }
+
+    close(terminal_pipe[0]);
+    if (release_pipe[1] >= 0) close(release_pipe[1]);
+    EXPECT_EQ(munmap(mailbox, MAILBOX_SIZE), 0);
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, StopTerminalizesOutstandingProgress) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot active_slot = make_progress_slot(allocator, /*run_id=*/51, /*pipeline_slot=*/0, /*generation=*/1);
+    TaskSlot staged_slot = make_progress_slot(allocator, /*run_id=*/52, /*pipeline_slot=*/1, /*generation=*/1);
+    ASSERT_NE(active_slot, INVALID_SLOT);
+    ASSERT_NE(staged_slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    std::mutex completion_mu;
+    std::condition_variable completion_cv;
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            std::lock_guard<std::mutex> lk(completion_mu);
+            completed.push_back(std::move(completion));
+            completion_cv.notify_all();
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+    worker.dispatch(WorkerDispatch{active_slot, 0});
+    worker.dispatch_prepared(WorkerDispatch{staged_slot, 0});
+    EXPECT_TRUE(endpoint_ptr->wait_submitted(2));
+
+    std::promise<void> stopped;
+    std::future<void> stop_done = stopped.get_future();
+    std::thread stopper([&] {
+        worker.stop();
+        stopped.set_value();
+    });
+    EXPECT_TRUE(endpoint_ptr->wait_stop_requested());
+    std::future_status stop_status = stop_done.wait_for(std::chrono::seconds(3));
+    EXPECT_EQ(stop_status, std::future_status::ready);
+    if (stop_status != std::future_status::ready) endpoint_ptr->force_stop_terminalization();
+    stopper.join();
+    {
+        std::lock_guard<std::mutex> lk(completion_mu);
+        ASSERT_EQ(completed.size(), 2u);
+        EXPECT_EQ(completed[0].outcome, EndpointOutcome::ENDPOINT_FAILURE);
+        EXPECT_EQ(completed[1].outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    }
+    EXPECT_FALSE(worker.busy());
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, ProgressStopRepeatsUntilOutstandingWorkTerminalizes) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/53, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    endpoint_ptr->terminalize_after_stop_request(2);
+    std::mutex completion_mu;
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            std::lock_guard<std::mutex> lk(completion_mu);
+            completed.push_back(std::move(completion));
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+    worker.dispatch(WorkerDispatch{slot, 0});
+    EXPECT_TRUE(endpoint_ptr->wait_submitted(1));
+
+    std::promise<void> stopped;
+    std::future<void> stop_done = stopped.get_future();
+    std::thread stopper([&] {
+        worker.stop();
+        stopped.set_value();
+    });
+    std::future_status stop_status = stop_done.wait_for(std::chrono::seconds(3));
+    EXPECT_EQ(stop_status, std::future_status::ready);
+    if (stop_status != std::future_status::ready) endpoint_ptr->force_stop_terminalization();
+    stopper.join();
+
+    EXPECT_EQ(endpoint_ptr->stop_request_count(), 2u)
+        << "the first stop request may be overwritten by an in-flight control completion";
+    {
+        std::lock_guard<std::mutex> lk(completion_mu);
+        ASSERT_EQ(completed.size(), 1u);
+        EXPECT_EQ(completed[0].outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    }
+    EXPECT_FALSE(worker.busy());
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, PollExceptionTerminalizesOutstandingProgressAndStopsTheDriver) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/54, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    endpoint_ptr->throw_on_next_poll();
+    std::mutex completion_mu;
+    std::condition_variable completion_cv;
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            std::lock_guard<std::mutex> lk(completion_mu);
+            completed.push_back(std::move(completion));
+            completion_cv.notify_all();
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+    worker.dispatch(WorkerDispatch{slot, 0});
+    EXPECT_TRUE(endpoint_ptr->wait_submitted(1));
+    EXPECT_TRUE(endpoint_ptr->wait_progress_error());
+
+    bool completion_ready = false;
+    {
+        std::unique_lock<std::mutex> lk(completion_mu);
+        completion_ready = completion_cv.wait_for(lk, std::chrono::seconds(3), [&] {
+            return completed.size() == 1;
+        });
+    }
+    EXPECT_TRUE(completion_ready);
+    if (!completion_ready) endpoint_ptr->force_stop_terminalization();
+
+    std::promise<void> stopped;
+    std::future<void> stop_done = stopped.get_future();
+    std::thread stopper([&] {
+        worker.stop();
+        stopped.set_value();
+    });
+    std::future_status stop_status = stop_done.wait_for(std::chrono::seconds(3));
+    EXPECT_EQ(stop_status, std::future_status::ready);
+    if (stop_status != std::future_status::ready) endpoint_ptr->force_stop_terminalization();
+    stopper.join();
+
+    EXPECT_EQ(endpoint_ptr->progress_error(), "poll_progress failed: injected poll failure");
+    {
+        std::lock_guard<std::mutex> lk(completion_mu);
+        ASSERT_EQ(completed.size(), 1u);
+        EXPECT_EQ(completed[0].outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    }
+    EXPECT_FALSE(worker.busy());
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, StopKeepsWorkerBusyUntilItsLastCompletionIsPublished) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/61, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+    allocator.slot_state(slot)->state.store(TaskState::RUNNING, std::memory_order_release);
+
+    WorkerManager manager;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    manager.add_next_level_endpoint(std::move(endpoint));
+    Scheduler scheduler;
+    std::promise<void> completion_entered;
+    std::future<void> completion_entered_future = completion_entered.get_future();
+    std::promise<void> allow_completion;
+    std::shared_future<void> allow_completion_future = allow_completion.get_future().share();
+    manager.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            completion_entered.set_value();
+            allow_completion_future.wait();
+            scheduler.worker_done(std::move(completion));
+        },
+        [](WorkerDispatch) {}
+    );
+
+    ReadyQueue ready_sub;
+    NextLevelReadyQueues ready_next;
+    ready_next.reset(manager.next_level_worker_ids());
+    Scheduler::Config scheduler_config;
+    scheduler_config.ring = &allocator;
+    scheduler_config.ready_sub_queue = &ready_sub;
+    scheduler_config.ready_next_level_queues = &ready_next;
+    scheduler_config.manager = &manager;
+    scheduler_config.enqueue_ready_cb = [](TaskSlot) {};
+    scheduler.start(scheduler_config);
+
+    WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
+    ASSERT_NE(worker, nullptr);
+    worker->dispatch(WorkerDispatch{slot, 0});
+    ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
+    scheduler.request_stop();
+
+    std::thread manager_stopper([&] {
+        manager.stop_workers();
+    });
+    EXPECT_EQ(completion_entered_future.wait_for(std::chrono::seconds(3)), std::future_status::ready);
+
+    std::promise<void> scheduler_stopped;
+    std::future<void> scheduler_stopped_future = scheduler_stopped.get_future();
+    std::thread scheduler_stopper([&] {
+        scheduler.stop();
+        scheduler_stopped.set_value();
+    });
+    EXPECT_EQ(scheduler_stopped_future.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout)
+        << "scheduler exited before the worker published its terminal completion";
+
+    allow_completion.set_value();
+    manager_stopper.join();
+    scheduler_stopper.join();
+    EXPECT_EQ(scheduler_stopped_future.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    EXPECT_EQ(allocator.slot_state(slot)->state.load(std::memory_order_acquire), TaskState::FAILED);
+    manager.stop();
+    allocator.shutdown();
+}
+
+struct ProgressSchedulerFixture : public ::testing::Test {
+    TensorMap tensor_map;
+    Ring allocator;
+    Scope scope;
+    ReadyQueue ready_sub;
+    NextLevelReadyQueues ready_next;
+    Orchestrator orchestrator;
+    WorkerManager manager;
+    Scheduler scheduler;
+    CallConfig config;
+    DeterministicProgressEndpoint *endpoint0{nullptr};
+    DeterministicProgressEndpoint *endpoint1{nullptr};
+
+    virtual uint32_t endpoint0_capacity() const { return 2; }
+
+    void SetUp() override {
+        allocator.init(/*heap_bytes=*/1ULL << 20);
+        auto first_endpoint = std::make_unique<DeterministicProgressEndpoint>(0, endpoint0_capacity());
+        auto second_endpoint = std::make_unique<DeterministicProgressEndpoint>(1);
+        endpoint0 = first_endpoint.get();
+        endpoint1 = second_endpoint.get();
+        manager.add_next_level_endpoint(std::move(first_endpoint));
+        manager.add_next_level_endpoint(std::move(second_endpoint));
+        manager.start(
+            &allocator,
+            [this](WorkerCompletion completion) {
+                scheduler.worker_done(std::move(completion));
+            },
+            [this](WorkerDispatch dispatch) {
+                orchestrator.mark_task_accepted(dispatch.task_slot);
+            }
+        );
+        ready_next.reset(manager.next_level_worker_ids());
+        orchestrator.init(&tensor_map, &allocator, &scope, &ready_sub, &ready_next, &manager, [this] {
+            scheduler.notify_ready();
+        });
+        orchestrator.configure_pipeline_depth(2);
+
+        Scheduler::Config scheduler_config;
+        scheduler_config.ring = &allocator;
+        scheduler_config.ready_sub_queue = &ready_sub;
+        scheduler_config.ready_next_level_queues = &ready_next;
+        scheduler_config.manager = &manager;
+        scheduler_config.enqueue_ready_cb = [this](TaskSlot task_slot) {
+            orchestrator.enqueue_ready(task_slot);
+        };
+        scheduler_config.active_run_cb = [this] {
+            return orchestrator.dispatchable_run_id();
+        };
+        scheduler_config.preparable_run_cb = [this] {
+            return orchestrator.preparable_run_id();
+        };
+        scheduler_config.on_consumed_cb = [this](TaskSlot task_slot) {
+            orchestrator.on_consumed(task_slot);
+        };
+        scheduler_config.on_task_failed_cb = [this](TaskSlot task_slot, const std::string &message) {
+            orchestrator.report_task_error(task_slot, message);
+        };
+        scheduler.start(scheduler_config);
+    }
+
+    void TearDown() override {
+        scheduler.request_stop();
+        manager.stop_workers();
+        scheduler.stop();
+        manager.stop();
+        allocator.shutdown();
+    }
+};
+
+struct CapacityOneProgressSchedulerFixture : public ProgressSchedulerFixture {
+    uint32_t endpoint0_capacity() const override { return 1; }
+};
+
+TEST_F(ProgressSchedulerFixture, SuccessorStagesButActivatesOnlyAfterFifoPromotion) {
+    RunId first_run = orchestrator.begin_run();
+    SubmitResult first =
+        orchestrator.submit_next_level(C(1), single_tensor_args(0x1000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(first_run);
+    RunId second_run = orchestrator.begin_run();
+    SubmitResult second =
+        orchestrator.submit_next_level(C(2), single_tensor_args(0x2000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(second_run);
+
+    EXPECT_TRUE(endpoint0->wait_submitted(2));
+    std::vector<WorkerDispatch> submitted = endpoint0->submitted();
+    ASSERT_EQ(submitted.size(), 2u);
+    auto first_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == first.task_slot;
+    });
+    auto second_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == second.task_slot;
+    });
+    ASSERT_NE(first_dispatch, submitted.end());
+    ASSERT_NE(second_dispatch, submitted.end());
+    EXPECT_FALSE(first_dispatch->prepare_only);
+    EXPECT_TRUE(second_dispatch->prepare_only);
+    EXPECT_EQ(orchestrator.active_run_id(), first_run);
+    EXPECT_EQ(orchestrator.preparable_run_id(), second_run);
+    EXPECT_FALSE(endpoint0->wait_activated(second_run, std::chrono::milliseconds(20)));
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, *first_dispatch);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, *first_dispatch);
+    EXPECT_TRUE(endpoint0->wait_activated(second_run));
+    EXPECT_EQ(orchestrator.active_run_id(), second_run);
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, *second_dispatch);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, *second_dispatch);
+    EXPECT_TRUE(orchestrator.wait_run_for(first_run, 3.0));
+    EXPECT_TRUE(orchestrator.wait_run_for(second_run, 3.0));
+    if (orchestrator.run_done(first_run)) orchestrator.release_run(first_run);
+    if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
+}
+
+TEST_F(ProgressSchedulerFixture, ActivatedRunReleasesTheStagingLaneForItsSuccessor) {
+    RunId first_run = orchestrator.begin_run();
+    SubmitResult first =
+        orchestrator.submit_next_level(C(7), single_tensor_args(0x8000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(first_run);
+    RunId second_run = orchestrator.begin_run();
+    SubmitResult second =
+        orchestrator.submit_next_level(C(8), single_tensor_args(0x9000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(second_run);
+
+    ASSERT_TRUE(endpoint0->wait_submitted(2));
+    std::vector<WorkerDispatch> submitted = endpoint0->submitted();
+    auto first_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == first.task_slot;
+    });
+    auto second_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == second.task_slot;
+    });
+    ASSERT_NE(first_dispatch, submitted.end());
+    ASSERT_NE(second_dispatch, submitted.end());
+    const WorkerDispatch first_dispatch_copy = *first_dispatch;
+    const WorkerDispatch second_dispatch_copy = *second_dispatch;
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, first_dispatch_copy);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, first_dispatch_copy);
+    ASSERT_TRUE(endpoint0->wait_activated(second_run));
+    ASSERT_TRUE(orchestrator.wait_run_for(first_run, 3.0));
+
+    RunId third_run = orchestrator.begin_run();
+    SubmitResult third =
+        orchestrator.submit_next_level(C(9), single_tensor_args(0xA000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(third_run);
+    ASSERT_TRUE(endpoint0->wait_submitted(3));
+    submitted = endpoint0->submitted();
+    auto third_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == third.task_slot;
+    });
+    ASSERT_NE(third_dispatch, submitted.end());
+    EXPECT_TRUE(third_dispatch->prepare_only);
+    EXPECT_FALSE(endpoint0->wait_activated(third_run, std::chrono::milliseconds(20)));
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, second_dispatch_copy);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, second_dispatch_copy);
+    ASSERT_TRUE(endpoint0->wait_activated(third_run));
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, *third_dispatch);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, *third_dispatch);
+
+    EXPECT_TRUE(orchestrator.wait_run_for(second_run, 3.0));
+    EXPECT_TRUE(orchestrator.wait_run_for(third_run, 3.0));
+    if (orchestrator.run_done(first_run)) orchestrator.release_run(first_run);
+    if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
+    if (orchestrator.run_done(third_run)) orchestrator.release_run(third_run);
+}
+
+TEST_F(CapacityOneProgressSchedulerFixture, PublicationFailureCompletesTheClaimedSuccessor) {
+    RunId first_run = orchestrator.begin_run();
+    orchestrator.submit_next_level(C(5), single_tensor_args(0x6000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(first_run);
+    EXPECT_TRUE(endpoint0->wait_submitted(1));
+
+    RunId second_run = orchestrator.begin_run();
+    orchestrator.submit_next_level(C(6), single_tensor_args(0x7000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(second_run);
+
+    // Wait for the scheduler to claim and reject the successor while the first
+    // dispatch still owns the endpoint's only inflight slot. This successor
+    // remains PREPARED after its task error and is not terminal until FIFO
+    // promotion, so observe its recorded failure rather than wait_run_for().
+    // Completing the first dispatch before this fence races promotion and can
+    // turn the successor into an ordinary active dispatch.
+    const auto publication_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (!orchestrator.run_failed(second_run) && std::chrono::steady_clock::now() < publication_deadline) {
+        std::this_thread::yield();
+    }
+    ASSERT_TRUE(orchestrator.run_failed(second_run));
+    std::vector<WorkerDispatch> submitted = endpoint0->submitted();
+    ASSERT_EQ(submitted.size(), 1u) << "the rejected successor must not reach the endpoint";
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, submitted[0]);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, submitted[0]);
+
+    EXPECT_TRUE(orchestrator.wait_run_for(first_run, 3.0));
+    EXPECT_THROW((void)orchestrator.wait_run_for(second_run, 3.0), std::runtime_error);
+    EXPECT_TRUE(scheduler.running());
+    if (orchestrator.run_done(first_run)) orchestrator.release_run(first_run);
+    if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
+}
+
+TEST_F(ProgressSchedulerFixture, PreparedSuccessorGroupRemainsQueuedUntilPromotion) {
+    RunId first_run = orchestrator.begin_run();
+    orchestrator.submit_next_level(C(3), single_tensor_args(0x3000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(first_run);
+    RunId second_run = orchestrator.begin_run();
+    orchestrator.submit_next_level_group(
+        C(4), {single_tensor_args(0x4000, TensorArgType::OUTPUT), single_tensor_args(0x5000, TensorArgType::OUTPUT)},
+        config, {0, 1}
+    );
+    orchestrator.close_run_submission(second_run);
+
+    EXPECT_TRUE(endpoint0->wait_submitted(1));
+    EXPECT_TRUE(ready_next.singles_empty(second_run));
+    EXPECT_FALSE(ready_next.empty(second_run));
+    EXPECT_FALSE(manager.has_staged_run(second_run));
+    EXPECT_TRUE(endpoint1->submitted().empty());
+    std::vector<WorkerDispatch> first_submissions = endpoint0->submitted();
+    ASSERT_EQ(first_submissions.size(), 1u);
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, first_submissions[0]);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, first_submissions[0]);
+    EXPECT_TRUE(endpoint0->wait_submitted(2));
+    EXPECT_TRUE(endpoint1->wait_submitted(1));
+    std::vector<WorkerDispatch> worker0_submissions = endpoint0->submitted();
+    std::vector<WorkerDispatch> worker1_submissions = endpoint1->submitted();
+    ASSERT_EQ(worker0_submissions.size(), 2u);
+    ASSERT_EQ(worker1_submissions.size(), 1u);
+    EXPECT_FALSE(worker0_submissions[1].prepare_only);
+    EXPECT_FALSE(worker1_submissions[0].prepare_only);
+    EXPECT_EQ(orchestrator.active_run_id(), second_run);
+    EXPECT_EQ(orchestrator.preparable_run_id(), INVALID_RUN_ID);
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, worker0_submissions[1]);
+    endpoint1->emit(WorkerProgressKind::ACCEPTED, worker1_submissions[0]);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, worker0_submissions[1]);
+    endpoint1->emit(WorkerProgressKind::COMPLETED, worker1_submissions[0]);
+    EXPECT_TRUE(orchestrator.wait_run_for(first_run, 3.0));
+    EXPECT_TRUE(orchestrator.wait_run_for(second_run, 3.0));
+    if (orchestrator.run_done(first_run)) orchestrator.release_run(first_run);
+    if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
+}
+
+TEST_F(ProgressSchedulerFixture, PreparedSuccessorSingleCannotBypassItsReadyGroup) {
+    RunId first_run = orchestrator.begin_run();
+    SubmitResult first =
+        orchestrator.submit_next_level(C(10), single_tensor_args(0xB000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(first_run);
+
+    RunId second_run = orchestrator.begin_run();
+    SubmitResult group = orchestrator.submit_next_level_group(
+        C(11), {single_tensor_args(0xC000, TensorArgType::OUTPUT), single_tensor_args(0xD000, TensorArgType::OUTPUT)},
+        config, {0, 1}
+    );
+    SubmitResult single =
+        orchestrator.submit_next_level(C(12), single_tensor_args(0xE000, TensorArgType::OUTPUT), config, 0);
+    orchestrator.close_run_submission(second_run);
+
+    ASSERT_TRUE(endpoint0->wait_submitted(1));
+    EXPECT_EQ(endpoint0->submitted()[0].task_slot, first.task_slot);
+    EXPECT_TRUE(endpoint1->submitted().empty());
+    EXPECT_FALSE(manager.has_staged_run(second_run));
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, endpoint0->submitted()[0]);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, endpoint0->submitted()[0]);
+
+    ASSERT_TRUE(endpoint0->wait_submitted(2));
+    ASSERT_TRUE(endpoint1->wait_submitted(1));
+    std::vector<WorkerDispatch> worker0_submissions = endpoint0->submitted();
+    std::vector<WorkerDispatch> worker1_submissions = endpoint1->submitted();
+    ASSERT_EQ(worker0_submissions.size(), 2u);
+    ASSERT_EQ(worker1_submissions.size(), 1u);
+    EXPECT_EQ(worker0_submissions[1].task_slot, group.task_slot);
+    EXPECT_EQ(worker1_submissions[0].task_slot, group.task_slot);
+    EXPECT_FALSE(worker0_submissions[1].prepare_only);
+    EXPECT_FALSE(worker1_submissions[0].prepare_only);
+
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, worker0_submissions[1]);
+    endpoint1->emit(WorkerProgressKind::ACCEPTED, worker1_submissions[0]);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, worker0_submissions[1]);
+    endpoint1->emit(WorkerProgressKind::COMPLETED, worker1_submissions[0]);
+
+    ASSERT_TRUE(endpoint0->wait_submitted(3));
+    worker0_submissions = endpoint0->submitted();
+    ASSERT_EQ(worker0_submissions.size(), 3u);
+    EXPECT_EQ(worker0_submissions[2].task_slot, single.task_slot);
+    EXPECT_FALSE(worker0_submissions[2].prepare_only);
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, worker0_submissions[2]);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, worker0_submissions[2]);
+
+    EXPECT_TRUE(orchestrator.wait_run_for(first_run, 3.0));
+    EXPECT_TRUE(orchestrator.wait_run_for(second_run, 3.0));
+    if (orchestrator.run_done(first_run)) orchestrator.release_run(first_run);
+    if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
+}
+
 TEST(WorkerManagerTest, LocalMailboxPublishesAcceptanceBeforeCompletion) {
     MockMailboxWorker child;
     child.start();
@@ -593,7 +1771,9 @@ TEST(WorkerManagerTest, LocalMailboxPublishesAcceptanceBeforeCompletion) {
     EXPECT_EQ(wire_lease.generation, 7u);
     child.write_task_accepted();
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
-    while (!accepted.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {}
+    while (!accepted.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
     EXPECT_TRUE(accepted.load(std::memory_order_acquire));
     EXPECT_EQ(done.wait_for(std::chrono::milliseconds(0)), std::future_status::timeout);
 

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -25,7 +25,7 @@ import time
 import weakref
 from multiprocessing.shared_memory import SharedMemory
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Optional, cast
 from unittest.mock import patch
 
 import pytest
@@ -139,6 +139,7 @@ def _chip_payload_shm(callable_obj: ChipCallable) -> SharedMemory:
 def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
     events: list[tuple] = []
     published_depths: list[int] = []
+    published_frame_counts: list[int] = []
 
     class FakeChipWorker:
         pipeline_depth = 2
@@ -149,8 +150,9 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
         def finalize(self) -> None:
             events.append(("finalize",))
 
-    def fake_run_chip_main_loop(cw, *_args, chip_platform, chip_runtime, prepared=None):
+    def fake_run_chip_main_loop(cw, *_args, chip_platform, chip_runtime, prepared=None, task_frame_count=1):
         published_depths.append(worker_mod._PIPELINE_LEASE_FMT.unpack_from(_args[0], worker_mod._OFF_PIPELINE_LEASE)[0])
+        published_frame_counts.append(task_frame_count)
         events.append(("main_loop", cw, chip_platform, chip_runtime))
 
     monkeypatch.setattr(worker_mod, "ChipWorker", FakeChipWorker)
@@ -178,6 +180,611 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
     assert events[1][2:] == ("a2a3", "tensormap_and_ringbuffer")
     assert events[2] == ("finalize",)
     assert published_depths == [2]
+    assert published_frame_counts == [2]
+
+
+@pytest.mark.parametrize(
+    ("platform", "runtime", "depth", "expected"),
+    [
+        ("a2a3", "host_build_graph", 2, 2),
+        ("a2a3", "host_build_graph", 1, 1),
+        ("a2a3", "tensormap_and_ringbuffer", 2, 2),
+        ("a5", "host_build_graph", 2, 1),
+        ("a2a3sim", "host_build_graph", 2, 1),
+    ],
+)
+def test_local_task_frame_count_uses_direct_a2a3_pipeline_depth(platform, runtime, depth, expected):
+    assert worker_mod._local_task_frame_count(platform, runtime, depth) == expected
+
+
+def test_start_hierarchical_passes_each_chip_its_negotiated_frame_count(monkeypatch):
+    class FakeParentWorker:
+        def __init__(self) -> None:
+            self.configured_depths: list[int] = []
+            self.next_level_calls: list[tuple[int, int, int]] = []
+            self.initialized = False
+
+        def configure_pipeline_depth(self, depth: int) -> None:
+            self.configured_depths.append(int(depth))
+
+        def add_next_level_worker(self, mailbox_addr: int, pid: int, task_frame_count: int) -> None:
+            self.next_level_calls.append((int(mailbox_addr), int(pid), int(task_frame_count)))
+
+        def init(self) -> None:
+            self.initialized = True
+
+        def get_orchestrator(self):
+            return object()
+
+    worker = Worker(
+        level=3,
+        device_ids=[0, 1],
+        num_sub_workers=0,
+        platform="a2a3",
+        runtime="host_build_graph",
+    )
+    worker._chip_shms = [SharedMemory(create=True, size=MAILBOX_SIZE) for _ in range(2)]
+    fake_parent = FakeParentWorker()
+    worker._worker = cast(Any, fake_parent)
+    worker._startup_deadline = time.monotonic() + 5.0
+    fork_pids = iter((12001, 12002))
+
+    def fake_await_children_ready(shms, _pids, kind: str, _deadline: float) -> None:
+        if kind != "chip":
+            return
+        for shm, depth in zip(shms, (2, 1)):
+            assert shm.buf is not None
+            worker_mod._PIPELINE_LEASE_FMT.pack_into(shm.buf, worker_mod._OFF_PIPELINE_LEASE, depth, 0, 0)
+
+    monkeypatch.setattr(worker_mod.os, "fork", lambda: next(fork_pids))
+    monkeypatch.setattr(worker, "_await_children_ready", fake_await_children_ready)
+    monkeypatch.setattr(worker_mod, "Orchestrator", lambda native, owner: (native, owner))
+    try:
+        worker._start_hierarchical()
+    finally:
+        for shm in worker._chip_shms:
+            shm.close()
+            shm.unlink()
+
+    assert fake_parent.configured_depths == [1]
+    assert [call[1:] for call in fake_parent.next_level_calls] == [(12001, 2), (12002, 1)]
+    assert fake_parent.initialized
+
+
+class _FakeNativeRunImpl:
+    def __init__(self) -> None:
+        self.events: list[tuple] = []
+        self.completed = [threading.Event(), threading.Event()]
+        self.prepared = [threading.Event(), threading.Event()]
+        self.launched = [threading.Event(), threading.Event()]
+        self.finalized = [threading.Event(), threading.Event()]
+        self.launch_errors: dict[tuple[int, int], BaseException] = {}
+        self.poll_errors: dict[tuple[int, int], BaseException] = {}
+        self.finalize_errors: dict[tuple[int, int], BaseException] = {}
+        self.register_calls: list[tuple[int, int]] = []
+        self.register_called = threading.Event()
+        self._finalized_runs: set[tuple[int, int]] = set()
+        self._polled_slots: set[int] = set()
+
+    def register_callable_from_blob(self, cid: int, blob_addr: int) -> None:
+        self.register_calls.append((int(cid), int(blob_addr)))
+        self.register_called.set()
+
+    def _prepare_native_run_from_blob(self, _cid, _blob_addr, _capacity, _cfg, slot_id, generation):
+        slot = int(slot_id)
+        token = SimpleNamespace(slot_id=slot, generation=int(generation), run_epoch=slot + 1)
+        self.events.append(("prepare", slot))
+        self.prepared[slot].set()
+        return token
+
+    def _launch_native_run(self, token, accepted_addr, accepted_value) -> None:
+        slot = int(token.slot_id)
+        state_addr = int(accepted_addr) - worker_mod._OFF_ACCEPTED
+        self.events.append(
+            (
+                "launch_enter",
+                slot,
+                _mailbox_load_i32(int(accepted_addr)),
+                _mailbox_load_i32(state_addr),
+            )
+        )
+        launch_error = self.launch_errors.get((slot, int(token.generation)))
+        if launch_error is not None:
+            raise launch_error
+        _mailbox_store_i32(int(accepted_addr), int(accepted_value))
+        self.events.append(("launch", slot))
+        self.launched[slot].set()
+
+    def _poll_native_run(self, token) -> bool:
+        slot = int(token.slot_id)
+        error = self.poll_errors.get((slot, int(token.generation)))
+        if error is not None:
+            raise error
+        if slot not in self._polled_slots:
+            self._polled_slots.add(slot)
+            self.events.append(("poll", slot))
+        return self.completed[slot].is_set()
+
+    def _finalize_native_run(self, token) -> None:
+        slot = int(token.slot_id)
+        run_key = (slot, int(token.generation))
+        assert run_key not in self._finalized_runs
+        self._finalized_runs.add(run_key)
+        self.events.append(("finalize", slot))
+        self.finalized[slot].set()
+        error = self.finalize_errors.get(run_key)
+        if error is not None:
+            raise error
+
+
+class _FakeTwoFrameChipWorker:
+    pipeline_depth = 2
+
+    def __init__(self) -> None:
+        self._impl = _FakeNativeRunImpl()
+        self.malloc_called = threading.Event()
+        self.unregister_calls: list[int] = []
+        self.unregister_called = threading.Event()
+        self.unregister_error: Optional[BaseException] = None
+
+    def malloc(self, size: int) -> int:
+        self._impl.events.append(("malloc", int(size)))
+        self.malloc_called.set()
+        return 0xCAFE
+
+    def _unregister_slot(self, cid: int) -> None:
+        self.unregister_calls.append(int(cid))
+        self.unregister_called.set()
+        if self.unregister_error is not None:
+            raise self.unregister_error
+
+
+class _TwoFrameLoopHarness:
+    def __init__(self) -> None:
+        self.shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+        self.buf = cast(memoryview, self.shm.buf)
+        assert self.buf is not None
+        self.mailbox_addr = _mailbox_addr(self.shm)
+        self.digest = bytes([0x42]) * worker_mod.CALLABLE_HASH_DIGEST_BYTES
+        self.cw = _FakeTwoFrameChipWorker()
+        self.registry = {7: object()}
+        self.identity_table = {self.digest: 7}
+        self.identity_refs = {self.digest: 1}
+        self.prepared = {7}
+        self.thread = threading.Thread(
+            target=worker_mod._run_chip_main_loop,
+            args=(
+                self.cw,
+                self.buf,
+                self.mailbox_addr,
+                self.mailbox_addr + _OFF_STATE,
+                0,
+                self.registry,
+                self.identity_table,
+                self.identity_refs,
+            ),
+            kwargs={"chip_platform": "a2a3", "prepared": self.prepared, "task_frame_count": 2},
+        )
+
+    def _frame_offset(self, index: int) -> int:
+        return (1 + index) * worker_mod.MAILBOX_FRAME_SIZE
+
+    def state_addr(self, index: int) -> int:
+        return self.mailbox_addr + self._frame_offset(index) + _OFF_STATE
+
+    def accepted_addr(self, index: int) -> int:
+        return self.mailbox_addr + self._frame_offset(index) + worker_mod._OFF_ACCEPTED
+
+    def publish(
+        self,
+        index: int,
+        dispatch_id: int,
+        *,
+        state: int = worker_mod._TASK_READY,
+        generation: int = 11,
+    ) -> None:
+        offset = self._frame_offset(index)
+        frame = self.buf[offset : offset + worker_mod.MAILBOX_FRAME_SIZE]
+        try:
+            frame[worker_mod._OFF_TASK_CALLABLE_HASH : worker_mod._OFF_TASK_ARGS_BLOB] = self.digest
+            struct.pack_into("=ii", frame, worker_mod._OFF_TASK_ARGS_BLOB, 0, 0)
+            cfg_values = [0] * (6 + 3 * worker_mod.RUNTIME_ENV_RING_COUNT)
+            worker_mod._CFG_FMT.pack_into(frame, worker_mod._OFF_CONFIG, *cfg_values, b"")
+            worker_mod._PIPELINE_LEASE_FMT.pack_into(frame, worker_mod._OFF_PIPELINE_LEASE, index, 0, generation)
+            struct.pack_into("=Q", frame, worker_mod._OFF_FRAME_PROTOCOL, worker_mod._TASK_PROTOCOL_VERSION)
+            struct.pack_into("=Q", frame, worker_mod._OFF_FRAME_RUN_ID, 5)
+            struct.pack_into("=Q", frame, worker_mod._OFF_FRAME_SLOT_ID, index)
+            struct.pack_into("=Q", frame, worker_mod._OFF_FRAME_GENERATION, generation)
+            struct.pack_into("=Q", frame, worker_mod._OFF_FRAME_DISPATCH_ID, dispatch_id)
+        finally:
+            frame.release()
+        _mailbox_store_i32(self.accepted_addr(index), 0)
+        _mailbox_store_i32(self.state_addr(index), state)
+
+    def wait_state(self, index: int, expected: int) -> None:
+        deadline = time.monotonic() + 5.0
+        while _mailbox_load_i32(self.state_addr(index)) != expected:
+            assert time.monotonic() < deadline
+            time.sleep(0.001)
+
+    def wait_control_state(self, expected: int) -> None:
+        deadline = time.monotonic() + 5.0
+        while _mailbox_load_i32(self.mailbox_addr + _OFF_STATE) != expected:
+            assert time.monotonic() < deadline
+            time.sleep(0.001)
+
+    def assert_control_stays_pending(self, duration: float = 0.05) -> None:
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline:
+            assert _mailbox_load_i32(self.mailbox_addr + _OFF_STATE) == worker_mod._CONTROL_REQUEST
+            time.sleep(0.001)
+
+    def publish_unregister(self, digest: Optional[bytes] = None) -> None:
+        digest = self.digest if digest is None else digest
+        struct.pack_into("Q", self.buf, worker_mod._OFF_CALLABLE, worker_mod._CTRL_UNREGISTER)
+        self.buf[worker_mod._OFF_CONTROL_CALLABLE_HASH : worker_mod._OFF_CONTROL_CALLABLE_HASH + len(digest)] = digest
+        _mailbox_store_i32(self.mailbox_addr + _OFF_STATE, worker_mod._CONTROL_REQUEST)
+
+    def publish_register(self, callable_obj: ChipCallable, payload_shm: SharedMemory, digest: bytes) -> None:
+        struct.pack_into("Q", self.buf, worker_mod._OFF_CALLABLE, worker_mod._CTRL_REGISTER)
+        struct.pack_into("Q", self.buf, worker_mod._CTRL_OFF_ARG0, int(callable_obj.buffer_size()))
+        self.buf[worker_mod._OFF_CONTROL_CALLABLE_HASH : worker_mod._OFF_CONTROL_CALLABLE_HASH + len(digest)] = digest
+        encoded_name = payload_shm.name.encode("utf-8")
+        assert len(encoded_name) + 1 <= worker_mod._CTRL_SHM_NAME_BYTES
+        self.buf[worker_mod._OFF_ARGS : worker_mod._OFF_ARGS + worker_mod._CTRL_SHM_NAME_BYTES] = b"\x00" * (
+            worker_mod._CTRL_SHM_NAME_BYTES
+        )
+        self.buf[worker_mod._OFF_ARGS : worker_mod._OFF_ARGS + len(encoded_name)] = encoded_name
+        _mailbox_store_i32(self.mailbox_addr + _OFF_STATE, worker_mod._CONTROL_REQUEST)
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def stop(self) -> None:
+        if self.thread.is_alive():
+            _mailbox_store_i32(self.mailbox_addr + _OFF_STATE, worker_mod._SHUTDOWN)
+            self.thread.join(5.0)
+        assert not self.thread.is_alive()
+
+    def close(self) -> None:
+        self.stop()
+        self.shm.close()
+        self.shm.unlink()
+
+
+def test_two_frame_stages_b_without_native_prepare_until_a_finalizes():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+
+        harness.publish(1, 2)
+        harness.wait_state(1, worker_mod._FRAME_STAGED)
+        assert not harness.cw._impl.prepared[1].is_set()
+        assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
+
+        harness.cw._impl.completed[0].set()
+        assert harness.cw._impl.finalized[0].wait(5.0)
+        assert harness.cw._impl.launched[1].wait(5.0)
+        assert _mailbox_load_i32(harness.accepted_addr(1)) == worker_mod._TASK_ACCEPTED
+        harness.cw._impl.completed[1].set()
+        harness.wait_state(1, worker_mod._TASK_DONE)
+
+        lifecycle = [event[:2] for event in harness.cw._impl.events if event[0] in {"prepare", "launch", "finalize"}]
+        assert lifecycle == [
+            ("prepare", 0),
+            ("launch", 0),
+            ("finalize", 0),
+            ("prepare", 1),
+            ("launch", 1),
+            ("finalize", 1),
+        ]
+        launch_entries = [event for event in harness.cw._impl.events if event[0] == "launch_enter"]
+        assert launch_entries == [
+            ("launch_enter", 0, 0, worker_mod._FRAME_STAGED),
+            ("launch_enter", 1, 0, worker_mod._FRAME_STAGED),
+        ]
+    finally:
+        harness.close()
+
+
+def test_two_frame_launches_by_dispatch_id_when_frames_are_ready_in_reverse_order():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 2)
+        harness.publish(1, 1)
+        harness.start()
+        assert harness.cw._impl.launched[1].wait(5.0)
+        assert not harness.cw._impl.prepared[0].is_set()
+        harness.cw._impl.completed[1].set()
+        assert harness.cw._impl.launched[0].wait(5.0)
+        harness.cw._impl.completed[0].set()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+        launches = [event for event in harness.cw._impl.events if event[0] == "launch"]
+        assert launches == [("launch", 1), ("launch", 0)]
+    finally:
+        harness.close()
+
+
+def test_two_frame_prepare_ready_waits_for_sticky_activation():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1, state=worker_mod._PREPARE_READY)
+        harness.start()
+        harness.wait_state(0, worker_mod._FRAME_STAGED)
+        assert not harness.cw._impl.prepared[0].is_set()
+
+        _mailbox_store_i32(harness.state_addr(0), worker_mod._ACTIVATE)
+        assert harness.cw._impl.launched[0].wait(5.0)
+        harness.cw._impl.completed[0].set()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+    finally:
+        harness.close()
+
+
+def test_two_frame_processes_control_while_native_run_is_active():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+
+        struct.pack_into("Q", harness.buf, worker_mod._OFF_CALLABLE, worker_mod._CTRL_MALLOC)
+        struct.pack_into("Q", harness.buf, worker_mod._CTRL_OFF_ARG0, 4096)
+        _mailbox_store_i32(harness.mailbox_addr + _OFF_STATE, worker_mod._CONTROL_REQUEST)
+        assert harness.cw.malloc_called.wait(5.0)
+        assert _mailbox_load_i32(harness.mailbox_addr + _OFF_STATE) == worker_mod._CONTROL_DONE
+        assert struct.unpack_from("Q", harness.buf, worker_mod._CTRL_OFF_RESULT)[0] == 0xCAFE
+        assert not harness.cw._impl.completed[0].is_set()
+
+        harness.cw._impl.completed[0].set()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+    finally:
+        harness.close()
+
+
+def test_two_frame_defers_unregister_until_active_native_run_finalizes():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+
+        harness.publish_unregister()
+        harness.assert_control_stays_pending()
+        assert harness.cw.unregister_calls == []
+        assert harness.identity_table == {harness.digest: 7}
+
+        harness.cw._impl.completed[0].set()
+        assert harness.cw._impl.finalized[0].wait(5.0)
+        harness.wait_control_state(worker_mod._CONTROL_DONE)
+        assert harness.cw.unregister_calls == [7]
+        assert harness.identity_table == {}
+        assert harness.registry == {}
+        assert harness.prepared == set()
+    finally:
+        harness.close()
+
+
+def test_two_frame_defers_register_until_active_native_run_finalizes():
+    harness = _TwoFrameLoopHarness()
+    callable_obj = _unique_chip_callable(23)
+    digest = _chip_digest(callable_obj, platform="a2a3")
+    payload_shm = _chip_payload_shm(callable_obj)
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+
+        harness.publish_register(callable_obj, payload_shm, digest)
+        harness.assert_control_stays_pending()
+        assert harness.cw._impl.register_calls == []
+        assert digest not in harness.identity_table
+
+        harness.cw._impl.completed[0].set()
+        assert harness.cw._impl.finalized[0].wait(5.0)
+        harness.wait_control_state(worker_mod._CONTROL_DONE)
+        assert len(harness.cw._impl.register_calls) == 1
+        cid = harness.identity_table[digest]
+        assert harness.cw._impl.register_calls[0][0] == cid
+        assert cid in harness.registry
+        assert cid in harness.prepared
+    finally:
+        harness.close()
+        payload_shm.close()
+        payload_shm.unlink()
+
+
+def test_two_frame_defers_final_unregister_while_matching_frame_is_staged():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1, state=worker_mod._PREPARE_READY)
+        harness.start()
+        harness.wait_state(0, worker_mod._FRAME_STAGED)
+
+        harness.publish_unregister()
+        harness.assert_control_stays_pending()
+        assert harness.cw.unregister_calls == []
+
+        _mailbox_store_i32(harness.state_addr(0), worker_mod._ACTIVATE)
+        assert harness.cw._impl.launched[0].wait(5.0)
+        harness.assert_control_stays_pending()
+        assert harness.cw.unregister_calls == []
+
+        harness.cw._impl.completed[0].set()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+        harness.wait_control_state(worker_mod._CONTROL_DONE)
+        assert harness.cw.unregister_calls == [7]
+        assert harness.identity_table == {}
+        assert harness.registry == {}
+        assert harness.prepared == set()
+    finally:
+        harness.close()
+
+
+def test_two_frame_native_unregister_failure_preserves_local_identity_state():
+    harness = _TwoFrameLoopHarness()
+    original_callable = harness.registry[7]
+    harness.cw.unregister_error = RuntimeError("native unregister failed")
+    try:
+        harness.publish_unregister()
+        harness.start()
+        harness.wait_control_state(worker_mod._CONTROL_DONE)
+
+        assert harness.cw.unregister_calls == [7]
+        assert harness.identity_table == {harness.digest: 7}
+        assert harness.identity_refs == {harness.digest: 1}
+        assert harness.registry == {7: original_callable}
+        assert harness.prepared == {7}
+        assert struct.unpack_from("i", harness.buf, worker_mod._OFF_ERROR)[0] == 1
+        error = bytes(
+            harness.buf[
+                worker_mod.MAILBOX_OFF_ERROR_MSG : worker_mod.MAILBOX_OFF_ERROR_MSG + worker_mod.MAILBOX_ERROR_MSG_SIZE
+            ]
+        ).split(b"\x00", 1)[0]
+        assert b"native unregister failed" in error
+    finally:
+        harness.close()
+
+
+def test_two_frame_shutdown_finalizes_active_and_fails_staged_without_launch():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+        harness.publish(1, 2)
+        harness.wait_state(1, worker_mod._FRAME_STAGED)
+
+        _mailbox_store_i32(harness.mailbox_addr + _OFF_STATE, worker_mod._SHUTDOWN)
+        harness.thread.join(5.0)
+        assert not harness.thread.is_alive()
+        assert harness.cw._impl.finalized[0].is_set()
+        assert not harness.cw._impl.prepared[1].is_set()
+        assert _mailbox_load_i32(harness.state_addr(1)) == worker_mod._TASK_FAILED
+    finally:
+        harness.close()
+
+
+def test_two_frame_reuses_completed_frame_for_next_staged_successor():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+
+        harness.publish(1, 2, state=worker_mod._PREPARE_READY)
+        harness.wait_state(1, worker_mod._FRAME_STAGED)
+        assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
+
+        harness.cw._impl.completed[0].set()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+        _mailbox_store_i32(harness.state_addr(1), worker_mod._ACTIVATE)
+        harness.wait_state(1, worker_mod._TASK_LAUNCHED)
+        assert _mailbox_load_i32(harness.accepted_addr(1)) == worker_mod._TASK_ACCEPTED
+
+        harness.cw._impl.completed[0].clear()
+        harness.publish(0, 3, state=worker_mod._PREPARE_READY, generation=12)
+        harness.wait_state(0, worker_mod._FRAME_STAGED)
+        assert _mailbox_load_i32(harness.accepted_addr(0)) == 0
+        lifecycle_before_c_activation = [
+            event[:2] for event in harness.cw._impl.events if event[0] in {"prepare", "launch", "finalize"}
+        ]
+        assert lifecycle_before_c_activation == [
+            ("prepare", 0),
+            ("launch", 0),
+            ("finalize", 0),
+            ("prepare", 1),
+            ("launch", 1),
+        ]
+
+        harness.cw._impl.completed[1].set()
+        harness.wait_state(1, worker_mod._TASK_DONE)
+        _mailbox_store_i32(harness.state_addr(0), worker_mod._ACTIVATE)
+        harness.wait_state(0, worker_mod._TASK_LAUNCHED)
+        assert _mailbox_load_i32(harness.accepted_addr(0)) == worker_mod._TASK_ACCEPTED
+        harness.cw._impl.completed[0].set()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+
+        lifecycle = [event[:2] for event in harness.cw._impl.events if event[0] in {"prepare", "launch", "finalize"}]
+        assert lifecycle == [
+            ("prepare", 0),
+            ("launch", 0),
+            ("finalize", 0),
+            ("prepare", 1),
+            ("launch", 1),
+            ("finalize", 1),
+            ("prepare", 0),
+            ("launch", 0),
+            ("finalize", 0),
+        ]
+    finally:
+        harness.close()
+
+
+def test_two_frame_launch_failure_does_not_accept_and_finalizes_once():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.cw._impl.launch_errors[(0, 11)] = RuntimeError("launch failed")
+        harness.publish(0, 1)
+        harness.start()
+        harness.wait_state(0, worker_mod._TASK_FAILED)
+
+        assert _mailbox_load_i32(harness.accepted_addr(0)) == 0
+        lifecycle = [event[:2] for event in harness.cw._impl.events if event[0] in {"prepare", "launch", "finalize"}]
+        assert lifecycle == [("prepare", 0), ("finalize", 0)]
+        assert harness.cw._impl.finalized[0].is_set()
+        assert sum(event == ("finalize", 0) for event in harness.cw._impl.events) == 1
+    finally:
+        harness.close()
+
+
+def test_two_frame_launch_cleanup_failure_terminalizes_staged_successor():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.cw._impl.launch_errors[(0, 11)] = RuntimeError("launch failed")
+        harness.cw._impl.finalize_errors[(0, 11)] = RuntimeError("launch cleanup failed")
+        harness.publish(0, 1)
+        harness.publish(1, 2)
+        harness.start()
+
+        harness.wait_state(0, worker_mod._TASK_FAILED)
+        harness.wait_state(1, worker_mod._TASK_FAILED)
+        harness.thread.join(5.0)
+        assert not harness.thread.is_alive()
+        assert not harness.cw._impl.prepared[1].is_set()
+        assert not harness.cw._impl.launched[1].is_set()
+        assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
+    finally:
+        harness.close()
+
+
+@pytest.mark.parametrize("failure_point", ["poll", "finalize"])
+def test_two_frame_native_progress_failure_terminalizes_staged_successor(failure_point):
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.publish(0, 1)
+        harness.start()
+        assert harness.cw._impl.launched[0].wait(5.0)
+        harness.publish(1, 2)
+        harness.wait_state(1, worker_mod._FRAME_STAGED)
+
+        if failure_point == "poll":
+            harness.cw._impl.poll_errors[(0, 11)] = RuntimeError("poll failed")
+        else:
+            harness.cw._impl.finalize_errors[(0, 11)] = RuntimeError("finalize failed")
+            harness.cw._impl.completed[0].set()
+
+        harness.wait_state(0, worker_mod._TASK_FAILED)
+        harness.wait_state(1, worker_mod._TASK_FAILED)
+        harness.thread.join(5.0)
+        assert not harness.thread.is_alive()
+        assert not harness.cw._impl.prepared[1].is_set()
+        assert not harness.cw._impl.launched[1].is_set()
+        assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
+    finally:
+        harness.close()
 
 
 def _chip_digest(callable_obj: ChipCallable, *, platform: str = "", runtime: str = "") -> bytes:
@@ -1613,6 +2220,7 @@ class TestRunHandle:
 
         third_callback = threading.Event()
         third_result: dict[str, RunHandle] = {}
+        submitter: Optional[threading.Thread] = None
         hw = Worker(level=3, num_sub_workers=2)
         try:
 
@@ -1671,6 +2279,8 @@ class TestRunHandle:
         finally:
             _set_flag(state_buf, 4, 1)
             _set_flag(state_buf, 12, 1)
+            if submitter is not None:
+                submitter.join(5.0)
             hw.close()
             state_shm.close()
             state_shm.unlink()


### PR DESCRIPTION
## Summary

- add two generation-safe task frames behind a separate mailbox control frame
- let one bounded progress owner poll active run A while validating and owning
  successor frame B
- defer B native prepare and launch until FIFO promotion and A native
  finalization fence, preserving the one-unfinished-native-run invariant
- keep launch acceptance as a sticky per-frame word and validate protocol,
  run, slot, generation, and dispatch identity before reuse
- terminalize both lanes when native reuse or child quiescence is uncertain;
  registry controls remain coherent with active and staged frame ownership
- retain the single-frame compatibility path for SUB, nested/remote workers,
  simulation, A5, and depth-one local chip endpoints

## Scope boundary

FRAME_STAGED means the child validated and owns an immutable mailbox payload;
it is not HBG/TMR native preparation. Runtime-specific preparation overlap and
resource banking remain follow-up B4/B5 work.

The production two-frame path is enabled only for direct A2/A3 onboard chip
children that advertise pipeline depth >= 2. HBG and TMR share the common
endpoint contract while continuing to serialize their native run lifecycles.

## CI robustness follow-ups

- make endpoint capacity immutable before scheduler startup and fence the
  publication-failure regression on the recorded successor failure, removing
  the macOS test data/timing race
- make HCCL destroy markers atomic and add arrival/departure plus post-teardown
  per-follower release handoff on A2/A3 and A5, preventing a fast rank-0 cleanup
  from stranding a slower peer or splitting sequential rootinfo generations

## Validation

- Python unit suite: 1034 passed, 9 skipped
- C++ unit suite: 74/74 passed after the final rebase
- file-marker generation/cleanup regression: 50/50 repeated passes
- changed-file pre-commit hooks: all passed, including clang-tidy, cpplint,
  markdownlint, Ruff, and pyright
- A2/A3 and A5 host runtimes: HBG and TMR all compile/link successfully
- A2/A3 onboard HBG two-frame scene: standalone 3/3 repeated passes plus
  pytest pass
- A2/A3 onboard final pipeline task task_20260802_040006_317367021979: HBG
  two-frame scene and TMR L3 dependency smoke passed
- A2/A3 onboard final teardown task task_20260802_050029_390675130917:
  communicator lifecycle and two-rank TMR allreduce both passed
