### PR TITLE
Docs: disambiguate "overlap" in the dual-domain L3 examples

### DIFF
--- a/examples/workers/l3/domain_rank_map/README.md
+++ b/examples/workers/l3/domain_rank_map/README.md
@@ -21,11 +21,12 @@ tail = workers [1, 2]        # chip 2 is in both
 | **Two lifetime styles** | The inspection pass allocates both domains and releases them in a `finally` via `handle.release()`; the reduce pass uses `with orch.allocate_domain(...) as handle`. |
 
 After the inspection pass, each domain runs its own small allreduce — in its
-**own `worker.run()`**, so chip 2 never juggles two collectives at once. That
-separation is deliberate; see `dual_domain_overlap` for the case where both
-domains are live across the same DAG. The ranks within each allreduce are one
-`submit_next_level_group`, so every peer that participates in the device
-barrier is dispatched as a complete set.
+**own `worker.run()`**, so chip 2 never juggles two collectives at once. Both
+domains are live simultaneously only during the inspection pass, which runs no
+collective; `dual_domain_overlap` drives real work through two overlapping
+domains and likewise gives each its own run. The ranks within each allreduce
+are one `submit_next_level_group`, so every peer that participates in the
+device barrier is dispatched as a complete set.
 
 ## Run
 

--- a/examples/workers/l3/dual_domain_overlap/README.md
+++ b/examples/workers/l3/dual_domain_overlap/README.md
@@ -7,9 +7,14 @@ left  = workers [0, 1]
 right = workers [1, 2]        # chip 1 is in both
 ```
 
-Chip 1 receives **two independent `ChipDomainContext` objects**, one per
-domain, each with its own rank, its own scratch pointer, and its own peers.
-Nothing about being in one domain constrains its role in the other.
+Chip 1 receives **an independent `ChipDomainContext` per domain**, each with
+its own rank, its own scratch pointer, and its own peers. Nothing about being
+in one domain constrains its role in the other.
+
+The overlap is in **membership, not in time**: each context is created in its
+own domain's run, the two are never live at the same time, and the two
+domains' collectives never run concurrently. See
+[Execution shape](#execution-shape).
 
 Where `domain_rank_map` inspects the handles, this example runs real work
 through both and then computes on the results.
@@ -18,10 +23,36 @@ through both and then computes on the results.
 
 | Concept | How |
 | ------- | --- |
-| **Per-domain identity** | Chip 1 is rank 1 in `left` and rank 0 in `right`. The `workers` list order defines the dense rank, so the same chip legitimately holds two different ranks at once. |
+| **Per-domain identity** | Chip 1 is rank 1 in `left` and rank 0 in `right`. The `workers` list order defines the dense rank, so the same chip legitimately holds a different rank in each domain. |
 | **Domains allocated inside the orch function** | `with orch.allocate_domain(name=..., workers=..., window_size=..., buffers=[CommBufferSpec(...)])` — created and released within one orchestration, not configured on the `Worker`. |
 | **`submit_next_level_group`** | Both the peer-waiting allreduce and the affine stage submit one `TaskArgs` per member in a single call with `workers=worker_indices`. |
-| **Compute that depends only on its own domain's result** | Each affine task reads `reduce_out[domain][chip]`. The dependency is implicit — same `buffer.addr` as the reduce output — so `left`'s affine work can never consume `right`'s reduction. |
+| **Per-domain outputs on a shared chip** | `reduce_out` and `affine_out` are keyed by `(domain, chip)`, so chip 1 owns a separate buffer in each domain and writes a different value to each. `left`'s affine reads `reduce_out["left"][chip]`, so it cannot see `right`'s reduction. |
+
+Ordering between the reduce and affine stages comes from the run boundary,
+not from a producer/consumer edge — see [Execution shape](#execution-shape).
+For an example where TensorMap's implicit same-`buffer.addr` dependency is
+what orders two stages, see [`../ffn_tp_parallel/`](../ffn_tp_parallel/).
+
+## Execution shape
+
+Three synchronous `worker.run` calls — `run()` is `submit(...).wait()`, so
+each one finishes before the next is submitted:
+
+```text
+run 1   allocate domain "left"   →  allreduce group over workers [0, 1]
+run 2   allocate domain "right"  →  allreduce group over workers [1, 2]
+run 3   affine group over [0, 1]  +  affine group over [1, 2]
+```
+
+Each run is its own DAG. A domain allocated inside a run stays live for that
+whole run: `release()` on `with` exit is a non-blocking mark, and the backend
+release happens after the run's completion wait, so tasks already submitted
+with that `device_ctx` still see live memory.
+
+The allreduce is one `submit_next_level_group` per domain because its Phase-2
+device barrier makes every rank wait for its peers — a rank dispatched
+without them cannot finish. The affine stage is grouped for symmetry; its
+kernel does no cross-rank communication.
 
 ## Run
 

--- a/examples/workers/l3/dual_domain_overlap/main.py
+++ b/examples/workers/l3/dual_domain_overlap/main.py
@@ -7,17 +7,26 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""L3 multi-communication-domain demo with overlapping domains.
+"""L3 demo: one chip belonging to two communication domains.
 
-Three chip workers form two communication domains:
+Three chip workers form two domains whose *membership* overlaps — the
+overlap is structural, not temporal, and the two domains' collectives never
+run concurrently:
 
   left   = workers [0, 1]
-  right  = workers [1, 2]
+  right  = workers [1, 2]        # chip 1 is in both
 
-Worker 1 participates in both domains and receives two independent domain
-contexts.  The L3 orchestration submits communication in both domains and
-then submits affine compute tasks that depend only on their own domain's
-reduced tensor.
+Chip 1 belongs to both domains — rank 1 in `left`, rank 0 in `right` — and
+receives an independent ChipDomainContext, with its own scratch pointer and
+device_ctx, in each domain's own reduction run. The two contexts are never
+live at the same time. `reduce_out` and `affine_out` are keyed by
+(domain, chip), so chip 1 writes a distinct result per domain — that pair of
+values is what the golden check makes sharp.
+
+Three synchronous `worker.run` calls, each its own DAG: one allreduce per
+domain, then a final run holding both affine groups. A domain allocated in
+a run stays live for exactly that run, and reduce precedes affine by the
+run boundary rather than by a dependency edge.
 
 Run:
     python examples/workers/l3/dual_domain_overlap/main.py -p a2a3sim -d 0-2


### PR DESCRIPTION
## Summary

`dual_domain_overlap` overlaps in domain **membership** — chip 1 belongs to
both domains — but its module docstring said only "with overlapping domains",
which reads equally as *temporal* overlap. Combined with the directory name,
that is a real trap: it led a reviewer to conclude the example demonstrates
concurrent/pipelined execution and to propose changes on that basis.

Two claims were also factually wrong:

- `dual_domain_overlap`'s README credited the reduce→affine ordering to
  TensorMap's implicit same-`buffer.addr` edge. Those stages sit in separate
  synchronous `worker.run` calls, so the run boundary orders them and that
  edge carries no weight here. The per-domain isolation actually comes from
  `reduce_out` / `affine_out` being keyed by `(domain, chip)`.
  `ffn_tp_parallel` is the example where the implicit edge *is* load-bearing,
  and is now linked as such.
- `domain_rank_map`'s README pointed at `dual_domain_overlap` as "the case
  where both domains are live across the same DAG". It is not — it gives each
  domain its own run too. Both domains are live simultaneously only in
  `domain_rank_map`'s own inspection pass, which runs no collective.

Changes:

- Rewrite the `dual_domain_overlap` module docstring: state that the overlap
  is structural rather than temporal, and name the actual sharp edge (chip 1
  writing a distinct result per domain).
- Add an **Execution shape** section to the README covering the three
  synchronous runs, the domain lifetime rule (`release()` on `with` exit is a
  non-blocking mark; the backend release lands after the run's completion
  wait), and why the allreduce must be submitted as a group.
- Correct the two claims above.

Doc-only; no behavior change.

## Testing

- [x] `ast.parse` on `main.py`; docstring content verified (it is user-visible
      via `argparse(description=__doc__)` with `RawDescriptionHelpFormatter`)
- [x] README heading structure and the `#execution-shape` anchor checked
- [ ] Simulation tests pass — not run; no code changed
- [ ] Hardware tests pass — not applicable

Follow-up from the review of #1565.