### PR TITLE
fix(a5): expose SPMD sub-retires in L2 swimlane

### DIFF
--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -161,20 +161,48 @@ def auto_select_l2_swimlane_records_json():
     return files[0]
 
 
-def parse_scheduler_from_json_phases(data):
+def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
     """Extract scheduler Phase breakdown from l2_swimlane_records JSON.
 
-    Computes per-thread loop counts, task counts, and phase totals
-    from aicpu_scheduler_phases records (present at l2_swimlane_level >= 3).
+    Computes per-thread loop counts, logical task counts, FIN/retire counts,
+    and phase totals from aicpu_scheduler_phases records (present at
+    l2_swimlane_level >= 3). Complete.tasks_processed is a FIN/retire count;
+    logical task counts are reconstructed from the final finish row per task.
 
     Returns:
         dict: Thread data keyed by thread index, with per-phase us / pct,
-              pop_hit / pop_miss, loops, completed, tasks_per_loop. Returns
+              pop_hit / pop_miss, loops, completed, finishes, tasks_per_loop,
+              and finishes_per_loop. Returns
               empty dict if phase data is not available.
     """
     phases_by_thread = data.get("aicpu_scheduler_phases", [])
     if not phases_by_thread:
         return {}
+
+    # A logical task may emit one perf row per SPMD subtask/core. Select its
+    # final finish row across all cores before attributing it to a scheduler
+    # thread; otherwise a task whose subtasks finish on different threads is
+    # counted once by every thread that observed one of its rows.
+    core_to_thread = data.get("core_to_thread") or []
+    final_finish_thread_by_task = {}
+    for task in data.get("tasks", []):
+        task_id = _to_uint64(task.get("task_id"))
+        core_id = task.get("core_id")
+        finish_us = task.get("finish_time_us")
+        if task_id is None or not isinstance(core_id, int) or not isinstance(finish_us, (int, float)):
+            continue
+        if not (0 <= core_id < len(core_to_thread)):
+            continue
+        thread_idx = core_to_thread[core_id]
+        if not isinstance(thread_idx, int) or thread_idx < 0:
+            continue
+        previous = final_finish_thread_by_task.get(task_id)
+        if previous is None or finish_us > previous[0]:
+            final_finish_thread_by_task[task_id] = (float(finish_us), thread_idx)
+
+    logical_tasks_by_thread = defaultdict(int)
+    for _finish_us, thread_idx in final_finish_thread_by_task.values():
+        logical_tasks_by_thread[thread_idx] += 1
 
     threads = {}
     for tid, records in enumerate(phases_by_thread):
@@ -197,7 +225,7 @@ def parse_scheduler_from_json_phases(data):
             continue
 
         phase_us = {"complete": 0.0, "async_poll": 0.0, "dispatch": 0.0, "idle": 0.0}
-        total_tasks = 0
+        total_finishes = 0
         max_loop_iter = 0
         pop_hit = 0
         pop_miss = 0
@@ -217,7 +245,7 @@ def parse_scheduler_from_json_phases(data):
             if dur > 0:
                 phase_us[phase] += dur
             if phase == "complete":
-                total_tasks += rec.get("tasks_processed", 0)
+                total_finishes += int(rec.get("tasks_processed") or 0)
             # Per-emit queue-health deltas; only present on dispatch records.
             # Summing across records gives the run-cumulative pop_hit /
             # pop_miss (the runtime's final-drain emit closes the tail).
@@ -228,17 +256,29 @@ def parse_scheduler_from_json_phases(data):
             if prev_end is None or end > prev_end:
                 prev_end = end
 
+        # Complete.tasks_processed is the per-thread FIN/retire count. When
+        # valid finish rows are available, logical tasks are attributed only
+        # to the thread that observed each task's final finish row. Fall back
+        # to the phase count only for artifacts without any valid finish rows.
+        logical_task_count = logical_tasks_by_thread.get(tid, 0) if final_finish_thread_by_task else total_finishes
+
         total_us = sum(phase_us.values())
         loops = max_loop_iter
