### PR TITLE
Fix: split A5 L2 record reserve and commit

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -146,7 +146,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             //
             // Early-dispatch (src_payload != 0): receive_time stays at pickup —
             // before the doorbell wait — so it may precede the producer's end.
-            uint64_t receive_time = get_sys_cnt_aicore();
+            uint64_t receive_time = l2_swimlane_enabled ? get_sys_cnt_aicore() : 0;
 
             uint32_t task_id = reg_val;  // Decode: register holds task_id directly
 
@@ -203,10 +203,17 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 }
             }
 
+            // Bind this task to the currently-published L2 buffer generation
+            // before ACK makes progress visible to AICPU. The PMU staging ring
+            // is stable for the full run and does not participate in rotation.
+            __gm__ L2SwimlaneAicoreTaskRecord *l2_swimlane_record = nullptr;
+            if (l2_swimlane_enabled) {
+                l2_swimlane_record = l2_swimlane_aicore_reserve_task_record(l2_swimlane_head, &l2_swimlane_local);
+            }
+
             write_reg(RegId::COND, MAKE_ACK_VALUE(task_id));
 
-            // Performance profiling: record start time
-            uint64_t start_time = get_sys_cnt_aicore();
+            uint64_t start_time = l2_swimlane_enabled ? get_sys_cnt_aicore() : 0;
 
             if (pmu_enabled) {
                 pmu_aicore_begin();
@@ -215,10 +222,18 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // Execute the task
             execute_task(exec_payload);
 
+            // Keep start_time -> end_time scoped to AICore execution.
+            uint64_t end_time = l2_swimlane_enabled ? get_sys_cnt_aicore() : 0;
+
             if (pmu_enabled) {
                 pmu_aicore_end();
+                // PMU's stable per-core staging slot must be visible before FIN:
+                // the AICPU completion path consumes it as soon as FIN arrives.
                 pmu_aicore_record_task(pmu_ring, pmu_reg_base, task_id);
             }
+
+            last_reg_val = reg_val;
+            write_reg(RegId::COND, MAKE_FIN_VALUE(task_id));
 
             if (dump_args_enabled) {
                 pipe_barrier(PIPE_ALL);
@@ -229,15 +244,11 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // payload); reg_task_id is the per-core dispatch token AICore just
             // read. Host uses reg_task_id as join key vs the AICPU stream.
             if (l2_swimlane_enabled) {
-                uint64_t end_time = get_sys_cnt_aicore();
                 uint64_t task_token_raw = exec_payload->local_context.async_ctx.task_token.raw;
-                l2_swimlane_aicore_record_task(
-                    l2_swimlane_head, &l2_swimlane_local, task_token_raw, task_id, receive_time, start_time, end_time
+                l2_swimlane_aicore_commit_task_record(
+                    l2_swimlane_record, task_token_raw, task_id, receive_time, start_time, end_time
                 );
             }
-
-            last_reg_val = reg_val;
-            write_reg(RegId::COND, MAKE_FIN_VALUE(task_id));
         }
     }
 

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -561,6 +561,23 @@ target_link_libraries(test_scope_stats_collector PRIVATE
 add_test(NAME test_scope_stats_collector COMMAND test_scope_stats_collector)
 set_tests_properties(test_scope_stats_collector PROPERTIES LABELS "no_hardware")
 
+add_executable(test_l2_swimlane_aicore
+    common/test_l2_swimlane_aicore.cpp
+)
+target_include_directories(test_l2_swimlane_aicore PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/sim/aicore
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+)
+target_link_libraries(test_l2_swimlane_aicore PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_l2_swimlane_aicore COMMAND test_l2_swimlane_aicore)
+set_tests_properties(test_l2_swimlane_aicore PROPERTIES LABELS "no_hardware")
+
 # AICPU-side dep_gen writer. The shared-memory layout is byte-identical across
 # platforms, so compiling against a2a3's platform_config covers a5 too.
 add_executable(test_dep_gen_collector_aicpu

--- a/tests/ut/cpp/common/test_l2_swimlane_aicore.cpp
+++ b/tests/ut/cpp/common/test_l2_swimlane_aicore.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "inner_kernel.h"
+#undef OUT_OF_ORDER_STORE_BARRIER
+#include "aicore/l2_swimlane_collector_aicore.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+TEST(L2SwimlaneAicoreTest, CommitUsesReservedBufferGeneration) {
+    L2SwimlaneAicoreTaskBuffer first{};
+    L2SwimlaneAicoreTaskBuffer second{};
+    L2SwimlaneActiveHead head{};
+    head.current_buf_ptr = reinterpret_cast<uint64_t>(&first);
+    head.current_buf_seq = 0;
+
+    L2SwimlaneAicoreLocalState local{};
+    local.cached_buf_seq = UINT32_MAX;
+
+    L2SwimlaneAicoreTaskRecord *reserved = l2_swimlane_aicore_reserve_task_record(&head, &local);
+    ASSERT_EQ(reserved, &first.records[0]);
+
+    head.current_buf_ptr = reinterpret_cast<uint64_t>(&second);
+    head.current_buf_seq = 1;
+
+    l2_swimlane_aicore_commit_task_record(reserved, 0x1234, 17, 100, 120, 180);
+
+    EXPECT_EQ(first.records[0].task_token_raw, 0x1234u);
+    EXPECT_EQ(first.records[0].reg_task_id, 17u);
+    EXPECT_EQ(first.records[0].start_time, 120u);
+    EXPECT_EQ(first.records[0].end_time, 180u);
+    EXPECT_EQ(first.records[0].receive_to_start_cycles, 20u);
+    EXPECT_EQ(second.records[0].task_token_raw, 0u);
+
+    L2SwimlaneAicoreTaskRecord *next = l2_swimlane_aicore_reserve_task_record(&head, &local);
+    EXPECT_EQ(next, &second.records[0]);
+}


### PR DESCRIPTION
## Summary

- reserve the A5 L2 task-record slot before ACK and commit that exact slot after execution, so buffer rotation cannot move a record into a later generation
- avoid reading the AICore system timer when L2 swimlane DFX is disabled
- preserve A5 PMU per-task staging order and lazy L2 head resolution
- add a focused unit test for reserve/commit across buffer generation changes

Related to #1582 (missing item #5).

## Correctness

The reserved L2 record remains bound to the buffer generation that was active before ACK. PMU data is still published before FIN for AICPU consumption, while the L2 record is committed after FIN using the reserved pointer.

## Validation

- pre-commit on all changed files: passed
- focused C++ generation test: passed
- A5Sim L2-only, level 4 + dep-gen: 2 passed
- A5Sim PMU-only: 1 passed
- A5Sim L2 + PMU, level 4: 2 passed
- A5Sim DFX-off vector smoke: 1 passed
- A5 onboard L2 + PMU, level 4 + dep-gen: 2 passed
- full A5Sim tensor-map/ring-buffer suite: 72 passed, 2 skipped; 3 timing-marker tests failed in the sweep and passed when rerun in isolation (existing capture flake, outside this L2 path)

## Performance (`--enable-l2-swimlane 4`)

Same main commit (`ce81c973`), device 4, serial execution. Each variant used 10 independent processes with `--rounds 1 --enable-l2-swimlane 4`, because the scene-test runner disables L2 swimlane when `--rounds` is greater than 1. All 40 valid case runs per variant passed.

`Device` is the complete on-NPU AICPU `run_prepared.runner_run.device_wall` span emitted by `[STRACE]`; it excludes Python startup and host-side swimlane export/validation. Values below are arithmetic means over the 10 independent runs:

```text
mean Device = sum(Device for 10 runs) / 10
delta = (PR mean - main mean) / main mean * 100%
```

A negative delta means the PR is faster. For example, paged-attention Case1 is `(2457.97 - 2467.15) / 2467.15 = -0.37%`.

| Case | Metric | main mean | this PR mean | delta |
| --- | --- | ---: | ---: | ---: |
| paged_attention_unroll / Case1 | Device | 2467.15 us | 2457.97 us | -0.37% |
| paged_attention_unroll / Case1 | Effective | 2050.99 us | 2054.23 us | +0.16% |
| paged_attention_unroll / Case2 | Device | 1526.57 us | 1523.77 us | -0.18% |
| paged_attention_unroll / Case2 | Effective | 1109.29 us | 1106.36 us | -0.26% |
| manual_scope / Case1 | Device | 2461.55 us | 2406.86 us | -2.22% |
| manual_scope / Case1 | Effective | 2017.20 us | 1968.11 us | -2.43% |
| manual_scope / Case2 | Device | 1506.94 us | 1507.77 us | +0.06% |
| manual_scope / Case2 | Effective | 1075.78 us | 1079.31 us | +0.33% |

No level-4 performance regression observed; three cases are effectively flat and manual-scope Case1 improves by about 2.2%-2.4%.