### PR TITLE
Test: cover overlapping group reservations

### DIFF
--- a/tests/st/worker/collectives/README.md
+++ b/tests/st/worker/collectives/README.md
@@ -21,5 +21,6 @@ collectives/
 ├── reduce_scatter/       # Mesh reduce-scatter
 ├── broadcast/            # Mesh broadcast
 ├── all_to_all/           # Push-based mesh all-to-all (TPUT → barrier → local copy-out)
+├── group_reservation/    # Overlapping NEXT_LEVEL group reservation ordering
 └── README.md
 ```

--- a/tests/st/worker/collectives/group_reservation/README.md
+++ b/tests/st/worker/collectives/group_reservation/README.md
@@ -1,0 +1,23 @@
+# Group reservation scene test
+
+This scene deterministically exercises overlapping `NEXT_LEVEL` group
+reservations on workers 0, 1, and 2:
+
+```text
+group {0,1}: worker 1 waits for a device-side notification
+group {1,2}: remains at the group queue head while worker 1 is busy
+single {0}:  must run because worker 0 is unrelated; it releases worker 1
+single {2}:  must wait behind group {1,2}
+```
+
+The second group's worker-2 task records a device-side marker before the final
+single reads it. A result of `1` proves the single did not overtake the
+reservation. Completion of the whole test proves the blocked group did not
+reserve unrelated worker 0.
+
+Run on the 3-device simulator:
+
+```bash
+python -m pytest tests/st/worker/collectives/group_reservation \
+  --platform a2a3sim --device 0-2 -v
+```

--- a/tests/st/worker/collectives/group_reservation/__init__.py
+++ b/tests/st/worker/collectives/group_reservation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/st/worker/collectives/group_reservation/kernels/aiv/group_reservation_kernel.cpp
+++ b/tests/st/worker/collectives/group_reservation/kernels/aiv/group_reservation_kernel.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "platform_comm/comm_context.h"
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "intrinsic.h"
+
+#if defined(__CCE_AICORE__) && !defined(__CPU_SIM) && !defined(__COSTMODEL)
+#define GROUP_RESERVATION_USE_DEV_INTRIN 1
+#else
+#define GROUP_RESERVATION_USE_DEV_INTRIN 0
+#endif
+
+enum class Operation : int32_t {
+    FIRST_GROUP = 0,
+    RELEASE_FIRST_GROUP = 1,
+    SECOND_GROUP = 2,
+    CHECK_SECOND_GROUP = 3,
+};
+
+static __aicore__ inline void store_i32(__gm__ int32_t *ptr, int32_t value) {
+#if GROUP_RESERVATION_USE_DEV_INTRIN
+    st_dev(static_cast<uint32_t>(value), reinterpret_cast<__gm__ uint32_t *>(ptr), 0);
+#else
+    *reinterpret_cast<volatile int32_t *>(ptr) = value;
+#endif
+}
+
+static __aicore__ inline int32_t load_i32(__gm__ int32_t *ptr) {
+#if GROUP_RESERVATION_USE_DEV_INTRIN
+    return static_cast<int32_t>(ld_dev(reinterpret_cast<__gm__ uint32_t *>(ptr), 0));
+#else
+    return *reinterpret_cast<volatile int32_t *>(ptr);
+#endif
+}
+
+static __aicore__ inline void ddr_fence() {
+#if GROUP_RESERVATION_USE_DEV_INTRIN
+    dsb(DSB_DDR);
+#endif
+}
+
+template <typename T>
+static __aicore__ inline __gm__ T *remote_ptr(__gm__ CommContext *context, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = context->windowsIn[context->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(context->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    if (get_block_idx(args) != 0) {
+        return;
+    }
+
+    __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    Operation operation = static_cast<Operation>(args[1]);
+    __gm__ int32_t *state = reinterpret_cast<__gm__ int32_t *>(args[2]);
+    __gm__ CommContext *context = reinterpret_cast<__gm__ CommContext *>(args[3]);
+    __gm__ int32_t *output =
+        reinterpret_cast<__gm__ int32_t *>(output_tensor->buffer.addr) + output_tensor->start_offset;
+
+    int rank = static_cast<int>(context->rankId);
+    int32_t marker = -1;
+
+    switch (operation) {
+    case Operation::FIRST_GROUP:
+        if (rank == 1) {
+            pto::comm::Signal signal(state);
+            pto::comm::TWAIT(signal, static_cast<int32_t>(1), pto::comm::WaitCmp::GE);
+        }
+        marker = 10 + rank;
+        break;
+    case Operation::RELEASE_FIRST_GROUP: {
+        __gm__ int32_t *remote_state = remote_ptr(context, state, 1);
+        pto::comm::Signal signal(remote_state);
+        pto::comm::TNOTIFY(signal, static_cast<int32_t>(1), pto::comm::NotifyOp::AtomicAdd);
+        marker = 20;
+        break;
+    }
+    case Operation::SECOND_GROUP:
+        if (rank == 2) {
+            store_i32(state + 1, 1);
+            ddr_fence();
+        }
+        marker = 30 + rank;
+        break;
+    case Operation::CHECK_SECOND_GROUP:
+        ddr_fence();
+        marker = load_i32(state + 1) >= 1 ? 1 : 0;
+        break;
+    }
+
+    store_i32(output, marker);
+    ddr_fence();
+    pipe_barrier(PIPE_ALL);
+}

--- a/tests/st/worker/collectives/group_reservation/kernels/orchestration/group_reservation_orch.cpp
+++ b/tests/st/worker/collectives/group_reservation/kernels/orchestration/group_reservation_orch.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+group_reservation_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,
+    };
+}
+
+__attribute__((visibility("default"))) void group_reservation_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &output = orch_args.tensor(0).ref();
+
+    L0TaskArgs params;
+    params.add_output(output);
+    params.add_scalar(orch_args.scalar(0));
+    params.add_scalar(orch_args.scalar(1));
+    params.add_scalar(orch_args.scalar(2));
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/tests/st/worker/collectives/group_reservation/test_group_reservation.py
+++ b/tests/st/worker/collectives/group_reservation/test_group_reservation.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""End-to-end coverage for overlapping NEXT_LEVEL group reservations."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, TaskArgs, TensorArgType
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, scene_test
+from simpler_setup import Tensor as STensor
+from simpler_setup.torch_interop import make_tensor_arg
+
+FIRST_GROUP = 0
+RELEASE_FIRST_GROUP = 1
+SECOND_GROUP = 2
+CHECK_SECOND_GROUP = 3
+
+
+def group_reservation_orch_fn(orch, callables, task_args, config):
+    chip = callables.group_reservation
+
+    with orch.allocate_domain(
+        name="reservation",
+        workers=[0, 1, 2],
+        window_size=4 * 1024,
+        buffers=[CommBufferSpec(name="state", dtype="int32", count=2, nbytes=8)],
+    ) as handle:
+
+        def make_args(worker_id, output_name, operation):
+            domain = handle[worker_id]
+            args = TaskArgs()
+            args.add_tensor(make_tensor_arg(getattr(task_args, output_name)), TensorArgType.OUTPUT_EXISTING)
+            args.add_scalar(operation)
+            args.add_scalar(domain.buffer_ptrs["state"])
+            args.add_scalar(domain.device_ctx)
+            return args
+
+        orch.submit_next_level_group(
+            chip,
+            [
+                make_args(0, "first_group_0", FIRST_GROUP),
+                make_args(1, "first_group_1", FIRST_GROUP),
+            ],
+            config,
+            workers=[0, 1],
+        )
+        orch.submit_next_level_group(
+            chip,
+            [
+                make_args(1, "second_group_1", SECOND_GROUP),
+                make_args(2, "second_group_2", SECOND_GROUP),
+            ],
+            config,
+            workers=[1, 2],
+        )
+        orch.submit_next_level(
+            chip,
+            make_args(0, "unrelated_single_0", RELEASE_FIRST_GROUP),
+            config,
+            worker=0,
+        )
+        orch.submit_next_level(
+            chip,
+            make_args(2, "reserved_single_2", CHECK_SECOND_GROUP),
+            config,
+            worker=2,
+        )
+
+
+_CALLABLE = {
+    "orchestration": group_reservation_orch_fn,
+    "callables": [
+        {
+            "name": "group_reservation",
+            "orchestration": {
+                "source": "kernels/orchestration/group_reservation_orch.cpp",
+                "function_name": "group_reservation_orchestration",
+                "config_name": "group_reservation_orchestration_config",
+                "signature": [D.OUT],
+            },
+            "incores": [
+                {
+                    "func_id": 0,
+                    "source": "kernels/aiv/group_reservation_kernel.cpp",
+                    "core_type": "aiv",
+                    "signature": [D.OUT],
+                }
+            ],
+        }
+    ],
+}
+
+
+def _make_args():
+    names = [
+        "first_group_0",
+        "first_group_1",
+        "second_group_1",
+        "second_group_2",
+        "unrelated_single_0",
+        "reserved_single_2",
+    ]
+    return TaskArgsBuilder(*(STensor(name, torch.zeros(1, dtype=torch.int32).share_memory_()) for name in names))
+
+
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestConsecutiveGroupReservation(SceneTestCase):
+    CALLABLE = _CALLABLE
+    CASES = [
+        {
+            "name": "overlapping_targets",
+            "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "config": {"device_count": 3},
+            "params": {},
+        }
+    ]
+
+    def generate_args(self, params):
+        return _make_args()
+
+    def compute_golden(self, args, params):
+        args.first_group_0.fill_(10)
+        args.first_group_1.fill_(11)
+        args.second_group_1.fill_(31)
+        args.second_group_2.fill_(32)
+        args.unrelated_single_0.fill_(20)
+        args.reserved_single_2.fill_(1)
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

- add a dedicated three-worker scene for overlapping `NEXT_LEVEL` group reservations
- hold the first group with a device-side notification instead of timing sleeps
- prove an unrelated worker can progress while a later group is blocked
- prove a single on a reserved target cannot overtake the blocked group

## Scenario

The first group uses workers `{0,1}` and leaves worker 1 waiting. A second group for `{1,2}` blocks at the group queue head. A worker-0 single releases the first group, while a worker-2 single checks a marker written by the second group.

## Review context

https://github.com/hw-native-sys/simpler/pull/1565#issuecomment-5129123225

## Testing

- `a2a3sim`, three devices: passed
- `a5sim`, three devices: passed
- onboard not run: local DCMI initialization failed before the mandatory architecture precheck (`dcmi module initialize failed (-8005)`)