### PR TITLE
CI: revert lane packaging venv to plain (ci.yml parity)

### DIFF
--- a/.github/workflows/ci-self-cpu.yml
+++ b/.github/workflows/ci-self-cpu.yml
@@ -217,7 +217,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Install build + runtime deps in venv
         run: |
-          python3 -m venv --system-site-packages .venv
+          python3 -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
           pip install scikit-build-core nanobind cmake pytest


### PR DESCRIPTION
#1626 switched the lane's packaging venv to `--system-site-packages`, but ci.yml's packaging venv is plain. On runners whose system site carries nanobind (e.g. conda-based cpu-4), the system-site venv treats nanobind as satisfied and never installs it, so `verify_packaging.sh`'s wheel build fails at `find_package(nanobind)`. Plain venv installs nanobind into the venv and matches ci.yml.