### PR TITLE
CI: lane pre-commit diff against canonical main and PR head

### DIFF
--- a/.github/workflows/ci-self-cpu.yml
+++ b/.github/workflows/ci-self-cpu.yml
@@ -175,13 +175,19 @@ jobs:
         run: |
           source .venv/bin/activate
           python simpler_setup/build_runtimes.py --platforms a2a3sim a5sim
-      - name: Resolve base SHA (merge-base with target main)
+      - name: Resolve base SHA (merge-base with canonical main)
         id: base
-        run: echo "base_sha=$(git merge-base origin/main HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          # The checkout is the PR head of the input repository (a fork), whose
+          # main lags; pre-commit's diff must span the PR head against the
+          # canonical repo's main, so fetch it (the runner's github extraheader
+          # authenticates the fetch).
+          git fetch --no-tags https://github.com/${{ github.repository }}.git main
+          echo "base_sha=$(git merge-base FETCH_HEAD HEAD)" >> "$GITHUB_OUTPUT"
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
         with:
-          extra_args: --from-ref ${{ steps.base.outputs.base_sha }} --to-ref ${{ github.sha }}
+          extra_args: --from-ref ${{ steps.base.outputs.base_sha }} --to-ref ${{ inputs.ref || github.sha }}
 
   ut:
     needs: [detect-changes]


### PR DESCRIPTION
Round 8: pre-commit failed with `CalledProcessError: git diff 2a85eb93..259f2336`. `--to-ref` used `github.sha` (default-branch latest) while `--from-ref` came from `origin/main` — for a fork PR the checkout is the fork, whose main lags and which lacks the new canonical commits, so the diff range doesn't exist locally.\n\nFix: fetch the canonical repo's main (`git fetch https://github.com/${{ github.repository }}.git main` — the runner's github extraheader authenticates it) and diff `merge-base(FETCH_HEAD, HEAD)..inputs.ref` — both endpoints exist in the checkout.