-        tasks_per_loop = total_tasks / loops if loops > 0 else 0.0
+        tasks_per_loop = logical_task_count / loops if loops > 0 else 0.0
+        finishes_per_loop = total_finishes / loops if loops > 0 else 0.0
         pop_total = pop_hit + pop_miss
         pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0.0
 
         t = {
-            "completed": total_tasks,
+            # `completed` remains the legacy logical-task field used by the
+            # report; `finishes` exposes the raw Complete FIN/retire count.
+            "completed": logical_task_count,
+            "logical_tasks": logical_task_count,
+            "finishes": total_finishes,
             "total_us": total_us,
             "loops": loops,
             "tasks_per_loop": tasks_per_loop,
+            "finishes_per_loop": finishes_per_loop,
             "pop_hit": pop_hit,
             "pop_miss": pop_miss,
             "pop_hit_rate": pop_hit_rate,
@@ -825,7 +865,7 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     print()
 
     fmt2 = "  {:<10} {:>7} {:>10} {:>12} {:>11}"
-    print(fmt2.format("Thread", "Loops", "Completed", "ns/loop", "Total (us)"))
+    print(fmt2.format("Thread", "Loops", "Tasks", "ns/loop", "Total (us)"))
     print("  " + "-" * 54)
     for tid in sorted(threads.keys()):
         t = threads[tid]
@@ -836,6 +876,8 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     total_loops = sum(t["loops"] for t in threads.values())
     avg_ns_per_loop = total_us * 1000 / total_loops if total_loops > 0 else 0
     print(fmt2.format("SUM", total_loops, total_completed, f"{avg_ns_per_loop:.0f}", f"{total_us:.1f}"))
+    total_finishes = sum(t.get("finishes", 0) for t in threads.values())
+    print(f"  FINs observed (Complete phase): {total_finishes}")
     print()
 
     # Phase breakdown. Idle is reconstructed from gaps between work

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -1439,11 +1439,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             "dummy_task": "grey",
         }
 
-        # Per-complete subtask-finish counts surface "how many AICore FINs
-        # did the AICPU poll in this phase" — useful context that
-        # tasks_processed (logical task count) doesn't convey. Computed
-        # with "phase contains finish_us" semantics so it matches how the
-        # AICPU actually attributes finishes to its polling windows.
+        # Per-complete task-finish rows are retained as an attribution check.
+        # The runtime's Complete `tasks_processed` field is the authoritative
+        # number of AICore FIN/retire events in the phase (including non-final
+        # SPMD sub-block retires), not necessarily a logical-task count.
         complete_phases_by_thread_pre = []
         complete_starts_by_thread_pre = []
         for thread_records in scheduler_phases:
@@ -1632,11 +1631,18 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         }
                     )
                 if phase == "complete":
