### PR TITLE
Docs: select the SDMA tests by marker in the testing skill's recipe

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -20,14 +20,14 @@ copying a path list. PTO-ISA reproducibility comes from the repo-root
 `pto_isa.pin`.
 
 **CI does not run one flat sweep.** Some tests are quarantined out of the
-general onboard sweep and run in their own step on their own devices, because
-they are only correct in isolation. Reproducing CI means reproducing that
+general onboard sweep and run in a step of their own, after it, because they are
+only correct in isolation. Reproducing CI means reproducing that
 shape — a bare `pytest examples tests/st --platform a2a3` is *not* what CI runs
 and will report failures that CI never sees:
 
 | Quarantine | Excludes | Runs instead in |
 | ---------- | -------- | --------------- |
-| `@pytest.mark.sdma` | `sdma_async_completion_demo`, `prefetch_async_demo` | dedicated "SDMA pytest (a2a3)" step, `--device-num 2` |
+| `@pytest.mark.sdma` | `sdma_async_completion_demo`, `prefetch_async_demo` | the "SDMA pytest (a2a3)" step, which runs after the sweep |
 
 The SDMA demos provision 48 device-only STARS streams, which makes an AICore
 fault take ~306 s to tear down instead of ~0.3 s — so they must not share a
@@ -76,9 +76,10 @@ pytest examples tests/st --platform a2a3sim \
 pytest examples tests/st -m "not sdma" --platform a2a3 --device <range> \
     --pto-session-timeout <timeout>
 
-# The quarantined tests, the way CI runs them — alone, on their own devices
-pytest examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo \
-       examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo \
+# The quarantined tests, the way CI runs them — same corpus, selected by the
+# marker, run after the sweep rather than inside it. Never a path list: that is
+# what the marker replaced.
+pytest examples tests/st -m sdma \
     --platform a2a3 --device <2 devs> --pto-session-timeout <timeout>
 
 # Single runtime


### PR DESCRIPTION
## Summary

Follow-up to #1609 and #1617 — the same two defects, in the file whose stated purpose is *reproducing CI*.

**1. The recipe contradicted the instruction three lines above it.** The skill says quarantines "are markers on the tests, so mirror the sweep with `-m "not sdma"` rather than copying a path list" — and then the command block copied a path list:

```bash
pytest examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo \
       examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo
```

That is exactly the fragility #1609 removed from `ci.yml`. It is now `pytest examples tests/st -m sdma` — the same corpus and the same selector as the workflow's `SDMA_TESTS`, so the recipe cannot drift from the job it mirrors.

**2. "Their own devices" is aarch64-only,** in three places (prose, the quarantine table's "runs instead in" cell, and the command comment). Only the aarch64 branch gives the SDMA step `task-submit --device auto --device-num 2`; x86_64 has no `task-submit` and both steps use `${DEVICE_RANGE}`. What holds on both is **ordering** — SDMA runs after the sweep, so no fault-injection case meets a device that has already provisioned SDMA. Same correction #1617 made to `docs/ci.md`.

## Testing

- [x] Both recipes now match `ci.yml` verbatim in corpus and selector: sweep `examples tests/st -m "not sdma"`, SDMA step `examples tests/st -m sdma` (`ci.yml:627`)
- [x] No hardcoded demo path remains in any command; the demo names survive only in the table's "Excludes" column, which describes what the marker covers rather than being copied
- [x] `.claude/` is in `NON_CODE`, so every gated job should report `skipping`