### PR TITLE
Docs: give the local onboard sweep the same marker shape as CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,8 +595,11 @@ jobs:
           # device fault/sync domain, so a fault on that device pays a multi-minute
           # teardown (issue #1425). Keep EVERY SDMA test out of this general sweep
           # — which also runs the aicore_op_timeout fault-injection test — and run
-          # them on their own dedicated device(s) in the SDMA step below, so an
-          # SDMA fault's slow teardown can never mix with ordinary fault recovery.
+          # them in the SDMA step below, after this sweep, so an SDMA fault's slow
+          # teardown can never mix with ordinary fault recovery. Device
+          # disjointness holds only on aarch64 (`task-submit --device auto`); the
+          # x86_64 branch has no task-submit and shares ${DEVICE_RANGE}, so there
+          # ordering is the separation.
           #
           # Selected by marker, not by path. `pytest --ignore=<moved path>` exits
           # 0 and says nothing, so a rename used to drop the quarantine silently
@@ -609,8 +612,8 @@ jobs:
               --run "python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
           fi
 
-      # SDMA pytest — every SDMA test runs here on its own dedicated device(s),
-      # isolated from the general sweep's aicore_op_timeout fault-injection test
+      # SDMA pytest — every SDMA test runs here, after the sweep above, isolated
+      # from the general sweep's aicore_op_timeout fault-injection test
       # (issue #1425). Both demos create their Worker with enable_sdma=True so the
       # runtime provisions the SDMA workspace: prefetch_async_demo on 1 device (L2),
       # sdma_async_completion_demo on 2 devices (L3, workspace provisioned per chip

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ See runtime docs per arch: [a2a3](src/a2a3/docs/runtimes.md), [a5](src/a5/docs/r
 pytest examples tests/st --platform a2a3sim
 
 # Hardware scene tests (requires Ascend device)
-pytest examples tests/st --platform a2a3 --device 4-7
+# SDMA cases are quarantined by marker, as in CI; run them separately with -m sdma
+pytest examples tests/st -m "not sdma" --platform a2a3 --device 4-7
 
 # Python unit tests
 pytest tests/ut -m "not requires_hardware" -v

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,8 +46,13 @@ ctest --test-dir tests/ut/cpp/build -L "^requires_hardware(_a2a3)?$" --output-on
 # Scene tests (pytest, @scene_test classes)
 pytest examples tests/st                          # all sim platforms (auto-parametrized)
 pytest examples tests/st --platform a2a3sim       # specific sim
-pytest examples tests/st --platform a2a3          # hardware
-pytest examples tests/st --platform a2a3 --device 4-7  # hardware with device pool
+pytest examples tests/st -m "not sdma" --platform a2a3          # hardware
+pytest examples tests/st -m "not sdma" --platform a2a3 --device 4-7  # hardware with device pool
+
+# SDMA cases run separately, as they do in CI: they are quarantined by
+# @pytest.mark.sdma so no fault-injection case shares a device with a
+# provisioned SDMA workspace (issue #1425)
+pytest examples tests/st -m sdma --platform a2a3 --device 4-5
 
 # Single scene test (standalone)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim
@@ -625,8 +630,8 @@ pytest examples tests/st --platform a2a3sim
 # Standalone (single case)
 python test_my_kernel.py -p a2a3sim
 
-# On hardware
-pytest examples tests/st --platform a2a3
+# On hardware (SDMA cases quarantined by marker; run them with -m sdma)
+pytest examples tests/st -m "not sdma" --platform a2a3
 ```
 
 Key fields:

--- a/docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
+++ b/docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
@@ -63,7 +63,7 @@ exception you must surface the CANN device slog, which is otherwise hidden:
 
    ```bash
    ASCEND_SLOG_PRINT_TO_STDOUT=1 ASCEND_GLOBAL_LOG_LEVEL=1 \
-   python -m pytest examples tests/st --platform a2a3 --device <range> -v \
+   python -m pytest examples tests/st -m "not sdma" --platform a2a3 --device <range> -v \
      --pto-session-timeout 600
    ```
 

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -6,7 +6,7 @@ How you select what runs, turn diagnostics on, and read the artifacts back.
 
 ```bash
 pytest examples tests/st --platform a2a3sim            # simulation, no device
-pytest examples tests/st --platform a2a3 --device 4-7  # hardware
+pytest examples tests/st -m "not sdma" --platform a2a3 --device 4-7  # hardware (SDMA quarantined by marker)
 python examples/my_example/test_my_example.py -p a2a3sim   # standalone, no pytest
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ on both simulators:
 
 ```bash
 pytest examples --platform a2a3sim
-pytest examples --platform a2a3 --device 0-1        # hardware
+pytest examples -m "not sdma" --platform a2a3 --device 0-1        # hardware (SDMA quarantined by marker)
 ```
 
 A single example:

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -210,7 +210,7 @@ python tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_p
 Final validation:
 
 ```bash
-pytest examples tests/st --platform a2a3
+pytest examples tests/st -m "not sdma" --platform a2a3   # SDMA cases quarantined by marker; run them with -m sdma
 ```
 
 ## 14. Resolved Decisions

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -208,7 +208,7 @@ python tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_p
 Final validation:
 
 ```bash
-pytest examples tests/st --platform a2a3
+pytest examples tests/st -m "not sdma" --platform a2a3   # SDMA cases quarantined by marker; run them with -m sdma
 ```
 
 ## 14. Resolved Decisions

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -208,7 +208,7 @@ python tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_p
 Final validation:
 
 ```bash
-pytest examples tests/st --platform a2a3
+pytest examples tests/st -m "not sdma" --platform a2a3   # SDMA cases quarantined by marker; run them with -m sdma
 ```
 
 ## 14. Resolved Decisions


### PR DESCRIPTION
## Summary

Everywhere a doc told the reader to run the full a2a3 scene-test sweep on real hardware, it gave a bare `pytest examples tests/st --platform a2a3` — the exact invocation `testing/SKILL.md` warns "is *not* what CI runs and will report failures that CI never sees": it mixes SDMA cases with the sweep's `aicore_op_timeout` fault-injection test, the collision the dedicated SDMA step exists to prevent (#1425, ~306 s fault teardown on an SDMA-provisioned device).

**Nine sites now carry `-m "not sdma"` and name the marker:**

| File | What |
| ---- | ---- |
| `README.md` | hardware scan line |
| `docs/testing.md` | both hardware scan sites; first gains the separate `-m sdma` pass with the reason |
| `docs/user/reference/cli.md` | hardware scan line |
| `examples/README.md` | hardware scan line |
| `docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md` | repro scan |
| `SUBMIT_BY_CLUSTER.md` ×3 (a2a3/a5 × tmr, a2a3 hbg) | final-validation scans |

**Untouched, deliberately:** sim lines (no SDMA cases), single-directory invocations (marker irrelevant), and all a5 scans (`st-onboard-a5` has no marker filter).

**Also fixed, the deferred `ci.yml` comments** — the two that claimed the SDMA step runs "on its own dedicated device(s)", flagged in #1617 and left until ci.yml was next touched for a substantive reason. Device disjointness holds only on aarch64 (`task-submit --device auto`); the x86_64 branch shares `${DEVICE_RANGE}` and ordering is the separation. This change touches `ci.yml`, so the full matrix runs — which was the reason it had been deferred.

## Testing

- [x] Swept every `pytest examples tests/st --platform a2a3` / `pytest examples --platform a2a3` site: none remain unfiltered (except the SKILL.md warning sentence, which is not a command)
- [x] a5 scan lines verified unchanged (no marker filter in `st-onboard-a5`)
- [x] YAML parses after the comment edits
- [x] `ci.yml` in the diff → full matrix expected