### PR TITLE
Add: the Buffer/Tensor wire ABI and owner-side create_buffer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ changing simpler's own internals.
 | [Chip-Level Architecture (L2)](chip-level-arch.md) | Three-program model (host / AICPU / AICore), API layers, handshake |
 | [Hierarchical Level Runtime](hierarchical-level-runtime.md) | The L0–L6 level model and component composition |
 | [Task Flow](task-flow.md) | Callable / TaskArgs / CallConfig pass-through, `IWorker` |
+| [Buffer Memory Model](buffer-abi.md) | How L3+ tasks name data: canonical identity, backend descriptor, strided view |
 | [Orchestrator](orchestrator.md) | DAG submission: TensorMap, Scope, Ring, task state machine |
 | [Scheduler](scheduler.md) | DAG dispatch: wiring / ready / completion queues, dispatch loop |
 | [Worker Manager](worker-manager.md) | Worker pool, THREAD/PROCESS modes, fork + mailbox mechanics |

--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -1,0 +1,306 @@
+# Buffer / Tensor — the L3+ memory model
+
+At L3 and above, tasks name their data with typed, self-describing **buffer
+handles and views**, not raw pointers. This replaces the legacy "raw pointer +
+`child_memory` bool" mechanism with an ABI that carries a canonical identity, a
+backend descriptor, and a strided view — so a buffer can be resolved exactly
+across the L3→L2 (and L4→L3) boundaries without a side table.
+
+This page is the user-facing how-to. The byte layout itself is pinned by the
+`static_assert`s in [`src/common/task_interface/buffer.h`](../src/common/task_interface/buffer.h)
+— sizes, field offsets, and enum values all fail the build if they drift, and
+[`tests/ut/cpp/types/test_buffer.cpp`](../tests/ut/cpp/types/test_buffer.cpp)
+pins them again from the outside.
+
+All three types are that header's C++ structs bound directly, so Python and C++
+name one definition of the layout with no encode step between them. Everything
+that is host-side by nature — the `Buffer` that owns a POSIX shm, the consumer's
+`ImportRegistry` — lives in [`python/simpler/buffer.py`](../python/simpler/buffer.py)
+and composes them.
+
+**No bytes cross that binding in either direction.** You build a `Tensor` from its
+fields and receive one already decoded; turning wire bytes into a `Tensor` happens
+only inside C++, where `validate_tensor` runs on the way out. That is what makes
+the validator a gate rather than a convention — there is no second way in to
+forget it on.
+
+## Three types
+
+| Type | What it is | Where it lives |
+| ---- | ---------- | -------------- |
+| **`Buffer`** | An owned backing (POSIX shm / fork-COW / device malloc) with a canonical identity + lifecycle. Stays with the Worker that created it. | owner side (L3+) |
+| **`Tensor`** | A **self-describing task argument**: the full buffer descriptor embedded + a strided view `(byte_offset, shapes, strides, dtype)`. The wire element of `TaskArgs`. Carries no materialized address. | `simpler.buffer`, foundation-only until the wire flip |
+| **`ChipTensor`** | The materialized POD the device runtime ABI reads (address + strided view). Exists **only** at the L2 device-runtime boundary. | L2 leaf, internal |
+
+**You never build a `ChipTensor`.** Name a `Tensor` over a buffer and submit it;
+the address is resolved on the consuming endpoint, and the C++ orchestration on
+the chip receives the resolved form.
+
+> **Status.** That is the model this page describes, not what the tree does yet.
+> `TaskArgs.add_tensor` still takes a `ChipTensor`, so `Tensor` lives in
+> `simpler.buffer` and is deliberately **not** re-exported from
+> `simpler.task_interface` — a public type whose own submit call rejects it would
+> be worse than no public type. It moves onto that surface in the wire flip that
+> makes `TaskArgs` carry it. The Scope / status section at the end of this page says what else
+> the wire flip brings.
+
+## Why `Tensor` and `ChipTensor` are two types
+
+The two sit on opposite sides of one resolution step. A `Tensor` *cannot* carry an
+address: at submit time none exists — a `POSIX_SHM` backing maps to a different VA
+in every process, and a `DEVICE_MALLOC` one is only valid on its owner chip. A
+`ChipTensor` *must* carry one; it is what the kernel dereferences. Two ways to
+collapse that into a single type were considered and dropped.
+
+### Rejected: merge `Tensor` into `ChipTensor`
+
+Drop `buffer.addr`, add the buffer descriptor, and have the H2D staging step
+rewrite the backend tag and body (and mint a fresh identity for the device copy).
+That is self-consistent, but it charges the device for host-side fields:
+
+- **Device cost.** `sizeof(ChipTensor)` is pinned at **128 B** by
+  `static_assert(… == 128, "ChipTensor must be exactly 2 cache lines (128 bytes)")` and by
+  `PTO2_TASKPAYLOAD_TENSOR_STRIDE`, which the AICPU scheduler strides the payload
+  with. A merged struct is ~192–216 B, taking `PTO2TaskPayload` from 4864 B to
+  6912–7680 B — **+42% to +58% per task slot** — because the payload embeds
+  `ChipTensor tensors[MAX_TENSOR_ARGS]` **by value** in the device task ring.
+- **Zero return for that cost.** Most of what a merge would add has no reader on
+  the far side. The field-by-field split is below.
+
+#### What each type carries, and what the other has no use for
+
+Only the middle block means the same thing in both — the geometry of the view.
+Everything above it answers *"where does this live?"*, everything below it is
+*"what has the L2 runtime decided about it?"*, and neither question is open on
+the other side of materialization.
+
+Both types have a member called `buffer`, and they are not the same thing: on the
+wire it is the `BufferDescriptor` that says how to find the backing, on the device
+it is the resolved `addr` + `size`. That is the whole of what materialization does.
+
+| `Tensor` (144 B, wire) | rel | `ChipTensor` (128 B, device) |
+| ---------------------- | --- | ---------------------------- |
+| `buffer.magic` | ⟂ | — |
+| `buffer.identity` (32 B) | ⟂ | — |
+| `buffer.backend_kind` | ⟂ | — |
+| `buffer.body[32]` + `body_len` | ⟂ | — |
+| `buffer.nbytes` | ≈ | `buffer.size` |
+| `buffer.access` | ⟂ | — |
+| `buffer.owner_worker_path_id` | ⟂ | — |
+| — | ⟂ | `buffer.addr` |
+| `byte_offset` (bytes) | ≈ | `start_offset` (elements) |
+| `shapes[5]` / `strides[5]` / `ndims` / `dtype` | = | `shapes[5]` / `strides[5]` / `ndims` / `dtype` |
+| `buffer.address_space` | = | `address_space` (still spelled `child_memory` until the wire flip) |
+| — | ⟂ | `owner_task_id` |
+| — | ⟂ | `version` |
+| — | ⟂ | `manual_dep` |
+| — | ⟂ | `is_contiguous`, `extent_elem_cache` |
+
+**Dead on the device** (`Tensor`-only): `magic` discriminates untrusted bytes at
+a decode boundary the device does not have. `identity` / `backend_kind` / `body`
+/ `body_len` are the *recipe* for finding the backing — spent once at
+materialization, never consulted again. `access` has no device enforcement point
+(it is checked at submit). `owner_worker_path_id` is diagnostic.
+
+**Meaningless before materialization** (`ChipTensor`-only): `buffer.addr` is the
+resolved address, which by definition does not exist while the argument is still
+crossing processes. `owner_task_id` / `version` / `manual_dep` are L2 OverlapMap
+state — the producing task and its dependency treatment are decided by the chip
+runtime, so an L3 builder has nothing to put there (`make_tensor_strided` fills
+`PTO2TaskId::invalid()`, `0`, `false`). `is_contiguous` and `extent_elem_cache`
+are derived from `shapes`/`strides`, cached for the AICore hot path so it can
+skip cache line 2.
+
+So a merged struct would carry ~70 B that the AICore never reads, in a type whose
+size is pinned at two cache lines precisely because the scheduler walks it per
+task.
+
+> The one row with a plausible future device reader is `identity`: keying the L2
+> OverlapMap by it rather than by `buffer.addr` would make two views of one
+> backing bucket together by construction. That needs 32 B — which fits the
+> existing `_pad_cl2[36]` at `sizeof == 128`, i.e. **without** merging anything
+> else. If it is ever done, the H2D staging step must mint a *new* identity for
+> each staged copy, because the device buffer is a distinct backing from the host
+> one it was copied from.
+
+### Rejected: keep the wire type transport-only, use `ChipTensor` in the L3 orch
+
+This keeps one user-visible type but pays a conversion at every hop: the orch
+builds a `ChipTensor`, the mailbox needs the self-describing form, and the
+consumer needs a `ChipTensor` again. Each conversion has to **rewrite the
+address** — and the sender cannot know the receiver's, so the receiver ends up
+guessing. That is the pre-P1-B mechanism: `_rewrite_blob_host_addrs` rewrote
+addresses by **numeric range** and mis-rewrote device pointers that happened to
+fall inside a registered host range, patched by adding a `child_memory` skip
+whose own comment records the hazard.
+
+### Shipped instead: each named for what it is
+
+Both are called what they are, and by the **same** name in both languages, which
+is what [codestyle rule 13](../.claude/rules/codestyle.md) requires of a public
+type. The L3+ wire type is `Tensor` — `simpler.task_interface.Tensor` in Python,
+the global `Tensor` of `src/common/task_interface/buffer.h` in C++. The device
+POD is `ChipTensor` in both, from `src/common/task_interface/tensor.h`.
+
+Rule 13 is what makes the plain names available: the device POD held the global
+`Tensor` name until #1681 moved it to `ChipTensor`, prefixing it for the chip
+context it belongs to. Neither type needs a namespace to disambiguate it, and
+a Python module that imports the wrong one now names a type that exists and
+behaves differently — so the mismatch surfaces where it is used.
+
+**So the split costs the user nothing to know.** You name a `Tensor`, submit it,
+and the chip's C++ orchestration receives it resolved; the type name does not
+even appear in your code — you write `buffer.tensor(shapes, dtype)` and
+`args.add_tensor(t, tag)`. Resolving the address in between is the framework's
+job, and keeping the two forms as separate types is what makes that boundary a
+type change rather than a silently wrong address.
+
+## Allocating buffers
+
+```python
+h  = worker.create_buffer(nbytes)                 # kind3: explicit shared host buffer (POSIX shm)
+h  = worker.alloc_shared_tensor((M, N), dtype)    # kind3: shape-sized create_buffer
+# inside an orch fn, for device (chip-private) memory:
+d  = orch.alloc_child_tensor(worker, (M, N), dtype)  # kind4: DEVICE_MALLOC on that chip
+```
+
+`create_buffer` returns a `Buffer` backed by a POSIX shm the consumer maps
+lazily on first receipt of a tensor over it (map-once, by identity);
+`alloc_shared_tensor` returns a runtime-managed intermediate over a FORK_SHM ring
+VA. `alloc_child_tensor` allocates device memory on a specific next-level worker
+and wraps the pointer; its `.base` is the device pointer (the `orch.copy_to`
+destination), and a tensor over it must be dispatched only to that worker.
+
+## Naming a view
+
+`buffer.tensor(...)` names a view over the backing:
+
+```python
+v = h.tensor(shapes=(M, N), dtype)                        # contiguous (row-major strides)
+v = h.tensor(shapes=(N, M), dtype, strides=(1, M))        # transposed
+v = h.tensor(shapes=(M, K), dtype, byte_offset=off)       # sub-region
+```
+
+`strides` are **element** strides and are strictly > 0 — broadcast (stride 0) and
+negative step are unsupported, and a singleton dimension's stride is never
+normalized away. `byte_offset` is a **byte** offset and must be a multiple of the
+dtype size.
+
+## Submitting a task
+
+```python
+ta = TaskArgs()
+ta.add_tensor(a_h.tensor((SIZE,), DataType.FLOAT32), TensorArgType.INPUT)
+ta.add_tensor(out_h.tensor((SIZE,), DataType.FLOAT32), TensorArgType.OUTPUT_EXISTING)
+orch.submit_next_level(chip_handle, ta, cfg, worker=0)
+```
+
+`TaskArgs` carries `Tensor`s. Tags drive dependency inference, which keys on
+the **canonical identity** (buffer granularity, the successor of the former
+buffer-address key); byte-range overlap between same-buffer views is refined by
+the L2 OverlapMap on the materialized tensors, not by the L3 key.
+
+## Reading and writing data — torch only at the boundaries
+
+The orch fn is a pure DAG builder: computing on data there would be invisible to
+dependency inference. So **torch is used only outside `run()`** (fill inputs,
+read outputs) or **inside a Python sub-worker** (a compute leaf):
+
+```python
+h = worker.create_buffer(n * 4)
+torch.frombuffer(h.shm.buf, dtype=torch.float32, count=n).fill_(5.0)  # before run()
+worker.run(my_orch, ...)                                             # orch names tensors only
+result = torch.frombuffer(out_h.shm.buf, dtype=torch.float32, count=n)  # after run()
+```
+
+## How a tensor reaches its consumer (three-way split)
+
+A `Tensor` on the wire is materialized differently by each consumer:
+
+| Consumer | What it does |
+| -------- | ------------ |
+| **Chip leaf (L2 runtime)** | Materialize each one to a `ChipTensor` (map-once, keyed by identity), including **strided** views; hand the POD blob to `run_from_blob`. |
+| **Python sub-worker** (compute) | Map each one into a `MappedArg`; the callable computes with `torch.frombuffer(arg.buffer, ...)`. No `ChipTensor`. |
+| **Nested L4→L3 orch** (forwarding) | **Re-export** each backing to a descriptor `H'` that keeps the source's canonical identity — no pass-through, no map on the forwarding hop. |
+
+**Re-export (no pass-through).** An upper-level tensor is forwarded on receipt as a
+descriptor `H'` that keeps the source's **canonical identity unchanged** (invariant
+across every edge — an L4 buffer forwarded L4→L3→L2 carries one identity at all
+three layers; only role / materialized VA / view change), per-backing and without
+mapping. A downstream compute leaf maps lazily, so pure forwarding carries no map
+cost. Dependency inference keys on the invariant identity, so an alias /
+retain-release does not split across layers.
+
+## Canonical identity
+
+Every backing carries a fixed-length 32-byte identity — an opaque per-incarnation
+`owner_instance_id`, a `buffer_id` unique within that incarnation, and a `generation` that starts at
+1 and increments whenever a `buffer_id` slot is reused (so a stale descriptor for a recycled slot is
+rejected rather than silently resolving). It is **invariant across every edge**: an L4 buffer
+forwarded L4→L3→L2 carries one identity at all three layers.
+
+Identity is what dependency inference and the map-once import cache key on — never a materialized
+address, which means nothing different in another process.
+
+Nothing inside the identity bounds a read: it has no length field. Hashing and comparison are
+therefore in-bounds for any bytes that arrive, structurally rather than by validation. The owning
+worker's tree path is deliberately **not** part of it — a path is reused across restarts and
+contributes no uniqueness, so it is interned to a diagnostic `owner_worker_path_id` whose table lives
+only in the owning process. An id another process minted renders as `<path#N>`; nothing routes,
+gates, or keys on it.
+
+## Backends
+
+| Backend | Materializes to | Used for |
+| ------- | --------------- | -------- |
+| `POSIX_SHM` | a named shm mapped into the consumer | `create_buffer` / `alloc_shared_tensor` |
+| `FORK_SHM` | the same VA, no map | a pre-fork `MAP_SHARED` host buffer (e.g. `share_memory_()`), writable from the child |
+| `FORK_COW` | the same VA, no map | a pre-fork plain host buffer: copy-on-write, so **READ only** |
+| `VMM_WINDOW` | the device VA of the window carved by `allocate_domain`, no map | communication-domain window / buffer |
+| `DEVICE_MALLOC` | the device pointer, no map (chip-local) | `alloc_child_tensor` |
+| `REMOTE_SIDECAR` | (P2) resolved via the remote transport | an arg to a remote L3; the descriptor rides in the sidecar |
+
+## What a submit checks
+
+Naming an argument is not enough on its own — two things are verified where the
+values are final, at submit:
+
+- **`access ⊆ granted`.** A tag may only request what the backing grants: `INPUT`
+  needs READ, `OUTPUT_EXISTING` needs WRITE, `INOUT` needs READWRITE. This is
+  re-checked at submit rather than trusted from `add_tensor`, because a tag stays
+  mutable afterwards. It is what stops a plain (copy-on-write) tensor from being
+  named as an output and then silently losing every write in the child.
+- **No overlapping writes within one task.** Two arguments of one task that name
+  intersecting bytes of the same backing are rejected: they belong to one node,
+  so there is no order between them to express, and a device-staged copy of a
+  host backing does not even alias on the device for the L2 overlap map to
+  notice. Disjoint slices of one buffer stay legal — that is what `byte_offset`
+  is for.
+
+Group members are not compared against each other: a group is one node, and
+naming one buffer as every member's output is how it publishes a single
+completion token for a downstream task to depend on.
+
+## Scope / status
+
+This page describes the memory model end to end. What the tree has today is the
+ABI itself — the three types, the canonical identity, the shared validator — plus
+`create_buffer` and the owner/consumer registries. **The dispatch wire is not
+connected yet**: `TaskArgs` still carries the device POD, so `buffer.tensor(...)`
+has no consumer, the other allocators (`alloc_shared_tensor`,
+`alloc_child_tensor`) do not exist, and the submit-time checks above are not
+reachable. Those land with the wire flip, which is what every section from
+"Submitting a task" onward describes.
+
+**There is no second blob format.** A `Tensor` travels in the TaskArgs mailbox
+blob that `write_blob` / `read_blob` already implement in
+[`task_args.h`](../src/common/task_interface/task_args.h); the wire flip swaps
+that blob's element from `ChipTensor` to `Tensor` and updates `TaskArgsView` with
+it. `ChipTensor` then survives only in `ChipStorageTaskArgs`, the POD
+`ChipWorker` consumes — an L2 worker materializes into it inside `run` before
+calling down.
+
+Single-machine (host + device) L3→L2 and L4→L3→L2 dispatch is implemented and
+verified in `a2a3sim` and onboard `a2a3` on that branch. The remote **receive**
+side and the buffer lifecycle robustness (`release_buffer`, in-flight retain /
+deferred-free) are later phases (P2).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Chip-Level Architecture: chip-level-arch.md
       - Hierarchical Level Runtime: hierarchical-level-runtime.md
       - Task Flow: task-flow.md
