### PR TITLE
fix(scheduler): make consumed-head advances contention-safe

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -185,7 +185,9 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
     sync_to_sm()  // release-store last_task_alive
 ```
 
-Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving heap_tail writes within the same ring.
+Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving heap_tail writes within the same ring. A scheduler thread that changes a ring head to `CONSUMED` but fails to acquire that ring's `advance_lock` records a coalesced request in `advance_pending_mask`. Scheduler no-progress iterations retry pending rings under the same lock; a busy lock leaves the bit set, and a successful retry clears the bit before rescanning.
+
+For ring-heap stall triage, a `CONSUMED` head whose ring bit remains set means the deferred request has not yet been cleared by a retry that acquired `advance_lock`. If the bit clears and `last_task_alive` is still pinned, the stall is not caused by this deferred advance path.
 
 ### 5.2 Cross-Ring Dependencies
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -589,7 +589,9 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
     sync_to_sm()  // release-store last_task_alive
 ```
 
-This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time.
+This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time. If a scheduler thread changes a ring head to `CONSUMED` but loses this try-lock, it sets the ring bit in `advance_pending_mask`. Scheduler no-progress iterations drain that mask: each pending ring retries the same in-order `advance_ring_pointers()` under `advance_lock`, leaves the bit set while the lock is still busy, and treats a successful watermark advance as scheduler progress.
+
+For ring-heap stall triage, a `CONSUMED` head whose ring bit is still set means no retry has acquired `advance_lock` and cleared the deferred request yet. If the bit clears and the published `last_task_alive` remains pinned, the stall is outside this deferred consumed-head advance path.
 
 ### 8.5 SchedulerContext
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include <atomic>
-
 #include "common/core_type.h"
 #include "common/memory_barrier.h"
 #include "utils/device_arena.h"
@@ -501,6 +500,8 @@ struct PTO2SchedulerState {
         }
     } ring_sched_states[PTO2_MAX_RING_DEPTH];
 
+    alignas(64) std::atomic<uint32_t> advance_pending_mask;
+
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
@@ -543,6 +544,45 @@ struct PTO2SchedulerState {
         }
     }
 
+    static uint32_t ring_advance_pending_bit(int32_t ring_id) {
+        static_assert(PTO2_MAX_RING_DEPTH <= 32, "advance_pending_mask uses one uint32_t bit per ring");
+        return 1u << static_cast<uint32_t>(ring_id);
+    }
+
+    // A failed consumed-head advance is a deferred reclaim publication request.
+    // The mask keeps one coalesced request per ring. Later successful advances
+    // may cover it before the scheduler no-progress path drains the final
+    // missed edge.
+    void mark_ring_advance_pending(int32_t ring_id) {
+        advance_pending_mask.fetch_or(ring_advance_pending_bit(ring_id), std::memory_order_release);
+    }
+
+    bool drain_pending_ring_advances() {
+        uint32_t pending = advance_pending_mask.load(std::memory_order_acquire);
+        if (pending == 0) return false;
+
+        bool advanced = false;
+        for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+            uint32_t bit = ring_advance_pending_bit(ring_id);
+            if ((pending & bit) == 0) continue;
+
+            auto &ring_sched = ring_sched_states[ring_id];
+            int32_t expected_lock = 0;
+            if (!ring_sched.advance_lock.compare_exchange_strong(
+                    expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+                )) {
+                continue;
+            }
+
+            advance_pending_mask.fetch_and(~bit, std::memory_order_acq_rel);
+            int32_t before = ring_sched.last_task_alive;
+            ring_sched.advance_ring_pointers();
+            advanced = advanced || ring_sched.last_task_alive != before;
+            ring_sched.advance_lock.store(0, std::memory_order_release);
+        }
+        return advanced;
+    }
+
     bool try_claim_ready_once(PTO2TaskSlotState &slot_state) {
         uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
         for (;;) {
@@ -581,16 +621,15 @@ struct PTO2SchedulerState {
 #endif
 
         int32_t ring_id = slot_state.ring_id;
-        // advance_ring_pointers (and the reset_for_reuse it triggers) MUST run
-        // outside fanout_lock: reset_for_reuse stores fanout_lock=0 and would
-        // clobber a held lock. Safe here — the slot is CONSUMED and quiescent.
-        // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
+        // Runs outside fanout_lock: reset_for_reuse stores fanout_lock=0.
         int32_t expected_lock = 0;
         if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
                 expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
             )) {
             ring_sched_states[ring_id].advance_ring_pointers();
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
+        } else {
+            mark_ring_advance_pending(ring_id);
         }
     }
 
@@ -620,9 +659,7 @@ struct PTO2SchedulerState {
 #endif
 
         int32_t ring_id = slot_state.ring_id;
-        // advance_ring_pointers + reset_for_reuse run outside fanout_lock (reset
-        // stores fanout_lock=0). Safe — the slot is CONSUMED and quiescent.
-        // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
+        // Runs outside fanout_lock: reset_for_reuse stores fanout_lock=0.
         int32_t expected_lock = 0;
         if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
                 expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
@@ -631,7 +668,8 @@ struct PTO2SchedulerState {
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
         } else {
-            atomic_count += 1;  // failed try-lock CAS
+            mark_ring_advance_pending(ring_id);
+            atomic_count += 2;  // failed try-lock CAS + pending mark
         }
     }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1383,54 +1383,65 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 );
             }
 #endif
