### PR TITLE
Fix: cap torch threads for goldens, and put qwen back in the scene-test sweep

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -25,8 +25,7 @@ and will report failures that CI never sees:
 
 | Quarantine | Excludes | Runs instead in |
 | ---------- | -------- | --------------- |
-| `SDMA_IGNORE` (`ci.yml:600`) | `sdma_async_completion_demo`, `prefetch_async_demo` | dedicated "SDMA pytest (a2a3)" step, `--device-num 2` (`ci.yml:628-643`) |
-| `HEAVY_IGNORE` (`ci.yml:605`) | `qwen3_14b_decode` | its own long-timeout step |
+| `SDMA_IGNORE` | `sdma_async_completion_demo`, `prefetch_async_demo` | dedicated "SDMA pytest (a2a3)" step, `--device-num 2` |
 
 The SDMA demos provision 48 device-only STARS streams, which makes an AICore
 fault take ~306 s to tear down instead of ~0.3 s — so they must not share a
@@ -69,9 +68,9 @@ ctest --test-dir tests/ut/cpp/build -L "^requires_hardware(_a2a3)?$" --output-on
 pytest examples tests/st --platform a2a3sim \
     --pto-session-timeout <timeout>
 
-# All hardware scene tests — mirror ci.yml: carry its --ignore sets, or the
-# quarantined tests fail here and nowhere else (extract both from ci.yml)
-pytest examples tests/st $SDMA_IGNORE $HEAVY_IGNORE --platform a2a3 --device <range> \
+# All hardware scene tests — mirror ci.yml: carry its --ignore set, or the
+# quarantined tests fail here and nowhere else (extract it from ci.yml)
+pytest examples tests/st $SDMA_IGNORE --platform a2a3 --device <range> \
     --pto-session-timeout <timeout>
 
 # The quarantined tests, the way CI runs them — alone, on their own devices

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,31 +598,11 @@ jobs:
           # them on their own dedicated device(s) in the SDMA step below, so an
           # SDMA fault's slow teardown can never mix with ordinary fault recovery.
           SDMA_IGNORE="--ignore=examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo --ignore=examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo"
-          # qwen3_14b_decode runs all 40 Qwen3-14B decode layers against a 38 GiB
-          # fixture and takes ~5 min on its own — over half this sweep's 600 s
-          # session budget. It gets its own step below with its own budget, so the
-          # short timeout here keeps its job: catching a genuine hang.
-          HEAVY_IGNORE="--ignore=examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode"
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest examples tests/st $SDMA_IGNORE $HEAVY_IGNORE --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
+            python -m pytest examples tests/st $SDMA_IGNORE --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest examples tests/st $SDMA_IGNORE $HEAVY_IGNORE --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
-          fi
-
-      # qwen3_14b_decode is the full 40-layer Qwen3-14B decode — a 38 GiB fixture
-      # (x40-stacked weights + paged KV) and ~5 min wall. It runs here on its own
-      # device with its own session budget rather than eating the general sweep's.
-      - name: Qwen3-14B 40-layer decode (a2a3)
-        run: |
-          source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
-          QWEN_TEST="examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode"
-          if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest $QWEN_TEST --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1800
-          else
-            task-submit --timeout 3600 --max-time 3600 --device auto --device-num 1 \
-              --run "python -m pytest $QWEN_TEST --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1800"
+              --run "python -m pytest examples tests/st $SDMA_IGNORE --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
           fi
 
       # SDMA pytest — every SDMA test runs here on its own dedicated device(s),

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/README.md
@@ -167,12 +167,27 @@ harvest if you need a clean trace.
 Passes on device: output **and all 40 layers' KV caches** match the torch
 reference at `RTOL=5e-2 / ATOL=1e-1`.
 
-In CI it runs as its own `st-onboard-a2a3` step on a dedicated device, not in
-the general scene-test sweep: at ~5 min it would eat over half that sweep's 600 s
-session budget, and keeping the budget short there is what makes it a hang
-detector. See `.github/workflows/ci.yml`.
+## Cost
 
