### PR TITLE
Fix: block scheduler while group heads wait

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -42,13 +42,32 @@ a task is enqueued under its own `run_id`, and the Scheduler pops only from the
 partition of the run that currently holds the FIFO head. That is what keeps two
 admitted runs from interleaving their device work while both are live.
 
-Root submission, stop requests, and group-member completions that do not
-enqueue a terminal task completion advance a wake generation under the
-Scheduler condition-variable mutex. Terminal task completions push the
-completion FIFO under the same mutex. The wait predicate checks for a
-completion or an unconsumed wake generation.
+Root submission, run activation, stop requests, a worker publishing itself
+idle, and group-member completions that do not enqueue a terminal task
+completion all advance a wake generation under the Scheduler
+condition-variable mutex. Terminal task completions push the completion FIFO
+under the same mutex. The wait predicate checks for a completion or an
+unconsumed wake generation.
 Blocked queue heads therefore remain queued without keeping the predicate
 permanently true. Ready queues have no blocking pop or shutdown state.
+
+The predicate is edge-triggered, and that is a contract on everything that
+feeds it: **any state change that turns already-queued work into placeable
+work must push a completion or advance the generation.** The predicate no
+longer re-reads queue occupancy or worker state, so a change that only mutates
+those is invisible to a parked Scheduler.
+
+Two producers are easy to miss because the change happens outside the
+Scheduler thread and outside `Orchestrator`. `dispatch_ready` re-queues work it
+could not place — through `enqueue_ready_cb`, which by design does not notify —
+so the retry depends entirely on a later edge. And a `WorkerThread` publishes
+its completion *before* it publishes its lane state: it calls `on_complete` and
+only then stores `active_inflight_`/`inflight_`. That order is deliberate, so a
+stopping Scheduler cannot read a worker as no longer busy while its final
+completion is still unqueued — which means the completion wake alone can land
+on a worker that still reads as occupied, and the dispatch pass it triggers
+finds nothing placeable. The `on_idle` callback fires after that publication
+and supplies the edge that makes the retry happen.
 
 Popping a slot is not the same as owning it. A run whose graph callback throws
 fails and consumes its own unstarted slots, so the Scheduler claims each slot

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -40,11 +40,15 @@ NEXT_LEVEL queue after waiting in PENDING.
 Each `ReadyQueue` is a mutex-protected non-blocking FIFO, partitioned by run:
 a task is enqueued under its own `run_id`, and the Scheduler pops only from the
 partition of the run that currently holds the FIFO head. That is what keeps two
-admitted runs from interleaving their device work while both are live. Root
-submission, worker completion, and stop requests notify the Scheduler condition
-variable; its wait predicate checks the completion FIFO, the dispatchable run's
-partitions, and the stop flag. Ready queues have no blocking pop or shutdown
-state.
+admitted runs from interleaving their device work while both are live.
+
+Root submission, stop requests, and group-member completions that do not
+enqueue a terminal task completion advance a wake generation under the
+Scheduler condition-variable mutex. Terminal task completions push the
+completion FIFO under the same mutex. The wait predicate checks for a
+completion or an unconsumed wake generation.
+Blocked queue heads therefore remain queued without keeping the predicate
+permanently true. Ready queues have no blocking pop or shutdown state.
 
 Popping a slot is not the same as owning it. A run whose graph callback throws
 fails and consumes its own unstarted slots, so the Scheduler claims each slot