-            idle_iterations++;
-
-            if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
-                LoopAction action = check_idle_fatal_error(thread_idx, header, runtime);
-                if (action == LoopAction::BREAK_LOOP) break;
-            }
-
-            if (idle_iterations % STALL_LOG_INTERVAL == 0) {
-                log_stall_diagnostics(thread_idx, total_tasks_, idle_iterations, last_progress_count);
-            }
-            // Wall-clock budget gate, with two fatal-latch branches:
-            //
-            // 1. Self owns a RUNNING task — first-hand evidence the
-            //    dispatch is stuck. Latch.
-            // 2. No thread anywhere owns a RUNNING task AND tasks remain
-            //    unfinished — the system is in a pre-dispatch / WAIT-only
-            //    deadlock (e.g. dependency cycle). Ownerless idle threads
-            //    are the only observers; let this one latch on the global
-            //    evidence (`completed_tasks_ < total_tasks_` and
-            //    `no_thread_owns_running_task()`).
-            //
-            // Otherwise: a sibling thread owns a RUNNING task but hasn't
-            // hit its own budget yet (typical distributed startup-skew
-            // case) — refresh last_progress_ts and keep spinning. The
-            // STALL diagnostic above still fires periodically so
-            // observability is preserved.
-            if (get_sys_cnt_aicpu() - last_progress_ts > scheduler_timeout_cycles) {
-                bool self_owns = self_owns_running_task(thread_idx);
-                bool global_stuck = !self_owns && total_tasks_ > 0 &&
-                                    completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&
-                                    no_thread_owns_running_task();
-                if (self_owns || global_stuck) {
-                    // Latch the error + emergency_shutdown, then break to the
-                    // shared end-of-loop cleanup so the diagnostic buffers get
-                    // flushed to the host. An early return here would strand the
-                    // stuck task's already-dumped inputs and every completed
-                    // task's in/out records in the unflushed per-thread dump
-                    // buffer — exactly the state we need to triage the hang.
-                    timeout_rc = handle_timeout_exit(
-                        thread_idx, header, runtime, idle_iterations, last_progress_count
-#if SIMPLER_DFX
-                        ,
-                        l2_swimlane.sched_start_ts
-#endif
-                    );
-                    break;
-                }
+            // Deferred consumed-head advances retry from the no-progress path.
+            // During a ring-heap stall, a CONSUMED head with its pending bit
+            // still set means no retry has acquired advance_lock and cleared
+            // the request yet. If the bit clears and the watermark remains
+            // pinned, the stall is outside this deferred-advance path.
+            bool advanced_reclaim = sched_->drain_pending_ring_advances();
+            if (advanced_reclaim) {
+                idle_iterations = 0;
                 last_progress_ts = get_sys_cnt_aicpu();
+            } else {
+                idle_iterations++;
+
+                if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
+                    LoopAction action = check_idle_fatal_error(thread_idx, header, runtime);
+                    if (action == LoopAction::BREAK_LOOP) break;
+                }
+
+                if (idle_iterations % STALL_LOG_INTERVAL == 0) {
+                    log_stall_diagnostics(thread_idx, total_tasks_, idle_iterations, last_progress_count);
+                }
+                // Wall-clock budget gate, with two fatal-latch branches:
+                //
+                // 1. Self owns a RUNNING task — first-hand evidence the
+                //    dispatch is stuck. Latch.
+                // 2. No thread anywhere owns a RUNNING task AND tasks remain
+                //    unfinished — the system is in a pre-dispatch / WAIT-only
+                //    deadlock (e.g. dependency cycle). Ownerless idle threads
+                //    are the only observers; let this one latch on the global
+                //    evidence (`completed_tasks_ < total_tasks_` and
+                //    `no_thread_owns_running_task()`).
+                //
+                // Otherwise: a sibling thread owns a RUNNING task but hasn't
+                // hit its own budget yet (typical distributed startup-skew
+                // case) — refresh last_progress_ts and keep spinning. The
+                // STALL diagnostic above still fires periodically so
+                // observability is preserved.
+                if (get_sys_cnt_aicpu() - last_progress_ts > scheduler_timeout_cycles) {
+                    bool self_owns = self_owns_running_task(thread_idx);
+                    bool global_stuck = !self_owns && total_tasks_ > 0 &&
+                                        completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&
+                                        no_thread_owns_running_task();
+                    if (self_owns || global_stuck) {
+                        // Latch the error + emergency_shutdown, then break to the
+                        // shared end-of-loop cleanup so the diagnostic buffers get
+                        // flushed to the host. An early return here would strand the
+                        // stuck task's already-dumped inputs and every completed
+                        // task's in/out records in the unflushed per-thread dump
+                        // buffer — exactly the state we need to triage the hang.
+                        timeout_rc = handle_timeout_exit(
+                            thread_idx, header, runtime, idle_iterations, last_progress_count
+#if SIMPLER_DFX
+                            ,
+                            l2_swimlane.sched_start_ts
+#endif
+                        );
+                        break;
+                    }
+                    last_progress_ts = get_sys_cnt_aicpu();
+                }
             }
             SPIN_WAIT_HINT();
 #if SIMPLER_DFX

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -174,6 +174,7 @@ bool PTO2SchedulerState::init_data_from_layout(
 ) {
     PTO2SchedulerState *sched = this;
     sched->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
+    sched->advance_pending_mask.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
@@ -232,6 +233,7 @@ bool PTO2SchedulerState::init_data_from_layout(
 void PTO2SchedulerState::reset_for_reuse(const PTO2SchedulerLayout &layout, void *sm_dev_base) {
     PTO2SchedulerState *sched = this;
     sched->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
+    sched->advance_pending_mask.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -185,7 +185,9 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
     sync_to_sm()  // release-store last_task_alive
 ```
 
-Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving heap_tail writes within the same ring.
+Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving heap_tail writes within the same ring. A scheduler thread that changes a ring head to `CONSUMED` but fails to acquire that ring's `advance_lock` records a coalesced request in `advance_pending_mask`. Scheduler no-progress iterations retry pending rings under the same lock; a busy lock leaves the bit set, and a successful retry clears the bit before rescanning.
+
+For ring-heap stall triage, a `CONSUMED` head whose ring bit remains set means the deferred request has not yet been cleared by a retry that acquired `advance_lock`. If the bit clears and `last_task_alive` is still pinned, the stall is not caused by this deferred advance path.
 
 ### 5.2 Cross-Ring Dependencies
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -587,7 +587,9 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
     sync_to_sm()  // release-store last_task_alive
 ```
 
-This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time.
+This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time. If a scheduler thread changes a ring head to `CONSUMED` but loses this try-lock, it sets the ring bit in `advance_pending_mask`. Scheduler no-progress iterations drain that mask: each pending ring retries the same in-order `advance_ring_pointers()` under `advance_lock`, leaves the bit set while the lock is still busy, and treats a successful watermark advance as scheduler progress.
+
+For ring-heap stall triage, a `CONSUMED` head whose ring bit is still set means no retry has acquired `advance_lock` and cleared the deferred request yet. If the bit clears and the published `last_task_alive` remains pinned, the stall is outside this deferred consumed-head advance path.
 
 ### 8.5 SchedulerContext
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include <atomic>
-
 #include "common/core_type.h"
 #include "utils/device_arena.h"
 #include "pto_async_wait.h"
@@ -501,6 +500,8 @@ struct PTO2SchedulerState {
         }
     } ring_sched_states[PTO2_MAX_RING_DEPTH];
 
+    alignas(64) std::atomic<uint32_t> advance_pending_mask;
+
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
@@ -532,6 +533,45 @@ struct PTO2SchedulerState {
         }
     }
 
+    static uint32_t ring_advance_pending_bit(int32_t ring_id) {
+        static_assert(PTO2_MAX_RING_DEPTH <= 32, "advance_pending_mask uses one uint32_t bit per ring");
+        return 1u << static_cast<uint32_t>(ring_id);
+    }
+
+    // A failed consumed-head advance is a deferred reclaim publication request.
+    // The mask keeps one coalesced request per ring. Later successful advances
+    // may cover it before the scheduler no-progress path drains the final
+    // missed edge.
+    void mark_ring_advance_pending(int32_t ring_id) {
+        advance_pending_mask.fetch_or(ring_advance_pending_bit(ring_id), std::memory_order_release);
+    }
+
+    bool drain_pending_ring_advances() {
+        uint32_t pending = advance_pending_mask.load(std::memory_order_acquire);
+        if (pending == 0) return false;
+
+        bool advanced = false;
+        for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+            uint32_t bit = ring_advance_pending_bit(ring_id);
+            if ((pending & bit) == 0) continue;
+
+            auto &ring_sched = ring_sched_states[ring_id];
+            int32_t expected_lock = 0;
+            if (!ring_sched.advance_lock.compare_exchange_strong(
+                    expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+                )) {
+                continue;
+            }
+
+            advance_pending_mask.fetch_and(~bit, std::memory_order_acq_rel);
+            int32_t before = ring_sched.last_task_alive;
+            ring_sched.advance_ring_pointers();
+            advanced = advanced || ring_sched.last_task_alive != before;
+            ring_sched.advance_lock.store(0, std::memory_order_release);
+        }
+        return advanced;
+    }
+
     void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
         // Read fanout_refcount/fanout_count and flip COMPLETED->CONSUMED under
         // fanout_lock. The orchestrator claims producers (fanout_count++) under the
