### PR TITLE
Fix: preserve dep-gen tail buffers on the host

### DIFF
--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -48,9 +48,11 @@ inputs to each submit are captured and the graph is reconstructed afterwards.
 - **In-memory drain.** The host `DepGenCollector` (background mgmt
   thread, ProfilerBase machinery shared with PMU / L2 Perf / Tensor
   Dump) drains the ring into a `std::vector<DepGenRecord>` resident on
-  the runner. No `submit_trace.bin` lands on disk — the host already
-  has the records once the run ends, and going through the filesystem
-  would just be extra I/O.
+  the runner. Its host hand-off queue is sized independently from the
+  smaller device ready queue so a stop-time burst of flushed buffers can
+  drain without losing the tail. No `submit_trace.bin` lands on disk —
+  the host already has the records once the run ends, and going through
+  the filesystem would just be extra I/O.
 - **Host replay (dual-pass, self-checking).** After `reconcile_counters()`
   confirms a clean trace (no drops, no leftovers),
   `dep_gen_replay_emit_deps_json` runs every record back through *two*

--- a/docs/dfx/profiling-framework.md
+++ b/docs/dfx/profiling-framework.md
@@ -85,7 +85,8 @@ parameterized on a small per-subsystem trait, and the device side to
               │  Pmu / L2Swimlane / DepGen /      │  Pure static trait (no state)
               │  Dump / Scope modules             │  ─ DataHeader / ReadyEntry / FreeQueue
               └────────────────────────────────┘  ─ kBufferKinds / kReadyQueueSize
-                                                  ─ kHostPoolQueueSize / kHostRecycledQueueSize
+                                                  ─ kHostReadyQueueSize / kHostPoolQueueSize
+                                                  ─ kHostRecycledQueueSize
                                                   ─ resolve_entry / for_each_instance
 
   AICPU device side:
@@ -218,6 +219,7 @@ the required members are:
 | `using DataHeader / ReadyEntry / ReadyBufferInfo / FreeQueue` | Layout types |
 | `kBufferKinds` | Number of buffer kinds inside each recycled shard |
 | `kReadyQueueSize`, `kSlotCount` | AICPU ready queue / free queue depth |
