### PR TITLE
Add: dispatch MPI worker groups through mailbox

### DIFF
--- a/docs/mpi-l3-mailbox.md
+++ b/docs/mpi-l3-mailbox.md
@@ -1,0 +1,135 @@
+# MPI L3 group mailbox protocol
+
+An MPI L3 group has one L4-owned, named shared-memory mailbox. Only local MPI
+rank 0 opens that mailbox. All ranks participate in the same ordered
+`dispatch_comm` collectives, while Global CommDomain descriptor exchange uses
+a separate `domain_comm`.
+
+```text
+L4 / MpiGroupMailboxEndpoint
+          |
+          | named SharedMemory (one request lane)
+          v
+local MPI rank 0 / L3
+          |
+          | dispatch_comm Bcast + Gather
+          v
+all MPI ranks / L3 -> each rank's local L2 workers
+```
+
+MPI groups never start or connect Simpler command/health TCP sockets. Ordinary
+`RemoteWorkerSpec` workers still use `RemoteL3SocketTransport` and keep their
+existing command and health lanes.
+
+## Startup and shutdown
+
+1. L4 creates the mailbox and writes its name, protocol version, size, and
+   world size into the group manifest.
+2. L4 starts `mpirun` as a new process group and monitors that direct child.
+3. Each rank creates and initializes its own L3 `Worker`.
+4. All ranks complete a readiness `allgather`.
+5. Rank 0 reopens the mailbox by name and publishes `READY`. Other ranks never
+   map it.
+6. L4 attaches every stable MPI worker id to the same
+   `MpiGroupMailboxChannel`; it does not create `RemoteL3Endpoint` sockets.
+7. Shutdown is a mailbox `SHUTDOWN` request, followed by one MPI broadcast.
+   Each rank closes its inner worker, communicators are freed, `mpirun` exits,
+   and L4 unlinks the mailbox and manifest directory.
+
+If startup, a collective, the mailbox, or `mpirun` fails, the group becomes
+terminal. Runtime timeout also kills the complete `mpirun` process group.
+There is no TCP fallback.
+
+## Envelope and state
+
+Protocol version 1 has a fixed 256-byte header and two 16 MiB payload regions.
+The header contains:
+
+- magic `SMPIBOX\0`
+- protocol version and layout size
+- MPI world size
+- group state: `INITIALIZING`, `READY`, `TERMINAL`, or `CLOSED`
+- request state: `IDLE`, `REQUEST_READY`, `TASK_ACCEPTED`, `TASK_DONE`,
+  `TASK_FAILED`, `SHUTDOWN_READY`, or `SHUTDOWN_DONE`
+- monotonic mailbox `sequence_id`
+- opcode: `TASK`, `CONTROL`, `PING`, or `SHUTDOWN`
+- target: `GROUP`, `RANK`, or `PER_RANK`
+- target rank, payload count, and byte lengths
+
+Rank 0 copies the complete request to private memory before publishing
+`TASK_ACCEPTED`. It publishes `TASK_DONE` only after gathering every rank's
+status. Duplicate or decreasing sequence ids make the group terminal.
+
+Every gathered error contains `rank`, `error_type`, and `message`. Any target
+rank failure fails the group operation. A broken command processor or
+collective is terminal; an ordinary task/control application error is returned
+to L4 and the communicator may be reused.
+
+## Target and API semantics
+
+- `orch.submit_next_level(..., worker=id)` remains a directed rank operation.
+  Every MPI rank receives the envelope in collective order, but only the
+  selected rank executes it.
+- `orch.submit_next_level_group(args_list, workers=...)` remains one DAG node.
+  When `workers` is the complete MPI group, C++ batches all members into one
+  `PER_RANK` mailbox request. Rank `workers[i]` uses `args_list[i]`.
+- A subset group remains supported as ordered directed requests. It is not
+  silently widened to the complete MPI group.
+- Group-wide controls use one `GROUP` mailbox request. The caller marks them
+  explicitly with the `FRAME_FLAG_GROUP_TARGET` frame flag; a control frame
+  without the flag is always a directed rank request, whatever its control
+  name.
+
+The existing remote task codec is reused. It serializes scalar values, tensor
+metadata, inline host payloads, and `RemoteTensorRef` descriptors. Bare host or
+child virtual addresses without a valid remote sidecar are rejected before
+execution; a pointer value is never forwarded as if it were meaningful on
+another rank. `PYTHON_SERIALIZED` callable payloads remain unsupported by the
+underlying Remote L3 protocol; `PYTHON_IMPORT` and inline `CHIP_CALLABLE`
+registration are supported.
+
+## Remote protocol audit and MPI mapping
+
+The wire `FrameType` values remain unchanged:
+
+| Existing frame | MPI mailbox mapping |
+| -------------- | ------------------- |
+| `HELLO` / ready | rank-local initialization, readiness `allgather`, then rank 0 publishes mailbox `READY` |
+| `TASK` | `TASK`; directed `RANK`, or one full-group `PER_RANK` vector |
+| `CONTROL` / `CONTROL_REPLY` | `CONTROL`; directed unless the frame carries `FRAME_FLAG_GROUP_TARGET` |
+| `COMPLETION` | gathered per-rank status; selected/per-rank replies returned to L4 |
+| `HEALTH` | `PING` to `GROUP`, gathered before success |
+| `SHUTDOWN` | `SHUTDOWN` to `GROUP`, gathered before `SHUTDOWN_DONE` |
+
+All existing remote controls use the mailbox path:
+
+| Number | Control | MPI target |
+| -----: | ------- | ---------- |
+| 1 | `UNREGISTER_CALLABLE` | directed rank |
+| 2 | `PREPARE_REGISTER_CALLABLE` | directed rank |
+| 3 | `COMMIT_REGISTER_CALLABLE` | directed rank |
+| 4 | `ABORT_REGISTER_CALLABLE` | directed rank |
+| 5 | `PREPARE_CALLABLE` | directed rank |
+| 6 | `ALLOC_REMOTE_BUFFER` | directed rank |
+| 7 | `FREE_REMOTE_BUFFER` | directed rank |
+| 8 | `COPY_TO_REMOTE` | directed rank |
+| 9 | `COPY_FROM_REMOTE` | directed rank |
+| 10 | `EXPORT_BUFFER` | directed rank |
+| 11 | `IMPORT_BUFFER` | directed rank |
+| 12 | `RELEASE_IMPORT` | directed rank |
+| 13 | `COMM_INIT` | directed rank |
+| 14 | `ALLOC_DOMAIN` prepare/import/commit/abort | group request when the frame carries the group-target flag; otherwise directed rank |
+| 15 | `RELEASE_DOMAIN` | group request when the frame carries the group-target flag; otherwise directed rank |
+| 16 | `COPY_TO_DOMAIN` | directed rank |
+| 17 | `COPY_FROM_DOMAIN` | directed rank |
+
+Remote control number 18 is intentionally not assigned. The local hierarchical
+protocol keeps number 18 for committed-device-memory control.
+
+## Threading
+
+Only the main dispatcher thread calls MPI. The existing command processor runs
+on a rank-local thread over an in-memory, socket-shaped queue. Global
+CommDomain operations cross back to the dispatcher through a queue and
+`threading.Event`, so they use `domain_comm` on the MPI-owning thread. This
+design does not require `MPI_THREAD_MULTIPLE`.

--- a/docs/mpi-l3-mailbox.md
+++ b/docs/mpi-l3-mailbox.md
@@ -55,10 +55,22 @@ The header contains:
 - opcode: `TASK`, `CONTROL`, `PING`, or `SHUTDOWN`
 - target: `GROUP`, `RANK`, or `PER_RANK`
 - target rank, payload count, and byte lengths
+- reserved tail bytes (offsets 80 through 255), zero in version 1
 
-Rank 0 copies the complete request to private memory before publishing
-`TASK_ACCEPTED`. It publishes `TASK_DONE` only after gathering every rank's
-status. Duplicate or decreasing sequence ids make the group terminal.
+Rank 0 parks on the request-state word between requests — a shared futex on
+Linux, woken by every L4 publish — instead of polling it. Rank 0 copies the
+complete request to private memory before publishing `TASK_ACCEPTED`. It
+publishes `TASK_DONE` only after gathering every rank's status. Duplicate or
+decreasing sequence ids make the group terminal.
+
+### Versioning
+
+Version 1 freezes the layout above. The creator zeroes the reserved header
+bytes and both attach paths — the L4 channel and the rank-0 reopen — reject a
+mailbox whose reserved bytes are non-zero, so a version 1 peer cannot silently
+carry fields it does not understand. Any layout or semantic change bumps the
+protocol version, and each side rejects a version it does not implement: a
+mixed-version pair fails closed at attach instead of misreading the lane.
 
 Every gathered error contains `rank`, `error_type`, and `message`. Any target
 rank failure fails the group operation. A broken command processor or

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -9,6 +9,7 @@ Detailed protocol, buffer, transport, and rollout notes live in:
 
 - [protocol.md](remote-l3-worker-design/protocol.md)
 - [buffers-and-transports.md](remote-l3-worker-design/buffers-and-transports.md)
+- [MPI L3 group mailbox](mpi-l3-mailbox.md)
 - [implementation-plan.md](remote-l3-worker-design/implementation-plan.md)
 - [pr-split-and-audit-plan.md][split-audit-plan]
 
@@ -63,6 +64,10 @@ Implemented:
 - Socket-backed simulation remote sessions via `simpler-remote-worker` and
   `simpler-remote-l3-session`, including `HELLO READY`, TASK/COMPLETION,
   CONTROL/CONTROL_REPLY, SHUTDOWN, and an independent health lane.
+- MPI L3 groups use one rank-0 named shared-memory mailbox plus ordered MPI
+  collectives for task, control, health, Global CommDomain, error, and shutdown
+  handling. They do not create Simpler command or health TCP sockets; ordinary
+  non-MPI Remote L3 sessions retain the socket transport.
 - Simulation remote buffer allocation, copy, export, import, release-import,
   imported-handle scheduling eligibility, and deferred owner free.
 - Registry-scope-aware remote callable manifest/control install for dispatcher

--- a/docs/remote-l3-worker-design/implementation-record.md
+++ b/docs/remote-l3-worker-design/implementation-record.md
@@ -92,8 +92,8 @@ It is updated as each documented feature is completed and verified.
   descriptors are collected by L3, assembled by L4, returned to every L3/L2
   for import, and released after the L4 DAG drain by default. Domains created
   with `retain_after_run=True` remain live for a later run until explicitly
-  released or the Worker closes. Sim shm and A3 Fabric V2 use the same
-  descriptor ABI.
+  released or the Worker closes. The sim shm and `a3-fabric-v1` profiles use
+  the same descriptor ABI.
 - Added startup-manifest delivery for pre-registered inner `CHIP_CALLABLE`
   payloads, allowing remote sessions to resolve installed chip callables
   before task dispatch.

--- a/examples/workers/l4/global_tload_mpirun_l3/README.md
+++ b/examples/workers/l4/global_tload_mpirun_l3/README.md
@@ -15,13 +15,16 @@ it exercises that the sibling cannot:
 
 - `add_mpirun_worker_group` / `MpiL3GroupSpec`: rank 0 must land on the parent
   machine (only it can read the parent-written group manifest, which it then
-  broadcasts over MPI), and every rank publishes READY back over TCP
-  (`ready_host`) — file-based READY cannot cross machines.
+  broadcasts over MPI), and rank 0 marks the group's named shared-memory
+  mailbox READY once every rank reports in over MPI — task and control
+  traffic then flows through that mailbox instead of per-rank TCP sessions.
 - The full-group MPI descriptor exchange: the Global CommDomain members cover
   every device of both ranks, so descriptors are exchanged rank-side over an
   MPI collective and the L4 import fanout is skipped.
 - One TLOAD task per NPU device on each machine (the sibling drives one device
   per side), so the domain spans four windows on the pod pair.
+- One `submit_next_level_group` round over the full MPI group, so the batched
+  `PER_RANK` mailbox envelope path runs alongside the directed dispatches.
 
 ## Prerequisites beyond the sibling example
 
@@ -49,7 +52,7 @@ chmod +x /tmp/simpler-mpi-python
 ## Run on the L4 parent
 
 `192.0.2.10` / `192.0.2.20` are documentation placeholders. Hosts must be
