### PR TITLE
Update: prebuild A5 dispatch context

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -21,9 +21,10 @@
  * initialized during scheduler cold start from core topology and the resident
  * per-device config, then remains stable for that scheduler instance.
  *
- * LocalContext (s_block_idx, s_block_num) and args[] are rebuilt by build_payload()
- * before each dispatch.  Both context struct pointers are written into the
- * args[] suffix on every dispatch (since args[] is rebuilt entirely each time).
+ * The scheduler prefills the AsyncCtx slab pointers and capacity, along with
+ * both context pointers in the args[] suffix, during cold initialization.
+ * build_payload() updates only the task-varying LocalContext fields and
+ * args[0..num_args) before each dispatch.
  *
  * AICore caches a pointer to its per-core slot at startup and reads from
  * it on each dispatch.  The struct is cache-line aligned to avoid false
@@ -86,15 +87,15 @@ struct alignas(64) PTO2DispatchPayload {
     // === Cache line 0 (64B): control block, the only line written per dispatch ===
     // function_bin_addr, local_context.{s_block_idx,s_block_num,async_ctx.task_token}
     // and src_payload are the per-dispatch writes; async_ctx's slab pointers +
-    // capacity are cold (prefilled once at init / rebuilt per a5 dispatch) but
-    // ride this hot line for free.
+    // capacity are cold (prefilled once at init) but ride this hot line for free.
     // Sized to exactly 64B so both dispatch paths write one control line: the
     // ready path (src_payload = 0) then also fills args[0..num_args); the gated
     // path (src_payload = &PTO2TaskPayload) leaves args[] to the idle AICore.
     uint64_t function_bin_addr; /**< Kernel entry address in GM (set by Scheduler). */
 
     /** Per-dispatch context: s_block_idx/s_block_num (hot) + async_ctx (task_token hot,
-     *  slab pointers + capacity). args[SPMD_LOCAL_CONTEXT_INDEX] points here. */
+     *  slab pointers + capacity prefilled once at init). args[SPMD_LOCAL_CONTEXT_INDEX]
+     *  points here. */
     LocalContext local_context;
 
     /** Early-dispatch gate AND source pointer, folded into one field. 0 = ready:
@@ -107,9 +108,9 @@ struct alignas(64) PTO2DispatchPayload {
 
     // === Cache lines 1..7: kernel argument vector ===
     /** [0..num_args) = GM tensor pointers + scalar values; [SPMD_LOCAL_CONTEXT_INDEX]
-     *  = &local_context, [SPMD_GLOBAL_CONTEXT_INDEX] = &global_context (both written
-     *  each dispatch on a5). On the gated path the AICPU leaves [0..num_args)
-     *  unwritten and the idle AICore fills them from src_payload during its gate wait. */
+     *  = &local_context, [SPMD_GLOBAL_CONTEXT_INDEX] = &global_context (both prefilled
+     *  once at init). On the gated path the AICPU leaves [0..num_args) unwritten and
+     *  the idle AICore fills them from src_payload during its gate wait. */
     uint64_t args[PTO2_DISPATCH_MAX_ARGS];
 
     /** Per-core global context: sub_block_id (AIV lane identity) plus optional

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -927,8 +927,6 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
 
     // Per-cluster GlobalContext sub_block_id (mirrors post_handshake_init) for
     // this thread's owned cores only — a thread only ever dispatches to its own.
-    // The per-dispatch AsyncCtx / deferred-slab fields are written by build_payload
-    // at dispatch time (see deinit()'s note), so there is no per-core prefill here.
     for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
         int32_t cluster_offset = c * 3;
         int32_t aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
@@ -937,14 +935,28 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
         payload_per_core_[aiv0_id][1].global_context.sub_block_id = 0;
         payload_per_core_[aiv1_id][0].global_context.sub_block_id = 1;
         payload_per_core_[aiv1_id][1].global_context.sub_block_id = 1;
-        // dma_workspace is a device constant: prefill it once per owned core
-        // (all cores in the cluster, both buffers), never on the dispatch path.
+    }
+
+    // Per-dispatch AsyncCtx constant prefill + one-time slab clear for owned cores
+    // (mirrors post_handshake_init's all-core loop, restricted to this thread's).
+    for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
         for (int32_t sub = 0; sub < 3; sub++) {
-            int32_t core_id = tracker.get_core_id_by_offset(cluster_offset + sub);
+            int32_t core_id = tracker.get_core_id_by_offset(c * 3 + sub);
             for (int32_t buf = 0; buf < 2; buf++) {
+                PTO2DispatchPayload &dp = payload_per_core_[core_id][buf];
+                AsyncCtx &ac = dp.local_context.async_ctx;
+                volatile DeferredCompletionSlab *slab = &deferred_slab_per_core_[core_id][buf];
+                ac.completion_count = &slab->count;
+                ac.completion_error_code = &slab->error_code;
+                ac.completion_entries = &slab->entries[0];
+                ac.completion_capacity = MAX_COMPLETIONS_PER_TASK;
+                slab->count = 0;
+                slab->error_code = PTO2_ERROR_NONE;
                 for (int k = 0; k < DMA_WORKSPACE_KIND_COUNT; ++k) {
-                    payload_per_core_[core_id][buf].global_context.dma_workspace[k] = get_dma_workspace_addr(k);
+                    dp.global_context.dma_workspace[k] = get_dma_workspace_addr(k);
                 }
+                dp.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dp.local_context);
+                dp.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dp.global_context);
             }
         }
     }
@@ -1216,13 +1228,6 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     // Device orchestration: the orchestrator thread flips this when the graph is built.
     orchestrator_done_.store(false, std::memory_order_release);
 
-    // prepare_subtask_to_core fully writes a per-core payload / deferred-slab slot
-    // before the AICore is told to read it: build_payload sets
-    // function_bin_addr/args/local_context/not_ready, and deferred_slab->count/
-    // error_code are reset inline on every dispatch. An AICore reads a slot only
-    // after a dispatch targets it (DATA_MAIN_BASE), so a prior round's bytes in an
-    // untouched slot are never observed.
-
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
     for (int32_t t = 0; t < sched_thread_num_; t++) {
@@ -1235,16 +1240,38 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
             payload_per_core_[aiv0_id][1].global_context.sub_block_id = 0;
             payload_per_core_[aiv1_id][0].global_context.sub_block_id = 1;
             payload_per_core_[aiv1_id][1].global_context.sub_block_id = 1;
-            // dma_workspace is a device constant: prefill it once per core here,
-            // never on the dispatch path.
-            for (int32_t sub = 0; sub < 3; sub++) {
-                int32_t core_id = tracker.get_core_id_by_offset(cluster_offset + sub);
-                for (int32_t buf = 0; buf < 2; buf++) {
-                    for (int k = 0; k < DMA_WORKSPACE_KIND_COUNT; ++k) {
-                        payload_per_core_[core_id][buf].global_context.dma_workspace[k] = get_dma_workspace_addr(k);
-                    }
-                }
+        }
+    }
+
+    // Prefill the per-dispatch AsyncCtx constant fields once. Of AsyncCtx's five
+    // fields, four are constant for a given (core, buf_idx): the three pointers
+    // target the fixed deferred_slab_per_core_[core][buf] members, and capacity is
+    // MAX_COMPLETIONS_PER_TASK. Only task_token varies per dispatch, so build_payload
+    // writes just that; these constants survive across dispatches because the
+    // payload buffer is never zeroed between them.
+    // The two context-pointer args are also per-(core, buf_idx) constants — they
+    // target this buffer's own local_context / global_context — so prefill them
+    // here too and drop them from the per-dispatch build_payload writes. This keeps
+    // the per-dispatch write footprint on the CL0 control block only (args[48]/[49]
+    // live on a later line).
+    for (int32_t core_id = 0; core_id < RUNTIME_MAX_WORKER; core_id++) {
+        for (int32_t buf = 0; buf < 2; buf++) {
+            PTO2DispatchPayload &dp = payload_per_core_[core_id][buf];
+            AsyncCtx &ac = dp.local_context.async_ctx;
+            volatile DeferredCompletionSlab *slab = &deferred_slab_per_core_[core_id][buf];
+            ac.completion_count = &slab->count;
+            ac.completion_error_code = &slab->error_code;
+            ac.completion_entries = &slab->entries[0];
+            ac.completion_capacity = MAX_COMPLETIONS_PER_TASK;
+            // Clear the slab once here; thereafter only the completion path re-clears
+            // count (and only when a deferred task dirtied it), never per dispatch.
+            slab->count = 0;
+            slab->error_code = PTO2_ERROR_NONE;
+            for (int k = 0; k < DMA_WORKSPACE_KIND_COUNT; ++k) {
+                dp.global_context.dma_workspace[k] = get_dma_workspace_addr(k);
             }
+            dp.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dp.local_context);
+            dp.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dp.global_context);
         }
     }
 
@@ -1262,12 +1289,11 @@ void SchedulerContext::deinit() {
     }
 
     // No per-core memset of payload_per_core_ / deferred_slab_per_core_ here
-    // (~300 KB across all cores). Both are fully re-initialized at dispatch
-    // before they can be read: dispatch_task sets deferred_slab->count = 0 /
-    // error_code = NONE and build_payload() overwrites every payload field
-    // (function addr, args[], contexts, not_ready) on the exact [core][buf_idx]
-    // about to run. The consumer side cannot reach a stale slot either: the
-    // drain only services a core's running_reg_task_id, and the loop above
+    // (~300 KB across all cores). The next initialization rewires every owned
+    // core's context pointers and clears both slabs before dispatch begins.
+    // build_payload() overwrites the task-varying fields on the exact
+    // [core][buf_idx] about to run. The consumer side cannot reach a stale slot:
+    // the drain only services a core's running_reg_task_id, and the loop above
     // already reset every core_exec_states_[].running/pending_reg_task_id to
     // AICPU_TASK_INVALID — so no FIN for an undispatched slot is processed, and
     // the count-gated consumer never reads entries[] past the fresh count.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -131,6 +131,11 @@ void SchedulerContext::complete_slot_task(
                     SPIN_WAIT_HINT();
                 }
             }
+            // Re-clear for the next reuse of this (core, buf) slot. Done here — on
+            // the hot cache line we just read — instead of on every dispatch, since
+            // only a deferred task (count > 0) ever dirties it. error_code needs no
+            // reset: a non-NONE code aborted the run above.
+            deferred_slab->count = 0;
         }
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -250,7 +250,7 @@ private:
 
     void build_payload(
         PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
-        const AsyncCtx &async_ctx, int32_t block_idx, bool force_gate = false
+        int32_t block_idx, bool force_gate = false
     );
 
     // Batched-dispatch primitives. prepare_* builds the payload and per-core

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -112,8 +112,8 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
-    const AsyncCtx &async_ctx, int32_t block_idx, bool force_gate
+    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
+    bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
     uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
@@ -136,9 +136,7 @@ void SchedulerContext::build_payload(
     }
     dispatch_payload.local_context.s_block_idx = block_idx;
     dispatch_payload.local_context.s_block_num = slot_state.logical_block_num;
-    dispatch_payload.local_context.async_ctx = async_ctx;
-    dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
-    dispatch_payload.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
+    dispatch_payload.local_context.async_ctx.task_token = slot_state.task->task_id;
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
@@ -161,15 +159,7 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    // a5 clears the deferred slab per dispatch (unlike a2a3's init-once path):
-    // AsyncCtx::make wires the slab into the payload, and a stale count from a
-    // prior deferred completion on this (core, buf) would be observed as a live
-    // wait entry.
-    DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][buf_idx];
-    deferred_slab->count = 0;
-    deferred_slab->error_code = PTO2_ERROR_NONE;
-    AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
-    build_payload(payload, slot_state, subslot, async_ctx, block_idx, force_gate);
+    build_payload(payload, slot_state, subslot, block_idx, force_gate);
 
     if (to_pending) {
         core_exec_state.pending_subslot = subslot;


### PR DESCRIPTION
## Summary

- prefill invariant A5 dispatch context pointers and completion metadata during scheduler initialization
- limit the dispatch hot path to task-varying payload fields
- align A5 cold-path initialization and deferred-completion slab reuse with A2/A3
- clear deferred completion counts only after a deferred task has been consumed

Part of #1582.

## Validation

- C++ tests: 66/66 passed
- full A5 TMR simulation: 29 passed, 3 deselected
- single-card A5 PagedAttention Case1 with L2 swimlane level 3: passed in 3/3 runs
- local pre-commit: passed, including clang-format, clang-tidy, and cpplint; pyright skipped as previously agreed

## Performance

Measured on one A5 device with `task-submit --max-time 30 --timeout 30`. The comparison uses scheduler `dispatch` swimlane cycles divided by `tasks_processed`.

PagedAttention Case1:

| Version | Dispatch time per task |
| --- | ---: |
| `upstream/main` baseline | 2.629 us |
| Initial PR revision | 1.476 us |
| Review-aligned revision | 1.463 us |

The review-aligned revision measured 1462.8, 1455.4, and 1492.1 cycles/task (median 1462.8 cycles/task). It retains the original 44% reduction relative to main; the 0.9% change from the initial PR revision is within normal run-to-run variation.

The board CPU_TOPO query returned 65534, so the hardware runs used the same temporary OCCUPY fallback as the original baseline/PR comparison. That fallback was removed before commit and is not included in this PR.