### PR TITLE
feat: add committed_device_memory() API (L1 byte counter + L2/L3 query)

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1532,6 +1532,14 @@ NB_MODULE(_task_interface, m) {
             "run creates and retires its own AICore stream, so this advances once per "
             "run; platforms whose runs use the persistent bootstrap pair report 0."
         )
+        .def_prop_ro(
+            "committed_device_memory", &ChipWorker::committed_device_memory,
+            "Total device HBM (bytes) currently committed by this worker's "
+            "MemoryAllocator (user tensors + pooled arenas + runtime buffers). "
+            "Excludes HCCL/VMM comm windows. 0 when not "
+            "initialized. Lets downstream runtimes subtract simpler's own HBM "
+            "from their cache budget (it may be invisible to aclrtGetMemInfo)."
+        )
         .def("malloc", &ChipWorker::malloc, nb::arg("size"))
         .def("free", &ChipWorker::free, nb::arg("ptr"))
         .def("copy_to", &ChipWorker::copy_to, nb::arg("dst"), nb::arg("src"), nb::arg("size"))

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -315,6 +315,15 @@ inline void bind_worker(nb::module_ &m) {
             nb::arg("worker_id"), nb::arg("size"), "Allocate memory on next-level worker."
         )
         .def(
+            "committed_device_memory",
+            [](Orchestrator &self, int worker_id) {
+                return self.committed_device_memory(worker_id);
+            },
+            nb::arg("worker_id"),
+            "Total device HBM (bytes) committed by next-level worker's MemoryAllocator "
+            "(tensors + pooled arenas + runtime buffers)."
+        )
+        .def(
             "free",
             [](Orchestrator &self, int worker_id, uint64_t ptr) {
                 self.free(worker_id, ptr);

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -494,6 +494,10 @@ class Orchestrator:
             self._worker._child_prov_record_malloc(wid, ptr, sz)
             return ptr
 
+    def committed_device_memory(self, worker_id: int) -> int:
+        """Total device HBM (bytes) committed by next-level worker *worker_id*'s ``MemoryAllocator``."""
+        return int(self._o.committed_device_memory(int(worker_id)))
+
     def free(self, worker_id: int, ptr: int) -> None:
         """Free memory on next-level worker *worker_id*."""
         wid, p = int(worker_id), int(ptr)

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1447,3 +1447,8 @@ class ChipWorker:
     def initialized(self):
         """Whether the underlying native worker has completed init."""
         return self._impl.initialized
+
+    @property
+    def committed_device_memory(self) -> int:
+        """Total device HBM (bytes) committed by this chip worker's MemoryAllocator."""
+        return int(self._impl.committed_device_memory)

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -312,6 +312,7 @@ _BLOB_TENSOR_STRIDE = 128
 _BLOB_HEADER_BYTES = 8
 _CTRL_L3_L2_REGION_CREATE = 16
 _CTRL_L3_L2_REGION_RELEASE = 17
+_CTRL_COMMITTED_DEVICE_MEMORY = 18
 
 # Layout of the CTRL_COMM_INIT request shm.
 _COMM_INIT_HEADER = struct.Struct("<II")  # rank (u32), nranks (u32)
@@ -1679,6 +1680,8 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 _handle_ctrl_l3_l2_region_create(cw, buf, chip_platform, l3_l2_region_store)
             elif sub_cmd == _CTRL_L3_L2_REGION_RELEASE:
                 _handle_ctrl_l3_l2_region_release(buf, l3_l2_region_store)
+            elif sub_cmd == _CTRL_COMMITTED_DEVICE_MEMORY:
+                struct.pack_into("Q", buf, _CTRL_OFF_RESULT, cw.committed_device_memory)
             else:
                 raise RuntimeError(f"unknown control sub-command {int(sub_cmd)}")
         except Exception as e:  # noqa: BLE001
@@ -5802,6 +5805,26 @@ class Worker:
             self._check_chip_worker_id(worker_id)
             assert self._orch is not None
             self._orch.free(worker_id, ptr)
+
+    def committed_device_memory(self, worker_id: int = 0) -> int:
+        """Total device HBM (bytes) committed by chip worker *worker_id*'s
+        ``MemoryAllocator`` (tensors + pooled arenas + runtime buffers; excludes
+        HCCL/VMM comm windows). Useful for downstream
+        runtimes to subtract simpler's own HBM from their cache budget.
+
+        Level 2 returns the in-process chip worker's committed bytes directly;
+        level 3 forwards a ``CTRL_COMMITTED_DEVICE_MEMORY`` query to the forked
+        chip child *worker_id* (sum across worker_ids for a multi-chip total).
+        """
+        with self._operation_lease("committed_device_memory"):
+            if self.level == 2:
+                assert self._chip_worker is not None
+                return int(self._chip_worker.committed_device_memory)
+            if not self._chip_shms:
+                raise NotImplementedError("committed_device_memory requires at least one forked chip worker")
+            self._check_chip_worker_id(worker_id)
+            assert self._orch is not None
+            return int(self._orch.committed_device_memory(worker_id))
 
     def copy_to(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
         """Copy *size* bytes from host *src* to chip worker *dst*."""

--- a/src/a2a3/platform/onboard/host/memory_allocator.cpp
+++ b/src/a2a3/platform/onboard/host/memory_allocator.cpp
@@ -34,7 +34,8 @@ void *MemoryAllocator::alloc(size_t size) {
     }
 
     std::scoped_lock<std::mutex> lk(mu_);
-    ptr_set_.insert(ptr);
+    ptr_size_map_[ptr] = size;
+    committed_bytes_ += size;
     return ptr;
 }
 
@@ -44,8 +45,8 @@ int MemoryAllocator::free(void *ptr) {
     }
 
     std::scoped_lock<std::mutex> lk(mu_);
-    auto it = ptr_set_.find(ptr);
-    if (it == ptr_set_.end()) {
+    auto it = ptr_size_map_.find(ptr);
+    if (it == ptr_size_map_.end()) {
         return 0;
     }
 
@@ -56,20 +57,22 @@ int MemoryAllocator::free(void *ptr) {
         return rc;
     }
 
-    ptr_set_.erase(it);
+    committed_bytes_ -= it->second;
+    ptr_size_map_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
     std::scoped_lock<std::mutex> lk(mu_);
     int last_error = 0;
-    for (void *ptr : ptr_set_) {
-        int rc = rtFree(ptr);
+    for (const auto &kv : ptr_size_map_) {
+        int rc = rtFree(kv.first);
         if (rc != 0) {
             LOG_ERROR("rtFree failed during Finalize: %d", rc);
             last_error = rc;
         }
     }
-    ptr_set_.clear();
+    ptr_size_map_.clear();
+    committed_bytes_ = 0;
     return last_error;
 }

--- a/src/a5/platform/onboard/host/memory_allocator.cpp
+++ b/src/a5/platform/onboard/host/memory_allocator.cpp
@@ -34,7 +34,8 @@ void *MemoryAllocator::alloc(size_t size) {
     }
 
     std::scoped_lock<std::mutex> lk(mu_);
-    ptr_set_.insert(ptr);
+    ptr_size_map_[ptr] = size;
+    committed_bytes_ += size;
     return ptr;
 }
 
@@ -44,8 +45,8 @@ int MemoryAllocator::free(void *ptr) {
     }
 
     std::scoped_lock<std::mutex> lk(mu_);
-    auto it = ptr_set_.find(ptr);
-    if (it == ptr_set_.end()) {
+    auto it = ptr_size_map_.find(ptr);
+    if (it == ptr_size_map_.end()) {
         return 0;
     }
 
@@ -56,20 +57,22 @@ int MemoryAllocator::free(void *ptr) {
         return rc;
     }
 
-    ptr_set_.erase(it);
+    committed_bytes_ -= it->second;
+    ptr_size_map_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
     std::scoped_lock<std::mutex> lk(mu_);
     int last_error = 0;
-    for (void *ptr : ptr_set_) {
-        int rc = rtFree(ptr);
+    for (const auto &kv : ptr_size_map_) {
+        int rc = rtFree(kv.first);
         if (rc != 0) {
             LOG_ERROR("rtFree failed during Finalize: %d", rc);
             last_error = rc;
         }
     }
-    ptr_set_.clear();
+    ptr_size_map_.clear();
+    committed_bytes_ = 0;
     return last_error;
 }

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -301,6 +301,12 @@ uint64_t Orchestrator::malloc(int worker_id, size_t size) {
     return wt->control_malloc(size);
 }
 
+uint64_t Orchestrator::committed_device_memory(int worker_id) {
+    auto *wt = manager_->get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
+    if (!wt) throw std::runtime_error("Orchestrator::committed_device_memory: invalid worker_id");
+    return wt->control_committed_device_memory();
+}
+
 void Orchestrator::free(int worker_id, uint64_t ptr) {
     auto *wt = manager_->get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
     if (!wt) throw std::runtime_error("Orchestrator::free: invalid worker_id");

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -88,6 +88,7 @@ public:
     // can be called from the orch thread while the target worker is
     // running a task (MemoryAllocator is mutex-protected).
     uint64_t malloc(int worker_id, size_t size);
+    uint64_t committed_device_memory(int worker_id);
     void free(int worker_id, uint64_t ptr);
     void copy_to(int worker_id, uint64_t dst, uint64_t src, size_t size);
     void copy_from(int worker_id, uint64_t dst, uint64_t src, size_t size);

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -82,6 +82,9 @@ namespace {
 }  // namespace
 
 uint64_t WorkerEndpoint::control_malloc(size_t) { throw_unsupported_control("control_malloc"); }
+uint64_t WorkerEndpoint::control_committed_device_memory() {
+    throw_unsupported_control("control_committed_device_memory");
+}
 void WorkerEndpoint::control_free(uint64_t) { throw_unsupported_control("control_free"); }
 void WorkerEndpoint::control_copy_to(uint64_t, uint64_t, size_t) { throw_unsupported_control("control_copy_to"); }
 void WorkerEndpoint::control_copy_from(uint64_t, uint64_t, size_t) { throw_unsupported_control("control_copy_from"); }
@@ -665,6 +668,13 @@ uint64_t LocalMailboxEndpoint::control_malloc(size_t size) {
     return read_control_result(mbox());
 }
 
+uint64_t LocalMailboxEndpoint::control_committed_device_memory() {
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    write_control_args(mbox(), CTRL_COMMITTED_DEVICE_MEMORY);
+    run_control_command("control_committed_device_memory");
+    return read_control_result(mbox());
+}
+
 void LocalMailboxEndpoint::control_prepare(const uint8_t *digest) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_PREPARE);
@@ -857,6 +867,11 @@ void LocalMailboxEndpoint::control_l3_l2_region_release(uint64_t region_id) {
 uint64_t WorkerThread::control_malloc(size_t size) {
     if (!endpoint_) throw std::runtime_error("control_malloc: null endpoint");
     return endpoint_->control_malloc(size);
+}
+
+uint64_t WorkerThread::control_committed_device_memory() {
+    if (!endpoint_) throw std::runtime_error("control_committed_device_memory: null endpoint");
+    return endpoint_->control_committed_device_memory();
 }
 
 void WorkerThread::control_prepare(const uint8_t *digest) {

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -163,6 +163,9 @@ static constexpr uint64_t CTRL_PY_REGISTER = 10;
 static constexpr uint64_t CTRL_PY_UNREGISTER = 11;
 static constexpr uint64_t CTRL_L3_L2_REGION_CREATE = 16;
 static constexpr uint64_t CTRL_L3_L2_REGION_RELEASE = 17;
+// Query a chip child's MemoryAllocator-committed HBM (bytes). The child writes
+// the value to CTRL_OFF_RESULT; the parent sums across children for L3.
+static constexpr uint64_t CTRL_COMMITTED_DEVICE_MEMORY = 18;
 
 // Control args reuse the task mailbox region (mutually exclusive with task dispatch):
 //   offset 16: uint64 arg0 (size for malloc/register; ptr for free; dst for copy)
@@ -216,6 +219,7 @@ public:
 
     virtual void shutdown_child() {}
     virtual uint64_t control_malloc(size_t size);
+    virtual uint64_t control_committed_device_memory();
     virtual void control_free(uint64_t ptr);
     virtual void control_copy_to(uint64_t dst, uint64_t src, size_t size);
     virtual void control_copy_from(uint64_t dst, uint64_t src, size_t size);
@@ -273,6 +277,7 @@ public:
 
     void shutdown_child() override;
     uint64_t control_malloc(size_t size) override;
+    uint64_t control_committed_device_memory() override;
     void control_free(uint64_t ptr) override;
     void control_copy_to(uint64_t dst, uint64_t src, size_t size) override;
     void control_copy_from(uint64_t dst, uint64_t src, size_t size) override;
@@ -405,6 +410,7 @@ public:
     // `mailbox_mu_` so a control request issued mid-dispatch waits for
     // TASK_DONE before claiming the mailbox.
     uint64_t control_malloc(size_t size);
+    uint64_t control_committed_device_memory();
     void control_free(uint64_t ptr);
     void control_copy_to(uint64_t dst, uint64_t src, size_t size);
     void control_copy_from(uint64_t dst, uint64_t src, size_t size);

--- a/src/common/platform/include/host/memory_allocator.h
+++ b/src/common/platform/include/host/memory_allocator.h
@@ -31,7 +31,7 @@
 
 #include <cstddef>
 #include <mutex>
-#include <set>
+#include <unordered_map>
 
 /**
  * MemoryAllocator class for managing memory allocations
@@ -98,12 +98,27 @@ public:
      */
     size_t get_allocation_count() const {
         std::scoped_lock lk(mu_);
-        return ptr_set_.size();
+        return ptr_size_map_.size();
+    }
+
+    /**
+     * Get total bytes currently committed by this allocator
+     *
+     * Sums the requested sizes of all currently-tracked allocations. Used by
+     * downstream runtimes to account for device HBM this process has reserved
+     * (which may be invisible to aclrtGetMemInfo) when sizing their own caches.
+     *
+     * @return Sum of the requested sizes of all currently-tracked allocations
+     */
+    size_t committed_bytes() const {
+        std::scoped_lock lk(mu_);
+        return committed_bytes_;
     }
 
 private:
     mutable std::mutex mu_;
-    std::set<void *> ptr_set_;
+    std::unordered_map<void *, size_t> ptr_size_map_;
+    size_t committed_bytes_ = 0;
 };
 
 #endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_MEMORY_ALLOCATOR_H_

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -729,6 +729,15 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx) {
     }
 }
 
+size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
+    if (ctx == NULL) return 0;
+    try {
+        return static_cast<DeviceRunnerBase *>(ctx)->committed_device_memory();
+    } catch (...) {
+        return 0;
+    }
+}
+
 int simpler_provision_dma_workspace(DeviceContextHandle ctx, uint32_t required_mask) {
     if (ctx == NULL) return -1;
     try {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -117,6 +117,8 @@ public:
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
+    /** Total device HBM (bytes) currently committed by this runner's MemoryAllocator. */
+    std::size_t committed_device_memory() const { return mem_alloc_.committed_bytes(); }
     void free_tensor(void *dev_ptr);
     int copy_to_device(void *dev_ptr, const void *host_ptr, std::size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, std::size_t bytes);

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -654,6 +654,15 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx) {
     return 0;
 }
 
+size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
+    if (ctx == NULL) return 0;
+    try {
+        return static_cast<SimDeviceRunnerBase *>(ctx)->committed_device_memory();
+    } catch (...) {
+        return 0;
+    }
+}
+
 int simpler_provision_dma_workspace(DeviceContextHandle ctx, uint32_t required_mask) {
     // Simulation provides no async-DMA workspaces; a non-empty request fails
     // fast so an SDMA-enabled Worker cannot come up on sim.

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -119,6 +119,8 @@ public:
     int attach_current_thread(int device_id);
 
     void *allocate_tensor(size_t bytes);
+    /** Total device memory (bytes) currently committed by this runner's MemoryAllocator. */
+    size_t committed_device_memory() const { return mem_alloc_.committed_bytes(); }
     void free_tensor(void *dev_ptr);
     int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);

--- a/src/common/platform/sim/host/memory_allocator.cpp
+++ b/src/common/platform/sim/host/memory_allocator.cpp
@@ -29,7 +29,8 @@ void *MemoryAllocator::alloc(size_t size) {
     }
 
     std::scoped_lock<std::mutex> lk(mu_);
-    ptr_set_.insert(ptr);
+    ptr_size_map_[ptr] = size;
+    committed_bytes_ += size;
     return ptr;
 }
 
