### PR TITLE
fix(ring-buffer): make structural deadlock detection scope-aware

### DIFF
--- a/.claude/rules/running-onboard.md
+++ b/.claude/rules/running-onboard.md
@@ -172,16 +172,19 @@ for the signature that actually fired:**
 
 | device-log signature | mechanism | note |
 | -------------------- | --------- | ---- |
-| `FATAL: Task Allocator Deadlock` / `Provable head-of-line` | ring/heap or dep-pool **deadlock** (alloc can't reclaim) | AICPU detector: 500ms backstop (`PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES`) or immediate structural `head_blocked_on_scope_end`. Real capacity/scope deadlock. |
+| `FATAL: Task Allocator Deadlock` / `FATAL: Dependency Pool Deadlock` / `FATAL: Fanin Spill Pool Deadlock` | an allocator or pool could not reclaim enough space | This header identifies the blocked resource, not the root cause. Classify it using the structural/timeout line that follows. |
+| `Provable head-of-line deadlock` | **proven open-scope structural deadlock** | TRB only: the reclaim head is the oldest task owned by an open scope on that ring. The blocked orchestrator cannot end that scope, so the head cannot become consumed. |
+| `No reclaim progress for ~500 ms` / `cannot reclaim space after ~500 ms` | allocator/pool **reclaim timeout** | The 500ms backstop (`PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES`) exists in HBG and TRB. It proves prolonged lack of reclaim progress, not why progress stopped; check capacity, the dumped head, consumers and scheduler state. |
 | `Timeout (N cycles): producer/consumers ...` | **SPIN** wait on a specific producer/consumer | `pto_runtime2.cpp`. |
 | `HandleTaskTimeout` / `kill aicpu-sd` | **OS op-execute timeout** | STARS/tsdaemon, default 45s (`PLATFORM_OP_EXECUTE_TIMEOUT_US`). **A 45s kill ≠ deadlock** — the op was merely long or stalled. Raise this constant to measure true on-device duration. |
 | `log_stall_diagnostics` (cores idle + tasks `state=WAIT fanin 0/N` + `completed` frozen) | **forward-progress stall** | No dedicated detector — intermittent races (often contention-triggered) land here and are reaped only by the op-timeout above. |
 
-Decisive rule: **if a capacity/deadlock detector did NOT fire (counts of
-`Task Allocator Deadlock` / `Timeout (cycles)` are 0) and only
-`HandleTaskTimeout` did, it is NOT a proven deadlock or capacity bug** — it is a
-long/stalled op. A capacity exhaustion would trip its own detector; silence ⇒
-look for a race or just-too-slow, not "the ring is too small". For the
+Decisive rule: **if no allocator/pool fatal, producer/consumer
+`Timeout (N cycles)`, or scheduler timeout diagnostic fired and only
+`HandleTaskTimeout` did, it is NOT a proven deadlock or capacity bug** — it is
+a long/stalled op.
+A blocked allocator or pool would print its own fatal; silence means look for
+a race or just-too-slow, not "the ring is too small". For the
 host/device timing breakdown of a (completed) run, parse its `[STRACE]` markers
 with `python -m simpler_setup.tools.strace_timing <log> --rounds-table` (see
 `simpler_setup/tools/README.md`); for the per-thread `loops`/`tasks_scheduled`

--- a/docs/troubleshooting/device-error-codes/capacity.md
+++ b/docs/troubleshooting/device-error-codes/capacity.md
@@ -2,11 +2,20 @@
 
 ← [Device Error Codes](../device-error-codes.md)
 
-SCOPE_DEADLOCK, HEAP_RING_DEADLOCK and DEP_POOL_OVERFLOW all say the same thing —
-"some resource ran out" — without saying *which* resource or *which* scope. Do not
-guess at the ring sizes. Turn on `scope_stats`, which records the high-water mark of
-all four resources (task-window slots, heap bytes, dep-pool entries, tensormap
-entries) per `PTO2_SCOPE`:
+SCOPE_DEADLOCK, HEAP_RING_DEADLOCK and DEP_POOL_OVERFLOW all mean that an
+allocation could not obtain enough space. The adjacent device-log line determines
+how strong that diagnosis is:
+
+- `Provable head-of-line deadlock` is a structural proof: in TRB the reclaim head
+  is the oldest task owned by an open scope on that ring, and the blocked
+  orchestrator cannot end the scope that pins it.
+- `No reclaim progress for ~500 ms` or `cannot reclaim space after ~500 ms` is
+  the backstop. It proves that reclaim remained stalled, but not whether the root
+  cause is undersizing, a stuck consumer, or a stalled scheduler.
+
+Do not guess at the ring sizes from the error code alone. Turn on `scope_stats`,
+which records the high-water mark of all four resources (task-window slots, heap
+bytes, dep-pool entries, tensormap entries) per `PTO2_SCOPE`:
 
 ```python
 cfg = CallConfig()

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_ring_buffer.h
@@ -179,15 +179,11 @@ public:
                 if (error_code_ptr_ != nullptr && error_code_ptr_->load(std::memory_order_acquire) != PTO2_ERROR_NONE) {
                     return {-1, -1, nullptr, nullptr};
                 }
-                // Reclaim watermark is stuck. Run the deadlock checks only once
-                // per 1024 spins: get_sys_cnt_aicpu() is an MMIO read and
-                // head_blocked_on_scope_end() walks the head slot, neither of
-                // which needs to fire on every hot spin (1024 spins is far below
-                // the wall-clock timeout, so detection latency is unaffected).
-                // (1) Structural, immediate: if the head task is COMPLETED with
-                // every consumer released but its scope still open, only
-                // scope_end can free it and a blocked orchestrator can never
-                // call it -> provable deadlock now.
+                // Reclaim watermark is stuck. Run the cold checks only once per
+                // 1024 spins. The structural hook is intentionally inert for
+                // host_build_graph because tasks cannot complete during graph
+                // construction; this runtime therefore relies on the wall-clock
+                // backstop below.
                 if (head_blocked_on_scope_end(last_alive)) {
                     report_deadlock(output_size, blocked_on_heap, /*scope_gated=*/true);
                     return {-1, -1, nullptr, nullptr};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -431,6 +431,14 @@ void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32
     }
 }
 
+static PTO2TaskSlotState *oldest_open_task_on_current_ring(const PTO2OrchestratorState *orch) {
+    // Scope depth maps directly to a ring until the deepest ring, where all
+    // further nested scopes share that ring. Its shallowest open scope begin
+    // therefore marks the oldest task pinned by any open scope on this ring.
+    int32_t begin = orch->scope_begins[orch->current_ring_id()];
+    return begin < orch->scope_tasks_size ? orch->scope_tasks[begin] : nullptr;
+}
+
 static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotState &slot_state, int32_t wfanin) {
     PTO2SchedulerState *sched = orch->scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
@@ -441,7 +449,7 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
     // heap/task-window allocator uses (all three share last_task_alive), latches
     // PTO2_ERROR_DEP_POOL_OVERFLOW, and emits the structured report. A false
     // return also covers a fatal already latched elsewhere.
-    if (!rss.dep_pool.ensure_space(*rss.ring, wfanin)) {
+    if (!rss.dep_pool.ensure_space(*rss.ring, wfanin, oldest_open_task_on_current_ring(orch))) {
         orch->fatal = true;
         return false;
     }
@@ -518,7 +526,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->alloc_result = allocator.alloc(total_output_size);
+    out->alloc_result = allocator.alloc(total_output_size, oldest_open_task_on_current_ring(orch));
     if (out->alloc_result.failed()) {
         orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -142,8 +142,8 @@ void PTO2DepListPool::report_deadlock(
     LOG_ERROR("FATAL: Dependency Pool Deadlock Detected!");
     LOG_ERROR("========================================");
     if (scope_gated) {
-        LOG_ERROR("Head task %d COMPLETED, all consumers released, scope still open ->", last_alive);
-        LOG_ERROR("only scope_end can free it and the orchestrator is blocked here.");
+        LOG_ERROR("Head task %d is the oldest task owned by an open scope on this ring ->", last_alive);
+        LOG_ERROR("no open scope can end while the orchestrator is blocked here.");
         LOG_ERROR("Provable head-of-line deadlock.");
     } else {
         LOG_ERROR("DepListPool cannot reclaim space after ~500 ms (no progress).");
@@ -176,7 +176,9 @@ void PTO2DepListPool::report_deadlock(
     LOG_ERROR("========================================");
 }
 
-bool PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
+bool PTO2DepListPool::ensure_space(
+    PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task
+) {
     if (available() >= needed) return true;
 
     int spin_count = 0;
@@ -200,19 +202,12 @@ bool PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t nee
             if (error_code_ptr != nullptr && error_code_ptr->load(std::memory_order_acquire) != PTO2_ERROR_NONE) {
                 return false;
             }
-            // (1) Structural, immediate: head task COMPLETED with every consumer
-            // released but its scope still open -> only scope_end frees it and a
-            // blocked orchestrator can never call it -> provable deadlock now.
-            // slot_states is null on a ring with no task-window backing.
-            bool head_scope_gated = false;
-            if (ring.slot_states != nullptr) {
-                PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(cur_last_alive);
-                if (head.task_state.load(std::memory_order_acquire) == PTO2_TASK_COMPLETED) {
-                    uint32_t rc = head.fanout_refcount.load(std::memory_order_acquire);
-                    head_scope_gated = rc == (head.fanout_count & ~PTO2_FANOUT_SCOPE_BIT);
-                }
-            }
-            if (head_scope_gated) {
+            // (1) Structural, immediate: no open scope can end while this
+            // orchestrator is blocked here, so its oldest task on this ring
+            // cannot become CONSUMED.
+            bool head_is_oldest_open_task = oldest_open_task != nullptr && ring.slot_states != nullptr &&
+                                            oldest_open_task == &ring.get_slot_state_by_task_id(cur_last_alive);
+            if (head_is_oldest_open_task) {
                 report_deadlock(ring, needed, cur_last_alive, /*scope_gated=*/true);
                 latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
                 return false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -53,11 +53,10 @@
 
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
-// Heap/task deadlock is detected structurally (head task COMPLETED + all
-// consumers released + scope still open -> only scope_end can free it, which a
-// blocked orchestrator can never reach). This wall-clock value is only a
-// backstop for the residual case the structural test can't prove locally; it is
-// an ABSOLUTE TIME (not a spin count), so it is stable across chips/contention.
+// Heap/task deadlock is detected structurally when the reclaim head is the
+// oldest task owned by an open scope on the blocked ring. This wall-clock value
+// is the backstop for all other cases; it is an ABSOLUTE TIME (not a spin
+// count), so it is stable across chips/contention.
 #define PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES (PLATFORM_PROF_SYS_CNT_FREQ / 2)  // 500 ms
 
 // =============================================================================
@@ -119,10 +118,11 @@ public:
      * published to shared memory only on success. Since the orchestrator is
      * single-threaded, no CAS or fetch_add is needed — just check-then-commit.
      *
-     * @param output_size  Total packed output size in bytes (0 = no heap needed)
+     * @param output_size     Total packed output size in bytes (0 = no heap needed)
+     * @param oldest_open_task Oldest task owned by any open scope on this ring
      * @return Allocation result; check failed() for errors
      */
-    PTO2TaskAllocResult alloc(int32_t output_size) {
+    PTO2TaskAllocResult alloc(int32_t output_size, PTO2TaskSlotState *oldest_open_task = nullptr) {
         uint64_t aligned_size =
             output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
@@ -179,14 +179,12 @@ public:
                 // Reclaim watermark is stuck. Run the deadlock checks only once
                 // per 1024 spins to keep the hot reclaim loop tight:
                 // get_sys_cnt_aicpu() is a cheap cntvct_el0 read, while this
-                // block polls the fatal flag and head_blocked_on_scope_end()
-                // walks the head slot (1024 spins is far below the wall-clock
-                // timeout, so detection latency is unaffected).
-                // (1) Structural, immediate: if the head task is COMPLETED with
-                // every consumer released but its scope still open, only
-                // scope_end can free it and a blocked orchestrator can never
-                // call it -> provable deadlock now.
-                if (head_blocked_on_scope_end(last_alive)) {
+                // block polls the fatal flag and compares the reclaim head with
+                // the oldest task pinned by an open scope on this ring.
+                // (1) Structural, immediate: no open scope can end while this
+                // orchestrator is blocked here, so that head cannot become
+                // CONSUMED.
+                if (head_is_oldest_open_task(last_alive, oldest_open_task)) {
                     report_deadlock(output_size, blocked_on_heap, /*scope_gated=*/true);
                     return {-1, -1, nullptr, nullptr};
                 }
@@ -257,7 +255,7 @@ private:
     // --- Task Ring ---
     PTO2TaskDescriptor *descriptors_ = nullptr;
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
-    // used by the deadlock detector to inspect the head task's state + fanout.
+    // used by the deadlock detector to identify the head task's slot.
     PTO2TaskSlotState *slot_states_ = nullptr;
     uint8_t ring_id_ = 0;
     int32_t window_size_ = 0;
@@ -407,31 +405,15 @@ private:
     }
 #endif
 
-    /**
-     * Structural deadlock test on the reclaim head.
-     *
-     * The head (oldest un-CONSUMED task, at last_task_alive) gates all
-     * reclamation. If it is COMPLETED and every consumer reference is released
-     * (low bits of fanout_refcount == consumer count) but the scope reference
-     * (bit31) is still unset, the only release left is its scope_end. Because
-     * this is evaluated while the orchestrator is blocked in alloc(), scope_end
-     * can never be reached -> provable deadlock, no timeout required.
-     *
-     * The COMPLETED guard is mandatory: a zero-consumer task has
-     * refcount == 0 == (count & ~SCOPE_BIT) from birth, before it has run.
-     */
-    bool head_blocked_on_scope_end(int32_t head_task_id) const {
-        if (slot_states_ == nullptr) return false;
-        PTO2TaskSlotState &h = slot_states_[head_task_id & window_mask_];
-        if (h.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) return false;
-        uint32_t rc = h.fanout_refcount.load(std::memory_order_acquire);
-        return rc == (h.fanout_count & ~PTO2_FANOUT_SCOPE_BIT);
+    bool head_is_oldest_open_task(int32_t head_task_id, const PTO2TaskSlotState *oldest_open_task) const {
+        return oldest_open_task != nullptr && slot_states_ != nullptr &&
+               oldest_open_task == &slot_states_[head_task_id & window_mask_];
     }
 
     /**
      * Report deadlock with targeted diagnostics. scope_gated == true means the
-     * head-of-line structural test proved it (waiting only on scope_end);
-     * false means the wall-clock backstop fired.
+     * head is pinned by an open scope on this ring; false means the wall-clock
+     * backstop fired.
      */
     void report_deadlock(int32_t requested_output_size, bool heap_blocked, bool scope_gated) {
         int32_t last_alive = last_alive_ptr_->load(std::memory_order_acquire);
@@ -446,8 +428,8 @@ private:
         }
         LOG_ERROR("========================================");
         if (scope_gated) {
-            LOG_ERROR("Head task %d COMPLETED, all consumers released, scope still open ->", last_alive);
-            LOG_ERROR("only scope_end can free it and the orchestrator is blocked here.");
+            LOG_ERROR("Head task %d is the oldest task owned by an open scope on this ring ->", last_alive);
+            LOG_ERROR("no open scope can end while the orchestrator is blocked here.");
             LOG_ERROR("Provable head-of-line deadlock.");
         } else {
             LOG_ERROR(
@@ -479,9 +461,9 @@ private:
         }
         LOG_ERROR("Solution:");
         if (scope_gated) {
-            LOG_ERROR("  The open scope's own allocation exceeds this ring. Either:");
-            LOG_ERROR("  1. Split the scope / reduce per-scope allocation (reclaim sooner), or");
-            LOG_ERROR("  2. Size the ring >= the scope's peak live-set (heap*2 may not be enough).");
+            LOG_ERROR("  The live-set retained behind this open-scope head cannot fit in the ring. Either:");
+            LOG_ERROR("  1. Split scopes / reduce the live-set retained behind that head, or");
+            LOG_ERROR("  2. Size the ring for the peak live-set retained behind the oldest open-scope task.");
         } else if (heap_blocked) {
             LOG_ERROR(
                 "  Increase heap (current: %" PRIu64 "); env PTO2_RING_HEAP=<bytes> (e.g. %" PRIu64 ")", heap_size_,
@@ -743,12 +725,12 @@ struct PTO2DepListPool {
      * reclaim watermark the same way PTO2TaskAllocator::alloc does: a structural
      * head-of-line check plus a wall-clock backstop, each emitting report_deadlock.
      */
-    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task = nullptr);
 
     /**
      * Structured dep-pool deadlock report, mirroring PTO2TaskAllocator::report_deadlock.
-     * scope_gated marks the provable head-of-line case (head COMPLETED, all
-     * consumers released, scope still open) as opposed to the wall-clock backstop.
+     * scope_gated marks the provable head-of-line case where the head is pinned
+     * by an open scope on this ring, as opposed to the wall-clock backstop.
      */
     void report_deadlock(PTO2SharedMemoryRingHeader &ring, int32_t needed, int32_t last_alive, bool scope_gated);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -448,10 +448,9 @@ static_assert(
 // (rather than folding scope + consumers into one count) lets a consumer reach
 // fanout_refcount == (fanout_count & ~PTO2_FANOUT_SCOPE_BIT) while the scope bit
 // is still unset -- i.e. "all consumers done but scope still open" stays
-// distinguishable from "fully consumed". The heap/task deadlock detector keys
-// off exactly that complement: that condition with state==COMPLETED means the
-// head can only be released by scope_end, which a blocked orchestrator can
-// never reach -> provable deadlock.
+// distinguishable from "fully consumed". Structural allocation deadlock is
+// detected separately by checking whether the blocking ring head is the oldest
+// task pinned by any open scope on that ring.
 static constexpr uint32_t PTO2_FANOUT_SCOPE_BIT = 0x80000000u;
 
 enum PTO2TaskLifecycleFlag : uint8_t {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -317,7 +317,7 @@ inline PTO2TaskDescriptor *ring_task_descriptors_addr(
 }
 
 // Device address of ring `ring_id`'s slot_states array (used by the allocator's
-// deadlock detector to inspect the head task's state/fanout).
+// deadlock detector to identify the head task's slot).
 inline PTO2TaskSlotState *
 ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
     return reinterpret_cast<PTO2TaskSlotState *>(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -680,10 +680,7 @@ struct PTO2SchedulerState {
     }
 
     // Scope-end release: sets bit31 (PTO2_FANOUT_SCOPE_BIT) instead of bumping a
-    // consumer ref. Called exactly once per task from on_scope_end. Keeping it a
-    // distinct add lets the deadlock detector tell "waiting only on scope_end"
-    // (head COMPLETED, refcount == fanout_count & ~SCOPE_BIT) apart from
-    // "waiting on a consumer".
+    // consumer ref. Called exactly once per task from on_scope_end.
     void release_producer_scope(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -425,6 +425,14 @@ void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32
     }
 }
 
+static PTO2TaskSlotState *oldest_open_task_on_current_ring(const PTO2OrchestratorState *orch) {
+    // Scope depth maps directly to a ring until the deepest ring, where all
+    // further nested scopes share that ring. Its shallowest open scope begin
+    // therefore marks the oldest task pinned by any open scope on this ring.
+    int32_t begin = orch->scope_begins[orch->current_ring_id()];
+    return begin < orch->scope_tasks_size ? orch->scope_tasks[begin] : nullptr;
+}
+
 static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotState &slot_state, int32_t wfanin) {
     PTO2SchedulerState *sched = orch->scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
@@ -435,7 +443,7 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
     // heap/task-window allocator uses (all three share last_task_alive), latches
     // PTO2_ERROR_DEP_POOL_OVERFLOW, and emits the structured report. A false
     // return also covers a fatal already latched elsewhere.
-    if (!rss.dep_pool.ensure_space(*rss.ring, wfanin)) {
+    if (!rss.dep_pool.ensure_space(*rss.ring, wfanin, oldest_open_task_on_current_ring(orch))) {
         orch->fatal = true;
         return false;
     }
@@ -525,7 +533,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->alloc_result = allocator.alloc(total_output_size);
+    out->alloc_result = allocator.alloc(total_output_size, oldest_open_task_on_current_ring(orch));
     if (out->alloc_result.failed()) {
         orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -142,8 +142,8 @@ void PTO2DepListPool::report_deadlock(
     LOG_ERROR("FATAL: Dependency Pool Deadlock Detected!");
     LOG_ERROR("========================================");
     if (scope_gated) {
-        LOG_ERROR("Head task %d COMPLETED, all consumers released, scope still open ->", last_alive);
-        LOG_ERROR("only scope_end can free it and the orchestrator is blocked here.");
+        LOG_ERROR("Head task %d is the oldest task owned by an open scope on this ring ->", last_alive);
+        LOG_ERROR("no open scope can end while the orchestrator is blocked here.");
         LOG_ERROR("Provable head-of-line deadlock.");
     } else {
         LOG_ERROR("DepListPool cannot reclaim space after ~500 ms (no progress).");
@@ -176,7 +176,9 @@ void PTO2DepListPool::report_deadlock(
     LOG_ERROR("========================================");
 }
 
-bool PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
+bool PTO2DepListPool::ensure_space(
+    PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task
+) {
     if (available() >= needed) return true;
 
     int spin_count = 0;
@@ -200,19 +202,12 @@ bool PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t nee
             if (error_code_ptr != nullptr && error_code_ptr->load(std::memory_order_acquire) != PTO2_ERROR_NONE) {
                 return false;
             }
-            // (1) Structural, immediate: head task COMPLETED with every consumer
-            // released but its scope still open -> only scope_end frees it and a
-            // blocked orchestrator can never call it -> provable deadlock now.
-            // slot_states is null on a ring with no task-window backing.
-            bool head_scope_gated = false;
-            if (ring.slot_states != nullptr) {
-                PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(cur_last_alive);
-                if (head.task_state.load(std::memory_order_acquire) == PTO2_TASK_COMPLETED) {
-                    uint32_t rc = head.fanout_refcount.load(std::memory_order_acquire);
-                    head_scope_gated = rc == (head.fanout_count & ~PTO2_FANOUT_SCOPE_BIT);
-                }
-            }
-            if (head_scope_gated) {
+            // (1) Structural, immediate: no open scope can end while this
+            // orchestrator is blocked here, so its oldest task on this ring
+            // cannot become CONSUMED.
+            bool head_is_oldest_open_task = oldest_open_task != nullptr && ring.slot_states != nullptr &&
+                                            oldest_open_task == &ring.get_slot_state_by_task_id(cur_last_alive);
+            if (head_is_oldest_open_task) {
                 report_deadlock(ring, needed, cur_last_alive, /*scope_gated=*/true);
                 latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
                 return false;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -53,11 +53,10 @@
 
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
-// Heap/task deadlock is detected structurally (head task COMPLETED + all
-// consumers released + scope still open -> only scope_end can free it, which a
-// blocked orchestrator can never reach). This wall-clock value is only a
-// backstop for the residual case the structural test can't prove locally; it is
-// an ABSOLUTE TIME (not a spin count), so it is stable across chips/contention.
+// Heap/task deadlock is detected structurally when the reclaim head is the
+// oldest task owned by an open scope on the blocked ring. This wall-clock value
+// is the backstop for all other cases; it is an ABSOLUTE TIME (not a spin
+// count), so it is stable across chips/contention.
 #define PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES (PLATFORM_PROF_SYS_CNT_FREQ / 2)  // 500 ms
 
 // =============================================================================
@@ -119,10 +118,11 @@ public:
      * published to shared memory only on success. Since the orchestrator is
      * single-threaded, no CAS or fetch_add is needed — just check-then-commit.
      *
-     * @param output_size  Total packed output size in bytes (0 = no heap needed)
+     * @param output_size     Total packed output size in bytes (0 = no heap needed)
+     * @param oldest_open_task Oldest task owned by any open scope on this ring
      * @return Allocation result; check failed() for errors
      */
-    PTO2TaskAllocResult alloc(int32_t output_size) {
+    PTO2TaskAllocResult alloc(int32_t output_size, PTO2TaskSlotState *oldest_open_task = nullptr) {
         uint64_t aligned_size =
             output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
@@ -179,14 +179,12 @@ public:
                 // Reclaim watermark is stuck. Run the deadlock checks only once
                 // per 1024 spins to keep the hot reclaim loop tight:
                 // get_sys_cnt_aicpu() is a cheap cntvct_el0 read, while this
-                // block polls the fatal flag and head_blocked_on_scope_end()
-                // walks the head slot (1024 spins is far below the wall-clock
-                // timeout, so detection latency is unaffected).
-                // (1) Structural, immediate: if the head task is COMPLETED with
-                // every consumer released but its scope still open, only
-                // scope_end can free it and a blocked orchestrator can never
-                // call it -> provable deadlock now.
-                if (head_blocked_on_scope_end(last_alive)) {
+                // block polls the fatal flag and compares the reclaim head with
+                // the oldest task pinned by an open scope on this ring.
+                // (1) Structural, immediate: no open scope can end while this
+                // orchestrator is blocked here, so that head cannot become
+                // CONSUMED.
+                if (head_is_oldest_open_task(last_alive, oldest_open_task)) {
                     report_deadlock(output_size, blocked_on_heap, /*scope_gated=*/true);
                     return {-1, -1, nullptr, nullptr};
                 }
@@ -257,7 +255,7 @@ private:
     // --- Task Ring ---
     PTO2TaskDescriptor *descriptors_ = nullptr;
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
-    // used by the deadlock detector to inspect the head task's state + fanout.
+    // used by the deadlock detector to identify the head task's slot.
     PTO2TaskSlotState *slot_states_ = nullptr;
     uint8_t ring_id_ = 0;
     int32_t window_size_ = 0;
@@ -407,31 +405,15 @@ private:
     }
 #endif
 
-    /**
-     * Structural deadlock test on the reclaim head.
-     *
-     * The head (oldest un-CONSUMED task, at last_task_alive) gates all
-     * reclamation. If it is COMPLETED and every consumer reference is released
-     * (low bits of fanout_refcount == consumer count) but the scope reference
-     * (bit31) is still unset, the only release left is its scope_end. Because
-     * this is evaluated while the orchestrator is blocked in alloc(), scope_end
-     * can never be reached -> provable deadlock, no timeout required.
-     *
-     * The COMPLETED guard is mandatory: a zero-consumer task has
-     * refcount == 0 == (count & ~SCOPE_BIT) from birth, before it has run.
-     */
-    bool head_blocked_on_scope_end(int32_t head_task_id) const {
-        if (slot_states_ == nullptr) return false;
-        PTO2TaskSlotState &h = slot_states_[head_task_id & window_mask_];
-        if (h.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) return false;
-        uint32_t rc = h.fanout_refcount.load(std::memory_order_acquire);
-        return rc == (h.fanout_count & ~PTO2_FANOUT_SCOPE_BIT);
+    bool head_is_oldest_open_task(int32_t head_task_id, const PTO2TaskSlotState *oldest_open_task) const {
+        return oldest_open_task != nullptr && slot_states_ != nullptr &&
+               oldest_open_task == &slot_states_[head_task_id & window_mask_];
     }
 
     /**
      * Report deadlock with targeted diagnostics. scope_gated == true means the
-     * head-of-line structural test proved it (waiting only on scope_end);
-     * false means the wall-clock backstop fired.
+     * head is pinned by an open scope on this ring; false means the wall-clock
+     * backstop fired.
      */
     void report_deadlock(int32_t requested_output_size, bool heap_blocked, bool scope_gated) {
         int32_t last_alive = last_alive_ptr_->load(std::memory_order_acquire);
@@ -446,8 +428,8 @@ private:
         }
         LOG_ERROR("========================================");
         if (scope_gated) {
-            LOG_ERROR("Head task %d COMPLETED, all consumers released, scope still open ->", last_alive);
-            LOG_ERROR("only scope_end can free it and the orchestrator is blocked here.");
+            LOG_ERROR("Head task %d is the oldest task owned by an open scope on this ring ->", last_alive);
+            LOG_ERROR("no open scope can end while the orchestrator is blocked here.");
             LOG_ERROR("Provable head-of-line deadlock.");
         } else {
             LOG_ERROR(
@@ -479,9 +461,9 @@ private:
         }
         LOG_ERROR("Solution:");
         if (scope_gated) {
-            LOG_ERROR("  The open scope's own allocation exceeds this ring. Either:");
-            LOG_ERROR("  1. Split the scope / reduce per-scope allocation (reclaim sooner), or");
-            LOG_ERROR("  2. Size the ring >= the scope's peak live-set (heap*2 may not be enough).");
+            LOG_ERROR("  The live-set retained behind this open-scope head cannot fit in the ring. Either:");
+            LOG_ERROR("  1. Split scopes / reduce the live-set retained behind that head, or");
+            LOG_ERROR("  2. Size the ring for the peak live-set retained behind the oldest open-scope task.");
         } else if (heap_blocked) {
             LOG_ERROR(
                 "  Increase heap (current: %" PRIu64 "); env PTO2_RING_HEAP=<bytes> (e.g. %" PRIu64 ")", heap_size_,
@@ -743,12 +725,12 @@ struct PTO2DepListPool {
      * reclaim watermark the same way PTO2TaskAllocator::alloc does: a structural
      * head-of-line check plus a wall-clock backstop, each emitting report_deadlock.
      */
-    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task = nullptr);
 
     /**
      * Structured dep-pool deadlock report, mirroring PTO2TaskAllocator::report_deadlock.
-     * scope_gated marks the provable head-of-line case (head COMPLETED, all
-     * consumers released, scope still open) as opposed to the wall-clock backstop.
+     * scope_gated marks the provable head-of-line case where the head is pinned
+     * by an open scope on this ring, as opposed to the wall-clock backstop.
      */
     void report_deadlock(PTO2SharedMemoryRingHeader &ring, int32_t needed, int32_t last_alive, bool scope_gated);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -385,10 +385,9 @@ static_assert(
 // (rather than folding scope + consumers into one count) lets a consumer reach
 // fanout_refcount == (fanout_count & ~PTO2_FANOUT_SCOPE_BIT) while the scope bit
 // is still unset -- i.e. "all consumers done but scope still open" stays
-// distinguishable from "fully consumed". The heap/task deadlock detector keys
-// off exactly that complement: that condition with state==COMPLETED means the
-// head can only be released by scope_end, which a blocked orchestrator can
-// never reach -> provable deadlock.
+// distinguishable from "fully consumed". Structural allocation deadlock is
+// detected separately by checking whether the blocking ring head is the oldest
+// task pinned by any open scope on that ring.
 static constexpr uint32_t PTO2_FANOUT_SCOPE_BIT = 0x80000000u;
 
 enum PTO2TaskLifecycleFlag : uint8_t {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -317,7 +317,7 @@ inline PTO2TaskDescriptor *ring_task_descriptors_addr(
 }
 
 // Device address of ring `ring_id`'s slot_states array (used by the allocator's
-// deadlock detector to inspect the head task's state/fanout).
+// deadlock detector to identify the head task's slot).
 inline PTO2TaskSlotState *
 ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
     return reinterpret_cast<PTO2TaskSlotState *>(

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -665,6 +665,7 @@ add_a2a3_test(test_task_timing_slots a2a3/test_task_timing_slots.cpp)
 
 # PTO2 runtime-linked tests
 add_a2a3_runtime_test(test_task_allocator   a2a3/test_task_allocator.cpp)
+add_a2a3_runtime_test(test_scope_deadlock_detection common/test_scope_deadlock_detection.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_task_allocator a2a3/test_task_allocator.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensormap a2a3/test_hbg_tensormap.cpp)
 # PTO2TensorMap's out-of-line members (reserve_layout / init / valid_count) live
@@ -695,6 +696,7 @@ add_a5_test(test_a5_fatal a5/test_a5_fatal.cpp)
 # the unprefixed a2a3 runtime targets test_scheduler_state / test_ready_queue
 # / ...) already own those bare names.
 add_a5_runtime_test(test_a5_task_allocator   a5/test_task_allocator.cpp)
+add_a5_runtime_test(test_a5_scope_deadlock_detection common/test_scope_deadlock_detection.cpp)
 add_a5_runtime_test(test_a5_dep_list_pool    a5/test_dep_list_pool.cpp)
 add_a5_runtime_test(test_a5_scheduler_state  a5/test_scheduler_state.cpp)
 add_a5_runtime_test(test_a5_task_state       a5/test_task_state.cpp)

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -108,7 +108,14 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     ASSERT_TRUE(first.task_id().is_valid());
 
     auto &ring = sm_handle->header->rings[1];
-    ring.fc.last_task_alive.store(1, std::memory_order_release);
+    auto &first_slot = ring.get_slot_state_by_task_id(static_cast<int32_t>(first.task_id().local()));
+    orch.end_scope();
+    first_slot.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
+    sched.check_and_handle_consumed(first_slot);
+    ASSERT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), 1);
+
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), 1);
 
     L0TaskArgs wrap_args;
     add_runtime_output_arg(wrap_args, create_infos, 1);  // wraps, packed to 1024 bytes
@@ -122,11 +129,6 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     ASSERT_EQ(orch.rings[1].task_allocator.heap_used_bytes(), 3072ULL);
     ASSERT_EQ(orch.rings[1].task_allocator.heap_available(), 1024ULL);
 
-    auto &head = ring.get_slot_state_by_task_id(static_cast<int32_t>(wrapped.task_id().local()));
-    head.fanout_count = PTO2_FANOUT_SCOPE_BIT;
-    head.fanout_refcount.store(0, std::memory_order_release);
-    head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
-
     L0TaskArgs blocked_args;
     add_runtime_output_arg(blocked_args, create_infos, 1);
     testing::internal::CaptureStderr();
@@ -137,10 +139,76 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     EXPECT_TRUE(orch.fatal);
     EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
     EXPECT_NE(log.find("FATAL: Task Allocator Deadlock - Heap Exhausted! ring=1"), std::string::npos);
+    EXPECT_NE(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
     EXPECT_NE(log.find("Heap ring 1:"), std::string::npos);
     EXPECT_NE(log.find("used=3072"), std::string::npos);
     EXPECT_NE(log.find("available=1024"), std::string::npos);
     EXPECT_EQ(log.find("PTO2_RING_HEAP=<pow2>"), std::string::npos);
+}
+
+TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopesShareRing) {
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(2);
+
+    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+        orch.begin_scope();
+    }
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs parent_args;
+    add_runtime_output_arg(parent_args, create_infos, 1024);
+    TaskOutputTensors parent = orch.submit_dummy_task(parent_args);
+    ASSERT_TRUE(parent.task_id().is_valid());
+
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs child_args;
+    add_runtime_output_arg(child_args, create_infos, 1);
+    testing::internal::CaptureStderr();
+    TaskOutputTensors child = orch.submit_dummy_task(child_args);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(child.task_id().is_valid());
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
+    EXPECT_NE(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
+}
+
+TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRing) {
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(3);
+
+    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+        orch.begin_scope();
+    }
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs child_args;
+    add_runtime_output_arg(child_args, create_infos, 768);
+    TaskOutputTensors child = orch.submit_dummy_task(child_args);
+    ASSERT_TRUE(child.task_id().is_valid());
+
+    orch.end_scope();
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs parent_args;
+    add_runtime_output_arg(parent_args, create_infos, 256);
+    TaskOutputTensors parent = orch.submit_dummy_task(parent_args);
+    ASSERT_TRUE(parent.task_id().is_valid());
+
+    L0TaskArgs blocked_args;
+    add_runtime_output_arg(blocked_args, create_infos, 1);
+    testing::internal::CaptureStderr();
+    TaskOutputTensors blocked = orch.submit_dummy_task(blocked_args);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(blocked.task_id().is_valid());
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
+    EXPECT_NE(log.find("No reclaim progress for ~500 ms"), std::string::npos);
+    EXPECT_EQ(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
 }
 
 // Regression for issue #1188: scope_tasks_cap must equal the real in-flight budget

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -108,7 +108,14 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     ASSERT_TRUE(first.task_id().is_valid());
 
     auto &ring = sm_handle->header->rings[1];
-    ring.fc.last_task_alive.store(1, std::memory_order_release);
+    auto &first_slot = ring.get_slot_state_by_task_id(static_cast<int32_t>(first.task_id().local()));
+    orch.end_scope();
+    first_slot.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
+    sched.check_and_handle_consumed(first_slot);
+    ASSERT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), 1);
+
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), 1);
 
     L0TaskArgs wrap_args;
     add_runtime_output_arg(wrap_args, create_infos, 1);  // wraps, packed to 1024 bytes
@@ -122,11 +129,6 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     ASSERT_EQ(orch.rings[1].task_allocator.heap_used_bytes(), 3072ULL);
     ASSERT_EQ(orch.rings[1].task_allocator.heap_available(), 1024ULL);
 
-    auto &head = ring.get_slot_state_by_task_id(static_cast<int32_t>(wrapped.task_id().local()));
-    head.fanout_count = PTO2_FANOUT_SCOPE_BIT;
-    head.fanout_refcount.store(0, std::memory_order_release);
-    head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
-
     L0TaskArgs blocked_args;
     add_runtime_output_arg(blocked_args, create_infos, 1);
     testing::internal::CaptureStderr();
@@ -137,10 +139,76 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     EXPECT_TRUE(orch.fatal);
     EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
     EXPECT_NE(log.find("FATAL: Task Allocator Deadlock - Heap Exhausted! ring=1"), std::string::npos);
+    EXPECT_NE(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
     EXPECT_NE(log.find("Heap ring 1:"), std::string::npos);
     EXPECT_NE(log.find("used=3072"), std::string::npos);
     EXPECT_NE(log.find("available=1024"), std::string::npos);
     EXPECT_EQ(log.find("PTO2_RING_HEAP=<pow2>"), std::string::npos);
+}
+
+TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopesShareRing) {
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(2);
+
+    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+        orch.begin_scope();
+    }
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs parent_args;
+    add_runtime_output_arg(parent_args, create_infos, 1024);
+    TaskOutputTensors parent = orch.submit_dummy_task(parent_args);
+    ASSERT_TRUE(parent.task_id().is_valid());
+
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs child_args;
+    add_runtime_output_arg(child_args, create_infos, 1);
+    testing::internal::CaptureStderr();
+    TaskOutputTensors child = orch.submit_dummy_task(child_args);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(child.task_id().is_valid());
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
+    EXPECT_NE(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
+}
+
+TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRing) {
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(3);
+
+    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+        orch.begin_scope();
+    }
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs child_args;
+    add_runtime_output_arg(child_args, create_infos, 768);
+    TaskOutputTensors child = orch.submit_dummy_task(child_args);
+    ASSERT_TRUE(child.task_id().is_valid());
+
+    orch.end_scope();
+    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+
+    L0TaskArgs parent_args;
+    add_runtime_output_arg(parent_args, create_infos, 256);
+    TaskOutputTensors parent = orch.submit_dummy_task(parent_args);
+    ASSERT_TRUE(parent.task_id().is_valid());
+
+    L0TaskArgs blocked_args;
+    add_runtime_output_arg(blocked_args, create_infos, 1);
+    testing::internal::CaptureStderr();
+    TaskOutputTensors blocked = orch.submit_dummy_task(blocked_args);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(blocked.task_id().is_valid());
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
+    EXPECT_NE(log.find("No reclaim progress for ~500 ms"), std::string::npos);
+    EXPECT_EQ(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
 }
 
 // Regression for issue #1188: scope_tasks_cap must equal the real in-flight budget

--- a/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
+++ b/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+
+#include "pto_ring_buffer.h"
+
+// CMake compiles this source against both the a2a3 and a5 runtime objects.
+namespace {
+
+constexpr int32_t WINDOW_SIZE = 16;
+constexpr int32_t POOL_CAPACITY = 8;
+
+void make_head_match_old_structural_predicate(PTO2TaskSlotState &head) {
+    head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
+    head.fanout_count = PTO2_FANOUT_SCOPE_BIT;
+    head.fanout_refcount.store(0, std::memory_order_release);
+}
+
+}  // namespace
+
+TEST(ScopeDeadlockDetectionTest, DepPoolUsesTimeoutForDifferentScopeHead) {
+    PTO2DepListEntry entries[POOL_CAPACITY]{};
+    std::atomic<int32_t> error_code{PTO2_ERROR_NONE};
+    PTO2DepListPool pool;
+    pool.init(entries, POOL_CAPACITY, &error_code);
+    for (int32_t i = 0; i < POOL_CAPACITY; ++i) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    alignas(64) PTO2TaskSlotState slot_states[WINDOW_SIZE]{};
+    PTO2SharedMemoryRingHeader ring{};
+    ring.fc.init();
+    ring.task_window_size = WINDOW_SIZE;
+    ring.task_window_mask = WINDOW_SIZE - 1;
+    ring.slot_states = slot_states;
+    ring.fc.current_task_index.store(2, std::memory_order_release);
+    ring.fc.last_task_alive.store(0, std::memory_order_release);
+
+    make_head_match_old_structural_predicate(slot_states[0]);
+    PTO2TaskSlotState *oldest_open_task = &slot_states[1];
+
+    testing::internal::CaptureStderr();
+    bool available = pool.ensure_space(ring, 1, oldest_open_task);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(available);
+    EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
+    EXPECT_NE(log.find("cannot reclaim space after ~500 ms"), std::string::npos);
+    EXPECT_EQ(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
+}
+
+TEST(ScopeDeadlockDetectionTest, DepPoolRejectsCurrentScopeHeadStructurally) {
+    PTO2DepListEntry entries[POOL_CAPACITY]{};
+    std::atomic<int32_t> error_code{PTO2_ERROR_NONE};
+    PTO2DepListPool pool;
+    pool.init(entries, POOL_CAPACITY, &error_code);
+    for (int32_t i = 0; i < POOL_CAPACITY; ++i) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    alignas(64) PTO2TaskSlotState slot_states[WINDOW_SIZE]{};
+    PTO2SharedMemoryRingHeader ring{};
+    ring.fc.init();
+    ring.task_window_size = WINDOW_SIZE;
+    ring.task_window_mask = WINDOW_SIZE - 1;
+    ring.slot_states = slot_states;
+    ring.fc.current_task_index.store(1, std::memory_order_release);
+    PTO2TaskSlotState *oldest_open_task = &slot_states[0];
+
+    testing::internal::CaptureStderr();
+    bool available = pool.ensure_space(ring, 1, oldest_open_task);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(available);
+    EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
+    EXPECT_NE(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

This change makes the `tensormap_and_ringbuffer` structural-deadlock check use
scope identity: it reports an immediate fatal only for a cycle that the
blocked orchestrator itself makes impossible to break. Other no-progress
states remain covered by the existing timeout.

### Issue

The affected allocation paths are:

- `PTO2TaskAllocator::alloc()`, which reserves both a task-window slot and the
  task's output bytes from the ring heap and diagnoses task-window
  (`PTO2_ERROR_FLOW_CONTROL_DEADLOCK`) or heap
  (`PTO2_ERROR_HEAP_RING_DEADLOCK`) exhaustion;
- `PTO2DepListPool::ensure_space()`, which reserves dependency-list entries for
  a task with live fanin and reports `PTO2_ERROR_DEP_POOL_OVERFLOW` when it
  gives up.

Insufficient space does not immediately mean allocation has failed. Both paths
wait for the scheduler to make the ring's reclaim head `CONSUMED`, advance
`last_task_alive`, reclaim space, and then retry. This is normal backpressure.
They return failure only after another fatal is observed or their own
structural/timeout detector concludes that waiting cannot continue.

The task window, ring heap, and dependency-list pool hold different data, but
all three reclaim in task order using the same ring-local `last_task_alive`
watermark. Therefore the same head task controls whether any of these blocked
allocations can recover.

The merge-base structural detector turns that wait into an immediate fatal
when the reclaim-head task appears `COMPLETED`, has released all consumer
references, but has not released its scope reference. The same lifecycle-based
predicate is used for task-window exhaustion, heap exhaustion, and
dependency-pool exhaustion.

Those lifecycle fields do not identify which scope owns the reclaim head.
The head may belong to a closed child, sibling, or earlier serial scope whose
`scope_end` has already executed. The scheduler can still transition such a
head to `CONSUMED`, advance `last_task_alive`, and unblock the allocation.
Because the merge-base check reads the lifecycle fields while the scheduler is
progressing them, it can report a structural fatal immediately before that
valid reclaim.

The missing proof is whether this allocation wait prevents a still-pending
`scope_end` that is required for this particular head to become `CONSUMED`.
Lifecycle state alone cannot establish that relationship.

## Versions

- Fix: `b7ad6e97e383868ba34326caa3ff2ada733349f2`.
- Upstream merge base: `21e82d5e54eb8dbb922557a102afca8f58a89ea0`.
- PTO-ISA: `83d01313d9bfc247c4b7c8bcf969d1019f0d106f`.

## Fix

- Replace the lifecycle/refcount structural predicate in both
  `PTO2TaskAllocator::alloc()` and `PTO2DepListPool::ensure_space()` with an
  oldest-open-task identity check.
- Derive the oldest task retained by any open scope on the blocked ring in
  O(1) from the orchestrator's existing `scope_begins` and `scope_tasks`
  bookkeeping.
- Pass its slot pointer into both allocation paths.
- When task-window, heap, or dependency-pool space is unavailable, report an
  immediate structural fatal only if that pointer equals the reclaim-head
  slot. Otherwise, keep waiting for reclaim and use the existing approximately
  500 ms no-progress timeout as the fallback.
- Apply the same behavior to A2/A3 and A5
  `tensormap_and_ringbuffer`.
- Distinguish a proven open-scope cycle from a generic reclaim timeout in
  diagnostics and troubleshooting documentation.

No shared-memory fields, task-slot fields, locks, atomics, runtime hooks, or
linear scope scans are added.

### Definitions

- **Blocked ring** is the ring on which the current task-window, heap, or
  dependency-pool allocation cannot obtain space.
- An **open scope** has executed `scope_begin` but not its matching
  `scope_end`. `scope_tasks` records emitted task-slot pointers in order, and
  `scope_begins[depth]` records where each open scope starts in that array.
- **`H` (head)** is the slot addressed by the blocked ring's currently observed
  `last_task_alive`: `slot_states[last_task_alive & window_mask]`. It is the
  oldest slot that this ring has not reclaimed. The reclaim boundary cannot
  move past `H` until the scheduler makes `H` `CONSUMED`.
- **`O` (oldest open task)** is obtained from
  `begin = scope_begins[current_ring_id()]`. If `begin < scope_tasks_size`,
  then `O = scope_tasks[begin]`; otherwise `O = nullptr`. Because task pointers
  are recorded in emission order, `O` is the oldest task on the blocked ring
  retained by the shallowest open scope mapped to that ring, including its
  still-open descendants. Its scope reference cannot be released until the
  blocked orchestrator reaches the corresponding `scope_end`.

`H == O` compares task-slot pointers, not task IDs or independently sampled
lifecycle fields.

### Cases

The same `H/O` decision applies whether the unavailable resource is a
task-window slot, ring-heap space, or dependency-list capacity.

1. **Current-scope head: `H == O`**

   The current scope has emitted `H` and then blocks in one of the affected
   allocation paths on the same ring. The orchestrator cannot reach this
   scope's `scope_end`, so `H` cannot release its scope reference or become
   `CONSUMED`. The fix reports an immediate structural fatal.

2. **Open-parent head: `H == O`**

   A nested scope blocks while allocating on a ring also used by an open
   parent, and `H` is the parent's oldest retained task on that ring. The
   orchestrator cannot leave the child and reach the parent's `scope_end`, so
   `H` cannot become `CONSUMED`. The fix also reports an immediate structural
   fatal. This includes nesting deeper than the number of physical rings,
   where multiple scope depths share the deepest ring.

3. **Earlier sibling head on the same ring: `H != O`**

   Two sibling scopes execute serially on the same ring. The earlier scope has
   executed `scope_end`, but its head `H` has not yet transitioned to
   `CONSUMED`. The later scope is now open and blocks while allocating on that
   ring; `O` belongs to the later scope, so `H != O`. The scheduler may still
   consume `H` and unblock allocation, which makes an immediate structural
   fatal unsafe. The fix keeps waiting. If `H` never advances, the existing
   timeout reports the sustained no-progress deadlock.

## Why this proves a deadlock

When `H == O`, the blocked allocation prevents the orchestrator from reaching
the `scope_end` that would release `O`'s scope reference. `O` therefore cannot
become `CONSUMED`, while ordered reclamation cannot advance past the same slot
as `H`. The allocation is waiting for a reclaim that the blocked allocation
itself prevents, so this is a structural cycle and can be reported
immediately.

When `H != O`, the blocked orchestrator is not proven to pin `H`. The scheduler
may still consume it and advance the reclaim boundary. The allocator therefore
continues waiting; if the boundary remains stuck, the timeout reports sustained
no progress without misclassifying a transient scheduler state.

Scope depth maps one-to-one to rings until the deepest ring; deeper scopes
share that ring. For that ring, `scope_begins` selects the shallowest open
scope, so `O` still includes tasks retained by any open ancestor.

## Concurrency and ABA safety

`scope_tasks` and `scope_begins` have one orchestrator writer, and the scheduler
does not modify them. While blocked in allocation, that orchestrator cannot
close a scope or change `O`. Because `O` remains scope-retained, its slot cannot
be consumed and reused. A concurrent reclaim-boundary read may therefore delay
detection when `H != O`, but it cannot turn `H == O` into a false positive.

The dependency-list path uses the new task's `slot_state.ring_id`, while the
scope helper uses `current_ring_id()`; `prepare_task()` establishes that these
refer to the same ring before live-fanin wiring can block.

## Assumptions and unchanged concerns

The proof relies on existing runtime contracts: scope references are retained
until `scope_end`, each scope stack has one orchestrator writer, and a live task
slot is not reused. Those contracts would need to be revisited if early scope
release or multiple orchestrator writers are introduced.

This change does not alter the existing `int32_t` task-ID lifetime limit,
`current_task_index` publication ordering, or the allocator's possible
diagnostic-code overwrite by a concurrent fatal. None is used to establish
`H == O`.

## Regression coverage

Focused A2/A3 and A5 tests cover:

- an allocation blocked by the current open-scope head;
- an allocation blocked by an open ancestor when nested scopes share the
  deepest ring;
- a different-scope head that must use the timeout instead of an immediate
  structural fatal;
- both heap/task allocation and dependency-pool exhaustion.

These cases distinguish oldest-open-task slot identity from the old
`COMPLETED + consumers released + scope bit unset` approximation.
They use the normal scope-end and scheduler-consume lifecycle and add no
production test hooks or AICPU hot-path logging.

## Validation

- A2/A3 and A5 scope-deadlock and orchestrator-fanin tests passed.
- The focused scope detector and nested-scope regressions passed 20 repeated
  runs on both architectures.
- `git diff --check origin/main...HEAD` and modified-file pre-commit checks
  passed.

## Performance

Computing `O` is O(1): one ring lookup, one `scope_begins` load, one bounds
check, and at most one `scope_tasks` load. It adds no scan, lock, atomic
operation, or shared-memory layout change. The allocator compares slots once
per 1024 blocked spins; live-fanin computes `O` once before the dependency
pool's existing availability check.

An on-device ABBA benchmark compared the two validated commits:

- Platform: `a2a3`.
- Workload:
  `tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/`
  `test_multi_round_paged_attention.py`, `Case1`, `--skip-golden`.
- Sequence: 10-round base/fix warm-ups, then base/fix/fix/base with 500 rounds
  per measurement.
- All four measurements reported 500/500 valid device rounds.
- The measured fix commit was `19fca94a0ae0ccb86203173a1f03b8bfcf0bb846`.
  The final commit only amends its message; both commits have source-tree hash
  `b04e4b339cc260f55414c3ac9c3e43cd657cfa4a`.

| Run | Host (us) | Device (us) | Effective (us) | Orch (us) | Sched (us) |
| --- | --------: | ----------: | -------------: | --------: | ---------: |
| Base 1 | 1394.5 | 58.0 | 35.7 | 15.3 | 31.2 |
| Fix 1 | 1296.3 | 57.9 | 35.7 | 14.8 | 30.8 |
| Fix 1 vs. base 1 | -7.04% | -0.17% | 0.00% | -3.27% | -1.28% |
| Fix 2 | 1363.6 | 57.7 | 35.7 | 14.8 | 30.9 |
| Base 2 | 1307.6 | 57.1 | 35.3 | 14.6 | 30.7 |
| Fix 2 vs. base 2 | +4.28% | +1.05% | +1.13% | +1.37% | +0.65% |
| Base mean | 1351.05 | 57.55 | 35.50 | 14.95 | 30.95 |
| Fix mean | 1329.95 | 57.80 | 35.70 | 14.80 | 30.85 |
| Combined delta | -1.56% | +0.43% | +0.56% | -1.00% | -0.32% |

The paired deltas change direction between the two measurements, and the
combined device, effective, orchestrator, and scheduler deltas remain within
1%. The benchmark therefore shows no stable performance regression from this
change.
