### PR TITLE
Test: probe CPU lane across all jobs

### DIFF
--- a/tests/lint/.markdownlint.yaml
+++ b/tests/lint/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# Lane probe: shared test infrastructure flips every detect-changes flag.
 MD013: false
 MD024:
   siblings_only: true


### PR DESCRIPTION
Probe PR for the ci-self-cpu lane. Comment-only change to a shared test-infra file (tests/lint/) so every detect-changes flag is true and /run-cpu exercises all T1 and T3 jobs.