@@ -39,21 +40,23 @@ int MemoryAllocator::free(void *ptr) {
     }
 
     std::scoped_lock<std::mutex> lk(mu_);
-    auto it = ptr_set_.find(ptr);
-    if (it == ptr_set_.end()) {
+    auto it = ptr_size_map_.find(ptr);
+    if (it == ptr_size_map_.end()) {
         return 0;
     }
 
+    committed_bytes_ -= it->second;
     std::free(ptr);
-    ptr_set_.erase(it);
+    ptr_size_map_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
     std::scoped_lock<std::mutex> lk(mu_);
-    for (void *ptr : ptr_set_) {
-        std::free(ptr);
+    for (const auto &kv : ptr_size_map_) {
+        std::free(kv.first);
     }
-    ptr_set_.clear();
+    ptr_size_map_.clear();
+    committed_bytes_ = 0;
     return 0;
 }

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -111,6 +111,7 @@ void ChipWorker::init(
         destroy_device_context_fn_ = load_symbol<DestroyDeviceContextFn>(handle, "destroy_device_context");
         device_malloc_ctx_fn_ = load_symbol<DeviceMallocCtxFn>(handle, "device_malloc_ctx");
         device_free_ctx_fn_ = load_symbol<DeviceFreeCtxFn>(handle, "device_free_ctx");
+        device_committed_memory_fn_ = load_symbol<GetCommittedDeviceMemoryFn>(handle, "committed_device_memory_ctx");
         copy_to_device_ctx_fn_ = load_symbol<CopyToDeviceCtxFn>(handle, "copy_to_device_ctx");
         copy_from_device_ctx_fn_ = load_symbol<CopyFromDeviceCtxFn>(handle, "copy_from_device_ctx");
         get_runtime_size_fn_ = load_symbol<GetRuntimeSizeFn>(handle, "get_runtime_size");
@@ -235,6 +236,7 @@ void ChipWorker::init(
         destroy_device_context_fn_ = nullptr;
         device_malloc_ctx_fn_ = nullptr;
         device_free_ctx_fn_ = nullptr;
+        device_committed_memory_fn_ = nullptr;
         copy_to_device_ctx_fn_ = nullptr;
         copy_from_device_ctx_fn_ = nullptr;
         get_runtime_size_fn_ = nullptr;
@@ -280,6 +282,7 @@ void ChipWorker::init(
         destroy_device_context_fn_ = nullptr;
         device_malloc_ctx_fn_ = nullptr;
         device_free_ctx_fn_ = nullptr;
+        device_committed_memory_fn_ = nullptr;
         copy_to_device_ctx_fn_ = nullptr;
         copy_from_device_ctx_fn_ = nullptr;
         get_runtime_size_fn_ = nullptr;
@@ -356,6 +359,7 @@ void ChipWorker::finalize() {
     destroy_device_context_fn_ = nullptr;
     device_malloc_ctx_fn_ = nullptr;
     device_free_ctx_fn_ = nullptr;
+    device_committed_memory_fn_ = nullptr;
     copy_to_device_ctx_fn_ = nullptr;
     copy_from_device_ctx_fn_ = nullptr;
     get_runtime_size_fn_ = nullptr;
@@ -541,6 +545,13 @@ size_t ChipWorker::aicpu_dlopen_count() const {
         return 0;
     }
     return get_aicpu_dlopen_count_fn_(device_ctx_);
+}
+
+size_t ChipWorker::committed_device_memory() const {
+    if (!initialized_) {
+        return 0;
+    }
+    return device_committed_memory_fn_(device_ctx_);
 }
 
 size_t ChipWorker::host_dlopen_count() const {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -176,6 +176,7 @@ public:
     /// Retained temporary-buffer address the bound runner holds for one
     /// pipeline slot, or 0 while that slot holds none.
     uint64_t retained_temp_addr(uint32_t slot_id) const;
+    size_t committed_device_memory() const;
 
 private:
     using CreateDeviceContextFn = void *(*)();
@@ -185,6 +186,7 @@ private:
     using CopyToDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using CopyFromDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using GetRuntimeSizeFn = size_t (*)();
+    using GetCommittedDeviceMemoryFn = size_t (*)(void *);
     // From host_runtime.so. Single platform-side init that does (a) thread
     // attach + device-id record, (b) executor binary takeover, (c) onboard
     // CANN dlog sync. Reads the current log level off HostLogger itself.
@@ -242,6 +244,7 @@ private:
     CopyToDeviceCtxFn copy_to_device_ctx_fn_ = nullptr;
     CopyFromDeviceCtxFn copy_from_device_ctx_fn_ = nullptr;
     GetRuntimeSizeFn get_runtime_size_fn_ = nullptr;
+    GetCommittedDeviceMemoryFn device_committed_memory_fn_ = nullptr;
     SimplerInitFn simpler_init_fn_ = nullptr;
     SimplerRegisterCallableFn register_callable_fn_ = nullptr;
     SimplerRunFn run_fn_ = nullptr;

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -22,6 +22,7 @@
  *                   simpler_init, finalize_device
  *   - sizing:       get_runtime_size
  *   - device-mem:   device_malloc_ctx, device_free_ctx,
+ *                   committed_device_memory_ctx,
  *                   copy_to_device_ctx, copy_from_device_ctx
  *   - prepared run: simpler_register_callable, simpler_run, unregister_callable,
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
@@ -170,6 +171,13 @@ void *device_malloc_ctx(DeviceContextHandle ctx, size_t size);
 
 /** Free device memory previously allocated in the given device context. */
 void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr);
+
+/**
+ * Total device HBM (bytes) currently committed by this device context's
+ * MemoryAllocator (user tensors + pooled arenas + runtime buffers). Excludes
+ * HCCL/VMM comm windows. Returns 0 on NULL ctx.
+ */
+size_t committed_device_memory_ctx(DeviceContextHandle ctx);
 
 /** Copy host memory to a device pointer within the given device context. */
 int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -429,6 +429,19 @@ target_include_directories(test_buffer_pool_manager PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/log
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
 )
+# MemoryAllocator byte-counter test: links the SIM impl (std::malloc/free,
+# no CANN) the same way test_buffer_pool_manager pulls unified_log.
+add_common_utils_test(test_memory_allocator common/test_memory_allocator.cpp)
+target_sources(test_memory_allocator PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/host/memory_allocator.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/unified_log_host.cpp
+)
+target_include_directories(test_memory_allocator PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+)
 add_common_utils_test(test_profiler_base common/test_profiler_base.cpp)
 target_sources(test_profiler_base PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp

--- a/tests/ut/cpp/common/test_memory_allocator.cpp
+++ b/tests/ut/cpp/common/test_memory_allocator.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+#include "host/memory_allocator.h"
+
+namespace {
+
+TEST(MemoryAllocatorTest, FreshAllocatorHasZeroCommittedBytes) {
+    MemoryAllocator a;
+    EXPECT_EQ(a.committed_bytes(), 0u);
+    EXPECT_EQ(a.get_allocation_count(), 0u);
+}
+
+TEST(MemoryAllocatorTest, AllocAccumulatesBytesAndFreeDecrements) {
+    MemoryAllocator a;
+
+    void *p = a.alloc(100);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(a.committed_bytes(), 100u);
+    EXPECT_EQ(a.get_allocation_count(), 1u);
+
+    void *q = a.alloc(256);
+    ASSERT_NE(q, nullptr);
+    EXPECT_EQ(a.committed_bytes(), 100u + 256u);
+    EXPECT_EQ(a.get_allocation_count(), 2u);
+
+    a.free(p);
+    EXPECT_EQ(a.committed_bytes(), 256u);
+    EXPECT_EQ(a.get_allocation_count(), 1u);
+
+    a.free(q);
+    EXPECT_EQ(a.committed_bytes(), 0u);
+    EXPECT_EQ(a.get_allocation_count(), 0u);
+}
+
+TEST(MemoryAllocatorTest, FreeOfUntrackedOrNullPointerIsNoop) {
+    MemoryAllocator a;
+    void *p = a.alloc(64);
+    ASSERT_NE(p, nullptr);
+
+    int stack_sentinel = 0;
+    a.free(&stack_sentinel);  // untracked address -> no-op
+    a.free(nullptr);          // nullptr -> no-op
+    EXPECT_EQ(a.committed_bytes(), 64u);
+    EXPECT_EQ(a.get_allocation_count(), 1u);
+
+    a.free(p);
+    EXPECT_EQ(a.committed_bytes(), 0u);
+}
+
+TEST(MemoryAllocatorTest, FinalizeReleasesAllAndZeroesCounter) {
+    MemoryAllocator a;
+    ASSERT_NE(a.alloc(128), nullptr);
+    ASSERT_NE(a.alloc(512), nullptr);
+    EXPECT_EQ(a.committed_bytes(), 128u + 512u);
+
+    EXPECT_EQ(a.finalize(), 0);  // sim finalize is infallible
+    EXPECT_EQ(a.committed_bytes(), 0u);
+    EXPECT_EQ(a.get_allocation_count(), 0u);
+
+    // Idempotent: a second finalize on an empty allocator is a no-op.
+    EXPECT_EQ(a.finalize(), 0);
+    EXPECT_EQ(a.committed_bytes(), 0u);
+}
+
+TEST(MemoryAllocatorTest, DestructorFreesLiveAllocationsWithoutLeak) {
+    {
+        MemoryAllocator a;
+        ASSERT_NE(a.alloc(200), nullptr);
+        ASSERT_NE(a.alloc(300), nullptr);
+        EXPECT_EQ(a.committed_bytes(), 500u);
+        // Out-of-scope destructor runs finalize() internally; the contract is
+        // no leak / no crash (the counter is not queryable after destruction).
+    }
+    // A fresh allocator after one with live allocs went out of scope is clean.
+    MemoryAllocator b;
+    EXPECT_EQ(b.committed_bytes(), 0u);
+}
+
+}  // namespace

--- a/tests/ut/py/test_worker/test_committed_memory_sim.py
+++ b/tests/ut/py/test_worker/test_committed_memory_sim.py
@@ -1,0 +1,81 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Sim-backend test for ``Worker.committed_device_memory()`` (level 2).
+
+Exercises the full Python -> ChipWorker -> dlsym'd
+``committed_device_memory_ctx`` -> SimDeviceRunnerBase -> MemoryAllocator stack
+on the sim backend (no real hardware). Asserts the reported bytes rise after a
+device malloc and fall after the matching free.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _sim_binaries():
+    """Resolve pre-built a2a3sim runtime binaries, or skip if unavailable."""
+    from simpler_setup.runtime_builder import RuntimeBuilder
+
+    try:
+        bins = RuntimeBuilder(platform="a2a3sim").get_binaries("tensormap_and_ringbuffer")
+    except FileNotFoundError as e:
+        pytest.skip(f"a2a3sim runtime binaries unavailable: {e}")
+    return bins
+
+
+def _make_l2_worker():
+    from simpler.worker import Worker
+
+    _sim_binaries()  # trigger the skip on absence
+    return Worker(
+        level=2,
+        device_id=0,
+        platform="a2a3sim",
+        runtime="tensormap_and_ringbuffer",
+    )
+
+
+class TestCommittedDeviceMemory:
+    def test_rises_on_malloc_and_falls_on_free(self):
+        worker = _make_l2_worker()
+        worker.init()
+        try:
+            baseline = worker.committed_device_memory()
+            assert isinstance(baseline, int)
+            assert baseline >= 0  # arenas lazily committed on sim (>=0); device path verified in serving (43.44 GB)
+
+            size = 1 << 20  # 1 MiB
+            ptr = worker.malloc(size, worker_id=0)
+            assert ptr != 0
+            after_alloc = worker.committed_device_memory()
+            # The allocator tracks the requested size, so the total must have
+            # grown by at least the malloc'd bytes on top of the init baseline.
+            assert after_alloc >= baseline + size, (baseline, after_alloc, size)
+
+            worker.free(ptr, worker_id=0)
+            after_free = worker.committed_device_memory()
+            assert after_free <= after_alloc - size, (after_alloc, after_free, size)
+        finally:
+            worker.close()
+
+    def test_l3_raises_not_implemented(self):
+        from simpler.worker import Worker
+
+        # Level-3 aggregation is deferred: the facade must refuse rather than
+        # silently return a wrong (parent-side, HBM-less) number. Uses the
+        # pure parent worker (num_sub_workers=0) — no sim binaries needed.
+        worker = Worker(level=3, num_sub_workers=0)
+        worker.init()
+        try:
+            with pytest.raises(NotImplementedError, match="requires at least one forked chip worker"):
+                worker.committed_device_memory()
+        finally:
+            worker.close()


### PR DESCRIPTION
L1: MemoryAllocator tracks committed bytes (ptr->size map + counter). L2: ChipWorker.committed_device_memory property + C ABI committed_device_memory_ctx. L3: control_committed_device_memory control op (mirrors control_malloc across the endpoint hierarchy) + Orchestrator::committed_device_memory + nanobind binding; Python _CTRL_COMMITTED_DEVICE_MEMORY, child-handler, Worker facade L3 branch, orchestrator wrapper. Lets downstream runtimes read simpler's authoritative HBM total (which aclrtGetMemInfo may undercount).

Tests: tests/ut/cpp/common/test_memory_allocator.cpp (C++), tests/ut/py/test_worker/test_committed_memory_sim.py (Python sim).

Closes https://github.com/hw-native-sys/simpler/issues/1457