@@ -557,16 +597,15 @@ struct PTO2SchedulerState {
 #endif
 
         int32_t ring_id = slot_state.ring_id;
-        // advance_ring_pointers (and the reset_for_reuse it triggers) MUST run
-        // outside fanout_lock: reset_for_reuse stores fanout_lock=0 and would
-        // clobber a held lock. Safe here — the slot is CONSUMED and quiescent.
-        // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
+        // Runs outside fanout_lock: reset_for_reuse stores fanout_lock=0.
         int32_t expected_lock = 0;
         if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
                 expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
             )) {
             ring_sched_states[ring_id].advance_ring_pointers();
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
+        } else {
+            mark_ring_advance_pending(ring_id);
         }
     }
 
@@ -596,9 +635,7 @@ struct PTO2SchedulerState {
 #endif
 
         int32_t ring_id = slot_state.ring_id;
-        // advance_ring_pointers + reset_for_reuse run outside fanout_lock (reset
-        // stores fanout_lock=0). Safe — the slot is CONSUMED and quiescent.
-        // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
+        // Runs outside fanout_lock: reset_for_reuse stores fanout_lock=0.
         int32_t expected_lock = 0;
         if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
                 expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
@@ -607,7 +644,8 @@ struct PTO2SchedulerState {
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
         } else {
-            atomic_count += 1;  // failed try-lock CAS
+            mark_ring_advance_pending(ring_id);
+            atomic_count += 2;  // failed try-lock CAS + pending mark
         }
     }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1127,54 +1127,65 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
             }
