### PR TITLE
Fix: zip(strict=) breaks Python 3.9 support

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -5732,8 +5732,10 @@ class Worker:
         """
         if not self._remote_worker_specs:
             return
+        if len(self._remote_worker_ids) != len(self._remote_worker_specs):
+            raise ValueError("remote worker ids/specs length mismatch")
         session_timeout = self._remote_session_timeout_s()
-        for worker_id, spec in zip(self._remote_worker_ids, self._remote_worker_specs, strict=True):
+        for worker_id, spec in zip(self._remote_worker_ids, self._remote_worker_specs):
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise RuntimeError("remote L3 session activation: startup deadline exceeded")


### PR DESCRIPTION
worker.py used `zip(..., strict=True)` (3.10+ keyword) while `pyproject.toml` declares `requires-python = ">=3.9"`. Replaced with an explicit length check + plain zip, preserving strict semantics on both 3.9 and 3.10. The CI ut job runs setup-python 3.10, so this never surfaced; the cpu lane's runner python (3.9) caught it (46 ut failures: `TypeError: zip() takes no keyword arguments`).