### PR TITLE
Add TMR prepared-state pipeline with compatibility fallback

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -80,6 +80,8 @@ extern "C" const PipelineContract *get_pipeline_contract(void) {
     return &contract;
 }
 
+extern "C" int concurrent_native_prepare_supported_impl(void) { return 1; }
+
 static_assert(
     RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match PTO2 runtime ring depth"
 );
@@ -497,6 +499,33 @@ static PrebuiltRuntimeArenaCacheProbe make_prebuilt_runtime_arena_cache_probe(co
     }
     probe.hash = hash;
     return probe;
+}
+
+static bool resolve_arena_sizing(
+    const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool, ArenaSizingConfig *out
+);
+
+extern "C" int prepared_run_config_compatible_impl(
+    const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+) {
+    if (api == nullptr) return -1;
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) return -1;
+
+    PrebuiltRuntimeArenaCacheProbe probe = make_prebuilt_runtime_arena_cache_probe(sizing);
+    void *gm_heap = nullptr;
+    void *gm_sm = nullptr;
+    void *runtime_arena = nullptr;
+    size_t runtime_offset = 0;
+    const void *image = nullptr;
+    size_t image_size = 0;
+    return api->lookup_prebuilt_runtime_arena_cache(
+               probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), &gm_heap, &gm_sm, &runtime_arena,
+               &runtime_offset, &image, &image_size
+           ) ?
+               1 :
+               0;
 }
 
 // per-(cid,config): resolve the cache-key sizing knobs. Pure host parsing over

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -65,6 +65,12 @@ extern "C" {
 int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out);
 int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
 __attribute__((weak)) int concurrent_native_prepare_supported_impl(void) { return 0; }