-            idle_iterations++;
-
-            if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
-                LoopAction action = check_idle_fatal_error(thread_idx, header, runtime);
-                if (action == LoopAction::BREAK_LOOP) break;
-            }
-
-            if (idle_iterations % STALL_LOG_INTERVAL == 0) {
-                log_stall_diagnostics(thread_idx, total_tasks_, idle_iterations, last_progress_count);
-            }
-            // Wall-clock budget gate, with two fatal-latch branches:
-            //
-            // 1. Self owns a RUNNING task — first-hand evidence the
-            //    dispatch is stuck. Latch.
-            // 2. No thread anywhere owns a RUNNING task AND tasks remain
-            //    unfinished — the system is in a pre-dispatch / WAIT-only
-            //    deadlock (e.g. dependency cycle). Ownerless idle threads
-            //    are the only observers; let this one latch on the global
-            //    evidence (`completed_tasks_ < total_tasks_` and
-            //    `no_thread_owns_running_task()`).
-            //
-            // Otherwise: a sibling thread owns a RUNNING task but hasn't
-            // hit its own budget yet (typical distributed startup-skew
-            // case) — refresh last_progress_ts and keep spinning. The
-            // STALL diagnostic above still fires periodically so
-            // observability is preserved.
-            if (get_sys_cnt_aicpu() - last_progress_ts > scheduler_timeout_cycles) {
-                bool self_owns = self_owns_running_task(thread_idx);
-                bool global_stuck = !self_owns && total_tasks_ > 0 &&
-                                    completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&
-                                    no_thread_owns_running_task();
-                if (self_owns || global_stuck) {
-                    // Latch the error + emergency_shutdown, then break to the
-                    // shared end-of-loop cleanup so the diagnostic buffers get
-                    // flushed to the host. An early return here would strand the
-                    // stuck task's already-dumped inputs and every completed
-                    // task's in/out records in the unflushed per-thread dump
-                    // buffer — exactly the state we need to triage the hang.
-                    timeout_rc = handle_timeout_exit(
-                        thread_idx, header, runtime, idle_iterations, last_progress_count
-#if SIMPLER_DFX
-                        ,
-                        l2_swimlane.sched_start_ts
-#endif
-                    );
-                    break;
-                }
+            // Deferred consumed-head advances retry from the no-progress path.
+            // During a ring-heap stall, a CONSUMED head with its pending bit
+            // still set means no retry has acquired advance_lock and cleared
+            // the request yet. If the bit clears and the watermark remains
+            // pinned, the stall is outside this deferred-advance path.
+            bool advanced_reclaim = sched_->drain_pending_ring_advances();
+            if (advanced_reclaim) {
+                idle_iterations = 0;
                 last_progress_ts = get_sys_cnt_aicpu();
+            } else {
+                idle_iterations++;
+
+                if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
+                    LoopAction action = check_idle_fatal_error(thread_idx, header, runtime);
+                    if (action == LoopAction::BREAK_LOOP) break;
+                }
+
+                if (idle_iterations % STALL_LOG_INTERVAL == 0) {
+                    log_stall_diagnostics(thread_idx, total_tasks_, idle_iterations, last_progress_count);
+                }
+                // Wall-clock budget gate, with two fatal-latch branches:
+                //
+                // 1. Self owns a RUNNING task — first-hand evidence the
+                //    dispatch is stuck. Latch.
+                // 2. No thread anywhere owns a RUNNING task AND tasks remain
+                //    unfinished — the system is in a pre-dispatch / WAIT-only
+                //    deadlock (e.g. dependency cycle). Ownerless idle threads
+                //    are the only observers; let this one latch on the global
+                //    evidence (`completed_tasks_ < total_tasks_` and
+                //    `no_thread_owns_running_task()`).
+                //
+                // Otherwise: a sibling thread owns a RUNNING task but hasn't
+                // hit its own budget yet (typical distributed startup-skew
+                // case) — refresh last_progress_ts and keep spinning. The
+                // STALL diagnostic above still fires periodically so
+                // observability is preserved.
+                if (get_sys_cnt_aicpu() - last_progress_ts > scheduler_timeout_cycles) {
+                    bool self_owns = self_owns_running_task(thread_idx);
+                    bool global_stuck = !self_owns && total_tasks_ > 0 &&
+                                        completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&
+                                        no_thread_owns_running_task();
+                    if (self_owns || global_stuck) {
+                        // Latch the error + emergency_shutdown, then break to the
+                        // shared end-of-loop cleanup so the diagnostic buffers get
+                        // flushed to the host. An early return here would strand the
+                        // stuck task's already-dumped inputs and every completed
+                        // task's in/out records in the unflushed per-thread dump
+                        // buffer — exactly the state we need to triage the hang.
+                        timeout_rc = handle_timeout_exit(
+                            thread_idx, header, runtime, idle_iterations, last_progress_count
+#if SIMPLER_DFX
+                            ,
+                            l2_swimlane.sched_start_ts
+#endif
+                        );
+                        break;
+                    }
+                    last_progress_ts = get_sys_cnt_aicpu();
+                }
             }
             SPIN_WAIT_HINT();
 #if SIMPLER_DFX

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -157,6 +157,7 @@ bool PTO2SchedulerState::init_data_from_layout(
 ) {
     PTO2SchedulerState *sched = this;
     sched->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
+    sched->advance_pending_mask.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
@@ -208,6 +209,7 @@ bool PTO2SchedulerState::init_data_from_layout(
 void PTO2SchedulerState::reset_for_reuse(const PTO2SchedulerLayout &layout, void *sm_dev_base) {
     PTO2SchedulerState *sched = this;
     sched->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
+    sched->advance_pending_mask.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <thread>
 
 #include "utils/device_arena.h"
 #include "scheduler/scheduler_types.h"
@@ -99,6 +100,61 @@ protected:
         memset(&slot_pl, 0, sizeof(slot_pl));
         slot.payload = &slot_pl;
     }
+
+    void init_ring_slot(
+        PTO2SharedMemoryRingHeader &ring, int32_t task_id, PTO2TaskState state, uint8_t ring_id,
+        uint32_t fanout_count = 1, uint32_t fanout_refcount = 1
+    ) {
+        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(task_id);
+        PTO2TaskPayload &payload = ring.get_payload_by_task_id(task_id);
+        PTO2TaskDescriptor &task = ring.get_task_by_task_id(task_id);
+        memset(&slot, 0, sizeof(slot));
+        memset(&payload, 0, sizeof(payload));
+        memset(&task, 0, sizeof(task));
+        slot.task_state.store(state, std::memory_order_relaxed);
+        slot.fanin_count = 0;
+        slot.fanin_refcount.store(0, std::memory_order_relaxed);
+        slot.fanout_count = fanout_count;
+        slot.fanout_refcount.store(fanout_refcount, std::memory_order_relaxed);
+        slot.fanout_lock.store(0, std::memory_order_relaxed);
+        slot.fanout_head = nullptr;
+        slot.ring_id = ring_id;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
+        slot.completed_subtasks.store(0, std::memory_order_relaxed);
+        slot.total_required_subtasks = 1;
+        slot.logical_block_num = 1;
+        slot.lifecycle_flags.store(PTO2_COMPLETION_DONE, std::memory_order_relaxed);
+        slot.payload = &payload;
+        slot.task = &task;
+    }
+
+    void setup_ring_for_reclaim_race(int32_t ring_id, int32_t current_task_index, int32_t blocked_task_id) {
+        PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+        PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+
+        ring.fc.current_task_index.store(current_task_index, std::memory_order_release);
+        ring.fc.last_task_alive.store(0, std::memory_order_release);
+        ring_sched.last_task_alive = 0;
+        ring_sched.advance_lock.store(0, std::memory_order_release);
+        sched.advance_pending_mask.store(0, std::memory_order_release);
+
+        for (int32_t task_id = 0; task_id < current_task_index; task_id++) {
+            PTO2TaskState state = task_id < blocked_task_id ? PTO2_TASK_CONSUMED : PTO2_TASK_COMPLETED;
+            init_ring_slot(ring, task_id, state, static_cast<uint8_t>(ring_id));
+        }
+    }
+
+    void setup_contended_head_case(int32_t ring_id, int32_t head_task_id) {
+        PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+        PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+        ring.fc.current_task_index.store(head_task_id + 2, std::memory_order_release);
+        ring.fc.last_task_alive.store(head_task_id, std::memory_order_release);
+        ring_sched.last_task_alive = head_task_id;
+        ring_sched.advance_lock.store(0, std::memory_order_release);
+        sched.advance_pending_mask.store(0, std::memory_order_release);
+        init_ring_slot(ring, head_task_id, PTO2_TASK_COMPLETED, static_cast<uint8_t>(ring_id));
+        init_ring_slot(ring, head_task_id + 1, PTO2_TASK_COMPLETED, static_cast<uint8_t>(ring_id), 1, 0);
+    }
 };
 
 // =============================================================================
@@ -123,6 +179,33 @@ TEST_F(SchedulerStateTest, ConsumedTransition) {
     EXPECT_EQ(slot.task_state.load(), PTO2_TASK_CONSUMED);
 }
 
+TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
+    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t head_task_id = 0;
+    setup_ring_for_reclaim_race(ring_id, /*current_task_index=*/1, head_task_id);
+
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+    PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+
+    ring_sched.advance_lock.store(1, std::memory_order_release);
+    std::thread unlocker([&]() {
+        while ((sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit) == 0) {
+            std::this_thread::yield();
+        }
+        ring_sched.advance_lock.store(0, std::memory_order_release);
+    });
+
+    sched.check_and_handle_consumed(head);
+    unlocker.join();
+
+    EXPECT_TRUE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(head.task_state.load(std::memory_order_acquire), PTO2_TASK_CONSUMED);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), 1)
+        << "a CONSUMED ring head must not remain pinned after advance_lock contention clears";
+}
+
 TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
     alignas(64) PTO2TaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
