### PR TITLE
CI: lane T1 jobs use setup-python 3.10 with pip cache (ci.yml parity)

### DIFF
--- a/.github/workflows/ci-self-cpu.yml
+++ b/.github/workflows/ci-self-cpu.yml
@@ -10,12 +10,11 @@ run-name: CI Self CPU / PR ${{ inputs.pr_number || inputs.ref }}
 #
 # Provisioning contract for the cpu runner (out-of-repo, dnf): every cpu agent
 # needs the same set — cmake ninja-build gcc-c++ clang-tools-extra graphviz
-# gtest-devel python3-devel — and a CLEAN python site: no simpler/
-# simpler_setup/_task_interface anywhere in system or user site-packages.
-# With --system-site-packages a stale install satisfies pip and shadows the
-# fresh venv install (ci.yml's NPU jobs rely on the same clean-runner
-# contract). g++-15 is a symlink stand-in for the ubuntu-toolchain ppa g++ —
-# see below.
+# gtest-devel. T1 jobs use actions/setup-python (3.10) with no venv and a pip
+# cache, like ci.yml's GitHub-hosted jobs: the toolchain python is isolated,
+# so runner system/user python state cannot affect them. T3 (NPU) jobs keep
+# their --system-site-packages venvs (driver bindings). g++-15 is a symlink
+# stand-in for the ubuntu-toolchain ppa g++ — see below.
 
 permissions:
   contents: read
@@ -156,17 +155,25 @@ jobs:
             ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
             echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           fi
-      - name: venv + deps
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
         run: |
-          python3 -m venv --system-site-packages .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install .
       - name: Build sim runtimes (per-target compile_commands.json for clang-tidy)
-        run: |
-          source .venv/bin/activate
-          python simpler_setup/build_runtimes.py --platforms a2a3sim a5sim
+        run: python simpler_setup/build_runtimes.py --platforms a2a3sim a5sim
       - name: Resolve base SHA (merge-base with target main)
         id: base
         run: echo "base_sha=$(git merge-base origin/main HEAD)" >> "$GITHUB_OUTPUT"
@@ -187,17 +194,25 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
-      - name: venv + deps
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
         run: |
-          python3 -m venv --system-site-packages .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install '.[test]'
       - name: Run Python unit tests
-        run: |
-          source .venv/bin/activate
-          python -m pytest tests/ut -m "not requires_hardware" -v
+        run: python -m pytest tests/ut -m "not requires_hardware" -v
       - name: Build and run C++ unit tests
         run: |
           cmake -B tests/ut/cpp/build -S tests/ut/cpp
@@ -215,6 +230,21 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # verify_packaging.sh requires an activated venv; the venv is created
+      # from the setup-python 3.10, so it carries no runner system site.
       - name: Install build + runtime deps in venv
         run: |
           python3 -m venv .venv
@@ -238,16 +268,25 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.sha }}
-      - name: venv + editable install
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies (editable)
         run: |
-          python3 -m venv --system-site-packages .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e '.[test]'
       - name: Run all profiling flag combos x 2 arches
         run: |
-          source .venv/bin/activate
           COMBO_NAMES=(dfx-off orch orch-tensormap sched orch-sched all-on)
           COMBO_DEFS=(
             "-DSIMPLER_DFX=0"
@@ -304,16 +343,25 @@ jobs:
             ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
             echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           fi
-      - name: venv + deps
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
         run: |
-          python3 -m venv --system-site-packages .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install '.[test]'
       - name: Run pytest scene tests (a2a3sim)
         run: |
-          source .venv/bin/activate
           python -m pytest examples tests/st --platform a2a3sim --device 0-15 -v \
             --pto-session-timeout 600 --require-pto-isa
       # DFX per-feature smokes (dep_gen / l2_swimlane / pmu / args_dump) mirror
@@ -342,16 +390,25 @@ jobs:
             ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
             echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           fi
-      - name: venv + deps
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
         run: |
-          python3 -m venv --system-site-packages .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install '.[test]'
       - name: Run pytest scene tests (a5sim)
         run: |
-          source .venv/bin/activate
           python -m pytest examples tests/st --platform a5sim --device 0-15 -v \
             --pto-session-timeout 600 --require-pto-isa
 


### PR DESCRIPTION
The cpu runner's system python is 3.9, but the repo uses `zip(strict=)` (3.10+) in worker.py — the lane's T1 venvs failed 46 ut tests with `TypeError: zip() takes no keyword arguments`.\n\nT1 jobs now mirror ci.yml's GitHub-hosted pattern: `actions/setup-python@v6` 3.10 + `actions/cache` for `~/.cache/pip` + plain `pip install` (no venv). The toolchain python is isolated, so runner system/user python state (version, site-packages pollution) can no longer affect T1; the runner contract shrinks to the dnf binaries. packaging keeps a venv (`verify_packaging.sh` requires an activated one) but creates it from the setup-python 3.10. T3 (NPU) jobs unchanged.