@@ -57,7 +61,7 @@ The Scheduler drains completions before dispatching new work:
 
 ```cpp
 while (true) {
-    wait_until_completion_ready_or_stop();
+    wait_until_completion_or_new_wake_generation();
 
     while (completion_queue has an item) {
         on_task_complete(item);

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -103,6 +103,11 @@ void Scheduler::start(const Config &cfg) {
         throw std::invalid_argument("Scheduler::start: null config fields");
     cfg_ = cfg;
 
+    {
+        std::lock_guard<std::mutex> lk(completion_mu_);
+        wake_generation_ = 1;
+    }
+    dispatch_round_count_.store(0, std::memory_order_relaxed);
     stop_requested_.store(false, std::memory_order_relaxed);
     running_.store(true, std::memory_order_release);
     sched_thread_ = std::thread(&Scheduler::run, this);
@@ -110,6 +115,10 @@ void Scheduler::start(const Config &cfg) {
 
 void Scheduler::request_stop() {
     stop_requested_.store(true, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lk(completion_mu_);
+        ++wake_generation_;
+    }
     completion_cv_.notify_all();
 }
 
@@ -152,7 +161,10 @@ void Scheduler::worker_done(WorkerCompletion completion) {
             int32_t index = invalid_group_index ? -1 : terminal.group_index;
             if (index >= 0 && index < group_size) {
                 GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(index)];
-                if (is_terminal_group_state(member_state)) return;
+                if (is_terminal_group_state(member_state)) {
+                    notify_ready();
+                    return;
+                }
 
                 if (terminal.outcome == EndpointOutcome::SUCCESS) {
                     member_state = GroupMemberState::SUCCESS;
@@ -185,7 +197,10 @@ void Scheduler::worker_done(WorkerCompletion completion) {
                 }
             }
 
-            if (s.group_terminal_count.load(std::memory_order_acquire) < group_size) return;
+            if (s.group_terminal_count.load(std::memory_order_acquire) < group_size) {
+                notify_ready();
+                return;
+            }
 
             if (s.group_failed) {
                 int32_t failure_index = s.group_first_failure_index;
@@ -216,7 +231,10 @@ void Scheduler::worker_done(WorkerCompletion completion) {
 }
 
 void Scheduler::notify_ready() {
-    std::lock_guard<std::mutex> lk(completion_mu_);
+    {
+        std::lock_guard<std::mutex> lk(completion_mu_);
+        ++wake_generation_;
+    }
     completion_cv_.notify_one();
 }
 
@@ -239,27 +257,14 @@ bool stageable_successor_ready(const NextLevelReadyQueues &ready_queues, const W
 // =============================================================================
 
 void Scheduler::run() {
+    uint64_t observed_wake_generation = 0;
     while (true) {
-        // Wait until there's something to process
         {
             std::unique_lock<std::mutex> lk(completion_mu_);
-            completion_cv_.wait(lk, [this] {
-                bool ready = false;
-                if (cfg_.active_run_cb) {
-                    RunId active = cfg_.active_run_cb();
-                    ready = active != INVALID_RUN_ID &&
-                            (!cfg_.ready_next_level_queues->empty(active) || !cfg_.ready_sub_queue->empty(active) ||
-                             cfg_.manager->needs_activation(active));
-                    if (!ready && cfg_.preparable_run_cb) {
-                        RunId preparable = cfg_.preparable_run_cb();
-                        ready = preparable != INVALID_RUN_ID && !cfg_.manager->has_staged_run(preparable) &&
-                                stageable_successor_ready(*cfg_.ready_next_level_queues, *cfg_.manager, preparable);
-                    }
-                } else {
-                    ready = !cfg_.ready_next_level_queues->empty() || !cfg_.ready_sub_queue->empty();
-                }
-                return !completion_queue_.empty() || ready || stop_requested_.load(std::memory_order_acquire);
+            completion_cv_.wait(lk, [this, &observed_wake_generation] {
+                return !completion_queue_.empty() || wake_generation_ != observed_wake_generation;
             });
+            observed_wake_generation = wake_generation_;
         }
 
         // Hold loop_mu_ across the entire slot-touching body so quiescent
@@ -343,7 +348,6 @@ void Scheduler::on_task_complete(const WorkerCompletion &completion) {
         // lost: submit's publication compares the pair under the same lock.
         if (try_mark_ready(cs)) {
             cfg_.enqueue_ready_cb(consumer);
-            completion_cv_.notify_one();
         }
     }
 
@@ -417,6 +421,7 @@ void Scheduler::try_consume(TaskSlot slot) {
 // sched_thread_ with no surrounding handler, any throw is fatal to the whole
 // worker tree (std::terminate), not a per-task failure.
 void Scheduler::dispatch_ready() {
+    dispatch_round_count_.fetch_add(1, std::memory_order_release);
     std::optional<RunId> run_snapshot;
     if (cfg_.active_run_cb) {
         RunId active_run = cfg_.active_run_cb();

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -104,8 +104,10 @@ void Scheduler::start(const Config &cfg) {
     cfg_ = cfg;
 
     {
+        // run()'s observed generation restarts at zero, so any advance here
+        // arms the first round.
         std::lock_guard<std::mutex> lk(completion_mu_);
-        wake_generation_ = 1;
+        ++wake_generation_;
     }
     dispatch_round_count_.store(0, std::memory_order_relaxed);
     stop_requested_.store(false, std::memory_order_relaxed);
@@ -145,7 +147,7 @@ void Scheduler::worker_done(WorkerCompletion completion) {
     if (s.is_group()) {
         WorkerCompletion terminal = completion;
         {
-            std::lock_guard<std::mutex> lk(s.group_mu);
+            std::unique_lock<std::mutex> lk(s.group_mu);
             const int32_t group_size = s.group_size();
             PreparedGroupVectors prepared =
                 prepare_group_vectors_locked(s, group_size, GroupMemberState::NOT_DISPATCHED);
@@ -162,6 +164,7 @@ void Scheduler::worker_done(WorkerCompletion completion) {
             if (index >= 0 && index < group_size) {
                 GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(index)];
                 if (is_terminal_group_state(member_state)) {
+                    lk.unlock();
                     notify_ready();
                     return;
                 }
@@ -198,6 +201,7 @@ void Scheduler::worker_done(WorkerCompletion completion) {
             }
 
             if (s.group_terminal_count.load(std::memory_order_acquire) < group_size) {
+                lk.unlock();
                 notify_ready();
                 return;
             }
@@ -236,20 +240,6 @@ void Scheduler::notify_ready() {
         ++wake_generation_;
     }
     completion_cv_.notify_one();
-}
-
-bool stageable_successor_ready(const NextLevelReadyQueues &ready_queues, const WorkerManager &manager, RunId run_id) {
-    // B3b stages singles only. If the successor has a group head, retain the
-    // established all-or-nothing group priority instead of letting a staged
-    // single occupy one of its reserved workers after FIFO promotion.
-    if (!ready_queues.groups_empty(run_id)) return false;
-    for (int32_t worker_id : ready_queues.worker_ids()) {
-        WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
-        if (worker != nullptr && worker->can_stage() && !ready_queues.single_empty(worker_id, run_id)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 // =============================================================================
@@ -421,7 +411,7 @@ void Scheduler::try_consume(TaskSlot slot) {
 // sched_thread_ with no surrounding handler, any throw is fatal to the whole
 // worker tree (std::terminate), not a per-task failure.
 void Scheduler::dispatch_ready() {
-    dispatch_round_count_.fetch_add(1, std::memory_order_release);
+    dispatch_round_count_.fetch_add(1, std::memory_order_relaxed);
     std::optional<RunId> run_snapshot;
     if (cfg_.active_run_cb) {
         RunId active_run = cfg_.active_run_cb();

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -22,7 +22,7 @@
  *   Orch: submit() → directed NEXT_LEVEL queue or shared SUB queue + notify
  *
  *   Scheduler thread:
- *     wait on cv (ready queue OR completion queue OR stop requested)
+ *     wait on cv (completion queue OR unconsumed wake generation)
  *     drain completion_queue → on_task_complete → fanout release → ready_queue
  *     launch directed NEXT_LEVEL tasks, then freely scheduled SUB tasks
  *
@@ -103,6 +103,7 @@ public:
     void stop();
 
     bool running() const { return running_.load(std::memory_order_acquire); }
+    uint64_t dispatch_round_count() const { return dispatch_round_count_.load(std::memory_order_acquire); }
 
     // Called by WorkerManager (from WorkerThread) after endpoint run() reaches
     // a terminal outcome.
@@ -126,10 +127,12 @@ private:
     std::queue<WorkerCompletion> completion_queue_;
     std::mutex completion_mu_;
     std::condition_variable completion_cv_;
+    uint64_t wake_generation_{0};
 
     std::thread sched_thread_;
     std::atomic<bool> stop_requested_{false};
     std::atomic<bool> running_{false};
+    std::atomic<uint64_t> dispatch_round_count_{0};
 
     void run();
     void on_task_complete(const WorkerCompletion &completion);

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -29,6 +29,14 @@
  *   WorkerThread (managed by WorkerManager):
  *     loop: task_queue.pop() → endpoint.run(dispatch) →
  *           completion callback → Scheduler.worker_done(completion)
+ *           → lane state published → idle callback → Scheduler.notify_ready()
+ *
+ * The wait is edge-triggered, so it carries an obligation on everything that
+ * feeds it: any state change that turns already-queued work into placeable
+ * work must push a completion or advance the wake generation. Queue occupancy
+ * is no longer re-read by the predicate, so a change that only mutates it —
+ * a requeue from dispatch, a worker publishing itself idle, a run reaching the
+ * FIFO head — is invisible until someone posts the matching edge.
  */
 
 #pragma once
@@ -69,7 +77,6 @@ struct WorkerDispatch;
  * window this closes is exactly the code between the queue pop and the launch.
  */
 bool claim_for_dispatch(TaskSlotState &s);
-bool stageable_successor_ready(const NextLevelReadyQueues &ready_queues, const WorkerManager &manager, RunId run_id);
 
 class Scheduler {
 public:
@@ -103,7 +110,9 @@ public:
     void stop();
 
     bool running() const { return running_.load(std::memory_order_acquire); }
-    uint64_t dispatch_round_count() const { return dispatch_round_count_.load(std::memory_order_acquire); }
+    // Diagnostic only — counts dispatch passes so an observer can tell a parked
+    // scheduler from one spinning on unplaceable work. Orders nothing.
+    uint64_t dispatch_round_count() const { return dispatch_round_count_.load(std::memory_order_relaxed); }
 
     // Called by WorkerManager (from WorkerThread) after endpoint run() reaches
     // a terminal outcome.

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -273,22 +273,6 @@ bool NextLevelReadyQueues::try_front_group(RunId run_id, TaskSlot &out) { return
 bool NextLevelReadyQueues::try_pop_group(TaskSlot &out) { return group_queue_.try_pop(out); }
 bool NextLevelReadyQueues::try_pop_group(RunId run_id, TaskSlot &out) { return group_queue_.try_pop(run_id, out); }
 
-bool NextLevelReadyQueues::empty() const {
-    if (!group_queue_.empty()) return false;
-    for (const auto &queue : queues_) {
-        if (!queue->empty()) return false;
-    }
-    return true;
-}
-
-bool NextLevelReadyQueues::empty(RunId run_id) const {
-    if (!group_queue_.empty(run_id)) return false;
-    for (const auto &queue : queues_) {
-        if (!queue->empty(run_id)) return false;
-    }
-    return true;
-}
-
 bool NextLevelReadyQueues::groups_empty(RunId run_id) const { return group_queue_.empty(run_id); }
 
 bool NextLevelReadyQueues::single_empty(int32_t worker_id, RunId run_id) const {

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -543,8 +543,6 @@ public:
     bool try_front_group(RunId run_id, TaskSlot &out);
     bool try_pop_group(TaskSlot &out);
     bool try_pop_group(RunId run_id, TaskSlot &out);
-    bool empty() const;
-    bool empty(RunId run_id) const;
     bool groups_empty(RunId run_id) const;
     bool single_empty(int32_t worker_id, RunId run_id) const;
     bool singles_empty(RunId run_id) const;

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -106,6 +106,9 @@ void Worker::init() {
         },
         [this](WorkerDispatch dispatch) {
             orchestrator_.mark_task_accepted(dispatch.task_slot);
+        },
+        [this] {
+            scheduler_.notify_ready();
         }
     );
     ready_next_level_queues_.reset(manager_.next_level_worker_ids());

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -269,12 +269,14 @@ char *LocalMailboxEndpoint::task_frame(size_t index) const {
 
 void WorkerThread::start(
     Ring *ring, const std::function<void(WorkerCompletion)> &on_complete,
-    const std::function<void(WorkerDispatch)> &on_accept, std::unique_ptr<WorkerEndpoint> endpoint
+    const std::function<void(WorkerDispatch)> &on_accept, const std::function<void()> &on_idle,
+    std::unique_ptr<WorkerEndpoint> endpoint
 ) {
     if (!endpoint) throw std::invalid_argument("WorkerThread::start: null endpoint");
     ring_ = ring;
     on_complete_ = on_complete;
     on_accept_ = on_accept;
+    on_idle_ = on_idle;
     endpoint_ = std::move(endpoint);
     shutdown_ = false;
     if (endpoint_->caps().max_inflight_tasks == 0) {
@@ -391,12 +393,6 @@ bool WorkerThread::activate_prepared(RunId run_id) {
 bool WorkerThread::has_staged_run(RunId run_id) const {
     std::lock_guard<std::mutex> lane_lk(lane_mu_);
     return staged_run_id_.load(std::memory_order_relaxed) == run_id;
-}
-
-bool WorkerThread::needs_activation(RunId run_id) const {
-    std::lock_guard<std::mutex> lane_lk(lane_mu_);
-    return staged_run_id_.load(std::memory_order_relaxed) == run_id &&
-           activated_run_id_.load(std::memory_order_relaxed) != run_id;
 }
 
 bool WorkerThread::can_stage() const {
@@ -578,10 +574,16 @@ void WorkerThread::loop() {
             }
         }
 
+        // on_complete_ runs before the lane state is published so a stopping
+        // scheduler cannot read this worker as no longer busy while its final
+        // completion is still unqueued. That leaves the reverse window — the
+        // scheduler placing work sees a stale non-idle lane — which is what
+        // on_idle_ closes.
         on_complete_(std::move(completion));
         active_inflight_.store(false, std::memory_order_release);
         inflight_.fetch_sub(1, std::memory_order_acq_rel);
         cv_.notify_one();
+        if (on_idle_) on_idle_();
     }
 }
 
@@ -639,6 +641,7 @@ void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progre
     }
     inflight_.fetch_sub(1, std::memory_order_acq_rel);
     cv_.notify_one();
+    if (on_idle_) on_idle_();
 }
 
 void WorkerThread::fail_progress_driver(const std::string &reason) noexcept {
@@ -1095,7 +1098,9 @@ void WorkerManager::add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endp
 
 void WorkerManager::add_sub(void *mailbox, int child_pid) { sub_entries_.push_back(LocalSubEntry{mailbox, child_pid}); }
 
-void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept) {
+void WorkerManager::start(
+    Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept, const OnIdleFn &on_idle
+) {
     if (ring == nullptr) throw std::invalid_argument("WorkerManager::start: null ring");
 
     std::vector<int32_t> next_level_worker_ids;
@@ -1125,7 +1130,7 @@ void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete, const OnA
             auto endpoint = std::make_unique<LocalMailboxEndpoint>(
                 entry.worker_id, entry.mailbox, entry.child_pid, entry.task_frame_count
             );
-            wt->start(ring, on_complete, on_accept, std::move(endpoint));
+            wt->start(ring, on_complete, on_accept, on_idle, std::move(endpoint));
             next_level_threads_.push_back(std::move(wt));
         }
     };
@@ -1136,14 +1141,14 @@ void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete, const OnA
             auto endpoint = std::make_unique<LocalMailboxEndpoint>(
                 static_cast<int32_t>(i), entries[i].mailbox, entries[i].child_pid
             );
-            wt->start(ring, on_complete, on_accept, std::move(endpoint));
+            wt->start(ring, on_complete, on_accept, on_idle, std::move(endpoint));
             threads.push_back(std::move(wt));
         }
     };
     make_next_level_threads();
     for (auto &endpoint : next_level_endpoint_entries_) {
         auto wt = std::make_unique<WorkerThread>();
-        wt->start(ring, on_complete, on_accept, std::move(endpoint));
+        wt->start(ring, on_complete, on_accept, on_idle, std::move(endpoint));
         next_level_threads_.push_back(std::move(wt));
     }
     next_level_endpoint_entries_.clear();
@@ -1633,12 +1638,6 @@ bool WorkerManager::any_busy() const {
 bool WorkerManager::has_staged_run(RunId run_id) const {
     for (const auto &worker : next_level_threads_)
         if (worker->has_staged_run(run_id)) return true;
-    return false;
-}
-
-bool WorkerManager::needs_activation(RunId run_id) const {
-    for (const auto &worker : next_level_threads_)
-        if (worker->needs_activation(run_id)) return true;
     return false;
 }
 

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -474,9 +474,17 @@ public:
     // `ring->slot_state(task_slot)` on each dispatch.
     // on_complete(completion) is called (in the WorkerThread) after each
     // endpoint run().
+    //
+    // on_idle() is called (in the WorkerThread) after the lane state for a
+    // finished dispatch is published, so `idle()` and `busy()` already report
+    // the post-completion values when it runs. on_complete() runs strictly
+    // before that publication — a scheduler that treats the completion as its
+    // only wake can therefore still observe this worker as occupied, and
+    // on_idle() is the edge that says otherwise.
     void start(
         Ring *ring, const std::function<void(WorkerCompletion)> &on_complete,
-        const std::function<void(WorkerDispatch)> &on_accept, std::unique_ptr<WorkerEndpoint> endpoint
+        const std::function<void(WorkerDispatch)> &on_accept, const std::function<void()> &on_idle,
+        std::unique_ptr<WorkerEndpoint> endpoint
     );
 
     // Enqueue a dispatch for the worker. Non-blocking.
@@ -487,7 +495,6 @@ public:
     // still needs its conservative terminal fallback.
     void complete_unpublished(WorkerDispatch d, const std::string &error_message);
     bool has_staged_run(RunId run_id) const;
-    bool needs_activation(RunId run_id) const;
     bool activate_prepared(RunId run_id);
 
     // The active lane and staged-successor lane are intentionally distinct.
@@ -578,6 +585,7 @@ private:
     std::unique_ptr<WorkerEndpoint> endpoint_;
     std::function<void(WorkerCompletion)> on_complete_;
     std::function<void(WorkerDispatch)> on_accept_;
+    std::function<void()> on_idle_;
 
     std::thread thread_;
     std::queue<WorkerDispatch> queue_;
@@ -610,6 +618,7 @@ class WorkerManager {
 public:
     using OnCompleteFn = std::function<void(WorkerCompletion)>;
     using OnAcceptFn = std::function<void(WorkerDispatch)>;
+    using OnIdleFn = std::function<void()>;
 
     // Register a worker. `mailbox` is a MAILBOX_SIZE-byte MAP_SHARED
     // region; the real worker (a `ChipWorker` for NEXT_LEVEL, a Python
@@ -624,7 +633,13 @@ public:
     // `on_accept` advances the run's launch fence; pass an empty function only
     // when nothing waits on that fence, since an omitted callback leaves
     // pending_accepts non-zero forever. No default: the choice is the caller's.
-    void start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept);
+    //
+    // `on_idle` fires once per finished dispatch, after that worker's lane
+    // state is published. An edge-triggered scheduler must supply it: a
+    // completion alone does not prove the worker is dispatchable again. It is
+    // defaulted empty because pools driven by no scheduler have nothing to
+    // wake.
+    void start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept, const OnIdleFn &on_idle = {});
     void stop_workers();
     void stop();
 
@@ -637,7 +652,6 @@ public:
 
     bool any_busy() const;
     bool has_staged_run(RunId run_id) const;
-    bool needs_activation(RunId run_id) const;
     bool activate_prepared_run(RunId run_id);
 
     // Forward CTRL_PREPARE to a specific NEXT_LEVEL worker. Thin wrapper

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -1655,7 +1655,7 @@ TEST_F(ProgressSchedulerFixture, PreparedSuccessorGroupRemainsQueuedUntilPromoti
 
     EXPECT_TRUE(endpoint0->wait_submitted(1));
     EXPECT_TRUE(ready_next.singles_empty(second_run));
-    EXPECT_FALSE(ready_next.empty(second_run));
+    EXPECT_FALSE(ready_next.groups_empty(second_run));
     EXPECT_FALSE(manager.has_staged_run(second_run));
     EXPECT_TRUE(endpoint1->submitted().empty());
     std::vector<WorkerDispatch> first_submissions = endpoint0->submitted();
@@ -2252,19 +2252,27 @@ TEST_F(GroupSchedulerFixture, BlockedGroupReservesTargetsThatBecomeIdleOneAtATim
     EXPECT_EQ(worker_a.dispatched[1].callable_hash0, 72u);
     EXPECT_EQ(worker_b.dispatched[1].callable_hash0, 72u);
 
+    // Completing one group member makes only worker A idle. Its queued single
+    // must progress from the incomplete-member wake while worker B still runs
+    // the other member and the group remains aggregate-incomplete.
     worker_a.complete();
-    worker_b.complete();
-
     deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
-    while ((worker_a.dispatched_count() < 3 || worker_b.dispatched_count() < 3) &&
-           std::chrono::steady_clock::now() < deadline) {
+    while (worker_a.dispatched_count() < 3 && std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     ASSERT_GE(worker_a.dispatched_count(), 3);
-    ASSERT_GE(worker_b.dispatched_count(), 3);
+    EXPECT_EQ(worker_b.dispatched_count(), 2);
+    EXPECT_EQ(S(group.task_slot).state.load(), TaskState::RUNNING);
     EXPECT_EQ(worker_a.dispatched[2].callable_hash0, 73u);
-    EXPECT_EQ(worker_b.dispatched[2].callable_hash0, 74u);
     worker_a.complete();
+
+    worker_b.complete();
+    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (worker_b.dispatched_count() < 3 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_GE(worker_b.dispatched_count(), 3);
+    EXPECT_EQ(worker_b.dispatched[2].callable_hash0, 74u);
     worker_b.complete();
 
     wait_consumed(running_a.task_slot);
@@ -2345,9 +2353,15 @@ TEST(SchedulerDispatchPassTest, ActiveRunSwitchCannotBypassSuccessorGroupReserva
         return active_run.load(std::memory_order_acquire);
     };
     // The run switch lands after the group phase selected A and before the
-    // singles phase can select a queue partition.
+    // singles phase can select a queue partition. Production run admission
+    // advances the scheduler wake generation (ready_notify_cb_), so the seam
+    // must signal the switch the same way: in the edge-triggered wake model
+    // the switch itself is the wake event.
     config.before_claim_cb = [&](TaskSlot slot) {
-        if (allocator.slot_state(slot)->run_id == run_a) active_run.store(run_b, std::memory_order_release);
+        if (allocator.slot_state(slot)->run_id == run_a) {
+            active_run.store(run_b, std::memory_order_release);
+            sched.notify_ready();
+        }
     };
     config.on_consumed_cb = [&](TaskSlot slot) {
         allocator.slot_state(slot)->state.store(TaskState::CONSUMED, std::memory_order_release);
@@ -2478,6 +2492,56 @@ TEST_F(GroupSchedulerFixture, TearDownDrainsCurrentAndQueuedDispatches) {
     EXPECT_TRUE(worker_b.is_running.load(std::memory_order_acquire));
 }
 
+TEST_F(GroupSchedulerFixture, BlockedGroupSleepsUntilWorkerCompletion) {
+    auto running = orch.submit_next_level(C(78), single_tensor_args(0xFA, TensorArgType::OUTPUT), cfg, 0);
+    worker_a.wait_running();
+    EXPECT_TRUE(worker_a.is_running.load(std::memory_order_acquire));
+
+    const uint64_t rounds_before_blocked_group = sched.dispatch_round_count();
+    auto blocked = orch.submit_next_level_group(
+        C(79), {single_tensor_args(0xFB, TensorArgType::OUTPUT), single_tensor_args(0xFC, TensorArgType::OUTPUT)}, cfg,
+        {0, 1}
+    );
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (sched.dispatch_round_count() == rounds_before_blocked_group && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const uint64_t settled_rounds = sched.dispatch_round_count();
+    ASSERT_GT(settled_rounds, rounds_before_blocked_group);
+    // The fix's property: with the group blocked, dispatch rounds stop
+    // advancing once the scheduler parks. Poll for a quiet window instead of
+    // a fixed sleep so a loaded runner cannot fail the check spuriously.
+    uint64_t quiet_rounds = settled_rounds;
+    bool parked = false;
+    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        const uint64_t rounds_now = sched.dispatch_round_count();
+        if (rounds_now == quiet_rounds) {
+            parked = true;
+            break;
+        }
+        quiet_rounds = rounds_now;
+    }
+    EXPECT_TRUE(parked) << "scheduler did not park while the group head was blocked";
+    EXPECT_EQ(S(blocked.task_slot).state.load(std::memory_order_acquire), TaskState::READY);
+
+    worker_a.complete();
+    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while ((worker_a.dispatched_count() < 2 || worker_b.dispatched_count() < 1) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(worker_a.dispatched_count(), 2);
+    EXPECT_EQ(worker_b.dispatched_count(), 1);
+    worker_a.complete();
+    worker_b.complete();
+
+    wait_consumed(running.task_slot);
+    wait_consumed(blocked.task_slot);
+}
+
 TEST_F(GroupSchedulerFixture, LaunchableGroupPrecedesConflictingSingles) {
     auto running_a = orch.submit_next_level(C(73), single_tensor_args(0xF4, TensorArgType::OUTPUT), cfg, 0);
     auto running_b = orch.submit_next_level(C(74), single_tensor_args(0xF5, TensorArgType::OUTPUT), cfg, 1);
@@ -2602,6 +2666,9 @@ TEST_F(GroupSchedulerFixture, InvalidGroupIndexFailsAndConsumesGroup) {
     worker_a.wait_running();
     worker_b.wait_running();
 
+    auto single_a = orch.submit_next_level(C(43), single_tensor_args(0xD2, TensorArgType::OUTPUT), cfg, 0);
+    auto single_b = orch.submit_next_level(C(44), single_tensor_args(0xD3, TensorArgType::OUTPUT), cfg, 1);
+
     WorkerCompletion bad;
     bad.task_slot = slot;
     bad.group_index = 99;
@@ -2612,8 +2679,46 @@ TEST_F(GroupSchedulerFixture, InvalidGroupIndexFailsAndConsumesGroup) {
     wait_consumed(slot);
     EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 
-    worker_a.complete();
-    worker_b.complete();
+    {
+        // Wait for the invalid completion's dispatch round to finish, then
+        // make both terminalized group members idle while the scheduler loop
+        // is paused. Their completion callbacks must provide the next wake.
+        std::lock_guard<std::mutex> scheduler_pause(sched.loop_mutex());
+        worker_a.complete();
+        worker_b.complete();
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+        WorkerThread *manager_worker_a = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
+        WorkerThread *manager_worker_b = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 1);
+        while ((!manager_worker_a->idle() || !manager_worker_b->idle()) &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        EXPECT_TRUE(manager_worker_a->idle());
+        EXPECT_TRUE(manager_worker_b->idle());
+    }
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while ((worker_a.dispatched_count() < 2 || worker_b.dispatched_count() < 2) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(worker_a.dispatched_count(), 2);
+    EXPECT_EQ(worker_b.dispatched_count(), 2);
+
+    // Keep cleanup non-fatal so a missing wake reports a test failure instead
+    // of hanging the fixture in Scheduler::stop().
+    if (worker_a.dispatched_count() < 2 || worker_b.dispatched_count() < 2) {
+        sched.notify_ready();
+        deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+        while ((worker_a.dispatched_count() < 2 || worker_b.dispatched_count() < 2) &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+    if (worker_a.dispatched_count() >= 2) worker_a.complete();
+    if (worker_b.dispatched_count() >= 2) worker_b.complete();
+    wait_consumed(single_a.task_slot);
+    wait_consumed(single_b.task_slot);
 }
 
 TEST_F(GroupSchedulerFixture, ExplicitTargetWithinEligibilityIsUsed) {

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -767,6 +767,9 @@ struct SchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orch.mark_task_accepted(dispatch.task_slot);
+            },
+            [this] {
+                sched.notify_ready();
             }
         );
         rq_next_level.reset(manager.next_level_worker_ids());
@@ -863,9 +866,118 @@ TEST(WorkerManagerTest, SingleFrameSuccessorIsNotReportedAsStageable) {
     ready.push_single(/*worker_id=*/0, successor_run, /*slot=*/3);
 
     EXPECT_FALSE(ready.singles_empty(successor_run));
-    EXPECT_FALSE(stageable_successor_ready(ready, manager, successor_run));
+    WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
+    ASSERT_NE(worker, nullptr);
+    EXPECT_FALSE(worker->can_stage());
 
     manager.stop();
+    allocator.shutdown();
+}
+
+// The scheduler's wait is edge-triggered, so the wake it consumes for a
+// finished dispatch has to imply the worker can take the next one. A
+// completion cannot carry that: it is published before the lane state, on
+// purpose, so a stopping scheduler never reads a worker as no longer busy
+// while its last completion is still unqueued. These two pin the ordering the
+// idle edge restores — one per endpoint driving mode.
+TEST(WorkerManagerTest, IdleCallbackFollowsTheLanePublicationOnBlockingEndpoints) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/71, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+
+    WorkerManager manager;
+    manager.add_next_level_endpoint(std::make_unique<FakeEndpoint>(0));
+
+    std::mutex mu;
+    std::condition_variable cv;
+    int completions = 0;
+    int idle_calls = 0;
+    bool completion_seen_first = false;
+    bool worker_readable_as_idle = false;
+
+    manager.start(
+        &allocator,
+        [&](WorkerCompletion) {
+            std::lock_guard<std::mutex> lk(mu);
+            ++completions;
+        },
+        [](WorkerDispatch) {},
+        [&] {
+            WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
+            std::lock_guard<std::mutex> lk(mu);
+            ++idle_calls;
+            completion_seen_first = completions == 1;
+            worker_readable_as_idle = worker != nullptr && worker->idle() && !worker->busy();
+            cv.notify_all();
+        }
+    );
+
+    WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
+    ASSERT_NE(worker, nullptr);
+    worker->dispatch(WorkerDispatch{slot, 0});
+
+    {
+        std::unique_lock<std::mutex> lk(mu);
+        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(3), [&] {
+            return idle_calls == 1;
+        })) << "the worker never signalled that its lane freed up";
+        EXPECT_TRUE(completion_seen_first) << "the idle edge must not precede the completion it belongs to";
+        EXPECT_TRUE(worker_readable_as_idle) << "a dispatch placed on this edge would find the worker occupied";
+    }
+
+    manager.stop();
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, IdleCallbackFollowsTheLanePublicationOnProgressEndpoints) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/72, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+
+    std::mutex mu;
+    std::condition_variable cv;
+    int completions = 0;
+    int idle_calls = 0;
+    bool completion_seen_first = false;
+    bool worker_readable_as_idle = false;
+
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion) {
+            std::lock_guard<std::mutex> lk(mu);
+            ++completions;
+        },
+        [](WorkerDispatch) {},
+        [&] {
+            std::lock_guard<std::mutex> lk(mu);
+            ++idle_calls;
+            completion_seen_first = completions == 1;
+            worker_readable_as_idle = worker.idle() && !worker.busy();
+            cv.notify_all();
+        },
+        std::move(endpoint)
+    );
+
+    worker.dispatch(WorkerDispatch{slot, 0});
+    ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
+    endpoint_ptr->force_stop_terminalization();
+
+    {
+        std::unique_lock<std::mutex> lk(mu);
+        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(3), [&] {
+            return idle_calls == 1;
+        })) << "the worker never signalled that its lane freed up";
+        EXPECT_TRUE(completion_seen_first) << "the idle edge must not precede the completion it belongs to";
+        EXPECT_TRUE(worker_readable_as_idle) << "a dispatch placed on this edge would find the worker occupied";
+    }
+
+    worker.stop();
     allocator.shutdown();
 }
 
@@ -896,7 +1008,7 @@ TEST(WorkerManagerTest, WorkerThreadUsesOneProgressOwnerForActiveAndStagedLanes)
             accepted.push_back(dispatch);
             callback_cv.notify_all();
         },
-        std::move(endpoint)
+        {}, std::move(endpoint)
     );
 
     worker.dispatch(WorkerDispatch{active_slot, 0});
@@ -1014,7 +1126,7 @@ TEST(WorkerManagerTest, ThirdDispatchCannotMutateTwoOccupiedFrames) {
             ++completion_count;
             completion_cv.notify_all();
         },
-        [](WorkerDispatch) {},
+        [](WorkerDispatch) {}, {},
         std::make_unique<LocalMailboxEndpoint>(
             /*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/2
         )
@@ -1247,7 +1359,7 @@ TEST(WorkerManagerTest, StopTerminalizesOutstandingProgress) {
             completed.push_back(std::move(completion));
             completion_cv.notify_all();
         },
-        [](WorkerDispatch) {}, std::move(endpoint)
+        [](WorkerDispatch) {}, {}, std::move(endpoint)
     );
     worker.dispatch(WorkerDispatch{active_slot, 0});
     worker.dispatch_prepared(WorkerDispatch{staged_slot, 0});
@@ -1292,7 +1404,7 @@ TEST(WorkerManagerTest, ProgressStopRepeatsUntilOutstandingWorkTerminalizes) {
             std::lock_guard<std::mutex> lk(completion_mu);
             completed.push_back(std::move(completion));
         },
-        [](WorkerDispatch) {}, std::move(endpoint)
+        [](WorkerDispatch) {}, {}, std::move(endpoint)
     );
     worker.dispatch(WorkerDispatch{slot, 0});
     EXPECT_TRUE(endpoint_ptr->wait_submitted(1));
@@ -1339,7 +1451,7 @@ TEST(WorkerManagerTest, PollExceptionTerminalizesOutstandingProgressAndStopsTheD
             completed.push_back(std::move(completion));
             completion_cv.notify_all();
         },
-        [](WorkerDispatch) {}, std::move(endpoint)
+        [](WorkerDispatch) {}, {}, std::move(endpoint)
     );
     worker.dispatch(WorkerDispatch{slot, 0});
     EXPECT_TRUE(endpoint_ptr->wait_submitted(1));
@@ -1399,7 +1511,10 @@ TEST(WorkerManagerTest, StopKeepsWorkerBusyUntilItsLastCompletionIsPublished) {
             allow_completion_future.wait();
             scheduler.worker_done(std::move(completion));
         },
-        [](WorkerDispatch) {}
+        [](WorkerDispatch) {},
+        [&scheduler] {
+            scheduler.notify_ready();
+        }
     );
 
     ReadyQueue ready_sub;
@@ -1472,6 +1587,9 @@ struct ProgressSchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orchestrator.mark_task_accepted(dispatch.task_slot);
+            },
+            [this] {
+                scheduler.notify_ready();
             }
         );
         ready_next.reset(manager.next_level_worker_ids());
@@ -2074,6 +2192,9 @@ struct GroupSchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orch.mark_task_accepted(dispatch.task_slot);
+            },
+            [this] {
+                sched.notify_ready();
             }
         );
         rq_next_level.reset(manager.next_level_worker_ids());
@@ -2305,7 +2426,10 @@ TEST(SchedulerDispatchPassTest, ActiveRunSwitchCannotBypassSuccessorGroupReserva
         [&sched](WorkerCompletion completion) {
             sched.worker_done(std::move(completion));
         },
-        [](WorkerDispatch) {}
+        [](WorkerDispatch) {},
+        [&sched] {
+            sched.notify_ready();
+        }
     );
     rq_next_level.reset(manager.next_level_worker_ids());
 
@@ -2490,6 +2614,30 @@ TEST_F(GroupSchedulerFixture, TearDownDrainsCurrentAndQueuedDispatches) {
     worker_b.wait_running();
     EXPECT_TRUE(worker_a.is_running.load(std::memory_order_acquire));
     EXPECT_TRUE(worker_b.is_running.load(std::memory_order_acquire));
+}
+
+// The shape that hangs when the idle edge is missing: a second task queued for
+// the only worker that can run it. Its wake is the first task's completion,
+// which a dispatch pass can consume while that worker still reads as occupied.
+TEST_F(GroupSchedulerFixture, QueuedSingleRunsAfterItsWorkerFreesUp) {
+    auto first = orch.submit_next_level(C(81), single_tensor_args(0x1A, TensorArgType::OUTPUT), cfg, 0);
+    worker_a.wait_running();
+    EXPECT_EQ(worker_a.dispatched_count(), 1);
+
+    auto queued = orch.submit_next_level(C(82), single_tensor_args(0x1B, TensorArgType::OUTPUT), cfg, 0);
+    EXPECT_EQ(worker_a.dispatched_count(), 1);
+
+    worker_a.complete();
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (worker_a.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(worker_a.dispatched_count(), 2) << "the queued single never reached the worker that freed up";
+    EXPECT_EQ(worker_a.dispatched[1].callable_hash0, 82u);
+    worker_a.complete();
+
+    wait_consumed(first.task_slot);
+    wait_consumed(queued.task_slot);
 }
 
 TEST_F(GroupSchedulerFixture, BlockedGroupSleepsUntilWorkerCompletion) {
@@ -2898,6 +3046,9 @@ TEST(SchedulerWorkerTargetTest, NextLevelTargetUsesWorkerIdNotVectorIndex) {
         },
         [&orch](WorkerDispatch dispatch) {
             orch.mark_task_accepted(dispatch.task_slot);
+        },
+        [&sched] {
+            sched.notify_ready();
         }
     );
     rq_next_level.reset(manager.next_level_worker_ids());
@@ -3032,6 +3183,9 @@ struct MixedTypeSchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orch.mark_task_accepted(dispatch.task_slot);
+            },
+            [this] {
+                sched.notify_ready();
             }
         );
         rq_next_level.reset(manager.next_level_worker_ids());


### PR DESCRIPTION
## Summary

- replace ready-queue/stop level predicates with a consumed wake generation
- keep completions as queued wake events while consuming readiness and stop notifications once
- wake on incomplete group-member completion so newly idle targets can run queued singles
- remove the blocked group busy-spin path and document the wake model

## Why

A blocked group leaves its queue non-empty, so the previous condition-variable predicate remained permanently true and repeatedly ran dispatch. The stop flag had the same level-triggered behavior while workers were still busy.

## Review context

https://github.com/hw-native-sys/simpler/pull/1565#issuecomment-5129123225

## Testing

- pre-fix regression observed thousands of extra dispatch rounds in 30 ms
- partial group-member wake regression repeated 20 times
- `test_scheduler`: 27/27 passed
- non-hardware C++ UT: 67/67 passed