-                    # finishes_processed kept in args (hover) for forensics —
-                    # SPMD cases where one logical task has N subtask FINs
-                    # observed in the phase. Label stays minimal.
-                    finishes_count = finishes_per_complete.get(id(record), 0)
-                    phase_args["finishes_processed"] = finishes_count
+                    matched_finish_rows = finishes_per_complete.get(id(record), 0)
+                    if "tasks_processed" in record:
+                        # Preserve the raw runtime count for trace consumers;
+                        # it includes both final and non-final SPMD FINs.
+                        phase_args["finishes_processed"] = tasks_processed
+                        phase_args["finish_rows_attributed"] = matched_finish_rows
+                    else:
+                        # Older/synthetic records have no raw count. Keep the
+                        # converter useful by falling back to row attribution.
+                        phase_args["finishes_processed"] = matched_finish_rows
+                        tasks_processed = matched_finish_rows
+                        phase_args["tasks_processed"] = tasks_processed
                 display_name = f"{phase}({tasks_processed})"
                 event_tid = resolve_tid if phase == "resolve" else tid
                 events.append(

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -243,6 +243,10 @@ header just like on onboard.
 
 Bare `--enable-l2-swimlane` = level 4 (backward compatible).
 
+The Complete phase's `tasks_processed` value is the number of AICore FIN/retire
+events observed by the scheduler poll. For SPMD tasks this includes non-final
+sub-block retires; it is therefore not always the number of logical tasks.
+
 ### Level gating in AICPU code
 
 Use the strongly-typed `L2SwimlaneLevel` enum so each gate names the

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -141,6 +141,15 @@ void SchedulerContext::complete_slot_task(
 
     bool task_complete = sched_->on_subtask_complete(slot_state);
 
+#if SIMPLER_DFX
+    // A multi-block task can retire several subtasks before its final block
+    // arrives. Count those non-final FINs so the scheduler lane does not hide
+    // the serial-harvest tail between two logical task completions.
+    if (!task_complete && l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
+        l2_swimlane.phase_subretire_count++;
+    }
+#endif
+
     if (task_complete && slot_state.payload != nullptr && slot_state.has_any_subtask_deferred()) {
         while (!mailbox->try_push_normal_done(slot_state.task->task_id, reinterpret_cast<uint64_t>(&slot_state))) {
             sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -918,23 +918,25 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             CYCLE_COUNT_LAP(l2_swimlane.sched_idle_cycle);
         } else {
             CYCLE_COUNT_LAP(l2_swimlane.sched_complete_cycle);
-            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES && l2_swimlane.phase_complete_count > 0) {
+            if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES &&
+                (l2_swimlane.phase_complete_count > 0 || l2_swimlane.phase_subretire_count > 0)) {
                 // Complete's release_fanin pushes newly-ready consumers into the
                 // shared ready_queues[], so the end depth differs from the start.
                 int16_t phase_end_shared[L2SWIMLANE_NUM_QUEUE_SHAPES];
                 capture_phase_end_fresh(phase_end_shared);
                 l2_swimlane_aicpu_record_sched_phase(
                     thread_idx, L2SwimlaneSchedPhaseKind::Complete, _t0_phase, _t1, l2_swimlane.sched_loop_count,
-                    l2_swimlane.phase_complete_count, /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared,
-                    phase_end_shared
+                    l2_swimlane.phase_complete_count + l2_swimlane.phase_subretire_count,
+                    /*pop_hit=*/0, /*pop_miss=*/0, phase_start_shared, phase_end_shared
                 );
                 for (int s = 0; s < L2SWIMLANE_NUM_QUEUE_SHAPES; s++)
                     phase_start_shared[s] = phase_end_shared[s];
                 l2_swimlane.phase_complete_count = 0;
+                l2_swimlane.phase_subretire_count = 0;
             }
             // Advance past the completion check even when no Complete bar was
-            // emitted (count 0). Otherwise its wall time folds into the next
-            // bar (AsyncPoll, or Dispatch when the poll is skipped).
+            // emitted (both counts 0). Otherwise its wall time folds into the
+            // next bar (AsyncPoll, or Dispatch when the poll is skipped).
             _t0_phase = _t1;
         }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -511,6 +511,11 @@ struct alignas(64) SchedL2SwimlaneCounters {
     uint64_t sched_async_cycle{0};
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
+    // Sub-block retires that did not finish a slot (SPMD blocks of a
+    // multi-block task retiring one at a time). Keep this separate from
+    // phase_complete_count so the Complete phase remains visible during the
+    // serial-harvest tail of an SPMD task.
+    uint32_t phase_subretire_count{0};
     uint32_t phase_dispatch_count{0};
     // Per-emit delta is (current - *_at_last_emit). Accumulated only when
     // l2_swimlane_level_ >= SCHED_PHASES.

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/_swimlane_validate.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/_swimlane_validate.py
@@ -46,7 +46,13 @@ _REQUIRED_TASK_FIELDS = (
 )
 
 
-def validate_perf_artifact(case_label: str, *, since: float, expected_task_count: int | None = None) -> None:
+def validate_perf_artifact(
+    case_label: str,
+    *,
+    since: float,
+    expected_task_count: int | None = None,
+    expected_complete_finishes: int | None = None,
+) -> None:
     """Locate this invocation's output dir for ``case_label`` and run the full
     capture-→-tools-→-differential sequence.
 
@@ -61,6 +67,9 @@ def validate_perf_artifact(case_label: str, *, since: float, expected_task_count
         expected_task_count: when provided, assert ``len(tasks) == N``.
             Workloads whose task count varies with sim/onboard timing should
             leave this ``None`` and rely on the differential gate.
+        expected_complete_finishes: when provided, assert the sum of
+            Complete-phase ``tasks_processed`` values. This is a FIN/retire
+            count, so an SPMD workload can exceed its logical task count.
     """
     safe_label = _sanitize_for_filename(case_label)
     matches = [p for p in _outputs_dir().glob(f"{safe_label}_*") if p.stat().st_mtime >= since]
@@ -83,6 +92,16 @@ def validate_perf_artifact(case_label: str, *, since: float, expected_task_count
     if expected_task_count is not None:
         assert len(tasks) == expected_task_count, (
             f"got {len(tasks)} perf records, expected {expected_task_count} under {perf}"
+        )
+    if expected_complete_finishes is not None:
+        complete_finishes = sum(
+            int(record.get("tasks_processed", 0))
+            for thread_records in data.get("aicpu_scheduler_phases", [])
+            for record in thread_records
+            if record.get("phase") == "complete"
+        )
+        assert complete_finishes == expected_complete_finishes, (
+            f"got {complete_finishes} Complete FINs, expected {expected_complete_finishes} under {perf}"
         )
     # Spot-check a single record's required fields — guards against drift in
     # the swimlane schema that swimlane_converter.py / deps_viewer.py rely on.

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
@@ -144,7 +144,11 @@ class TestL2SwimlaneMixed(SceneTestCase):
                     # the chain produces 3 MIX task_ids × 2 subtask rows = 6
                     # perf rows and 2 deps.json edges, so the dedup branch in
                     # the oracle has an arithmetically observable effect.
-                    validate_perf_artifact(f"TestL2SwimlaneMixed_{case['name']}", since=run_marker)
+                    validate_perf_artifact(
+                        f"TestL2SwimlaneMixed_{case['name']}",
+                        since=run_marker,
+                        expected_complete_finishes=6,
+                    )
         # Full-dump modes give the func_id array its regression barrier on the
         # cooperative-mix path (single-kernel coverage lives in test_args_dump).
         if int(request.config.getoption("--dump-args", default=0)) >= 2:

--- a/tests/ut/py/test_sched_overhead_analysis.py
+++ b/tests/ut/py/test_sched_overhead_analysis.py
@@ -14,6 +14,7 @@ from simpler_setup.tools.sched_overhead_analysis import (
     compute_critical_path,
     compute_head_tail,
     compute_overhead,
+    parse_scheduler_from_json_phases,
     per_id_timing,
     print_distribution,
 )
@@ -144,3 +145,77 @@ def test_print_distribution(capsys):
 
     print_distribution("Head OH", [])
     assert "(no tasks)" in capsys.readouterr().out
+
+
+def test_parse_scheduler_distinguishes_logical_tasks_from_finishes():
+    task_id = (1 << 32) | 7
+    data = {
+        "core_to_thread": [0, 0],
+        "tasks": [
+            {"task_id": task_id, "core_id": 0, "finish_time_us": 1.25},
+            {"task_id": task_id, "core_id": 1, "finish_time_us": 1.75},
+        ],
+        "aicpu_scheduler_phases": [
+            [
+                {
+                    "phase": "complete",
+                    "start_time_us": 1.0,
+                    "end_time_us": 2.0,
+                    "loop_iter": 1,
+                    "tasks_processed": 2,
+                }
+            ]
+        ],
+    }
+
+    threads = parse_scheduler_from_json_phases(data)
+
+    assert threads[0]["completed"] == 1
+    assert threads[0]["logical_tasks"] == 1
+    assert threads[0]["finishes"] == 2
+    assert threads[0]["tasks_per_loop"] == 1
+    assert threads[0]["finishes_per_loop"] == 2
+
+
+def test_parse_scheduler_attributes_spmd_task_to_final_finish_thread():
+    task_id = (1 << 32) | 7
+    data = {
+        "core_to_thread": [0, 1],
+        "tasks": [
+            {"task_id": task_id, "core_id": 0, "finish_time_us": 1.25},
+            {"task_id": task_id, "core_id": 1, "finish_time_us": 1.75},
+        ],
+        "aicpu_scheduler_phases": [
+            [
+                {
+                    "phase": "complete",
+                    "start_time_us": 1.0,
+                    "end_time_us": 2.0,
+                    "loop_iter": 1,
+                    "tasks_processed": 1,
+                }
+            ],
+            [
+                {
+                    "phase": "complete",
+                    "start_time_us": 1.0,
+                    "end_time_us": 2.0,
+                    "loop_iter": 1,
+                    "tasks_processed": 1,
+                }
+            ],
+        ],
+    }
+
+    threads = parse_scheduler_from_json_phases(data)
+
+    assert threads[0]["completed"] == 0
+    assert threads[0]["logical_tasks"] == 0
+    assert threads[0]["finishes"] == 1
+    assert threads[0]["tasks_per_loop"] == 0
+    assert threads[0]["finishes_per_loop"] == 1
+    assert threads[1]["completed"] == 1
+    assert threads[1]["logical_tasks"] == 1
+    assert threads[1]["finishes"] == 1
+    assert threads[1]["tasks_per_loop"] == 1
+    assert threads[1]["finishes_per_loop"] == 1

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -424,6 +424,42 @@ def test_complete_flow_uses_independent_view_anchors(tmp_path):
     assert len({(e["pid"], e["tid"], e["ts"]) for e in finishes}) == 1
 
 
+def test_complete_phase_preserves_runtime_fin_count(tmp_path):
+    task_id = 101
+    tasks = [
+        _task_row(task_id, 0, start=1.0, end=2.0),
+        _task_row(task_id, 1, start=1.5, end=2.5),
+    ]
+    scheduler_phases = [
+        [
+            {
+                "phase": "complete",
+                "start_time_us": 2.5,
+                "end_time_us": 3.5,
+                # A5/a2a3 runtime count: two AICore FINs, one of which may
+                # be a non-final SPMD sub-block retire.
+                "tasks_processed": 2,
+            }
+        ]
+    ]
+
+    out = tmp_path / "trace.json"
+    sc.generate_chrome_trace_json(
+        tasks,
+        str(out),
+        scheduler_phases=scheduler_phases,
+        core_to_thread=[0, 0],
+        deps_edges={},
+        deps_block_map={task_id: 2},
+    )
+
+    with out.open() as f:
+        events = json.load(f)["traceEvents"]
+    complete = next(e for e in events if e.get("cat") == "scheduler" and e.get("name") == "complete(2)")
+    assert complete["args"]["finishes_processed"] == 2
+    assert complete["args"]["finish_rows_attributed"] == 2
+
+
 def test_complete_flow_worker_view_only_without_scheduler_phases(tmp_path):
     # Without scheduler_phases the complete-flow block is skipped entirely:
     # neither view gets a complete arrow (regression guard on the gate).


### PR DESCRIPTION
## Summary

A5's `tensormap_and_ringbuffer` scheduler was missing the A2A3 `phase_subretire_count` DFX accounting. As a result, non-final SPMD FIN/retire events could be absent from Complete-phase records, and the profiling tools could conflate FIN counts with logical-task counts.

## Changes

- Port `phase_subretire_count` to the A5 scheduler and emit a Complete phase when either logical completions or non-final SPMD retires were observed.
- Preserve the runtime FIN/retire count in Chrome traces while retaining finish-row attribution for diagnostics.
- Update scheduler overhead analysis to report logical tasks and FINs separately.
- Document the `tasks_processed` semantics for Complete phases.
- Add Python regression tests and extend the A5 mixed-workload swimlane validation to check the expected FIN count.

## Scope

This is a DFX/profiling-accounting fix. Normal scheduling semantics are unchanged when DFX is disabled.

## Validation

- A5 sim runtime build (host, AICPU, and AICore): passed.
- Focused converter and scheduler-overhead tests: 33 passed.
- Commit hooks: clang-format, clang-tidy, cpplint, markdownlint, Ruff, and Pyright passed.
- The broader suites were not fully runnable in this environment: the full Python UT reached 866 passed and 17 skipped with 5 environment-related failures, and the A5 ST workload was blocked by a host `GLIBCXX_3.4.32` mismatch.

Related to #1582