+| `kHostReadyQueueSize` | Optional mgmt-to-collector ready ring depth; defaults to `kReadyQueueSize` |
 | `kHostPoolQueueSize` | Optional host done ring depth |
 | `kHostRecycledQueueSize` | Optional per-kind, per-shard recycled ring depth; defaults to `kHostPoolQueueSize` |
 | `kSubsystemName` | Tag used in framework log lines |

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -153,12 +153,12 @@ struct ProfilerModuleMaxCollectorThreads<Module, std::void_t<decltype(Module::kM
 
 template <typename Module, typename = void>
 struct ProfilerModuleHostQueueCapacity {
-    static constexpr size_t value = 1024;
+    static constexpr size_t value = Module::kReadyQueueSize > 0 ? Module::kReadyQueueSize : 1;
 };
 
 template <typename Module>
-struct ProfilerModuleHostQueueCapacity<Module, std::void_t<decltype(Module::kReadyQueueSize)>> {
-    static constexpr size_t value = Module::kReadyQueueSize > 0 ? Module::kReadyQueueSize : 1;
+struct ProfilerModuleHostQueueCapacity<Module, std::void_t<decltype(Module::kHostReadyQueueSize)>> {
+    static constexpr size_t value = Module::kHostReadyQueueSize > 0 ? Module::kHostReadyQueueSize : 1;
 };
 
 template <typename Module, typename = void>

--- a/src/common/platform/include/host/dep_gen_collector.h
+++ b/src/common/platform/include/host/dep_gen_collector.h
@@ -86,6 +86,7 @@ struct DepGenModule {
     static constexpr int kBufferKinds = 1;
     static constexpr uint32_t kReadyQueueSize = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
     static constexpr uint32_t kHostPoolQueueSize = PLATFORM_MAX_AICPU_THREADS * PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE;
+    static constexpr uint32_t kHostReadyQueueSize = kHostPoolQueueSize;
     static constexpr uint32_t kSlotCount = PLATFORM_DEP_GEN_SLOT_COUNT;
     static constexpr const char *kSubsystemName = "DepGenModule";
     // The orchestrator is the sole device-side producer (dep_gen_collector_aicpu

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -38,6 +38,9 @@
  *   // Constants
  *   static constexpr int      kBufferKinds;    // L2Swimlane=4, Dump=1, PMU=1.
  *   static constexpr uint32_t kReadyQueueSize; // Per-thread ready-queue depth.
+ *   // Optional: mgmt-to-collector host ready ring depth.
+ *   // Defaults to kReadyQueueSize.
+ *   static constexpr uint32_t kHostReadyQueueSize;
  *   // Optional: host-side done ring depth (defaults to 1024).
  *   static constexpr uint32_t kHostPoolQueueSize;
  *   // Optional: shard-local per-kind recycled ring depth.

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -53,6 +53,7 @@ struct SplitCapacityModule {
     static constexpr int kBufferKinds = 1;
     static constexpr int kMaxCollectorThreads = 1;
     static constexpr uint32_t kReadyQueueSize = 2;
+    static constexpr uint32_t kHostReadyQueueSize = 3;
     static constexpr uint32_t kHostPoolQueueSize = 5;
 };
 
@@ -386,13 +387,16 @@ TEST(BufferPoolManagerShardingTest, StartupRecyclePopCanUseAnyShard) {
     EXPECT_EQ(manager.pop_recycled_for_startup(/*kind=*/0), nullptr);
 }
 
-TEST(BufferPoolManagerShardingTest, PoolQueuesUseCapacityIndependentFromReadyQueue) {
+TEST(BufferPoolManagerShardingTest, HostQueuesUseIndependentCapacities) {
     using Manager = profiling_common::BufferPoolManager<SplitCapacityModule>;
 
+    EXPECT_EQ(Manager::kHostQueueCapacity, SplitCapacityModule::kHostReadyQueueSize);
+
     Manager manager;
-    EXPECT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000), 0}, 0));
-    EXPECT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1001), 1}, 0));
-    EXPECT_FALSE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1002), 2}, 0));
+    for (uintptr_t i = 0; i < SplitCapacityModule::kHostReadyQueueSize; i++) {
+        EXPECT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000 + i), static_cast<uint32_t>(i)}, 0)) << i;
+    }
+    EXPECT_FALSE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1999), 99}, 0));
 
     for (uintptr_t i = 0; i < SplitCapacityModule::kHostPoolQueueSize; i++) {
         EXPECT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x2000 + i), 0)) << i;


### PR DESCRIPTION
## Problem

Dep-gen's management-to-collector host ready ring inherited the
device-side `kReadyQueueSize` (8), even though the host buffer-pool
capacity is larger. During the final stop-time drain, a burst of flushed
buffers can fill that host ring. An excess buffer is then retired before
collection, leaving reconciliation incomplete and preventing `deps.json`
from being emitted.

## Fix

- Add an optional `kHostReadyQueueSize` module trait for the host hand-off
  ring. It defaults to `kReadyQueueSize`, preserving existing collector
  behavior.
- Size `DepGenModule`'s host ready ring to `kHostPoolQueueSize`, covering
  the full retained-buffer bound during the final drain.
- Document the trait and extend the buffer-pool unit test to cover
  independent ready, done, and recycled capacities.

This fixes dependency-graph completeness only. Clean swimlane timing is
provided separately by PyPTO's graph/timing two-pass flow, whose timing
pass disables dep-gen. This change does not remove dep-gen timing
perturbation or address cross-rank launch skew.

## Testing

- `python -m pip install --no-build-isolation -e .` — passed.
- `python -m simpler_setup.build_runtimes --platforms a2a3` — passed for
  `host_build_graph` and `tensormap_and_ringbuffer`.
- `ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure`
  — 66/66 passed.
- `pre-commit run --from-ref origin/main --to-ref HEAD` — passed.
- A2A3 four-card integration of the same source diff before rebasing onto
  current `main` (`device=0,2,4,6`, EP=4, TP=4) — the L3 decode run exited
  successfully, and all `rank0..3/{d0,d1}` directories contained
  `deps.json`, L2 swimlane records, and merged swimlanes (8/8 each). This
  validates execution and DFX artifact completeness, not numerical
  correctness.