+__attribute__((weak)) int prepared_run_config_compatible_impl(
+    const HostApi * /*api*/, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    const uint64_t * /*ring_dep_pool*/
+) {
+    return 1;
+}
 
 /* ===========================================================================
  * Context-bound HostApi functions passed to runtime implementations.
@@ -713,6 +719,21 @@ int simpler_prepare_run(
 
         int rc = runner->attach_current_thread(runner->device_id());
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
+
+        if (overlaps_active_run) {
+            int compatibility_rc = 0;
+            {
+                STRACE("simpler_run.bind.compatibility");
+                compatibility_rc = prepared_run_config_compatible_impl(
+                    &state->host_api, config->runtime_env.ring_task_window, config->runtime_env.ring_heap,
+                    config->runtime_env.ring_dep_pool
+                );
+            }
+            if (compatibility_rc <= 0) {
+                if (compatibility_rc == 0) compatibility_rc = PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+                return cleanup_failed_prepare(state, compatibility_rc, true);
+            }
+        }
 
         state->runner_resources_owned = true;
         rc = runner->provision_native_run_resources(state->descriptor.pipeline_slot);

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1658,8 +1658,7 @@ bool DeviceRunnerBase::try_reserve_native_run(
     const NativeRunReservation *existing = nullptr;
     for (const NativeRunReservation &reservation : native_run_reservations_) {
         if (reservation.owner == nullptr) continue;
-        if (reservation.owner == owner || reservation.pipeline_slot == pipeline_slot ||
-            reservation.arena_bank == arena_bank) {
+        if (reservation.owner == owner || reservation.pipeline_slot == pipeline_slot) {
             return false;
         }
         ++occupied;

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -108,7 +108,9 @@ public:
     /**
      * Reserve caller-owned native-run storage before binding starts. A
      * concurrent reservation is admitted only while the first reservation
-     * owns the execution claim and selects distinct per-run resources.
+     * owns the execution claim and selects a distinct pipeline slot. A backend
+     * that shares an arena bank must reject or defer incompatible preparation
+     * before mutating that bank.
      */
     bool try_reserve_native_run(
         const void *owner, uint32_t pipeline_slot, uint32_t arena_bank, bool allow_prepared_successor

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -39,6 +39,7 @@ struct ChipRunState {
     bool pipeline_leased{true};
     bool activated{false};
     bool crossed_launch_fence{false};
+    bool depth_one_fallback{false};
     std::exception_ptr error;
 };
 
@@ -137,10 +138,13 @@ struct ChipRunLaneState {
 
     void prepare_successor_if_eligible(const std::shared_ptr<ChipRunState> &run) {
         if (fifo.size() != 2 || fifo.back() != run || fifo.front() == run) return;
-        if (run->phase != ChipRunState::Phase::QUEUED) return;
+        if (run->phase != ChipRunState::Phase::QUEUED || run->depth_one_fallback) return;
         if (!permits_native_successor(*fifo.front(), *run)) return;
         try {
             prepare(run);
+        } catch (const ChipWorker::PreparedRunIncompatible &) {
+            run->depth_one_fallback = true;
+            return;
         } catch (...) {
             run->error = std::current_exception();
             run->phase = ChipRunState::Phase::TERMINAL;

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -635,7 +635,8 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
                 "prepare_native_run already owns a prepared successor " + format_native_run_identity(run_identity)
             );
         }
-        if (admit_pipeline_generation && !pipeline_generations_.admit(PipelineSlotLease{slot_id, 0, generation})) {
+        if (admit_pipeline_generation &&
+            !pipeline_generations_.is_admissible(PipelineSlotLease{slot_id, 0, generation})) {
             throw std::runtime_error(
                 "native-run pipeline lease generation is stale " + format_native_run_identity(run_identity)
             );
@@ -668,6 +669,11 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
         if (state.run_epoch == run_epoch && state.phase == NativeRunPhase::PREPARING) {
             state = NativeRunSlotState{};
         }
+        if (rc == PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE) {
+            throw PreparedRunIncompatible(
+                "native prepare requires depth-one fallback " + format_native_run_identity(run_identity)
+            );
+        }
         throw std::runtime_error(
             "prepare_native_run failed with code " + std::to_string(rc) + " " + format_native_run_identity(run_identity)
         );
@@ -680,6 +686,14 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
             (void)finalize_run_fn_(device_ctx_, runtime_bufs_[slot_id].data());
             state = NativeRunSlotState{};
             throw std::runtime_error("native-run identity changed while prepare was in progress");
+        }
+        if (admit_pipeline_generation && !pipeline_generations_.admit(PipelineSlotLease{slot_id, 0, generation})) {
+            (void)finalize_run_fn_(device_ctx_, runtime_bufs_[slot_id].data());
+            state = NativeRunSlotState{};
+            throw std::runtime_error(
+                "native-run pipeline lease generation became stale while prepare was in progress " +
+                format_native_run_identity(run_identity)
+            );
         }
         state.phase = NativeRunPhase::PREPARED;
     }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -346,6 +347,10 @@ private:
     uint32_t arena_bank_for_slot(uint32_t slot_id) const;
 
     enum class NativeRunPhase : uint8_t { EMPTY, PREPARING, PREPARED, LAUNCHED, REAPED, FINALIZING };
+    class PreparedRunIncompatible : public std::runtime_error {
+    public:
+        using std::runtime_error::runtime_error;
+    };
     struct NativeRunSlotState {
         uint64_t lease_generation{0};
         uint64_t run_epoch{0};

--- a/src/common/worker/pipeline_slot_pool.h
+++ b/src/common/worker/pipeline_slot_pool.h
@@ -113,6 +113,12 @@ private:
  */
 class PipelineSlotGenerationFilter {
 public:
+    bool is_admissible(const PipelineSlotLease &lease) {
+        if (lease.slot_id >= newest_.size()) return false;
+        std::lock_guard<std::mutex> lock(mu_);
+        return lease.generation >= newest_[lease.slot_id];
+    }
+
     bool admit(const PipelineSlotLease &lease) {
         if (lease.slot_id >= newest_.size()) return false;
         std::lock_guard<std::mutex> lock(mu_);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -72,6 +72,7 @@ typedef void *DeviceContextHandle;
 
 enum {
     PTO_RUNTIME_ERR_UNSUPPORTED = -2,
+    PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = -3,
 };
 
 /** Return values from simpler_poll_run(). */

--- a/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
+++ b/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
@@ -287,3 +287,25 @@ class TestRunStreamReuseHbg(SceneTestCase):
             assert st_worker.run_stream_set_create_count == stream_sets
         finally:
             st_worker.unregister(add_handle)
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestRunStreamFreshTmr(SceneTestCase):
+    """TMR preparation keeps the same fresh run-owned AICore stream rule."""
+
+    CALLABLE = TestRunStreamReuseHbg.CALLABLE
+    CASES = TestRunStreamReuseHbg.CASES
+
+    generate_args = TestRunStreamReuseHbg.generate_args
+    compute_golden = TestRunStreamReuseHbg.compute_golden
+
+    def test_every_run_creates_its_own_aicore_stream(self, st_platform, st_worker):
+        if st_platform != "a2a3":
+            pytest.skip("run stream sets are an a2a3 onboard resource")
+
+        callable_obj = self.build_callable(st_platform)
+        self._run_and_validate_l2(st_worker, callable_obj, self.CASES[0], rounds=1)
+        after_first = st_worker.run_stream_set_create_count
+        rounds = _REPEATED_RUNS - 1
+        self._run_and_validate_l2(st_worker, callable_obj, self.CASES[0], rounds=rounds)
+        assert st_worker.run_stream_set_create_count == after_first + rounds

--- a/tests/st/a2a3/host_build_graph/worker_async_fifo/test_worker_async_fifo.py
+++ b/tests/st/a2a3/host_build_graph/worker_async_fifo/test_worker_async_fifo.py
@@ -483,5 +483,74 @@ class TestWorkerAsyncWholeRunFifo(SceneTestCase):
                     buffer.close()
 
 
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestWorkerAsyncWholeRunFifoTmr(TestWorkerAsyncWholeRunFifo):
+    """TMR uses the common FIFO with shared-arena compatibility fallback."""
+
+    def test_incompatible_runtime_env_falls_back_to_depth_one(self, st_platform, st_worker):
+        if st_platform != "a2a3":
+            pytest.skip("TMR prepared-state validation requires an a2a3 onboard worker")
+
+        _SUB_ENTERED.clear()
+        _SUB_RELEASE.clear()
+        buffers = []
+        tensors = []
+        first = None
+        second = None
+        try:
+            for value in (2.0, 3.0, 0.0, 5.0, 7.0, 0.0):
+                buffer, tensor = self._tensor_from_host_buffer(st_worker, value)
+                buffers.append(buffer)
+                tensors.append(tensor)
+            first_a, first_b, first_out, second_a, second_b, second_out = tensors
+            first_bufs, second_bufs = buffers[:3], buffers[3:]
+            vector_handle = type(self)._st_chip_handles["vector"]
+            vector_signature = type(self)._st_chip_handles["vector_sig"]
+            sub_handle = type(self)._st_sub_handles["wait_for_release"]
+
+            def submit_vector(orch, arg_buffers, config, *, spin_iters=0, hold_open=False):
+                chip_args = _chip_args(arg_buffers, vector_signature, spin_iters)
+                orch.submit_next_level(vector_handle, chip_args, config, worker=0)
+                if hold_open:
+                    orch.submit_sub(sub_handle)
+
+            default_config = self._build_config(self.CASES[0]["config"])
+            incompatible_config = self._build_config(
+                {
+                    **self.CASES[0]["config"],
+                    "runtime_env": {"ring_heap": [128 * 1024 * 1024] * 4},
+                }
+            )
+            first = st_worker.submit(
+                lambda orch, _args, _cfg: submit_vector(
+                    orch, first_bufs, default_config, spin_iters=_DEVICE_SPIN_ITERS, hold_open=True
+                )
+            )
+            _wait_for_active_device_run(st_worker, 10.0)
+            assert _SUB_ENTERED.wait(10.0)
+
+            second = st_worker.submit(lambda orch, _args, _cfg: submit_vector(orch, second_bufs, incompatible_config))
+            _wait_for_backend_prepared_successor(st_worker, 10.0)
+            assert torch.count_nonzero(second_out).item() == 0
+
+            _SUB_RELEASE.set()
+            first.wait(30.0)
+            second.wait(30.0)
+            assert torch.allclose(first_out, first_a + first_b + _CHAIN_LENGTH)
+            assert torch.allclose(second_out, second_a + second_b + _CHAIN_LENGTH)
+        finally:
+            _SUB_RELEASE.set()
+            for handle in (first, second):
+                if handle is not None:
+                    with suppress(Exception):
+                        handle.wait(30.0)
+            tensors.clear()
+            tensor = None
+            first_a = first_b = first_out = second_a = second_b = second_out = None
+            if all(handle is None or handle.done for handle in (first, second)):
+                for buffer in buffers:
+                    buffer.close()
+
+
 if __name__ == "__main__":
     SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -41,6 +41,10 @@ extern "C" int bind_callable_to_runtime_impl(
     const uint64_t *ring_dep_pool
 );
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
+extern "C" int concurrent_native_prepare_supported_impl(void);
+extern "C" int prepared_run_config_compatible_impl(
+    const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+);
 
 namespace {
 
@@ -66,6 +70,11 @@ struct FakeHostApi {
     std::vector<uint8_t> gm_heap;
     std::vector<uint8_t> gm_sm;
     std::vector<uint8_t> runtime_arena;
+    bool compatibility_key_valid = false;
+    uint64_t compatibility_hash = 0;
+    std::vector<uint8_t> compatibility_key;
+    uint64_t observed_hash = 0;
+    std::vector<uint8_t> observed_key;
 
     ~FakeHostApi() { release_all(); }
 
@@ -168,11 +177,24 @@ void *fake_acquire_pooled_runtime_arena(void * /*runner_ctx*/, uint32_t /*arena_
     return g_fake->runtime_arena.empty() ? nullptr : g_fake->runtime_arena.data();
 }
 bool fake_lookup_prebuilt_runtime_arena_cache(
-    void * /*runner_ctx*/, uint32_t /*arena_bank*/, uint64_t /* hash */, const void * /* key_data */,
-    size_t /* key_size */, void ** /* gm_heap_base */, void ** /* sm_base */, void ** /* runtime_arena_base */,
-    size_t * /* runtime_off */, const void ** /* image_data */, size_t * /* image_size */
+    void * /*runner_ctx*/, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size,
+    void **gm_heap_base, void **sm_base, void **runtime_arena_base, size_t *runtime_off, const void **image_data,
+    size_t *image_size
 ) {
-    return false;
+    const auto *key = static_cast<const uint8_t *>(key_data);
+    g_fake->observed_hash = hash;
+    g_fake->observed_key.assign(key, key + key_size);
+    const bool hit = arena_bank == 0 && g_fake->compatibility_key_valid && hash == g_fake->compatibility_hash &&
+                     g_fake->observed_key == g_fake->compatibility_key;
+    if (hit) {
+        *gm_heap_base = reinterpret_cast<void *>(1);
+        *sm_base = reinterpret_cast<void *>(2);
+        *runtime_arena_base = reinterpret_cast<void *>(3);
+        *runtime_off = 4;
+        *image_data = reinterpret_cast<const void *>(5);
+        *image_size = 6;
+    }
+    return hit;
 }
 void fake_mark_prebuilt_runtime_arena_cached(
     void * /*runner_ctx*/, uint32_t /*arena_bank*/, uint64_t /* hash */, const void * /* key_data */,
@@ -442,4 +464,23 @@ TEST_F(TrbRuntimeTempBufferTest, FailedCopyOnTemporaryPathDoesNotFreeRetainedBuf
     EXPECT_EQ(fake_.device_free_count, 0);
     EXPECT_NE(fake_.retained_addr, nullptr);
     EXPECT_TRUE(runtime.tensor_leases_.empty());
+}
+
+TEST_F(TrbRuntimeTempBufferTest, PreparedRuntimeEnvRequiresTheActiveArenaKey) {
+    fake_.reset();
+    HostApi compatibility_api = make_host_api();
+    uint64_t task_window[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    uint64_t heap[PTO2_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
+    uint64_t dep_pool[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
+
+    EXPECT_EQ(concurrent_native_prepare_supported_impl(), 1);
+    EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 0);
+    fake_.compatibility_key_valid = true;
+    fake_.compatibility_hash = fake_.observed_hash;
+    fake_.compatibility_key = fake_.observed_key;
+
+    EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 1);
+    heap[2] = 2048;
+    EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 0);
+    EXPECT_NE(fake_.observed_key, fake_.compatibility_key);
 }

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -39,6 +39,8 @@ std::array<int, 2> g_launch_rc{};
 std::array<int, 2> g_poll_rc{};
 std::array<int, 2> g_wait_rc{};
 std::array<int, 2> g_finalize_rc{};
+std::array<size_t, 2> g_prepare_count{};
+std::array<bool, 2> g_reject_first_prepare{};
 size_t g_poll_count{0};
 // When nonzero, the poll stub completes the run after this many polls. Only
 // UnboundedWaitBlocksInsteadOfPolling sets it, so that a regression there fails
@@ -54,6 +56,10 @@ int prepare_run(
     EXPECT_EQ(slot_of(runtime), descriptor->pipeline_slot);
     g_complete[descriptor->pipeline_slot] = false;
     g_events.push_back("prepare" + std::to_string(descriptor->pipeline_slot));
+    ++g_prepare_count[descriptor->pipeline_slot];
+    if (g_reject_first_prepare[descriptor->pipeline_slot] && g_prepare_count[descriptor->pipeline_slot] == 1) {
+        return -3;
+    }
     return g_prepare_rc[descriptor->pipeline_slot];
 }
 
@@ -94,6 +100,8 @@ void prime_worker(ChipWorker &worker) {
     g_poll_rc = {};
     g_wait_rc = {};
     g_finalize_rc = {};
+    g_prepare_count = {};
+    g_reject_first_prepare = {};
     g_poll_count = 0;
     g_poll_completes_after = 0;
     g_events.clear();
@@ -162,6 +170,31 @@ TEST(ChipRunLaneTest, ValidationOnlySuccessorPreparesAfterPromotion) {
     EXPECT_TRUE(first.done());
     EXPECT_FALSE(second.done());
     EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "finalize0", "prepare1", "launch1"}));
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, IncompatibleSuccessorRetriesAfterPredecessorFence) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    g_reject_first_prepare[1] = true;
+
+    ChipRun first = submit(lane, 101, 0);
+    ChipRun second = submit(lane, 102, 1, false);
+    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::VALIDATED_ONLY);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1"}));
+
+    second.activate();
+    g_complete[0] = true;
+    EXPECT_TRUE(first.done());
+    EXPECT_TRUE(second.launched());
+    EXPECT_EQ(
+        g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1", "finalize0", "prepare1", "launch1"})
+    );
+
+    g_complete[1] = true;
+    EXPECT_TRUE(second.done());
     lane.close();
     worker.finalize();
 }

--- a/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
+++ b/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
@@ -242,4 +242,22 @@ TEST(PipelineSlotPool, StaleGenerationCannotAccessOrReleaseAReusedSlot) {
     EXPECT_TRUE(pool.release(replacement));
 }
 
+TEST(PipelineSlotGenerationFilter, CompatibilityPreviewDoesNotConsumeGeneration) {
+    PipelineSlotGenerationFilter filter;
+    const PipelineSlotLease retried{1, 0, 2};
+
+    EXPECT_TRUE(filter.is_admissible(retried));
+    EXPECT_TRUE(filter.admit(PipelineSlotLease{1, 0, 1}));
+    EXPECT_TRUE(filter.admit(retried));
+}
+
+TEST(PipelineSlotGenerationFilter, CommitRechecksGenerationAfterCompatibilityPreview) {
+    PipelineSlotGenerationFilter filter;
+    const PipelineSlotLease delayed{0, 0, 1};
+
+    EXPECT_TRUE(filter.is_admissible(delayed));
+    EXPECT_TRUE(filter.admit(PipelineSlotLease{0, 0, 2}));
+    EXPECT_FALSE(filter.admit(delayed));
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary

This rebuilds B5 directly on current `main` after #1650.

- enable concurrent native preparation only for A2/A3 TMR
- admit a TMR successor only when its resolved prebuilt-arena key matches the active shared arena
- retain FIFO ownership and publish `VALIDATED_ONLY` on a compatibility miss, then retry the same lease after the predecessor fence
- preview lease generation admissibility before preparation and commit it only after preparation succeeds
- preserve depth-one behavior for diagnostics, simulation, A5, and incompatible RuntimeEnv settings

The old Python-side lane from the previous #1588 stack is not included; `ChipRunLane` remains the single native-lane owner from #1650.

## Validation

- C++ UT: `91/91 passed`
- Focused C++ B5 suites: `14 + 23 + 10 passed`
- Worker Python UT: `232 passed`
- Available local Python UT: `1209 passed, 18 skipped, 6 deselected` (the six deselected tests require local `torch`, which was unavailable)
- Runtime-builder integration: `4 passed, 4 skipped`
- `clang-format --dry-run --Werror` passed on changed C++ files
- `ruff check` and `ruff format --check` passed on changed Python files

Local A2/A3 ST was not submitted: the mandatory onboard arch precheck could not read `Chip Name/NPU Name` because `npu-smi` failed DCMI initialization on the validation host. No unlocked hardware command was run.