@@ -140,6 +223,57 @@ TEST_F(SchedulerStateTest, ConsumedIdempotent) {
 
     sched.check_and_handle_consumed(slot);
     EXPECT_EQ(slot.task_state.load(), PTO2_TASK_CONSUMED);
+}
+
+TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances) {
+    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t head_task_id = 17;
+    setup_contended_head_case(ring_id, head_task_id);
+
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+    PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+
+    ring_sched.advance_lock.store(1, std::memory_order_release);
+    sched.check_and_handle_consumed(head);
+
+    EXPECT_EQ(head.task_state.load(std::memory_order_acquire), PTO2_TASK_CONSUMED);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id);
+    EXPECT_NE(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+
+    EXPECT_FALSE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id);
+    EXPECT_NE(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+
+    ring_sched.advance_lock.store(0, std::memory_order_release);
+    EXPECT_TRUE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(ring_sched.last_task_alive, head_task_id + 1);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id + 1);
+    EXPECT_EQ(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+}
+
+TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
+    const int32_t head_task_ids[] = {0, 1, 127, PTO2_TASK_WINDOW_SIZE - 2, PTO2_TASK_WINDOW_SIZE + 3};
+
+    for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+        for (int32_t head_task_id : head_task_ids) {
+            SCOPED_TRACE(::testing::Message() << "ring_id=" << ring_id << " head_task_id=" << head_task_id);
+            setup_contended_head_case(ring_id, head_task_id);
+
+            PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+            PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+            PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+
+            ring_sched.advance_lock.store(1, std::memory_order_release);
+            sched.check_and_handle_consumed(head);
+            ring_sched.advance_lock.store(0, std::memory_order_release);
+
+            EXPECT_TRUE(sched.drain_pending_ring_advances());
+            EXPECT_EQ(ring_sched.last_task_alive, head_task_id + 1);
+            EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id + 1);
+        }
+    }
 }
 
 // =============================================================================

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <thread>
 
 #include "utils/device_arena.h"
 #include "scheduler/scheduler_types.h"
