### PR TITLE
Add: support mpirun-launched multi-host L3 workers

### DIFF
--- a/.github/actions/pod-stage/action.yml
+++ b/.github/actions/pod-stage/action.yml
@@ -113,3 +113,28 @@ runs:
           pip install --upgrade pip
           pip install '.[test]'
         REMOTE_STAGE
+
+        # One mpirun command line launches an L3 rank on each machine, so the
+        # interpreter must resolve at a single absolute path on both. The
+        # launcher pinned here sources CANN, enters that machine's copy of
+        # this run's tree (rank-side orchestration imports resolve from the
+        # cwd), and execs that machine's venv python. mpirun/mpi4py are
+        # machine-provisioned; tests skip when they are absent.
+        MPI_PYTHON="/tmp/simpler-pod-mpi-python-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        cat > "$MPI_PYTHON" <<LOCAL_LAUNCHER
+        #!/usr/bin/env bash
+        source '$POD_CANN_ENV'
+        cd '$GITHUB_WORKSPACE'
+        exec '$GITHUB_WORKSPACE/.venv/bin/python' "\$@"
+        LOCAL_LAUNCHER
+        chmod +x "$MPI_PYTHON"
+        pod_ssh "
+          cat > '$MPI_PYTHON' <<'REMOTE_LAUNCHER'
+        #!/usr/bin/env bash
+        source '$POD_REMOTE_CANN_ENV'
+        cd '$REMOTE_WORKDIR'
+        exec '$REMOTE_WORKDIR/.venv/bin/python' \"\$@\"
+        REMOTE_LAUNCHER
+          chmod +x '$MPI_PYTHON'
+        "
+        echo "POD_MPI_PYTHON=$MPI_PYTHON" >> "$GITHUB_ENV"

--- a/.github/actions/pod-teardown/action.yml
+++ b/.github/actions/pod-teardown/action.yml
@@ -17,6 +17,16 @@ runs:
         source "$POD_SSH_HELPER"
 
         pod_ssh "pkill -f 'python -m simpler.remote_l3_worker --host ${REMOTE_DAEMON_HOST}' || true"
+        # A run killed before Worker.close() (runner shutdown, job cancel)
+        # leaves mpirun and its simpler.mpi_l3_session ranks alive holding the
+        # fixed command/health ports, so the next run's rank bind fails. The
+        # runner is single-job, so any survivor on either machine is ours.
+        pkill -f 'simpler[.]mpi_l3_session'
+        pod_ssh "pkill -f 'simpler[.]mpi_l3_session' || true"
+        if [ -n "${POD_MPI_PYTHON:-}" ]; then
+          rm -f "$POD_MPI_PYTHON"
+          pod_ssh "rm -f '$POD_MPI_PYTHON'"
+        fi
         # rm -rf on a tree a surviving chip child is still writing fails with
         # ENOTEMPTY, so retry once after giving it a moment.
         pod_ssh "rm -rf '$REMOTE_WORKDIR' 2>/dev/null || { sleep 5; rm -rf '$REMOTE_WORKDIR'; }"

--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -70,6 +70,15 @@ domain ranks. A remote node reads `comm_profile` and `global_device_ranks`
 from `RemoteWorkerSpec`; a local L3 reads the same fields from its `Worker`
 configuration. All participating nodes must use the same profile.
 
+An MPI-launched group registered with `add_mpirun_worker_group` uses the same
+member contract. Rank 0 writes the group manifest before launch, every MPI rank
+must publish READY before the L4 parent exposes the returned worker ids, and
+the `MpiL3GroupSpec.hosts` order defines node ranks. Global CommDomain members
+must include the complete returned group; their order still defines dense
+domain ranks. A full MPI group exchanges descriptors rank-side over an MPI
+collective, so the L4 import fanout is skipped; a partial group falls back to
+the L4 descriptor broker above.
+
 Global CommDomain capability follows the backend that the node actually
 loads: a platform ending in `sim` supports the `sim` profile, and a real
 `a2a3` platform supports `a3-fabric-v1`. Real A5 and any other

--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -33,10 +33,11 @@ workers/
   l3/                       # Multi-chip examples (host-level DAG)
     multi_chip_dispatch/    # Worker(level=3) + orchestration + SubWorker
     child_memory/           # orch.malloc + child_memory=True, weight reuse across tasks
-  l4/                       # Multi-machine examples (one L3 here, one over TCP)
+  l4/                       # Multi-machine examples (one L3 here, one over TCP or mpirun)
     vector_add_mixed_l3/    # Worker(level=4) + add_remote_worker, golden checked on both sides
     global_tload_mixed_l3/  # Global CommDomain build + cross-machine peer TLOAD on both ranks
     compute_then_tload_mixed_l3/  # compute round on both L2s, then peer TLOAD through the same domain