+      - Buffer Memory Model: buffer-abi.md
       - Orchestrator: orchestrator.md
       - Scheduler: scheduler.md
       - A5 AICPU core selection: design/a5-fg-pg-core-selection.en.md

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <cstdint>
 #include <exception>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -50,6 +51,7 @@
 #include <vector>
 
 #include "arg_direction.h"
+#include "buffer.h"
 #include "callable.h"
 #include "callable_protocol.h"
 #include "chip_worker.h"
@@ -885,6 +887,23 @@ void append_cleanup_error(std::string &cleanup_error, const std::string &message
     cleanup_error += message;
 }
 
+// The int wire value of a dtype given either a DataType enumerator or its int value. The nanobind
+// DataType enum is not arithmetic, so a caller holding one has only `.value`; accept both forms.
+uint8_t datatype_wire_value(nb::object dtype) {
+    if (nb::hasattr(dtype, "value")) dtype = dtype.attr("value");
+    return nb::cast<uint8_t>(dtype);
+}
+
+// The leading `ndims` entries of a wire shapes[] / strides[] array as a Python tuple. The trailing
+// entries are unused padding, so exposing them would invent dimensions the tensor does not have.
+nb::tuple dims_tuple(const uint32_t *dims, uint32_t ndims) {
+    if (ndims > static_cast<uint32_t>(MAX_TENSOR_DIMS)) ndims = static_cast<uint32_t>(MAX_TENSOR_DIMS);
+    nb::list out;
+    for (uint32_t i = 0; i < ndims; ++i)
+        out.append(dims[i]);
+    return nb::tuple(out);
+}
+
 }  // namespace
 
 // ============================================================================