@@ -99,6 +100,61 @@ protected:
         memset(&slot_pl, 0, sizeof(slot_pl));
         slot.payload = &slot_pl;
     }
+
+    void init_ring_slot(
+        PTO2SharedMemoryRingHeader &ring, int32_t task_id, PTO2TaskState state, uint8_t ring_id,
+        uint32_t fanout_count = 1, uint32_t fanout_refcount = 1
+    ) {
+        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(task_id);
+        PTO2TaskPayload &payload = ring.get_payload_by_task_id(task_id);
+        PTO2TaskDescriptor &task = ring.get_task_by_task_id(task_id);
+        memset(&slot, 0, sizeof(slot));
+        memset(&payload, 0, sizeof(payload));
+        memset(&task, 0, sizeof(task));
+        slot.task_state.store(state, std::memory_order_relaxed);
+        slot.fanin_count = 0;
+        slot.fanin_refcount.store(0, std::memory_order_relaxed);
+        slot.fanout_count = fanout_count;
+        slot.fanout_refcount.store(fanout_refcount, std::memory_order_relaxed);
+        slot.fanout_lock.store(0, std::memory_order_relaxed);
+        slot.fanout_head = nullptr;
+        slot.ring_id = ring_id;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
+        slot.completed_subtasks.store(0, std::memory_order_relaxed);
+        slot.total_required_subtasks = 1;
+        slot.logical_block_num = 1;
+        slot.lifecycle_flags.store(PTO2_COMPLETION_DONE, std::memory_order_relaxed);
+        slot.payload = &payload;
+        slot.task = &task;
+    }
+
+    void setup_ring_for_reclaim_race(int32_t ring_id, int32_t current_task_index, int32_t blocked_task_id) {
+        PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+        PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+
+        ring.fc.current_task_index.store(current_task_index, std::memory_order_release);
+        ring.fc.last_task_alive.store(0, std::memory_order_release);
+        ring_sched.last_task_alive = 0;
+        ring_sched.advance_lock.store(0, std::memory_order_release);
+        sched.advance_pending_mask.store(0, std::memory_order_release);
+
+        for (int32_t task_id = 0; task_id < current_task_index; task_id++) {
+            PTO2TaskState state = task_id < blocked_task_id ? PTO2_TASK_CONSUMED : PTO2_TASK_COMPLETED;
+            init_ring_slot(ring, task_id, state, static_cast<uint8_t>(ring_id));
+        }
+    }
+
+    void setup_contended_head_case(int32_t ring_id, int32_t head_task_id) {
+        PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+        PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+        ring.fc.current_task_index.store(head_task_id + 2, std::memory_order_release);
+        ring.fc.last_task_alive.store(head_task_id, std::memory_order_release);
+        ring_sched.last_task_alive = head_task_id;
+        ring_sched.advance_lock.store(0, std::memory_order_release);
+        sched.advance_pending_mask.store(0, std::memory_order_release);
+        init_ring_slot(ring, head_task_id, PTO2_TASK_COMPLETED, static_cast<uint8_t>(ring_id));
+        init_ring_slot(ring, head_task_id + 1, PTO2_TASK_COMPLETED, static_cast<uint8_t>(ring_id), 1, 0);
+    }
 };
 
 // =============================================================================