-Measured on an idle a2a3 die, one device: **~5 min wall** for the whole case,
-of which ~11 s is fixture generation and ~49 s the torch golden (both host-side,
-single-threaded torch over 40 layers × 16 batch × 8 KV heads); the rest is
-kernel compilation, the 38 GiB host→device upload, and the device run itself.
+It runs in the general `st-onboard-a2a3` scene-test sweep like any other case.
+Measured on this repo's a2a3 box, one device:
+
+| Phase | Wall |
+| ----- | ---- |
+| kernel compilation — 36 incores + 1 orchestration | **59 s** |
+| `generate_inputs` (the 38 GiB fixture) | **13 s** |
+| `compute_golden` (40 layers, torch, thread-capped) | **~43 s** |
+| host→device upload, device run, comparison | the remainder; the device itself is busy for tens of ms |
+| | **~115 s** |
+
+Two details behind those numbers. The 38 GiB is mostly replication —
+`torch.cat([w] * 40)` of one layer's weights — so only ~2 GB is actually
+generated; and the vendor FAI kernel is the compile outlier at 8.4 s for its AIV
+variant against ~1.2 s for an ordinary incore.
+
+The golden is thread-capped by the scene-test framework, and that matters more
+than its size: its 3584 small slice operations per layer took **6.35 s per layer
+at 320 torch threads against 1.05 s at 4**, so on a many-core host the untamed
+thread pool cost 5-8x the work it was doing. Before the cap this case held a
+device for **406 s** (ci run 30507320146, job 90761014912) and had to be kept out
+of the sweep with a `--ignore` and a step of its own.

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -78,6 +78,46 @@ def clear_compile_cache() -> None:
     gc.collect()
 
 
+# Goldens are torch reference implementations built from per-tile Python loops —
+# thousands of small slice, matmul and reduce calls per case. torch defaults its
+# intra-op pool to the core count, so on a many-core host every one of those
+# calls pays a fork/join across hundreds of threads to move a few KiB. Measured
+# on a 320-core box with qwen3_14b_decode's 40-layer golden (3584 slice ops per
+# layer): 6.35 s per layer at 320 threads against 1.05 s at 4 and 1.07 s at 8,
+# so the pool costs 5-8x more than the work. The curve is flat from 4 to 16 and
+# turns back up below 4, hence the cap below.
+#
+# Results are unaffected: the same fixture golden-computed at 320 and at 8
+# threads is bit-identical across `out`, `k_cache` and `v_cache`.
+_GOLDEN_MAX_THREADS = 8
+
+
+@contextmanager
+def _golden_thread_cap():
+    """Cap torch's intra-op threads for the duration of a golden computation.
+
+    Only ever lowers the limit — a caller who already asked for fewer keeps
+    theirs. Restores the previous value on the way out, including on exception,
+    so nothing else in the session inherits the cap.
+    """
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        yield
+        return
+
+    previous = torch.get_num_threads()
+    target = min(_GOLDEN_MAX_THREADS, previous)
+    if target == previous:
+        yield
+        return
+    torch.set_num_threads(target)
+    try:
+        yield
+    finally:
+        torch.set_num_threads(previous)
+
+
 # ---------------------------------------------------------------------------
 # Spec types
 # ---------------------------------------------------------------------------
@@ -1245,7 +1285,8 @@ class SceneTestCase:
         golden_args = None
         if not skip_golden:
             golden_args = test_args.clone()
-            self.compute_golden(golden_args, params)
+            with _golden_thread_cap():
+                self.compute_golden(golden_args, params)
 
         # Save initial output tensor values for reset between rounds
         initial_outputs = {}
@@ -1323,7 +1364,8 @@ class SceneTestCase:
         golden_args = None
         if not skip_golden:
             golden_args = test_args.clone()
-            self.compute_golden(golden_args, params)
+            with _golden_thread_cap():
+                self.compute_golden(golden_args, params)
 
         # Eager Worker.init() forked the chip/sub children before generate_args
         # ran, so move test_args' host tensors into born-shared buffers the


