### PR TITLE
CI: restore pip upgrade in lane T1 venv steps

### DIFF
--- a/.github/workflows/ci-self-cpu.yml
+++ b/.github/workflows/ci-self-cpu.yml
@@ -168,6 +168,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install .
       - name: Build sim runtimes (per-target compile_commands.json for clang-tidy)
@@ -206,6 +207,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install '.[test]'
       - name: Run Python unit tests
@@ -274,6 +276,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e '.[test]'
       - name: Run all profiling flag combos x 2 arches
@@ -347,6 +350,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install '.[test]'
       - name: Run pytest scene tests (a2a3sim)
@@ -392,6 +396,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install '.[test]'
       - name: Run pytest scene tests (a5sim)


### PR DESCRIPTION
The setup-python rewrite dropped `pip install --upgrade pip`, leaving T1 venvs on the runner's pip 21.3.1 (python3.9 ensurepip). Round 7 hit a sympy hash mismatch during `pip install torch` — a corrupted pip-cache entry from an interrupted earlier run that old pip reused. Upgrading pip first restores sane cache/hash handling.\n\nAlso deleted the stale `Linux-pip-*` actions-cache entries and the runner's `~/.cache/pip` should be cleared (`rm -rf ~/.cache/pip`) so the next run downloads fresh and re-uploads clean.