@@ -123,6 +179,33 @@ TEST_F(SchedulerStateTest, ConsumedTransition) {
     EXPECT_EQ(slot.task_state.load(), PTO2_TASK_CONSUMED);
 }
 
+TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
+    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t head_task_id = 0;
+    setup_ring_for_reclaim_race(ring_id, /*current_task_index=*/1, head_task_id);
+
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+    PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+
+    ring_sched.advance_lock.store(1, std::memory_order_release);
+    std::thread unlocker([&]() {
+        while ((sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit) == 0) {
+            std::this_thread::yield();
+        }
+        ring_sched.advance_lock.store(0, std::memory_order_release);
+    });
+
+    sched.check_and_handle_consumed(head);
+    unlocker.join();
+
+    EXPECT_TRUE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(head.task_state.load(std::memory_order_acquire), PTO2_TASK_CONSUMED);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), 1)
+        << "a CONSUMED ring head must not remain pinned after advance_lock contention clears";
+}
+
 TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
     alignas(64) PTO2TaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
@@ -140,6 +223,57 @@ TEST_F(SchedulerStateTest, ConsumedIdempotent) {
 
     sched.check_and_handle_consumed(slot);
     EXPECT_EQ(slot.task_state.load(), PTO2_TASK_CONSUMED);
+}
+
+TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances) {
+    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t head_task_id = 17;
+    setup_contended_head_case(ring_id, head_task_id);
+
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+    PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+
+    ring_sched.advance_lock.store(1, std::memory_order_release);
+    sched.check_and_handle_consumed(head);
+
+    EXPECT_EQ(head.task_state.load(std::memory_order_acquire), PTO2_TASK_CONSUMED);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id);
+    EXPECT_NE(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+
+    EXPECT_FALSE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id);
+    EXPECT_NE(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+
+    ring_sched.advance_lock.store(0, std::memory_order_release);
+    EXPECT_TRUE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(ring_sched.last_task_alive, head_task_id + 1);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id + 1);
+    EXPECT_EQ(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+}
+
+TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
+    const int32_t head_task_ids[] = {0, 1, 127, PTO2_TASK_WINDOW_SIZE - 2, PTO2_TASK_WINDOW_SIZE + 3};
+
+    for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+        for (int32_t head_task_id : head_task_ids) {
+            SCOPED_TRACE(::testing::Message() << "ring_id=" << ring_id << " head_task_id=" << head_task_id);
+            setup_contended_head_case(ring_id, head_task_id);
+
+            PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+            PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+            PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+
+            ring_sched.advance_lock.store(1, std::memory_order_release);
+            sched.check_and_handle_consumed(head);
+            ring_sched.advance_lock.store(0, std::memory_order_release);
+
+            EXPECT_TRUE(sched.drain_pending_ring_advances());
+            EXPECT_EQ(ring_sched.last_task_alive, head_task_id + 1);
+            EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id + 1);
+        }
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION

## Summary