-numeric IPs; the local host is where rank 0 and the READY listener bind:
+numeric IPs; the local host is where rank 0 lands:
 
 ```bash
 source .venv/bin/activate

--- a/examples/workers/l4/global_tload_mpirun_l3/main.py
+++ b/examples/workers/l4/global_tload_mpirun_l3/main.py
@@ -12,9 +12,9 @@
 One L4 parent (this process) registers a two-rank ``MpiL3GroupSpec`` — rank 0
 on this machine, rank 1 on the peer — and launches both L3 workers through a
 single parent-owned ``mpirun``. Rank 0 must be this machine: only it can read
-the parent-written group manifest, which it then broadcasts over MPI. After
-both ranks publish READY back over TCP (``ready_host`` — file-based READY
-cannot cross machines), the parent attaches them as ordinary remote L3
+the parent-written group manifest, which it then broadcasts over MPI. Rank 0
+marks the group's named shared-memory mailbox READY once every rank reports
+in over MPI, the parent attaches the group as mailbox-backed remote L3
 endpoints and dispatches one TLOAD task per NPU device on each machine. The
 Global CommDomain (``a3-fabric-v1`` on real A3 devices) spans every device of
 both ranks, so it is built over the MPI collective descriptor-exchange path
@@ -81,8 +81,6 @@ def run(  # noqa: PLR0913, PLR0915 -- mirrors the CLI surface; one linear two-ru
     platform: str = "a2a3",
     runtime: str = "tensormap_and_ringbuffer",
     comm_profile: str = "a3-fabric-v1",
-    command_port_base: int = 21173,
-    health_port_base: int = 22173,
     session_timeout: float = 120.0,
     mpirun_path: str = "mpirun",
 ) -> int:
@@ -108,12 +106,9 @@ def run(  # noqa: PLR0913, PLR0915 -- mirrors the CLI surface; one linear two-ru
                 hosts=(local_host, remote_host),
                 platform=platform,
                 runtime=runtime,
-                command_port_base=int(command_port_base),
-                health_port_base=int(health_port_base),
                 device_ids_by_rank=device_ids_by_rank,
                 comm_profile=comm_profile,
                 global_device_ranks_by_rank=global_ranks_by_rank,
-                ready_host=local_host,
                 mpirun_path=mpirun_path,
                 # Hydra and Open MPI both propagate the parent's cwd to every
                 # rank and fail the launch when it is missing on a remote
@@ -159,6 +154,19 @@ def run(  # noqa: PLR0913, PLR0915 -- mirrors the CLI surface; one linear two-ru
                 _add_digest_scalars(task_args, chip_handle.digest)
                 parent_keepalive.append(task_args)
                 orch.submit_next_level(rank_handle, task_args, cfg, worker=node_id)
+            # One full-group batched dispatch: every rank's task travels in a
+            # single PER_RANK mailbox envelope. It re-runs TLOAD on each
+            # rank's first device, rewriting the same summed values, so the
+            # golden check below also proves the batched path executed.
+            group_args = []
+            for node_id in node_ids:
+                task_args = TaskArgs()
+                task_args.add_scalar(domain.domain_id)
+                task_args.add_scalar(0)
+                _add_digest_scalars(task_args, chip_handle.digest)
+                parent_keepalive.append(task_args)
+                group_args.append(task_args)
+            orch.submit_next_level_group(rank_handle, group_args, cfg, workers=list(node_ids))
             domain_handle = domain
 
         worker.run(build_and_run, args=None, config=CallConfig())
@@ -217,8 +225,6 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--platform", default="a2a3")
     parser.add_argument("--runtime", default="tensormap_and_ringbuffer")
     parser.add_argument("--comm-profile", default="a3-fabric-v1")
-    parser.add_argument("--command-port-base", type=int, default=21173)
-    parser.add_argument("--health-port-base", type=int, default=22173)
     parser.add_argument("--session-timeout", type=float, default=120.0)
     parser.add_argument("--mpirun-path", default="mpirun")
     return parser.parse_args()
@@ -235,8 +241,6 @@ def main() -> int:
         platform=args.platform,
         runtime=args.runtime,
         comm_profile=args.comm_profile,
-        command_port_base=args.command_port_base,
-        health_port_base=args.health_port_base,
         session_timeout=args.session_timeout,
         mpirun_path=args.mpirun_path,
     )

--- a/examples/workers/l4/global_tload_mpirun_l3/test_global_tload_mpirun_l3.py
+++ b/examples/workers/l4/global_tload_mpirun_l3/test_global_tload_mpirun_l3.py
@@ -45,7 +45,7 @@ def _require_mpirun_pod_env() -> tuple[str, str, str]:
         pytest.skip("mpi4py is not installed (required inside the mpirun rank processes)")
     local_ip = os.environ.get("POD_LOCAL_IP", "")
     if not local_ip:
-        pytest.skip("POD_LOCAL_IP is required: mpirun rank 0 and the READY listener bind this machine's address")
+        pytest.skip("POD_LOCAL_IP is required: mpirun places rank 0 on this machine's address")
     mpi_python = os.environ.get("POD_MPI_PYTHON", "")
     if not mpi_python:
         pytest.skip("POD_MPI_PYTHON is required: per-machine rank launcher at one shared absolute path")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - Remote L3 Worker Design:
           - Overview: remote-l3-worker-design.md
           - Design document index: remote-l3-worker-design/README.md
+      - MPI L3 group mailbox: mpi-l3-mailbox.md
   - Profiling and DFX:
       - Overview: dfx/README.md
       - Profiling Framework: dfx/profiling-framework.md

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "ring.h"
+#include "mpi_group_mailbox.h"
 #include "orchestrator.h"
 #include "types.h"
 #include "worker.h"
@@ -200,7 +201,8 @@ inline std::vector<RemoteTaskArgsSidecar> parse_remote_task_args_sidecars(nb::ha
 
 // ---------------------------------------------------------------------------
 // Mailbox acquire/release helpers (exposed to Python as _mailbox_load_i32 /
-// _mailbox_store_i32). Mirror WorkerThread::read_mailbox_state /
+// _mailbox_store_i32, consumed by simpler.worker and
+// simpler.mpi_group_mailbox). Mirror WorkerThread::read_mailbox_state /
 // write_mailbox_state in worker_manager.cpp so the Python side of the mailbox
 // handshake uses the same memory order as the C++ side. Without these, a
 // plain struct.pack_into("i", ...) on the Python child followed by the parent
@@ -905,6 +907,70 @@ inline void bind_worker(nb::module_ &m) {
             mailbox_store_i32(addr, value);
         },
         nb::arg("addr"), nb::arg("value"), "Release-store a 32-bit mailbox word at `addr`."
+    );
+    m.def(
+        "_mailbox_wait_i32",
+        [](uint64_t addr, int32_t expected, double timeout_s) {
+            nb::gil_scoped_release release;
+            mpi_group_mailbox::wait_word(reinterpret_cast<int32_t *>(addr), expected, timeout_s);
+        },
+        nb::arg("addr"), nb::arg("expected"), nb::arg("timeout_s"),
+        "Block (GIL released) until the mailbox word at `addr` differs from `expected`, a peer "
+        "wakes the word, or `timeout_s` elapses. May return spuriously; callers re-check the word."
+    );
+    m.def(
+        "_mpi_mailbox_layout",
+        []() {
+            using namespace mpi_group_mailbox;
+            nb::dict layout;
+            layout["MAGIC"] = nb::bytes(reinterpret_cast<const char *>(MAGIC), sizeof(MAGIC));
+            layout["PROTOCOL_VERSION"] = PROTOCOL_VERSION;
+            layout["HEADER_BYTES"] = HEADER_BYTES;
+            layout["PAYLOAD_BYTES"] = PAYLOAD_BYTES;
+            layout["ERROR_BYTES"] = ERROR_BYTES;
+            layout["REQUEST_OFFSET"] = REQUEST_OFFSET;
+            layout["RESPONSE_OFFSET"] = RESPONSE_OFFSET;
+            layout["ERROR_OFFSET"] = ERROR_OFFSET;
+            layout["MAILBOX_BYTES"] = MAILBOX_BYTES;
+            layout["OFF_MAGIC"] = OFF_MAGIC;
+            layout["OFF_PROTOCOL_VERSION"] = OFF_PROTOCOL_VERSION;
+            layout["OFF_HEADER_BYTES"] = OFF_HEADER_BYTES;
+            layout["OFF_MAILBOX_BYTES"] = OFF_MAILBOX_BYTES;
+            layout["OFF_WORLD_SIZE"] = OFF_WORLD_SIZE;
+            layout["OFF_GROUP_STATE"] = OFF_GROUP_STATE;
+            layout["OFF_REQUEST_STATE"] = OFF_REQUEST_STATE;
+            layout["OFF_SEQUENCE_ID"] = OFF_SEQUENCE_ID;
+            layout["OFF_OPCODE"] = OFF_OPCODE;
+            layout["OFF_TARGET"] = OFF_TARGET;
+            layout["OFF_TARGET_RANK"] = OFF_TARGET_RANK;
+            layout["OFF_REQUEST_COUNT"] = OFF_REQUEST_COUNT;
+            layout["OFF_REQUEST_BYTES"] = OFF_REQUEST_BYTES;
+            layout["OFF_RESPONSE_COUNT"] = OFF_RESPONSE_COUNT;
+            layout["OFF_RESPONSE_BYTES"] = OFF_RESPONSE_BYTES;
+            layout["OFF_ERROR_BYTES"] = OFF_ERROR_BYTES;
+            layout["RESERVED_OFFSET"] = RESERVED_OFFSET;
+            layout["GROUP_STATE_INITIALIZING"] = static_cast<int32_t>(GroupState::INITIALIZING);
+            layout["GROUP_STATE_READY"] = static_cast<int32_t>(GroupState::READY);
+            layout["GROUP_STATE_TERMINAL"] = static_cast<int32_t>(GroupState::TERMINAL);
+            layout["GROUP_STATE_CLOSED"] = static_cast<int32_t>(GroupState::CLOSED);
+            layout["REQUEST_STATE_IDLE"] = static_cast<int32_t>(RequestState::IDLE);
+            layout["REQUEST_STATE_REQUEST_READY"] = static_cast<int32_t>(RequestState::REQUEST_READY);
+            layout["REQUEST_STATE_TASK_ACCEPTED"] = static_cast<int32_t>(RequestState::TASK_ACCEPTED);
+            layout["REQUEST_STATE_TASK_DONE"] = static_cast<int32_t>(RequestState::TASK_DONE);
+            layout["REQUEST_STATE_TASK_FAILED"] = static_cast<int32_t>(RequestState::TASK_FAILED);
+            layout["REQUEST_STATE_SHUTDOWN_READY"] = static_cast<int32_t>(RequestState::SHUTDOWN_READY);
+            layout["REQUEST_STATE_SHUTDOWN_DONE"] = static_cast<int32_t>(RequestState::SHUTDOWN_DONE);
+            layout["OPCODE_TASK"] = static_cast<uint32_t>(Opcode::TASK);
+            layout["OPCODE_CONTROL"] = static_cast<uint32_t>(Opcode::CONTROL);
+            layout["OPCODE_PING"] = static_cast<uint32_t>(Opcode::PING);
+            layout["OPCODE_SHUTDOWN"] = static_cast<uint32_t>(Opcode::SHUTDOWN);
+            layout["TARGET_GROUP"] = static_cast<uint32_t>(Target::GROUP);
+            layout["TARGET_RANK"] = static_cast<uint32_t>(Target::RANK);
+            layout["TARGET_PER_RANK"] = static_cast<uint32_t>(Target::PER_RANK);
+            return layout;
+        },
+        "The MPI group mailbox wire layout as declared by mpi_group_mailbox.h, keyed by constant "
+        "name. Backs the Python/C++ layout-agreement test."
     );
     m.def(
         "_read_control_copy_request",

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -474,6 +474,20 @@ inline void bind_worker(nb::module_ &m) {
             nb::arg("health_host"), nb::arg("health_port"), nb::arg("attach_timeout_s") = 30.0,
             nb::arg("runtime_timeout_s") = 30.0, "Register a REMOTE_L3 endpoint after the session reports HELLO READY."
         )
+        .def(
+            "add_mpi_group_mailbox",
+            [](Worker &self, const std::vector<int32_t> &worker_ids, const std::vector<uint64_t> &session_ids,
+               uint64_t mailbox_ptr, size_t mailbox_bytes, int mpirun_pid, double runtime_timeout_s) {
+                nb::gil_scoped_release release;
+                self.add_mpi_group_mailbox(
+                    worker_ids, session_ids, reinterpret_cast<void *>(mailbox_ptr), mailbox_bytes, mpirun_pid,
+                    runtime_timeout_s
+                );
+            },
+            nb::arg("worker_ids"), nb::arg("session_ids"), nb::arg("mailbox_ptr"), nb::arg("mailbox_bytes"),
+            nb::arg("mpirun_pid"), nb::arg("runtime_timeout_s") = 30.0,
+            "Register one shared-memory MPI group endpoint for each worker id."
+        )
 
         // Release the GIL while starting the Scheduler thread so another Python
         // thread can run during it — e.g. a concurrent close() observing
@@ -732,7 +746,7 @@ inline void bind_worker(nb::module_ &m) {
         )
         .def(
             "remote_domain_control",
-            [](Worker &self, int worker_id, uint32_t control_name, nb::bytes command) {
+            [](Worker &self, int worker_id, uint32_t control_name, nb::bytes command, bool group_target) {
                 std::vector<uint8_t> command_bytes(
                     reinterpret_cast<const uint8_t *>(command.c_str()),
                     reinterpret_cast<const uint8_t *>(command.c_str()) + command.size()
@@ -741,13 +755,14 @@ inline void bind_worker(nb::module_ &m) {
                 {
                     nb::gil_scoped_release release;
                     result = self.remote_domain_control(
-                        worker_id, static_cast<remote_l3::ControlName>(control_name), command_bytes
+                        worker_id, static_cast<remote_l3::ControlName>(control_name), command_bytes, group_target
                     );
                 }
                 return nb::bytes(reinterpret_cast<const char *>(result.data()), result.size());
             },
-            nb::arg("worker_id"), nb::arg("control_name"), nb::arg("command"),
-            "Send one Global CommDomain control to a remote L3 endpoint."
+            nb::arg("worker_id"), nb::arg("control_name"), nb::arg("command"), nb::arg("group_target") = false,
+            "Send one Global CommDomain control to a remote L3 endpoint. With group_target, a "
+            "group-capable transport delivers the control to every rank of the worker's group."
         )
         .def(
             "broadcast_unregister_all",

--- a/python/simpler/global_comm_domain.py
+++ b/python/simpler/global_comm_domain.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 GLOBAL_DOMAIN_VERSION = 1
 GLOBAL_DOMAIN_MAX_RANKS = 64
+GLOBAL_DOMAIN_MAX_BUFFERS = 64
 GLOBAL_DOMAIN_HANDLE_BYTES = 256
 GLOBAL_DOMAIN_DESCRIPTOR = struct.Struct("<IIIIQII256s")
 GLOBAL_DOMAIN_DESCRIPTOR_BYTES = GLOBAL_DOMAIN_DESCRIPTOR.size
@@ -394,6 +395,8 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:
         raise ValueError("global domain command name must be non-empty")
     if command.profile not in GLOBAL_DOMAIN_PROFILE_IDS:
         raise ValueError(f"unsupported global domain profile {command.profile!r}")
+    if len(command.buffers) > GLOBAL_DOMAIN_MAX_BUFFERS:
+        raise ValueError("global domain command buffer count exceeds maximum")
     if len({buffer.name for buffer in command.buffers}) != len(command.buffers):
         raise ValueError("global domain command contains duplicate buffer names")
     if any(not buffer.name or buffer.nbytes <= 0 for buffer in command.buffers):
@@ -452,7 +455,7 @@ def decode_domain_command(data: bytes) -> GlobalDomainCommand:
         raise ValueError("global domain command member count exceeds maximum")
     members = tuple(_read_member(reader) for _ in range(member_count))
     buffer_count = reader.u32()
-    if buffer_count > GLOBAL_DOMAIN_MAX_RANKS:
+    if buffer_count > GLOBAL_DOMAIN_MAX_BUFFERS:
         raise ValueError("global domain command buffer count exceeds maximum")
     buffers = tuple(GlobalDomainBuffer(reader.string("buffer.name"), reader.u64()) for _ in range(buffer_count))
     descriptor_count = reader.u32()

--- a/python/simpler/mpi_group_mailbox.py
+++ b/python/simpler/mpi_group_mailbox.py
@@ -1,0 +1,507 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Named shared-memory protocol used between L4 and an MPI L3 group."""
+
+from __future__ import annotations
+
+import ctypes
+import enum
+import json
+import struct
+from dataclasses import asdict, dataclass
+from multiprocessing.shared_memory import SharedMemory
+from typing import Any
+
+MAILBOX_MAGIC = b"SMPIBOX\0"
+MAILBOX_PROTOCOL_VERSION = 1
+MAILBOX_HEADER_BYTES = 256
+MAILBOX_PAYLOAD_BYTES = 16 * 1024 * 1024
+MAILBOX_ERROR_BYTES = 64 * 1024
+MAILBOX_REQUEST_OFFSET = MAILBOX_HEADER_BYTES
+MAILBOX_RESPONSE_OFFSET = MAILBOX_REQUEST_OFFSET + MAILBOX_PAYLOAD_BYTES
+MAILBOX_ERROR_OFFSET = MAILBOX_RESPONSE_OFFSET + MAILBOX_PAYLOAD_BYTES
+MAILBOX_SIZE = MAILBOX_ERROR_OFFSET + MAILBOX_ERROR_BYTES
+
+_OFF_MAGIC = 0
+_OFF_PROTOCOL_VERSION = 8
+_OFF_HEADER_BYTES = 12
+_OFF_MAILBOX_BYTES = 16
+_OFF_WORLD_SIZE = 24
+_OFF_GROUP_STATE = 28
+_OFF_REQUEST_STATE = 32
+_OFF_SEQUENCE_ID = 40
+_OFF_OPCODE = 48
+_OFF_TARGET = 52
+_OFF_TARGET_RANK = 56
+_OFF_REQUEST_COUNT = 60
+_OFF_REQUEST_BYTES = 64
+_OFF_RESPONSE_COUNT = 68
+_OFF_RESPONSE_BYTES = 72
+_OFF_ERROR_BYTES = 76
+
+
+class MailboxGroupState(enum.IntEnum):
+    INITIALIZING = 0
+    READY = 1
+    TERMINAL = 2
+    CLOSED = 3
+
+
+class MailboxRequestState(enum.IntEnum):
+    IDLE = 0
+    REQUEST_READY = 1
+    TASK_ACCEPTED = 2
+    TASK_DONE = 3
+    TASK_FAILED = 4
+    SHUTDOWN_READY = 5
+    SHUTDOWN_DONE = 6
+
+
+class MailboxOpcode(enum.IntEnum):
+    TASK = 1
+    CONTROL = 2
+    PING = 3
+    SHUTDOWN = 4
+
+
+class MailboxTarget(enum.IntEnum):
+    GROUP = 1
+    RANK = 2
+    PER_RANK = 3
+
+
+@dataclass(frozen=True)
+class MpiRankError:
+    rank: int
+    error_type: str
+    message: str
+
+
+@dataclass(frozen=True)
+class MailboxRequest:
+    sequence_id: int
+    opcode: MailboxOpcode
+    target: MailboxTarget
+    target_rank: int
+    payloads: tuple[bytes, ...]
+
+
+@dataclass(frozen=True)
+class MailboxResult:
+    sequence_id: int
+    payloads: tuple[bytes, ...]
+
+
+class MpiGroupError(RuntimeError):
+    """A mailbox or MPI group operation failed."""
+
+
+def _encode_payloads(payloads: tuple[bytes, ...]) -> bytes:
+    values = tuple(bytes(payload) for payload in payloads)
+    prefix_bytes = 4 + 4 * len(values)
+    payload_bytes = sum(len(payload) for payload in values)
+    if prefix_bytes + payload_bytes > MAILBOX_PAYLOAD_BYTES:
+        raise ValueError("MPI group mailbox payload vector exceeds capacity")
+    out = bytearray(struct.pack("<I", len(values)))
+    for payload in values:
+        out.extend(struct.pack("<I", len(payload)))
+    for payload in values:
+        out.extend(payload)
+    return bytes(out)
+
+
+def _decode_payloads(data: bytes, expected_count: int) -> tuple[bytes, ...]:
+    if len(data) < 4:
+        raise MpiGroupError("MPI group mailbox payload vector is truncated")
+    (count,) = struct.unpack_from("<I", data)
+    if count != expected_count:
+        raise MpiGroupError(f"MPI group mailbox payload count mismatch: header={expected_count}, vector={count}")
+    prefix_bytes = 4 + 4 * count
+    if prefix_bytes > len(data):
+        raise MpiGroupError("MPI group mailbox payload lengths are truncated")
+    lengths = struct.unpack_from(f"<{count}I", data, 4) if count else ()
+    offset = prefix_bytes
+    payloads: list[bytes] = []
+    for length in lengths:
+        if offset > len(data) or length > len(data) - offset:
+            raise MpiGroupError("MPI group mailbox payload entry is truncated")
+        payloads.append(bytes(data[offset : offset + length]))
+        offset += length
+    if offset != len(data):
+        raise MpiGroupError("MPI group mailbox payload vector has trailing bytes")
+    return tuple(payloads)
+
+
+def _as_byte_view(buffer: memoryview) -> memoryview:
+    """Normalize platform-specific shared-memory formats to a byte view."""
+    return buffer.cast("B")
+
+
+def _buffer_address(buffer: memoryview) -> int:
+    return ctypes.addressof(ctypes.c_char.from_buffer(buffer))
+
+
+class MpiGroupMailbox:
+    """Owner or reopened view of one MPI group mailbox."""
+
+    def __init__(self, shm: SharedMemory, *, owner: bool) -> None:
+        self._shm = shm
+        self._owner = bool(owner)
+        self._closed = False
+        self._validate_header()
+
+    @classmethod
+    def create(cls, *, world_size: int) -> MpiGroupMailbox:
+        if int(world_size) <= 0:
+            raise ValueError("MPI group mailbox world_size must be positive")
+        shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+        buffer = shm.buf
+        if buffer is None:
+            shm.close()
+            shm.unlink()
+            raise MpiGroupError("MPI group mailbox mapping returned no buffer")
+        buffer = _as_byte_view(buffer)
+        ctypes.memset(_buffer_address(buffer), 0, MAILBOX_SIZE)
+        struct.pack_into(
+            "<8sIIQ", buffer, _OFF_MAGIC, MAILBOX_MAGIC, MAILBOX_PROTOCOL_VERSION, MAILBOX_HEADER_BYTES, MAILBOX_SIZE
+        )
+        struct.pack_into("<I", buffer, _OFF_WORLD_SIZE, int(world_size))
+        struct.pack_into("<i", buffer, _OFF_GROUP_STATE, int(MailboxGroupState.INITIALIZING))
+        struct.pack_into("<i", buffer, _OFF_REQUEST_STATE, int(MailboxRequestState.IDLE))
+        return cls(shm, owner=True)
+
+    @classmethod
+    def open(cls, *, name: str) -> MpiGroupMailbox:
+        try:
+            shm = SharedMemory(name=str(name), create=False, track=False)
+        except TypeError:  # Python < 3.13 has no per-instance resource-tracker switch.
+            shm = SharedMemory(name=str(name), create=False)
+            # A reopened rank-0 view is not the owner. Older Python versions
+            # register every SharedMemory view and otherwise try to unlink it
+            # when rank 0 exits, racing the L4 owner and emitting leak warnings.
+            from multiprocessing import resource_tracker  # noqa: PLC0415
+
+            resource_tracker.unregister(shm._name, "shared_memory")  # noqa: SLF001
+        return cls(shm, owner=False)
+
+    @property
+    def name(self) -> str:
+        return self._shm.name
+
+    @property
+    def address(self) -> int:
+        self._require_open()
+        return ctypes.addressof(ctypes.c_char.from_buffer(self._buffer))
+
+    @property
+    def world_size(self) -> int:
+        return self._read_u32(_OFF_WORLD_SIZE)
+
+    @property
+    def group_state(self) -> MailboxGroupState:
+        return MailboxGroupState(self._load_i32(_OFF_GROUP_STATE))
+
+    @property
+    def request_state(self) -> MailboxRequestState:
+        return MailboxRequestState(self._load_i32(_OFF_REQUEST_STATE))
+
+    def manifest(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "protocol_version": MAILBOX_PROTOCOL_VERSION,
+            "mailbox_bytes": MAILBOX_SIZE,
+            "world_size": self.world_size,
+        }
+
+    def publish_ready(self) -> None:
+        if self.group_state is not MailboxGroupState.INITIALIZING:
+            raise MpiGroupError("MPI group mailbox READY can only be published from INITIALIZING")
+        self._store_i32(_OFF_GROUP_STATE, int(MailboxGroupState.READY))
+
+    def publish_closed(self) -> None:
+        if self.group_state is MailboxGroupState.TERMINAL:
+            return
+        self._store_i32(_OFF_GROUP_STATE, int(MailboxGroupState.CLOSED))
+
+    def write_request(
+        self,
+        *,
+        sequence_id: int,
+        opcode: MailboxOpcode,
+        target: MailboxTarget,
+        target_rank: int,
+        payloads: tuple[bytes, ...],
+    ) -> None:
+        self._require_ready()
+        if self.request_state is not MailboxRequestState.IDLE:
+            raise MpiGroupError(f"MPI group mailbox is busy in state {self.request_state.name}")
+        sequence_id = int(sequence_id)
+        if sequence_id <= 0:
+            raise ValueError("MPI group mailbox sequence_id must be positive")
+        opcode = MailboxOpcode(opcode)
+        target = MailboxTarget(target)
+        target_rank = int(target_rank)
+        payloads = tuple(bytes(payload) for payload in payloads)
+        if target is MailboxTarget.RANK:
+            if target_rank < 0 or target_rank >= self.world_size:
+                raise ValueError("MPI group mailbox target rank is outside the group")
+            if len(payloads) != 1:
+                raise ValueError("rank-targeted MPI group request requires one payload")
+        elif target is MailboxTarget.GROUP:
+            if target_rank != -1 or len(payloads) != 1:
+                raise ValueError("group-targeted MPI request requires target_rank=-1 and one payload")
+        elif target is MailboxTarget.PER_RANK:
+            if target_rank != -1 or len(payloads) != self.world_size:
+                raise ValueError("per-rank MPI request requires one payload for every rank")
+        data = _encode_payloads(payloads)
+        self._write_bytes(MAILBOX_REQUEST_OFFSET, data)
+        self._write_u64(_OFF_SEQUENCE_ID, sequence_id)
+        self._write_u32(_OFF_OPCODE, int(opcode))
+        self._write_u32(_OFF_TARGET, int(target))
+        self._write_i32(_OFF_TARGET_RANK, target_rank)
+        self._write_u32(_OFF_REQUEST_COUNT, len(payloads))
+        self._write_u32(_OFF_REQUEST_BYTES, len(data))
+        self._write_u32(_OFF_RESPONSE_COUNT, 0)
+        self._write_u32(_OFF_RESPONSE_BYTES, 0)
+        self._write_u32(_OFF_ERROR_BYTES, 0)
+        ready_state = (
+            MailboxRequestState.SHUTDOWN_READY
+            if opcode is MailboxOpcode.SHUTDOWN
+            else MailboxRequestState.REQUEST_READY
+        )
+        self._store_i32(_OFF_REQUEST_STATE, int(ready_state))
+
+    def accept_request(self, *, last_sequence_id: int) -> MailboxRequest:
+        state = self.request_state
+        if state not in (MailboxRequestState.REQUEST_READY, MailboxRequestState.SHUTDOWN_READY):
+            raise MpiGroupError(f"MPI group mailbox has no request to accept (state={state.name})")
+        sequence_id = self._read_u64(_OFF_SEQUENCE_ID)
+        request_bytes = self._read_u32(_OFF_REQUEST_BYTES)
+        request_count = self._read_u32(_OFF_REQUEST_COUNT)
+        if request_bytes > MAILBOX_PAYLOAD_BYTES:
+            self.mark_terminal("request payload exceeds mailbox capacity")
+            raise MpiGroupError("MPI group mailbox request payload exceeds capacity")
+        data = self._read_bytes(MAILBOX_REQUEST_OFFSET, request_bytes)
+        try:
+            if sequence_id <= int(last_sequence_id):
+                raise MpiGroupError(
+                    f"MPI group mailbox sequence_id {sequence_id} is not newer than {int(last_sequence_id)}"
+                )
+            request = MailboxRequest(
+                sequence_id=sequence_id,
+                opcode=MailboxOpcode(self._read_u32(_OFF_OPCODE)),
+                target=MailboxTarget(self._read_u32(_OFF_TARGET)),
+                target_rank=self._read_i32(_OFF_TARGET_RANK),
+                payloads=_decode_payloads(data, request_count),
+            )
+        except BaseException as exc:
+            self.mark_terminal(str(exc))
+            raise
+        self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.TASK_ACCEPTED))
+        return request
+
+    def complete_request(self, *, sequence_id: int, payloads: tuple[bytes, ...]) -> None:
+        self._validate_active_sequence(sequence_id)
+        values = tuple(bytes(payload) for payload in payloads)
+        data = _encode_payloads(values)
+        self._write_bytes(MAILBOX_RESPONSE_OFFSET, data)
+        self._write_u32(_OFF_RESPONSE_COUNT, len(values))
+        self._write_u32(_OFF_RESPONSE_BYTES, len(data))
+        self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.TASK_DONE))
+
+    def complete_shutdown(self, *, sequence_id: int) -> None:
+        self._validate_active_sequence(sequence_id)
+        self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.SHUTDOWN_DONE))
+
+    def fail_request(
+        self,
+        *,
+        sequence_id: int,
+        errors: tuple[MpiRankError, ...],
+        terminal: bool,
+    ) -> None:
+        self._validate_active_sequence(sequence_id)
+        if not errors:
+            raise ValueError("MPI group mailbox failure requires at least one rank error")
+        data = json.dumps([asdict(error) for error in errors], sort_keys=True).encode("utf-8")
+        if len(data) > MAILBOX_ERROR_BYTES:
+            data = data[: MAILBOX_ERROR_BYTES - 1]
+        self._write_bytes(MAILBOX_ERROR_OFFSET, data)
+        self._write_u32(_OFF_ERROR_BYTES, len(data))
+        if terminal:
+            self._store_i32(_OFF_GROUP_STATE, int(MailboxGroupState.TERMINAL))
+        self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.TASK_FAILED))
+
+    def read_result(self, *, sequence_id: int) -> MailboxResult:
+        if self._read_u64(_OFF_SEQUENCE_ID) != int(sequence_id):
+            raise MpiGroupError("MPI group mailbox result sequence does not match the request")
+        state = self.request_state
+        if state is MailboxRequestState.TASK_DONE:
+            response_bytes = self._read_u32(_OFF_RESPONSE_BYTES)
+            response_count = self._read_u32(_OFF_RESPONSE_COUNT)
+            if response_bytes > MAILBOX_PAYLOAD_BYTES:
+                self.mark_terminal("response payload exceeds mailbox capacity")
+                raise MpiGroupError("MPI group mailbox response payload exceeds capacity")
+            data = self._read_bytes(MAILBOX_RESPONSE_OFFSET, response_bytes)
+            result = MailboxResult(int(sequence_id), _decode_payloads(data, response_count))
+            self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.IDLE))
+            return result
+        if state is MailboxRequestState.TASK_FAILED:
+            error_bytes = min(self._read_u32(_OFF_ERROR_BYTES), MAILBOX_ERROR_BYTES)
+            raw = self._read_bytes(MAILBOX_ERROR_OFFSET, error_bytes)
+            try:
+                entries = json.loads(raw.decode("utf-8"))
+                message = "; ".join(
+                    f"rank {int(entry['rank'])}: {entry['error_type']}: {entry['message']}" for entry in entries
+                )
+            except BaseException:
+                message = raw.decode("utf-8", errors="replace") or "MPI group request failed"
+            if self.group_state is MailboxGroupState.READY:
+                self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.IDLE))
+            raise MpiGroupError(message)
+        raise MpiGroupError(f"MPI group mailbox result is not ready (state={state.name})")
+
+    def mark_terminal(self, reason: str) -> None:
+        data = str(reason).encode("utf-8")[:MAILBOX_ERROR_BYTES]
+        self._write_bytes(MAILBOX_ERROR_OFFSET, data)
+        self._write_u32(_OFF_ERROR_BYTES, len(data))
+        self._store_i32(_OFF_GROUP_STATE, int(MailboxGroupState.TERMINAL))
+        self._store_i32(_OFF_REQUEST_STATE, int(MailboxRequestState.TASK_FAILED))
+
+    def terminal_reason(self) -> str:
+        error_bytes = min(self._read_u32(_OFF_ERROR_BYTES), MAILBOX_ERROR_BYTES)
+        return self._read_bytes(MAILBOX_ERROR_OFFSET, error_bytes).decode("utf-8", errors="replace")
+
+    def overwrite_request_payload_for_test(self, data: bytes) -> None:
+        value = bytes(data)
+        self._write_bytes(MAILBOX_REQUEST_OFFSET, value)
+
+    def close(self, *, unlink: bool = False) -> None:
+        if self._closed:
+            return
+        if unlink and not self._owner:
+            raise RuntimeError("only the MPI group mailbox owner may unlink it")
+        self._shm.close()
+        if unlink:
+            try:
+                self._shm.unlink()
+            except FileNotFoundError:
+                # Python < 3.13 may let a non-owner process resource tracker
+                # unlink the name first; the owner mapping still closes here.
+                pass
+        self._closed = True
+
+    def _validate_header(self) -> None:
+        if len(self._buffer) < MAILBOX_SIZE:
+            raise MpiGroupError("MPI group mailbox is smaller than the protocol layout")
+        magic, version, header_bytes, mailbox_bytes = struct.unpack_from("<8sIIQ", self._buffer, _OFF_MAGIC)
+        if magic != MAILBOX_MAGIC:
+            raise MpiGroupError("MPI group mailbox magic does not match")
+        if version != MAILBOX_PROTOCOL_VERSION:
+            raise MpiGroupError(f"MPI group mailbox protocol version {version} is not supported")
+        if header_bytes != MAILBOX_HEADER_BYTES or mailbox_bytes != MAILBOX_SIZE:
+            raise MpiGroupError("MPI group mailbox layout does not match the protocol")
+        if self._read_u32(_OFF_WORLD_SIZE) == 0:
+            raise MpiGroupError("MPI group mailbox world_size must be positive")
+
+    def _validate_active_sequence(self, sequence_id: int) -> None:
+        if self.request_state is not MailboxRequestState.TASK_ACCEPTED:
+            raise MpiGroupError("MPI group mailbox request has not been accepted")
+        if self._read_u64(_OFF_SEQUENCE_ID) != int(sequence_id):
+            raise MpiGroupError("MPI group mailbox active sequence does not match")
+
+    def _require_ready(self) -> None:
+        state = self.group_state
+        if state is MailboxGroupState.TERMINAL:
+            reason = self.terminal_reason() or "terminal failure"
+            raise MpiGroupError(f"MPI group mailbox is terminal: {reason}")
+        if state is not MailboxGroupState.READY:
+            raise MpiGroupError(f"MPI group mailbox is not ready (state={state.name})")
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("MPI group mailbox is closed")
+
+    @property
+    def _buffer(self) -> memoryview:
+        buffer = self._shm.buf
+        if buffer is None:
+            raise RuntimeError("MPI group mailbox mapping has no buffer")
+        return _as_byte_view(buffer)
+
+    def _write_bytes(self, offset: int, data: bytes) -> None:
+        self._require_open()
+        offset = int(offset)
+        buffer = self._buffer
+        if offset < 0 or offset > len(buffer) or len(data) > len(buffer) - offset:
+            raise ValueError("MPI group mailbox write is outside the mapping")
+        if data:
+            ctypes.memmove(_buffer_address(buffer) + offset, data, len(data))
+
+    def _read_bytes(self, offset: int, length: int) -> bytes:
+        self._require_open()
+        offset = int(offset)
+        length = int(length)
+        buffer = self._buffer
+        if offset < 0 or length < 0 or offset > len(buffer) or length > len(buffer) - offset:
+            raise ValueError("MPI group mailbox read is outside the mapping")
+        if length == 0:
+            return b""
+        return ctypes.string_at(_buffer_address(buffer) + offset, length)
+
+    def _load_i32(self, offset: int) -> int:
+        self._require_open()
+        try:
+            from .task_interface import _mailbox_load_i32  # noqa: PLC0415
+        except (ImportError, AttributeError):
+            return self._read_i32(offset)
+        return int(_mailbox_load_i32(self.address + offset))
+
+    def _store_i32(self, offset: int, value: int) -> None:
+        self._require_open()
+        try:
+            from .task_interface import _mailbox_store_i32  # noqa: PLC0415
+        except (ImportError, AttributeError):
+            self._write_i32(offset, value)
+            return
+        _mailbox_store_i32(self.address + offset, int(value))
+
+    def _read_i32(self, offset: int) -> int:
+        return int(struct.unpack_from("<i", self._buffer, offset)[0])
+
+    def _write_i32(self, offset: int, value: int) -> None:
+        struct.pack_into("<i", self._buffer, offset, int(value))
+
+    def _read_u32(self, offset: int) -> int:
+        return int(struct.unpack_from("<I", self._buffer, offset)[0])
+
+    def _write_u32(self, offset: int, value: int) -> None:
+        struct.pack_into("<I", self._buffer, offset, int(value))
+
+    def _read_u64(self, offset: int) -> int:
+        return int(struct.unpack_from("<Q", self._buffer, offset)[0])
+
+    def _write_u64(self, offset: int, value: int) -> None:
+        struct.pack_into("<Q", self._buffer, offset, int(value))
+
+
+def open_rank_mailbox(manifest: dict[str, Any], *, rank: int) -> MpiGroupMailbox | None:
+    """Open the L4 mailbox on rank 0; all other ranks stay MPI-only."""
+
+    if int(rank) != 0:
+        return None
+    if int(manifest.get("protocol_version", -1)) != MAILBOX_PROTOCOL_VERSION:
+        raise MpiGroupError("MPI group manifest mailbox protocol version does not match")
+    if int(manifest.get("mailbox_bytes", -1)) != MAILBOX_SIZE:
+        raise MpiGroupError("MPI group manifest mailbox size does not match")
+    mailbox = MpiGroupMailbox.open(name=str(manifest["name"]))
+    if mailbox.world_size != int(manifest.get("world_size", -1)):
+        mailbox.close()
+        raise MpiGroupError("MPI group manifest world_size does not match the mailbox")
+    return mailbox

--- a/python/simpler/mpi_group_mailbox.py
+++ b/python/simpler/mpi_group_mailbox.py
@@ -18,6 +18,15 @@ from dataclasses import asdict, dataclass
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any
 
+# The acquire/release helpers are required, not optional: the cross-process
+# handshake is built on their publication barriers, so a missing extension must
+# fail the import instead of silently degrading to plain struct reads.
+from _task_interface import (  # pyright: ignore[reportMissingImports]
+    _mailbox_load_i32,
+    _mailbox_store_i32,
+    _mailbox_wait_i32,
+)
+
 MAILBOX_MAGIC = b"SMPIBOX\0"
 MAILBOX_PROTOCOL_VERSION = 1
 MAILBOX_HEADER_BYTES = 256
@@ -44,6 +53,15 @@ _OFF_REQUEST_BYTES = 64
 _OFF_RESPONSE_COUNT = 68
 _OFF_RESPONSE_BYTES = 72
 _OFF_ERROR_BYTES = 76
+# Header bytes [_OFF_RESERVED, MAILBOX_HEADER_BYTES) are reserved in protocol
+# version 1: the creator zeroes them and every attach path rejects non-zero
+# reserved bytes, so a future version can assign them.
+_OFF_RESERVED = 80
+
+# Per-rank error messages are capped before serializing so the gathered JSON
+# stays parseable inside MAILBOX_ERROR_BYTES instead of being clipped into
+# invalid JSON.
+_RANK_ERROR_MESSAGE_LIMIT_BYTES = 2048
 
 
 class MailboxGroupState(enum.IntEnum):
@@ -138,6 +156,40 @@ def _decode_payloads(data: bytes, expected_count: int) -> tuple[bytes, ...]:
     return tuple(payloads)
 
 
+def _bounded_rank_error(error: MpiRankError) -> MpiRankError:
+    encoded = str(error.message).encode("utf-8")
+    if len(encoded) <= _RANK_ERROR_MESSAGE_LIMIT_BYTES:
+        return error
+    clipped = encoded[:_RANK_ERROR_MESSAGE_LIMIT_BYTES].decode("utf-8", errors="replace")
+    return MpiRankError(error.rank, error.error_type, clipped + " [truncated]")
+
+
+def _encode_rank_errors(errors: tuple[MpiRankError, ...]) -> bytes:
+    """Serialize rank errors as JSON guaranteed to fit MAILBOX_ERROR_BYTES.
+
+    Oversized messages are clipped per rank; if the list itself does not fit,
+    trailing entries are replaced by one rank=-1 sentinel naming the dropped
+    count, so the stored blob always parses as JSON.
+    """
+    entries = [asdict(_bounded_rank_error(error)) for error in errors]
+    dropped = 0
+    while True:
+        payload = list(entries)
+        if dropped:
+            payload.append(
+                {
+                    "rank": -1,
+                    "error_type": "TruncatedErrorList",
+                    "message": f"{dropped} more rank errors were dropped",
+                }
+            )
+        data = json.dumps(payload, sort_keys=True).encode("utf-8")
+        if len(data) <= MAILBOX_ERROR_BYTES or not entries:
+            return data
+        entries.pop()
+        dropped += 1
+
+
 def _as_byte_view(buffer: memoryview) -> memoryview:
     """Normalize platform-specific shared-memory formats to a byte view."""
     return buffer.cast("B")
@@ -154,6 +206,9 @@ class MpiGroupMailbox:
         self._shm = shm
         self._owner = bool(owner)
         self._closed = False
+        # The mapping's base address is stable for the mapping's lifetime; the
+        # cache keeps the state-word hot path off repeated ctypes exports.
+        self._address = _buffer_address(self._buffer)
         self._validate_header()
 
     @classmethod
@@ -197,7 +252,7 @@ class MpiGroupMailbox:
     @property
     def address(self) -> int:
         self._require_open()
-        return ctypes.addressof(ctypes.c_char.from_buffer(self._buffer))
+        return self._address
 
     @property
     def world_size(self) -> int:
@@ -329,9 +384,7 @@ class MpiGroupMailbox:
         self._validate_active_sequence(sequence_id)
         if not errors:
             raise ValueError("MPI group mailbox failure requires at least one rank error")
-        data = json.dumps([asdict(error) for error in errors], sort_keys=True).encode("utf-8")
-        if len(data) > MAILBOX_ERROR_BYTES:
-            data = data[: MAILBOX_ERROR_BYTES - 1]
+        data = _encode_rank_errors(errors)
         self._write_bytes(MAILBOX_ERROR_OFFSET, data)
         self._write_u32(_OFF_ERROR_BYTES, len(data))
         if terminal:
@@ -378,9 +431,12 @@ class MpiGroupMailbox:
         error_bytes = min(self._read_u32(_OFF_ERROR_BYTES), MAILBOX_ERROR_BYTES)
         return self._read_bytes(MAILBOX_ERROR_OFFSET, error_bytes).decode("utf-8", errors="replace")
 
-    def overwrite_request_payload_for_test(self, data: bytes) -> None:
-        value = bytes(data)
-        self._write_bytes(MAILBOX_REQUEST_OFFSET, value)
+    def wait_request_state(self, expected: MailboxRequestState, *, timeout_s: float) -> None:
+        """Block until the request word differs from ``expected``, a peer wakes
+        the word, or ``timeout_s`` elapses. May return spuriously; callers
+        re-check the state."""
+        self._require_open()
+        _mailbox_wait_i32(self._address + _OFF_REQUEST_STATE, int(expected), float(timeout_s))
 
     def close(self, *, unlink: bool = False) -> None:
         if self._closed:
@@ -409,6 +465,8 @@ class MpiGroupMailbox:
             raise MpiGroupError("MPI group mailbox layout does not match the protocol")
         if self._read_u32(_OFF_WORLD_SIZE) == 0:
             raise MpiGroupError("MPI group mailbox world_size must be positive")
+        if any(bytes(self._buffer[_OFF_RESERVED:MAILBOX_HEADER_BYTES])):
+            raise MpiGroupError("MPI group mailbox reserved header bytes must be zero")
 
     def _validate_active_sequence(self, sequence_id: int) -> None:
         if self.request_state is not MailboxRequestState.TASK_ACCEPTED:
@@ -442,7 +500,7 @@ class MpiGroupMailbox:
         if offset < 0 or offset > len(buffer) or len(data) > len(buffer) - offset:
             raise ValueError("MPI group mailbox write is outside the mapping")
         if data:
-            ctypes.memmove(_buffer_address(buffer) + offset, data, len(data))
+            ctypes.memmove(self._address + offset, data, len(data))
 
     def _read_bytes(self, offset: int, length: int) -> bytes:
         self._require_open()
@@ -453,25 +511,19 @@ class MpiGroupMailbox:
             raise ValueError("MPI group mailbox read is outside the mapping")
         if length == 0:
             return b""
-        return ctypes.string_at(_buffer_address(buffer) + offset, length)
+        return ctypes.string_at(self._address + offset, length)
 
     def _load_i32(self, offset: int) -> int:
         self._require_open()
-        try:
-            from .task_interface import _mailbox_load_i32  # noqa: PLC0415
-        except (ImportError, AttributeError):
-            return self._read_i32(offset)
-        return int(_mailbox_load_i32(self.address + offset))
+        return int(_mailbox_load_i32(self._address + offset))
 
     def _store_i32(self, offset: int, value: int) -> None:
         self._require_open()
-        try:
-            from .task_interface import _mailbox_store_i32  # noqa: PLC0415
-        except (ImportError, AttributeError):
-            self._write_i32(offset, value)
-            return
-        _mailbox_store_i32(self.address + offset, int(value))
+        _mailbox_store_i32(self._address + offset, int(value))
 
+    # Plain field accessors: every non-state field is written before the
+    # release-store that publishes it and read after the acquire-load that
+    # observed it, so only the state words need the atomic helpers.
     def _read_i32(self, offset: int) -> int:
         return int(struct.unpack_from("<i", self._buffer, offset)[0])
 

--- a/python/simpler/mpi_l3_session.py
+++ b/python/simpler/mpi_l3_session.py
@@ -6,24 +6,20 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""MPI-launched Remote L3 session runner.
-
-Each mpirun rank runs one ordinary Remote L3 session. The L4 parent still owns
-the task/control lane over the existing RemoteL3 socket transport; MPI is used
-only when the full mpirun group participates in one Global CommDomain prepare.
-"""
+"""MPI L3 group runner driven by one rank-0 named shared-memory mailbox."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import math
-import os
+import queue
 import signal
-import socket
 import struct
 import sys
 import threading
+import time
+from dataclasses import dataclass
 from typing import Any
 
 from .global_comm_domain import (
@@ -34,12 +30,34 @@ from .global_comm_domain import (
     encode_descriptor_table,
     validate_descriptor_table,
 )
-from .remote_l3_session import _format_remote_error, run_session
+from .mpi_group_mailbox import (
+    MailboxGroupState,
+    MailboxOpcode,
+    MailboxRequest,
+    MailboxRequestState,
+    MailboxTarget,
+    MpiGroupMailbox,
+    MpiRankError,
+    open_rank_mailbox,
+)
+from .remote_l3_protocol import (
+    FrameHeader,
+    FrameType,
+    decode_frame,
+    encode_frame,
+)
+from .remote_l3_session import (
+    _format_remote_error,
+    _install_manifest_dispatcher_registry,
+    _install_manifest_inner_registry,
+    _run_command_loop,
+    _startup_deadline,
+)
 from .worker import Worker
 
 
 class MpiGlobalDomainExchange:
-    """Descriptor exchange hook for a full mpirun-launched L3 group."""
+    """Run Global CommDomain collectives on the dispatcher thread."""
 
     def __init__(self, comm: Any, *, group_worker_ids: tuple[int, ...], timeout_s: float) -> None:
         self._comm = comm
@@ -178,24 +196,87 @@ class MpiGlobalDomainExchange:
         return encode_descriptor_table(descriptors)
 
 
-def _write_ready_file(ready_dir: str, rank: int, payload: dict[str, Any]) -> None:
-    os.makedirs(ready_dir, exist_ok=True)
-    final_path = os.path.join(ready_dir, f"rank-{int(rank)}.json")
-    tmp_path = f"{final_path}.tmp.{os.getpid()}"
-    with open(tmp_path, "w", encoding="utf-8") as f:
-        json.dump(payload, f, sort_keys=True)
-        f.write("\n")
-    os.replace(tmp_path, final_path)
+@dataclass
+class _DomainRequest:
+    exchange: MpiGlobalDomainExchange
+    command: GlobalDomainCommand
+    inner_worker: Worker
+    worker_id: int
+    done: threading.Event
+    result: bytes | None = None
+    error: BaseException | None = None
+
+    def execute(self) -> None:
+        try:
+            self.result = self.exchange.prepare_import(self.command, self.inner_worker, self.worker_id)
+        except BaseException as exc:  # noqa: BLE001
+            self.error = exc
+        finally:
+            self.done.set()
 
 
-def _send_ready_tcp(host: str, port: int, payload: dict[str, Any]) -> None:
-    data = json.dumps(payload, sort_keys=True).encode("utf-8")
-    with socket.create_connection((host, int(port)), timeout=10.0) as sock:
-        sock.sendall(struct.pack("<I", len(data)) + data)
+class _DomainBridge:
+    def __init__(self, events: queue.Queue[tuple[str, Any]], exchange: MpiGlobalDomainExchange) -> None:
+        self._events = events
+        self._exchange = exchange
+
+    def prepare_import(self, command: GlobalDomainCommand, inner_worker: Worker, worker_id: int) -> bytes | None:
+        request = _DomainRequest(
+            self._exchange,
+            command,
+            inner_worker,
+            int(worker_id),
+            threading.Event(),
+        )
+        self._events.put(("domain", request))
+        request.done.wait()
+        if request.error is not None:
+            raise request.error
+        return request.result
 
 
-def _raise_keyboard_interrupt(_signum, _frame):
-    raise KeyboardInterrupt
+class _InMemoryCommandConnection:
+    """Socket-shaped blocking stream backed by queues, with no OS socket."""
+
+    def __init__(self) -> None:
+        self._incoming: queue.Queue[bytes] = queue.Queue()
+        self._events: queue.Queue[tuple[str, Any]] = queue.Queue()
+        self._recv_buffer = bytearray()
+
+    @property
+    def events(self) -> queue.Queue[tuple[str, Any]]:
+        return self._events
+
+    def recv(self, nbytes: int) -> bytes:
+        while not self._recv_buffer:
+            self._recv_buffer.extend(self._incoming.get())
+        count = min(int(nbytes), len(self._recv_buffer))
+        data = bytes(self._recv_buffer[:count])
+        del self._recv_buffer[:count]
+        return data
+
+    def sendall(self, data: bytes) -> None:
+        self._events.put(("reply", bytes(data)))
+
+    def feed(self, frame: bytes) -> None:
+        self._incoming.put(bytes(frame))
+
+    def next_reply(self) -> bytes:
+        while True:
+            kind, value = self._events.get()
+            if kind == "domain":
+                value.execute()
+                continue
+            if kind == "processor_error":
+                error_type, message = value
+                raise RuntimeError(f"{error_type}: {message}")
+            if kind != "reply":
+                raise RuntimeError(f"MPI command processor emitted unknown event {kind!r}")
+            return bytes(value)
+
+    def exchange(self, frame: bytes) -> bytes:
+        self.feed(frame)
+        return self.next_reply()
 
 
 def _load_group_manifest_from_rank0(comm: Any, manifest_path: str) -> dict[str, Any]:
@@ -216,6 +297,307 @@ def _load_group_manifest_from_rank0(comm: Any, manifest_path: str) -> dict[str, 
     return value
 
 
+def _rewrite_frame_identity(
+    frame_bytes: bytes,
+    manifest: dict[str, Any],
+    *,
+    sequence: int | None = None,
+) -> bytes:
+    frame = decode_frame(frame_bytes)
+    header = FrameHeader(
+        frame_type=frame.header.frame_type,
+        session_id=int(manifest["session_id"]),
+        worker_id=int(manifest["worker_id"]),
+        sequence=frame.header.sequence if sequence is None else int(sequence),
+        flags=frame.header.flags,
+    )
+    return encode_frame(header, frame.payload)
+
+
+def _reply_error(reply_bytes: bytes) -> tuple[str, str] | None:
+    frame = decode_frame(reply_bytes)
+    if frame.header.frame_type is FrameType.COMPLETION:
+        if len(frame.payload) < 16:
+            return ("ProtocolError", "truncated completion reply")
+        _sequence, error_code, message_bytes = struct.unpack_from("<QiI", frame.payload)
+        offset = 16
+    elif frame.header.frame_type is FrameType.CONTROL_REPLY:
+        if len(frame.payload) < 24:
+            return ("ProtocolError", "truncated control reply")
+        _sequence, _control, _version, error_code, message_bytes = struct.unpack_from("<QIIiI", frame.payload)
+        offset = 24
+    else:
+        return None
+    if message_bytes > len(frame.payload) - offset:
+        return ("ProtocolError", "reply error message is truncated")
+    if error_code == 0:
+        return None
+    message = frame.payload[offset : offset + message_bytes].decode("utf-8", errors="replace")
+    return ("RemoteOperationError", message)
+
+
+def _payload_for_rank(request: MailboxRequest, rank: int) -> bytes | None:
+    if request.target is MailboxTarget.GROUP:
+        return request.payloads[0]
+    if request.target is MailboxTarget.RANK:
+        return request.payloads[0] if rank == request.target_rank else None
+    if request.target is MailboxTarget.PER_RANK:
+        return request.payloads[rank]
+    raise ValueError(f"unsupported MPI mailbox target {request.target}")
+
+
+def _shutdown_frame(manifest: dict[str, Any]) -> bytes:
+    return encode_frame(
+        FrameHeader(
+            frame_type=FrameType.SHUTDOWN,
+            session_id=int(manifest["session_id"]),
+            worker_id=int(manifest["worker_id"]),
+            sequence=0,
+        ),
+        b"",
+    )
+
+
+def _select_mailbox_replies(
+    request: MailboxRequest,
+    gathered: list[tuple[int, bool, bytes, MpiRankError | None]],
+    worker_ids: tuple[int, ...],
+) -> tuple[bytes, ...]:
+    def _for_request(reply: bytes, request_frame: bytes) -> bytes:
+        if not reply:
+            return b""
+        decoded_reply = decode_frame(reply)
+        decoded_request = decode_frame(request_frame)
+        reply_payload = bytearray(decoded_reply.payload)
+        if decoded_reply.header.frame_type in (FrameType.COMPLETION, FrameType.CONTROL_REPLY):
+            if len(reply_payload) < 8:
+                raise RuntimeError("MPI rank reply is truncated before its sequence field")
+            struct.pack_into("<Q", reply_payload, 0, decoded_request.header.sequence)
+        return encode_frame(
+            FrameHeader(
+                frame_type=decoded_reply.header.frame_type,
+                session_id=decoded_request.header.session_id,
+                worker_id=decoded_request.header.worker_id,
+                sequence=decoded_request.header.sequence,
+                flags=decoded_reply.header.flags,
+            ),
+            bytes(reply_payload),
+        )
+
+    replies_by_rank = {int(result_rank): bytes(reply) for result_rank, executed, reply, _error in gathered if executed}
+    if request.target is MailboxTarget.GROUP and request.payloads and request.payloads[0]:
+        requested_worker_id = int(decode_frame(request.payloads[0]).header.worker_id)
+        if requested_worker_id in worker_ids:
+            requested_rank = worker_ids.index(requested_worker_id)
+            return (_for_request(replies_by_rank.get(requested_rank, b""), request.payloads[0]),)
+    if request.target is MailboxTarget.RANK:
+        return (_for_request(replies_by_rank.get(request.target_rank, b""), request.payloads[0]),)
+    if request.target is MailboxTarget.PER_RANK:
+        return tuple(
+            _for_request(replies_by_rank.get(reply_rank, b""), request.payloads[reply_rank])
+            for reply_rank in range(len(request.payloads))
+        )
+    return tuple(replies_by_rank[reply_rank] for reply_rank in sorted(replies_by_rank)) or (b"",)
+
+
+def _run_group_session(  # noqa: PLR0912, PLR0915 -- startup, ordered dispatch, gather, and teardown stay linear
+    *,
+    dispatch_comm: Any,
+    domain_comm: Any,
+    group_manifest: dict[str, Any],
+    manifest: dict[str, Any],
+) -> int:
+    rank = int(dispatch_comm.Get_rank())
+    worker_ids = tuple(int(value) for value in group_manifest["worker_ids"])
+    mailbox: MpiGroupMailbox | None = None
+    inner_worker = Worker(
+        level=3,
+        platform=str(manifest["platform"]),
+        runtime=str(manifest.get("runtime", "tensormap_and_ringbuffer")),
+        device_ids=tuple(int(value) for value in manifest.get("device_ids", ())),
+        num_sub_workers=int(manifest.get("num_sub_workers", 0)),
+        heap_ring_size=int(manifest["heap_ring_size"]) if manifest.get("heap_ring_size") is not None else None,
+    )
+    connection = _InMemoryCommandConnection()
+    processor_thread: threading.Thread | None = None
+    startup_ok = True
+    startup_error = ""
+
+    try:
+        dispatch_registry = _install_manifest_dispatcher_registry(manifest)
+        inner_handles = _install_manifest_inner_registry(manifest, inner_worker)
+        inner_worker.init(_startup_deadline=_startup_deadline(manifest))
+        exchange = MpiGlobalDomainExchange(
+            domain_comm,
+            group_worker_ids=worker_ids,
+            timeout_s=float(manifest["session_timeout_s"]),
+        )
+        bridge = _DomainBridge(connection.events, exchange)
+
+        def _processor() -> None:
+            try:
+                _run_command_loop(
+                    connection,  # type: ignore[arg-type]
+                    manifest,
+                    inner_worker,
+                    inner_handles,
+                    dispatch_registry,
+                    bridge.prepare_import,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                connection.events.put(("processor_error", (type(exc).__name__, str(exc))))
+
+        processor_thread = threading.Thread(target=_processor, name=f"simpler-mpi-command-rank-{rank}")
+        processor_thread.start()
+        hello = decode_frame(connection.next_reply())
+        if hello.header.frame_type is not FrameType.HELLO:
+            raise RuntimeError("MPI command processor did not publish HELLO")
+    except BaseException as exc:  # noqa: BLE001
+        startup_ok = False
+        startup_error = _format_remote_error(f"MPI rank {rank} startup", exc)
+
+    readiness = dispatch_comm.allgather((rank, startup_ok, startup_error))
+    mailbox_ready = True
+    mailbox_error = ""
+    if rank == 0:
+        try:
+            mailbox = open_rank_mailbox(group_manifest["mailbox"], rank=rank)
+            assert mailbox is not None
+            failures = [(ready_rank, error) for ready_rank, ok, error in readiness if not ok]
+            if failures:
+                mailbox_error = "; ".join(f"rank {ready_rank}: {error}" for ready_rank, error in failures)
+                mailbox.mark_terminal(mailbox_error)
+                mailbox_ready = False
+            else:
+                mailbox.publish_ready()
+        except BaseException as exc:  # noqa: BLE001
+            mailbox_ready = False
+            mailbox_error = _format_remote_error("MPI rank 0 mailbox startup", exc)
+            if mailbox is not None:
+                mailbox.mark_terminal(mailbox_error)
+    mailbox_ready, mailbox_error = dispatch_comm.bcast((mailbox_ready, mailbox_error), root=0)
+    if not mailbox_ready:
+        if processor_thread is not None:
+            connection.feed(_shutdown_frame(manifest))
+            processor_thread.join(timeout=1.0)
+        inner_worker.close()
+        if mailbox is not None:
+            mailbox.close()
+        return 1
+
+    last_sequence_id = 0
+    local_command_sequence = 0
+    session_timeout_s = float(manifest["session_timeout_s"])
+    exit_code = 0
+    try:
+        while True:
+            if rank == 0:
+                assert mailbox is not None
+                request_wait_deadline = time.monotonic() + session_timeout_s
+                while True:
+                    request_state = mailbox.request_state
+                    if request_state in (
+                        MailboxRequestState.REQUEST_READY,
+                        MailboxRequestState.SHUTDOWN_READY,
+                    ):
+                        break
+                    if mailbox.group_state is MailboxGroupState.TERMINAL:
+                        break
+                    now = time.monotonic()
+                    if request_state is MailboxRequestState.IDLE:
+                        request_wait_deadline = now + session_timeout_s
+                    elif now >= request_wait_deadline:
+                        mailbox.mark_terminal(f"MPI group mailbox request lane stalled in state {request_state.name}")
+                        break
+                if mailbox.group_state is MailboxGroupState.TERMINAL:
+                    request = None
+                else:
+                    try:
+                        request = mailbox.accept_request(last_sequence_id=last_sequence_id)
+                        last_sequence_id = request.sequence_id
+                    except Exception as exc:
+                        mailbox.mark_terminal(_format_remote_error("MPI rank 0 mailbox request", exc))
+                        request = None
+            else:
+                request = None
+            request = dispatch_comm.bcast(request, root=0)
+            if request is None:
+                exit_code = 1
+                break
+
+            local_reply = b""
+            local_error: MpiRankError | None = None
+            payload = None
+            try:
+                payload = _payload_for_rank(request, rank)
+                if request.opcode is MailboxOpcode.PING:
+                    local_reply = b""
+                elif request.opcode is MailboxOpcode.SHUTDOWN:
+                    assert payload is not None
+                    connection.feed(_rewrite_frame_identity(payload, manifest))
+                elif payload is not None:
+                    local_command_sequence += 1
+                    local_reply = connection.exchange(
+                        _rewrite_frame_identity(payload, manifest, sequence=local_command_sequence)
+                    )
+            except BaseException as exc:  # noqa: BLE001
+                local_error = MpiRankError(rank, type(exc).__name__, str(exc))
+
+            gathered = dispatch_comm.gather((rank, payload is not None, local_reply, local_error), root=0)
+            terminal_dispatch_failure = False
+            if rank == 0:
+                assert mailbox is not None and gathered is not None
+                transport_errors = tuple(item[3] for item in gathered if item[3] is not None)
+                application_errors: list[MpiRankError] = []
+                for result_rank, executed, reply, _error in gathered:
+                    if not executed or not reply:
+                        continue
+                    decoded_error = _reply_error(reply)
+                    if decoded_error is not None:
+                        error_type, message = decoded_error
+                        application_errors.append(MpiRankError(int(result_rank), error_type, message))
+                if transport_errors:
+                    mailbox.fail_request(
+                        sequence_id=request.sequence_id,
+                        errors=transport_errors,
+                        terminal=True,
+                    )
+                    exit_code = 1
+                    terminal_dispatch_failure = True
+                elif application_errors:
+                    mailbox.fail_request(
+                        sequence_id=request.sequence_id,
+                        errors=tuple(application_errors),
+                        terminal=False,
+                    )
+                elif request.opcode is MailboxOpcode.SHUTDOWN:
+                    mailbox.complete_shutdown(sequence_id=request.sequence_id)
+                    mailbox.publish_closed()
+                else:
+                    replies = _select_mailbox_replies(request, gathered, worker_ids)
+                    mailbox.complete_request(sequence_id=request.sequence_id, payloads=replies)
+            terminal_dispatch_failure = dispatch_comm.bcast(terminal_dispatch_failure, root=0)
+            if terminal_dispatch_failure:
+                break
+            if request.opcode is MailboxOpcode.SHUTDOWN:
+                break
+    finally:
+        if processor_thread is not None:
+            if processor_thread.is_alive():
+                connection.feed(_shutdown_frame(manifest))
+            processor_thread.join(timeout=5.0)
+        try:
+            inner_worker.close()
+        finally:
+            if mailbox is not None:
+                mailbox.close()
+    return exit_code
+
+
+def _raise_keyboard_interrupt(_signum, _frame):
+    raise KeyboardInterrupt
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--group-manifest", required=True)
@@ -227,46 +609,30 @@ def main(argv: list[str] | None = None) -> int:
     except ImportError as exc:
         raise RuntimeError("simpler.mpi_l3_session requires mpi4py inside the mpirun Python environment") from exc
 
-    comm = MPI.COMM_WORLD
-    rank = int(comm.Get_rank())
-    world_size = int(comm.Get_size())
-
-    group_manifest = _load_group_manifest_from_rank0(comm, ns.group_manifest)
+    world = MPI.COMM_WORLD
+    group_manifest = _load_group_manifest_from_rank0(world, ns.group_manifest)
     rank_manifests = group_manifest.get("rank_manifests")
     if not isinstance(rank_manifests, list):
         raise ValueError("MPI L3 group manifest requires a rank_manifests list")
-    if len(rank_manifests) != world_size:
+    world_size = int(world.Get_size())
+    rank = int(world.Get_rank())
+    if len(rank_manifests) != world_size or int(group_manifest.get("world_size", -1)) != world_size:
         raise ValueError("MPI L3 group manifest world size does not match MPI_COMM_WORLD")
-    manifest = dict(rank_manifests[rank])
-    group_worker_ids = tuple(int(x) for x in group_manifest.get("worker_ids", ()))
-    if len(group_worker_ids) != world_size:
+    if len(group_manifest.get("worker_ids", ())) != world_size:
         raise ValueError("MPI L3 group manifest worker_ids must match MPI_COMM_WORLD size")
 
-    ready_dir = str(group_manifest["ready_dir"])
-    ready_host = str(group_manifest.get("ready_host") or "")
-    ready_port = int(group_manifest.get("ready_port") or 0)
-    ready_token = str(group_manifest.get("ready_token") or "")
-
-    def ready_writer(payload: dict[str, Any]) -> None:
-        payload = dict(payload)
-        payload["mpi_rank"] = rank
-        if ready_host:
-            payload["ready_token"] = ready_token
-            _send_ready_tcp(ready_host, ready_port, payload)
-        else:
-            _write_ready_file(ready_dir, rank, payload)
-
-    exchange = MpiGlobalDomainExchange(
-        comm,
-        group_worker_ids=group_worker_ids,
-        timeout_s=float(manifest["session_timeout_s"]),
-    )
-    return run_session(
-        manifest,
-        None,
-        ready_writer=ready_writer,
-        global_domain_prepare_import=exchange.prepare_import,
-    )
+    dispatch_comm = world.Dup()
+    domain_comm = world.Dup()
+    try:
+        return _run_group_session(
+            dispatch_comm=dispatch_comm,
+            domain_comm=domain_comm,
+            group_manifest=group_manifest,
+            manifest=dict(rank_manifests[rank]),
+        )
+    finally:
+        domain_comm.Free()
+        dispatch_comm.Free()
 
 
 if __name__ == "__main__":

--- a/python/simpler/mpi_l3_session.py
+++ b/python/simpler/mpi_l3_session.py
@@ -55,6 +55,11 @@ from .remote_l3_session import (
 )
 from .worker import Worker
 
+# Upper bound on one rank-0 park on the request word. An L4 publish wakes the
+# wait immediately; the bound only caps how long a lost wake or an untracked
+# state change can defer the next predicate re-check.
+_REQUEST_WAIT_CHUNK_S = 1.0
+
 
 class MpiGlobalDomainExchange:
     """Run Global CommDomain collectives on the dispatcher thread."""
@@ -509,6 +514,10 @@ def _run_group_session(  # noqa: PLR0912, PLR0915 -- startup, ordered dispatch, 
                     elif now >= request_wait_deadline:
                         mailbox.mark_terminal(f"MPI group mailbox request lane stalled in state {request_state.name}")
                         break
+                    mailbox.wait_request_state(
+                        request_state,
+                        timeout_s=min(_REQUEST_WAIT_CHUNK_S, max(request_wait_deadline - now, 0.0)),
+                    )
                 if mailbox.group_state is MailboxGroupState.TERMINAL:
                     request = None
                 else:

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -369,6 +369,10 @@ class Orchestrator:
 
         ``workers`` contains the exact stable NEXT_LEVEL worker id for each
         member. For L3 chip dispatch, these are the existing chip worker ids.
+        When ``workers`` is the complete worker-id set of one MPI L3 group,
+        ``args_list`` becomes one per-rank mailbox request: MPI rank
+        ``workers[i]`` executes only ``args_list[i]``. A single worker id remains
+        directed and is never silently widened to the whole group.
         """
         cfg = config if config is not None else CallConfig()
         worker_ids = [_require_next_level_worker_id(value, argument="workers entries") for value in workers]
@@ -376,6 +380,21 @@ class Orchestrator:
             raise ValueError("workers length must match args_list length")
         if len(set(worker_ids)) != len(worker_ids):
             raise ValueError("workers must not contain duplicate NEXT_LEVEL worker ids")
+        if self._worker is not None:
+            # The mailbox transport batches a dispatch whose size equals its MPI
+            # world size, so a same-sized selection that is not exactly the
+            # group would strand the group members in the batch rendezvous.
+            for mpi_group in getattr(self._worker, "_mpi_l3_groups", ()):
+                group_workers = {rank.worker_id for rank in mpi_group.ranks}
+                if (
+                    group_workers.intersection(worker_ids)
+                    and len(worker_ids) == len(group_workers)
+                    and set(worker_ids) != group_workers
+                ):
+                    raise ValueError(
+                        "submit_next_level_group: workers mixes MPI group members with other workers at the "
+                        "group's world size; target exactly the full MPI group or a smaller directed subset"
+                    )
         expected_namespace = (
             None
             if isinstance(callable_handle, CallableHandle)

--- a/python/simpler/remote_l3_protocol.py
+++ b/python/simpler/remote_l3_protocol.py
@@ -49,6 +49,13 @@ REMOTE_BUFFER_ACCESS_WRITE = 1 << 1
 REMOTE_BUFFER_ACCESS_READ_WRITE = REMOTE_BUFFER_ACCESS_READ | REMOTE_BUFFER_ACCESS_WRITE
 CALLABLE_HASH_DIGEST_BYTES = 32
 FRAME_HEADER_BYTES = 40
+
+# FrameHeader.flags bit: the caller addresses every member of the target's
+# worker group, not just the worker named in the header. Only group-capable
+# transports (the MPI mailbox) act on it; point-to-point transports ignore it.
+FRAME_FLAG_GROUP_TARGET = 0x1
+# Every defined flag bit; a frame carrying any other bit is rejected.
+FRAME_FLAGS_KNOWN = FRAME_FLAG_GROUP_TARGET
 MAGIC = b"SLR3"
 
 
@@ -359,8 +366,8 @@ def _validate_import_result_identity(result: ImportBufferResult) -> None:
 def encode_frame(header: FrameHeader, payload: bytes) -> bytes:
     if len(payload) > MAX_FRAME_PAYLOAD_BYTES:
         raise ValueError("remote_wire: frame payload exceeds maximum")
-    if header.flags != 0:
-        raise ValueError("remote_wire: frame flags are reserved in v1")
+    if header.flags & ~FRAME_FLAGS_KNOWN:
+        raise ValueError("remote_wire: unknown frame flags")
     return (
         MAGIC
         + struct.pack(
@@ -389,8 +396,8 @@ def decode_frame(data: bytes) -> Frame:
         frame_type = FrameType(raw_type)
     except ValueError as exc:
         raise ValueError("remote_wire: unknown frame type") from exc
-    if flags != 0:
-        raise ValueError("remote_wire: frame flags are reserved in v1")
+    if flags & ~FRAME_FLAGS_KNOWN:
+        raise ValueError("remote_wire: unknown frame flags")
     if payload_bytes > MAX_FRAME_PAYLOAD_BYTES:
         raise ValueError("remote_wire: frame payload exceeds maximum")
     if len(data) - FRAME_HEADER_BYTES != payload_bytes:

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1175,8 +1175,8 @@ class GlobalCommDomainHandle:
     def release(self) -> None:
         if self._released:
             return
-        self._release_fn(self)
         self._released = True
+        self._release_fn(self)
 
     def __enter__(self) -> GlobalCommDomainHandle:
         return self

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -713,18 +713,25 @@ class RemoteWorkerSpec:
 
 @dataclass(frozen=True)
 class MpiL3GroupSpec:
-    """Describes a group of L3 workers launched by one parent-owned ``mpirun``."""
+    """Describes L3 workers launched by one parent-owned ``mpirun``.
+
+    ``command_port_base``, ``health_port_base``, ``session_listen_hosts``,
+    ``connect_hosts``, ``allow_wildcard_session_bind``, ``ready_host``, and
+    ``ready_port`` are accepted only for source compatibility with PR #1623.
+    MPI groups ignore them and use the local named mailbox plus MPI collectives.
+    Non-MPI ``RemoteWorkerSpec`` continues to use its TCP fields.
+    """
 
     hosts: tuple[str, ...]
     platform: str
-    command_port_base: int
-    health_port_base: int
     device_ids_by_rank: tuple[tuple[int, ...], ...]
     runtime: str = "tensormap_and_ringbuffer"
     num_sub_workers_by_rank: tuple[int, ...] = ()
     transport: str = HOST_TCP_TRANSPORT_PROFILE
     comm_profile: str = "sim"
     global_device_ranks_by_rank: tuple[tuple[int, ...], ...] = ()
+    command_port_base: int | None = None
+    health_port_base: int | None = None
     session_listen_hosts: tuple[str, ...] = ()
     connect_hosts: tuple[str, ...] = ()
     allow_wildcard_session_bind: bool = False
@@ -775,30 +782,25 @@ class MpiL3GroupSpec:
         flat_global_ranks = [rank for ranks in global_device_ranks_by_rank for rank in ranks]
         if len(set(flat_global_ranks)) != len(flat_global_ranks):
             raise ValueError("MpiL3GroupSpec.global_device_ranks_by_rank must be unique across the whole group")
-        session_listen_hosts = (
-            hosts if not self.session_listen_hosts else tuple(str(host) for host in self.session_listen_hosts)
-        )
-        connect_hosts = hosts if not self.connect_hosts else tuple(str(host) for host in self.connect_hosts)
-        if len(session_listen_hosts) != len(hosts):
+        session_listen_hosts = tuple(str(host) for host in self.session_listen_hosts)
+        connect_hosts = tuple(str(host) for host in self.connect_hosts)
+        if session_listen_hosts and len(session_listen_hosts) != len(hosts):
             raise ValueError("MpiL3GroupSpec.session_listen_hosts must match hosts length")
-        if len(connect_hosts) != len(hosts):
+        if connect_hosts and len(connect_hosts) != len(hosts):
             raise ValueError("MpiL3GroupSpec.connect_hosts must match hosts length")
         if any(not host for host in session_listen_hosts) or any(not host for host in connect_hosts):
             raise ValueError("MpiL3GroupSpec host fields must be non-empty")
-        command_port_base = int(self.command_port_base)
-        health_port_base = int(self.health_port_base)
-        last_command_port = command_port_base + len(hosts) - 1
-        last_health_port = health_port_base + len(hosts) - 1
-        if command_port_base <= 0 or health_port_base <= 0 or last_command_port > 65535 or last_health_port > 65535:
-            raise ValueError("MpiL3GroupSpec command/health port ranges must be within 1..65535")
+        command_port_base = None if self.command_port_base is None else int(self.command_port_base)
+        health_port_base = None if self.health_port_base is None else int(self.health_port_base)
+        for name, value in (("command_port_base", command_port_base), ("health_port_base", health_port_base)):
+            if value is not None and (value <= 0 or value + len(hosts) - 1 > 65535):
+                raise ValueError(f"MpiL3GroupSpec.{name} deprecated port range must be within 1..65535")
         ready_host = str(self.ready_host)
         ready_port = int(self.ready_port)
         if ready_port < 0 or ready_port > 65535:
             raise ValueError("MpiL3GroupSpec.ready_port must be within 0..65535")
         if self.transport != HOST_TCP_TRANSPORT_PROFILE:
-            raise ValueError(
-                f"MpiL3GroupSpec.transport must be {HOST_TCP_TRANSPORT_PROFILE!r} for the TCP control plane"
-            )
+            raise ValueError(f"MpiL3GroupSpec.transport must be {HOST_TCP_TRANSPORT_PROFILE!r}")
         _validate_global_comm_capability("MpiL3GroupSpec", self.platform, self.comm_profile)
         if not self.mpirun_path:
             raise ValueError("MpiL3GroupSpec.mpirun_path must be non-empty")
@@ -836,15 +838,23 @@ class _RemoteSession:
 
 
 @dataclass(frozen=True)
+class _MpiL3RankSpec:
+    platform: str
+    runtime: str
+    device_ids: tuple[int, ...]
+    num_sub_workers: int
+    transport: str
+    comm_profile: str
+    global_device_ranks: tuple[int, ...]
+
+
+@dataclass(frozen=True)
 class _MpiL3RankRuntime:
     group_id: str
     rank: int
     worker_id: int
-    spec: RemoteWorkerSpec
-    command_host: str
-    command_port: int
-    health_host: str
-    health_port: int
+    session_id: int
+    spec: _MpiL3RankSpec
 
 
 @dataclass
@@ -855,6 +865,9 @@ class _MpiL3GroupRuntime:
     process: subprocess.Popen[Any] | None = None
     manifest_path: str | None = None
     ready_dir: str | None = None
+    mailbox: Any | None = None
+    monitor_thread: threading.Thread | None = None
+    closing: bool = False
 
 
 @dataclass(frozen=True)
@@ -4711,10 +4724,9 @@ class Worker:
     def add_mpirun_worker_group(self, spec: MpiL3GroupSpec) -> tuple[int, ...]:
         """Register L3 workers that will be launched by one parent-owned ``mpirun``.
 
-        The returned ids are ordinary NEXT_LEVEL worker ids for dispatch and
-        Global CommDomain membership. They must be used as a complete set for
-        the v1 MPI descriptor-exchange path; partial groups fall back to the
-        existing L4 descriptor broker.
+        A single named mailbox is created for the group during ``init()``.
+        The returned ids remain exact NEXT_LEVEL targets, but all of them route
+        through that group mailbox and the MPI collective dispatcher.
         """
         with self._hierarchical_start_cv:
             if self._lifecycle is not _Lifecycle.NEW:
@@ -4723,33 +4735,12 @@ class Worker:
                 raise TypeError("Worker.add_mpirun_worker_group: MPI L3 groups require a level >= 4 parent")
             if not isinstance(spec, MpiL3GroupSpec):
                 raise TypeError("Worker.add_mpirun_worker_group expects a MpiL3GroupSpec")
-            for host in spec.connect_hosts:
-                self._validate_numeric_endpoint_host(host)
-            if spec.ready_host:
-                self._validate_numeric_endpoint_host(spec.ready_host)
-            seen_listeners: set[tuple[str, int]] = set()
-            for rank, listen_host in enumerate(spec.session_listen_hosts):
-                if self._is_wildcard_session_host(listen_host):
-                    if not spec.allow_wildcard_session_bind:
-                        raise ValueError(
-                            "MpiL3GroupSpec wildcard session bind requires allow_wildcard_session_bind=True"
-                        )
-                else:
-                    self._validate_numeric_endpoint_host(listen_host)
-                for port in (spec.command_port_base + rank, spec.health_port_base + rank):
-                    key = (listen_host, int(port))
-                    if key in seen_listeners:
-                        raise ValueError("MpiL3GroupSpec command/health ports overlap on the same listen host")
-                    seen_listeners.add(key)
 
             group_id = uuid.uuid4().hex
             ranks: list[_MpiL3RankRuntime] = []
-            for rank, connect_host in enumerate(spec.connect_hosts):
+            for rank in range(len(spec.hosts)):
                 worker_id = self._allocate_next_level_worker_id()
-                command_port = spec.command_port_base + rank
-                health_port = spec.health_port_base + rank
-                rank_spec = RemoteWorkerSpec(
-                    endpoint=f"{connect_host}:{command_port}",
+                rank_spec = _MpiL3RankSpec(
                     platform=spec.platform,
                     runtime=spec.runtime,
                     device_ids=spec.device_ids_by_rank[rank],
@@ -4757,18 +4748,13 @@ class Worker:
                     transport=spec.transport,
                     comm_profile=spec.comm_profile,
                     global_device_ranks=spec.global_device_ranks_by_rank[rank],
-                    session_listen_host=spec.session_listen_hosts[rank],
-                    allow_wildcard_session_bind=spec.allow_wildcard_session_bind,
                 )
                 runtime = _MpiL3RankRuntime(
                     group_id=group_id,
                     rank=rank,
                     worker_id=worker_id,
+                    session_id=self._new_remote_session_id(),
                     spec=rank_spec,
-                    command_host=connect_host,
-                    command_port=command_port,
-                    health_host=connect_host,
-                    health_port=health_port,
                 )
                 ranks.append(runtime)
                 self._mpi_worker_ids.append(worker_id)
@@ -4918,7 +4904,7 @@ class Worker:
             )
         return entries
 
-    def _inner_registry_entries_for_spec(self, spec: RemoteWorkerSpec) -> list[dict[str, Any]]:
+    def _inner_registry_entries_for_spec(self, spec: RemoteWorkerSpec | _MpiL3RankSpec) -> list[dict[str, Any]]:
         from .remote_l3_protocol import (  # noqa: PLC0415
             ChipCallableBlobLocation,
             RemoteChipCallablePayload,
@@ -5115,6 +5101,37 @@ class Worker:
             "feature_flags": [],
         }
 
+    def _build_mpi_rank_manifest(
+        self,
+        *,
+        rank: _MpiL3RankRuntime,
+        startup_remaining_s: float,
+    ) -> dict[str, Any]:
+        spec = rank.spec
+        runtime = self._resolved_global_nodes()[int(rank.worker_id)]
+        return {
+            "session_id": int(rank.session_id),
+            "parent_worker_level": int(self.level),
+            "remote_worker_level": 3,
+            "worker_id": int(rank.worker_id),
+            "platform": spec.platform,
+            "runtime": spec.runtime,
+            "device_ids": list(spec.device_ids),
+            "num_sub_workers": int(spec.num_sub_workers),
+            "heap_ring_size": self._config.get("remote_heap_ring_size", None),
+            "transport": spec.transport,
+            "comm_profile": spec.comm_profile,
+            "cluster_id": self._global_cluster_id,
+            "node_rank": runtime.node_rank,
+            "node_count": runtime.node_count,
+            "global_device_ranks": list(runtime.global_device_ranks),
+            "session_timeout_s": self._remote_session_timeout_s(),
+            "startup_remaining_s": float(startup_remaining_s),
+            "remote_task_dispatcher": self._remote_dispatcher_entries_for_worker(rank.worker_id),
+            "inner_l3_worker": self._inner_registry_entries_for_spec(spec),
+            "feature_flags": ["mpi-group-mailbox-v1"],
+        }
+
     def _open_remote_session(
         self, *, spec: RemoteWorkerSpec, worker_id: int, session_id: int, deadline: float
     ) -> _RemoteSession:
@@ -5178,86 +5195,13 @@ class Worker:
         return any(arg in host_args or arg.startswith("--host=") or arg.startswith("--hostfile=") for arg in args)
 
     @staticmethod
-    def _mpi_ready_path(ready_dir: str, rank: int) -> str:
-        return os.path.join(ready_dir, f"rank-{int(rank)}.json")
-
-    def _wait_mpi_ready_files(self, group: _MpiL3GroupRuntime, deadline: float) -> dict[int, dict[str, Any]]:
-        if group.ready_dir is None:
-            raise RuntimeError("MPI L3 group has no ready directory")
-        pending = {rank.rank for rank in group.ranks}
-        ready: dict[int, dict[str, Any]] = {}
-        while pending:
-            if group.process is not None and group.process.poll() is not None:
-                raise RuntimeError(
-                    f"MPI L3 group {group.group_id} exited before ranks became ready "
-                    f"(status {group.process.returncode})"
-                )
-            for rank in list(pending):
-                path = self._mpi_ready_path(group.ready_dir, rank)
-                try:
-                    with open(path, encoding="utf-8") as f:
-                        payload = json.load(f)
-                except FileNotFoundError:
-                    continue
-                if not payload.get("ok", False):
-                    raise RuntimeError(f"MPI L3 rank {rank} startup failed: {payload.get('error')}")
-                ready[rank] = payload
-                pending.remove(rank)
-            if pending:
-                remaining = self._remaining_until(deadline, "MPI L3 group ready")
-                time.sleep(min(0.05, remaining))
-        return ready
-
-    @staticmethod
-    def _open_mpi_ready_listener(host: str, port: int) -> socket.socket:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind((host, int(port)))
-            sock.listen()
-            return sock
-        except BaseException:
-            sock.close()
-            raise
-
-    def _wait_mpi_ready_tcp(
-        self,
+    def _close_mpirun_group(  # noqa: PLR0912 -- cleanup reports every independent process/resource failure
         group: _MpiL3GroupRuntime,
-        ready_sock: socket.socket,
-        ready_token: str,
-        deadline: float,
-    ) -> dict[int, dict[str, Any]]:
-        pending = {rank.rank for rank in group.ranks}
-        ready: dict[int, dict[str, Any]] = {}
-        while pending:
-            if group.process is not None and group.process.poll() is not None:
-                raise RuntimeError(
-                    f"MPI L3 group {group.group_id} exited before ranks became ready "
-                    f"(status {group.process.returncode})"
-                )
-            ready_sock.settimeout(min(0.2, self._remaining_until(deadline, "MPI L3 TCP ready")))
-            try:
-                conn, _addr = ready_sock.accept()
-            except TimeoutError:
-                continue
-            except socket.timeout:
-                continue
-            with conn:
-                payload = self._recv_remote_daemon_json(conn, deadline)
-            rank_value = int(payload.get("mpi_rank", -1))
-            if payload.get("ready_token") != ready_token:
-                raise RuntimeError("MPI L3 rank published ready with an unexpected token")
-            if rank_value not in pending:
-                raise RuntimeError(f"MPI L3 rank published duplicate or unexpected ready rank={rank_value}")
-            if not payload.get("ok", False):
-                raise RuntimeError(f"MPI L3 rank {rank_value} startup failed: {payload.get('error')}")
-            ready[rank_value] = payload
-            pending.remove(rank_value)
-        return ready
-
-    @staticmethod
-    def _close_mpirun_group(group: _MpiL3GroupRuntime, *, timeout_s: float) -> list[str]:
+        *,
+        timeout_s: float,
+    ) -> list[str]:
         failures: list[str] = []
+        group.closing = True
         proc = group.process
         if proc is not None:
             try:
@@ -5271,14 +5215,18 @@ class Worker:
                         proc.wait(timeout=timeout_s)
                 if proc.poll() is None:
                     try:
-                        proc.terminate()
+                        os.killpg(proc.pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
                     except BaseException as exc:  # noqa: BLE001
                         failures.append(f"terminate: {exc}")
                 try:
                     proc.wait(timeout=timeout_s)
                 except subprocess.TimeoutExpired:
                     try:
-                        proc.kill()
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
                     except BaseException as exc:  # noqa: BLE001
                         failures.append(f"kill: {exc}")
                     try:
@@ -5289,6 +5237,16 @@ class Worker:
                     failures.append(f"wait after terminate: {exc}")
             finally:
                 group.process = None
+        if group.monitor_thread is not None:
+            group.monitor_thread.join(timeout=timeout_s)
+            group.monitor_thread = None
+        if group.mailbox is not None:
+            try:
+                group.mailbox.close(unlink=True)
+            except BaseException as exc:  # noqa: BLE001
+                failures.append(f"close mailbox: {exc}")
+            finally:
+                group.mailbox = None
         try:
             if group.ready_dir is not None:
                 shutil.rmtree(group.ready_dir)
@@ -5316,38 +5274,43 @@ class Worker:
             if not suppress_errors:
                 raise RuntimeError(failures[0])
 
+    @staticmethod
+    def _monitor_mpirun_group(group: _MpiL3GroupRuntime, proc: subprocess.Popen[Any]) -> None:
+        returncode = proc.wait()
+        if group.closing or group.mailbox is None:
+            return
+        with contextlib.suppress(BaseException):
+            group.mailbox.mark_terminal(f"mpirun exited unexpectedly with status {returncode}")
+
+    @staticmethod
+    def _mark_mpirun_groups_closing(groups: list[_MpiL3GroupRuntime]) -> None:
+        for group in groups:
+            group.closing = True
+
     def _activate_mpirun_worker_groups(self, deadline: float) -> None:
         if not self._mpi_l3_groups:
             return
+        from .mpi_group_mailbox import MAILBOX_SIZE as MPI_MAILBOX_SIZE  # noqa: PLC0415
+        from .mpi_group_mailbox import MailboxGroupState, MpiGroupMailbox  # noqa: PLC0415
+
         session_timeout = self._remote_session_timeout_s()
         assert self._worker is not None
         for group in self._mpi_l3_groups:
-            ready_dir = tempfile.mkdtemp(prefix="simpler-mpirun-ready-")
+            ready_dir = tempfile.mkdtemp(prefix="simpler-mpirun-manifest-")
             manifest_path = os.path.join(ready_dir, "group.json")
             group.ready_dir = ready_dir
             group.manifest_path = manifest_path
-            ready_sock: socket.socket | None = None
-            ready_token = uuid.uuid4().hex
-            ready_host = group.spec.ready_host
-            ready_port = 0
-            if ready_host:
-                ready_sock = self._open_mpi_ready_listener(ready_host, group.spec.ready_port)
-                ready_port = int(ready_sock.getsockname()[1])
+            mailbox = MpiGroupMailbox.create(world_size=len(group.ranks))
+            group.mailbox = mailbox
             rank_manifests: list[dict[str, Any]] = []
-            sessions: dict[int, _RemoteSession] = {}
             startup_remaining_s = self._remaining_until(deadline, "MPI L3 group manifest")
             for rank in group.ranks:
-                session_id = self._new_remote_session_id()
-                manifest = self._build_remote_manifest(
-                    spec=rank.spec,
-                    worker_id=rank.worker_id,
-                    session_id=session_id,
+                manifest = self._build_mpi_rank_manifest(
+                    rank=rank,
                     startup_remaining_s=startup_remaining_s,
                 )
                 manifest.update(
                     {
-                        "command_port": rank.command_port,
-                        "health_port": rank.health_port,
                         "mpi_group_id": group.group_id,
                         "mpi_rank": rank.rank,
                         "mpi_world_size": len(group.ranks),
@@ -5356,23 +5319,11 @@ class Worker:
                     }
                 )
                 rank_manifests.append(manifest)
-                sessions[rank.rank] = _RemoteSession(
-                    worker_id=rank.worker_id,
-                    session_id=session_id,
-                    command_host=rank.command_host,
-                    command_port=rank.command_port,
-                    health_host=rank.health_host,
-                    health_port=rank.health_port,
-                    pid=0,
-                )
             group_manifest = {
                 "group_id": group.group_id,
                 "world_size": len(group.ranks),
                 "worker_ids": [rank.worker_id for rank in group.ranks],
-                "ready_dir": ready_dir,
-                "ready_host": ready_host,
-                "ready_port": ready_port,
-                "ready_token": ready_token,
+                "mailbox": mailbox.manifest(),
                 "rank_manifests": rank_manifests,
             }
             with open(manifest_path, "w", encoding="utf-8") as f:
@@ -5392,33 +5343,31 @@ class Worker:
                     manifest_path,
                 ]
             )
-            group.process = subprocess.Popen(cmd)
-            try:
-                if ready_sock is None:
-                    ready = self._wait_mpi_ready_files(group, deadline)
-                else:
-                    ready = self._wait_mpi_ready_tcp(group, ready_sock, ready_token, deadline)
-            finally:
-                if ready_sock is not None:
-                    ready_sock.close()
-            for rank in group.ranks:
-                payload = ready[rank.rank]
-                if int(payload["command_port"]) != rank.command_port or int(payload["health_port"]) != rank.health_port:
-                    raise RuntimeError(f"MPI L3 rank {rank.rank} published unexpected command/health ports")
-                session = sessions[rank.rank]
-                self._remote_sessions.append(session)
-                remaining = self._remaining_until(deadline, "MPI L3 endpoint attach")
-                self._worker.add_remote_l3_socket(
-                    session.worker_id,
-                    session.session_id,
-                    rank.spec.comm_profile,
-                    str(payload.get("command_host", rank.command_host)),
-                    int(payload["command_port"]),
-                    str(payload.get("health_host", rank.health_host)),
-                    int(payload["health_port"]),
-                    remaining,
-                    session_timeout,
-                )
+            group.process = subprocess.Popen(cmd, start_new_session=True)
+            while mailbox.group_state is MailboxGroupState.INITIALIZING:
+                if group.process.poll() is not None:
+                    raise RuntimeError(
+                        f"MPI L3 group {group.group_id} exited before READY (status {group.process.returncode})"
+                    )
+                self._remaining_until(deadline, "MPI L3 mailbox READY")
+                time.sleep(_STARTUP_POLL_INTERVAL_S)
+            if mailbox.group_state is not MailboxGroupState.READY:
+                raise RuntimeError(f"MPI L3 group {group.group_id} failed before READY: {mailbox.terminal_reason()}")
+            self._worker.add_mpi_group_mailbox(
+                [rank.worker_id for rank in group.ranks],
+                [rank.session_id for rank in group.ranks],
+                mailbox.address,
+                MPI_MAILBOX_SIZE,
+                group.process.pid,
+                session_timeout,
+            )
+            group.monitor_thread = threading.Thread(
+                target=self._monitor_mpirun_group,
+                args=(group, group.process),
+                daemon=True,
+                name=f"simpler-mpirun-monitor-{group.group_id[:8]}",
+            )
+            group.monitor_thread.start()
         if time.monotonic() >= deadline:
             raise RuntimeError("MPI L3 activation: startup deadline exceeded after attach")
 
@@ -9526,75 +9475,20 @@ class Worker:
             raise RuntimeError("local Global CommDomain control reply is invalid")
         return reply[start : start + response_size]
 
-    def _global_domain_control(self, worker_id: int, control_name: int, payload: bytes) -> bytes:
+    def _global_domain_control(
+        self, worker_id: int, control_name: int, payload: bytes, *, group: bool = False
+    ) -> bytes:
         if self._worker is None:
             raise RuntimeError("Global CommDomain control requires a ready hierarchical Worker")
         if worker_id in self._remote_like_worker_ids():
-            return bytes(self._worker.remote_domain_control(int(worker_id), int(control_name), bytes(payload)))
+            return bytes(
+                self._worker.remote_domain_control(
+                    int(worker_id), int(control_name), bytes(payload), group_target=bool(group)
+                )
+            )
         if worker_id in self._next_level_worker_ids:
             return self._local_global_domain_control(worker_id, control_name, payload)
         raise ValueError(f"Global CommDomain worker {worker_id} is not a registered L3 worker")
-
-    def _global_domain_control_many(
-        self,
-        worker_ids: tuple[int, ...],
-        control_name: int,
-        payload: bytes,
-        *,
-        mpi_group: _MpiL3GroupRuntime,
-    ) -> dict[int, bytes]:
-        replies: dict[int, bytes] = {}
-        errors: list[tuple[int, BaseException]] = []
-        completed = threading.Condition()
-
-        def _send(worker_id: int) -> None:
-            try:
-                reply = self._global_domain_control(worker_id, control_name, payload)
-            except BaseException as exc:  # noqa: BLE001
-                with completed:
-                    errors.append((worker_id, exc))
-                    completed.notify_all()
-                return
-            with completed:
-                replies[worker_id] = reply
-                completed.notify_all()
-
-        threads = [
-            (int(worker_id), threading.Thread(target=_send, args=(int(worker_id),), daemon=True))
-            for worker_id in worker_ids
-        ]
-        for _worker_id, thread in threads:
-            thread.start()
-        deadline = time.monotonic() + self._py_control_timeout_s
-        with completed:
-            while len(replies) + len(errors) < len(worker_ids) and not errors:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    break
-                completed.wait(timeout=remaining)
-
-        pending = [worker_id for worker_id, thread in threads if thread.is_alive()]
-        if pending:
-            cleanup_failures = self._close_mpirun_group(
-                mpi_group,
-                timeout_s=min(1.0, self._py_control_timeout_s),
-            )
-            if cleanup_failures:
-                sys.stderr.write(
-                    "\n".join(f"[worker pid={os.getpid()}] WARN: {failure}" for failure in cleanup_failures) + "\n"
-                )
-                sys.stderr.flush()
-            for _worker_id, thread in threads:
-                thread.join(timeout=1.0)
-        if errors:
-            worker_id, exc = errors[0]
-            raise RuntimeError(f"Global CommDomain control fanout failed on worker {worker_id}: {exc}") from exc
-        if pending:
-            raise TimeoutError(f"Global CommDomain control fanout timed out on workers {pending}")
-        missing = sorted(set(worker_ids) - replies.keys())
-        if missing:
-            raise RuntimeError(f"Global CommDomain control fanout returned no reply for workers {missing}")
-        return replies
 
     def _mpi_group_for_involved_nodes(self, involved_nodes: tuple[int, ...]) -> _MpiL3GroupRuntime | None:
         involved = set(int(worker_id) for worker_id in involved_nodes)
@@ -9604,23 +9498,17 @@ class Worker:
                 return group
         return None
 
-    @staticmethod
-    def _descriptor_table_from_mpi_replies(
-        replies: dict[int, bytes],
-        *,
-        rank_count: int,
-        profile: str,
-    ) -> tuple[GlobalDomainDescriptor, ...]:
-        tables = tuple(decode_descriptor_table(payload) for payload in replies.values())
-        if not tables:
-            raise RuntimeError("MPI Global CommDomain prepare returned no descriptor tables")
-        first = tables[0]
-        validate_descriptor_table(first, rank_count=rank_count, profile=profile)
-        for table in tables[1:]:
-            validate_descriptor_table(table, rank_count=rank_count, profile=profile)
-            if table != first:
-                raise RuntimeError("MPI Global CommDomain prepare returned inconsistent descriptor tables")
-        return first
+    def _mpi_group_control(
+        self,
+        group: _MpiL3GroupRuntime,
+        control_name: int,
+        payload: bytes,
+    ) -> bytes:
+        if not group.ranks:
+            raise RuntimeError(f"MPI L3 group {group.group_id} has no ranks")
+        # One L4 request enters the rank-0 mailbox with the group-target frame
+        # flag set, so every MPI rank receives the same envelope.
+        return self._global_domain_control(group.ranks[0].worker_id, control_name, payload, group=True)
 
     def _allocate_global_domain(  # noqa: PLR0912 -- transaction validation and prepare/import/commit rollback stay ordered
         self,
@@ -9721,6 +9609,7 @@ class Worker:
         )
 
         prepared_nodes: list[int] = []
+        mpi_group: _MpiL3GroupRuntime | None = None
         try:
             for node_worker_id in involved_nodes:
                 node = nodes[node_worker_id]
@@ -9749,17 +9638,12 @@ class Worker:
                 # runner's collective), so one ALLOC_DOMAIN fanout both prepares
                 # and imports; the reply already carries the complete table.
                 prepared_nodes.extend(involved_nodes)
-                replies = self._global_domain_control_many(
-                    involved_nodes,
+                reply = self._mpi_group_control(
+                    mpi_group,
                     ControlName.ALLOC_DOMAIN,
                     encode_domain_command(base_command),
-                    mpi_group=mpi_group,
                 )
-                descriptors = self._descriptor_table_from_mpi_replies(
-                    replies,
-                    rank_count=len(domain_members_tuple),
-                    profile=profile,
-                )
+                descriptors = decode_descriptor_table(reply)
             else:
                 descriptor_by_rank: dict[int, GlobalDomainDescriptor] = {}
                 for node_worker_id in involved_nodes:
@@ -9790,11 +9674,10 @@ class Worker:
                 descriptors=descriptors,
             )
             if mpi_group is not None:
-                self._global_domain_control_many(
-                    involved_nodes,
+                self._mpi_group_control(
+                    mpi_group,
                     ControlName.ALLOC_DOMAIN,
                     encode_domain_command(commit_command),
-                    mpi_group=mpi_group,
                 )
             else:
                 import_command = GlobalDomainCommand(
@@ -9831,10 +9714,10 @@ class Worker:
                 members=domain_members_tuple,
                 buffers=global_buffers,
             )
-            for node_worker_id in prepared_nodes:
+            if mpi_group is not None and prepared_nodes:
                 try:
-                    self._global_domain_control(
-                        node_worker_id,
+                    self._mpi_group_control(
+                        mpi_group,
                         ControlName.ALLOC_DOMAIN,
                         encode_domain_command(abort_command),
                     )
@@ -9845,10 +9728,29 @@ class Worker:
                     # that keeps a later run from being admitted as if the
                     # teardown had succeeded.
                     self._record_unreclaimable(
-                        f"Global CommDomain {name!r} ABORT cleanup failed for node worker "
-                        f"{node_worker_id}; backend windows may remain mapped",
+                        f"Global CommDomain {name!r} ABORT cleanup failed for MPI group "
+                        f"{mpi_group.group_id!r}; backend windows may remain mapped",
                         abort_error,
                     )
+            else:
+                for node_worker_id in prepared_nodes:
+                    try:
+                        self._global_domain_control(
+                            node_worker_id,
+                            ControlName.ALLOC_DOMAIN,
+                            encode_domain_command(abort_command),
+                        )
+                    except BaseException as abort_error:  # noqa: BLE001
+                        # The domain is not registered on this path, so no run fence
+                        # and no close() sweep can reach whatever the failed ABORT
+                        # leaves mapped. Refusing further work is the only boundary
+                        # that keeps a later run from being admitted as if the
+                        # teardown had succeeded.
+                        self._record_unreclaimable(
+                            f"Global CommDomain {name!r} ABORT cleanup failed for node worker "
+                            f"{node_worker_id}; backend windows may remain mapped",
+                            abort_error,
+                        )
             raise
 
         handle = GlobalCommDomainHandle(
@@ -9925,11 +9827,19 @@ class Worker:
 
         command = encode_release_command(GlobalDomainReleaseCommand(handle.domain_id, handle.generation))
         errors: list[BaseException] = []
-        for node_worker_id in dict.fromkeys(member.node_worker_id for member in handle.members):
+        involved_nodes = tuple(dict.fromkeys(member.node_worker_id for member in handle.members))
+        mpi_group = self._mpi_group_for_involved_nodes(involved_nodes)
+        if mpi_group is not None:
             try:
-                self._global_domain_control(node_worker_id, ControlName.RELEASE_DOMAIN, command)
+                self._mpi_group_control(mpi_group, ControlName.RELEASE_DOMAIN, command)
             except BaseException as exc:  # noqa: BLE001
                 errors.append(exc)
+        else:
+            for node_worker_id in involved_nodes:
+                try:
+                    self._global_domain_control(node_worker_id, ControlName.RELEASE_DOMAIN, command)
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
         if errors:
             raise RuntimeError(f"Global CommDomain release failed: {errors[0]}") from errors[0]
         if self._live_global_domains.get(handle.name) is handle:
@@ -11820,6 +11730,7 @@ class Worker:
 
             def _close_worker() -> None:
                 if self._worker:
+                    self._mark_mpirun_groups_closing(self._mpi_l3_groups)
                     self._worker.close()
                     self._worker = None
                     self._orch = None
@@ -11828,14 +11739,14 @@ class Worker:
             journal_err = self._cleanup_journal.drive({("native", "hierarchical Worker")})
             if journal_err is not None:
                 errors.append(journal_err)
-                if not startup_abort:
-                    raise errors[0]
+            # A failed native close must not strand the mpirun children: their
+            # reaping and mailbox unlink run before the error propagates.
             self._cleanup_journal.add_once("child", "MPI L3 groups", self._close_mpirun_groups)
             journal_err = self._cleanup_journal.drive({("child", "MPI L3 groups")})
             if journal_err is not None:
                 errors.append(journal_err)
-                if not startup_abort:
-                    raise errors[0]
+            if errors and not startup_abort:
+                raise errors[0]
             self._cleanup_journal.add_once(
                 "shm", "Worker-Chip orchestration mappings", self._close_worker_chip_orch_comm
             )

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -94,6 +94,7 @@ static_assert(
     sizeof(aclrtMemFabricHandle) <= COMM_GLOBAL_DOMAIN_HANDLE_BYTES, "Fabric handle exceeds global descriptor"
 );
 static std::unordered_map<uint64_t, std::unique_ptr<DomainAllocation>> global_domain_allocations;
+static std::mutex global_domain_allocations_mutex;
 
 struct CommHandle_ {
     int rank;
@@ -1531,7 +1532,11 @@ extern "C" int comm_global_domain_prepare(
 ) try {
     if (domain_id == 0 || rank_count == 0 || rank_count > COMM_MAX_RANK_NUM || domain_rank >= rank_count ||
         window_size == 0 || profile != COMM_GLOBAL_DOMAIN_PROFILE_A3_FABRIC || descriptor_out == nullptr ||
-        local_window_base_out == nullptr || global_domain_allocations.count(domain_id) != 0) {
+        local_window_base_out == nullptr) {
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(global_domain_allocations_mutex);
+    if (global_domain_allocations.count(domain_id) != 0) {
         return -1;
     }
 
@@ -1587,6 +1592,7 @@ extern "C" int comm_global_domain_prepare(
 extern "C" int comm_global_domain_import(
     uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
 ) try {
+    std::lock_guard<std::mutex> lock(global_domain_allocations_mutex);
     auto it = global_domain_allocations.find(domain_id);
     if (it == global_domain_allocations.end() || descriptors == nullptr || device_ctx_out == nullptr) {
         return -1;
@@ -1668,6 +1674,7 @@ extern "C" int comm_global_domain_import(
 }
 
 extern "C" int comm_global_domain_release(uint64_t domain_id) try {
+    std::lock_guard<std::mutex> lock(global_domain_allocations_mutex);
     auto it = global_domain_allocations.find(domain_id);
     if (it == global_domain_allocations.end()) {
         return 0;

--- a/src/common/hierarchical/mpi_group_mailbox.h
+++ b/src/common/hierarchical/mpi_group_mailbox.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mpi_group_mailbox {
+
+inline constexpr uint8_t MAGIC[8] = {'S', 'M', 'P', 'I', 'B', 'O', 'X', '\0'};
+inline constexpr uint32_t PROTOCOL_VERSION = 1;
+inline constexpr size_t HEADER_BYTES = 256;
+inline constexpr size_t PAYLOAD_BYTES = 16U * 1024U * 1024U;
+inline constexpr size_t ERROR_BYTES = 64U * 1024U;
+inline constexpr size_t REQUEST_OFFSET = HEADER_BYTES;
+inline constexpr size_t RESPONSE_OFFSET = REQUEST_OFFSET + PAYLOAD_BYTES;
+inline constexpr size_t ERROR_OFFSET = RESPONSE_OFFSET + PAYLOAD_BYTES;
+inline constexpr size_t MAILBOX_BYTES = ERROR_OFFSET + ERROR_BYTES;
+
+inline constexpr size_t OFF_MAGIC = 0;
+inline constexpr size_t OFF_PROTOCOL_VERSION = 8;
+inline constexpr size_t OFF_HEADER_BYTES = 12;
+inline constexpr size_t OFF_MAILBOX_BYTES = 16;
+inline constexpr size_t OFF_WORLD_SIZE = 24;
+inline constexpr size_t OFF_GROUP_STATE = 28;
+inline constexpr size_t OFF_REQUEST_STATE = 32;
+inline constexpr size_t OFF_SEQUENCE_ID = 40;
+inline constexpr size_t OFF_OPCODE = 48;
+inline constexpr size_t OFF_TARGET = 52;
+inline constexpr size_t OFF_TARGET_RANK = 56;
+inline constexpr size_t OFF_REQUEST_COUNT = 60;
+inline constexpr size_t OFF_REQUEST_BYTES = 64;
+inline constexpr size_t OFF_RESPONSE_COUNT = 68;
+inline constexpr size_t OFF_RESPONSE_BYTES = 72;
+inline constexpr size_t OFF_ERROR_BYTES = 76;
+
+enum class GroupState : int32_t {
+    INITIALIZING = 0,
+    READY = 1,
+    TERMINAL = 2,
+    CLOSED = 3,
+};
+
+enum class RequestState : int32_t {
+    IDLE = 0,
+    REQUEST_READY = 1,
+    TASK_ACCEPTED = 2,
+    TASK_DONE = 3,
+    TASK_FAILED = 4,
+    SHUTDOWN_READY = 5,
+    SHUTDOWN_DONE = 6,
+};
+
+enum class Opcode : uint32_t {
+    TASK = 1,
+    CONTROL = 2,
+    PING = 3,
+    SHUTDOWN = 4,
+};
+
+enum class Target : uint32_t {
+    GROUP = 1,
+    RANK = 2,
+    PER_RANK = 3,
+};
+
+}  // namespace mpi_group_mailbox

--- a/src/common/hierarchical/mpi_group_mailbox.h
+++ b/src/common/hierarchical/mpi_group_mailbox.h
@@ -14,6 +14,16 @@
 #include <cstddef>
 #include <cstdint>
 
+#if defined(__linux__)
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <ctime>
+#else
+#include <chrono>
+#endif
+
 namespace mpi_group_mailbox {
 
 inline constexpr uint8_t MAGIC[8] = {'S', 'M', 'P', 'I', 'B', 'O', 'X', '\0'};
@@ -42,6 +52,42 @@ inline constexpr size_t OFF_REQUEST_BYTES = 64;
 inline constexpr size_t OFF_RESPONSE_COUNT = 68;
 inline constexpr size_t OFF_RESPONSE_BYTES = 72;
 inline constexpr size_t OFF_ERROR_BYTES = 76;
+// Header bytes [RESERVED_OFFSET, HEADER_BYTES) are reserved in protocol
+// version 1: the creator zeroes them and every attach path rejects a mailbox
+// whose reserved bytes are non-zero, so a future version can assign them.
+inline constexpr size_t RESERVED_OFFSET = 80;
+
+// The request-state word doubles as a shared futex: the mailbox is mapped by
+// more than one process, so the wake must not use FUTEX_PRIVATE_FLAG. Both
+// helpers may return spuriously; callers re-check the word.
+inline void wake_word(int32_t *addr) {
+#if defined(__linux__)
+    (void)::syscall(SYS_futex, addr, FUTEX_WAKE, INT32_MAX, nullptr, nullptr, 0);
+#else
+    (void)addr;
+#endif
+}
+
+// Blocks until the word at `addr` differs from `expected`, a wake arrives, or
+// `timeout_s` elapses. Non-Linux builds have no futex and poll the word until
+// the timeout instead.
+inline void wait_word(int32_t *addr, int32_t expected, double timeout_s) {
+    if (!(timeout_s > 0.0)) return;
+#if defined(__linux__)
+    struct timespec ts;
+    const int64_t timeout_ns = static_cast<int64_t>(timeout_s * 1e9);
+    ts.tv_sec = static_cast<time_t>(timeout_ns / 1000000000);
+    ts.tv_nsec = static_cast<long>(timeout_ns % 1000000000);
+    (void)::syscall(SYS_futex, addr, FUTEX_WAIT, expected, &ts, nullptr, 0);
+#else
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::duration<double>(timeout_s);
+    int32_t value = expected;
+    while (std::chrono::steady_clock::now() < deadline) {
+        __atomic_load(addr, &value, __ATOMIC_ACQUIRE);
+        if (value != expected) return;
+    }
+#endif
+}
 
 enum class GroupState : int32_t {
     INITIALIZING = 0,

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <poll.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -354,6 +355,10 @@ void validate_owner_buffer_handle(const RemoteBufferHandle &handle, size_t reque
 }
 
 }  // namespace
+
+void RemoteL3Transport::submit_group_progress_frame(const std::vector<uint8_t> &frame, uint64_t, int32_t, int32_t) {
+    submit_progress_frame(frame);
+}
 
 RemoteL3SocketTransport::RemoteL3SocketTransport(
     std::string host, uint16_t port, std::string health_host, uint16_t health_port, double attach_timeout_s,
@@ -704,21 +709,536 @@ void RemoteL3SocketTransport::reset_progress_command() noexcept {
 
 void RemoteL3SocketTransport::shutdown() { close_socket(); }
 
+MpiGroupMailboxChannel::MpiGroupMailboxChannel(
+    void *mailbox, size_t mailbox_bytes, int32_t world_size, int mpirun_pid, double runtime_timeout_s
+) :
+    mailbox_(static_cast<uint8_t *>(mailbox)),
+    mailbox_bytes_(mailbox_bytes),
+    world_size_(world_size),
+    mpirun_pid_(mpirun_pid),
+    runtime_timeout_s_(runtime_timeout_s) {
+    using namespace mpi_group_mailbox;
+    if (mailbox_ == nullptr) throw std::invalid_argument("MpiGroupMailboxChannel: null mailbox");
+    if (mailbox_bytes_ < MAILBOX_BYTES) throw std::invalid_argument("MpiGroupMailboxChannel: mailbox is too small");
+    if (world_size_ <= 0) throw std::invalid_argument("MpiGroupMailboxChannel: world_size must be positive");
+    if (!(runtime_timeout_s_ > 0.0)) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: runtime_timeout_s must be positive");
+    }
+    if (std::memcmp(mailbox_ + OFF_MAGIC, MAGIC, sizeof(MAGIC)) != 0) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: mailbox magic mismatch");
+    }
+    if (read_u32(OFF_PROTOCOL_VERSION) != PROTOCOL_VERSION || read_u32(OFF_HEADER_BYTES) != HEADER_BYTES) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: mailbox protocol mismatch");
+    }
+    if (read_u64(OFF_MAILBOX_BYTES) != MAILBOX_BYTES ||
+        read_u32(OFF_WORLD_SIZE) != static_cast<uint32_t>(world_size_)) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: mailbox layout or world size mismatch");
+    }
+}
+
+int32_t MpiGroupMailboxChannel::load_i32(size_t offset) const {
+    int32_t value = 0;
+    __atomic_load(reinterpret_cast<const int32_t *>(mailbox_ + offset), &value, __ATOMIC_ACQUIRE);
+    return value;
+}
+
+void MpiGroupMailboxChannel::store_i32(size_t offset, int32_t value) {
+    __atomic_store(reinterpret_cast<int32_t *>(mailbox_ + offset), &value, __ATOMIC_RELEASE);
+}
+
+uint32_t MpiGroupMailboxChannel::read_u32(size_t offset) const {
+    uint32_t value = 0;
+    std::memcpy(&value, mailbox_ + offset, sizeof(value));
+    return value;
+}
+
+uint64_t MpiGroupMailboxChannel::read_u64(size_t offset) const {
+    uint64_t value = 0;
+    std::memcpy(&value, mailbox_ + offset, sizeof(value));
+    return value;
+}
+
+void MpiGroupMailboxChannel::write_u32(size_t offset, uint32_t value) {
+    std::memcpy(mailbox_ + offset, &value, sizeof(value));
+}
+
+void MpiGroupMailboxChannel::write_u64(size_t offset, uint64_t value) {
+    std::memcpy(mailbox_ + offset, &value, sizeof(value));
+}
+
+std::string MpiGroupMailboxChannel::terminal_reason() const {
+    using namespace mpi_group_mailbox;
+    const size_t size = std::min(static_cast<size_t>(read_u32(OFF_ERROR_BYTES)), ERROR_BYTES);
+    return std::string(reinterpret_cast<const char *>(mailbox_ + ERROR_OFFSET), size);
+}
+
+void MpiGroupMailboxChannel::mark_terminal(const std::string &reason) {
+    using namespace mpi_group_mailbox;
+    const size_t size = std::min(reason.size(), ERROR_BYTES);
+    if (size > 0) std::memcpy(mailbox_ + ERROR_OFFSET, reason.data(), size);
+    write_u32(OFF_ERROR_BYTES, static_cast<uint32_t>(size));
+    store_i32(OFF_GROUP_STATE, static_cast<int32_t>(GroupState::TERMINAL));
+    store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(RequestState::TASK_FAILED));
+}
+
+void MpiGroupMailboxChannel::kill_mpirun_group() const {
+    if (mpirun_pid_ <= 0) return;
+    (void)::kill(-mpirun_pid_, SIGKILL);
+    (void)::kill(mpirun_pid_, SIGKILL);
+}
+
+bool MpiGroupMailboxChannel::terminal() const {
+    return load_i32(mpi_group_mailbox::OFF_GROUP_STATE) ==
+           static_cast<int32_t>(mpi_group_mailbox::GroupState::TERMINAL);
+}
+
+std::vector<std::vector<uint8_t>> MpiGroupMailboxChannel::run_exchange(
+    const std::vector<std::vector<uint8_t>> &frames, mpi_group_mailbox::Opcode opcode, mpi_group_mailbox::Target target,
+    int32_t target_rank
+) {
+    using namespace mpi_group_mailbox;
+    if (frames.empty()) throw std::invalid_argument("MpiGroupMailboxChannel: request requires a payload");
+    if (target == Target::PER_RANK && frames.size() != static_cast<size_t>(world_size_)) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: per-rank request must include every rank");
+    }
+    if (target != Target::PER_RANK && frames.size() != 1) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: rank/group request requires one payload");
+    }
+    size_t encoded_request_bytes = 4 + 4 * frames.size();
+    for (const auto &frame : frames) {
+        if (frame.size() > UINT32_MAX || frame.size() > PAYLOAD_BYTES ||
+            encoded_request_bytes > PAYLOAD_BYTES - frame.size()) {
+            throw std::invalid_argument("MpiGroupMailboxChannel: request frame vector exceeds mailbox capacity");
+        }
+        encoded_request_bytes += frame.size();
+    }
+    if (target == Target::RANK && (target_rank < 0 || target_rank >= world_size_)) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: target rank is outside the group");
+    }
+    const auto group_state = static_cast<GroupState>(load_i32(OFF_GROUP_STATE));
+    if (group_state == GroupState::TERMINAL) {
+        throw std::runtime_error("MpiGroupMailboxChannel: group is terminal: " + terminal_reason());
+    }
+    if (group_state != GroupState::READY) {
+        throw std::runtime_error("MpiGroupMailboxChannel: group is not ready");
+    }
+    if (static_cast<RequestState>(load_i32(OFF_REQUEST_STATE)) != RequestState::IDLE) {
+        throw std::runtime_error("MpiGroupMailboxChannel: request lane is not idle");
+    }
+
+    const uint64_t sequence = next_sequence_++;
+    const uint32_t count = static_cast<uint32_t>(frames.size());
+    std::memcpy(mailbox_ + REQUEST_OFFSET, &count, sizeof(count));
+    size_t request_offset = REQUEST_OFFSET + 4;
+    for (const auto &frame : frames) {
+        const uint32_t frame_size = static_cast<uint32_t>(frame.size());
+        std::memcpy(mailbox_ + request_offset, &frame_size, sizeof(frame_size));
+        request_offset += 4;
+    }
+    for (const auto &frame : frames) {
+        if (!frame.empty()) std::memcpy(mailbox_ + request_offset, frame.data(), frame.size());
+        request_offset += frame.size();
+    }
+    write_u64(OFF_SEQUENCE_ID, sequence);
+    write_u32(OFF_OPCODE, static_cast<uint32_t>(opcode));
+    write_u32(OFF_TARGET, static_cast<uint32_t>(target));
+    std::memcpy(mailbox_ + OFF_TARGET_RANK, &target_rank, sizeof(target_rank));
+    write_u32(OFF_REQUEST_COUNT, count);
+    write_u32(OFF_REQUEST_BYTES, static_cast<uint32_t>(encoded_request_bytes));
+    write_u32(OFF_RESPONSE_COUNT, 0);
+    write_u32(OFF_RESPONSE_BYTES, 0);
+    write_u32(OFF_ERROR_BYTES, 0);
+    const RequestState ready_state =
+        opcode == Opcode::SHUTDOWN ? RequestState::SHUTDOWN_READY : RequestState::REQUEST_READY;
+    store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(ready_state));
+
+    const Deadline deadline = deadline_from_now(runtime_timeout_s_);
+    while (true) {
+        const auto state = static_cast<RequestState>(load_i32(OFF_REQUEST_STATE));
+        if (state == RequestState::TASK_DONE) {
+            const uint32_t response_count = read_u32(OFF_RESPONSE_COUNT);
+            const size_t response_bytes = read_u32(OFF_RESPONSE_BYTES);
+            const uint32_t expected_count = target == Target::PER_RANK ? static_cast<uint32_t>(world_size_) : 1U;
+            const size_t prefix_bytes = 4 + 4 * static_cast<size_t>(response_count);
+            if (response_count != expected_count || response_bytes < prefix_bytes || response_bytes > PAYLOAD_BYTES) {
+                mark_terminal("MPI group mailbox returned an invalid response vector");
+                kill_mpirun_group();
+                throw std::runtime_error("MpiGroupMailboxChannel: invalid response vector");
+            }
+            uint32_t encoded_count = 0;
+            std::memcpy(&encoded_count, mailbox_ + RESPONSE_OFFSET, sizeof(encoded_count));
+            if (encoded_count != response_count) {
+                mark_terminal("MPI group mailbox response vector length mismatch");
+                kill_mpirun_group();
+                throw std::runtime_error("MpiGroupMailboxChannel: response vector length mismatch");
+            }
+            std::vector<uint32_t> payload_sizes(response_count);
+            size_t total_payload_bytes = 0;
+            for (uint32_t i = 0; i < response_count; ++i) {
+                std::memcpy(
+                    &payload_sizes[i], mailbox_ + RESPONSE_OFFSET + 4 + 4 * static_cast<size_t>(i),
+                    sizeof(payload_sizes[i])
+                );
+                total_payload_bytes += payload_sizes[i];
+            }
+            if (prefix_bytes + total_payload_bytes != response_bytes) {
+                mark_terminal("MPI group mailbox response vector length mismatch");
+                kill_mpirun_group();
+                throw std::runtime_error("MpiGroupMailboxChannel: response vector length mismatch");
+            }
+            std::vector<std::vector<uint8_t>> responses;
+            responses.reserve(response_count);
+            size_t response_offset = RESPONSE_OFFSET + prefix_bytes;
+            for (uint32_t payload_size : payload_sizes) {
+                std::vector<uint8_t> response(payload_size);
+                if (payload_size > 0) {
+                    std::memcpy(response.data(), mailbox_ + response_offset, payload_size);
+                }
+                response_offset += payload_size;
+                responses.push_back(std::move(response));
+            }
+            store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(RequestState::IDLE));
+            return responses;
+        }
+        if (state == RequestState::SHUTDOWN_DONE) {
+            store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(RequestState::IDLE));
+            return {{}};
+        }
+        if (state == RequestState::TASK_FAILED || terminal()) {
+            const std::string reason = terminal_reason();
+            if (!terminal()) store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(RequestState::IDLE));
+            throw std::runtime_error(
+                "MpiGroupMailboxChannel: MPI group request failed" + (reason.empty() ? std::string() : ": " + reason)
+            );
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            mark_terminal("MPI group mailbox request timed out at sequence " + std::to_string(sequence));
+            kill_mpirun_group();
+            throw std::runtime_error("MpiGroupMailboxChannel: request timed out");
+        }
+    }
+}
+
+std::vector<uint8_t> MpiGroupMailboxChannel::exchange(const std::vector<uint8_t> &frame, int32_t target_rank) {
+    std::lock_guard<std::mutex> lock(lane_mu_);
+    const auto decoded = remote_l3::decode_frame(frame);
+    mpi_group_mailbox::Opcode opcode = mpi_group_mailbox::Opcode::CONTROL;
+    mpi_group_mailbox::Target target = mpi_group_mailbox::Target::RANK;
+    if (decoded.header.frame_type == remote_l3::FrameType::TASK) {
+        opcode = mpi_group_mailbox::Opcode::TASK;
+    } else if (decoded.header.frame_type == remote_l3::FrameType::HEALTH) {
+        opcode = mpi_group_mailbox::Opcode::PING;
+        target = mpi_group_mailbox::Target::GROUP;
+        target_rank = -1;
+    } else if (decoded.header.frame_type == remote_l3::FrameType::CONTROL) {
+        if ((decoded.header.flags & remote_l3::FRAME_FLAG_GROUP_TARGET) != 0) {
+            target = mpi_group_mailbox::Target::GROUP;
+            target_rank = -1;
+        }
+    } else {
+        throw std::runtime_error("MpiGroupMailboxChannel: unsupported request frame type");
+    }
+    auto responses = run_exchange({frame}, opcode, target, target_rank);
+    return std::move(responses.front());
+}
+
+std::vector<uint8_t> MpiGroupMailboxChannel::exchange_group_task(
+    const std::vector<uint8_t> &frame, int32_t target_rank, uint64_t task_slot, int32_t group_size
+) {
+    if (group_size != world_size_) {
+        // Existing submit_next_level_group permits subsets. Keep that behavior
+        // as ordered rank-targeted requests; only a full MPI group is batched
+        // into one PER_RANK mailbox envelope.
+        return exchange(frame, target_rank);
+    }
+    if (target_rank < 0 || target_rank >= world_size_) {
+        throw std::invalid_argument("MpiGroupMailboxChannel: group task target rank is outside the group");
+    }
+
+    // Rendezvous timeouts fail only the waiting task: an incomplete arrival
+    // means the L4 dispatched an inconsistent group, not that a rank is
+    // wedged. Killing the mpirun process group is reserved for the mailbox
+    // round trip itself (run_exchange), which runs under lane_mu_.
+    const Deadline deadline = deadline_from_now(runtime_timeout_s_);
+    bool leader = false;
+    std::vector<std::vector<uint8_t>> frames;
+    {
+        std::unique_lock<std::mutex> lock(group_mu_);
+        while (group_active_ && group_task_slot_ != task_slot) {
+            if (group_cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
+                throw std::runtime_error("MpiGroupMailboxChannel: timed out waiting for the prior group task batch");
+            }
+        }
+        if (!group_active_) {
+            group_active_ = true;
+            group_done_ = false;
+            group_leader_running_ = false;
+            group_task_slot_ = task_slot;
+            group_arrived_ = 0;
+            group_departed_ = 0;
+            group_frames_.assign(static_cast<size_t>(world_size_), {});
+            group_replies_.clear();
+            group_error_ = nullptr;
+        }
+        if (group_frames_.size() != static_cast<size_t>(world_size_)) {
+            throw std::runtime_error("MpiGroupMailboxChannel: group task batch already dispatched for this slot");
+        }
+        auto &rank_frame = group_frames_[static_cast<size_t>(target_rank)];
+        if (!rank_frame.empty()) {
+            throw std::runtime_error("MpiGroupMailboxChannel: duplicate rank in one MPI group task");
+        }
+        rank_frame = frame;
+        ++group_arrived_;
+        if (group_arrived_ == world_size_) {
+            leader = true;
+            group_leader_running_ = true;
+            frames = std::move(group_frames_);
+            group_frames_.clear();
+        }
+    }
+
+    if (leader) {
+        try {
+            std::lock_guard<std::mutex> lane_lock(lane_mu_);
+            auto replies =
+                run_exchange(frames, mpi_group_mailbox::Opcode::TASK, mpi_group_mailbox::Target::PER_RANK, -1);
+            std::lock_guard<std::mutex> group_lock(group_mu_);
+            group_replies_ = std::move(replies);
+            group_done_ = true;
+            group_leader_running_ = false;
+        } catch (...) {
+            std::lock_guard<std::mutex> group_lock(group_mu_);
+            group_error_ = std::current_exception();
+            group_done_ = true;
+            group_leader_running_ = false;
+        }
+        group_cv_.notify_all();
+    }
+
+    std::unique_lock<std::mutex> lock(group_mu_);
+    while (!group_done_) {
+        if (group_cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
+            if (!group_leader_running_) {
+                // No leader formed: withdraw this rank's frame so a later,
+                // correctly-targeted batch starts from a clean slate.
+                auto &rank_frame = group_frames_[static_cast<size_t>(target_rank)];
+                rank_frame.clear();
+                --group_arrived_;
+                if (group_arrived_ == 0) {
+                    group_active_ = false;
+                    group_done_ = false;
+                    group_replies_.clear();
+                    group_error_ = nullptr;
+                }
+            } else {
+                ++group_departed_;
+                if (group_departed_ == world_size_) {
+                    group_active_ = false;
+                    group_done_ = false;
+                    group_frames_.clear();
+                    group_replies_.clear();
+                    group_error_ = nullptr;
+                }
+            }
+            lock.unlock();
+            group_cv_.notify_all();
+            throw std::runtime_error("MpiGroupMailboxChannel: group task batching timed out waiting for all ranks");
+        }
+    }
+    std::exception_ptr error = group_error_;
+    std::vector<uint8_t> reply;
+    if (error == nullptr) {
+        if (group_replies_.size() != static_cast<size_t>(world_size_)) {
+            error = std::make_exception_ptr(
+                std::runtime_error("MpiGroupMailboxChannel: MPI group task reply count mismatch")
+            );
+        } else {
+            reply = std::move(group_replies_[static_cast<size_t>(target_rank)]);
+        }
+    }
+    ++group_departed_;
+    if (group_departed_ == world_size_) {
+        group_active_ = false;
+        group_done_ = false;
+        group_frames_.clear();
+        group_replies_.clear();
+        group_error_ = nullptr;
+        group_cv_.notify_all();
+    }
+    lock.unlock();
+    if (error != nullptr) std::rethrow_exception(error);
+    return reply;
+}
+
+void MpiGroupMailboxChannel::shutdown(const std::vector<uint8_t> &frame) {
+    std::lock_guard<std::mutex> lock(lane_mu_);
+    if (shutdown_sent_ || terminal()) return;
+    shutdown_sent_ = true;
+    (void)run_exchange({frame}, mpi_group_mailbox::Opcode::SHUTDOWN, mpi_group_mailbox::Target::GROUP, -1);
+}
+
+MpiGroupMailboxTransport::MpiGroupMailboxTransport(
+    std::shared_ptr<MpiGroupMailboxChannel> channel, int32_t target_rank
+) :
+    channel_(std::move(channel)),
+    target_rank_(target_rank) {
+    if (!channel_) throw std::invalid_argument("MpiGroupMailboxTransport: null channel");
+    if (target_rank_ < 0) throw std::invalid_argument("MpiGroupMailboxTransport: target rank must be non-negative");
+}
+
+MpiGroupMailboxTransport::~MpiGroupMailboxTransport() {
+    {
+        std::lock_guard<std::mutex> lock(progress_mu_);
+        progress_stop_ = true;
+    }
+    progress_cv_.notify_all();
+    if (progress_thread_.joinable()) progress_thread_.join();
+}
+
+void MpiGroupMailboxTransport::submit_frame(const std::vector<uint8_t> &frame) {
+    if (pending_) throw std::runtime_error("MpiGroupMailboxTransport: a request is already pending");
+    pending_frame_ = frame;
+    pending_ = true;
+}
+
+std::vector<uint8_t> MpiGroupMailboxTransport::wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) {
+    if (!pending_) throw std::runtime_error("MpiGroupMailboxTransport: no request is pending");
+    auto frame = std::move(pending_frame_);
+    pending_frame_.clear();
+    pending_ = false;
+    auto reply = channel_->exchange(frame, target_rank_);
+    auto decoded = remote_l3::decode_frame(reply);
+    if (decoded.header.frame_type != frame_type || decoded.header.sequence != sequence) {
+        throw std::runtime_error("MpiGroupMailboxTransport: reply frame type or sequence mismatch");
+    }
+    return reply;
+}
+
+void MpiGroupMailboxTransport::start_progress(ProgressRequest request) {
+    std::lock_guard<std::mutex> lock(progress_mu_);
+    if (progress_stop_) throw std::runtime_error("MpiGroupMailboxTransport: transport is shut down");
+    if (progress_active_) throw std::logic_error("MpiGroupMailboxTransport: progress command is already active");
+    if (!progress_thread_.joinable()) {
+        progress_thread_ = std::thread([this]() {
+            progress_worker();
+        });
+    }
+    progress_request_ = std::move(request);
+    progress_reply_.clear();
+    progress_error_ = nullptr;
+    progress_done_ = false;
+    progress_active_ = true;
+    progress_cv_.notify_all();
+}
+
+void MpiGroupMailboxTransport::progress_worker() {
+    for (;;) {
+        ProgressRequest request;
+        {
+            std::unique_lock<std::mutex> lock(progress_mu_);
+            progress_cv_.wait(lock, [this]() {
+                return progress_stop_ || (progress_active_ && !progress_done_);
+            });
+            if (progress_stop_) return;
+            request = progress_request_;
+        }
+        std::vector<uint8_t> reply;
+        std::exception_ptr error;
+        try {
+            reply =
+                request.group ?
+                    channel_->exchange_group_task(request.frame, target_rank_, request.task_slot, request.group_size) :
+                    channel_->exchange(request.frame, target_rank_);
+        } catch (...) {
+            error = std::current_exception();
+        }
+        {
+            std::lock_guard<std::mutex> lock(progress_mu_);
+            progress_reply_ = std::move(reply);
+            progress_error_ = error;
+            progress_done_ = true;
+        }
+        progress_cv_.notify_all();
+    }
+}
+
+void MpiGroupMailboxTransport::submit_progress_frame(const std::vector<uint8_t> &frame) {
+    ProgressRequest request;
+    request.frame = frame;
+    start_progress(std::move(request));
+}
+
+void MpiGroupMailboxTransport::submit_group_progress_frame(
+    const std::vector<uint8_t> &frame, uint64_t task_slot, int32_t, int32_t group_size
+) {
+    ProgressRequest request;
+    request.frame = frame;
+    request.group = true;
+    request.task_slot = task_slot;
+    request.group_size = group_size;
+    start_progress(std::move(request));
+}
+
+bool MpiGroupMailboxTransport::poll_progress_reply(
+    remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply
+) {
+    std::exception_ptr error;
+    {
+        std::lock_guard<std::mutex> lock(progress_mu_);
+        if (!progress_active_) throw std::logic_error("MpiGroupMailboxTransport: no progress command is active");
+        if (!progress_done_) return false;
+        progress_active_ = false;
+        progress_done_ = false;
+        error = progress_error_;
+        progress_error_ = nullptr;
+        reply = std::move(progress_reply_);
+        progress_reply_.clear();
+    }
+    if (error != nullptr) std::rethrow_exception(error);
+    const auto decoded = remote_l3::decode_frame(reply);
+    if (decoded.header.frame_type != frame_type || decoded.header.sequence != sequence) {
+        throw std::runtime_error("MpiGroupMailboxTransport: reply frame type or sequence mismatch");
+    }
+    return true;
+}
+
+void MpiGroupMailboxTransport::shutdown() {
+    {
+        std::lock_guard<std::mutex> lock(progress_mu_);
+        progress_stop_ = true;
+    }
+    progress_cv_.notify_all();
+    if (!pending_) return;
+    auto frame = std::move(pending_frame_);
+    pending_frame_.clear();
+    pending_ = false;
+    channel_->shutdown(frame);
+}
+
 RemoteL3Endpoint::RemoteL3Endpoint(
-    int32_t worker_id, uint64_t session_id, std::string transport_name, std::unique_ptr<RemoteL3Transport> transport
+    int32_t worker_id, uint64_t session_id, std::string transport_name, std::unique_ptr<RemoteL3Transport> transport,
+    WorkerEndpointKind endpoint_kind
 ) :
     session_id_(session_id),
     transport_(std::move(transport)) {
     if (worker_id < 0) throw std::invalid_argument("RemoteL3Endpoint: worker_id must be non-negative");
     if (session_id == 0) throw std::invalid_argument("RemoteL3Endpoint: session_id must be non-zero");
     if (!transport_) throw std::invalid_argument("RemoteL3Endpoint: null transport");
-    caps_.kind = WorkerEndpointKind::REMOTE_L3;
+    caps_.kind = endpoint_kind;
     caps_.worker_id = worker_id;
     caps_.remote = true;
     caps_.supports_task_dispatch = true;
     caps_.supports_control = true;
     caps_.transport = std::move(transport_name);
 }
+
+MpiGroupMailboxEndpoint::MpiGroupMailboxEndpoint(
+    int32_t worker_id, uint64_t session_id, int32_t rank, std::shared_ptr<MpiGroupMailboxChannel> channel
+) :
+    RemoteL3Endpoint(
+        worker_id, session_id, "mpi-group-mailbox",
+        std::make_unique<MpiGroupMailboxTransport>(std::move(channel), rank), WorkerEndpointKind::MPI_GROUP_MAILBOX
+    ) {}
 
 remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotState &slot, int32_t group_index) const {
     remote_l3::TaskPayloadWire payload;
@@ -786,7 +1306,14 @@ void RemoteL3Endpoint::submit_progress(Ring *ring, const WorkerDispatch &dispatc
         header.session_id = session_id_;
         header.worker_id = caps_.worker_id;
         header.sequence = sequence;
-        transport_->submit_progress_frame(remote_l3::encode_frame(header, payload));
+        auto frame = remote_l3::encode_frame(header, payload);
+        if (slot->is_group() && transport_->supports_group_batch()) {
+            transport_->submit_group_progress_frame(
+                frame, static_cast<uint64_t>(dispatch.task_slot), dispatch.group_index, slot->group_size()
+            );
+        } else {
+            transport_->submit_progress_frame(frame);
+        }
         pending_task_.occupied = true;
         pending_task_.dispatch = dispatch;
         pending_task_.sequence = sequence;
@@ -874,8 +1401,9 @@ bool RemoteL3Endpoint::report_submission_error(const WorkerDispatch &dispatch, c
     }
 }
 
-remote_l3::ControlReplyPayload
-RemoteL3Endpoint::run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) {
+remote_l3::ControlReplyPayload RemoteL3Endpoint::run_control(
+    remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target
+) {
     std::unique_lock<std::mutex> command_lk(command_mu_);
     command_cv_.wait(command_lk, [this] {
         return !pending_task_.occupied || progress_stop_requested_;
@@ -897,6 +1425,7 @@ RemoteL3Endpoint::run_control(remote_l3::ControlName control_name, const std::ve
         header.session_id = session_id_;
         header.worker_id = caps_.worker_id;
         header.sequence = sequence;
+        if (group_target) header.flags |= remote_l3::FRAME_FLAG_GROUP_TARGET;
         transport_->submit_frame(remote_l3::encode_frame(header, remote_l3::encode_control(control)));
 
         auto reply_bytes = transport_->wait_for_reply(remote_l3::FrameType::CONTROL_REPLY, sequence);
@@ -1102,9 +1631,9 @@ void RemoteL3Endpoint::control_remote_release_import(const RemoteBufferHandle &h
 }
 
 std::vector<uint8_t> RemoteL3Endpoint::control_remote_domain(
-    remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+    remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target
 ) {
-    return run_control(control_name, command_bytes).result_bytes;
+    return run_control(control_name, command_bytes, group_target).result_bytes;
 }
 
 void RemoteL3Endpoint::shutdown_child() {

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -734,6 +734,11 @@ MpiGroupMailboxChannel::MpiGroupMailboxChannel(
         read_u32(OFF_WORLD_SIZE) != static_cast<uint32_t>(world_size_)) {
         throw std::invalid_argument("MpiGroupMailboxChannel: mailbox layout or world size mismatch");
     }
+    for (size_t offset = RESERVED_OFFSET; offset < HEADER_BYTES; ++offset) {
+        if (mailbox_[offset] != 0) {
+            throw std::invalid_argument("MpiGroupMailboxChannel: reserved header bytes must be zero");
+        }
+    }
 }
 
 int32_t MpiGroupMailboxChannel::load_i32(size_t offset) const {
@@ -744,6 +749,10 @@ int32_t MpiGroupMailboxChannel::load_i32(size_t offset) const {
 
 void MpiGroupMailboxChannel::store_i32(size_t offset, int32_t value) {
     __atomic_store(reinterpret_cast<int32_t *>(mailbox_ + offset), &value, __ATOMIC_RELEASE);
+}
+
+void MpiGroupMailboxChannel::wake_request_waiter() {
+    mpi_group_mailbox::wake_word(reinterpret_cast<int32_t *>(mailbox_ + mpi_group_mailbox::OFF_REQUEST_STATE));
 }
 
 uint32_t MpiGroupMailboxChannel::read_u32(size_t offset) const {
@@ -779,6 +788,7 @@ void MpiGroupMailboxChannel::mark_terminal(const std::string &reason) {
     write_u32(OFF_ERROR_BYTES, static_cast<uint32_t>(size));
     store_i32(OFF_GROUP_STATE, static_cast<int32_t>(GroupState::TERMINAL));
     store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(RequestState::TASK_FAILED));
+    wake_request_waiter();
 }
 
 void MpiGroupMailboxChannel::kill_mpirun_group() const {
@@ -851,6 +861,7 @@ std::vector<std::vector<uint8_t>> MpiGroupMailboxChannel::run_exchange(
     const RequestState ready_state =
         opcode == Opcode::SHUTDOWN ? RequestState::SHUTDOWN_READY : RequestState::REQUEST_READY;
     store_i32(OFF_REQUEST_STATE, static_cast<int32_t>(ready_state));
+    wake_request_waiter();
 
     const Deadline deadline = deadline_from_now(runtime_timeout_s_);
     while (true) {

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -129,6 +129,8 @@ private:
 
     int32_t load_i32(size_t offset) const;
     void store_i32(size_t offset, int32_t value);
+    // Wakes the rank-0 futex wait parked on the request-state word.
+    void wake_request_waiter();
     uint32_t read_u32(size_t offset) const;
     uint64_t read_u64(size_t offset) const;
     void write_u32(size_t offset, uint32_t value);

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -16,10 +16,12 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <exception>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include "mpi_group_mailbox.h"
 #include "remote_wire.h"
 #include "worker_manager.h"
 
@@ -31,6 +33,10 @@ public:
     virtual void submit_progress_frame(const std::vector<uint8_t> &frame) = 0;
     virtual bool
     poll_progress_reply(remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply) = 0;
+    virtual bool supports_group_batch() const { return false; }
+    virtual void submit_group_progress_frame(
+        const std::vector<uint8_t> &frame, uint64_t task_slot, int32_t group_index, int32_t group_size
+    );
     virtual void shutdown() {}
 };
 
@@ -88,10 +94,105 @@ private:
     void reset_progress_command() noexcept;
 };
 
+class MpiGroupMailboxChannel {
+public:
+    MpiGroupMailboxChannel(
+        void *mailbox, size_t mailbox_bytes, int32_t world_size, int mpirun_pid, double runtime_timeout_s
+    );
+
+    std::vector<uint8_t> exchange(const std::vector<uint8_t> &frame, int32_t target_rank);
+    std::vector<uint8_t>
+    exchange_group_task(const std::vector<uint8_t> &frame, int32_t target_rank, uint64_t task_slot, int32_t group_size);
+    void shutdown(const std::vector<uint8_t> &frame);
+    bool terminal() const;
+
+private:
+    uint8_t *mailbox_{nullptr};
+    size_t mailbox_bytes_{0};
+    int32_t world_size_{0};
+    int mpirun_pid_{-1};
+    double runtime_timeout_s_{30.0};
+    uint64_t next_sequence_{1};
+    bool shutdown_sent_{false};
+    mutable std::mutex lane_mu_;
+    std::mutex group_mu_;
+    std::condition_variable group_cv_;
+    bool group_active_{false};
+    bool group_done_{false};
+    bool group_leader_running_{false};
+    uint64_t group_task_slot_{0};
+    int32_t group_arrived_{0};
+    int32_t group_departed_{0};
+    std::vector<std::vector<uint8_t>> group_frames_;
+    std::vector<std::vector<uint8_t>> group_replies_;
+    std::exception_ptr group_error_;
+
+    int32_t load_i32(size_t offset) const;
+    void store_i32(size_t offset, int32_t value);
+    uint32_t read_u32(size_t offset) const;
+    uint64_t read_u64(size_t offset) const;
+    void write_u32(size_t offset, uint32_t value);
+    void write_u64(size_t offset, uint64_t value);
+    std::string terminal_reason() const;
+    void mark_terminal(const std::string &reason);
+    void kill_mpirun_group() const;
+    std::vector<std::vector<uint8_t>> run_exchange(
+        const std::vector<std::vector<uint8_t>> &frames, mpi_group_mailbox::Opcode opcode,
+        mpi_group_mailbox::Target target, int32_t target_rank
+    );
+};
+
+class MpiGroupMailboxTransport : public RemoteL3Transport {
+public:
+    MpiGroupMailboxTransport(std::shared_ptr<MpiGroupMailboxChannel> channel, int32_t target_rank);
+    ~MpiGroupMailboxTransport() override;
+
+    void submit_frame(const std::vector<uint8_t> &frame) override;
+    std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) override;
+    void submit_progress_frame(const std::vector<uint8_t> &frame) override;
+    bool poll_progress_reply(remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply) override;
+    bool supports_group_batch() const override { return true; }
+    void submit_group_progress_frame(
+        const std::vector<uint8_t> &frame, uint64_t task_slot, int32_t group_index, int32_t group_size
+    ) override;
+    void shutdown() override;
+
+private:
+    // One in-flight progress command runs on progress_thread_ so the
+    // scheduler's submit/poll never blocks: the channel's group rendezvous
+    // waits for every rank's frame, and those frames arrive one per
+    // endpoint from the same scheduler thread.
+    struct ProgressRequest {
+        std::vector<uint8_t> frame;
+        bool group{false};
+        uint64_t task_slot{0};
+        int32_t group_size{0};
+    };
+
+    void start_progress(ProgressRequest request);
+    void progress_worker();
+
+    std::shared_ptr<MpiGroupMailboxChannel> channel_;
+    int32_t target_rank_{-1};
+    std::vector<uint8_t> pending_frame_;
+    bool pending_{false};
+
+    std::thread progress_thread_;
+    std::mutex progress_mu_;
+    std::condition_variable progress_cv_;
+    bool progress_active_{false};
+    bool progress_done_{false};
+    bool progress_stop_{false};
+    ProgressRequest progress_request_;
+    std::vector<uint8_t> progress_reply_;
+    std::exception_ptr progress_error_;
+};
+
 class RemoteL3Endpoint : public WorkerEndpoint {
 public:
     RemoteL3Endpoint(
-        int32_t worker_id, uint64_t session_id, std::string transport_name, std::unique_ptr<RemoteL3Transport> transport
+        int32_t worker_id, uint64_t session_id, std::string transport_name,
+        std::unique_ptr<RemoteL3Transport> transport, WorkerEndpointKind endpoint_kind = WorkerEndpointKind::REMOTE_L3
     );
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
@@ -128,8 +229,9 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     ) override;
     void control_remote_release_import(const RemoteBufferHandle &handle) override;
-    std::vector<uint8_t>
-    control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) override;
+    std::vector<uint8_t> control_remote_domain(
+        remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target = false
+    ) override;
 
 private:
     WorkerEndpointCaps caps_;
@@ -150,6 +252,14 @@ private:
     remote_l3::TaskPayloadWire build_task_payload(const TaskSlotState &slot, int32_t group_index) const;
     // The caller holds command_mu_; this mutates pending_task_ and wakes waiters.
     void finish_progress_command(uint64_t sequence);
-    remote_l3::ControlReplyPayload
-    run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
+    remote_l3::ControlReplyPayload run_control(
+        remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target = false
+    );
+};
+
+class MpiGroupMailboxEndpoint final : public RemoteL3Endpoint {
+public:
+    MpiGroupMailboxEndpoint(
+        int32_t worker_id, uint64_t session_id, int32_t rank, std::shared_ptr<MpiGroupMailboxChannel> channel
+    );
 };

--- a/src/common/hierarchical/remote_wire.cpp
+++ b/src/common/hierarchical/remote_wire.cpp
@@ -236,7 +236,7 @@ void validate_desc_against_inline_payload(const RemoteTensorDesc &desc, size_t i
 
 std::vector<uint8_t> encode_frame(const FrameHeader &header, const std::vector<uint8_t> &payload) {
     ensure(payload.size() <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: frame payload exceeds maximum");
-    ensure(header.flags == 0, "remote_wire: frame flags are reserved in v1");
+    ensure((header.flags & ~FRAME_FLAGS_KNOWN) == 0, "remote_wire: unknown frame flags");
     std::vector<uint8_t> out;
     out.reserve(FRAME_HEADER_BYTES + payload.size());
     put_bytes(out, MAGIC, sizeof(MAGIC));
@@ -266,7 +266,7 @@ DecodedFrame decode_frame(const uint8_t *data, size_t size) {
     frame.header.sequence = get_u64(data, size, offset);
     frame.header.payload_bytes = get_u32(data, size, offset);
     frame.header.flags = get_u32(data, size, offset);
-    ensure(frame.header.flags == 0, "remote_wire: frame flags are reserved in v1");
+    ensure((frame.header.flags & ~FRAME_FLAGS_KNOWN) == 0, "remote_wire: unknown frame flags");
     ensure(frame.header.payload_bytes <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: frame payload exceeds maximum");
     ensure(size - offset == frame.header.payload_bytes, "remote_wire: frame payload length mismatch");
     frame.payload.assign(data + offset, data + size);

--- a/src/common/hierarchical/remote_wire.h
+++ b/src/common/hierarchical/remote_wire.h
@@ -80,6 +80,13 @@ enum class RemoteRegistryTarget : uint32_t {
     INNER_L3_WORKER = 2,
 };
 
+// FrameHeader::flags bit: the caller addresses every member of the target's
+// worker group, not just the worker named in the header. Only group-capable
+// transports (the MPI mailbox) act on it; point-to-point transports ignore it.
+inline constexpr uint32_t FRAME_FLAG_GROUP_TARGET = 0x1;
+// Every defined flag bit; a frame carrying any other bit is rejected.
+inline constexpr uint32_t FRAME_FLAGS_KNOWN = FRAME_FLAG_GROUP_TARGET;
+
 struct FrameHeader {
     FrameType frame_type{FrameType::HELLO};
     uint64_t session_id{0};

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -141,6 +141,26 @@ void Worker::add_remote_l3_socket(
     );
 }
 
+void Worker::add_mpi_group_mailbox(
+    const std::vector<int32_t> &worker_ids, const std::vector<uint64_t> &session_ids, void *mailbox,
+    size_t mailbox_bytes, int mpirun_pid, double runtime_timeout_s
+) {
+    if (initialized_) throw std::runtime_error("Worker: add_mpi_group_mailbox after init");
+    if (worker_ids.empty() || worker_ids.size() != session_ids.size()) {
+        throw std::invalid_argument("Worker: MPI group worker_ids and session_ids must have the same non-zero size");
+    }
+    auto channel = std::make_shared<MpiGroupMailboxChannel>(
+        mailbox, mailbox_bytes, static_cast<int32_t>(worker_ids.size()), mpirun_pid, runtime_timeout_s
+    );
+    for (size_t rank = 0; rank < worker_ids.size(); ++rank) {
+        manager_.add_next_level_endpoint(
+            std::make_unique<MpiGroupMailboxEndpoint>(
+                worker_ids[rank], session_ids[rank], static_cast<int32_t>(rank), channel
+            )
+        );
+    }
+}
+
 void Worker::init() {
     if (initialized_) throw std::runtime_error("Worker: already initialized");
 

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -85,6 +86,10 @@ public:
         int32_t worker_id, uint64_t session_id, const std::string &transport_name, const std::string &host,
         uint16_t port, const std::string &health_host, uint16_t health_port, double attach_timeout_s,
         double runtime_timeout_s
+    );
+    void add_mpi_group_mailbox(
+        const std::vector<int32_t> &worker_ids, const std::vector<uint64_t> &session_ids, void *mailbox,
+        size_t mailbox_bytes, int mpirun_pid, double runtime_timeout_s
     );
 
     // Start the scheduler thread. Must be called AFTER the parent has forked
@@ -187,9 +192,10 @@ public:
     }
     void remote_release_import(const RemoteBufferHandle &handle) { manager_.control_remote_release_import(handle); }
     std::vector<uint8_t> remote_domain_control(
-        int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+        int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes,
+        bool group_target = false
     ) {
-        return manager_.control_remote_domain(worker_id, control_name, command_bytes);
+        return manager_.control_remote_domain(worker_id, control_name, command_bytes, group_target);
     }
 
     // Device memory on a next-level worker. The Worker is the sole owner of buffer lifecycle; the

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -170,7 +170,7 @@ RemoteBufferHandle WorkerEndpoint::control_remote_import(int32_t, const RemoteBu
 void WorkerEndpoint::control_remote_release_import(const RemoteBufferHandle &) {
     throw_unsupported_control("control_remote_release_import");
 }
-std::vector<uint8_t> WorkerEndpoint::control_remote_domain(remote_l3::ControlName, const std::vector<uint8_t> &) {
+std::vector<uint8_t> WorkerEndpoint::control_remote_domain(remote_l3::ControlName, const std::vector<uint8_t> &, bool) {
     throw_unsupported_control("control_remote_domain");
 }
 void WorkerEndpoint::control_generic(uint64_t, const char *, size_t, double, const uint8_t *) {
@@ -1514,10 +1514,11 @@ void WorkerThread::control_remote_release_import(const RemoteBufferHandle &handl
     endpoint_->control_remote_release_import(handle);
 }
 
-std::vector<uint8_t>
-WorkerThread::control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) {
+std::vector<uint8_t> WorkerThread::control_remote_domain(
+    remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target
+) {
     if (!endpoint_) throw std::runtime_error("control_remote_domain: null endpoint");
-    return endpoint_->control_remote_domain(control_name, command_bytes);
+    return endpoint_->control_remote_domain(control_name, command_bytes, group_target);
 }
 
 void WorkerThread::control_generic(
@@ -1907,7 +1908,7 @@ void WorkerManager::control_remote_release_import(const RemoteBufferHandle &hand
 }
 
 std::vector<uint8_t> WorkerManager::control_remote_domain(
-    int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+    int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target
 ) {
     WorkerThread *wt = get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
     if (wt == nullptr) {
@@ -1919,7 +1920,7 @@ std::vector<uint8_t> WorkerManager::control_remote_domain(
     case remote_l3::ControlName::RELEASE_DOMAIN:
     case remote_l3::ControlName::COPY_TO_DOMAIN:
     case remote_l3::ControlName::COPY_FROM_DOMAIN:
-        return wt->control_remote_domain(control_name, command_bytes);
+        return wt->control_remote_domain(control_name, command_bytes, group_target);
     default:
         throw std::runtime_error("control_remote_domain: control name is not a domain operation");
     }

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -303,6 +303,7 @@ struct WorkerEndpointProgress {
 enum class WorkerEndpointKind : int32_t {
     LOCAL_MAILBOX = 0,
     REMOTE_L3 = 1,
+    MPI_GROUP_MAILBOX = 2,
 };
 
 struct WorkerEndpointCaps {
@@ -374,8 +375,9 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     );
     virtual void control_remote_release_import(const RemoteBufferHandle &handle);
-    virtual std::vector<uint8_t>
-    control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
+    virtual std::vector<uint8_t> control_remote_domain(
+        remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target = false
+    );
     virtual void control_generic(
         uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
     );
@@ -600,8 +602,9 @@ public:
         int32_t importer_worker_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
     );
     void control_remote_release_import(const RemoteBufferHandle &handle);
-    std::vector<uint8_t>
-    control_remote_domain(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
+    std::vector<uint8_t> control_remote_domain(
+        remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes, bool group_target = false
+    );
     void control_generic(
         uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
     );
@@ -754,7 +757,8 @@ public:
     );
     void control_remote_release_import(const RemoteBufferHandle &handle);
     std::vector<uint8_t> control_remote_domain(
-        int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes
+        int worker_id, remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes,
+        bool group_target = false
     );
 
     // Broadcast CTRL_REGISTER for `digest` to every NEXT_LEVEL worker in

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -45,6 +45,7 @@
 #include <fcntl.h>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -221,6 +222,7 @@ struct GlobalDomainAllocation {
 
 static_assert(sizeof(CommGlobalDomainDescriptor) == 288, "global domain descriptor ABI changed");
 static std::unordered_map<uint64_t, std::unique_ptr<GlobalDomainAllocation>> global_domain_allocations;
+static std::mutex global_domain_allocations_mutex;
 
 struct CommHandle_ {
     int rank;
@@ -751,6 +753,7 @@ extern "C" int comm_global_domain_prepare(
         local_window_base_out == nullptr) {
         return -1;
     }
+    std::lock_guard<std::mutex> lock(global_domain_allocations_mutex);
     if (global_domain_allocations.count(domain_id) != 0) {
         return -1;
     }
@@ -810,6 +813,7 @@ extern "C" int comm_global_domain_prepare(
 extern "C" int comm_global_domain_import(
     uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
 ) try {
+    std::lock_guard<std::mutex> lock(global_domain_allocations_mutex);
     auto it = global_domain_allocations.find(domain_id);
     if (it == global_domain_allocations.end() || descriptors == nullptr || device_ctx_out == nullptr) {
         return -1;
@@ -876,6 +880,7 @@ extern "C" int comm_global_domain_import(
 }
 
 extern "C" int comm_global_domain_release(uint64_t domain_id) try {
+    std::lock_guard<std::mutex> lock(global_domain_allocations_mutex);
     auto it = global_domain_allocations.find(domain_id);
     if (it == global_domain_allocations.end()) {
         return 0;

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -938,6 +938,13 @@ TEST(MpiGroupMailboxChannel, FullGroupTaskUsesOnePerRankEnvelope) {
     EXPECT_EQ(mailbox_state(mailbox, OFF_REQUEST_STATE), static_cast<int32_t>(RequestState::IDLE));
 }
 
+TEST(MpiGroupMailboxChannel, RejectsNonZeroReservedHeaderBytes) {
+    using namespace mpi_group_mailbox;
+    auto mailbox = ready_mpi_mailbox(1);
+    mailbox[RESERVED_OFFSET + 8] = 1;
+    EXPECT_THROW(MpiGroupMailboxChannel(mailbox.data(), mailbox.size(), 1, -1, 1.0), std::invalid_argument);
+}
+
 TEST(MpiGroupMailboxChannel, TimeoutMakesGroupTerminal) {
     using namespace mpi_group_mailbox;
     auto mailbox = ready_mpi_mailbox(1);

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -852,3 +852,158 @@ TEST(RemoteEndpoint, SidecarFreePlaceholderIsRejectedAtSubmission) {
     EXPECT_TRUE(transport->last_frame.empty());
     ring.shutdown();
 }
+
+namespace {
+
+std::vector<uint8_t> ready_mpi_mailbox(int32_t world_size) {
+    using namespace mpi_group_mailbox;
+    std::vector<uint8_t> mailbox(MAILBOX_BYTES, 0);
+    std::memcpy(mailbox.data() + OFF_MAGIC, MAGIC, sizeof(MAGIC));
+    const uint32_t version = PROTOCOL_VERSION;
+    const uint32_t header_bytes = HEADER_BYTES;
+    const uint64_t mailbox_bytes = MAILBOX_BYTES;
+    const uint32_t size = static_cast<uint32_t>(world_size);
+    const int32_t ready = static_cast<int32_t>(GroupState::READY);
+    const int32_t idle = static_cast<int32_t>(RequestState::IDLE);
+    std::memcpy(mailbox.data() + OFF_PROTOCOL_VERSION, &version, sizeof(version));
+    std::memcpy(mailbox.data() + OFF_HEADER_BYTES, &header_bytes, sizeof(header_bytes));
+    std::memcpy(mailbox.data() + OFF_MAILBOX_BYTES, &mailbox_bytes, sizeof(mailbox_bytes));
+    std::memcpy(mailbox.data() + OFF_WORLD_SIZE, &size, sizeof(size));
+    std::memcpy(mailbox.data() + OFF_GROUP_STATE, &ready, sizeof(ready));
+    std::memcpy(mailbox.data() + OFF_REQUEST_STATE, &idle, sizeof(idle));
+    return mailbox;
+}
+
+int32_t mailbox_state(const std::vector<uint8_t> &mailbox, size_t offset) {
+    int32_t value = 0;
+    __atomic_load(reinterpret_cast<const int32_t *>(mailbox.data() + offset), &value, __ATOMIC_ACQUIRE);
+    return value;
+}
+
+void set_mailbox_state(std::vector<uint8_t> &mailbox, size_t offset, int32_t value) {
+    __atomic_store(reinterpret_cast<int32_t *>(mailbox.data() + offset), &value, __ATOMIC_RELEASE);
+}
+
+void respond_with_payloads(std::vector<uint8_t> &mailbox, const std::vector<std::vector<uint8_t>> &payloads) {
+    using namespace mpi_group_mailbox;
+    while (mailbox_state(mailbox, OFF_REQUEST_STATE) != static_cast<int32_t>(RequestState::REQUEST_READY)) {}
+    const uint32_t count = static_cast<uint32_t>(payloads.size());
+    std::memcpy(mailbox.data() + RESPONSE_OFFSET, &count, sizeof(count));
+    size_t offset = RESPONSE_OFFSET + 4;
+    size_t response_bytes = 4 + 4 * payloads.size();
+    for (const auto &payload : payloads) {
+        const uint32_t size = static_cast<uint32_t>(payload.size());
+        std::memcpy(mailbox.data() + offset, &size, sizeof(size));
+        offset += 4;
+        response_bytes += payload.size();
+    }
+    for (const auto &payload : payloads) {
+        if (!payload.empty()) std::memcpy(mailbox.data() + offset, payload.data(), payload.size());
+        offset += payload.size();
+    }
+    std::memcpy(mailbox.data() + OFF_RESPONSE_COUNT, &count, sizeof(count));
+    const uint32_t encoded_bytes = static_cast<uint32_t>(response_bytes);
+    std::memcpy(mailbox.data() + OFF_RESPONSE_BYTES, &encoded_bytes, sizeof(encoded_bytes));
+    set_mailbox_state(mailbox, OFF_REQUEST_STATE, static_cast<int32_t>(mpi_group_mailbox::RequestState::TASK_DONE));
+}
+
+}  // namespace
+
+TEST(MpiGroupMailboxChannel, FullGroupTaskUsesOnePerRankEnvelope) {
+    using namespace mpi_group_mailbox;
+    auto mailbox = ready_mpi_mailbox(2);
+    MpiGroupMailboxChannel channel(mailbox.data(), mailbox.size(), 2, -1, 2.0);
+    std::vector<uint8_t> reply0;
+    std::vector<uint8_t> reply1;
+    std::thread rank0([&]() {
+        reply0 = channel.exchange_group_task({0x10}, 0, 7, 2);
+    });
+    std::thread rank1([&]() {
+        reply1 = channel.exchange_group_task({0x20}, 1, 7, 2);
+    });
+
+    while (mailbox_state(mailbox, OFF_REQUEST_STATE) != static_cast<int32_t>(RequestState::REQUEST_READY)) {}
+    uint32_t target = 0;
+    uint32_t request_count = 0;
+    std::memcpy(&target, mailbox.data() + OFF_TARGET, sizeof(target));
+    std::memcpy(&request_count, mailbox.data() + OFF_REQUEST_COUNT, sizeof(request_count));
+    EXPECT_EQ(target, static_cast<uint32_t>(Target::PER_RANK));
+    EXPECT_EQ(request_count, 2U);
+    respond_with_payloads(mailbox, {{0xA0}, {0xA1}});
+
+    rank0.join();
+    rank1.join();
+    EXPECT_EQ(reply0, std::vector<uint8_t>({0xA0}));
+    EXPECT_EQ(reply1, std::vector<uint8_t>({0xA1}));
+    EXPECT_EQ(mailbox_state(mailbox, OFF_REQUEST_STATE), static_cast<int32_t>(RequestState::IDLE));
+}
+
+TEST(MpiGroupMailboxChannel, TimeoutMakesGroupTerminal) {
+    using namespace mpi_group_mailbox;
+    auto mailbox = ready_mpi_mailbox(1);
+    MpiGroupMailboxChannel channel(mailbox.data(), mailbox.size(), 1, -1, 0.01);
+    EXPECT_THROW(channel.exchange_group_task({0x10}, 0, 9, 1), std::runtime_error);
+    EXPECT_TRUE(channel.terminal());
+    EXPECT_EQ(mailbox_state(mailbox, OFF_GROUP_STATE), static_cast<int32_t>(GroupState::TERMINAL));
+}
+
+TEST(MpiGroupMailboxChannel, GroupArrivalTimeoutFailsTaskWithoutKillingGroup) {
+    using namespace mpi_group_mailbox;
+    auto mailbox = ready_mpi_mailbox(2);
+    MpiGroupMailboxChannel channel(mailbox.data(), mailbox.size(), 2, -1, 0.05);
+    EXPECT_THROW(channel.exchange_group_task({0x10}, 0, 9, 2), std::runtime_error);
+    EXPECT_FALSE(channel.terminal());
+    EXPECT_EQ(mailbox_state(mailbox, OFF_GROUP_STATE), static_cast<int32_t>(GroupState::READY));
+    // The withdrawn arrival leaves a clean slate: a later full batch succeeds.
+    std::vector<uint8_t> reply0;
+    std::vector<uint8_t> reply1;
+    std::thread rank0([&]() {
+        reply0 = channel.exchange_group_task({0x11}, 0, 10, 2);
+    });
+    std::thread rank1([&]() {
+        reply1 = channel.exchange_group_task({0x21}, 1, 10, 2);
+    });
+    respond_with_payloads(mailbox, {{0xB0}, {0xB1}});
+    rank0.join();
+    rank1.join();
+    EXPECT_EQ(reply0, std::vector<uint8_t>({0xB0}));
+    EXPECT_EQ(reply1, std::vector<uint8_t>({0xB1}));
+}
+
+TEST(MpiGroupMailboxTransport, GroupProgressSubmitAndPollRoundTrip) {
+    using namespace mpi_group_mailbox;
+    auto mailbox = ready_mpi_mailbox(2);
+    auto channel = std::make_shared<MpiGroupMailboxChannel>(mailbox.data(), mailbox.size(), 2, -1, 2.0);
+    MpiGroupMailboxTransport rank0(channel, 0);
+    MpiGroupMailboxTransport rank1(channel, 1);
+
+    auto task_frame = [](int32_t worker_id, uint64_t sequence) {
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::TASK;
+        header.session_id = 77;
+        header.worker_id = worker_id;
+        header.sequence = sequence;
+        return remote_l3::encode_frame(header, {0x11});
+    };
+    auto completion_frame = [](int32_t worker_id, uint64_t sequence, uint8_t marker) {
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::COMPLETION;
+        header.session_id = 77;
+        header.worker_id = worker_id;
+        header.sequence = sequence;
+        return remote_l3::encode_frame(header, {marker});
+    };
+
+    rank0.submit_group_progress_frame(task_frame(10, 21), 7, 0, 2);
+    std::vector<uint8_t> reply;
+    EXPECT_FALSE(rank0.poll_progress_reply(remote_l3::FrameType::COMPLETION, 21, reply));
+    rank1.submit_group_progress_frame(task_frame(11, 22), 7, 1, 2);
+
+    respond_with_payloads(mailbox, {completion_frame(10, 21, 0xA0), completion_frame(11, 22, 0xA1)});
+
+    while (!rank0.poll_progress_reply(remote_l3::FrameType::COMPLETION, 21, reply)) {}
+    EXPECT_EQ(remote_l3::decode_frame(reply).payload, std::vector<uint8_t>({0xA0}));
+    while (!rank1.poll_progress_reply(remote_l3::FrameType::COMPLETION, 22, reply)) {}
+    EXPECT_EQ(remote_l3::decode_frame(reply).payload, std::vector<uint8_t>({0xA1}));
+    EXPECT_EQ(mailbox_state(mailbox, OFF_REQUEST_STATE), static_cast<int32_t>(RequestState::IDLE));
+}

--- a/tests/ut/cpp/hierarchical/test_remote_wire.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_wire.cpp
@@ -82,8 +82,12 @@ TEST(RemoteWire, FrameRejectsBadVersionFlagsAndUnknownType) {
     EXPECT_THROW((void)remote_l3::decode_frame(bad_type), std::runtime_error);
 
     auto bad_flags = encoded;
-    bad_flags[36] = 1;
+    bad_flags[36] = static_cast<uint8_t>(remote_l3::FRAME_FLAGS_KNOWN + 1);
     EXPECT_THROW((void)remote_l3::decode_frame(bad_flags), std::runtime_error);
+
+    auto group_flag = encoded;
+    group_flag[36] = remote_l3::FRAME_FLAG_GROUP_TARGET;
+    EXPECT_EQ(remote_l3::decode_frame(group_flag).header.flags, remote_l3::FRAME_FLAG_GROUP_TARGET);
 }
 
 TEST(RemoteWire, TaskPayloadRoundTripsTheArgTensorVerbatim) {

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -26,6 +26,7 @@ from simpler.global_comm_domain import (
     CTRL_GLOBAL_DOMAIN_PREPARE,
     CTRL_GLOBAL_DOMAIN_RELEASE,
     GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
+    GLOBAL_DOMAIN_MAX_BUFFERS,
     GLOBAL_DOMAIN_PROFILE_IDS,
     GLOBAL_DOMAIN_VERSION,
     GlobalCommInitCommand,
@@ -160,6 +161,22 @@ def test_global_domain_wire_round_trips_topology_and_descriptor_table():
     assert GLOBAL_DOMAIN_DESCRIPTOR_BYTES == 288
 
 
+def test_global_domain_encode_rejects_too_many_buffers():
+    command = GlobalDomainCommand(
+        phase=GlobalDomainPhase.PREPARE_EXPORT,
+        domain_id=11,
+        generation=1,
+        name="tp",
+        profile="sim",
+        window_size=GLOBAL_DOMAIN_MAX_BUFFERS + 1,
+        members=_members(),
+        buffers=tuple(GlobalDomainBuffer(f"payload-{index}", 1) for index in range(GLOBAL_DOMAIN_MAX_BUFFERS + 1)),
+    )
+
+    with pytest.raises(ValueError, match="buffer count exceeds maximum"):
+        encode_domain_command(command)
+
+
 def _failure_injection_worker(*, platform: str = "a2a3sim", profile: str = "sim"):
     from simpler.worker import RemoteWorkerSpec, Worker, _RunResources  # noqa: PLC0415
 
@@ -241,8 +258,6 @@ def _mpi_static_worker():
         MpiL3GroupSpec(
             hosts=("127.0.0.1", "127.0.0.1"),
             platform="a2a3sim",
-            command_port_base=21073,
-            health_port_base=22073,
             device_ids_by_rank=((0,), (0,)),
             comm_profile="sim",
             global_device_ranks_by_rank=((0,), (1,)),
@@ -554,7 +569,7 @@ def test_global_domain_descriptor_table_rejects_different_mapping_sizes():
         validate_descriptor_table(tuple(descriptors), rank_count=2, profile="sim")
 
 
-def test_global_domain_release_retries_after_callback_failure():
+def test_global_domain_release_stays_released_after_callback_failure():
     from simpler.task_interface import GlobalCommDomainHandle  # noqa: PLC0415
 
     attempts = 0
@@ -562,8 +577,7 @@ def test_global_domain_release_retries_after_callback_failure():
     def release_fn(_handle):
         nonlocal attempts
         attempts += 1
-        if attempts == 1:
-            raise RuntimeError("transient release failure")
+        raise RuntimeError("release failure")
 
     handle = GlobalCommDomainHandle(
         name="retry",
@@ -576,13 +590,12 @@ def test_global_domain_release_retries_after_callback_failure():
         _release_fn=release_fn,
     )
 
-    with pytest.raises(RuntimeError, match="transient release failure"):
+    with pytest.raises(RuntimeError, match="release failure"):
         handle.release()
 
-    assert not handle.released
-    handle.release()
     assert handle.released
-    assert attempts == 2
+    handle.release()
+    assert attempts == 1
 
 
 def test_old_global_domain_release_does_not_remove_same_name_replacement():
@@ -1071,7 +1084,7 @@ def test_mpirun_group_global_domain_uses_mpi_prepare_commit_without_l4_import(mo
     worker, resources, node_ids = _mpi_static_worker()
     calls = []
 
-    def control(worker_id, control_name, payload):
+    def control(worker_id, control_name, payload, *, group=False):
         control_name = ControlName(control_name)
         if control_name is ControlName.COMM_INIT:
             init = decode_comm_init(payload)
@@ -1118,9 +1131,15 @@ def test_mpirun_group_global_domain_uses_mpi_prepare_commit_without_l4_import(mo
         assert handle.members[1].global_device_rank == 1
         counts = Counter(phase for phase, _worker_id in calls)
         assert counts["COMM_INIT"] == 2
-        assert counts[GlobalDomainPhase.PREPARE_EXPORT] == 2
-        assert counts[GlobalDomainPhase.COMMIT] == 2
+        assert counts[GlobalDomainPhase.PREPARE_EXPORT] == 1
+        assert counts[GlobalDomainPhase.COMMIT] == 1
         assert counts[GlobalDomainPhase.IMPORT] == 0
+        group_phases = [
+            worker_id
+            for phase, worker_id in calls
+            if phase in (GlobalDomainPhase.PREPARE_EXPORT, GlobalDomainPhase.COMMIT)
+        ]
+        assert group_phases == [node_ids[0], node_ids[0]]
         assert worker._live_global_domains["mpi-static"] is handle
         assert resources.live_global_domains["mpi-static"] is handle
     finally:
@@ -1161,6 +1180,33 @@ def test_mpi_global_domain_collective_timeout_releases_local_state():
 
     assert releases == [True]
     assert comm.aborted
+
+
+def test_mpi_global_domain_collective_uses_pickle_allgather():
+    from simpler.mpi_l3_session import MpiGlobalDomainExchange  # noqa: PLC0415
+
+    class _Comm:
+        payloads = []
+
+        @staticmethod
+        def Get_rank():
+            return 0
+
+        def allgather(self, payload):
+            self.payloads.append(payload)
+            return [payload, b"peer"]
+
+    comm = _Comm()
+    exchange = MpiGlobalDomainExchange(comm, group_worker_ids=(7,), timeout_s=1.0)
+
+    gathered = exchange._allgather(
+        b"payload",
+        operation="prepare",
+        on_timeout=lambda: pytest.fail("pickle-based allgather completed without timing out"),
+    )
+
+    assert gathered == [b"payload", b"peer"]
+    assert comm.payloads == [b"payload"]
 
 
 def test_mpi_global_domain_prepare_failure_releases_before_collective():

--- a/tests/ut/py/test_mpi_group_mailbox.py
+++ b/tests/ut/py/test_mpi_group_mailbox.py
@@ -1,0 +1,227 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import ctypes
+
+import pytest
+from simpler.mpi_group_mailbox import (
+    MailboxGroupState,
+    MailboxOpcode,
+    MailboxRequestState,
+    MailboxTarget,
+    MpiGroupError,
+    MpiGroupMailbox,
+    MpiRankError,
+    _as_byte_view,
+    open_rank_mailbox,
+)
+
+
+def test_shared_memory_view_is_normalized_to_unsigned_bytes():
+    raw = (ctypes.c_ubyte * 4)()
+    original_view = memoryview(raw)
+    byte_view = _as_byte_view(original_view)
+
+    byte_view[:] = b"test"
+
+    assert byte_view is not original_view
+    assert byte_view.format == "B"
+    assert byte_view.ndim == 1
+    assert bytes(raw) == b"test"
+
+
+def test_named_mailbox_reopens_by_manifest_name_and_only_rank0_opens():
+    owner = MpiGroupMailbox.create(world_size=2)
+    reopened = None
+    try:
+        manifest = owner.manifest()
+        assert open_rank_mailbox(manifest, rank=1) is None
+
+        reopened = open_rank_mailbox(manifest, rank=0)
+        assert reopened is not None
+        assert reopened.name == owner.name
+        assert reopened.world_size == 2
+        assert reopened.group_state is MailboxGroupState.INITIALIZING
+
+        reopened.publish_ready()
+        assert owner.group_state is MailboxGroupState.READY
+    finally:
+        if reopened is not None:
+            reopened.close()
+        owner.close(unlink=True)
+
+
+@pytest.mark.parametrize(
+    ("target", "target_rank", "payloads"),
+    [
+        (MailboxTarget.GROUP, -1, (b"broadcast",)),
+        (MailboxTarget.RANK, 1, (b"rank-1",)),
+        (MailboxTarget.PER_RANK, -1, (b"rank-0", b"rank-1")),
+    ],
+)
+def test_request_envelope_round_trips_all_target_types(target, target_rank, payloads):
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=1,
+            opcode=MailboxOpcode.TASK,
+            target=target,
+            target_rank=target_rank,
+            payloads=payloads,
+        )
+
+        request = mailbox.accept_request(last_sequence_id=0)
+        assert request.sequence_id == 1
+        assert request.opcode is MailboxOpcode.TASK
+        assert request.target is target
+        assert request.target_rank == target_rank
+        assert request.payloads == payloads
+        assert mailbox.request_state is MailboxRequestState.TASK_ACCEPTED
+
+        mailbox.complete_request(sequence_id=1, payloads=(b"ok",))
+        result = mailbox.read_result(sequence_id=1)
+        assert result.payloads == (b"ok",)
+        assert mailbox.request_state is MailboxRequestState.IDLE
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_accept_copies_payload_before_publishing_task_accepted():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=1,
+            opcode=MailboxOpcode.TASK,
+            target=MailboxTarget.RANK,
+            target_rank=0,
+            payloads=(b"immutable-copy",),
+        )
+        request = mailbox.accept_request(last_sequence_id=0)
+        assert mailbox.request_state is MailboxRequestState.TASK_ACCEPTED
+
+        mailbox.overwrite_request_payload_for_test(b"changed-after-accept")
+        assert request.payloads == (b"immutable-copy",)
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_duplicate_sequence_marks_group_terminal():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=7,
+            opcode=MailboxOpcode.PING,
+            target=MailboxTarget.GROUP,
+            target_rank=-1,
+            payloads=(b"",),
+        )
+        with pytest.raises(MpiGroupError, match="sequence_id 7 is not newer than 7"):
+            mailbox.accept_request(last_sequence_id=7)
+        assert mailbox.group_state is MailboxGroupState.TERMINAL
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_rank_failure_is_reported_with_rank_and_terminal_is_reusable_only_when_requested():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=1,
+            opcode=MailboxOpcode.TASK,
+            target=MailboxTarget.GROUP,
+            target_rank=-1,
+            payloads=(b"task",),
+        )
+        mailbox.accept_request(last_sequence_id=0)
+        mailbox.fail_request(
+            sequence_id=1,
+            errors=(MpiRankError(rank=1, error_type="ValueError", message="rank one failed"),),
+            terminal=False,
+        )
+        with pytest.raises(MpiGroupError, match=r"rank 1.*ValueError.*rank one failed"):
+            mailbox.read_result(sequence_id=1)
+        assert mailbox.group_state is MailboxGroupState.READY
+
+        mailbox.write_request(
+            sequence_id=2,
+            opcode=MailboxOpcode.PING,
+            target=MailboxTarget.GROUP,
+            target_rank=-1,
+            payloads=(b"",),
+        )
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_terminal_group_rejects_new_requests():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.mark_terminal("collective timed out")
+        with pytest.raises(MpiGroupError, match="collective timed out"):
+            mailbox.write_request(
+                sequence_id=1,
+                opcode=MailboxOpcode.PING,
+                target=MailboxTarget.GROUP,
+                target_rank=-1,
+                payloads=(b"",),
+            )
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_rank0_failure_is_reported_and_marks_terminal():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=1,
+            opcode=MailboxOpcode.CONTROL,
+            target=MailboxTarget.GROUP,
+            target_rank=-1,
+            payloads=(b"control",),
+        )
+        mailbox.accept_request(last_sequence_id=0)
+        mailbox.fail_request(
+            sequence_id=1,
+            errors=(MpiRankError(rank=0, error_type="RuntimeError", message="rank zero exited"),),
+            terminal=True,
+        )
+        with pytest.raises(MpiGroupError, match=r"rank 0.*rank zero exited"):
+            mailbox.read_result(sequence_id=1)
+        assert mailbox.group_state is MailboxGroupState.TERMINAL
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_shutdown_has_distinct_ready_and_done_states():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=1,
+            opcode=MailboxOpcode.SHUTDOWN,
+            target=MailboxTarget.GROUP,
+            target_rank=-1,
+            payloads=(b"shutdown-frame",),
+        )
+        assert mailbox.request_state is MailboxRequestState.SHUTDOWN_READY
+        request = mailbox.accept_request(last_sequence_id=0)
+        assert request.opcode is MailboxOpcode.SHUTDOWN
+        assert mailbox.request_state is MailboxRequestState.TASK_ACCEPTED
+        mailbox.complete_shutdown(sequence_id=1)
+        assert mailbox.request_state is MailboxRequestState.SHUTDOWN_DONE
+    finally:
+        mailbox.close(unlink=True)

--- a/tests/ut/py/test_mpi_group_mailbox.py
+++ b/tests/ut/py/test_mpi_group_mailbox.py
@@ -10,9 +10,13 @@
 from __future__ import annotations
 
 import ctypes
+import time
 
 import pytest
+import simpler.mpi_group_mailbox as mailbox_mod
+from _task_interface import _mpi_mailbox_layout  # pyright: ignore[reportMissingImports]
 from simpler.mpi_group_mailbox import (
+    MAILBOX_REQUEST_OFFSET,
     MailboxGroupState,
     MailboxOpcode,
     MailboxRequestState,
@@ -109,7 +113,10 @@ def test_accept_copies_payload_before_publishing_task_accepted():
         request = mailbox.accept_request(last_sequence_id=0)
         assert mailbox.request_state is MailboxRequestState.TASK_ACCEPTED
 
-        mailbox.overwrite_request_payload_for_test(b"changed-after-accept")
+        overwrite = b"changed-after-accept"
+        buffer = mailbox._shm.buf  # noqa: SLF001
+        assert buffer is not None
+        buffer[MAILBOX_REQUEST_OFFSET : MAILBOX_REQUEST_OFFSET + len(overwrite)] = overwrite
         assert request.payloads == (b"immutable-copy",)
     finally:
         mailbox.close(unlink=True)
@@ -223,5 +230,109 @@ def test_shutdown_has_distinct_ready_and_done_states():
         assert mailbox.request_state is MailboxRequestState.TASK_ACCEPTED
         mailbox.complete_shutdown(sequence_id=1)
         assert mailbox.request_state is MailboxRequestState.SHUTDOWN_DONE
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_python_and_cpp_mailbox_layouts_agree():
+    layout = dict(_mpi_mailbox_layout())
+    assert layout == {
+        "MAGIC": mailbox_mod.MAILBOX_MAGIC,
+        "PROTOCOL_VERSION": mailbox_mod.MAILBOX_PROTOCOL_VERSION,
+        "HEADER_BYTES": mailbox_mod.MAILBOX_HEADER_BYTES,
+        "PAYLOAD_BYTES": mailbox_mod.MAILBOX_PAYLOAD_BYTES,
+        "ERROR_BYTES": mailbox_mod.MAILBOX_ERROR_BYTES,
+        "REQUEST_OFFSET": mailbox_mod.MAILBOX_REQUEST_OFFSET,
+        "RESPONSE_OFFSET": mailbox_mod.MAILBOX_RESPONSE_OFFSET,
+        "ERROR_OFFSET": mailbox_mod.MAILBOX_ERROR_OFFSET,
+        "MAILBOX_BYTES": mailbox_mod.MAILBOX_SIZE,
+        "OFF_MAGIC": mailbox_mod._OFF_MAGIC,  # noqa: SLF001
+        "OFF_PROTOCOL_VERSION": mailbox_mod._OFF_PROTOCOL_VERSION,  # noqa: SLF001
+        "OFF_HEADER_BYTES": mailbox_mod._OFF_HEADER_BYTES,  # noqa: SLF001
+        "OFF_MAILBOX_BYTES": mailbox_mod._OFF_MAILBOX_BYTES,  # noqa: SLF001
+        "OFF_WORLD_SIZE": mailbox_mod._OFF_WORLD_SIZE,  # noqa: SLF001
+        "OFF_GROUP_STATE": mailbox_mod._OFF_GROUP_STATE,  # noqa: SLF001
+        "OFF_REQUEST_STATE": mailbox_mod._OFF_REQUEST_STATE,  # noqa: SLF001
+        "OFF_SEQUENCE_ID": mailbox_mod._OFF_SEQUENCE_ID,  # noqa: SLF001
+        "OFF_OPCODE": mailbox_mod._OFF_OPCODE,  # noqa: SLF001
+        "OFF_TARGET": mailbox_mod._OFF_TARGET,  # noqa: SLF001
+        "OFF_TARGET_RANK": mailbox_mod._OFF_TARGET_RANK,  # noqa: SLF001
+        "OFF_REQUEST_COUNT": mailbox_mod._OFF_REQUEST_COUNT,  # noqa: SLF001
+        "OFF_REQUEST_BYTES": mailbox_mod._OFF_REQUEST_BYTES,  # noqa: SLF001
+        "OFF_RESPONSE_COUNT": mailbox_mod._OFF_RESPONSE_COUNT,  # noqa: SLF001
+        "OFF_RESPONSE_BYTES": mailbox_mod._OFF_RESPONSE_BYTES,  # noqa: SLF001
+        "OFF_ERROR_BYTES": mailbox_mod._OFF_ERROR_BYTES,  # noqa: SLF001
+        "RESERVED_OFFSET": mailbox_mod._OFF_RESERVED,  # noqa: SLF001
+        "GROUP_STATE_INITIALIZING": int(MailboxGroupState.INITIALIZING),
+        "GROUP_STATE_READY": int(MailboxGroupState.READY),
+        "GROUP_STATE_TERMINAL": int(MailboxGroupState.TERMINAL),
+        "GROUP_STATE_CLOSED": int(MailboxGroupState.CLOSED),
+        "REQUEST_STATE_IDLE": int(MailboxRequestState.IDLE),
+        "REQUEST_STATE_REQUEST_READY": int(MailboxRequestState.REQUEST_READY),
+        "REQUEST_STATE_TASK_ACCEPTED": int(MailboxRequestState.TASK_ACCEPTED),
+        "REQUEST_STATE_TASK_DONE": int(MailboxRequestState.TASK_DONE),
+        "REQUEST_STATE_TASK_FAILED": int(MailboxRequestState.TASK_FAILED),
+        "REQUEST_STATE_SHUTDOWN_READY": int(MailboxRequestState.SHUTDOWN_READY),
+        "REQUEST_STATE_SHUTDOWN_DONE": int(MailboxRequestState.SHUTDOWN_DONE),
+        "OPCODE_TASK": int(MailboxOpcode.TASK),
+        "OPCODE_CONTROL": int(MailboxOpcode.CONTROL),
+        "OPCODE_PING": int(MailboxOpcode.PING),
+        "OPCODE_SHUTDOWN": int(MailboxOpcode.SHUTDOWN),
+        "TARGET_GROUP": int(MailboxTarget.GROUP),
+        "TARGET_RANK": int(MailboxTarget.RANK),
+        "TARGET_PER_RANK": int(MailboxTarget.PER_RANK),
+    }
+
+
+def test_attach_rejects_nonzero_reserved_header_bytes():
+    owner = MpiGroupMailbox.create(world_size=1)
+    buffer = owner._shm.buf  # noqa: SLF001
+    assert buffer is not None
+    try:
+        buffer[200] = 1
+        with pytest.raises(MpiGroupError, match="reserved header bytes"):
+            MpiGroupMailbox(owner._shm, owner=False)  # noqa: SLF001
+    finally:
+        buffer[200] = 0
+        del buffer
+        owner.close(unlink=True)
+
+
+def test_rank_error_json_stays_parseable_when_truncated():
+    mailbox = MpiGroupMailbox.create(world_size=2)
+    try:
+        mailbox.publish_ready()
+        mailbox.write_request(
+            sequence_id=1,
+            opcode=MailboxOpcode.TASK,
+            target=MailboxTarget.GROUP,
+            target_rank=-1,
+            payloads=(b"task",),
+        )
+        mailbox.accept_request(last_sequence_id=0)
+        errors = tuple(MpiRankError(rank=index, error_type="RuntimeError", message="x" * 5000) for index in range(64))
+        mailbox.fail_request(sequence_id=1, errors=errors, terminal=False)
+        with pytest.raises(MpiGroupError) as failure:
+            mailbox.read_result(sequence_id=1)
+        message = str(failure.value)
+        assert "rank 0: RuntimeError:" in message
+        assert "[truncated]" in message
+        assert "more rank errors were dropped" in message
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_wait_request_state_unblocks_on_mismatch_and_bounds_the_park():
+    mailbox = MpiGroupMailbox.create(world_size=1)
+    try:
+        mailbox.publish_ready()
+        start = time.monotonic()
+        mailbox.wait_request_state(MailboxRequestState.TASK_DONE, timeout_s=30.0)
+        assert time.monotonic() - start < 5.0
+
+        start = time.monotonic()
+        mailbox.wait_request_state(MailboxRequestState.IDLE, timeout_s=0.05)
+        elapsed = time.monotonic() - start
+        assert 0.02 <= elapsed < 5.0
     finally:
         mailbox.close(unlink=True)

--- a/tests/ut/py/test_mpi_l3_group.py
+++ b/tests/ut/py/test_mpi_l3_group.py
@@ -1,0 +1,144 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""MPI L3 group activation and transport-isolation tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import simpler.mpi_group_mailbox as mailbox_mod
+import simpler.worker as worker_mod
+from simpler.mpi_group_mailbox import MAILBOX_SIZE, MailboxGroupState
+from simpler.remote_l3_protocol import ControlName
+from simpler.worker import MpiL3GroupSpec, Worker
+
+
+class _ReadyMailbox:
+    def __init__(self, world_size: int) -> None:
+        self.world_size = int(world_size)
+        self.group_state = MailboxGroupState.READY
+        self.address = 0x12340000
+        self.closed = False
+        self.terminal_messages: list[str] = []
+
+    def manifest(self):
+        return {
+            "name": "pytest-mpi-mailbox",
+            "protocol_version": 1,
+            "mailbox_bytes": MAILBOX_SIZE,
+            "world_size": self.world_size,
+        }
+
+    def terminal_reason(self):
+        return self.terminal_messages[-1] if self.terminal_messages else ""
+
+    def mark_terminal(self, message):
+        self.group_state = MailboxGroupState.TERMINAL
+        self.terminal_messages.append(str(message))
+
+    def close(self, *, unlink=False):
+        assert unlink
+        self.closed = True
+
+
+class _FakeProcess:
+    pid = 4242
+    returncode = None
+
+    def poll(self):
+        return self.returncode
+
+
+class _InertThread:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def start(self):
+        return None
+
+    def join(self, timeout=None):
+        return None
+
+
+def _mpi_worker() -> Worker:
+    worker = Worker(level=4, num_sub_workers=0)
+    worker.add_mpirun_worker_group(
+        MpiL3GroupSpec(
+            hosts=("127.0.0.1", "127.0.0.1"),
+            platform="a2a3sim",
+            device_ids_by_rank=((0,), (1,)),
+            global_device_ranks_by_rank=((0,), (1,)),
+        )
+    )
+    return worker
+
+
+def test_mpi_activation_attaches_only_mailbox_endpoint(monkeypatch):
+    worker = _mpi_worker()
+    mailbox = _ReadyMailbox(world_size=2)
+    native_worker = MagicMock()
+    worker._worker = native_worker
+    monkeypatch.setattr(mailbox_mod.MpiGroupMailbox, "create", lambda **_kwargs: mailbox)
+    monkeypatch.setattr(worker_mod.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(worker_mod.threading, "Thread", _InertThread)
+    try:
+        worker._activate_mpirun_worker_groups(worker_mod.time.monotonic() + 10.0)
+        native_worker.add_mpi_group_mailbox.assert_called_once()
+        native_worker.add_remote_l3_socket.assert_not_called()
+        group = worker._mpi_l3_groups[0]
+        assert group.manifest_path is not None
+        with open(group.manifest_path, encoding="utf-8") as manifest_file:
+            manifest = json.load(manifest_file)
+        assert manifest["mailbox"]["name"] == "pytest-mpi-mailbox"
+        assert "command_port" not in json.dumps(manifest)
+        assert "health_port" not in json.dumps(manifest)
+        assert "listen_host" not in json.dumps(manifest)
+        assert "connect_host" not in json.dumps(manifest)
+    finally:
+        group = worker._mpi_l3_groups[0]
+        group.process = None
+        group.monitor_thread = None
+        worker._worker = None
+        worker.close()
+        assert mailbox.closed
+
+
+def test_unexpected_mpirun_exit_marks_group_terminal():
+    worker = _mpi_worker()
+    mailbox = _ReadyMailbox(world_size=2)
+    group = worker._mpi_l3_groups[0]
+    group.mailbox = mailbox
+    process = _FakeProcess()
+    process.returncode = 17
+    process.wait = lambda: 17
+    worker._monitor_mpirun_group(group, cast(Any, process))
+    try:
+        assert mailbox.group_state is MailboxGroupState.TERMINAL
+        assert "status 17" in mailbox.terminal_reason()
+    finally:
+        group.process = None
+        group.mailbox = None
+        worker.close()
+
+
+def test_mpi_spec_tcp_fields_are_optional_and_control_18_stays_reserved():
+    spec = MpiL3GroupSpec(
+        hosts=("127.0.0.1", "127.0.0.1"),
+        platform="a2a3sim",
+        device_ids_by_rank=((0,), (1,)),
+    )
+    assert spec.command_port_base is None
+    assert spec.health_port_base is None
+    assert spec.session_listen_hosts == ()
+    assert spec.connect_hosts == ()
+    assert worker_mod._CTRL_COMMITTED_DEVICE_MEMORY == 18
+    assert 18 not in {int(control) for control in ControlName}

--- a/tests/ut/py/test_remote_l3_lifecycle.py
+++ b/tests/ut/py/test_remote_l3_lifecycle.py
@@ -270,7 +270,7 @@ def test_run_session_bounds_command_accept_by_startup_deadline_not_session_timeo
     monkeypatch.setattr(remote_l3_session, "Worker", FakeWorker)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_dispatcher_registry", lambda manifest: {})
     monkeypatch.setattr(remote_l3_session, "_install_manifest_inner_registry", lambda manifest, worker: {})
-    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda host: sockets.pop(0))
+    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda _host, _port=0: sockets.pop(0))
     monkeypatch.setattr(remote_l3_session, "_health_loop", lambda *args: None)
 
     try:
@@ -345,7 +345,7 @@ def test_run_session_forces_command_conn_blocking_for_idle(monkeypatch):
     monkeypatch.setattr(remote_l3_session, "Worker", FakeWorker)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_dispatcher_registry", lambda manifest: {})
     monkeypatch.setattr(remote_l3_session, "_install_manifest_inner_registry", lambda manifest, worker: {})
-    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda host: sockets.pop(0))
+    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda _host, _port=0: sockets.pop(0))
     monkeypatch.setattr(remote_l3_session, "_health_loop", lambda *args: None)
     monkeypatch.setattr(remote_l3_session, "_run_command_loop", lambda *args, **kwargs: None)
 
@@ -405,7 +405,7 @@ def test_run_session_bounds_subtree_by_startup_remaining_not_session_timeout(mon
     monkeypatch.setattr(remote_l3_session, "Worker", FakeWorker)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_dispatcher_registry", lambda manifest: {})
     monkeypatch.setattr(remote_l3_session, "_install_manifest_inner_registry", lambda manifest, worker: {})
-    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda host: sockets.pop(0))
+    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda _host, _port=0: sockets.pop(0))
     monkeypatch.setattr(remote_l3_session, "_health_loop", lambda *args: None)
 
     try:
@@ -466,7 +466,7 @@ def test_run_session_builds_deadline_before_registry_install(monkeypatch):
     monkeypatch.setattr(remote_l3_session, "Worker", FakeWorker)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_dispatcher_registry", slow_dispatch_registry)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_inner_registry", lambda manifest, worker: {})
-    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda host: sockets.pop(0))
+    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda _host, _port=0: sockets.pop(0))
     monkeypatch.setattr(remote_l3_session, "_health_loop", lambda *args: None)
 
     try:
@@ -526,7 +526,7 @@ def test_run_session_uses_daemon_absolute_deadline_verbatim(monkeypatch):
     monkeypatch.setattr(remote_l3_session, "Worker", FakeWorker)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_dispatcher_registry", slow_dispatch_registry)
     monkeypatch.setattr(remote_l3_session, "_install_manifest_inner_registry", lambda manifest, worker: {})
-    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda host: sockets.pop(0))
+    monkeypatch.setattr(remote_l3_session, "_bind_listener", lambda _host, _port=0: sockets.pop(0))
     monkeypatch.setattr(remote_l3_session, "_health_loop", lambda *args: None)
 
     try:


### PR DESCRIPTION
## Summary

- replace the MPI worker group's Simpler command/health TCP path with one L4-owned named shared-memory mailbox attached by local rank 0
- distribute ordered task and control envelopes with dedicated MPI communicators, including group, directed-rank, and per-rank payload semantics
- gather ranked results and errors before completing the mailbox request, with terminal timeout and complete `mpirun` process-group cleanup
- keep ordinary non-MPI Remote L3 workers on the existing TCP transport
- route full-group Global CommDomain setup through the mailbox and a separate domain communicator
- add protocol, lifecycle, compatibility, timeout, and compute/TLOAD smoke coverage

Review-round hardening (`87489e1`): the mailbox state words now use the `_task_interface` acquire/release helpers unconditionally (the previous import path silently fell back to plain struct reads), rank 0 parks on a shared futex instead of busy-polling the request lane, reserved header bytes [80, 256) are validated as zero with a documented version-evolution rule, a `_mpi_mailbox_layout` binding plus unit test pins the Python and C++ layout declarations together, gathered rank errors stay valid JSON under truncation, and the test-only payload-overwrite API is removed.

## Dependency

Stacked on #1623, which is now merged; this branch is rebased onto its merge commit.

## Testing

- [x] CI green on the mailbox head `cd51a88`, including `st-pod-onboard-a2a3` — the two-machine `test_global_tload_mpirun_l3` example runs the mailbox path end to end (`PASS 15.0s, devices=[12, 13]`)
- [x] full `tests/ut/py` on Linux: 1440 passed, 13 skipped (includes this PR's 46 mailbox/MPI tests)
- [x] changed-file header, English-only, EOF, whitespace, Markdownlint, clang-format, cpplint, Ruff, and Pyright checks
- [x] CI revalidation of the review-fix head `87489e1`: 18 checks green, including `st-pod-onboard-a2a3` re-running `test_global_tload_mpirun_l3` on the futex-park path (`PASS 15.1s, devices=[12, 13]`)