+    global_tload_mpirun_l3/ # one mpirun launches an L3 rank per machine; MPI descriptor exchange
 ```
 
 Why no `tensormap_and_ringbuffer/` layer? Because every example here hard-codes
@@ -59,6 +60,12 @@ Two processes, then, not one: a **daemon** on the peer and a **parent** here.
 The daemon is `python -m simpler.remote_l3_worker --host H --port P` — generic,
 identical for every example, nothing to write. All an example ships is the
 parent side.
+
+`global_tload_mpirun_l3` is the one exception to the daemon shape: there the
+parent owns a single `mpirun` that launches an L3 rank on each machine
+(`add_mpirun_worker_group`), so no daemon runs on the peer — see that
+example's README for its extra prerequisites (`mpirun` + `mpi4py` on both
+machines).
 
 ### What a new L4 example needs
 

--- a/examples/workers/l4/global_tload_mpirun_l3/README.md
+++ b/examples/workers/l4/global_tload_mpirun_l3/README.md
@@ -1,0 +1,77 @@
+# Global TLOAD mpirun L3 example
+
+This example runs the same Global CommDomain peer-`TLOAD` workload as
+[`global_tload_mixed_l3`](../global_tload_mixed_l3/), but brings the two L3
+workers up through a single parent-owned `mpirun` instead of a TCP daemon:
+
+```text
+L4 parent on machine A ─ mpirun -np 2 ─┬─ L3 rank 0 on machine A → its NPUs
+                                       └─ L3 rank 1 on machine B → its NPUs
+```
+
+The kernels, the chip callable, and the rank-side orchestration are imported
+from `global_tload_mixed_l3` — this example ships no kernels of its own. What
+it exercises that the sibling cannot:
+
+- `add_mpirun_worker_group` / `MpiL3GroupSpec`: rank 0 must land on the parent
+  machine (only it can read the parent-written group manifest, which it then
+  broadcasts over MPI), and every rank publishes READY back over TCP
+  (`ready_host`) — file-based READY cannot cross machines.
+- The full-group MPI descriptor exchange: the Global CommDomain members cover
+  every device of both ranks, so descriptors are exchanged rank-side over an
+  MPI collective and the L4 import fanout is skipped.
+- One TLOAD task per NPU device on each machine (the sibling drives one device
+  per side), so the domain spans four windows on the pod pair.
+
+## Prerequisites beyond the sibling example
+
+- `mpirun` and `mpi4py` on **both** machines, built against the **same** MPI
+  implementation (MPICH's Hydra and Open MPI both work; a `mpi4py` linked
+  against a different MPI than the `mpirun` that launches it degrades every
+  rank into an isolated single-process world).
+- `mpirun` executes one identical command line on both machines, so `--python`
+  must name an interpreter path valid on BOTH. Point it at a per-machine
+  launcher script installed at one shared absolute path; each machine's copy
+  sources the CANN environment, enters that machine's copy of this source
+  tree (the rank imports this package's orchestration module by name), and
+  execs that machine's `.venv` python:
+
+```bash
+cat > /tmp/simpler-mpi-python <<'EOF'
+#!/usr/bin/env bash
+source /usr/local/Ascend/cann/set_env.sh
+cd /path/to/this/machines/simpler
+exec /path/to/this/machines/simpler/.venv/bin/python "$@"
+EOF
+chmod +x /tmp/simpler-mpi-python
+```
+
+## Run on the L4 parent
+
+`192.0.2.10` / `192.0.2.20` are documentation placeholders. Hosts must be
+numeric IPs; the local host is where rank 0 and the READY listener bind:
+
+```bash
+source .venv/bin/activate
+python examples/workers/l4/global_tload_mpirun_l3/main.py \
+  --local-host 192.0.2.10 --remote-host 192.0.2.20 \
+  --python /tmp/simpler-mpi-python \
+  --local-devices 0,1 --remote-devices 0,1
+```
+
+Expected output ends with:
+
+```text
+[global-tload-mpirun-l3] domain_rank=3 node=1 device_index=1 max_diff=0.000e+00
+global_tload_mpirun_l3 passed
+```
+
+Any `max_diff` above the tolerance exits non-zero.
+
+## Running it in CI
+
+The pod job's `pod-stage` action writes the per-machine launcher on both
+machines at one shared path and exports it as `POD_MPI_PYTHON`; the
+`test_global_tload_mpirun_l3.py` wrapper reads it together with
+`POD_LOCAL_IP` and the standard pod fixtures, and skips when `mpirun`,
+`mpi4py`, or either variable is absent.

--- a/examples/workers/l4/global_tload_mpirun_l3/main.py
+++ b/examples/workers/l4/global_tload_mpirun_l3/main.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run a two-machine mpirun-launched L3 group through a Global CommDomain peer TLOAD.
+
+One L4 parent (this process) registers a two-rank ``MpiL3GroupSpec`` — rank 0
+on this machine, rank 1 on the peer — and launches both L3 workers through a
+single parent-owned ``mpirun``. Rank 0 must be this machine: only it can read
+the parent-written group manifest, which it then broadcasts over MPI. After
+both ranks publish READY back over TCP (``ready_host`` — file-based READY
+cannot cross machines), the parent attaches them as ordinary remote L3
+endpoints and dispatches one TLOAD task per NPU device on each machine. The
+Global CommDomain (``a3-fabric-v1`` on real A3 devices) spans every device of
+both ranks, so it is built over the MPI collective descriptor-exchange path
+(full-group members; no L4 import fanout), and each device's AIV kernel reads
+every peer window through the fabric and sums it — cross-machine link setup,
+communication, and compute in one pass.
+
+The kernels, the chip callable, and the rank-side orchestration are shared
+with ``examples/workers/l4/global_tload_mixed_l3``; this example differs only
+in how the two L3 ranks come up.
+
+``mpirun`` executes one identical command line on both machines, so
+``--python`` must name an interpreter path that is valid on BOTH: point it at
+a per-machine launcher script installed at one shared absolute path, which
+sources the CANN environment, enters that machine's copy of this source tree
+(the rank imports this package's orchestration module by name), and execs
+that machine's ``.venv`` python. ``mpirun`` (MPICH/Hydra or Open MPI) and
+``mpi4py`` must be installed on both machines; the default ``--host h1,h2``
+placement puts rank 0 on the first host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import struct
+
+from simpler.task_interface import (
+    CallConfig,
+    CommBufferSpec,
+    GlobalCommDomainHandle,
+    TaskArgs,
+)
+from simpler.worker import MpiL3GroupSpec, RemoteCallable, Worker
+
+from examples.workers.l4.global_tload_mixed_l3.main import (
+    COUNT,
+    FLOAT_NBYTES,
+    REMOTE_ORCH_TARGET,
+    WINDOW_SIZE,
+    _add_digest_scalars,
+    _build_tload_callable,
+    _expected_values,
+    _input_values,
+)
+
+NRANKS = 2
+
+
+def _parse_devices(value: str, *, label: str) -> tuple[int, ...]:
+    device_ids = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if not device_ids or any(device_id < 0 for device_id in device_ids):
+        raise ValueError(f"{label} device list must be non-empty non-negative ids")
+    return device_ids
+
+
+def run(  # noqa: PLR0913, PLR0915 -- mirrors the CLI surface; one linear two-run flow like the mixed_l3 sibling
+    *,
+    local_host: str,
+    remote_host: str,
+    python_executable: str,
+    local_devices: str,
+    remote_devices: str,
+    platform: str = "a2a3",
+    runtime: str = "tensormap_and_ringbuffer",
+    comm_profile: str = "a3-fabric-v1",
+    command_port_base: int = 21173,
+    health_port_base: int = 22173,
+    session_timeout: float = 120.0,
+    mpirun_path: str = "mpirun",
+) -> int:
+    local_ids = _parse_devices(local_devices, label="local")
+    remote_ids = _parse_devices(remote_devices, label="remote")
+    device_ids_by_rank = (local_ids, remote_ids)
+    # One domain member per NPU device on either machine, in (rank, device)
+    # order; the member count is what the TLOAD kernel sums across.
+    member_count = len(local_ids) + len(remote_ids)
+    global_ranks_by_rank = (
+        tuple(range(len(local_ids))),
+        tuple(range(len(local_ids), member_count)),
+    )
+
+    worker: Worker | None = None
+    domain_handle: GlobalCommDomainHandle | None = None
+    parent_keepalive: list[TaskArgs] = []
+    try:
+        chip_callable = _build_tload_callable(platform, runtime)
+        worker = Worker(level=4, num_sub_workers=0, remote_session_timeout_s=session_timeout)
+        node_ids = worker.add_mpirun_worker_group(
+            MpiL3GroupSpec(
+                hosts=(local_host, remote_host),
+                platform=platform,
+                runtime=runtime,
+                command_port_base=int(command_port_base),
+                health_port_base=int(health_port_base),
+                device_ids_by_rank=device_ids_by_rank,
+                comm_profile=comm_profile,
+                global_device_ranks_by_rank=global_ranks_by_rank,
+                ready_host=local_host,
+                mpirun_path=mpirun_path,
+                # Hydra and Open MPI both propagate the parent's cwd to every
+                # rank and fail the launch when it is missing on a remote
+                # machine. Any directory that exists everywhere does here: the
+                # --python launcher enters the real tree itself.
+                mpirun_args=("-wdir", "/tmp"),
+                python_executable=python_executable,
+            )
+        )
+        chip_handle = worker.register(chip_callable)
+        rank_handle = worker.register(RemoteCallable(REMOTE_ORCH_TARGET), workers=list(node_ids))
+        worker.init()
+
+        members = tuple(
+            (node_id, local_index)
+            for node_id, device_ids in zip(node_ids, device_ids_by_rank)
+            for local_index in range(len(device_ids))
+        )
+
+        def build_and_run(orch, _args, cfg):
+            nonlocal domain_handle
+            domain = orch.allocate_global_domain(
+                name="global-tload-mpirun-l3",
+                members=members,
+                window_size=WINDOW_SIZE,
+                buffers=(
+                    CommBufferSpec("input", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                    CommBufferSpec("result", "float32", COUNT, COUNT * FLOAT_NBYTES),
+                ),
+                retain_after_run=True,
+            )
+            for domain_rank in range(member_count):
+                orch.copy_to_global_domain(
+                    domain,
+                    domain_rank,
+                    struct.pack(f"<{COUNT}f", *_input_values(domain_rank)),
+                    buffer="input",
+                )
+            for node_id, local_index in members:
+                task_args = TaskArgs()
+                task_args.add_scalar(domain.domain_id)
+                task_args.add_scalar(local_index)
+                _add_digest_scalars(task_args, chip_handle.digest)
+                parent_keepalive.append(task_args)
+                orch.submit_next_level(rank_handle, task_args, cfg, worker=node_id)
+            domain_handle = domain
+
+        worker.run(build_and_run, args=None, config=CallConfig())
+        if domain_handle is None:
+            raise RuntimeError("the Global CommDomain was not allocated")
+        domain = domain_handle
+        observed: list[tuple[float, ...]] = []
+
+        def read_and_release(orch, _args, _cfg):
+            try:
+                for domain_rank in range(member_count):
+                    raw = orch.copy_from_global_domain(domain, domain_rank, COUNT * FLOAT_NBYTES, buffer="result")
+                    observed.append(tuple(float(value) for value in struct.unpack(f"<{COUNT}f", raw)))
+            finally:
+                domain.release()
+
+        worker.run(read_and_release, args=None, config=CallConfig())
+
+        expected = _expected_values(member_count)
+        failed_ranks: list[int] = []
+        for domain_rank, result in enumerate(observed):
+            max_diff = max(abs(actual - wanted) for actual, wanted in zip(result, expected))
+            node_id, local_index = members[domain_rank]
+            print(
+                f"[global-tload-mpirun-l3] domain_rank={domain_rank} "
+                f"node={node_id} device_index={local_index} max_diff={max_diff:.3e}"
+            )
+            if max_diff > 1e-3:
+                failed_ranks.append(domain_rank)
+        if failed_ranks:
+            raise AssertionError(f"peer TLOAD golden mismatch on domain rank(s) {failed_ranks}")
+
+        print("global_tload_mpirun_l3 passed")
+        return 0
+    finally:
+        parent_keepalive.clear()
+        if domain_handle is not None and not domain_handle.freed:
+            with contextlib.suppress(Exception):
+                domain_handle.release()
+        if worker is not None:
+            worker.close()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--local-host", required=True, help="this machine's numeric IP; rank 0 and READY bind here")
+    parser.add_argument("--remote-host", required=True, help="peer machine's numeric IP; rank 1 runs there")
+    parser.add_argument(
+        "--python",
+        dest="python_executable",
+        required=True,
+        help="interpreter path valid on BOTH machines (per-machine launcher at one shared absolute path)",
+    )
+    parser.add_argument("--local-devices", default="0", help="rank 0's NPU device ids, comma separated")
+    parser.add_argument("--remote-devices", default="0", help="rank 1's NPU device ids, comma separated")
+    parser.add_argument("--platform", default="a2a3")
+    parser.add_argument("--runtime", default="tensormap_and_ringbuffer")
+    parser.add_argument("--comm-profile", default="a3-fabric-v1")
+    parser.add_argument("--command-port-base", type=int, default=21173)
+    parser.add_argument("--health-port-base", type=int, default=22173)
+    parser.add_argument("--session-timeout", type=float, default=120.0)
+    parser.add_argument("--mpirun-path", default="mpirun")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    return run(
+        local_host=args.local_host,
+        remote_host=args.remote_host,
+        python_executable=args.python_executable,
+        local_devices=args.local_devices,
+        remote_devices=args.remote_devices,
+        platform=args.platform,
+        runtime=args.runtime,
+        comm_profile=args.comm_profile,
+        command_port_base=args.command_port_base,
+        health_port_base=args.health_port_base,
+        session_timeout=args.session_timeout,
+        mpirun_path=args.mpirun_path,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workers/l4/global_tload_mpirun_l3/test_global_tload_mpirun_l3.py
+++ b/examples/workers/l4/global_tload_mpirun_l3/test_global_tload_mpirun_l3.py
@@ -1,0 +1,73 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Pod ST for examples/workers/l4/global_tload_mpirun_l3.
+
+Runs the real two-machine mpirun path on the pod pair: one ``mpirun`` from
+the parent machine launches an L3 rank per machine, the parent dispatches a
+TLOAD task per NPU device on each machine, and the full-group
+``a3-fabric-v1`` Global CommDomain built over the MPI descriptor exchange
+carries the cross-machine peer reads.
+
+On top of the standard pod runner environment this test needs ``mpirun`` +
+``mpi4py`` on both machines and ``POD_MPI_PYTHON``: one absolute path, valid
+on BOTH machines, of a per-machine launcher that sources CANN, enters that
+machine's copy of this run's tree, and execs its ``.venv`` python (a single
+``mpirun`` command line launches every rank, so the interpreter path and the
+rank-side ``examples...`` import must resolve on each machine).
+"""
+
+import importlib.util
+import os
+import shutil
+
+import pytest
+
+from simpler_setup import SceneTestLevel, scene_level
+
+from .main import run
+
+
+def _device_spec(device_ids) -> str:
+    return ",".join(str(device_id) for device_id in device_ids)
+
+
+def _require_mpirun_pod_env() -> tuple[str, str, str]:
+    mpirun = shutil.which("mpirun")
+    if mpirun is None:
+        pytest.skip("mpirun is not on PATH")
+    if importlib.util.find_spec("mpi4py") is None:
+        pytest.skip("mpi4py is not installed (required inside the mpirun rank processes)")
+    local_ip = os.environ.get("POD_LOCAL_IP", "")
+    if not local_ip:
+        pytest.skip("POD_LOCAL_IP is required: mpirun rank 0 and the READY listener bind this machine's address")
+    mpi_python = os.environ.get("POD_MPI_PYTHON", "")
+    if not mpi_python:
+        pytest.skip("POD_MPI_PYTHON is required: per-machine rank launcher at one shared absolute path")
+    return mpirun, local_ip, mpi_python
+
+
+@scene_level(SceneTestLevel.POD)
+@pytest.mark.platforms(["a2a3"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.device_count(2)
+@pytest.mark.pod_remote_device_count(2)
+def test_global_tload_mpirun_l3(st_platform, st_device_ids, st_pod_peer, st_pod_remote_device_ids, st_pod_logs):
+    mpirun, local_ip, mpi_python = _require_mpirun_pod_env()
+    remote_host, _daemon_port = st_pod_peer.endpoint.rsplit(":", 1)
+    rc = run(
+        local_host=local_ip,
+        remote_host=remote_host,
+        python_executable=mpi_python,
+        local_devices=_device_spec(st_device_ids),
+        remote_devices=_device_spec(st_pod_remote_device_ids),
+        platform=st_platform,
+        session_timeout=st_pod_peer.session_timeout_s,
+        mpirun_path=mpirun,
+    )
+    assert rc == 0

--- a/python/simpler/mpi_l3_session.py
+++ b/python/simpler/mpi_l3_session.py
@@ -1,0 +1,273 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""MPI-launched Remote L3 session runner.
+
+Each mpirun rank runs one ordinary Remote L3 session. The L4 parent still owns
+the task/control lane over the existing RemoteL3 socket transport; MPI is used
+only when the full mpirun group participates in one Global CommDomain prepare.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import signal
+import socket
+import struct
+import sys
+import threading
+from typing import Any
+
+from .global_comm_domain import (
+    GlobalDomainCommand,
+    GlobalDomainPhase,
+    GlobalDomainReleaseCommand,
+    decode_descriptor_table,
+    encode_descriptor_table,
+    validate_descriptor_table,
+)
+from .remote_l3_session import _format_remote_error, run_session
+from .worker import Worker
+
+
+class MpiGlobalDomainExchange:
+    """Descriptor exchange hook for a full mpirun-launched L3 group."""
+
+    def __init__(self, comm: Any, *, group_worker_ids: tuple[int, ...], timeout_s: float) -> None:
+        self._comm = comm
+        self._rank = int(comm.Get_rank())
+        self._group_worker_ids = tuple(int(worker_id) for worker_id in group_worker_ids)
+        self._group_worker_id_set = set(self._group_worker_ids)
+        self._timeout_s = float(timeout_s)
+        if not (self._timeout_s > 0 and math.isfinite(self._timeout_s)):
+            raise ValueError("MPI Global CommDomain timeout must be a positive finite number")
+
+    def _allgather(self, payload: Any, *, operation: str, on_timeout) -> list[Any]:
+        # mpi4py exposes non-blocking collectives only in the buffer-based
+        # uppercase form, so the pickle-based allgather blocks. A helper
+        # thread carries the blocking call while this thread owns the
+        # timeout; Abort() tears the whole MPI job down, which is also what
+        # unsticks a peer rank wedged inside the collective.
+        result: list[list[Any]] = []
+        failure: list[BaseException] = []
+        done = threading.Event()
+
+        def _gather() -> None:
+            try:
+                result.append(self._comm.allgather(payload))
+            except BaseException as exc:  # noqa: BLE001
+                failure.append(exc)
+            finally:
+                done.set()
+
+        thread = threading.Thread(target=_gather, daemon=True, name=f"mpi-global-domain-{operation}")
+        thread.start()
+        if not done.wait(self._timeout_s):
+            on_timeout()
+            try:
+                self._comm.Abort(1)
+            except BaseException as exc:  # noqa: BLE001
+                raise TimeoutError(f"MPI Global CommDomain {operation} timed out") from exc
+            raise TimeoutError(f"MPI Global CommDomain {operation} timed out")
+        if failure:
+            raise failure[0]
+        return list(result[0])
+
+    def prepare_import(self, command: GlobalDomainCommand, inner_worker: Worker, worker_id: int) -> bytes | None:
+        if command.phase is not GlobalDomainPhase.PREPARE_EXPORT:
+            return None
+        if {int(member.node_worker_id) for member in command.members} != self._group_worker_id_set:
+            return None
+
+        ok = True
+        error_message = ""
+        local_payload = b""
+        release_command = GlobalDomainReleaseCommand(command.domain_id, command.generation)
+
+        def release_local() -> None:
+            inner_worker._release_global_domain_node(  # noqa: SLF001
+                release_command,
+                suppress_errors=True,
+            )
+
+        try:
+            descriptors = inner_worker._prepare_global_domain_node(command, int(worker_id))  # noqa: SLF001
+            local_payload = encode_descriptor_table(descriptors)
+        except BaseException as exc:  # noqa: BLE001
+            release_local()
+            ok = False
+            error_message = _format_remote_error(
+                f"mpi global domain prepare rank={self._rank} worker_id={worker_id}",
+                exc,
+            )
+
+        try:
+            gathered = self._allgather(
+                (self._rank, ok, error_message, local_payload),
+                operation="prepare",
+                on_timeout=release_local,
+            )
+        except BaseException:
+            release_local()
+            raise
+        errors = [(rank, message) for rank, rank_ok, message, _payload in gathered if not rank_ok]
+        if errors:
+            if ok:
+                release_local()
+            rank, message = errors[0]
+            raise RuntimeError(f"MPI Global CommDomain prepare failed on rank {rank}: {message}")
+
+        try:
+            descriptor_by_rank = {}
+            for _rank, _ok, _message, payload in sorted(gathered, key=lambda item: int(item[0])):
+                for descriptor in decode_descriptor_table(bytes(payload)):
+                    if descriptor.domain_rank in descriptor_by_rank:
+                        raise RuntimeError("MPI Global CommDomain exchange returned a duplicate domain rank")
+                    descriptor_by_rank[descriptor.domain_rank] = descriptor
+            descriptors = tuple(descriptor_by_rank[rank] for rank in range(len(command.members)))
+            validate_descriptor_table(descriptors, rank_count=len(command.members), profile=command.profile)
+        except BaseException:
+            release_local()
+            raise
+
+        import_command = GlobalDomainCommand(
+            phase=GlobalDomainPhase.IMPORT,
+            domain_id=command.domain_id,
+            generation=command.generation,
+            name=command.name,
+            profile=command.profile,
+            window_size=command.window_size,
+            members=command.members,
+            buffers=command.buffers,
+            descriptors=descriptors,
+        )
+        import_ok = True
+        import_error = ""
+        try:
+            inner_worker._import_global_domain_node(import_command, int(worker_id))  # noqa: SLF001
+        except BaseException as exc:  # noqa: BLE001
+            release_local()
+            import_ok = False
+            import_error = _format_remote_error(
+                f"mpi global domain import rank={self._rank} worker_id={worker_id}",
+                exc,
+            )
+
+        try:
+            statuses = self._allgather(
+                (self._rank, import_ok, import_error),
+                operation="import",
+                on_timeout=release_local,
+            )
+        except BaseException:
+            release_local()
+            raise
+        import_errors = [(rank, message) for rank, rank_ok, message in statuses if not rank_ok]
+        if import_errors:
+            release_local()
+            rank, message = import_errors[0]
+            raise RuntimeError(f"MPI Global CommDomain import failed on rank {rank}: {message}")
+        return encode_descriptor_table(descriptors)
+
+
+def _write_ready_file(ready_dir: str, rank: int, payload: dict[str, Any]) -> None:
+    os.makedirs(ready_dir, exist_ok=True)
+    final_path = os.path.join(ready_dir, f"rank-{int(rank)}.json")
+    tmp_path = f"{final_path}.tmp.{os.getpid()}"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp_path, final_path)
+
+
+def _send_ready_tcp(host: str, port: int, payload: dict[str, Any]) -> None:
+    data = json.dumps(payload, sort_keys=True).encode("utf-8")
+    with socket.create_connection((host, int(port)), timeout=10.0) as sock:
+        sock.sendall(struct.pack("<I", len(data)) + data)
+
+
+def _raise_keyboard_interrupt(_signum, _frame):
+    raise KeyboardInterrupt
+
+
+def _load_group_manifest_from_rank0(comm: Any, manifest_path: str) -> dict[str, Any]:
+    rank = int(comm.Get_rank())
+    if rank == 0:
+        try:
+            with open(manifest_path, encoding="utf-8") as f:
+                payload = (True, json.load(f))
+        except BaseException as exc:  # noqa: BLE001
+            payload = (False, f"{type(exc).__name__}: {exc}")
+    else:
+        payload = None
+    ok, value = comm.bcast(payload, root=0)
+    if not ok:
+        raise RuntimeError(f"MPI L3 rank0 failed to read group manifest {manifest_path!r}: {value}")
+    if not isinstance(value, dict):
+        raise ValueError("MPI L3 group manifest broadcast returned a non-object payload")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--group-manifest", required=True)
+    ns = parser.parse_args(argv)
+
+    signal.signal(signal.SIGTERM, _raise_keyboard_interrupt)
+    try:
+        from mpi4py import MPI  # noqa: PLC0415
+    except ImportError as exc:
+        raise RuntimeError("simpler.mpi_l3_session requires mpi4py inside the mpirun Python environment") from exc
+
+    comm = MPI.COMM_WORLD
+    rank = int(comm.Get_rank())
+    world_size = int(comm.Get_size())
+
+    group_manifest = _load_group_manifest_from_rank0(comm, ns.group_manifest)
+    rank_manifests = group_manifest.get("rank_manifests")
+    if not isinstance(rank_manifests, list):
+        raise ValueError("MPI L3 group manifest requires a rank_manifests list")
+    if len(rank_manifests) != world_size:
+        raise ValueError("MPI L3 group manifest world size does not match MPI_COMM_WORLD")
+    manifest = dict(rank_manifests[rank])
+    group_worker_ids = tuple(int(x) for x in group_manifest.get("worker_ids", ()))
+    if len(group_worker_ids) != world_size:
+        raise ValueError("MPI L3 group manifest worker_ids must match MPI_COMM_WORLD size")
+
+    ready_dir = str(group_manifest["ready_dir"])
+    ready_host = str(group_manifest.get("ready_host") or "")
+    ready_port = int(group_manifest.get("ready_port") or 0)
+    ready_token = str(group_manifest.get("ready_token") or "")
+
+    def ready_writer(payload: dict[str, Any]) -> None:
+        payload = dict(payload)
+        payload["mpi_rank"] = rank
+        if ready_host:
+            payload["ready_token"] = ready_token
+            _send_ready_tcp(ready_host, ready_port, payload)
+        else:
+            _write_ready_file(ready_dir, rank, payload)
+
+    exchange = MpiGlobalDomainExchange(
+        comm,
+        group_worker_ids=group_worker_ids,
+        timeout_s=float(manifest["session_timeout_s"]),
+    )
+    return run_session(
+        manifest,
+        None,
+        ready_writer=ready_writer,
+        global_domain_prepare_import=exchange.prepare_import,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/simpler/remote_l3_session.py
+++ b/python/simpler/remote_l3_session.py
@@ -54,6 +54,7 @@ from .callable_identity import (
 )
 from .global_comm_domain import (
     GLOBAL_DOMAIN_PROFILE_SIM,
+    GlobalDomainCommand,
     GlobalDomainPhase,
     GlobalDomainReleaseCommand,
     decode_comm_init,
@@ -217,10 +218,10 @@ def _load_import_target(target: str) -> Callable[..., Any]:
     return obj
 
 
-def _bind_listener(host: str) -> socket.socket:
+def _bind_listener(host: str, port: int = 0) -> socket.socket:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((host, 0))
+    sock.bind((host, int(port)))
     sock.listen(1)
     return sock
 
@@ -672,6 +673,7 @@ def _run_command_loop(  # noqa: PLR0912, PLR0915
     inner_worker: Worker,
     manifest_inner_handles: dict[tuple[CallableKind, bytes], CallableHandle] | None = None,
     manifest_dispatch_registry: dict[bytes, Callable[..., Any]] | None = None,
+    global_domain_prepare_import: Callable[[GlobalDomainCommand, Worker, int], bytes | None] | None = None,
 ) -> None:
     session_id = int(manifest["session_id"])
     worker_id = int(manifest["worker_id"])
@@ -1076,14 +1078,21 @@ def _run_command_loop(  # noqa: PLR0912, PLR0915
                         if command.phase is GlobalDomainPhase.PREPARE_EXPORT:
                             if command.descriptors:
                                 raise ValueError("PREPARE_EXPORT must not carry descriptors")
-                            descriptors = inner_worker._prepare_global_domain_node(command, worker_id)  # noqa: SLF001
+                            result = (
+                                global_domain_prepare_import(command, inner_worker, worker_id)
+                                if global_domain_prepare_import is not None
+                                else None
+                            )
+                            if result is None:
+                                descriptors = inner_worker._prepare_global_domain_node(command, worker_id)  # noqa: SLF001
+                                result = encode_descriptor_table(descriptors)
                             _control_result_reply(
                                 conn,
                                 manifest,
                                 header.sequence,
                                 control.control_name,
                                 control.control_version,
-                                encode_descriptor_table(descriptors),
+                                result,
                             )
                         elif command.phase is GlobalDomainPhase.IMPORT:
                             inner_worker._import_global_domain_node(command, worker_id)  # noqa: SLF001
@@ -1225,7 +1234,13 @@ def _run_command_loop(  # noqa: PLR0912, PLR0915
             _INNER_HANDLES.clear()
 
 
-def run_session(manifest: dict[str, Any], ready_fd: int) -> int:
+def run_session(
+    manifest: dict[str, Any],
+    ready_fd: int | None,
+    *,
+    ready_writer: Callable[[dict[str, Any]], None] | None = None,
+    global_domain_prepare_import: Callable[[GlobalDomainCommand, Worker, int], bytes | None] | None = None,
+) -> int:
     inner_worker = Worker(
         level=3,
         platform=str(manifest["platform"]),
@@ -1238,6 +1253,16 @@ def run_session(manifest: dict[str, Any], ready_fd: int) -> int:
     health_sock: socket.socket | None = None
     stop_health = threading.Event()
     health_thread: threading.Thread | None = None
+    ready_sent = False
+
+    def _publish_ready(payload: dict[str, Any]) -> None:
+        nonlocal ready_sent
+        if ready_writer is not None:
+            ready_writer(payload)
+        elif ready_fd is not None:
+            _send_ready(ready_fd, payload)
+        ready_sent = True
+
     try:
         # Validate the runtime command timeout wire value up front (rejects a
         # malformed session_timeout_s); the command lane itself idle-waits blocking.
@@ -1263,8 +1288,10 @@ def run_session(manifest: dict[str, Any], ready_fd: int) -> int:
         inner_worker.init(_startup_deadline=startup_deadline)
 
         listen_host = str(manifest.get("listen_host", "127.0.0.1"))
-        command_sock = _bind_listener(listen_host)
-        health_sock = _bind_listener(listen_host)
+        command_port = int(manifest.get("command_port", 0) or 0)
+        health_port = int(manifest.get("health_port", 0) or 0)
+        command_sock = _bind_listener(listen_host) if command_port == 0 else _bind_listener(listen_host, command_port)
+        health_sock = _bind_listener(listen_host) if health_port == 0 else _bind_listener(listen_host, health_port)
         health_thread = threading.Thread(
             target=_health_loop,
             args=(health_sock, stop_health, int(manifest["session_id"]), int(manifest["worker_id"])),
@@ -1274,8 +1301,7 @@ def run_session(manifest: dict[str, Any], ready_fd: int) -> int:
 
         command_port = int(command_sock.getsockname()[1])
         health_port = int(health_sock.getsockname()[1])
-        _send_ready(
-            ready_fd,
+        _publish_ready(
             {
                 "ok": True,
                 "command_host": str(manifest.get("connect_host", listen_host)),
@@ -1302,13 +1328,21 @@ def run_session(manifest: dict[str, Any], ready_fd: int) -> int:
         # parent closes the command socket (read_frame sees EOF).
         conn.settimeout(None)
         with conn:
-            _run_command_loop(conn, manifest, inner_worker, manifest_inner_handles, manifest_dispatch_registry)
+            _run_command_loop(
+                conn,
+                manifest,
+                inner_worker,
+                manifest_inner_handles,
+                manifest_dispatch_registry,
+                global_domain_prepare_import,
+            )
         return 0
     except BaseException as exc:  # noqa: BLE001
-        try:
-            _send_ready(ready_fd, {"ok": False, "error": _format_remote_error("remote session startup", exc)})
-        except OSError:
-            pass
+        if not ready_sent:
+            try:
+                _publish_ready({"ok": False, "error": _format_remote_error("remote session startup", exc)})
+            except OSError:
+                pass
         return 1
     finally:
         stop_health.set()

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -68,10 +68,13 @@ import json
 import math
 import os
 import re
+import shutil
 import signal
 import socket
 import struct
+import subprocess
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -161,6 +164,7 @@ from .global_comm_domain import (
     GLOBAL_DOMAIN_MAX_COPY_BYTES,
     GLOBAL_DOMAIN_MAX_RANKS,
     GLOBAL_DOMAIN_MAX_STRING_BYTES,
+    GLOBAL_DOMAIN_PROFILE_A3_FABRIC,
     GLOBAL_DOMAIN_PROFILE_IDS,
     GLOBAL_DOMAIN_VERSION,
     LOCAL_COPY_REPLY,
@@ -617,6 +621,31 @@ class RemoteCallable:
         return self.target.split(":", 1)[1]
 
 
+def _validate_global_comm_capability(label: str, platform: str, comm_profile: str) -> None:
+    """Reject a profile the platform's backend cannot implement.
+
+    ``a3-fabric-v1`` maps peer windows through ``aclrtMemFabricHandle``, which
+    exists only on real A3 silicon. Every spec that names a comm profile states
+    the rule from here, so a new L3 launch path cannot admit a combination the
+    others reject.
+    """
+    if comm_profile not in GLOBAL_DOMAIN_PROFILE_IDS:
+        raise ValueError(f"{label}.comm_profile {comm_profile!r} is not supported")
+    if comm_profile == GLOBAL_DOMAIN_PROFILE_A3_FABRIC:
+        if not platform.startswith("a2a3"):
+            raise ValueError(f"{label}.comm_profile {GLOBAL_DOMAIN_PROFILE_A3_FABRIC!r} requires an a2a3 platform")
+        if platform.endswith("sim"):
+            raise ValueError(f"{label}.comm_profile {GLOBAL_DOMAIN_PROFILE_A3_FABRIC!r} requires real A3 devices")
+
+
+def _validate_global_device_ranks(label: str, global_device_ranks: tuple[int, ...], device_count: int) -> None:
+    """One rank per local device, unique and non-negative."""
+    if global_device_ranks and len(global_device_ranks) != device_count:
+        raise ValueError(f"{label} must match device_ids length")
+    if any(rank < 0 for rank in global_device_ranks) or len(set(global_device_ranks)) != len(global_device_ranks):
+        raise ValueError(f"{label} must be unique and non-negative")
+
+
 @dataclass(frozen=True)
 class RemoteWorkerSpec:
     """Describes a remote L3 worker to attach via ``Worker.add_remote_worker``.
@@ -666,18 +695,156 @@ class RemoteWorkerSpec:
             raise ValueError(
                 f"RemoteWorkerSpec.transport must be {HOST_TCP_TRANSPORT_PROFILE!r} for the TCP daemon control plane"
             )
-        if self.comm_profile not in GLOBAL_DOMAIN_PROFILE_IDS:
-            raise ValueError(f"RemoteWorkerSpec.comm_profile {self.comm_profile!r} is not supported")
-        if self.comm_profile == "a3-fabric-v1" and not self.platform.startswith("a2a3"):
-            raise ValueError("RemoteWorkerSpec.comm_profile 'a3-fabric-v1' requires an a2a3 platform")
-        if self.comm_profile == "a3-fabric-v1" and self.platform.endswith("sim"):
-            raise ValueError("RemoteWorkerSpec.comm_profile 'a3-fabric-v1' requires real A3 devices")
-        if self.global_device_ranks and len(self.global_device_ranks) != len(self.device_ids):
-            raise ValueError("RemoteWorkerSpec.global_device_ranks must match device_ids length")
-        if any(rank < 0 for rank in self.global_device_ranks) or len(set(self.global_device_ranks)) != len(
-            self.global_device_ranks
-        ):
-            raise ValueError("RemoteWorkerSpec.global_device_ranks must be unique and non-negative")
+        _validate_global_comm_capability("RemoteWorkerSpec", self.platform, self.comm_profile)
+        _validate_global_device_ranks(
+            "RemoteWorkerSpec.global_device_ranks", self.global_device_ranks, len(self.device_ids)
+        )
+
+
+@dataclass(frozen=True)
+class MpiL3GroupSpec:
+    """Describes a group of L3 workers launched by one parent-owned ``mpirun``."""
+
+    hosts: tuple[str, ...]
+    platform: str
+    command_port_base: int
+    health_port_base: int
+    device_ids_by_rank: tuple[tuple[int, ...], ...]
+    runtime: str = "tensormap_and_ringbuffer"
+    num_sub_workers_by_rank: tuple[int, ...] = ()
+    transport: str = HOST_TCP_TRANSPORT_PROFILE
+    comm_profile: str = "sim"
+    global_device_ranks_by_rank: tuple[tuple[int, ...], ...] = ()
+    session_listen_hosts: tuple[str, ...] = ()
+    connect_hosts: tuple[str, ...] = ()
+    allow_wildcard_session_bind: bool = False
+    ready_host: str = ""
+    ready_port: int = 0
+    mpirun_path: str = "mpirun"
+    mpirun_args: tuple[str, ...] = ()
+    python_executable: str = field(default_factory=lambda: sys.executable)
+
+    def __post_init__(self) -> None:  # noqa: PLR0912 -- one place validates the public mpirun rank contract
+        hosts = tuple(str(host) for host in self.hosts)
+        if not hosts:
+            raise ValueError("MpiL3GroupSpec.hosts must be non-empty")
+        if not self.platform:
+            raise ValueError("MpiL3GroupSpec.platform must be non-empty")
+        device_ids_by_rank = tuple(tuple(int(device_id) for device_id in rank) for rank in self.device_ids_by_rank)
+        if len(device_ids_by_rank) != len(hosts):
+            raise ValueError("MpiL3GroupSpec.device_ids_by_rank must match hosts length")
+        if any(not rank for rank in device_ids_by_rank):
+            raise ValueError("MpiL3GroupSpec.device_ids_by_rank entries must be non-empty")
+        num_sub_workers_by_rank = (
+            tuple(0 for _ in hosts)
+            if not self.num_sub_workers_by_rank
+            else tuple(int(count) for count in self.num_sub_workers_by_rank)
+        )
+        if len(num_sub_workers_by_rank) != len(hosts):
+            raise ValueError("MpiL3GroupSpec.num_sub_workers_by_rank must match hosts length")
+        if any(count < 0 for count in num_sub_workers_by_rank):
+            raise ValueError("MpiL3GroupSpec.num_sub_workers_by_rank entries must be non-negative")
+        global_device_ranks_by_rank = (
+            tuple(() for _ in hosts)
+            if not self.global_device_ranks_by_rank
+            else tuple(tuple(int(rank) for rank in ranks) for ranks in self.global_device_ranks_by_rank)
+        )
+        if len(global_device_ranks_by_rank) != len(hosts):
+            raise ValueError("MpiL3GroupSpec.global_device_ranks_by_rank must match hosts length")
+        rank_pairs = zip(global_device_ranks_by_rank, device_ids_by_rank)
+        for rank_index, rank_pair in enumerate(rank_pairs):
+            global_ranks, device_ids = rank_pair
+            _validate_global_device_ranks(
+                f"MpiL3GroupSpec.global_device_ranks_by_rank[{rank_index}]", global_ranks, len(device_ids)
+            )
+        # A global device rank names one device in the whole cluster, so the
+        # group's ranks must be disjoint across mpirun ranks as well as within
+        # one. validate_member_table enforces the same rule on the members a
+        # domain is built from; stating it here names the offending spec field
+        # instead of surfacing as an opaque allocation failure.
+        flat_global_ranks = [rank for ranks in global_device_ranks_by_rank for rank in ranks]
+        if len(set(flat_global_ranks)) != len(flat_global_ranks):
+            raise ValueError("MpiL3GroupSpec.global_device_ranks_by_rank must be unique across the whole group")
+        session_listen_hosts = (
+            hosts if not self.session_listen_hosts else tuple(str(host) for host in self.session_listen_hosts)
+        )
+        connect_hosts = hosts if not self.connect_hosts else tuple(str(host) for host in self.connect_hosts)
+        if len(session_listen_hosts) != len(hosts):
+            raise ValueError("MpiL3GroupSpec.session_listen_hosts must match hosts length")
+        if len(connect_hosts) != len(hosts):
+            raise ValueError("MpiL3GroupSpec.connect_hosts must match hosts length")
+        if any(not host for host in session_listen_hosts) or any(not host for host in connect_hosts):
+            raise ValueError("MpiL3GroupSpec host fields must be non-empty")
+        command_port_base = int(self.command_port_base)
+        health_port_base = int(self.health_port_base)
+        last_command_port = command_port_base + len(hosts) - 1
+        last_health_port = health_port_base + len(hosts) - 1
+        if command_port_base <= 0 or health_port_base <= 0 or last_command_port > 65535 or last_health_port > 65535:
+            raise ValueError("MpiL3GroupSpec command/health port ranges must be within 1..65535")
+        ready_host = str(self.ready_host)
+        ready_port = int(self.ready_port)
+        if ready_port < 0 or ready_port > 65535:
+            raise ValueError("MpiL3GroupSpec.ready_port must be within 0..65535")
+        if self.transport != HOST_TCP_TRANSPORT_PROFILE:
+            raise ValueError(
+                f"MpiL3GroupSpec.transport must be {HOST_TCP_TRANSPORT_PROFILE!r} for the TCP control plane"
+            )
+        _validate_global_comm_capability("MpiL3GroupSpec", self.platform, self.comm_profile)
+        if not self.mpirun_path:
+            raise ValueError("MpiL3GroupSpec.mpirun_path must be non-empty")
+        if not self.python_executable:
+            raise ValueError("MpiL3GroupSpec.python_executable must be non-empty")
+        object.__setattr__(self, "hosts", hosts)
+        object.__setattr__(self, "platform", str(self.platform))
+        object.__setattr__(self, "runtime", str(self.runtime))
+        object.__setattr__(self, "transport", str(self.transport))
+        object.__setattr__(self, "comm_profile", str(self.comm_profile))
+        object.__setattr__(self, "device_ids_by_rank", device_ids_by_rank)
+        object.__setattr__(self, "num_sub_workers_by_rank", num_sub_workers_by_rank)
+        object.__setattr__(self, "global_device_ranks_by_rank", global_device_ranks_by_rank)
+        object.__setattr__(self, "session_listen_hosts", session_listen_hosts)
+        object.__setattr__(self, "connect_hosts", connect_hosts)
+        object.__setattr__(self, "command_port_base", command_port_base)
+        object.__setattr__(self, "health_port_base", health_port_base)
+        object.__setattr__(self, "allow_wildcard_session_bind", bool(self.allow_wildcard_session_bind))
+        object.__setattr__(self, "ready_host", ready_host)
+        object.__setattr__(self, "ready_port", ready_port)
+        object.__setattr__(self, "mpirun_path", str(self.mpirun_path))
+        object.__setattr__(self, "mpirun_args", tuple(str(arg) for arg in self.mpirun_args))
+        object.__setattr__(self, "python_executable", str(self.python_executable))
+
+
+@dataclass(frozen=True)
+class _RemoteSession:
+    worker_id: int
+    session_id: int
+    command_host: str
+    command_port: int
+    health_host: str
+    health_port: int
+    pid: int
+
+
+@dataclass(frozen=True)
+class _MpiL3RankRuntime:
+    group_id: str
+    rank: int
+    worker_id: int
+    spec: RemoteWorkerSpec
+    command_host: str
+    command_port: int
+    health_host: str
+    health_port: int
+
+
+@dataclass
+class _MpiL3GroupRuntime:
+    group_id: str
+    spec: MpiL3GroupSpec
+    ranks: tuple[_MpiL3RankRuntime, ...]
+    process: subprocess.Popen[Any] | None = None
+    manifest_path: str | None = None
+    ready_dir: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1544,6 +1711,8 @@ def _chip_descriptor_context(worker: Worker) -> tuple[str, str]:
             contexts.append(child_context)
     for spec in getattr(worker, "_remote_worker_specs", []):
         contexts.append((str(spec.platform), str(spec.runtime)))
+    for rank in getattr(worker, "_mpi_rank_by_worker_id", {}).values():
+        contexts.append((str(rank.spec.platform), str(rank.spec.runtime)))
     if not contexts:
         return "", ""
     first = contexts[0]
@@ -4361,6 +4530,9 @@ class Worker:
         self._remote_worker_specs: list[RemoteWorkerSpec] = []
         self._remote_worker_ids: list[int] = []
         self._remote_sessions: list[_RemoteSession] = []
+        self._mpi_l3_groups: list[_MpiL3GroupRuntime] = []
+        self._mpi_worker_ids: list[int] = []
+        self._mpi_rank_by_worker_id: dict[int, _MpiL3RankRuntime] = {}
         self._next_level_worker_id_count: int = 0
         # Fallback ownership for private helpers used outside Worker.submit.
         # Normal orchestration-owned refs live in RunHandle._resources.
@@ -4525,6 +4697,78 @@ class Worker:
             self._remote_worker_specs.append(spec)
             self._remote_worker_ids.append(worker_id)
             return worker_id
+
+    def add_mpirun_worker_group(self, spec: MpiL3GroupSpec) -> tuple[int, ...]:
+        """Register L3 workers that will be launched by one parent-owned ``mpirun``.
+
+        The returned ids are ordinary NEXT_LEVEL worker ids for dispatch and
+        Global CommDomain membership. They must be used as a complete set for
+        the v1 MPI descriptor-exchange path; partial groups fall back to the
+        existing L4 descriptor broker.
+        """
+        with self._hierarchical_start_cv:
+            if self._lifecycle is not _Lifecycle.NEW:
+                raise RuntimeError("Worker.add_mpirun_worker_group after init")
+            if self.level < 4:
+                raise TypeError("Worker.add_mpirun_worker_group: MPI L3 groups require a level >= 4 parent")
+            if not isinstance(spec, MpiL3GroupSpec):
+                raise TypeError("Worker.add_mpirun_worker_group expects a MpiL3GroupSpec")
+            for host in spec.connect_hosts:
+                self._validate_numeric_endpoint_host(host)
+            if spec.ready_host:
+                self._validate_numeric_endpoint_host(spec.ready_host)
+            seen_listeners: set[tuple[str, int]] = set()
+            for rank, listen_host in enumerate(spec.session_listen_hosts):
+                if self._is_wildcard_session_host(listen_host):
+                    if not spec.allow_wildcard_session_bind:
+                        raise ValueError(
+                            "MpiL3GroupSpec wildcard session bind requires allow_wildcard_session_bind=True"
+                        )
+                else:
+                    self._validate_numeric_endpoint_host(listen_host)
+                for port in (spec.command_port_base + rank, spec.health_port_base + rank):
+                    key = (listen_host, int(port))
+                    if key in seen_listeners:
+                        raise ValueError("MpiL3GroupSpec command/health ports overlap on the same listen host")
+                    seen_listeners.add(key)
+
+            group_id = uuid.uuid4().hex
+            ranks: list[_MpiL3RankRuntime] = []
+            for rank, connect_host in enumerate(spec.connect_hosts):
+                worker_id = self._allocate_next_level_worker_id()
+                command_port = spec.command_port_base + rank
+                health_port = spec.health_port_base + rank
+                rank_spec = RemoteWorkerSpec(
+                    endpoint=f"{connect_host}:{command_port}",
+                    platform=spec.platform,
+                    runtime=spec.runtime,
+                    device_ids=spec.device_ids_by_rank[rank],
+                    num_sub_workers=spec.num_sub_workers_by_rank[rank],
+                    transport=spec.transport,
+                    comm_profile=spec.comm_profile,
+                    global_device_ranks=spec.global_device_ranks_by_rank[rank],
+                    session_listen_host=spec.session_listen_hosts[rank],
+                    allow_wildcard_session_bind=spec.allow_wildcard_session_bind,
+                )
+                runtime = _MpiL3RankRuntime(
+                    group_id=group_id,
+                    rank=rank,
+                    worker_id=worker_id,
+                    spec=rank_spec,
+                    command_host=connect_host,
+                    command_port=command_port,
+                    health_host=connect_host,
+                    health_port=health_port,
+                )
+                ranks.append(runtime)
+                self._mpi_worker_ids.append(worker_id)
+                self._mpi_rank_by_worker_id[worker_id] = runtime
+            group = _MpiL3GroupRuntime(group_id=group_id, spec=spec, ranks=tuple(ranks))
+            self._mpi_l3_groups.append(group)
+            return tuple(rank.worker_id for rank in ranks)
+
+    def _remote_like_worker_ids(self) -> set[int]:
+        return set(self._remote_worker_ids) | set(self._mpi_worker_ids)
 
     @staticmethod
     def _parse_remote_endpoint(endpoint: str) -> tuple[str, int]:
@@ -4717,14 +4961,8 @@ class Worker:
         comm_profile: str,
         global_device_ranks: tuple[int, ...],
     ) -> None:
-        if comm_profile not in GLOBAL_DOMAIN_PROFILE_IDS:
-            raise ValueError(f"{label} comm_profile {comm_profile!r} is not supported")
-        if comm_profile == "a3-fabric-v1" and (not platform.startswith("a2a3") or platform.endswith("sim")):
-            raise ValueError(f"{label} comm_profile 'a3-fabric-v1' requires real A3 devices")
-        if global_device_ranks and len(global_device_ranks) != len(device_ids):
-            raise ValueError(f"{label} global_device_ranks must match device_ids length")
-        if any(rank < 0 for rank in global_device_ranks) or len(set(global_device_ranks)) != len(global_device_ranks):
-            raise ValueError(f"{label} global_device_ranks must be unique and non-negative")
+        _validate_global_comm_capability(label, platform, comm_profile)
+        _validate_global_device_ranks(f"{label}.global_device_ranks", global_device_ranks, len(device_ids))
 
     def _resolved_global_nodes(self) -> dict[int, _GlobalNodeRuntime]:
         configs: list[tuple[int, tuple[int, ...], str, str, tuple[int, ...], bool]] = []
@@ -4736,6 +4974,18 @@ class Worker:
                     spec.platform,
                     spec.comm_profile,
                     tuple(spec.global_device_ranks),
+                    True,
+                )
+            )
+        for worker_id in self._mpi_worker_ids:
+            rank = self._mpi_rank_by_worker_id[int(worker_id)]
+            configs.append(
+                (
+                    int(worker_id),
+                    tuple(rank.spec.device_ids),
+                    rank.spec.platform,
+                    rank.spec.comm_profile,
+                    tuple(rank.spec.global_device_ranks),
                     True,
                 )
             )
@@ -4818,7 +5068,7 @@ class Worker:
         listen_host = spec.session_listen_host or ("127.0.0.1" if daemon_host == "localhost" else daemon_host)
         if self._is_wildcard_session_host(listen_host) and not spec.allow_wildcard_session_bind:
             raise ValueError("RemoteWorkerSpec wildcard session bind requires allow_wildcard_session_bind=True")
-        if worker_id in self._remote_worker_ids:
+        if worker_id in self._remote_like_worker_ids():
             runtime = self._resolved_global_nodes()[int(worker_id)]
             node_rank = runtime.node_rank
             node_count = runtime.node_count
@@ -4907,6 +5157,261 @@ class Worker:
         self._close_remote_sessions(sessions)
         self._remote_sessions.clear()
 
+    @staticmethod
+    def _new_remote_session_id() -> int:
+        session_id = uuid.uuid4().int & ((1 << 63) - 1)
+        return session_id if session_id != 0 else 1
+
+    @staticmethod
+    def _mpirun_args_select_hosts(args: tuple[str, ...]) -> bool:
+        host_args = {"--host", "-host", "-H", "--hostfile", "-hostfile", "--machinefile", "-machinefile"}
+        return any(arg in host_args or arg.startswith("--host=") or arg.startswith("--hostfile=") for arg in args)
+
+    @staticmethod
+    def _mpi_ready_path(ready_dir: str, rank: int) -> str:
+        return os.path.join(ready_dir, f"rank-{int(rank)}.json")
+
+    def _wait_mpi_ready_files(self, group: _MpiL3GroupRuntime, deadline: float) -> dict[int, dict[str, Any]]:
+        if group.ready_dir is None:
+            raise RuntimeError("MPI L3 group has no ready directory")
+        pending = {rank.rank for rank in group.ranks}
+        ready: dict[int, dict[str, Any]] = {}
+        while pending:
+            if group.process is not None and group.process.poll() is not None:
+                raise RuntimeError(
+                    f"MPI L3 group {group.group_id} exited before ranks became ready "
+                    f"(status {group.process.returncode})"
+                )
+            for rank in list(pending):
+                path = self._mpi_ready_path(group.ready_dir, rank)
+                try:
+                    with open(path, encoding="utf-8") as f:
+                        payload = json.load(f)
+                except FileNotFoundError:
+                    continue
+                if not payload.get("ok", False):
+                    raise RuntimeError(f"MPI L3 rank {rank} startup failed: {payload.get('error')}")
+                ready[rank] = payload
+                pending.remove(rank)
+            if pending:
+                remaining = self._remaining_until(deadline, "MPI L3 group ready")
+                time.sleep(min(0.05, remaining))
+        return ready
+
+    @staticmethod
+    def _open_mpi_ready_listener(host: str, port: int) -> socket.socket:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, int(port)))
+            sock.listen()
+            return sock
+        except BaseException:
+            sock.close()
+            raise
+
+    def _wait_mpi_ready_tcp(
+        self,
+        group: _MpiL3GroupRuntime,
+        ready_sock: socket.socket,
+        ready_token: str,
+        deadline: float,
+    ) -> dict[int, dict[str, Any]]:
+        pending = {rank.rank for rank in group.ranks}
+        ready: dict[int, dict[str, Any]] = {}
+        while pending:
+            if group.process is not None and group.process.poll() is not None:
+                raise RuntimeError(
+                    f"MPI L3 group {group.group_id} exited before ranks became ready "
+                    f"(status {group.process.returncode})"
+                )
+            ready_sock.settimeout(min(0.2, self._remaining_until(deadline, "MPI L3 TCP ready")))
+            try:
+                conn, _addr = ready_sock.accept()
+            except TimeoutError:
+                continue
+            except socket.timeout:
+                continue
+            with conn:
+                payload = self._recv_remote_daemon_json(conn, deadline)
+            rank_value = int(payload.get("mpi_rank", -1))
+            if payload.get("ready_token") != ready_token:
+                raise RuntimeError("MPI L3 rank published ready with an unexpected token")
+            if rank_value not in pending:
+                raise RuntimeError(f"MPI L3 rank published duplicate or unexpected ready rank={rank_value}")
+            if not payload.get("ok", False):
+                raise RuntimeError(f"MPI L3 rank {rank_value} startup failed: {payload.get('error')}")
+            ready[rank_value] = payload
+            pending.remove(rank_value)
+        return ready
+
+    @staticmethod
+    def _close_mpirun_group(group: _MpiL3GroupRuntime, *, timeout_s: float) -> list[str]:
+        failures: list[str] = []
+        proc = group.process
+        if proc is not None:
+            try:
+                # The remote sessions received SHUTDOWN before this runs, so a
+                # healthy group exits by itself once its ranks close their
+                # inner workers. SIGTERM is the backstop, not the first move:
+                # a rank interrupted mid native teardown dies uncleanly and
+                # mpirun reports the whole job as a bad termination.
+                if proc.poll() is None:
+                    with contextlib.suppress(subprocess.TimeoutExpired):
+                        proc.wait(timeout=timeout_s)
+                if proc.poll() is None:
+                    try:
+                        proc.terminate()
+                    except BaseException as exc:  # noqa: BLE001
+                        failures.append(f"terminate: {exc}")
+                try:
+                    proc.wait(timeout=timeout_s)
+                except subprocess.TimeoutExpired:
+                    try:
+                        proc.kill()
+                    except BaseException as exc:  # noqa: BLE001
+                        failures.append(f"kill: {exc}")
+                    try:
+                        proc.wait(timeout=timeout_s)
+                    except BaseException as exc:  # noqa: BLE001
+                        failures.append(f"wait after kill: {exc}")
+                except BaseException as exc:  # noqa: BLE001
+                    failures.append(f"wait after terminate: {exc}")
+            finally:
+                group.process = None
+        try:
+            if group.ready_dir is not None:
+                shutil.rmtree(group.ready_dir)
+        except FileNotFoundError:
+            pass
+        except BaseException as exc:  # noqa: BLE001
+            failures.append(f"remove ready directory: {exc}")
+        finally:
+            group.ready_dir = None
+            group.manifest_path = None
+        return [f"MPI L3 group {group.group_id} cleanup {failure}" for failure in failures]
+
+    def _close_mpirun_groups(
+        self,
+        *,
+        timeout_s: float = _ROLLBACK_GRACEFUL_TIMEOUT_S,
+        suppress_errors: bool = False,
+    ) -> None:
+        failures: list[str] = []
+        for group in reversed(self._mpi_l3_groups):
+            failures.extend(self._close_mpirun_group(group, timeout_s=timeout_s))
+        if failures:
+            sys.stderr.write("\n".join(f"[worker pid={os.getpid()}] WARN: {failure}" for failure in failures) + "\n")
+            sys.stderr.flush()
+            if not suppress_errors:
+                raise RuntimeError(failures[0])
+
+    def _activate_mpirun_worker_groups(self, deadline: float) -> None:
+        if not self._mpi_l3_groups:
+            return
+        session_timeout = self._remote_session_timeout_s()
+        assert self._worker is not None
+        for group in self._mpi_l3_groups:
+            ready_dir = tempfile.mkdtemp(prefix="simpler-mpirun-ready-")
+            manifest_path = os.path.join(ready_dir, "group.json")
+            group.ready_dir = ready_dir
+            group.manifest_path = manifest_path
+            ready_sock: socket.socket | None = None
+            ready_token = uuid.uuid4().hex
+            ready_host = group.spec.ready_host
+            ready_port = 0
+            if ready_host:
+                ready_sock = self._open_mpi_ready_listener(ready_host, group.spec.ready_port)
+                ready_port = int(ready_sock.getsockname()[1])
+            rank_manifests: list[dict[str, Any]] = []
+            sessions: dict[int, _RemoteSession] = {}
+            startup_remaining_s = self._remaining_until(deadline, "MPI L3 group manifest")
+            for rank in group.ranks:
+                session_id = self._new_remote_session_id()
+                manifest = self._build_remote_manifest(
+                    spec=rank.spec,
+                    worker_id=rank.worker_id,
+                    session_id=session_id,
+                    startup_remaining_s=startup_remaining_s,
+                )
+                manifest.update(
+                    {
+                        "command_port": rank.command_port,
+                        "health_port": rank.health_port,
+                        "mpi_group_id": group.group_id,
+                        "mpi_rank": rank.rank,
+                        "mpi_world_size": len(group.ranks),
+                        "mpi_group_worker_ids": [item.worker_id for item in group.ranks],
+                        "mpi_global_domain_exchange": True,
+                    }
+                )
+                rank_manifests.append(manifest)
+                sessions[rank.rank] = _RemoteSession(
+                    worker_id=rank.worker_id,
+                    session_id=session_id,
+                    command_host=rank.command_host,
+                    command_port=rank.command_port,
+                    health_host=rank.health_host,
+                    health_port=rank.health_port,
+                    pid=0,
+                )
+            group_manifest = {
+                "group_id": group.group_id,
+                "world_size": len(group.ranks),
+                "worker_ids": [rank.worker_id for rank in group.ranks],
+                "ready_dir": ready_dir,
+                "ready_host": ready_host,
+                "ready_port": ready_port,
+                "ready_token": ready_token,
+                "rank_manifests": rank_manifests,
+            }
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                json.dump(group_manifest, f, sort_keys=True)
+                f.write("\n")
+
+            cmd = [group.spec.mpirun_path, "-np", str(len(group.ranks))]
+            if not self._mpirun_args_select_hosts(group.spec.mpirun_args):
+                cmd.extend(["--host", ",".join(group.spec.hosts)])
+            cmd.extend(group.spec.mpirun_args)
+            cmd.extend(
+                [
+                    group.spec.python_executable,
+                    "-m",
+                    "simpler.mpi_l3_session",
+                    "--group-manifest",
+                    manifest_path,
+                ]
+            )
+            group.process = subprocess.Popen(cmd)
+            try:
+                if ready_sock is None:
+                    ready = self._wait_mpi_ready_files(group, deadline)
+                else:
+                    ready = self._wait_mpi_ready_tcp(group, ready_sock, ready_token, deadline)
+            finally:
+                if ready_sock is not None:
+                    ready_sock.close()
+            for rank in group.ranks:
+                payload = ready[rank.rank]
+                if int(payload["command_port"]) != rank.command_port or int(payload["health_port"]) != rank.health_port:
+                    raise RuntimeError(f"MPI L3 rank {rank.rank} published unexpected command/health ports")
+                session = sessions[rank.rank]
+                self._remote_sessions.append(session)
+                remaining = self._remaining_until(deadline, "MPI L3 endpoint attach")
+                self._worker.add_remote_l3_socket(
+                    session.worker_id,
+                    session.session_id,
+                    rank.spec.comm_profile,
+                    str(payload.get("command_host", rank.command_host)),
+                    int(payload["command_port"]),
+                    str(payload.get("health_host", rank.health_host)),
+                    int(payload["health_port"]),
+                    remaining,
+                    session_timeout,
+                )
+        if time.monotonic() >= deadline:
+            raise RuntimeError("MPI L3 activation: startup deadline exceeded after attach")
+
     def _require_remote_worker_started(self, worker_id: int) -> None:
         """Argument + resource gate for the public remote-memory APIs. Admission
         (READY) is decided by the ``_operation_lease`` these APIs already hold —
@@ -4916,8 +5421,10 @@ class Worker:
         instead of spuriously failing."""
         if self.level < 4:
             raise TypeError("remote memory APIs require a level >= 4 parent Worker")
-        if int(worker_id) not in set(self._remote_worker_ids):
-            raise ValueError("remote memory APIs require a remote worker id returned by add_remote_worker")
+        if int(worker_id) not in self._remote_like_worker_ids():
+            raise ValueError(
+                "remote memory APIs require a remote worker id returned by add_remote_worker or add_mpirun_worker_group"
+            )
         if self._worker is None:
             raise RuntimeError("remote memory APIs require a started hierarchical Worker")
 
@@ -4929,8 +5436,10 @@ class Worker:
         public lifecycle, so teardown keeps its capability without re-opening
         public admission. Public entrypoints validate READY separately via
         ``_require_remote_worker_started``."""
-        if int(worker_id) not in set(self._remote_worker_ids):
-            raise ValueError("remote memory APIs require a remote worker id returned by add_remote_worker")
+        if int(worker_id) not in self._remote_like_worker_ids():
+            raise ValueError(
+                "remote memory APIs require a remote worker id returned by add_remote_worker or add_mpirun_worker_group"
+            )
         if self._worker is None:
             raise RuntimeError("remote memory APIs require a started hierarchical Worker")
 
@@ -5985,14 +6494,14 @@ class Worker:
             raise TypeError("Worker.register: level 2 only supports ChipCallable targets")
         reg = _build_callable_registration(self, target, workers=workers)
         if isinstance(target, RemoteCallable):
-            if not self._remote_worker_specs:
+            if not self._remote_worker_specs and not self._mpi_l3_groups:
                 raise RuntimeError("Worker.register(RemoteCallable): add at least one remote worker first")
-            remote_worker_ids = set(self._remote_worker_ids)
+            remote_worker_ids = self._remote_like_worker_ids()
             for worker_id in reg.eligible_worker_ids:
                 if worker_id not in remote_worker_ids:
                     raise ValueError(
                         "Worker.register(RemoteCallable): workers must name remote worker ids returned by "
-                        "add_remote_worker"
+                        "add_remote_worker or add_mpirun_worker_group"
                     )
             # Linearize against the startup epoch exactly like the local path: a
             # register that races an in-progress init() waits for it, then a
@@ -6921,13 +7430,15 @@ class Worker:
                     return True
                 if any(spec.device_ids for spec in worker._remote_worker_specs):
                     return True
+                if any(rank.spec.device_ids for rank in worker._mpi_rank_by_worker_id.values()):
+                    return True
                 return any(has_chip_target(child) for child in worker._next_level_workers)
 
             return None if has_chip_target(self) else "a chip device (device_ids)"
         if namespace == "REMOTE_TASK_DISPATCHER":
-            has_remote_workers = set(self._remote_worker_ids)
+            has_remote_workers = self._remote_like_worker_ids()
             ok = bool(has_remote_workers) and set(eligible_worker_ids) <= has_remote_workers
-            return None if ok else "its named remote worker(s) (add_remote_worker)"
+            return None if ok else "its named remote worker(s) (add_remote_worker/add_mpirun_worker_group)"
         return None
 
     def _validate_eligible_targets(self) -> None:
@@ -7118,7 +7629,7 @@ class Worker:
         # startup resource (mailbox shm, pre-fork _Worker mmap, child fork,
         # daemon socket) exists, so an invalid value fails without a
         # partially-built subtree to roll back.
-        if self._remote_worker_specs:
+        if self._remote_worker_specs or self._mpi_l3_groups:
             self._remote_session_timeout_s()
 
         # 1. Allocate sub-worker mailboxes (unified layout, MAILBOX_SIZE each).
@@ -7431,6 +7942,7 @@ class Worker:
         # L3 sessions: opening starts the remote subtree and registering spawns
         # the RemoteL3Endpoint health thread, so both must follow every local
         # fork. Each remote consumes this process's remaining startup budget.
+        self._activate_mpirun_worker_groups(deadline)
         self._activate_remote_sessions(deadline)
 
         # _Worker was constructed in _init_hierarchical (pre-fork) so children
@@ -8938,11 +9450,98 @@ class Worker:
     def _global_domain_control(self, worker_id: int, control_name: int, payload: bytes) -> bytes:
         if self._worker is None:
             raise RuntimeError("Global CommDomain control requires a ready hierarchical Worker")
-        if worker_id in self._remote_worker_ids:
+        if worker_id in self._remote_like_worker_ids():
             return bytes(self._worker.remote_domain_control(int(worker_id), int(control_name), bytes(payload)))
         if worker_id in self._next_level_worker_ids:
             return self._local_global_domain_control(worker_id, control_name, payload)
         raise ValueError(f"Global CommDomain worker {worker_id} is not a registered L3 worker")
+
+    def _global_domain_control_many(
+        self,
+        worker_ids: tuple[int, ...],
+        control_name: int,
+        payload: bytes,
+        *,
+        mpi_group: _MpiL3GroupRuntime,
+    ) -> dict[int, bytes]:
+        replies: dict[int, bytes] = {}
+        errors: list[tuple[int, BaseException]] = []
+        completed = threading.Condition()
+
+        def _send(worker_id: int) -> None:
+            try:
+                reply = self._global_domain_control(worker_id, control_name, payload)
+            except BaseException as exc:  # noqa: BLE001
+                with completed:
+                    errors.append((worker_id, exc))
+                    completed.notify_all()
+                return
+            with completed:
+                replies[worker_id] = reply
+                completed.notify_all()
+
+        threads = [
+            (int(worker_id), threading.Thread(target=_send, args=(int(worker_id),), daemon=True))
+            for worker_id in worker_ids
+        ]
+        for _worker_id, thread in threads:
+            thread.start()
+        deadline = time.monotonic() + self._py_control_timeout_s
+        with completed:
+            while len(replies) + len(errors) < len(worker_ids) and not errors:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                completed.wait(timeout=remaining)
+
+        pending = [worker_id for worker_id, thread in threads if thread.is_alive()]
+        if pending:
+            cleanup_failures = self._close_mpirun_group(
+                mpi_group,
+                timeout_s=min(1.0, self._py_control_timeout_s),
+            )
+            if cleanup_failures:
+                sys.stderr.write(
+                    "\n".join(f"[worker pid={os.getpid()}] WARN: {failure}" for failure in cleanup_failures) + "\n"
+                )
+                sys.stderr.flush()
+            for _worker_id, thread in threads:
+                thread.join(timeout=1.0)
+        if errors:
+            worker_id, exc = errors[0]
+            raise RuntimeError(f"Global CommDomain control fanout failed on worker {worker_id}: {exc}") from exc
+        if pending:
+            raise TimeoutError(f"Global CommDomain control fanout timed out on workers {pending}")
+        missing = sorted(set(worker_ids) - replies.keys())
+        if missing:
+            raise RuntimeError(f"Global CommDomain control fanout returned no reply for workers {missing}")
+        return replies
+
+    def _mpi_group_for_involved_nodes(self, involved_nodes: tuple[int, ...]) -> _MpiL3GroupRuntime | None:
+        involved = set(int(worker_id) for worker_id in involved_nodes)
+        for group in self._mpi_l3_groups:
+            group_workers = {rank.worker_id for rank in group.ranks}
+            if involved == group_workers:
+                return group
+        return None
+
+    @staticmethod
+    def _descriptor_table_from_mpi_replies(
+        replies: dict[int, bytes],
+        *,
+        rank_count: int,
+        profile: str,
+    ) -> tuple[GlobalDomainDescriptor, ...]:
+        tables = tuple(decode_descriptor_table(payload) for payload in replies.values())
+        if not tables:
+            raise RuntimeError("MPI Global CommDomain prepare returned no descriptor tables")
+        first = tables[0]
+        validate_descriptor_table(first, rank_count=rank_count, profile=profile)
+        for table in tables[1:]:
+            validate_descriptor_table(table, rank_count=rank_count, profile=profile)
+            if table != first:
+                raise RuntimeError("MPI Global CommDomain prepare returned inconsistent descriptor tables")
+        return first
 
     def _allocate_global_domain(  # noqa: PLR0912 -- transaction validation and prepare/import/commit rollback stay ordered
         self,
@@ -9065,40 +9664,41 @@ class Worker:
                 ):
                     raise RuntimeError(f"Global CommDomain COMM_INIT capability mismatch on node {node_worker_id}")
 
-            descriptor_by_rank: dict[int, GlobalDomainDescriptor] = {}
-            for node_worker_id in involved_nodes:
-                prepared_nodes.append(node_worker_id)
-                reply = self._global_domain_control(
-                    node_worker_id,
+            mpi_group = self._mpi_group_for_involved_nodes(involved_nodes)
+            if mpi_group is not None:
+                # A full MPI group exchanges descriptors rank-side (the session
+                # runner's collective), so one ALLOC_DOMAIN fanout both prepares
+                # and imports; the reply already carries the complete table.
+                prepared_nodes.extend(involved_nodes)
+                replies = self._global_domain_control_many(
+                    involved_nodes,
                     ControlName.ALLOC_DOMAIN,
                     encode_domain_command(base_command),
+                    mpi_group=mpi_group,
                 )
-                for descriptor in decode_descriptor_table(reply):
-                    if descriptor.domain_rank in descriptor_by_rank:
-                        raise RuntimeError("Global CommDomain prepare returned a duplicate rank")
-                    descriptor_by_rank[descriptor.domain_rank] = descriptor
-            descriptors = tuple(descriptor_by_rank[rank] for rank in range(len(domain_members_tuple)))
+                descriptors = self._descriptor_table_from_mpi_replies(
+                    replies,
+                    rank_count=len(domain_members_tuple),
+                    profile=profile,
+                )
+            else:
+                descriptor_by_rank: dict[int, GlobalDomainDescriptor] = {}
+                for node_worker_id in involved_nodes:
+                    prepared_nodes.append(node_worker_id)
+                    reply = self._global_domain_control(
+                        node_worker_id,
+                        ControlName.ALLOC_DOMAIN,
+                        encode_domain_command(base_command),
+                    )
+                    for descriptor in decode_descriptor_table(reply):
+                        if descriptor.domain_rank in descriptor_by_rank:
+                            raise RuntimeError("Global CommDomain prepare returned a duplicate rank")
+                        descriptor_by_rank[descriptor.domain_rank] = descriptor
+                descriptors = tuple(descriptor_by_rank[rank] for rank in range(len(domain_members_tuple)))
             validate_descriptor_table(descriptors, rank_count=len(domain_members_tuple), profile=profile)
             if descriptors[0].mapping_size < window_size:
                 raise RuntimeError("Global CommDomain backend mapped less than the requested window size")
 
-            import_command = GlobalDomainCommand(
-                phase=GlobalDomainPhase.IMPORT,
-                domain_id=domain_id,
-                generation=generation,
-                name=name,
-                profile=profile,
-                window_size=int(window_size),
-                members=domain_members_tuple,
-                buffers=global_buffers,
-                descriptors=descriptors,
-            )
-            for node_worker_id in involved_nodes:
-                self._global_domain_control(
-                    node_worker_id,
-                    ControlName.ALLOC_DOMAIN,
-                    encode_domain_command(import_command),
-                )
             commit_command = GlobalDomainCommand(
                 phase=GlobalDomainPhase.COMMIT,
                 domain_id=domain_id,
@@ -9110,12 +9710,37 @@ class Worker:
                 buffers=global_buffers,
                 descriptors=descriptors,
             )
-            for node_worker_id in involved_nodes:
-                self._global_domain_control(
-                    node_worker_id,
+            if mpi_group is not None:
+                self._global_domain_control_many(
+                    involved_nodes,
                     ControlName.ALLOC_DOMAIN,
                     encode_domain_command(commit_command),
+                    mpi_group=mpi_group,
                 )
+            else:
+                import_command = GlobalDomainCommand(
+                    phase=GlobalDomainPhase.IMPORT,
+                    domain_id=domain_id,
+                    generation=generation,
+                    name=name,
+                    profile=profile,
+                    window_size=int(window_size),
+                    members=domain_members_tuple,
+                    buffers=global_buffers,
+                    descriptors=descriptors,
+                )
+                for node_worker_id in involved_nodes:
+                    self._global_domain_control(
+                        node_worker_id,
+                        ControlName.ALLOC_DOMAIN,
+                        encode_domain_command(import_command),
+                    )
+                for node_worker_id in involved_nodes:
+                    self._global_domain_control(
+                        node_worker_id,
+                        ControlName.ALLOC_DOMAIN,
+                        encode_domain_command(commit_command),
+                    )
         except BaseException:
             abort_command = GlobalDomainCommand(
                 phase=GlobalDomainPhase.ABORT,
@@ -9500,7 +10125,7 @@ class Worker:
         C++ target check only rejects unregistered ids, so a registered remote
         worker slips through — this guards that hole.
         """
-        if worker_id in set(self._remote_worker_ids):
+        if worker_id in self._remote_like_worker_ids():
             raise ValueError(
                 f"orch.{api}: worker {worker_id} is a remote NEXT_LEVEL worker; a local callable "
                 f"must target a local child (remote workers only run RemoteCallable dispatches)"
@@ -10513,6 +11138,7 @@ class Worker:
             self._has_native_tree()
             or bool(self._sub_pids or self._chip_pids or self._next_level_pids)
             or bool(self._sub_shms or self._chip_shms or self._next_level_shms)
+            or any(group.process is not None or group.ready_dir is not None for group in self._mpi_l3_groups)
             or bool(self._live_worker_chip_regions)
             or bool(self._live_domains)
             or bool(self._live_global_domains or self._failed_global_domain_releases)
@@ -10534,6 +11160,9 @@ class Worker:
         n_shms = len(self._sub_shms) + len(self._chip_shms) + len(self._next_level_shms)
         if n_shms:
             parts.append(f"{n_shms} child shm(s)")
+        n_mpi = sum(1 for group in self._mpi_l3_groups if group.process is not None or group.ready_dir is not None)
+        if n_mpi:
+            parts.append(f"{n_mpi} mpirun group(s)")
         if self._live_worker_chip_regions:
             parts.append(f"{len(self._live_worker_chip_regions)} L3-L2 region(s)")
         if self._live_domains:
@@ -11088,6 +11717,12 @@ class Worker:
 
             self._cleanup_journal.add_once("native", "hierarchical Worker", _close_worker)
             journal_err = self._cleanup_journal.drive({("native", "hierarchical Worker")})
+            if journal_err is not None:
+                errors.append(journal_err)
+                if not startup_abort:
+                    raise errors[0]
+            self._cleanup_journal.add_once("child", "MPI L3 groups", self._close_mpirun_groups)
+            journal_err = self._cleanup_journal.drive({("child", "MPI L3 groups")})
             if journal_err is not None:
                 errors.append(journal_err)
                 if not startup_abort:

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -13,10 +13,18 @@ import os
 import socket
 import subprocess
 import sys
+import threading
 import time
+from collections import Counter
+from typing import cast
 
 import pytest
 from simpler.global_comm_domain import (
+    CTRL_GLOBAL_DOMAIN_COPY_FROM,
+    CTRL_GLOBAL_DOMAIN_COPY_TO,
+    CTRL_GLOBAL_DOMAIN_IMPORT,
+    CTRL_GLOBAL_DOMAIN_PREPARE,
+    CTRL_GLOBAL_DOMAIN_RELEASE,
     GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
     GLOBAL_DOMAIN_PROFILE_IDS,
     GLOBAL_DOMAIN_VERSION,
@@ -223,6 +231,44 @@ def _close_failure_injection_worker(worker, resources):
     resources.live_global_domains.clear()
     worker._worker = None
     worker.close()
+
+
+def _mpi_static_worker():
+    from simpler.worker import MpiL3GroupSpec, Worker, _RunResources  # noqa: PLC0415
+
+    worker = Worker(level=4, num_sub_workers=0)
+    node_ids = worker.add_mpirun_worker_group(
+        MpiL3GroupSpec(
+            hosts=("127.0.0.1", "127.0.0.1"),
+            platform="a2a3sim",
+            command_port_base=21073,
+            health_port_base=22073,
+            device_ids_by_rank=((0,), (0,)),
+            comm_profile="sim",
+            global_device_ranks_by_rank=((0,), (1,)),
+        )
+    )
+    resources = _RunResources()
+    worker._worker = object()
+    worker._building_run_resources = resources
+    return worker, resources, node_ids
+
+
+def test_mpi_group_spec_rejects_a_global_device_rank_reused_across_mpi_ranks():
+    from simpler.worker import MpiL3GroupSpec  # noqa: PLC0415
+
+    # A global device rank names one device in the cluster, so two mpirun ranks
+    # claiming rank 3 is the same defect as one rank listing it twice.
+    with pytest.raises(ValueError, match="unique across the whole group"):
+        MpiL3GroupSpec(
+            hosts=("127.0.0.1", "127.0.0.1"),
+            platform="a2a3sim",
+            command_port_base=21073,
+            health_port_base=22073,
+            device_ids_by_rank=((0,), (0,)),
+            comm_profile="sim",
+            global_device_ranks_by_rank=((3,), (3,)),
+        )
 
 
 @pytest.mark.parametrize(
@@ -1000,3 +1046,208 @@ def test_local_and_remote_l3_build_and_copy_global_domain_without_mpirun():
         except subprocess.TimeoutExpired:
             daemon.kill()
             daemon.wait(timeout=5)
+
+
+def test_global_domain_control_ids_do_not_overlap_worker_controls():
+    from simpler.worker import _CTRL_COMMITTED_DEVICE_MEMORY, _CTRL_GLOBAL_DOMAIN_NODE  # noqa: PLC0415
+
+    control_ids = (
+        _CTRL_COMMITTED_DEVICE_MEMORY,
+        CTRL_GLOBAL_DOMAIN_PREPARE,
+        CTRL_GLOBAL_DOMAIN_IMPORT,
+        CTRL_GLOBAL_DOMAIN_RELEASE,
+        CTRL_GLOBAL_DOMAIN_COPY_TO,
+        CTRL_GLOBAL_DOMAIN_COPY_FROM,
+        _CTRL_GLOBAL_DOMAIN_NODE,
+    )
+
+    assert len(control_ids) == len(set(control_ids))
+
+
+def test_mpirun_group_global_domain_uses_mpi_prepare_commit_without_l4_import(monkeypatch):
+    from simpler.remote_l3_protocol import ControlName  # noqa: PLC0415
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+
+    worker, resources, node_ids = _mpi_static_worker()
+    calls = []
+
+    def control(worker_id, control_name, payload):
+        control_name = ControlName(control_name)
+        if control_name is ControlName.COMM_INIT:
+            init = decode_comm_init(payload)
+            calls.append(("COMM_INIT", worker_id))
+            return encode_comm_init_result(
+                resolve_global_comm_capability(
+                    platform="a2a3sim",
+                    profile=init.profile,
+                    local_device_count=1,
+                )
+            )
+        assert control_name is ControlName.ALLOC_DOMAIN
+        command = decode_domain_command(payload)
+        calls.append((command.phase, worker_id))
+        if command.phase is GlobalDomainPhase.PREPARE_EXPORT:
+            descriptors = tuple(
+                GlobalDomainDescriptor(
+                    version=GLOBAL_DOMAIN_VERSION,
+                    profile_id=GLOBAL_DOMAIN_PROFILE_IDS[command.profile],
+                    domain_rank=member.domain_rank,
+                    rank_count=len(command.members),
+                    mapping_size=4096,
+                    handle=f"/mpi-prepared-{member.domain_rank}".encode(),
+                )
+                for member in command.members
+            )
+            return encode_descriptor_table(descriptors)
+        if command.phase is GlobalDomainPhase.IMPORT:
+            raise RuntimeError("L4 broker IMPORT should not run for a full mpirun group")
+        return b""
+
+    monkeypatch.setattr(worker, "_global_domain_control", control)
+    try:
+        handle = worker._allocate_global_domain(
+            name="mpi-static",
+            members=((node_ids[0], 0), (node_ids[1], 0)),
+            window_size=4096,
+            buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+            retain_after_run=False,
+        )
+
+        assert handle.mapping_size == 4096
+        assert handle.members[0].global_device_rank == 0
+        assert handle.members[1].global_device_rank == 1
+        counts = Counter(phase for phase, _worker_id in calls)
+        assert counts["COMM_INIT"] == 2
+        assert counts[GlobalDomainPhase.PREPARE_EXPORT] == 2
+        assert counts[GlobalDomainPhase.COMMIT] == 2
+        assert counts[GlobalDomainPhase.IMPORT] == 0
+        assert worker._live_global_domains["mpi-static"] is handle
+        assert resources.live_global_domains["mpi-static"] is handle
+    finally:
+        _close_failure_injection_worker(worker, resources)
+
+
+def test_mpi_global_domain_collective_timeout_releases_local_state():
+    from simpler.mpi_l3_session import MpiGlobalDomainExchange  # noqa: PLC0415
+
+    stuck = threading.Event()
+
+    class _Comm:
+        aborted = False
+
+        @staticmethod
+        def Get_rank():
+            return 0
+
+        @staticmethod
+        def allgather(_payload):
+            # A peer rank never entering the collective looks like this to
+            # the pickle-based blocking allgather.
+            stuck.wait(30.0)
+
+        def Abort(self, _error_code):
+            self.aborted = True
+            raise RuntimeError("fake MPI abort")
+
+    comm = _Comm()
+    exchange = MpiGlobalDomainExchange(comm, group_worker_ids=(7,), timeout_s=0.05)
+    releases = []
+
+    try:
+        with pytest.raises(TimeoutError, match="prepare timed out"):
+            exchange._allgather(b"payload", operation="prepare", on_timeout=lambda: releases.append(True))
+    finally:
+        stuck.set()
+
+    assert releases == [True]
+    assert comm.aborted
+
+
+def test_mpi_global_domain_prepare_failure_releases_before_collective():
+    from simpler.mpi_l3_session import MpiGlobalDomainExchange  # noqa: PLC0415
+    from simpler.worker import Worker  # noqa: PLC0415
+
+    class _Comm:
+        @staticmethod
+        def Get_rank():
+            return 0
+
+        @staticmethod
+        def allgather(payload):
+            return [payload]
+
+    class _InnerWorker:
+        released = False
+
+        @staticmethod
+        def _prepare_global_domain_node(_command, _worker_id):
+            raise RuntimeError("injected prepare failure")
+
+        def _release_global_domain_node(self, _command, *, suppress_errors):
+            assert suppress_errors
+            self.released = True
+
+    command = GlobalDomainCommand(
+        phase=GlobalDomainPhase.PREPARE_EXPORT,
+        domain_id=20,
+        generation=1,
+        name="mpi-failure",
+        profile="sim",
+        window_size=4096,
+        members=(GlobalDomainMember(7, 0, 0, 0),),
+        buffers=(),
+    )
+    inner_worker = _InnerWorker()
+    exchange = MpiGlobalDomainExchange(_Comm(), group_worker_ids=(7,), timeout_s=1.0)
+
+    with pytest.raises(RuntimeError, match="prepare failed on rank 0"):
+        exchange.prepare_import(command, cast(Worker, inner_worker), 7)
+
+    assert inner_worker.released
+
+
+def test_mpirun_group_cleanup_continues_after_one_process_wait_fails():
+    class _Process:
+        def __init__(self, *, fail_wait):
+            self.fail_wait = fail_wait
+            self.waited = False
+
+        @staticmethod
+        def poll():
+            return 0
+
+        def wait(self, *, timeout):
+            assert timeout == 0.1
+            self.waited = True
+            if self.fail_wait:
+                raise RuntimeError("injected wait failure")
+            return 0
+
+    worker, resources, _node_ids = _mpi_static_worker()
+    group = worker._mpi_l3_groups[0]
+    first_process = _Process(fail_wait=True)
+    second_process = _Process(fail_wait=False)
+    first = type(group)(
+        group_id="first",
+        spec=group.spec,
+        ranks=group.ranks,
+        process=cast(subprocess.Popen, first_process),
+    )
+    second = type(group)(
+        group_id="second",
+        spec=group.spec,
+        ranks=group.ranks,
+        process=cast(subprocess.Popen, second_process),
+    )
+    worker._mpi_l3_groups[:] = [first, second]
+    try:
+        with pytest.raises(RuntimeError, match="first cleanup wait after terminate"):
+            worker._close_mpirun_groups(timeout_s=0.1)
+
+        assert first_process.waited
+        assert second_process.waited
+        assert first.process is None
+        assert second.process is None
+    finally:
+        worker._mpi_l3_groups.clear()
+        _close_failure_injection_worker(worker, resources)


### PR DESCRIPTION
## Dependency
- stacked on #1456 at `c293351c` (`Add: support mixed local and remote L4 CommDomains`)
- this PR contributes one MPI-specific commit on top of that dependency; #1456 should merge first

## Summary
- add static MPI-launched L3 worker groups with rank-0 manifest broadcast, ready coordination, and deterministic worker topology
- extend Global CommDomains from the #1456 local/TCP foundation to MPI-backed L3 nodes
- add regression coverage for control-ID uniqueness and imported window/buffer extents

## Testing
- [x] `pytest tests/ut/py/test_global_comm_domain.py -m "not requires_hardware"` on the validated implementation (25 passed)
- [x] three consecutive two-host A3 2x2 runs (all exit 0; four-rank compute/communication `max_diff == 0`)
- [x] verified manifest broadcast, ready handshake, PREPARE_EXPORT, MPI allgather, IMPORT, COMMIT, copy, release, and process/shared-memory cleanup
- [x] current aligned commit: headers, English-only, YAML, whitespace, Ruff, Pyright, and Python syntax checks passed
- [ ] current aligned commit full pytest was not rerun on the Windows preparation host because the project setup imports the Unix-only `fcntl` module