### PR TITLE
Add: run deferred_notify_demo onboard on a2a3

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""L2 deferred completion + two-chip comm smoke test for a2a3sim."""
+"""L2 deferred completion + two-chip comm smoke test for a2a3, onboard and sim."""
 
 from __future__ import annotations
 
@@ -172,7 +172,7 @@ def run(
         worker.close()
 
 
-@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.platforms(["a2a3", "a2a3sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
 def test_deferred_notify_demo(st_device_ids, st_platform) -> None:


### PR DESCRIPTION
## Why this was sim-only, and why that was wrong

#1568 left `deferred_notify_demo` marked `platforms(["a2a3sim"])` because it failed when I temporarily widened it and ran a full onboard sweep.

That sweep carried **no `--ignore` sets**, so it included the SDMA demos that `ci.yml:600` quarantines out of the general sweep — precisely because they are only correct in isolation. By the standard #1580 has since written into the testing skill, that was an invalid baseline. The demo was condemned on evidence that does not stand.

## Re-test against a CI-shaped sweep

Mirroring `ci.yml:607` (`$SDMA_IGNORE $HEAVY_IGNORE`, no `--runtime`, so the real dispatcher runs), onboard a2a3:

| Run | scope | deferred_notify_demo |
| --- | ----- | -------------------- |
| 1 | `examples tests/st` | **PASS** 14.5 s, `devices=[9, 1]` |
| 2 | `examples tests/st` | **PASS** 14.3 s, `devices=[3, 5]` |
| 3 | `examples/a2a3` (ran to completion, exit 0) | **PASS** 13.8 s, `devices=[7, 9]` |

Three independent runs, three different device pairs. Runs 1 and 2 were cut short at 60–70% by the `task-submit` daemon restarting (`exit=137`) — infrastructure, not a test: both showed 55 passed / **0 failed** at the point of interruption. Run 3 used a narrower scope and completed cleanly.

Also still green under `a2a3sim` (`PASS 14.7 s`), and passes standalone at `max_diff=0.000e+00`.

## Why it was always plausible

Nothing in the demo is sim-specific. It uses the same `CommDomain` / `CommBufferSpec` path as `async_notify_demo`, which has always run onboard; a line-by-line diff shows the only real delta is that `deferred` additionally writes a peer mailbox in the comm window.

## Scope

a2a3 only. The a5 copy stays `["a5sim"]` — this box is a2a3 silicon, so widening it there would be an unverified claim. Worth a look by someone with a5 hardware, since the same reasoning likely applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)