@@ -896,7 +915,7 @@ void append_cleanup_error(std::string &cleanup_error, const std::string &message
 #endif
 
 NB_MODULE(_task_interface, m) {
-    m.doc() = "Nanobind bindings for task_interface (DataType, ChipTensor, TaskArgs variants)";
+    m.doc() = "Nanobind bindings for task_interface (DataType, Buffer/Tensor wire ABI, ChipTensor, TaskArgs variants)";
 
     // Source commit this extension was compiled from; "" when git was
     // unavailable at build time. simpler.task_interface compares it against the
@@ -941,10 +960,266 @@ NB_MODULE(_task_interface, m) {
     m.attr("RUNTIME_ENV_RING_COUNT") = RUNTIME_ENV_RING_COUNT;
     // Byte size of a ChipTensor and the offset of its child_memory flag within it.
     // A task-args blob stores ChipTensors as a raw memcpy array, so a Python-side
-    // blob walker locates tensor i's fields at i * TENSOR_STRIDE_BYTES without
+    // blob walker locates tensor i's fields at i * CHIP_TENSOR_STRIDE_BYTES without
     // reimplementing the struct layout.
-    m.attr("TENSOR_STRIDE_BYTES") = static_cast<int>(sizeof(ChipTensor));
-    m.attr("TENSOR_CHILD_MEMORY_OFFSET") = static_cast<int>(offsetof(ChipTensor, child_memory));
+    m.attr("CHIP_TENSOR_STRIDE_BYTES") = static_cast<int>(sizeof(ChipTensor));
+    m.attr("CHIP_TENSOR_CHILD_MEMORY_OFFSET") = static_cast<int>(offsetof(ChipTensor, child_memory));
+
+    // Width of the opaque per-incarnation nonce, so the owner can draw one of the right size.
+    // The struct sizes stay unexported: no Python path turns these types into bytes or back, so a
+    // byte count here would have no reader — the layout is pinned by buffer.h's static_asserts.
+    m.attr("OWNER_INSTANCE_ID_BYTES") = static_cast<int>(OWNER_INSTANCE_ID_BYTES);
+
+    // --- Buffer ABI enums ---
+    // nb::is_arithmetic makes these IntEnums, so a wire value and an enumerator compare and
+    // int()-convert interchangeably — the descriptor stores them as raw u8.
+    nb::enum_<AddressSpace>(m, "AddressSpace", nb::is_arithmetic())
+        .value("HOST", AddressSpace::HOST)
+        .value("DEVICE", AddressSpace::DEVICE);
+
+    nb::enum_<AccessMode>(m, "AccessMode", nb::is_arithmetic())
+        .value("READ", AccessMode::READ)
+        .value("WRITE", AccessMode::WRITE)
+        .value("READWRITE", AccessMode::READWRITE);
+
+    nb::enum_<BackendKind>(m, "BackendKind", nb::is_arithmetic())
+        .value("FORK_SHM", BackendKind::FORK_SHM)
+        .value("POSIX_SHM", BackendKind::POSIX_SHM)
+        .value("VMM_WINDOW", BackendKind::VMM_WINDOW)
+        .value("REMOTE_SIDECAR", BackendKind::REMOTE_SIDECAR)
+        .value("DEVICE_MALLOC", BackendKind::DEVICE_MALLOC)
+        .value("FORK_COW", BackendKind::FORK_COW);
+
+    // --- CanonicalIdentity ---
+    // Equality and hashing fold exactly the three meaningful fields, so a decode with dirty wire
+    // padding keys identically to a clean one — two views of a backing never split across buckets.
+    // There is deliberately no `pack()`: the only correct key for this type is the value itself, and
+    // exposing its bytes is what once let a registry key on padding and split one backing in two.
+    nb::class_<CanonicalIdentity>(m, "CanonicalIdentity")
+        .def(
+            "__init__",
+            [](CanonicalIdentity *self, nb::bytes owner_instance_id, uint64_t buffer_id, uint32_t generation) {
+                if (owner_instance_id.size() != OWNER_INSTANCE_ID_BYTES) {
+                    throw std::invalid_argument(
+                        "owner_instance_id must be " + std::to_string(OWNER_INSTANCE_ID_BYTES) + " bytes, got " +
+                        std::to_string(owner_instance_id.size())
+                    );
+                }
+                new (self) CanonicalIdentity{};
+                std::memcpy(self->owner_instance_id, owner_instance_id.c_str(), OWNER_INSTANCE_ID_BYTES);
+                self->buffer_id = buffer_id;
+                self->generation = generation;
+            },
+            nb::arg("owner_instance_id"), nb::arg("buffer_id"), nb::arg("generation") = 1
+        )
+
+        .def_prop_ro(
+            "owner_instance_id",
+            [](const CanonicalIdentity &self) {
+                return nb::bytes(reinterpret_cast<const char *>(self.owner_instance_id), OWNER_INSTANCE_ID_BYTES);
+            },
+            "The opaque per-incarnation nonce (bytewise-compared, no integer meaning)."
+        )
+        .def_ro("buffer_id", &CanonicalIdentity::buffer_id)
+        .def_ro("generation", &CanonicalIdentity::generation)
+
+        .def(
+            "__eq__",
+            [](const CanonicalIdentity &a, const CanonicalIdentity &b) {
+                return a == b;
+            }
+        )
+        .def(
+            "__ne__",
+            [](const CanonicalIdentity &a, const CanonicalIdentity &b) {
+                return a != b;
+            }
+        )
+        .def(
+            "__hash__",
+            [](const CanonicalIdentity &self) {
+                return CanonicalIdentityHash{}(self);
+            }
+        )
+        .def("__repr__", [](const CanonicalIdentity &self) -> std::string {
+            std::ostringstream os;
+            os << "CanonicalIdentity(owner_instance_id=0x" << std::hex;
+            for (uint32_t i = 0; i < OWNER_INSTANCE_ID_BYTES; ++i) {
+                os << std::setw(2) << std::setfill('0') << static_cast<int>(self.owner_instance_id[i]);
+            }
+            os << std::dec << ", buffer_id=" << self.buffer_id << ", generation=" << self.generation << ")";
+            return os.str();
+        });
+
+    // --- BufferDescriptor ---
+    // Construction runs validate_buffer_descriptor, so an unsupported address_space x backend_kind
+    // or an over-long backend body is refused before the descriptor can reach a Tensor or the wire.
+    nb::class_<BufferDescriptor>(m, "BufferDescriptor")
+        .def(
+            "__init__",
+            [](BufferDescriptor *self, const CanonicalIdentity &identity, AddressSpace address_space, AccessMode access,
+               BackendKind backend_kind, uint64_t nbytes, nb::bytes body, uint32_t owner_worker_path_id) {
+                if (body.size() > DESC_MAX_BYTES) {
+                    throw std::invalid_argument(
+                        "backend body exceeds DESC_MAX_BYTES (" + std::to_string(DESC_MAX_BYTES) + "), got " +
+                        std::to_string(body.size())
+                    );
+                }
+                new (self) BufferDescriptor{};
+                self->magic = BUFFER_DESCRIPTOR_MAGIC;
+                self->address_space = static_cast<uint8_t>(address_space);
+                self->access = static_cast<uint8_t>(access);
+                self->backend_kind = static_cast<uint8_t>(backend_kind);
+                self->identity = identity;
+                self->nbytes = nbytes;
+                self->owner_worker_path_id = owner_worker_path_id;
+                self->body_len = static_cast<uint16_t>(body.size());
+                std::memcpy(self->body, body.c_str(), body.size());
+                validate_buffer_descriptor(*self);
+            },
+            nb::arg("identity"), nb::arg("address_space"), nb::arg("access"), nb::arg("backend_kind"),
+            nb::arg("nbytes"), nb::arg("body") = nb::bytes(""), nb::arg("owner_worker_path_id") = 0
+        )
+
+        .def_ro("identity", &BufferDescriptor::identity)
+        .def_prop_ro(
+            "address_space",
+            [](const BufferDescriptor &self) {
+                return static_cast<AddressSpace>(self.address_space);
+            }
+        )
+        .def_prop_ro(
+            "access",
+            [](const BufferDescriptor &self) {
+                return static_cast<AccessMode>(self.access);
+            }
+        )
+        .def_prop_ro(
+            "backend_kind",
+            [](const BufferDescriptor &self) {
+                return static_cast<BackendKind>(self.backend_kind);
+            }
+        )
+        .def_ro("nbytes", &BufferDescriptor::nbytes)
+        .def_ro("owner_worker_path_id", &BufferDescriptor::owner_worker_path_id)
+        .def_prop_ro(
+            "body",
+            [](const BufferDescriptor &self) {
+                return nb::bytes(self.body, self.body_len);
+            },
+            "The per-backend materialization payload (shm name, base VA, ...), body_len bytes."
+        )
+
+        .def(
+            "__eq__",
+            [](const BufferDescriptor &a, const BufferDescriptor &b) {
+                return a == b;
+            }
+        )
+        .def(
+            "__ne__",
+            [](const BufferDescriptor &a, const BufferDescriptor &b) {
+                return a != b;
+            }
+        )
+        .def("__repr__", [](const BufferDescriptor &self) -> std::string {
+            std::ostringstream os;
+            os << "BufferDescriptor(buffer_id=" << self.identity.buffer_id
+               << ", generation=" << self.identity.generation << ", address_space=" << int(self.address_space)
+               << ", access=" << int(self.access) << ", backend_kind=" << int(self.backend_kind)
+               << ", nbytes=" << self.nbytes << ", body_len=" << self.body_len << ")";
+            return os.str();
+        });
+
+    // --- Tensor ---
+    // The L3+ task argument: a strided view over a buffer, carrying that buffer's descriptor whole
+    // and no address. Construction runs validate_tensor, the same gate blob decode runs, so a view
+    // that does not fit its backing cannot be built in the first place.
+    //
+    // No bytes cross this binding in either direction. Python builds a Tensor from its fields and
+    // receives one already decoded; turning mailbox bytes into a Tensor is task_args.h's job, and
+    // keeping that the only decode path is what makes validate_tensor a gate rather than a habit.
+    nb::class_<Tensor>(m, "Tensor")
+        .def(
+            "__init__",
+            [](Tensor *self, const BufferDescriptor &buffer, uint64_t byte_offset, nb::sequence shapes,
+               nb::sequence strides, nb::object dtype) {
+                const size_t ndims = nb::len(shapes);
+                if (ndims != nb::len(strides)) {
+                    throw std::invalid_argument("Tensor shapes and strides must have equal length");
+                }
+                if (ndims == 0 || ndims > static_cast<size_t>(MAX_TENSOR_DIMS)) {
+                    throw std::invalid_argument(
+                        "Tensor ndims must be in [1, " + std::to_string(MAX_TENSOR_DIMS) + "], got " +
+                        std::to_string(ndims)
+                    );
+                }
+                new (self) Tensor{};
+                self->buffer = buffer;
+                self->byte_offset = byte_offset;
+                self->ndims = static_cast<uint32_t>(ndims);
+                for (size_t i = 0; i < ndims; ++i) {
+                    self->shapes[i] = nb::cast<uint32_t>(shapes[i]);
+                    self->strides[i] = nb::cast<uint32_t>(strides[i]);
+                }
+                self->dtype = static_cast<DataType>(datatype_wire_value(dtype));
+                validate_tensor(*self);
+            },
+            nb::arg("buffer"), nb::arg("byte_offset"), nb::arg("shapes"), nb::arg("strides"), nb::arg("dtype")
+        )
+
+        .def_ro("buffer", &Tensor::buffer)
+        .def_ro("byte_offset", &Tensor::byte_offset)
+        .def_ro("ndims", &Tensor::ndims)
+        .def_prop_ro(
+            "shapes",
+            [](const Tensor &self) {
+                return dims_tuple(self.shapes, self.ndims);
+            }
+        )
+        .def_prop_ro(
+            "strides",
+            [](const Tensor &self) {
+                return dims_tuple(self.strides, self.ndims);
+            }
+        )
+        .def_prop_ro(
+            "dtype",
+            [](const Tensor &self) {
+                return static_cast<int>(self.dtype);
+            },
+            "The dtype's int wire value (a DataType enumerator's .value)."
+        )
+
+        .def(
+            "__eq__",
+            [](const Tensor &a, const Tensor &b) {
+                if (!(a.buffer == b.buffer) || a.byte_offset != b.byte_offset || a.ndims != b.ndims ||
+                    a.dtype != b.dtype) {
+                    return false;
+                }
+                for (uint32_t i = 0; i < a.ndims; ++i) {
+                    if (a.shapes[i] != b.shapes[i] || a.strides[i] != b.strides[i]) return false;
+                }
+                return true;
+            }
+        )
+        .def("__repr__", [](const Tensor &self) -> std::string {
+            std::ostringstream os;
+            os << "Tensor(buffer_id=" << self.buffer.identity.buffer_id << ", byte_offset=" << self.byte_offset
+               << ", shapes=(";
+            for (uint32_t i = 0; i < self.ndims; ++i) {
+                if (i) os << ", ";
+                os << self.shapes[i];
+            }
+            os << "), strides=(";
+            for (uint32_t i = 0; i < self.ndims; ++i) {
+                if (i) os << ", ";
+                os << self.strides[i];
+            }
+            os << "), dtype=" << get_dtype_name(self.dtype) << ")";
+            return os.str();
+        });
 
     // --- ChipTensor ---
     // The unified strided tensor descriptor. Constructed contiguous via make()

--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -1,0 +1,480 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Owner/consumer side of the Buffer ABI.
+
+The three wire types — ``CanonicalIdentity``, ``BufferDescriptor`` and ``Tensor`` — are the C++
+structs of ``buffer.h`` bound directly, so there is one definition of the layout and one validator
+(``validate_tensor``) behind every boundary that builds or decodes one. This module re-exports them
+and adds what is inherently host-side: ``Buffer``, which owns a POSIX shm, the constructors that wrap
+a backing as one, and ``ImportRegistry``, the consumer's map-once cache. Transporting a ``Tensor``
+is the TaskArgs mailbox blob's job and lives in ``task_args.h``, not here.
+
+``CanonicalIdentity`` is fixed-length (opaque ``owner_instance_id`` + ``buffer_id`` + ``generation``)
+so hashing and comparison cannot read past it whatever arrives on the wire. The owning worker's tree
+path is **not** part of the identity: it is interned to a diagnostic ``owner_worker_path_id`` whose
+side table lives only in the owning process.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from dataclasses import dataclass
+from multiprocessing.shared_memory import SharedMemory
+from typing import Any
+
+from _task_interface import (  # pyright: ignore[reportMissingImports]
+    OWNER_INSTANCE_ID_BYTES,
+    AccessMode,
+    AddressSpace,
+    BackendKind,
+    BufferDescriptor,
+    CanonicalIdentity,
+    DataType,
+    Tensor,
+)
+
+__all__ = [
+    "AccessMode",
+    "AddressSpace",
+    "BackendKind",
+    "Buffer",
+    "BufferDescriptor",
+    "CanonicalIdentity",
+    "ImportRegistry",
+    "ImportedBuffer",
+    "Tensor",
+    "create_host_shared_buffer",
+    "host_ptr_nbytes",
+    "intern_worker_path",
+    "mint_owner_instance_id",
+    "re_export",
+    "remote_sidecar_tensor",
+    "worker_path_for_id",
+    "wrap_device_malloc",
+    "wrap_fork_inherited",
+    "wrap_vmm_window",
+]
+
+
+# Owner-side residency for the diagnostic worker path. Ids are process-local and meaningful only in
+# the owning process: a consumer that cannot resolve one renders it as "<path#N>". Nothing routes,
+# gates or keys on a path, so an unresolvable id is never an error. Id 0 means "no path".
+_PATH_BY_ID: dict[int, str] = {0: ""}
+_ID_BY_PATH: dict[str, int] = {"": 0}
+
+
+def intern_worker_path(path: str) -> int:
+    """The diagnostic id for ``path`` in this process, assigning one on first sight."""
+    pid = _ID_BY_PATH.get(path)
+    if pid is None:
+        pid = len(_ID_BY_PATH)
+        _ID_BY_PATH[path] = pid
+        _PATH_BY_ID[pid] = path
+    return pid
+
+
+def worker_path_for_id(path_id: int) -> str:
+    """``path_id`` rendered for humans; an id minted in another process has no local text."""
+    return _PATH_BY_ID.get(int(path_id), f"<path#{int(path_id)}>")
+
+
+# `owner_worker_path` is resolved through this module's intern table, which is process-local, so it
+# hangs off the bound descriptor here rather than in the binding.
+BufferDescriptor.owner_worker_path = property(
+    lambda self: worker_path_for_id(self.owner_worker_path_id),
+    doc="The owning worker's tree path, for diagnostics only; ``<path#N>`` when minted elsewhere.",
+)
+
+
+def _row_major_strides(shapes: tuple[int, ...]) -> tuple[int, ...]:
+    """Contiguous (row-major) element strides for ``shapes``: strides[i] = prod(shapes[i+1:])."""
+    strides = [1] * len(shapes)
+    for i in range(len(shapes) - 2, -1, -1):
+        strides[i] = strides[i + 1] * shapes[i + 1]
+    return tuple(strides)
+
+
+def mint_owner_instance_id() -> bytes:
+    """A fresh opaque nonce, unique per owner incarnation (defends identity against ABA).
+
+    Must stay a full-width random draw. It is the only thing separating two Workers' buffer_id spaces,
+    so a structured value (timestamp/pid) would hand the same identity to two Workers constructed in
+    one process within one second — a routine pattern (an L4 and its L3 built back to back).
+    """
+    return os.urandom(OWNER_INSTANCE_ID_BYTES)
+
+
+def _shm_base_addr(shm: SharedMemory) -> int:
+    """Mapped base address of ``shm``; valid until ``shm.close()``."""
+    view = shm.buf
+    assert view is not None
+    exporter = ctypes.c_char.from_buffer(view)
+    addr = ctypes.addressof(exporter)
+    del exporter
+    return addr
+
+
+@dataclass
+class Buffer:
+    """Owner-side registry object for one shared backing; owns the POSIX shm that backs it."""
+
+    identity: CanonicalIdentity
+    address_space: AddressSpace
+    access: AccessMode
+    backend_kind: BackendKind
+    nbytes: int
+    body: bytes = b""
+    owner_worker_path_id: int = 0
+    shm: SharedMemory | None = None
+    base: int = 0
+    # Owner-side only, never serialized into the descriptor: which next-level worker a DEVICE_MALLOC
+    # backing lives on (0 for a host backing or an L2 own-device malloc). The device-pointer provenance
+    # guard and free/copy key on (owner_worker_id, base).
+    owner_worker_id: int = 0
+
+    def to_descriptor(self) -> BufferDescriptor:
+        """The wire descriptor for this backing — what a consumer needs to resolve it."""
+        return BufferDescriptor(
+            identity=self.identity,
+            address_space=self.address_space,
+            owner_worker_path_id=self.owner_worker_path_id,
+            access=self.access,
+            backend_kind=self.backend_kind,
+            nbytes=self.nbytes,
+            body=self.body,
+        )
+
+    def tensor(
+        self,
+        shapes: tuple[int, ...],
+        dtype: int | DataType,
+        strides: tuple[int, ...] | None = None,
+        byte_offset: int = 0,
+    ) -> Tensor:
+        """A self-describing ``Tensor`` viewing this buffer: embeds the full descriptor + the view.
+
+        ``strides`` default to contiguous (row-major) — ``buffer.tensor(shape, dtype)`` names the
+        whole buffer as a contiguous view; pass explicit element strides for a strided view.
+        ``byte_offset`` must be a multiple of the dtype size (checked at materialization).
+        ``dtype`` accepts a ``DataType`` enum or its int value.
+        """
+        shapes = tuple(shapes)
+        strides = _row_major_strides(shapes) if strides is None else tuple(strides)
+        return Tensor(
+            buffer=self.to_descriptor(),
+            byte_offset=byte_offset,
+            shapes=shapes,
+            strides=strides,
+            dtype=dtype,
+        )
+
+    def close(self) -> None:
+        """Release the backing. The owner unlinks it, so a later consumer map fails rather than
+        resolving a name whose bytes are gone. Idempotent."""
+        if self.shm is not None:
+            self.shm.close()
+            self.shm.unlink()
+            self.shm = None
+
+
+def create_host_shared_buffer(
+    nbytes: int,
+    owner_instance_id: bytes,
+    buffer_id: int,
+    owner_worker_path: str = "",
+    generation: int = 1,
+    access: AccessMode = AccessMode.READWRITE,
+) -> Buffer:
+    """Allocate a POSIX-shm host backing and wrap it as an owner ``Buffer`` (backend POSIX_SHM).
+
+    The backend body is the shm name (UTF-8); the consumer maps it by name in ``ImportRegistry``.
+    """
+    if nbytes <= 0:
+        raise ValueError(f"create_host_shared_buffer: nbytes must be positive, got {nbytes}")
+    shm = SharedMemory(create=True, size=nbytes)
+    identity = CanonicalIdentity(owner_instance_id, buffer_id, generation)
+    return Buffer(
+        identity=identity,
+        owner_worker_path_id=intern_worker_path(owner_worker_path),
+        address_space=AddressSpace.HOST,
+        access=access,
+        backend_kind=BackendKind.POSIX_SHM,
+        nbytes=nbytes,
+        body=shm.name.encode("utf-8"),
+        shm=shm,
+        base=_shm_base_addr(shm),
+    )
+
+
+def re_export(source: BufferDescriptor) -> Buffer:
+    """Re-export a received buffer descriptor for forwarding — identity **invariant**, no mapping.
+
+    Canonical identity is invariant across every edge (frozen model §5/§8): the re-exported ``H'``
+    keeps the SOURCE ``(owner_instance_id, buffer_id, generation)`` and the SAME
+    backing (backend_kind / body / nbytes / address_space / access) as ``source`` — an
+    L4-owned buffer forwarded L4→L3→L2 carries one identity at all three layers. Only the mapping is
+    stripped: ``base=0``, ``shm=None`` (no mmap on the forwarding hop); a downstream compute leaf
+    materializes lazily. Dependency inference keys on the (invariant) identity, so an alias /
+    retain-release does not split across layers. Re-export is per-backing (memoize by identity), so
+    pure forwarding carries no per-tensor map cost.
+    """
+    return Buffer(
+        identity=source.identity,
+        owner_worker_path_id=source.owner_worker_path_id,
+        address_space=source.address_space,
+        access=source.access,
+        backend_kind=source.backend_kind,
+        nbytes=source.nbytes,
+        body=source.body,
+        shm=None,
+        base=0,
+    )
+
+
+def remote_sidecar_tensor(
+    shapes: tuple[int, ...],
+    dtype: int,
+    nbytes: int,
+    owner_worker_id: int,
+    buffer_id: int,
+    generation: int,
+    address_space: AddressSpace,
+) -> Tensor:
+    """Build a ``REMOTE_SIDECAR`` ``Tensor`` for a task arg destined for a remote worker.
+
+    An arg passed L4→remote-L3 cannot be materialized from a local backing — the data lives on another
+    machine and travels via the remote transport. Its descriptor therefore carries ``backend_kind =
+    REMOTE_SIDECAR`` (a consumer decode-rejects a local materialize; the authoritative remote
+    descriptor rides in the per-task RemoteTaskArgsSidecar). The identity encodes the remote buffer
+    (``owner_worker_id`` folded into the opaque nonce, plus ``buffer_id`` / ``generation``) so
+    dependency inference and routing stay stable across the hop.
+    """
+    oid = int(owner_worker_id).to_bytes(OWNER_INSTANCE_ID_BYTES, "little")
+    # A HOST_INLINE placeholder has no backing and so no generation of its own; 0 is the reserved
+    # "uninitialized" value a decoder rejects, so the placeholder carries the initial generation.
+    identity = CanonicalIdentity(oid, buffer_id, int(generation) or 1)
+    descriptor = BufferDescriptor(
+        identity=identity,
+        owner_worker_path_id=intern_worker_path(f"remote/{owner_worker_id}"),
+        address_space=address_space,
+        access=AccessMode.READWRITE,
+        backend_kind=BackendKind.REMOTE_SIDECAR,
+        nbytes=nbytes,
+        body=b"",
+    )
+    shapes = tuple(shapes)
+    return Tensor(
+        buffer=descriptor,
+        byte_offset=0,
+        shapes=shapes,
+        strides=_row_major_strides(shapes),
+        dtype=int(dtype),
+    )
+
+
+def wrap_fork_inherited(
+    data_ptr: int,
+    nbytes: int,
+    owner_instance_id: bytes,
+    buffer_id: int,
+    owner_worker_path: str = "",
+    generation: int = 1,
+    access: AccessMode = AccessMode.READ,
+) -> Buffer:
+    """Wrap a pre-fork, fork-inherited host allocation as a zero-copy ``Buffer``.
+
+    Memory allocated before the children were forked is present in every child at the *same* virtual
+    address; the backend body is that base VA (u64 LE) and the consumer materializes to the same VA
+    with no mapping and no copy. The backend tag follows the mmap the caller actually has, which is
+    what ``access`` states:
+
+    * ``MAP_SHARED`` (e.g. a ``torch.Tensor.share_memory_()``) — a child's writes land in the pages
+      the parent reads, so it can serve as an OUTPUT. Pass ``access=READWRITE``; tagged FORK_SHM.
+    * plain ``MAP_PRIVATE`` — copy-on-write: a child's first write splits the page into a private
+      copy the parent never sees. Read-only, the default; tagged FORK_COW so the distinction is a
+      classification rather than something a reader has to infer from ``access``.
+    """
+    identity = CanonicalIdentity(owner_instance_id, buffer_id, generation)
+    backend = BackendKind.FORK_SHM if access != AccessMode.READ else BackendKind.FORK_COW
+    return Buffer(
+        identity=identity,
+        owner_worker_path_id=intern_worker_path(owner_worker_path),
+        address_space=AddressSpace.HOST,
+        access=access,
+        backend_kind=backend,
+        nbytes=nbytes,
+        body=int(data_ptr).to_bytes(8, "little"),
+        shm=None,
+        base=int(data_ptr),
+    )
+
+
+def host_ptr_nbytes(obj: Any) -> tuple[int, int]:
+    """Host address + byte length of a copy_to/copy_from buffer, without importing torch.
+
+    A torch tensor is read via its ``data_ptr`` / ``numel`` / ``element_size`` (duck-typed); any other
+    object goes through the buffer protocol and must be writable so its backing address is stable for
+    the duration of the synchronous copy.
+    """
+    if hasattr(obj, "data_ptr") and hasattr(obj, "numel") and hasattr(obj, "element_size"):
+        return int(obj.data_ptr()), int(obj.numel()) * int(obj.element_size())
+    mv = memoryview(obj)
+    if mv.readonly:
+        raise TypeError("copy_to/copy_from host buffer must be a torch tensor or a writable buffer")
+    return ctypes.addressof((ctypes.c_char * mv.nbytes).from_buffer(obj)), mv.nbytes
+
+
+def wrap_device_malloc(
+    device_ptr: int,
+    nbytes: int,
+    owner_instance_id: bytes,
+    buffer_id: int,
+    owner_worker_path: str = "",
+    generation: int = 1,
+    access: AccessMode = AccessMode.READWRITE,
+    owner_worker_id: int = 0,
+) -> Buffer:
+    """Wrap a device pointer (from a worker device malloc) as a ``DEVICE_MALLOC`` ``Buffer``.
+
+    The backend body is the device pointer (u64 LE); the consumer materializes to that pointer with no
+    mapping. The pointer is valid only on the chip that allocated it, so a tensor over this buffer must be
+    dispatched only to that chip (a topology invariant, as for the former ``child_memory`` tensor).
+    ``owner_worker_id`` records which next-level worker the backing lives on for free/copy provenance.
+    """
+    identity = CanonicalIdentity(owner_instance_id, buffer_id, generation)
+    return Buffer(
+        identity=identity,
+        owner_worker_path_id=intern_worker_path(owner_worker_path),
+        address_space=AddressSpace.DEVICE,
+        access=access,
+        backend_kind=BackendKind.DEVICE_MALLOC,
+        nbytes=nbytes,
+        body=int(device_ptr).to_bytes(8, "little"),
+        shm=None,
+        base=int(device_ptr),
+        owner_worker_id=int(owner_worker_id),
+    )
+
+
+def wrap_vmm_window(
+    device_ptr: int,
+    nbytes: int,
+    owner_instance_id: bytes,
+    buffer_id: int,
+    owner_worker_path: str = "",
+    generation: int = 1,
+    access: AccessMode = AccessMode.READWRITE,
+    owner_worker_id: int = 0,
+) -> Buffer:
+    """Wrap a domain-window-carved device VA as a ``VMM_WINDOW`` ``Buffer``.
+
+    A comm domain's per-rank window is device memory carved by ``allocate_domain``; each named buffer
+    slice is one such backing. The backend body is the device VA (u64 LE); the consumer materializes to
+    that VA with no mapping. The VA is valid only on the chip that owns the window, so a tensor over this
+    buffer must be dispatched only to that chip (``owner_worker_id``). Unlike ``DEVICE_MALLOC`` it is
+    not freed by ``worker.free`` — the domain owns its lifetime and reclaims it at ``release_domain``.
+    """
+    identity = CanonicalIdentity(owner_instance_id, buffer_id, generation)
+    return Buffer(
+        identity=identity,
+        owner_worker_path_id=intern_worker_path(owner_worker_path),
+        address_space=AddressSpace.DEVICE,
+        access=access,
+        backend_kind=BackendKind.VMM_WINDOW,
+        nbytes=nbytes,
+        body=int(device_ptr).to_bytes(8, "little"),
+        shm=None,
+        base=int(device_ptr),
+        owner_worker_id=int(owner_worker_id),
+    )
+
+
+@dataclass
+class ImportedBuffer:
+    """A buffer materialized into the consumer's address space: identity -> local base."""
+
+    identity: CanonicalIdentity
+    base: int
+    nbytes: int
+    address_space: AddressSpace = AddressSpace.HOST
+    shm: SharedMemory | None = None  # the consumer's own mapping for shm backends
+
+
+class ImportRegistry:
+    """Per-consumer-endpoint lazy import cache: materialize a ``Tensor``'s embedded descriptor to a
+    local base on first receipt (map-once), keyed by canonical identity.
+
+    A consumer calls ``materialize`` for each tensor's embedded descriptor as it arrives; the first
+    sight of an identity maps its backing into this process, later sights reuse the cached base
+    (a bumped generation is a distinct identity, materialized fresh). Keyed by the canonical identity
+    itself so lookups are exact — never a numeric-range guess, and never split by the wire padding
+    the identity's equality and hashing deliberately ignore.
+    """
+
+    def __init__(self) -> None:
+        self._by_identity: dict[CanonicalIdentity, ImportedBuffer] = {}
+
+    def materialize(self, desc: BufferDescriptor) -> ImportedBuffer:
+        """Map ``desc``'s backing into this process on first sight of its identity; reuse the
+        cached ImportedBuffer thereafter (map-once).
+
+        Takes the descriptor, never its bytes: every producer of one — an owner's ``to_descriptor()``,
+        a re-export, an element pulled out of a received TaskArgs — hands over the bound type, and a
+        caller holding raw bytes decodes them with ``BufferDescriptor.unpack`` so the decode is
+        visible at its call site.
+        """
+        key = desc.identity
+        cached = self._by_identity.get(key)
+        if cached is not None:
+            return cached
+        if desc.backend_kind in (
+            BackendKind.FORK_SHM,
+            BackendKind.FORK_COW,
+            BackendKind.DEVICE_MALLOC,
+            BackendKind.VMM_WINDOW,
+        ):
+            # The body is the base pointer (u64 LE), already valid in this process — no mapping.
+            # FORK_SHM: a COW-inherited host VA. DEVICE_MALLOC / VMM_WINDOW: a device pointer valid on
+            # the chip that allocated / carved it (the tensor must only reach that chip — a topology
+            # invariant).
+            base = int.from_bytes(desc.body, "little")
+            imported = ImportedBuffer(desc.identity, base, desc.nbytes, desc.address_space, None)
+        elif desc.backend_kind == BackendKind.POSIX_SHM:
+            shm = SharedMemory(name=desc.body.decode("utf-8"))
+            imported = ImportedBuffer(desc.identity, _shm_base_addr(shm), desc.nbytes, desc.address_space, shm)
+        elif desc.backend_kind == BackendKind.REMOTE_SIDECAR:
+            raise ValueError("ImportRegistry: REMOTE_SIDECAR backend is reserved for P2")
+        else:
+            raise NotImplementedError(f"ImportRegistry: backend {desc.backend_kind!r} not supported in P1-B")
+        self._by_identity[key] = imported
+        return imported
+
+    def resolve(self, identity: CanonicalIdentity) -> ImportedBuffer:
+        """The already-materialized import for ``identity``. Raises ``KeyError`` if this endpoint has
+        not materialized that backing — resolution never maps as a side effect."""
+        imported = self._by_identity.get(identity)
+        if imported is None:
+            raise KeyError(f"ImportRegistry: no buffer registered for {identity}")
+        return imported
+
+    def unregister(self, identity: CanonicalIdentity) -> None:
+        """Drop one import and close its mapping. The owner still holds the backing; only this
+        endpoint's view of it goes away. A no-op for an identity that was never materialized."""
+        imported = self._by_identity.pop(identity, None)
+        if imported is not None and imported.shm is not None:
+            imported.shm.close()
+
+    def close(self) -> None:
+        """Close every mapping this endpoint made. Consumer-side only — unlinking belongs to the
+        owning Worker, so this never destroys a backing."""
+        for imported in self._by_identity.values():
+            if imported.shm is not None:
+                imported.shm.close()
+        self._by_identity.clear()

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -9,13 +9,18 @@
 # ruff: noqa: PLW0603, PLC0415
 """Public Python API for task_interface nanobind bindings.
 
-Re-exports the canonical C++ types (DataType, ChipTensor, ChipStorageTaskArgs,
-TaskArgs, TensorArgType) plus ``scalar_to_uint64``. Torch-aware helpers
-(``make_tensor_arg``, ``torch_dtype_to_datatype``) live in
-``simpler_setup.torch_interop`` — this module has no torch dependency.
+Re-exports the canonical C++ types (DataType, ChipTensor, ChipStorageTaskArgs, TaskArgs,
+TensorArgType) plus ``scalar_to_uint64``. Torch-aware helpers (``make_tensor_arg``,
+``torch_dtype_to_datatype``) live in ``simpler_setup.torch_interop`` — this module has no torch
+dependency.
+
+The address-free L3+ ``Tensor`` of ``simpler.buffer`` is deliberately **not** re-exported here.
+``TaskArgs.add_tensor`` still takes a ``ChipTensor``, so a ``Tensor`` on this surface would be a
+public type whose advertised operation rejects it. It joins this module in the wire cutover that
+makes ``TaskArgs`` carry it, not before.
 
 Usage:
-    from simpler.task_interface import DataType, ChipTensor, ChipStorageTaskArgs
+    from simpler.task_interface import ChipTensor, DataType, TensorArgType
     from simpler_setup.torch_interop import make_tensor_arg
 """
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -82,10 +82,10 @@ from typing import Any, cast
 
 import cloudpickle
 from _task_interface import (  # pyright: ignore[reportMissingImports]
+    CHIP_TENSOR_CHILD_MEMORY_OFFSET,
     MAX_REGISTERED_CALLABLE_IDS,
     PTO_PIPELINE_MAX_DEPTH,
     RUNTIME_ENV_RING_COUNT,
-    TENSOR_CHILD_MEMORY_OFFSET,
     WorkerType,
     _l3_child_onboard_region_close,
     _l3_child_onboard_region_create,
@@ -100,6 +100,11 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
 )
 
 from . import _log as _simpler_log
+from .buffer import (
+    Buffer,
+    create_host_shared_buffer,
+    mint_owner_instance_id,
+)
 from .callable_identity import (
     CALLABLE_HASH_DIGEST_BYTES,
     CallableHandle,
@@ -1243,7 +1248,7 @@ def _rewrite_blob_host_addrs(buf: memoryview, blob_off: int, ranges: list[tuple[
     base = blob_off + _BLOB_HEADER_BYTES
     for i in range(tensor_count):
         addr_off = base + i * _BLOB_TENSOR_STRIDE
-        if buf[addr_off + TENSOR_CHILD_MEMORY_OFFSET]:
+        if buf[addr_off + CHIP_TENSOR_CHILD_MEMORY_OFFSET]:
             continue
         addr = struct.unpack_from("<Q", buf, addr_off)[0]
         for parent_lo, parent_hi, child_base in ranges:
@@ -3879,6 +3884,13 @@ class Worker:
         # dispatch) is now handled at the C++ boundary via mailbox_mu_, so
         # no quiescent-state guard is needed.
         self._registry_lock = threading.Lock()
+        # Owner-side buffer identity. `_owner_instance_id` is a fresh random draw per Worker
+        # incarnation, so a buffer_id reused by a later process can never collide with a live
+        # identity; `_buffers` keeps every Buffer this Worker owns so close() can unlink
+        # the backings.
+        self._owner_instance_id: bytes = mint_owner_instance_id()
+        self._buffer_id_counter: int = 1
+        self._buffers: dict[int, Buffer] = {}
         self._pending_unregister_cids: set[int] = set()
         self._pending_remote_unregister_hashids: set[bytes] = set()
         self._py_control_timeout_s = float(config.get("py_control_timeout_s", _PY_CONTROL_TIMEOUT_S))
@@ -8219,6 +8231,69 @@ class Worker:
             pass
         return warn
 
+    # ------------------------------------------------------------------
+    # Owner-side Buffer allocation
+    # ------------------------------------------------------------------
+
+    def create_buffer(self, nbytes: int) -> Buffer:
+        """Allocate a shared ``Buffer`` owned by this Worker.
+
+        The backing is a POSIX shm; the Buffer carries a typed canonical identity and a
+        self-describing descriptor, so a consumer can resolve it with no prior handshake. Build a
+        tensor over ``buffer.shm.buf`` with the buffer protocol. Not thread-safe against a concurrent
+        run/create/free on the same Worker.
+        """
+        if self.level < 2:
+            raise TypeError("create_buffer requires a level >= 2 Worker")
+        with self._operation_lease("create_buffer"):
+            return self._create_buffer_locked(int(nbytes))
+
+    def _next_buffer_id(self) -> int:
+        with self._registry_lock:
+            bid = self._buffer_id_counter
+            self._buffer_id_counter += 1
+        return bid
+
+    def _create_buffer_locked(self, nbytes: int) -> Buffer:
+        # An L3+ buffer is consumed by a forked child that lazily maps it, so a childless L3+ buffer
+        # can reach no consumer. An L2 leaf has no children and materializes in-process, so it needs
+        # none.
+        if self.level >= 3 and not self._chip_shms and not self._sub_shms:
+            raise RuntimeError("create_buffer requires at least one forked chip or sub child (this Worker has none)")
+        if nbytes <= 0:
+            raise ValueError("create_buffer: nbytes must be positive")
+        buffer_id = self._next_buffer_id()
+        buffer = create_host_shared_buffer(
+            nbytes,
+            owner_instance_id=self._owner_instance_id,
+            buffer_id=buffer_id,
+            owner_worker_path=f"L{self.level}",
+            generation=1,
+        )
+        with self._registry_lock:
+            self._buffers[buffer_id] = buffer
+        return buffer
+
+    def _release_all_buffers(self) -> None:
+        """Close + unlink every owner Buffer (called from close()).
+
+        Per-buffer best-effort: one buffer's failure never strands the rest, and the first error is
+        raised after all are attempted so close() reports the leak rather than swallowing it. A
+        buffer whose close fails keeps its registry entry so the cleanup journal can retry it."""
+        with self._registry_lock:
+            entries = list(self._buffers.items())
+        errors: list[BaseException] = []
+        for buffer_id, buffer in entries:
+            try:
+                buffer.close()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+                continue
+            with self._registry_lock:
+                self._buffers.pop(buffer_id, None)
+        if errors:
+            raise errors[0]
+
     def _release_all_host_buffers(self) -> None:
         """Unmap + free every still-registered host buffer (called from close()).
 
@@ -9300,6 +9375,7 @@ class Worker:
             ("provenance", "child allocation provenance", self._clear_child_prov),
             ("remote", "active remote slot references", self._release_active_remote_slot_refs),
             ("remote", "pending remote frees", self._flush_pending_remote_frees),
+            ("buffer", "all owner Buffers", self._release_all_buffers),
             ("host-buffer", "all host buffers", self._release_all_host_buffers),
         ):
             self._cleanup_journal.add_once(kind, identity, cleanup)

--- a/src/common/task_interface/buffer.h
+++ b/src/common/task_interface/buffer.h
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+/**
+ * Buffer / Tensor ABI — typed, opaque cross-layer buffer identity.
+ *
+ * Three types:
+ *   - CanonicalIdentity      : owner_instance_id + buffer_id + generation. The key both the owner
+ *                              registry and every consumer import cache use, invariant across every
+ *                              edge. Fixed-length with no length field, so hashing and comparison
+ *                              cannot read past it.
+ *   - BufferDescriptor       : the owner's self-describing wire descriptor — backing properties plus
+ *                              a length-delimited backend body. Embedded whole in every Tensor
+ *                              built over the buffer.
+ *   - Tensor                 : the argument an L3+ TaskArgs carries, and the element its mailbox
+ *                              blob transports. Embeds the full BufferDescriptor plus a view
+ *                              (byte_offset, shape, strides, dtype) — self-describing, so a consumer
+ *                              materializes it lazily on receipt with no prior handshake. Carries no
+ *                              address; the consuming endpoint materializes it into the
+ *                              GM-address-bearing `ChipTensor` of tensor.h, the distinct device POD
+ *                              the L2 runtime reads.
+ *
+ * The blob that carries these lives in task_args.h — it is the existing TaskArgs mailbox format,
+ * with Tensor as its element. This header owns the types and the gate every receive boundary runs,
+ * not their transport.
+ *
+ * There is no wire version. Every endpoint of a run comes from one `pip install`, so a version field
+ * would guard a skew that cannot arise; the skew that CAN arise (a stale compiled extension against
+ * newer Python) is caught by SIMPLER_BUILD_COMMIT. The descriptor's leading `magic` is a
+ * discriminator against non-descriptor bytes, not a version.
+ *
+ * Endianness: all multi-byte integers little-endian. owner_instance_id is an opaque byte sequence
+ * (bytewise-compared, no integer/endianness meaning). An unknown backend / address_space / access
+ * value is rejected, never silently accepted.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include "data_type.h"
+
+// Leading sentinel of a BufferDescriptor, NOT a version. A descriptor decoder needs a cheap
+// leading discriminator because `TaskArgs.add_tensor` accepts raw bytes; the sentinel rejects most
+// non-descriptor input before any field is trusted. It does not by itself prove the bytes are a
+// descriptor — every other field is still validated. There is no multi-version wire: every endpoint
+// of a run is built from one `pip install`, and build skew is caught by SIMPLER_BUILD_COMMIT.
+inline constexpr uint16_t BUFFER_DESCRIPTOR_MAGIC = 0x5342;  // 'BS' little-endian
+
+// owner_instance_id is a fixed-width opaque nonce (compared bytewise; no integer/endianness meaning).
+// It is the SOLE source of cross-incarnation uniqueness, so it must be generated with a full-width
+// random draw — a structured value (timestamp/pid) collides between two Workers built in the same
+// process and second.
+inline constexpr uint32_t OWNER_INSTANCE_ID_BYTES = 8;
+
+// Backend body upper bound. Only POSIX_SHM uses more than 8 bytes (a shm name); every other backend
+// stores a single u64 address.
+inline constexpr uint32_t DESC_MAX_BYTES = 32;
+
+// Memory space of a backing. Orthogonal to location (local/remote, derived) and to visibility.
+enum class AddressSpace : uint8_t {
+    HOST = 0,
+    DEVICE = 1,
+};
+
+// The backing's granted permission. A per-arg TensorArgType requests read/write and is validated
+// against this at submit (requested must be a subset of granted).
+enum class AccessMode : uint8_t {
+    READ = 0,
+    WRITE = 1,
+    READWRITE = 2,
+};
+
+// Materialization backend of a buffer. The consumer resolves a Tensor to a local address via the
+// import registry keyed by canonical identity; this tag selects how. REMOTE_SIDECAR is reserved for
+// P2 and rejected on decode in P1. Values are frozen; 6.. reserved (unknown tag => reject).
+//
+// FORK_SHM and FORK_COW materialize identically — the body is a base VA the child already has,
+// inherited across the fork — but the kernel's write semantics are opposite, so they are separate
+// tags rather than one tag plus a hint. A child's write to a MAP_SHARED page lands in the physical
+// page the parent reads; a write to a copy-on-write page splits it into a private copy the parent
+// never sees, silently. FORK_COW therefore grants READ only, and that is enforced on decode.
+enum class BackendKind : uint8_t {
+    FORK_SHM = 0,
+    POSIX_SHM = 1,
+    VMM_WINDOW = 2,
+    REMOTE_SIDECAR = 3,
+    DEVICE_MALLOC = 4,
+    FORK_COW = 5,
+};
+
+/**
+ * Canonical allocation identity — globally unique across owner incarnations, unchanged across every
+ * edge. `buffer_id` is unique only within one owner incarnation; `owner_instance_id` (a per-incarnation
+ * nonce) disambiguates it, and `generation` detects buffer_id slot reuse (ABA). The key of both the
+ * owner registry and every consumer import registry.
+ *
+ * FIXED-LENGTH BY DESIGN: no field here bounds a read. Hashing and comparison therefore cannot run
+ * off the end of the struct whatever bytes arrive on the wire — the property is structural, not
+ * something a validator has to enforce.
+ *
+ * `_pad` is excluded from comparison and hashing, so a decoded identity with dirty padding still
+ * matches the same backing (two views of one backing must never key differently).
+ *
+ * `generation` starts at 1; every reuse of a `buffer_id` slot increments it. 0 is reserved to mean
+ * uninitialized and is rejected on decode.
+ */
+struct CanonicalIdentity {
+    uint8_t owner_instance_id[OWNER_INSTANCE_ID_BYTES];
+    uint64_t buffer_id;
+    uint32_t generation;
+    uint8_t _pad[12];
+};
+
+static_assert(std::is_trivially_copyable_v<CanonicalIdentity>);
+static_assert(sizeof(CanonicalIdentity) == 32, "CanonicalIdentity is wire ABI");
+static_assert(offsetof(CanonicalIdentity, owner_instance_id) == 0);
+static_assert(offsetof(CanonicalIdentity, buffer_id) == 8);
+static_assert(offsetof(CanonicalIdentity, generation) == 16);
+
+inline bool operator==(const CanonicalIdentity &a, const CanonicalIdentity &b) {
+    return a.buffer_id == b.buffer_id && a.generation == b.generation &&
+           std::memcmp(a.owner_instance_id, b.owner_instance_id, OWNER_INSTANCE_ID_BYTES) == 0;
+}
+inline bool operator!=(const CanonicalIdentity &a, const CanonicalIdentity &b) { return !(a == b); }
+
+// Hash for use as an unordered_map key (consumer import registry). Folds exactly the fields
+// `operator==` compares — `_pad` is excluded so padding can never perturb the bucket.
+struct CanonicalIdentityHash {
+    size_t operator()(const CanonicalIdentity &k) const {
+        auto mix = [](size_t h, uint64_t v) {
+            return (h ^ (v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2)));
+        };
+        size_t h = 0;
+        for (uint32_t i = 0; i < OWNER_INSTANCE_ID_BYTES; ++i)
+            h = mix(h, k.owner_instance_id[i]);
+        h = mix(h, k.buffer_id);
+        h = mix(h, k.generation);
+        return h;
+    }
+};
+
+/**
+ * The owner's self-describing buffer descriptor — embedded whole in every Tensor built over the
+ * buffer. A consumer materializes it lazily on first receipt (no separate export handshake) and
+ * caches `canonical identity -> local base` (map-once). `backend_kind` + `body[0, body_len)` carry
+ * the per-backend materialization (POSIX shm name, fork-inherited VA, device VA, ...).
+ * `magic` leads as a cheap discriminator; `address_space` / `access` / `backend_kind` are raw u8 so
+ * an unknown value can be rejected without invoking undefined enum behavior.
+ *
+ * `owner_worker_path_id` is a DIAGNOSTIC id only — it names the owning worker in logs and
+ * post-mortems and takes part in no routing, visibility or identity decision. Its side table lives in
+ * the owning process; an id a consumer cannot resolve prints as `<path#N>` and is never an error.
+ */
+struct BufferDescriptor {
+    uint16_t magic;
+    uint8_t address_space;
+    uint8_t access;
+    uint8_t backend_kind;
+    uint8_t _pad0[3];
+    CanonicalIdentity identity;
+    uint64_t nbytes;
+    uint32_t owner_worker_path_id;
+    uint16_t body_len;
+    uint8_t _pad1[2];
+    char body[DESC_MAX_BYTES];
+};
+
+static_assert(std::is_trivially_copyable_v<BufferDescriptor>);
+static_assert(sizeof(BufferDescriptor) == 88, "BufferDescriptor is wire ABI");
+static_assert(offsetof(BufferDescriptor, magic) == 0);
+static_assert(offsetof(BufferDescriptor, address_space) == 2);
+static_assert(offsetof(BufferDescriptor, access) == 3);
+static_assert(offsetof(BufferDescriptor, backend_kind) == 4);
+static_assert(offsetof(BufferDescriptor, identity) == 8);
+static_assert(offsetof(BufferDescriptor, nbytes) == 40);
+static_assert(offsetof(BufferDescriptor, owner_worker_path_id) == 48);
+static_assert(offsetof(BufferDescriptor, body_len) == 52);
+static_assert(offsetof(BufferDescriptor, body) == 56);
+
+// Field-wise, so neither the struct padding nor the unused tail of `body` takes part: two decodes of
+// one backing describe the same buffer whatever bytes sit outside the fields that carry meaning.
+inline bool operator==(const BufferDescriptor &a, const BufferDescriptor &b) {
+    return a.identity == b.identity && a.address_space == b.address_space && a.access == b.access &&
+           a.backend_kind == b.backend_kind && a.nbytes == b.nbytes &&
+           a.owner_worker_path_id == b.owner_worker_path_id && a.body_len == b.body_len &&
+           std::memcmp(a.body, b.body, a.body_len) == 0;
+}
+inline bool operator!=(const BufferDescriptor &a, const BufferDescriptor &b) { return !(a == b); }
+
+/**
+ * The blob-carried, self-describing wire element: a full embedded buffer descriptor plus a strided
+ * view onto it. Because the descriptor travels with the tensor, a consumer needs no prior handshake
+ * — it materializes the embedded `buffer` (backend selects how) on first receipt, keyed by
+ * `buffer.identity`, and reuses the cached base for later tensors over the same identity.
+ *
+ * Invariants:
+ *   - Carries NO materialized address. The consumer materializes `buffer` to a local base, then
+ *     `Tensor.buffer.addr = base`, `Tensor.start_offset = byte_offset / dtype_bytes`.
+ *   - `byte_offset` is a BYTE offset of the view origin; a multiple of the dtype size (validated at
+ *     materialization).
+ *   - `strides[i] > 0` strictly (broadcast / negative step unsupported), carried explicitly — a
+ *     singleton dimension's stride is never normalized away.
+ */
+struct Tensor {
+    BufferDescriptor buffer;
+    uint64_t byte_offset;
+    uint32_t ndims;
+    uint32_t shapes[MAX_TENSOR_DIMS];
+    uint32_t strides[MAX_TENSOR_DIMS];
+    DataType dtype;
+    uint8_t _pad[3];
+};
+
+// Byte extent of a (possibly strided) view: the last addressable element, plus one element. Summed
+// in u64 so a hostile shape/stride cannot wrap it. Callers that have not yet validated `r` must not
+// trust the result for anything but a bound.
+inline uint64_t tensor_extent_bytes(const Tensor &r) {
+    uint64_t last_elem = 0;
+    for (uint32_t i = 0; i < r.ndims && i < static_cast<uint32_t>(MAX_TENSOR_DIMS); ++i) {
+        if (r.shapes[i] == 0) continue;
+        last_elem += static_cast<uint64_t>(r.shapes[i] - 1) * static_cast<uint64_t>(r.strides[i]);
+    }
+    return (last_elem + 1) * get_element_size(r.dtype);
+}
+
+/**
+ * Reject any BufferDescriptor whose fields are not self-consistent, BEFORE any of them is trusted.
+ *
+ * The descriptor half of the tensor gate below, split out because a descriptor also arrives on its
+ * own — construction from Python and blob descriptor extraction both hand one over with no view
+ * attached. `body_len` is bounded against `DESC_MAX_BYTES` here, mirroring what the fixed-length
+ * `CanonicalIdentity` gets structurally. Throws `std::invalid_argument` naming the field.
+ *
+ * `REMOTE_SIDECAR` is a legal wire value and passes: an arg bound for a remote worker rides the wire
+ * with no local backing, and it is *materialization* that refuses it in P1.
+ */
+inline void validate_buffer_descriptor(const BufferDescriptor &h) {
+    auto reject = [](const char *what) {
+        throw std::invalid_argument(what);
+    };
+
+    if (h.magic != BUFFER_DESCRIPTOR_MAGIC) reject("invalid BufferDescriptor: magic");
+    if (h.address_space > static_cast<uint8_t>(AddressSpace::DEVICE))
+        reject("invalid BufferDescriptor: address_space out of range");
+    if (h.access > static_cast<uint8_t>(AccessMode::READWRITE)) reject("invalid BufferDescriptor: access out of range");
+    if (h.backend_kind > static_cast<uint8_t>(BackendKind::FORK_COW))
+        reject("invalid BufferDescriptor: backend_kind out of range");
+    if (h.body_len > DESC_MAX_BYTES) reject("invalid BufferDescriptor: body_len exceeds DESC_MAX_BYTES");
+    if (h.identity.generation == 0) reject("invalid BufferDescriptor: generation 0 is reserved (uninitialized)");
+
+    // address_space x backend_kind capability gate. REMOTE_SIDECAR is legal in either space.
+    const auto backend = static_cast<BackendKind>(h.backend_kind);
+    const bool device_space = h.address_space == static_cast<uint8_t>(AddressSpace::DEVICE);
+    if (backend != BackendKind::REMOTE_SIDECAR) {
+        const bool device_backend = backend == BackendKind::VMM_WINDOW || backend == BackendKind::DEVICE_MALLOC;
+        if (device_backend != device_space)
+            reject("invalid BufferDescriptor: unsupported address_space x backend_kind (capability matrix)");
+    }
+
+    // A copy-on-write page splits on the consumer's first write into a private copy the owner never
+    // sees, so a write grant over FORK_COW would be silently unobservable rather than an error.
+    if (backend == BackendKind::FORK_COW && h.access != static_cast<uint8_t>(AccessMode::READ)) {
+        reject("invalid BufferDescriptor: FORK_COW grants READ only (a child's write would not reach the owner)");
+    }
+}
+
+/**
+ * Reject any Tensor whose fields are not self-consistent, BEFORE any of them is trusted.
+ *
+ * This is the single implementation behind every trust boundary — construction, the builder
+ * (`TaskArgs.add_tensor`, which accepts raw bytes), blob decode on receipt, and materialization —
+ * so they can never drift apart. Throws `std::invalid_argument` naming the field.
+ *
+ * `ndims` is bounded against `MAX_TENSOR_DIMS` here; the descriptor's own length-like field is
+ * bounded by `validate_buffer_descriptor` above, which this runs first.
+ */
+inline void validate_tensor(const Tensor &r) {
+    auto reject = [](const char *what) {
+        throw std::invalid_argument(what);
+    };
+    const BufferDescriptor &h = r.buffer;
+
+    validate_buffer_descriptor(h);
+
+    if (r.ndims == 0 || r.ndims > static_cast<uint32_t>(MAX_TENSOR_DIMS)) reject("invalid Tensor: ndims out of range");
+    if (r.dtype >= DataType::DATA_TYPE_NUM) reject("invalid Tensor: unknown dtype");
+    const uint64_t elem = get_element_size(r.dtype);
+    if (elem == 0) reject("invalid Tensor: unknown dtype");
+    if (r.byte_offset % elem != 0) reject("invalid Tensor: byte_offset is not a multiple of the dtype size");
+
+    for (uint32_t i = 0; i < r.ndims; ++i) {
+        if (r.shapes[i] == 0) reject("invalid Tensor: shape dimension is zero");
+        if (r.strides[i] == 0) reject("invalid Tensor: stride must be > 0 (broadcast and negative step unsupported)");
+    }
+    const uint64_t extent_bytes = tensor_extent_bytes(r);
+    if (r.byte_offset > h.nbytes || extent_bytes > h.nbytes - r.byte_offset) {
+        reject("invalid Tensor: view extends past the backing (byte_offset + extent > nbytes)");
+    }
+}
+
+// Do two views of the SAME backing touch a common byte? Compared as bounding ranges
+// [byte_offset, byte_offset + extent): a strided view's gaps are treated as occupied, so this is
+// conservative — it never misses a real overlap, and may report one for two interleaved views.
+inline bool tensors_overlap(const Tensor &a, const Tensor &b) {
+    if (!(a.buffer.identity == b.buffer.identity)) return false;
+    const uint64_t a_end = a.byte_offset + tensor_extent_bytes(a);
+    const uint64_t b_end = b.byte_offset + tensor_extent_bytes(b);
+    return a.byte_offset < b_end && b.byte_offset < a_end;
+}
+
+static_assert(std::is_trivially_copyable_v<Tensor>, "Tensor must be trivially copyable for blob memcpy");
+static_assert(sizeof(Tensor) == 144, "Tensor is wire ABI");
+static_assert(offsetof(Tensor, buffer) == 0);
+static_assert(offsetof(Tensor, byte_offset) == 88);
+static_assert(offsetof(Tensor, ndims) == 96);
+static_assert(offsetof(Tensor, shapes) == 100);
+static_assert(offsetof(Tensor, strides) == 120);
+static_assert(offsetof(Tensor, dtype) == 140);

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -28,6 +28,11 @@ template <typename T>
 inline constexpr bool is_supported_scalar_arg_v = std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<T>>> ||
                                                   std::is_enum_v<std::remove_cv_t<std::remove_reference_t<T>>>;
 
+// Maximum tensor rank a view can describe. Both the L3+ `Tensor` of buffer.h and the device
+// `ChipTensor` of tensor.h size their shapes[] / strides[] by it, so it is shared here rather than
+// owned by either.
+constexpr int MAX_TENSOR_DIMS = 5;
+
 /**
  * Supported data types for tensor elements
  */
@@ -80,7 +85,9 @@ inline uint64_t get_element_size(DataType dtype) {
         1,  // DataType::FP8E8M0 (A5 only)
         1,  // DataType::FP4E2M1 (A5 only)
     };
-    return data_type_size[static_cast<int>(dtype)];
+    // Bounds-checked: `dtype` is a raw u8 on the wire, so a decoder can hand this any value.
+    const auto index = static_cast<std::size_t>(dtype);
+    return index < data_type_size.size() ? data_type_size[index] : 0;
 }
 
 /**

--- a/src/common/task_interface/tensor.h
+++ b/src/common/task_interface/tensor.h
@@ -23,8 +23,6 @@
 #include "data_type.h"
 #include "pto_task_id.h"
 
-constexpr int MAX_TENSOR_DIMS = 5;
-
 /**
  * Buffer Handle
  *

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -435,6 +435,7 @@ set_tests_properties(test_sim_run_completion PROPERTIES LABELS "no_hardware")
 # ---------------------------------------------------------------------------
 # Types / task_interface tests (src/common/task_interface/)
 # ---------------------------------------------------------------------------
+add_task_interface_test(test_buffer types/test_buffer.cpp)
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)

--- a/tests/ut/cpp/types/test_buffer.cpp
+++ b/tests/ut/cpp/types/test_buffer.cpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+// Wire-ABI tests for Buffer / Tensor (buffer.h); the contract they pin is described
+// in docs/buffer-abi.md. Byte layout is pinned by static_assert in the header; these tests
+// pin the sizes, enum values, and the shared receive-side gate from the outside.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "buffer.h"
+#include <random>
+#include <vector>
+
+#include "task_args.h"
+
+namespace {
+
+CanonicalIdentity make_identity() {
+    CanonicalIdentity id{};
+    for (uint32_t i = 0; i < OWNER_INSTANCE_ID_BYTES; ++i)
+        id.owner_instance_id[i] = static_cast<uint8_t>(0xA0 + i);
+    id.buffer_id = 0x0102030405060708ULL;
+    id.generation = 7;
+    return id;
+}
+
+Tensor make_tensor() {
+    Tensor r{};
+    r.buffer.magic = BUFFER_DESCRIPTOR_MAGIC;
+    r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::POSIX_SHM);
+    r.buffer.identity = make_identity();
+    r.buffer.nbytes = 8192;  // must cover byte_offset + the strided extent below
+    r.byte_offset = 4096;
+    r.ndims = 3;
+    r.shapes[0] = 2;
+    r.shapes[1] = 4;
+    r.shapes[2] = 8;
+    r.strides[0] = 32;
+    r.strides[1] = 8;
+    r.strides[2] = 1;
+    r.dtype = DataType::FLOAT16;
+    return r;
+}
+
+// --- Layout / value contracts (frozen ABI) -----------------------------------------------------
+
+TEST(BufferAbi, StructSizesAreFrozen) {
+    EXPECT_EQ(sizeof(CanonicalIdentity), 32u);
+    EXPECT_EQ(sizeof(Tensor), 144u);
+    EXPECT_EQ(sizeof(BufferDescriptor), 88u);
+}
+
+TEST(BufferAbi, ConstantsAreFrozen) {
+    EXPECT_EQ(BUFFER_DESCRIPTOR_MAGIC, 0x5342);
+    EXPECT_EQ(OWNER_INSTANCE_ID_BYTES, 8u);
+    EXPECT_EQ(DESC_MAX_BYTES, 32u);
+}
+
+TEST(BufferAbi, EnumValuesAreFrozen) {
+    EXPECT_EQ(static_cast<uint8_t>(AddressSpace::HOST), 0);
+    EXPECT_EQ(static_cast<uint8_t>(AddressSpace::DEVICE), 1);
+    EXPECT_EQ(static_cast<uint8_t>(AccessMode::READ), 0);
+    EXPECT_EQ(static_cast<uint8_t>(AccessMode::WRITE), 1);
+    EXPECT_EQ(static_cast<uint8_t>(AccessMode::READWRITE), 2);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::FORK_SHM), 0);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::POSIX_SHM), 1);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::VMM_WINDOW), 2);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR), 3);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::DEVICE_MALLOC), 4);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::FORK_COW), 5);
+}
+
+// --- memcpy round trip -------------------------------------------------------------------------
+
+TEST(BufferAbi, TensorSurvivesByteRoundTrip) {
+    Tensor src = make_tensor();
+    uint8_t bytes[sizeof(Tensor)];
+    std::memcpy(bytes, &src, sizeof(Tensor));
+    Tensor dst{};
+    std::memcpy(&dst, bytes, sizeof(Tensor));
+    EXPECT_EQ(std::memcmp(&src, &dst, sizeof(Tensor)), 0);
+    EXPECT_EQ(dst.byte_offset, 4096u);
+    EXPECT_EQ(dst.dtype, DataType::FLOAT16);
+    EXPECT_EQ(dst.strides[0], 32u);
+    EXPECT_EQ(dst.buffer.identity, src.buffer.identity);
+}
+
+TEST(BufferAbi, DescriptorSurvivesByteRoundTrip) {
+    BufferDescriptor src{};
+    src.magic = BUFFER_DESCRIPTOR_MAGIC;
+    src.address_space = static_cast<uint8_t>(AddressSpace::DEVICE);
+    src.access = static_cast<uint8_t>(AccessMode::READWRITE);
+    src.backend_kind = static_cast<uint8_t>(BackendKind::POSIX_SHM);
+    src.owner_worker_path_id = 3;
+    src.identity = make_identity();
+    src.nbytes = 1 << 20;
+    const char *body = "psm_deadbeef";
+    src.body_len = static_cast<uint16_t>(std::strlen(body));
+    std::memcpy(src.body, body, src.body_len);
+
+    uint8_t bytes[sizeof(BufferDescriptor)];
+    std::memcpy(bytes, &src, sizeof(BufferDescriptor));
+    BufferDescriptor dst{};
+    std::memcpy(&dst, bytes, sizeof(BufferDescriptor));
+    EXPECT_EQ(std::memcmp(&src, &dst, sizeof(BufferDescriptor)), 0);
+    EXPECT_EQ(dst.magic, BUFFER_DESCRIPTOR_MAGIC);
+    EXPECT_EQ(dst.owner_worker_path_id, 3u);
+    EXPECT_EQ(dst.identity, src.identity);
+    EXPECT_EQ(std::string(dst.body, dst.body_len), "psm_deadbeef");
+}
+
+// --- canonical identity: the import-registry key -----------------------------------------------
+
+TEST(BufferAbi, IdentityDistinguishesGenerationAndIncarnation) {
+    CanonicalIdentity a = make_identity();
+    CanonicalIdentity b = make_identity();
+    EXPECT_EQ(a, b);
+
+    b.generation = a.generation + 1;  // buffer_id reuse across generations (ABA)
+    EXPECT_NE(a, b);
+
+    CanonicalIdentity c = make_identity();
+    c.owner_instance_id[0] ^= 0xFF;  // different owner incarnation nonce
+    EXPECT_NE(a, c);
+
+    CanonicalIdentity d = make_identity();
+    d.buffer_id ^= 0xFFULL;
+    EXPECT_NE(a, d);
+}
+
+// Padding is wire-visible but semantically absent: two decodes of one backing must key identically,
+// or the same buffer lands in two import-registry buckets and its dependencies split.
+TEST(BufferAbi, IdentityPaddingIsExcludedFromKeyAndHash) {
+    CanonicalIdentityHash h;
+    CanonicalIdentity clean = make_identity();
+    CanonicalIdentity dirty = make_identity();
+    std::memset(dirty._pad, 0xA5, sizeof(dirty._pad));
+    EXPECT_EQ(clean, dirty);
+    EXPECT_EQ(h(clean), h(dirty));
+}
+
+TEST(BufferAbi, IdentityHashMatchesEquality) {
+    CanonicalIdentityHash h;
+    CanonicalIdentity a = make_identity();
+    CanonicalIdentity b = make_identity();
+    EXPECT_EQ(h(a), h(b));
+
+    b.generation = a.generation + 1;
+    EXPECT_NE(h(a), h(b));  // good hash separates the ABA case (not a strict requirement)
+}
+
+// --- validate_tensor: the shared receive-side gate ------------------------------------------
+
+TEST(BufferAbi, ForkCowGrantsReadOnly) {
+    Tensor r = make_tensor();
+    r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::FORK_COW);
+    r.buffer.access = static_cast<uint8_t>(AccessMode::READ);
+    EXPECT_NO_THROW(validate_tensor(r));
+
+    // A write grant over copy-on-write would land in a private copy the owner never sees, so it is
+    // refused rather than silently dropped.
+    for (auto bad : {AccessMode::WRITE, AccessMode::READWRITE}) {
+        r.buffer.access = static_cast<uint8_t>(bad);
+        EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+    }
+
+    // The same grants stay legal over MAP_SHARED, where a child's write does reach the owner.
+    r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::FORK_SHM);
+    r.buffer.access = static_cast<uint8_t>(AccessMode::READWRITE);
+    EXPECT_NO_THROW(validate_tensor(r));
+}
+
+// --- Malformed wire bytes: what only a decoder can produce ------------------------------------
+//
+// A receiver memcpy's an element out of shared memory a peer wrote and then validates it, so every
+// field arrives as whatever bytes were there. These cases are unreachable through construction (the
+// constructor validates first) and unreachable from Python (no binding turns bytes into a Tensor),
+// which is why they live here: this is the only place the malformed state can be built at all.
+
+// Overwrite `len` bytes at `offset` of a packed Tensor, then decode it the way a receiver does.
+Tensor decode_with_corruption(size_t offset, const uint8_t *value, size_t len) {
+    uint8_t bytes[sizeof(Tensor)];
+    Tensor src = make_tensor();
+    std::memcpy(bytes, &src, sizeof(Tensor));
+    if (len > 0) std::memcpy(bytes + offset, value, len);
+    Tensor out;
+    std::memcpy(&out, bytes, sizeof(Tensor));
+    return out;
+}
+
+TEST(BufferAbi, DecodeRejectsEveryCorruptedField) {
+    // The untouched element is accepted, so each rejection below is attributable to the one field.
+    EXPECT_NO_THROW(validate_tensor(decode_with_corruption(0, nullptr, 0)));  // no-op corruption
+
+    struct Case {
+        const char *what;
+        size_t offset;
+        std::vector<uint8_t> value;
+    };
+    // Offsets are the frozen ones the static_asserts above pin.
+    const Case cases[] = {
+        {"descriptor magic", offsetof(Tensor, buffer) + offsetof(BufferDescriptor, magic), {0x00, 0x00}},
+        {"address_space out of range", offsetof(BufferDescriptor, address_space), {0x07}},
+        {"access out of range", offsetof(BufferDescriptor, access), {0x09}},
+        {"backend_kind out of range", offsetof(BufferDescriptor, backend_kind), {0x63}},
+        {"body_len past the array", offsetof(BufferDescriptor, body_len), {0xFF, 0xFF}},
+        {"generation 0 is reserved",
+         offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, generation),
+         {0, 0, 0, 0}},
+        {"ndims out of range", offsetof(Tensor, ndims), {0x63, 0, 0, 0}},
+        {"unknown dtype", offsetof(Tensor, dtype), {0x7F}},
+        {"stride must be > 0", offsetof(Tensor, strides), {0, 0, 0, 0}},
+        {"byte_offset is not a multiple", offsetof(Tensor, byte_offset), {0x03, 0, 0, 0, 0, 0, 0, 0}},
+    };
+    for (const auto &c : cases) {
+        SCOPED_TRACE(c.what);
+        EXPECT_THROW(
+            validate_tensor(decode_with_corruption(c.offset, c.value.data(), c.value.size())), std::invalid_argument
+        );
+    }
+}
+
+TEST(BufferAbi, DecodeRejectsAViewPastItsBacking) {
+    Tensor r = make_tensor();
+    r.buffer.nbytes = r.byte_offset + tensor_extent_bytes(r);
+    EXPECT_NO_THROW(validate_tensor(r));  // exact fit
+
+    r.buffer.nbytes -= 1;
+    EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+
+    r = make_tensor();
+    r.buffer.nbytes = r.byte_offset + tensor_extent_bytes(r);
+    r.byte_offset += get_element_size(r.dtype);  // shifting the origin pushes the tail out
+    EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+}
+
+TEST(BufferAbi, ValidateNeverWalksOffArbitraryBytes) {
+    // A peer can write anything of the right length. None of it may be accepted without passing
+    // every field check, and none of it may read past the struct — the fixed-length identity and
+    // the bounded body_len/ndims are what make that structural rather than a matter of luck.
+    std::mt19937 rng(0x5342);  // fixed seed: a failure here must reproduce
+    for (int i = 0; i < 4096; ++i) {
+        uint8_t bytes[sizeof(Tensor)];
+        for (auto &b : bytes)
+            b = static_cast<uint8_t>(rng());
+        Tensor r;
+        std::memcpy(&r, bytes, sizeof(Tensor));
+        try {
+            validate_tensor(r);
+        } catch (const std::invalid_argument &) {
+            continue;  // the expected outcome
+        }
+        // Surviving is legal only if every invariant genuinely holds.
+        EXPECT_EQ(r.buffer.magic, BUFFER_DESCRIPTOR_MAGIC);
+        EXPECT_NE(r.buffer.identity.generation, 0u);
+        EXPECT_LE(r.buffer.body_len, DESC_MAX_BYTES);
+        EXPECT_GT(r.ndims, 0u);
+        EXPECT_LE(r.ndims, static_cast<uint32_t>(MAX_TENSOR_DIMS));
+    }
+
+    for (uint8_t fill : {uint8_t{0x00}, uint8_t{0xFF}}) {
+        uint8_t bytes[sizeof(Tensor)];
+        std::memset(bytes, fill, sizeof(bytes));
+        Tensor r;
+        std::memcpy(&r, bytes, sizeof(Tensor));
+        EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+    }
+}
+
+TEST(BufferAbi, DecodedIdentityIgnoresWirePadding) {
+    // Two decodes of one backing must key identically however the padding arrived, or an import
+    // registry splits one buffer across two entries.
+    uint8_t clean[sizeof(CanonicalIdentity)];
+    CanonicalIdentity src = make_identity();
+    std::memcpy(clean, &src, sizeof(CanonicalIdentity));
+
+    uint8_t dirty[sizeof(CanonicalIdentity)];
+    std::memcpy(dirty, clean, sizeof(CanonicalIdentity));
+    std::memset(dirty + offsetof(CanonicalIdentity, _pad), 0xA5, sizeof(CanonicalIdentity::_pad));
+
+    CanonicalIdentity a;
+    CanonicalIdentity b;
+    std::memcpy(&a, clean, sizeof(a));
+    std::memcpy(&b, dirty, sizeof(b));
+    EXPECT_TRUE(a == b);
+    EXPECT_EQ(CanonicalIdentityHash{}(a), CanonicalIdentityHash{}(b));
+}
+
+}  // namespace

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -1,0 +1,278 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for simpler.buffer: identity/descriptor pack-unpack + create/import round trip.
+
+The three wire types are the C++ structs of buffer.h bound directly, so what is pinned here is the
+Python-visible contract over them — construction rejects what `validate_buffer_descriptor` rejects,
+a round trip through `pack`/`unpack` is the identity, and equality and hashing ignore wire padding.
+Imports come from `simpler.buffer` because that is where a caller reaches them, alongside the
+registry and the Buffer constructors that are genuinely defined there.
+"""
+
+import pytest
+from _task_interface import OWNER_INSTANCE_ID_BYTES, DataType
+from simpler.buffer import (
+    AccessMode,
+    AddressSpace,
+    BackendKind,
+    BufferDescriptor,
+    CanonicalIdentity,
+    ImportRegistry,
+    Tensor,
+    create_host_shared_buffer,
+    intern_worker_path,
+    mint_owner_instance_id,
+    re_export,
+    wrap_device_malloc,
+)
+from simpler.task_interface import ChipTensor
+
+_OID = bytes(range(0xA0, 0xA0 + OWNER_INSTANCE_ID_BYTES))
+
+
+def test_wire_tensor_and_device_pod_are_distinct_types():
+    # The whole point of the two names: one address-free argument, one GM-address-bearing POD. An
+    # alias here would give `Tensor` a second meaning and every later cutover would have to keep it.
+    assert ChipTensor is not Tensor
+
+
+def test_wire_tensor_stays_off_the_public_submit_surface():
+    # `TaskArgs.add_tensor` still takes a ChipTensor, so re-exporting `Tensor` from
+    # simpler.task_interface would advertise a public type that its own submit call rejects. The two
+    # facts move together: the wire cutover that makes add_tensor accept a Tensor is what earns it a
+    # place on that module, and this test fails then to say so.
+    import simpler.task_interface as ti  # noqa: PLC0415
+
+    assert not hasattr(ti, "Tensor")
+
+    h = create_host_shared_buffer(64, mint_owner_instance_id(), buffer_id=1)
+    try:
+        args = ti.TaskArgs()
+        with pytest.raises(TypeError):
+            args.add_tensor(h.tensor(shapes=(16,), dtype=DataType.FLOAT32))
+    finally:
+        h.close()
+
+
+def _identity(oid=_OID, buffer_id=7, generation=2):
+    return CanonicalIdentity(oid, buffer_id, generation)
+
+
+def test_identity_rejects_bad_oid_width():
+    with pytest.raises(ValueError):
+        CanonicalIdentity(b"\x00" * (OWNER_INSTANCE_ID_BYTES + 1), 1, 1)
+
+
+def test_identity_distinguishes_generation_and_incarnation():
+    a = _identity()
+    assert a != _identity(generation=a.generation + 1)  # ABA
+    assert a != _identity(oid=bytes(range(1, 1 + OWNER_INSTANCE_ID_BYTES)))  # different incarnation
+    assert a != _identity(buffer_id=a.buffer_id + 1)
+
+
+def _descriptor_with_path_id(path_id: int) -> BufferDescriptor:
+    return BufferDescriptor(
+        identity=_identity(),
+        address_space=AddressSpace.HOST,
+        access=AccessMode.READWRITE,
+        backend_kind=BackendKind.POSIX_SHM,
+        nbytes=8,
+        owner_worker_path_id=path_id,
+    )
+
+
+def test_worker_path_is_diagnostic_and_survives_an_unknown_id():
+    h = _descriptor_with_path_id(intern_worker_path("L4/L3[2]"))
+    assert h.owner_worker_path == "L4/L3[2]"
+    # An id minted in another process has no local text, and that is not an error.
+    assert _descriptor_with_path_id(99_999).owner_worker_path == "<path#99999>"
+    # The path takes no part in identity: two descriptors differing only by path are one backing.
+    assert _descriptor_with_path_id(0).identity == h.identity
+
+
+def test_descriptor_rejects_oversized_body():
+    with pytest.raises(ValueError, match="body"):
+        BufferDescriptor(
+            identity=_identity(),
+            address_space=AddressSpace.HOST,
+            access=AccessMode.READWRITE,
+            backend_kind=BackendKind.POSIX_SHM,
+            nbytes=8,
+            body=b"x" * 200,  # > DESC_MAX_BYTES
+        )
+
+
+def test_create_export_import_resolve_zero_copy():
+    oid = mint_owner_instance_id()
+    buffer = create_host_shared_buffer(nbytes=256, owner_instance_id=oid, buffer_id=1, owner_worker_path="L4")
+    reg = ImportRegistry()
+    try:
+        assert buffer.backend_kind == BackendKind.POSIX_SHM
+        imported = reg.materialize(buffer.to_descriptor())
+        assert reg.resolve(buffer.identity).base == imported.base
+        assert reg.materialize(buffer.to_descriptor()).base == imported.base  # map-once: same mapping
+        assert imported.nbytes == 256
+        owner_shm = buffer.shm
+        consumer_shm = imported.shm
+        assert owner_shm is not None
+        assert consumer_shm is not None
+        owner_buf = owner_shm.buf
+        consumer_buf = consumer_shm.buf
+        assert owner_buf is not None
+        assert consumer_buf is not None
+        owner_buf[:4] = b"\xde\xad\xbe\xef"
+        assert bytes(consumer_buf[:4]) == b"\xde\xad\xbe\xef"
+    finally:
+        reg.close()
+        buffer.close()
+
+
+def test_resolve_unregistered_raises():
+    reg = ImportRegistry()
+    with pytest.raises(KeyError):
+        reg.resolve(_identity())
+
+
+def test_tensor_full_view_is_contiguous():
+    oid = mint_owner_instance_id()
+    h = create_host_shared_buffer(nbytes=1024, owner_instance_id=oid, buffer_id=1)
+    try:
+        # buffer.tensor(shape, dtype) is a contiguous full view: row-major strides, zero offset.
+        v = h.tensor(shapes=(4, 8), dtype=DataType.FLOAT32)
+        assert v.shapes == (4, 8)
+        assert v.strides == (8, 1)
+        assert v.ndims == 2
+        assert v.byte_offset == 0
+        # An explicit stride is carried verbatim; a singleton dim is never normalized away.
+        strided = h.tensor(shapes=(4, 1), dtype=DataType.FLOAT32, strides=(8, 3))
+        assert strided.strides == (8, 3)
+    finally:
+        h.close()
+
+
+def test_re_export_preserves_identity_same_backing_no_map():
+    # Frozen model §5/§8: canonical identity is invariant across every edge. Re-exporting an L4-owned
+    # backing for forwarding keeps the SOURCE identity (owner_instance_id / path / buffer_id /
+    # generation) and the same backing, only stripping the mapping.
+    l4 = mint_owner_instance_id()
+    src = create_host_shared_buffer(64, l4, buffer_id=7, owner_worker_path="L4")
+    try:
+        sdesc = src.to_descriptor()
+        hp = re_export(sdesc)
+        assert hp.identity == src.identity  # identity invariant across the edge
+        assert hp.backend_kind == BackendKind.POSIX_SHM
+        assert hp.body == sdesc.body and hp.nbytes == 64  # same backing
+        assert hp.shm is None and hp.base == 0  # no map (lazy — a compute leaf maps)
+        # a tensor built from H' carries the source identity + the same shm body, so L2 can materialize it
+        r = hp.tensor(shapes=(16,), dtype=DataType.FLOAT32)
+        assert r.buffer.identity == src.identity
+        assert r.buffer.body == sdesc.body
+    finally:
+        src.close()
+
+
+def test_device_malloc_wrap_materialize():
+    # A device pointer (from orch.malloc) wrapped as DEVICE_MALLOC: materializes to the pointer with
+    # no map, address_space DEVICE (-> a child_memory Tensor).
+    oid = mint_owner_instance_id()
+    h = wrap_device_malloc(0xDEAD0000, 4096, oid, buffer_id=3, owner_worker_path="L3")
+    assert h.backend_kind == BackendKind.DEVICE_MALLOC
+    assert h.address_space == AddressSpace.DEVICE
+    assert h.shm is None and h.base == 0xDEAD0000
+    reg = ImportRegistry()
+    imp = reg.materialize(h.to_descriptor())
+    assert imp.base == 0xDEAD0000
+    assert imp.address_space == AddressSpace.DEVICE
+    assert imp.shm is None
+
+
+def test_materialize_remote_sidecar_rejected():
+    desc = BufferDescriptor(
+        identity=_identity(),
+        address_space=AddressSpace.HOST,
+        access=AccessMode.READWRITE,
+        backend_kind=BackendKind.REMOTE_SIDECAR,
+        nbytes=8,
+    )
+    reg = ImportRegistry()
+    with pytest.raises(ValueError, match="REMOTE_SIDECAR"):
+        reg.materialize(desc)
+
+
+def test_owner_instance_ids_are_distinct():
+    ids = {mint_owner_instance_id() for _ in range(64)}
+    assert len(ids) == 64
+    assert all(len(i) == OWNER_INSTANCE_ID_BYTES for i in ids)
+
+
+@pytest.mark.parametrize(
+    "space,backend",
+    [
+        (AddressSpace.HOST, BackendKind.VMM_WINDOW),
+        (AddressSpace.HOST, BackendKind.DEVICE_MALLOC),
+        (AddressSpace.DEVICE, BackendKind.FORK_SHM),
+        (AddressSpace.DEVICE, BackendKind.POSIX_SHM),
+    ],
+)
+def test_descriptor_rejects_bad_capability_combo(space, backend):
+    # §4.1 capability matrix: an unsupported address_space×backend_kind fails at construction (before
+    # dispatch, before it can ride the wire).
+    with pytest.raises(ValueError, match="capability"):
+        BufferDescriptor(
+            identity=_identity(),
+            address_space=space,
+            access=AccessMode.READWRITE,
+            backend_kind=backend,
+            nbytes=64,
+            body=b"",
+        )
+
+
+def test_descriptor_accepts_legal_combos():
+    for space, backend in [
+        (AddressSpace.HOST, BackendKind.FORK_SHM),
+        (AddressSpace.HOST, BackendKind.POSIX_SHM),
+        (AddressSpace.DEVICE, BackendKind.VMM_WINDOW),
+        (AddressSpace.DEVICE, BackendKind.DEVICE_MALLOC),
+        (AddressSpace.HOST, BackendKind.REMOTE_SIDECAR),
+        (AddressSpace.DEVICE, BackendKind.REMOTE_SIDECAR),
+    ]:
+        BufferDescriptor(_identity(), space, AccessMode.READWRITE, backend, 64, b"")
+
+
+# --- the shared validator, on the paths Python can reach --------------------------------------
+#
+# `validate_tensor` guards two boundaries: construction (here) and blob decode, which after the wire
+# flip is `TaskArgsView::tensors(i)` in task_args.h. Both are C++, and Python has no way to turn
+# bytes into a Tensor at all — so the malformed-bytes cases (bad magic, unknown backend tag,
+# generation 0, body_len past the array, a view that does not fit) are exercised where they can be
+# built: tests/ut/cpp/types/test_buffer.cpp. What is reachable from here is the construction gate.
+
+
+def test_construction_rejects_a_view_past_the_backing():
+    h = create_host_shared_buffer(64, mint_owner_instance_id(), buffer_id=1)
+    try:
+        h.tensor(shapes=(16,), dtype=DataType.FLOAT32)  # exactly 64 B: fits
+        with pytest.raises(ValueError, match="past the backing"):
+            h.tensor(shapes=(17,), dtype=DataType.FLOAT32)
+        with pytest.raises(ValueError, match="past the backing"):
+            h.tensor(shapes=(16,), dtype=DataType.FLOAT32, byte_offset=4)
+    finally:
+        h.close()
+
+
+def test_construction_rejects_a_zero_stride():
+    # strides are element strides and strictly > 0: broadcast and negative step are unsupported, and
+    # a 0 would make two coordinates alias without the overlap map ever seeing it.
+    h = create_host_shared_buffer(256, mint_owner_instance_id(), buffer_id=1)
+    try:
+        with pytest.raises(ValueError, match="stride"):
+            h.tensor(shapes=(4, 8), dtype=DataType.FLOAT32, strides=(8, 0))
+    finally:
+        h.close()

--- a/tests/ut/py/test_scene_test_rehost.py
+++ b/tests/ut/py/test_scene_test_rehost.py
@@ -137,7 +137,7 @@ def test_rehost_rejects_noncontiguous():
 # Characterization (partial) — SceneTest host-tensor rehost adapter.
 #
 # These pin CURRENT behavior of the Python rehost / arg-build layer as input to
-# a planned typed-BufferHandle change (that planning context lives in the PR
+# a planned typed-Buffer change (that planning context lives in the PR
 # description). They assert what is, not what should be:
 #   - a size-1 dimension's stride is normalized away, and
 #   - non-overlapping views of one storage are split into independent buffers.

--- a/tests/ut/py/test_worker/test_host_addr_rewrite.py
+++ b/tests/ut/py/test_worker/test_host_addr_rewrite.py
@@ -18,7 +18,7 @@ per-tensor ``child_memory`` flag, not on the numeric address alone.
 
 import struct
 
-from _task_interface import TENSOR_CHILD_MEMORY_OFFSET, TENSOR_STRIDE_BYTES
+from _task_interface import CHIP_TENSOR_CHILD_MEMORY_OFFSET, CHIP_TENSOR_STRIDE_BYTES
 from simpler.worker import _BLOB_HEADER_BYTES, _rewrite_blob_host_addrs
 
 _PARENT_LO = 0x7F00_0000_0000
@@ -27,25 +27,25 @@ _CHILD_BASE = 0x7E00_0000_0000
 
 
 def _make_blob(tensors: list[tuple[int, int]]) -> bytearray:
-    """Build a task-args blob: [int32 T][int32 S][Tensor*T].
+    """Build a task-args blob: [int32 T][int32 S][ChipTensor*T].
 
     ``tensors`` is a list of ``(addr, child_memory)``. Only the two fields the
     rewrite reads (buffer.addr at offset 0, child_memory at its struct offset)
     are populated; the rest of each 128-byte tensor stays zero.
     """
     n = len(tensors)
-    buf = bytearray(_BLOB_HEADER_BYTES + n * TENSOR_STRIDE_BYTES)
+    buf = bytearray(_BLOB_HEADER_BYTES + n * CHIP_TENSOR_STRIDE_BYTES)
     struct.pack_into("<i", buf, 0, n)  # tensor count
     struct.pack_into("<i", buf, 4, 0)  # scalar count
     for i, (addr, child_mem) in enumerate(tensors):
-        off = _BLOB_HEADER_BYTES + i * TENSOR_STRIDE_BYTES
+        off = _BLOB_HEADER_BYTES + i * CHIP_TENSOR_STRIDE_BYTES
         struct.pack_into("<Q", buf, off, addr)
-        struct.pack_into("<B", buf, off + TENSOR_CHILD_MEMORY_OFFSET, child_mem)
+        struct.pack_into("<B", buf, off + CHIP_TENSOR_CHILD_MEMORY_OFFSET, child_mem)
     return buf
 
 
 def _tensor_addr(buf: bytearray, i: int) -> int:
-    off = _BLOB_HEADER_BYTES + i * TENSOR_STRIDE_BYTES
+    off = _BLOB_HEADER_BYTES + i * CHIP_TENSOR_STRIDE_BYTES
     return struct.unpack_from("<Q", buf, off)[0]
 
 


### PR DESCRIPTION
## The buffer ABI: how L3+ tasks name their data

At L3 and above a task argument is a raw pointer plus a `child_memory` bool, so the receiver has to
guess what it was handed. This lands the typed, self-describing replacement — a canonical identity, a
backend descriptor, and a strided view — which together let a consumer resolve a buffer exactly
across the L3→L2 and L4→L3 boundaries with no side table and no address rewriting.

User guide: [`docs/buffer-abi.md`](../blob/p1-b-abi-foundation/docs/buffer-abi.md), including the
"Why `Tensor` and `ChipTensor` are two types" section with the two rejected unifications.

**Nothing dispatches a `Tensor` yet** — `TaskArgs` still carries the device POD — so this is
behavior-neutral. It lands on its own because the byte layout is frozen once it ships, and it should
be read in its own context rather than inside the cutover that consumes it.

### What lands here

| | |
| --- | --- |
| `src/common/task_interface/buffer.h` | 3 wire types + `validate_buffer_descriptor` / `validate_tensor` + `tensor_extent_bytes` / `tensors_overlap`, every offset and size pinned by `static_assert` |
| `python/bindings/task_interface.cpp` | those 3 types and their 3 enums bound directly |
| `python/simpler/buffer.py` | `Buffer` (owns a POSIX shm), the `wrap_*` constructors, `ImportRegistry` (map-once by canonical identity) |
| `python/simpler/worker.py` | `Worker.create_buffer`, released through the retryable cleanup journal |

Three types. `Buffer` is an owned backing with a lifecycle, which stays with the Worker that created
it. `Tensor` is the argument a user builds and submits: the buffer descriptor embedded whole, plus a
view, and no address — at submit time none exists, since a POSIX_SHM backing maps to a different VA
in every process and a DEVICE_MALLOC one is valid only on its owner chip. `ChipTensor` is the POD the
L2 runtime ABI reads, which must carry an address because the kernel dereferences it.

### Naming — the model from #1676 / #1681

```text
Worker domain:  Tensor      — address-free, cross-edge logical view
Chip domain:    ChipTensor  — materialized GM-address-bearing POD
```

Rebased onto #1681, which moved the device POD off the global `Tensor` name. That is what frees the
plain name for the L3+ type, so `Buffer` and `Tensor` are global in C++ and spelled identically in
Python — no namespace, no per-language alias, no second public meaning for `Tensor`.

`TENSOR_STRIDE_BYTES` and `TENSOR_CHILD_MEMORY_OFFSET`, which describe the device POD, become
`CHIP_TENSOR_STRIDE_BYTES` / `CHIP_TENSOR_CHILD_MEMORY_OFFSET` so they cannot be read as belonging to
the wire type exported beside them.

### Bound, not mirrored — and no bytes cross the binding

`CanonicalIdentity`, `BufferDescriptor` and `Tensor` are the C++ structs bound directly rather than a
Python re-encoding of the same bytes: one layout definition instead of two, one validator instead of
a full one and a weaker one. `Buffer` and `ImportRegistry` stay Python — they own a `SharedMemory`
and a process-local mapping cache, neither of which is ABI.

The types expose their fields and **not** their encoding: there is no `pack()` / `unpack()`. Python
builds a `Tensor` and receives one already decoded, and the sole path from wire bytes to a `Tensor`
runs inside C++. Withholding the encoding is what keeps `validate_tensor` a gate rather than a
habit — a second way in is a second thing to remember to validate on.

Measured on the receive path, decoding a 4-tensor blob into objects: **37 µs → 0.44 µs**.

### No second transport

A `Tensor` rides the TaskArgs mailbox blob that `write_blob` / `read_blob` already implement in
`task_args.h`. The cutover swaps that blob's element from `ChipTensor` to `Tensor` and moves
`TaskArgsView` with it, leaving `ChipTensor` only in `ChipStorageTaskArgs`. A second blob codec
beside the existing one would be the same structure twice, so this PR ships the types and their gate
and leaves the wire where it is.

> **Cutover note.** `TaskArgsView::tensors(i)` does not validate today, which is correct while the
> element is a `ChipTensor` — an address plus a shape has no wire invariant a decoder could test. The
> flip must add `validate_tensor(t)` there, because `Tensor` does have invariants and this PR
> deliberately leaves no other way in.

### `Tensor` is foundation-only until the wire flip

`TaskArgs.add_tensor` still takes a `ChipTensor`, so `Tensor` lives in `simpler.buffer` and is **not**
re-exported from `simpler.task_interface`. A public type whose own submit call rejects it is worse
than no public type; it joins that module in the cutover that makes `TaskArgs` carry it.

`test_wire_tensor_stays_off_the_public_submit_surface` pins the two facts to each other — whichever
moves first fails until the other follows.

### A latent defect, found and fixed

`ImportRegistry` keyed on `identity.pack()`, and `pack()` emitted `_pad`, which defeats the
padding-insensitive equality and hashing the model rests on: two decodes of one backing landed in two
registry entries, so map-once silently did not hold. Caught with a failing repro first. The registry
now keys on the identity itself; with `pack()` gone the mistake is no longer expressible at all,
which is a stronger guarantee than the regression test it replaces.

Today the padding is zero end to end, so this is latent — it becomes real the moment the cutover puts
descriptors on a live mailbox.

### What is deliberately NOT here

- **The wire flip.** `TaskArgs` still carries the device POD, so `buffer.tensor(...)` has no consumer
  and the submit-time checks the doc describes are not reachable.
- The other allocators (`alloc_shared_tensor`, `alloc_child_tensor`), device-memory ownership moving
  onto the `Worker`, comm-domain `VMM_WINDOW` buffers, and the example/scene-test migration.
- `ChipTaskArgs<ChipTensor>` naming at the chip boundary (#1676 point 4). Worth flagging for whoever
  picks it up: **`ChipTaskArgs` is already taken** by the device-side orchestration arg in
  `src/{arch}/runtime/*/pto_types.h`, while the host-side type is `ChipStorageTaskArgs`.

### Verification

- [x] Build green — all four arch×runtime C++ trees plus the nanobind extension
- [x] `pyut` — 1131 passed, 6 skipped
- [x] `cpput` — 81/81 (no-hardware subset); `test_buffer` is 13 cases, including field-by-field
      decode rejection, a fixed-seed 4096-iteration arbitrary-bytes pass, and padding-insensitive
      identity keying
- [x] pre-commit green (clang-format / clang-tidy / cpplint / markdownlint / ruff / pyright)
- [x] `a2a3sim` and `a5sim` full scene suites rc=0 on the immediately preceding revision; re-running
      on this one (the delta since is binding surface, tests and docs only — no runtime path)
- [ ] Hardware (onboard) — not run

The malformed-bytes cases live in `tests/ut/cpp/types/test_buffer.cpp` rather than Python, because
with no `unpack()` those states cannot be built from Python at all — which is the point.