### PR DESCRIPTION
> Replaces this PR's earlier nightly-split approach. Measuring the case showed the golden's cost was thread-pool overhead, not work — capping threads removes it, so there is nothing left to move to a nightly and the numeric guard stays on every PR.

## What was wrong

`qwen3_14b_decode` held a device for **406 s** (ci run 30507320146, job 90761014912) while the device itself was busy for tens of milliseconds. It was excluded from the general a2a3 sweep with a `--ignore` and given a step and an 1800 s budget of its own, because at that size it would have eaten the sweep's 600 s session budget — the budget that makes the sweep a hang detector.

Decomposed on this repo's a2a3 box, one device:

| Phase | Wall |
| ----- | ---- |
| kernel compilation — 36 incores + 1 orchestration | 59 s |
| `generate_inputs`, the 38 GiB fixture | 13 s |
| **`compute_golden`, 40 layers at 320 torch threads** | **359 s** |
| | **~431 s** vs 406 s measured |

The golden was 80–85% of it, and **none of that was arithmetic.**

## Root cause

The reference implementation walks **3584 small slice operations per layer**, and torch sizes its intra-op pool from the core count. On a 320-core host every one of those calls forks and joins hundreds of threads to move a few KiB:

| threads | 320 | 64 | 16 | **8** | **4** | 2 | 1 |
| ------- | --- | -- | -- | ----- | ----- | - | - |
| per layer | 6.35 s | 1.31 s | 1.13 s | 1.07 s | 1.05 s | 1.59 s | 1.82 s |

Five to eight times the cost of the work, flat from 4 to 16, turning back up below 4.

**Nothing in `simpler_setup/`, `conftest.py` or the workflows had ever set a thread count**, so every golden paid this on every many-core host. All three under `simpler_setup/goldens/` are built from per-tile Python loops — qwen is merely the densest (8 `for`-range loops against 2 each).

## Change

The cap goes where all three goldens pass — around the two `compute_golden` call sites in `scene_test.py` — rather than into any one golden. It **only ever lowers** the limit (a caller who asked for fewer keeps theirs) and restores the previous value on the way out, exception included.

That takes qwen's golden to **~38–43 s** and the whole case to **~115 s**: an ordinary member of a sweep whose own wall is ~505 s across four dies. So the `--ignore`, the dedicated step and its 1800 s budget are all deleted — **the case is nothing special now and runs like every other one.**

## Testing

- [x] **Results unaffected** — same fixture golden-computed at 320 and at 8 threads is **bit-identical** across `out`, `k_cache` and `v_cache` (`torch.equal` true, `max|diff| = 0`). Checked rather than assumed, since thread count can reorder float reductions.
- [x] Cap verified end to end: lowers 320 → 8 inside, restores 320 after, leaves a caller's 2 alone, and restores after an exception raised inside the block.
- [x] Effect measured through the helper: **0.95 s per layer → ~38 s for 40 layers**, against 6.35 s / 254 s uncapped.
- [x] Compile figures measured per source with `KernelCompiler` — 35 ordinary incores at 1.1–1.3 s each, orchestration 6.6 s, and the vendor FAI kernel as the outlier at 8.4 s / 1330 KiB for its AIV variant.
- [x] `yaml.safe_load` on `ci.yml`; `ast.parse` on `scene_test.py`; `markdownlint-cli2` clean
- [ ] The sweep has not yet run with qwen in it. That is the check that matters on this PR: `st-onboard-a2a3` should stay well inside its 600 s budget with the case included.

## Docs

`.claude/skills/testing/SKILL.md` loses the `HEAVY_IGNORE` quarantine row and the command carrying it, plus three `ci.yml:<line>` references this change would have invalidated. The README's cost section is rewritten around the measurements — it reported "~5 min wall, ~49 s golden" from an idle die, which is the 4–16-thread figure and does not describe CI.