Fixes [#1545](https://github.com/hw-native-sys/simpler/issues/1545).

A `COMPLETED -> CONSUMED` transition at a ring head can currently lose the
corresponding reclaim-publication edge when `RingSchedState::advance_lock` is
contended. The old path flips the task to `CONSUMED`, tries to advance the ring
watermark, and returns immediately if another scheduler thread owns the
advance lock.

That is safe only if the lock owner scans the head after the `CONSUMED` store.
If the owner already scanned the same head while it was still `COMPLETED`, the
try-lock loser may be the only thread that observed the new reclaimable head.
If no later successful consume happens on the same ring, `ring.fc.last_task_alive`
can remain pinned at a task that is already semantically reclaimable, causing
artificial task-window or heap backpressure.

## Fix

- Add a scheduler-local `advance_pending_mask`, with one coalesced pending bit
  per ring.
- When `check_and_handle_consumed()` successfully transitions a task to
  `CONSUMED` but loses the immediate `advance_lock` try-lock, mark that ring as
  having a deferred reclaim-publication request.
- Add `drain_pending_ring_advances()` to retry pending rings from the scheduler
  no-progress path:
  - if a ring's `advance_lock` is still busy, leave its pending bit set;
  - after acquiring the lock, clear the bit and run the existing in-order
    `advance_ring_pointers()`;
  - report whether the published watermark advanced.
- Treat a successful pending drain as scheduler progress so idle/stall accounting
  is reset for that iteration.
- Initialize and reset the pending mask with the scheduler state.
- Apply the same protocol to A2/A3 and A5 `tensormap_and_ringbuffer`.

This keeps reclaim semantics unchanged: the scheduler still only advances over
contiguous `PTO2_TASK_CONSUMED` slots, does not skip live tasks, and does not
introduce out-of-order heap freeing. The retry is scheduler-local; the
orchestrator remains a reader of the published `last_task_alive` watermark and
does not participate in scheduler synchronization.

The retry is intentionally deferred to the scheduler no-progress path instead
of forcing the try-lock loser or lock owner to rescan immediately on every
contention event. Immediate contention-time handoff/rescan is stronger, but it
adds work on the hot path when many heads are consumed concurrently. The pending
mask coalesces those missed edges and only pays the retry cost when the
scheduler has no normal forward progress to make. This still closes the
deadlock mode from #1545: if a stale `last_task_alive` creates task-window or
heap backpressure and prevents new work from being allocated/submitted, the
scheduler reaches its no-progress path and drains the pending advance before
treating the iteration as idle/stalled.

## Out of scope

This PR targets the running scheduler backpressure/deadlock path described in
#1545. It does not try to provide the stronger guarantee that every final
`CONSUMED` transition is republished after the scheduler loop has already exited
or after final deferred releases run during shutdown.

That shutdown/final-drain guarantee is separable from the live heap-stall fix.
If a future workload or shutdown diagnostic needs the final watermark to be
fully republished after all deferred releases, it can be handled in a follow-up
PR by adding an explicit shutdown/final pending-drain step. Until there is such
a requirement, this PR keeps that extra shutdown protocol out of scope to avoid
expanding the fix beyond the observed deadlock.

## Regression coverage

The final tree does not add runtime hooks, environment-variable gates,
production-only-for-test error codes, profiling counters, or AICPU hot-path
logs.

The new hook-free C++ unit tests force the missed-edge interleaving directly in
the scheduler state for both A2/A3 and A5:

- `SchedulerStateTest.ConsumedHeadAdvancesAfterContendedAdvanceLock`
- `SchedulerStateTest.ContendedConsumedHeadSetsPendingAndIdleDrainAdvances`
- `SchedulerStateTest.ContendedConsumedHeadIdleDrainStress`

These tests cover:

- a consumed head created while `advance_lock` is held;
- the pending bit remaining set while the ring lock is still contended;
- the idle/no-progress drain publishing the stale consumed head after
  contention clears;
- multiple rings and wrapped task ids.

## Validation

Draft branch head: `f78ab7302747e06eef4919658a04624d0df63e25`, based on
upstream `cb32999c21ed51d5182f4502d0b68716b3329294`.

- `git diff --check cb32999c21ed51d5182f4502d0b68716b3329294...f78ab7302747e06eef4919658a04624d0df63e25` passed.
- Modified-file header, formatting, cpplint, and markdownlint checks passed.
- `cmake --build tests/ut/cpp/build --target test_scheduler_state test_a5_scheduler_state` passed.
- `tests/ut/cpp/build/test_scheduler_state` passed: 24 tests.
- `tests/ut/cpp/build/test_a5_scheduler_state` passed: 24 tests.

## Performance

Rechecked against the benchmark merge-base with
`multi_round_paged_attention::Case1`, using 500 rounds in each AB/BA order on
the same accelerator device.

```text
merge-base: cb32999c21ed51d5182f4502d0b68716b3329294
fixed:      f78ab7302747e06eef4919658a04624d0df63e25
case:       multi_round_paged_attention::Case1
command:    --platform a2a3 --rounds 500 --skip-golden --case Case1
```

| Run | Branch | Host us | Device us | Effective us | Orch us | Sched us |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Pair 1 | baseline | 1218.3 | 58.8 | 37.0 | 14.6 | 31.9 |
| Pair 1 | fixed | 1302.0 | 58.5 | 36.5 | 14.3 | 31.4 |
| Pair 2 | fixed | 1243.8 | 59.0 | 36.5 | 14.4 | 32.2 |
| Pair 2 | baseline | 1482.1 | 58.3 | 36.7 | 14.5 | 31.7 |

Fixed vs baseline deltas:

- Pair 1, baseline first: `sched -1.567%`, `effective -1.351%`, `device -0.510%`
- Pair 2, fixed first: `sched +1.577%`, `effective -0.545%`, `device +1.201%`
- Combined 1000 rounds per side: `sched +0.000%`, `effective -0.950%`, `device +0.342%`

The combined result shows no measurable scheduler regression. Effective
orch+sched time was slightly lower, and the `+0.342%` device-wall delta is
within run-to-run noise.
