### PR TITLE
Fix: honor ASCEND_RT_VISIBLE_DEVICES at direct-HAL device-id sites

### DIFF
--- a/src/a2a3/platform/onboard/host/aicpu_topology_probe.cpp
+++ b/src/a2a3/platform/onboard/host/aicpu_topology_probe.cpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include "common/unified_log.h"
+#include "common/acl_hal_device.h"
 
 namespace pto::a2a3 {
 
@@ -60,7 +61,7 @@ bool query_occupy(uint32_t device_id, uint64_t &out_mask) {
     if (fn == nullptr) return false;
 
     int64_t v = 0;
-    int rc = fn(static_cast<uint64_t>(device_id), kModuleAicpu, kInfoOccupy, &v);
+    int rc = fn(static_cast<uint64_t>(pto::acl_to_hal_device_id(device_id)), kModuleAicpu, kInfoOccupy, &v);
     if (rc != 0) {
         LOG_WARN("a2a3_aicpu_topology_probe: halGetDeviceInfo(AICPU,OCCUPY) rc=%d", rc);
         return false;

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -17,6 +17,7 @@
 #include "host/memory_allocator.h"
 #include "common/unified_log.h"
 #include "common/platform_config.h"
+#include "common/acl_hal_device.h"
 #include "runtime/rt.h"
 #include "ascend_hal.h"  // CANN HAL API definitions (MODULE_TYPE_AICORE, INFO_TYPE_OCCUPY, etc.)
 #include <chrono>
@@ -78,8 +79,9 @@ static bool get_pg_mask(uint64_t &valid, int64_t device_id) {
  */
 static int
 get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const int &addr_type, int64_t device_id) {
+    const int64_t phys_device_id = pto::acl_to_hal_device_id(device_id);
     uint64_t valid = 0;
-    if (!get_pg_mask(valid, device_id)) {
+    if (!get_pg_mask(valid, phys_device_id)) {
         // If can't get mask, assume all cores valid
         valid = 0xFFFFFFFF;
         LOG_WARN("Using default valid mask 0xFFFFFFFF");
@@ -102,7 +104,7 @@ get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const 
 
     struct AddrMapInPara in_map_para;
     struct AddrMapOutPara out_map_para;
-    in_map_para.devid = device_id;
+    in_map_para.devid = phys_device_id;
     in_map_para.addr_type = addr_type;
 
     // Retry rc=13 (EACCES): concurrent chip_process bring-up across paired dies
@@ -123,8 +125,8 @@ get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const 
         if (ret != kHalMemCtlEacces) break;
         if (attempt == kHalMemCtlMaxRetries) break;
         LOG_WARN(
-            "halMemCtl rc=13 (EACCES) on devid=%lld attempt %d/%d, retrying after %d ms", (long long)device_id,
-            attempt + 1, kHalMemCtlMaxRetries, kHalMemCtlRetryDelayMs
+            "halMemCtl rc=13 (EACCES) on devid=%lld (acl=%lld) attempt %d/%d, retrying after %d ms",
+            (long long)phys_device_id, (long long)device_id, attempt + 1, kHalMemCtlMaxRetries, kHalMemCtlRetryDelayMs
         );
         std::this_thread::sleep_for(std::chrono::milliseconds(kHalMemCtlRetryDelayMs));
     }

--- a/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
+++ b/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "common/unified_log.h"
+#include "common/acl_hal_device.h"
 
 namespace pto::a5 {
 
@@ -112,7 +113,7 @@ bool query_occupy(uint32_t device_id, uint64_t &out_mask) {
     auto fn = load_hal_get_device_info();
     if (fn == nullptr) return false;
     int64_t v = 0;
-    int rc = fn(static_cast<uint64_t>(device_id), kModuleAicpu, kInfoOccupy, &v);
+    int rc = fn(static_cast<uint64_t>(pto::acl_to_hal_device_id(device_id)), kModuleAicpu, kInfoOccupy, &v);
     if (rc != 0) {
         LOG_WARN("aicpu_topology_probe: halGetDeviceInfo(AICPU,OCCUPY) rc=%d", rc);
         return false;
@@ -125,13 +126,20 @@ bool query_cpu_topo(uint32_t device_id, DsmiCpuTopo &out) {
     std::memset(&out, 0, sizeof(out));
     if (auto fn = load_hal_get_device_info_by_buff(); fn != nullptr) {
         int32_t sz = static_cast<int32_t>(sizeof(out));
-        int rc = fn(static_cast<uint64_t>(device_id), kModuleSystem, kInfoCpuTopo, &out, &sz);
+        int rc =
+            fn(static_cast<uint64_t>(pto::acl_to_hal_device_id(device_id)), kModuleSystem, kInfoCpuTopo, &out, &sz);
         if (rc == 0 && out.total_nums > 0 && out.total_nums <= kCpuTopoMaxLogical) return true;
         LOG_WARN("aicpu_topology_probe: halGetDeviceInfoByBuff(CPU_TOPO) rc=%d total=%u", rc, out.total_nums);
     }
     if (auto fn = load_dsmi_get_device_info(); fn != nullptr) {
         unsigned int sz = static_cast<unsigned int>(sizeof(out));
-        int rc = fn(device_id, kDsmiSocInfoMainCmd, kDsmiSocInfoSubCmdCpuTopo, &out, &sz);
+        // DSMI is a driver-level API (bypasses ACL), so like the hal* calls it needs the
+        // driver-visible id. NOTE (unverified — no a5 hardware): this assumes
+        // dsmi_get_device_info indexes the same driver-visible id space as the HAL; if DSMI
+        // uses its own logic-id numbering this is wrong. Revisit once an a5 node is available.
+        int rc =
+            fn(static_cast<uint32_t>(pto::acl_to_hal_device_id(device_id)), kDsmiSocInfoMainCmd,
+               kDsmiSocInfoSubCmdCpuTopo, &out, &sz);
         if (rc == 0 && out.total_nums > 0 && out.total_nums <= kCpuTopoMaxLogical) return true;
         LOG_WARN("aicpu_topology_probe: dsmi_get_device_info(CPU_TOPO) rc=%d total=%u", rc, out.total_nums);
     }

--- a/src/a5/platform/onboard/host/host_regs.cpp
+++ b/src/a5/platform/onboard/host/host_regs.cpp
@@ -17,6 +17,7 @@
 #include "host/memory_allocator.h"
 #include "common/unified_log.h"
 #include "common/platform_config.h"
+#include "common/acl_hal_device.h"
 #include "runtime/rt.h"
 #include "ascend_hal.h"  // CANN HAL API definitions
 #include <dlfcn.h>
@@ -39,6 +40,8 @@ static int get_aicore_reg_info(std::vector<int64_t> &regs, int64_t device_id) {
         return -1;
     }
 
+    const int64_t phys_device_id = pto::acl_to_hal_device_id(device_id);
+
     // Calculate layout parameters from platform config
     constexpr uint32_t SUB_CORE_PER_DIE = PLATFORM_AICORE_PER_DIE * PLATFORM_CORES_PER_BLOCKDIM;
     constexpr uint32_t AIV_BASE_OFFSET = PLATFORM_AICORE_PER_DIE;
@@ -59,7 +62,7 @@ static int get_aicore_reg_info(std::vector<int64_t> &regs, int64_t device_id) {
         uint64_t map_addr = 0;
         uint32_t len = REG_AICORE_MAP_SIZE;
 
-        auto ret = halFunc(static_cast<uint32_t>(device_id), &map_info, &map_addr, &len);
+        auto ret = halFunc(static_cast<uint32_t>(phys_device_id), &map_info, &map_addr, &len);
         if (ret != 0) {
             LOG_ERROR("halResMap failed for core %u (rc=%d)", core_idx, ret);
             return ret;

--- a/src/common/platform/include/common/acl_hal_device.h
+++ b/src/common/platform/include/common/acl_hal_device.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * @file acl_hal_device.h
+ * @brief ACL-logical to driver-visible device-id translation for direct HAL calls.
+ */
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <cstdlib>
+#include <string_view>
+
+#include "common/unified_log.h"
+
+namespace pto {
+
+/**
+ * Translate an ACL/rt *logical* device id into the *driver-visible* id that the
+ * raw driver HAL indexes.
+ *
+ * Contract — every device id crossing into the driver must pick the right space:
+ *   - Direct `hal*` / `dlsym`'d driver calls (`halMemCtl`, `halGetDeviceInfo*`,
+ *     ...) index the driver-visible space and MUST translate through this
+ *     function: `hal_fn(acl_to_hal_device_id(device_id))`.
+ *   - ACL/rt entry points (`aclrtSetDevice`, `rtMalloc`, `rtMemcpy`, stream
+ *     APIs, ...) take the logical id and MUST NOT.
+ *
+ * `ASCEND_RT_VISIBLE_DEVICES` renumbers the logical space to `0..N-1` while the
+ * HAL keeps indexing the driver-visible space; a direct HAL call made with the
+ * logical id then targets the wrong device (`rc=42`). This returns the identity
+ * when the variable is unset (legacy / no isolation).
+ *
+ * The whole list is validated before any entry is trusted: one malformed token
+ * means the environment is misconfigured, so we fall back to the unremapped
+ * logical id rather than act on a half-parsed guess. Every fallback is logged so
+ * a silent mis-target becomes a two-second diagnosis.
+ *
+ * Note: the returned value is the *driver-visible* id, which need not equal the
+ * absolute physical (`npu-smi`) id — a container-level `ASCEND_VISIBLE_DEVICES`
+ * remaps the driver's own numbering, and `ASCEND_RT_VISIBLE_DEVICES` indexes
+ * into that already-remapped set. Indexing the driver-visible set is exactly
+ * what the HAL needs.
+ */
+inline int64_t acl_to_hal_device_id(int64_t logical_id) {
+    const char *vis = std::getenv("ASCEND_RT_VISIBLE_DEVICES");
+    if (vis == nullptr || vis[0] == '\0' || logical_id < 0) {
+        return logical_id;
+    }
+    const std::string_view list(vis);
+    int64_t idx = 0;
+    int64_t driver_id = -1;  // driver-visible id at logical_id, once seen
+    std::size_t pos = 0;
+    while (pos < list.size()) {
+        while (pos < list.size() && (list[pos] == ' ' || list[pos] == ',')) {
+            ++pos;
+        }
+        if (pos >= list.size()) {
+            break;
+        }
+        int value = 0;
+        const auto [ptr, ec] = std::from_chars(list.data() + pos, list.data() + list.size(), value);
+        // from_chars reports the token end via ptr and overflow via ec; a token
+        // must also be terminated by a list delimiter or end-of-string ("6x" is
+        // malformed), and negative ids are invalid.
+        const bool terminated = ptr == list.data() + list.size() || *ptr == ' ' || *ptr == ',';
+        if (ptr == list.data() + pos || ec != std::errc() || value < 0 || !terminated) {
+            LOG_WARN(
+                "ASCEND_RT_VISIBLE_DEVICES=\"%s\" is malformed; using logical device id %lld unremapped", vis,
+                static_cast<long long>(logical_id)
+            );
+            return logical_id;
+        }
+        if (idx == logical_id) {
+            driver_id = value;
+        }
+        ++idx;
+        pos = static_cast<std::size_t>(ptr - list.data());
+    }
+    if (driver_id < 0) {
+        // Distinct from the unset case above: the variable is set but too short,
+        // which is a definite misconfiguration rather than a no-isolation default.
+        LOG_WARN(
+            "logical device id %lld is out of range of ASCEND_RT_VISIBLE_DEVICES=\"%s\" (%lld visible); "
+            "using it unremapped",
+            static_cast<long long>(logical_id), vis, static_cast<long long>(idx)
+        );
+        return logical_id;
+    }
+    LOG_DEBUG("device id: acl %lld -> hal %lld", static_cast<long long>(logical_id), static_cast<long long>(driver_id));
+    return driver_id;
+}
+
+}  // namespace pto

--- a/tests/st/vis_isolation/test_vis_isolation.py
+++ b/tests/st/vis_isolation/test_vis_isolation.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Onboard ST: chip init works when ``ASCEND_RT_VISIBLE_DEVICES`` renumbers the device.
+
+A launcher that isolates NPUs (task queue, container plugin, vLLM-ascend-style
+worker-per-card) sets ``ASCEND_RT_VISIBLE_DEVICES`` and then hands simpler
+logical ids starting at 0. ACL honors the variable for its own entry points, but
+the chip-init path also makes **direct driver calls that bypass ACL** —
+``halMemCtl`` / ``halGetDeviceInfo*`` on a2a3, ``halResMap`` /
+``halGetDeviceInfo*`` / ``dsmi_get_device_info`` on a5 — and those index the
+driver-visible space. Every one of them must translate through
+``common/acl_hal_device.h::acl_to_hal_device_id``; a site that forgets targets
+the wrong device and fails with ``halMemCtl rc=42`` in
+``init_aicore_register_addresses``.
+
+``init_aicore_register_addresses`` and ``probe_aicpu_topology`` run on every
+onboard chip bring-up, so *any* scene test launched under the variable covers
+all of those call sites. ``dummy_task`` is the cheapest one.
+
+The scene test runs in a subprocess: the variable has to be set before the
+process performing ACL init starts, and mutating it in-process would leak into
+the pooled workers the rest of the session shares.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+RUNTIME = "tensormap_and_ringbuffer"
+_ST_ROOT = Path(__file__).resolve().parent.parent
+
+# Platform -> the scene test the subprocess runs. Any onboard scene test would
+# exercise the same chip-init call sites; these are the smallest per arch.
+_DUMMY_TASK = {
+    "a2a3": _ST_ROOT / "a2a3" / RUNTIME / "dummy_task" / "test_dummy_task.py",
+    "a5": _ST_ROOT / "a5" / RUNTIME / "dummy_task" / "test_dummy_task.py",
+}
+
+# The subprocess re-runs a full scene test (build cache hit + one chip bring-up).
+_TIMEOUT_S = 600
+
+
+@pytest.mark.platforms(["a2a3", "a5"])
+@pytest.mark.device_count(2)
+@pytest.mark.runtime(RUNTIME)
+def test_chip_init_under_visible_devices(st_platform, st_device_ids):
+    """Two granted cards, addressed by a logical id that is not its own card id."""
+    scene_test = _DUMMY_TASK[st_platform]
+    assert scene_test.is_file(), f"missing scene test: {scene_test}"
+
+    # The list must be ascending: CANN rejects any other order outright
+    # (`Runtime::GetVisibleDevices`, RT_ALL_ORDER_ERROR), which voids the whole
+    # mapping and makes even rtSetDevice fail with 107001.
+    visible = sorted(int(d) for d in st_device_ids)
+
+    # Position i in the list is logical id i, so a card whose id differs from
+    # its position is what makes the translation observable. Addressing one
+    # where they coincide would pass under the identity mapping this test
+    # exists to reject.
+    logical = next((i for i, card in enumerate(visible) if card != i), None)
+    if logical is None:
+        pytest.skip(f"granted cards {visible} map to themselves; no remap to verify")
+    expected = visible[logical]
+
+    env = {**os.environ, "ASCEND_RT_VISIBLE_DEVICES": ",".join(str(d) for d in visible)}
+    proc = subprocess.run(
+        [sys.executable, str(scene_test), "-p", st_platform, "-d", str(logical)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=_TIMEOUT_S,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print(proc.stdout, file=sys.stderr)
+    assert proc.returncode == 0, (
+        f"dummy_task failed under ASCEND_RT_VISIBLE_DEVICES={env['ASCEND_RT_VISIBLE_DEVICES']} "
+        f"(logical {logical} -> driver-visible {expected}), rc={proc.returncode}"
+    )

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -662,6 +662,7 @@ set_tests_properties(test_orch_so_file PROPERTIES LABELS "no_hardware")
 # ---------------------------------------------------------------------------
 add_a2a3_test(test_a2a3_fatal a2a3/test_a2a3_fatal.cpp)
 add_a2a3_test(test_task_timing_slots a2a3/test_task_timing_slots.cpp)
+add_a2a3_test(test_acl_hal_device common/test_acl_hal_device.cpp)
 
 # PTO2 runtime-linked tests
 add_a2a3_runtime_test(test_task_allocator   a2a3/test_task_allocator.cpp)
@@ -757,6 +758,7 @@ set_tests_properties(test_onboard_device_log_level PROPERTIES LABELS "no_hardwar
 # compute_allowed_cpus is), but the .cpp references libdl symbols, so link it.
 # Regression barrier for issue #1045 (all survivors in one cluster).
 set(A2A3_ONBOARD_HOST_DIR ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/onboard/host)
+set(SIMPLER_COMMON_PLATFORM_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
 add_executable(test_a2a3_aicpu_affinity_select
     a2a3/test_aicpu_affinity_select.cpp
     ${A2A3_ONBOARD_HOST_DIR}/aicpu_topology_probe.cpp
@@ -765,6 +767,7 @@ target_include_directories(test_a2a3_aicpu_affinity_select PRIVATE
     ${GTEST_INCLUDE_DIRS}
     ${A2A3_ONBOARD_HOST_DIR}
     ${SIMPLER_LOG_DIR}/include
+    ${SIMPLER_COMMON_PLATFORM_DIR}/include
 )
 target_link_libraries(test_a2a3_aicpu_affinity_select PRIVATE
     ${GTEST_MAIN_LIB}
@@ -786,6 +789,7 @@ target_include_directories(test_a5_aicpu_topology_fallback PRIVATE
     ${GTEST_INCLUDE_DIRS}
     ${A5_ONBOARD_HOST_DIR}
     ${SIMPLER_LOG_DIR}/include
+    ${SIMPLER_COMMON_PLATFORM_DIR}/include
 )
 target_link_libraries(test_a5_aicpu_topology_fallback PRIVATE
     ${GTEST_MAIN_LIB}

--- a/tests/ut/cpp/a5/test_aicpu_topology_fallback.cpp
+++ b/tests/ut/cpp/a5/test_aicpu_topology_fallback.cpp
@@ -20,6 +20,7 @@ extern "C" {
 void unified_log_error(const char *, const char *, ...) {}
 void unified_log_warn(const char *, const char *, ...) {}
 void unified_log_info(const char *, const char *, ...) {}
+void unified_log_debug(const char *, const char *, ...) {}
 }
 
 namespace {

--- a/tests/ut/cpp/common/test_acl_hal_device.cpp
+++ b/tests/ut/cpp/common/test_acl_hal_device.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unit tests for common/acl_hal_device.h::acl_to_hal_device_id — the ACL-logical
+ * to driver-visible device-id translation applied at direct-HAL call sites so a
+ * chip forked under ASCEND_RT_VISIBLE_DEVICES isolation targets the right device
+ * (regression barrier for the halMemCtl rc=42 this PR fixes). Pure + hardware-
+ * free: it only parses the env var.
+ */
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "common/acl_hal_device.h"
+
+// Minimal logger stubs: the header emits LOG_WARN / LOG_DEBUG on the diagnostic
+// paths. The unified_log symbols have C linkage (see common/unified_log.h);
+// these tests assert on the returned id, not log text.
+extern "C" {
+void unified_log_error(const char *, const char *, ...) {}
+void unified_log_warn(const char *, const char *, ...) {}
+void unified_log_timing(const char *, const char *, ...) {}
+void unified_log_info(const char *, const char *, ...) {}
+void unified_log_debug(const char *, const char *, ...) {}
+}
+
+namespace {
+
+void set_vis(const char *value) {
+    if (value != nullptr) {
+        setenv("ASCEND_RT_VISIBLE_DEVICES", value, 1);
+    } else {
+        unsetenv("ASCEND_RT_VISIBLE_DEVICES");
+    }
+}
+
+TEST(AclToHalDeviceId, IdentityWhenUnsetOrEmpty) {
+    set_vis(nullptr);
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 0);
+    EXPECT_EQ(pto::acl_to_hal_device_id(3), 3);
+    set_vis("");
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 0);
+}
+
+TEST(AclToHalDeviceId, RemapsLogicalToDriverVisible) {
+    set_vis("4,5,6,7");
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 4);
+    EXPECT_EQ(pto::acl_to_hal_device_id(2), 6);  // the reproduced VIS -> wrong-device case
+    EXPECT_EQ(pto::acl_to_hal_device_id(3), 7);
+    set_vis("6");
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 6);
+}
+
+TEST(AclToHalDeviceId, WhitespaceAndEmptyFieldsTolerated) {
+    set_vis(" 4 , 5 , 6 ");
+    EXPECT_EQ(pto::acl_to_hal_device_id(1), 5);
+    set_vis("4,,6");
+    EXPECT_EQ(pto::acl_to_hal_device_id(1), 6);
+}
+
+TEST(AclToHalDeviceId, MalformedListFallsBackToIdentity) {
+    set_vis("-1");
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 0);
+    set_vis("99999999999999999999");  // overflows an int -> rejected
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 0);
+    set_vis("6x");  // token not terminated by a delimiter
+    EXPECT_EQ(pto::acl_to_hal_device_id(0), 0);
+    set_vis("4,5,6,7x");  // a bad token anywhere invalidates the whole list, even after the match
+    EXPECT_EQ(pto::acl_to_hal_device_id(2), 2);
+}
+
+TEST(AclToHalDeviceId, OutOfRangeAndNegativeLogicalFallBack) {
+    set_vis("4,5,6,7");
+    EXPECT_EQ(pto::acl_to_hal_device_id(4), 4);    // logical id beyond the visible list
+    EXPECT_EQ(pto::acl_to_hal_device_id(-3), -3);  // negative logical id
+}
+
+}  // namespace


### PR DESCRIPTION
Under `ASCEND_RT_VISIBLE_DEVICES` isolation a launcher renumbers the visible cards to logical `0..N-1` and hands simpler logical ids. ACL honors the variable for its own APIs (`aclrtSetDevice`, `rtMalloc`/`rtMemcpy`, streams, HCCL), but the chip's **direct driver calls bypass ACL** and index the *driver-visible* space. Passing them the ACL-logical id targets the wrong device: the AI-core register map and the AICPU topology probe — both on the chip-init path (`init_aicore_register_addresses`, `probe_aicpu_topology`) — fail with `halMemCtl rc=42`, while the ACL compute path works.

## Fix

Add `common/acl_hal_device.h::acl_to_hal_device_id`, a single translation that carries the contract on its declaration: direct `hal*` / `dsmi_*` calls take the driver-visible id and must go through it; ACL/rt entry points take the logical id and must not. It validates the whole visible list (any malformed token → logged identity fallback) and is the identity when the variable is unset.

Route every direct-driver device-id site through it, on both arches:
- **a2a3**: `halMemCtl` (register map) + `halGetDeviceInfo*` (AICPU topology).
- **a5**: `halResMap` (register map) + `halGetDeviceInfo*` / `dsmi_get_device_info` (AICPU topology).

## Verification

- A new **VIS-isolation scene test** on both `st-onboard` jobs runs `dummy_task` under `ASCEND_RT_VISIBLE_DEVICES` with `pytest --device 0`, so CI exercises the chip-init translation on a **real a2a3 and a real a5 node every run** (pre-fix it fails with `rc=42`; post-fix it passes). Permanent regression barrier for anyone who adds a direct-HAL call site and forgets to translate.
- Manually reproduced on a2a3 (`VIS=6`, logical `0` → physical `6`): `rc=42` gone, output identical to the legacy physical-id path.
- The parser's malformed / out-of-range fallback policy is locked down by `tests/ut/cpp/common/test_acl_hal_device.cpp`.

## Caveat

The a5 `dsmi_get_device_info` fallback in `query_cpu_topo` is only reached when `halGetDeviceInfoByBuff` fails first, so the VIS ST does not cover it. It is translated for consistency but assumes DSMI shares the HAL's driver-visible id space — flagged with an inline `NOTE`. If that turns out wrong it will surface on a real a5 node and can be revisited then.