### PR TITLE
CI: report /run-cpu lane results back on the PR

### DIFF
--- a/.github/workflows/ci-self-cpu-button.yml
+++ b/.github/workflows/ci-self-cpu-button.yml
@@ -1,4 +1,5 @@
 name: CI Self CPU Button
+run-name: /run-cpu PR ${{ github.event.issue.number }}
 
 # PR comment command: a repo admin comments "/run-cpu" on a pull request and
 # this calls ci-self-cpu.yml (workflow_call) to validate that PR's head on the

--- a/.github/workflows/ci-self-cpu-report.yml
+++ b/.github/workflows/ci-self-cpu-report.yml
@@ -1,0 +1,62 @@
+name: CI Self CPU Report
+
+# Posts the /run-cpu lane result back on the PR that triggered it. The button
+# workflow (ci-self-cpu-button.yml) sets its run-name to "/run-cpu PR <n>",
+# which this watcher parses to find the PR. Runs on the cpu runner so it is
+# not subject to GitHub-hosted congestion (the lane's reason to exist).
+
+on:
+  workflow_run:
+    workflows: ["CI Self CPU Button"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    runs-on: [self-hosted, cpu]
+    steps:
+      - name: Comment lane result on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            if (run.event !== 'issue_comment' || run.conclusion === 'skipped') {
+              core.info(`nothing to report: event=${run.event} conclusion=${run.conclusion}`);
+              return;
+            }
+            const m = (run.display_title || '').match(/PR (\d+)/);
+            if (!m) {
+              core.info(`no PR number in display_title: ${run.display_title}`);
+              return;
+            }
+            const prNumber = Number(m[1]);
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              ...context.repo,
+              run_id: run.id,
+              filter: 'latest',
+              per_page: 100,
+            });
+            const laneJobs = jobs.filter((j) => j.name.startsWith('lane /'));
+            if (!laneJobs.length) {
+              core.info('no lane jobs (gate denied); nothing to report');
+              return;
+            }
+
+            const lines = laneJobs.map((j) => {
+              const icon = j.conclusion === 'success' ? '✅'
+                         : j.conclusion === 'failure' ? '❌' : '⏭️';
+              return `- ${icon} ${j.name.replace('lane / ', '')}`;
+            });
+            const head = run.conclusion === 'success'
+              ? `✅ **/run-cpu lane passed** — ${run.html_url}`
+              : `❌ **/run-cpu lane finished with ${run.conclusion}** — ${run.html_url}`;
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: prNumber,
+              body: `${head}\n\n${lines.join('\n')}`,
+            });


### PR DESCRIPTION
The /run-cpu lane run is standalone (issue_comment runs attach no checks to the PR), so results were only visible inside the run. This adds a watcher that posts them back:\n\n- `ci-self-cpu-button.yml`: `run-name: /run-cpu PR ${{ github.event.issue.number }}` — the run's display title now carries the PR number.\n- `ci-self-cpu-report.yml` (new): `workflow_run` on the button workflow; parses the PR number from the display title, lists the lane jobs, and comments `✅/❌ + per-job status + run link` on the PR. Runs on `[self-hosted, cpu]` so it is not delayed by the congestion the lane exists for.\n\nOnly comments when the admin gate passed (lane jobs exist); denied or skipped button runs stay silent.