### PR TITLE
Fix: support 256 chip-level tensor arguments

### DIFF
--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -770,8 +770,8 @@ Slots carry scheduler-only state (atomics, mutex, `std::vector` of fanout
 consumers) that is parent-private. Putting them in shm would force cross-
 process atomics and shm-safe containers. The only data that needs to cross
 the fork boundary is per-task: callable, config, args — and that fits in a
-fixed 32 KiB task frame with a one-time memcpy per dispatch. A two-frame-capable
-local mailbox reserves a separate 32 KiB control base plus two such task frames;
+fixed 64 KiB task frame with a one-time memcpy per dispatch. A two-frame-capable
+local mailbox reserves a separate 64 KiB control base plus two such task frames;
 single-frame compatibility endpoints use the base frame and leave the reserved
 task frames unused.
 

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -87,13 +87,9 @@ bool mailbox_compare_exchange_state(char *frame, MailboxState expected, MailboxS
 
 // Sized so the args region can hold any TaskArgs the runtime itself accepts
 // (CHIP_MAX_TENSOR_ARGS tensors + CHIP_MAX_SCALAR_ARGS scalars; see the
-// static_assert after MAILBOX_ARGS_CAPACITY). 4096 was too tight for composed
-// child kernels with many tensor args (issue #1024).
-// Bumped 16384 -> 32768 when TaskArgs moved from the former 40 B compact tensor
-// to the unified 128 B Tensor: the worst-case blob (CHIP_MAX_TENSOR_ARGS tensors)
-// grew ~3x, and 128*128 B = 16 KB alone exceeded the old mailbox (see the
-// capacity static_assert after MAILBOX_ARGS_CAPACITY).
-static constexpr size_t MAILBOX_FRAME_SIZE = 32768;
+// static_assert after MAILBOX_ARGS_CAPACITY). At the 256-tensor cap, tensors
+// occupy 32 KiB of the 64 KiB frame and leave room for scalars and protocol metadata.
+static constexpr size_t MAILBOX_FRAME_SIZE = 65536;
 static constexpr size_t MAILBOX_TASK_FRAME_COUNT = 2;
 static constexpr size_t MAILBOX_CONTROL_FRAME = 0;
 static constexpr size_t MAILBOX_FIRST_TASK_FRAME = 1;

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -30,8 +30,8 @@ inline constexpr int CORE_MAX_TENSOR_ARGS = 32;
 // Chip-level entry-tensor cap. Sizes ChipCallable::signature_[] and
 // ChipStorageTaskArgs::tensors_[], both of which cross the host->device wire
 // as fixed POD — raising this is an additive ABI change (existing callers
-// still fit; transient storage grows by 64 * sizeof(Tensor)).
-inline constexpr int CHIP_MAX_TENSOR_ARGS = 128;
+// still fit; transient storage changes by the capacity delta * sizeof(Tensor)).
+inline constexpr int CHIP_MAX_TENSOR_ARGS = 256;
 inline constexpr int CORE_MAX_SCALAR_ARGS = 16;
 inline constexpr int CHIP_MAX_SCALAR_ARGS = 128;
 inline constexpr uint32_t CALLABLE_ALIGN = 64;

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -39,6 +39,7 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "arg_direction.h"
@@ -183,7 +184,12 @@ static_assert(
 template <int MaxSig>
 std::vector<uint8_t>
 make_callable(const ArgDirection *sig, int32_t sig_count, const void *binary, uint32_t binary_size) {
-    if (sig_count > MaxSig) throw std::invalid_argument("make_callable: sig_count exceeds MaxSig");
+    if (sig_count > MaxSig) {
+        throw std::invalid_argument(
+            "make_callable: requested tensor count " + std::to_string(sig_count) + " exceeds supported tensor count " +
+            std::to_string(MaxSig)
+        );
+    }
     if (sig_count > 0 && sig == nullptr)
         throw std::invalid_argument("make_callable: sig is required when sig_count > 0");
 
@@ -219,7 +225,12 @@ std::vector<uint8_t> make_callable(
     // it to "" at the nb::arg level), so the default was dead anyway.
     const char *config_name
 ) {
-    if (sig_count > MaxSig) throw std::invalid_argument("make_callable: sig_count exceeds MaxSig");
+    if (sig_count > MaxSig) {
+        throw std::invalid_argument(
+            "make_callable: requested tensor count " + std::to_string(sig_count) + " exceeds supported tensor count " +
+            std::to_string(MaxSig)
+        );
+    }
     if (child_count > MaxChildren) throw std::invalid_argument("make_callable: child_count exceeds MaxChildren");
 
     using T = Callable<Child, MaxSig, MaxChildren>;

--- a/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
+++ b/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
@@ -8,15 +8,13 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-// Regression test for #786: CHIP_MAX_TENSOR_ARGS was 64, which blocked the
-// DeepSeek-V4 decode-CSA orchestration at 69 entry tensors. After the bump
-// to 128 we verify (a) a ChipStorageTaskArgs accepts the 65th..128th tensor
-// and (b) view_to_chip_storage still rejects 129+.
-
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
+#include "callable.h"
 #include "task_args.h"
 
 namespace {
@@ -32,23 +30,47 @@ Tensor make_tensor(uint64_t addr) {
 
 }  // namespace
 
-TEST(ChipMaxTensorArgs, CapIsAtLeast128) {
+TEST(ChipMaxTensorArgs, CapIsAtLeast256) {
     // The cap is the contract — the storage struct and the chip callable
-    // signature_[] array both size off it. Lock in 128 explicitly so a
-    // future change that lowers it is caught.
-    static_assert(CHIP_MAX_TENSOR_ARGS >= 128, "CHIP_MAX_TENSOR_ARGS regressed below 128 (see #786)");
-    EXPECT_GE(CHIP_MAX_TENSOR_ARGS, 128);
+    // signature_[] array both size off it.
+    static_assert(CHIP_MAX_TENSOR_ARGS >= 256, "CHIP_MAX_TENSOR_ARGS must support 256 chip-level tensors");
+    EXPECT_GE(CHIP_MAX_TENSOR_ARGS, 256);
 }
 
-TEST(ChipMaxTensorArgs, ChipStorageHoldsAtLeast128Tensors) {
-    // Pre-#786 this throws std::out_of_range at the 65th add_tensor.
+TEST(ChipMaxTensorArgs, ChipStorageHoldsCapacity) {
     ChipStorageTaskArgs args;
-    for (int i = 0; i < 128; ++i) {
+    for (int i = 0; i < 256; ++i) {
         ASSERT_NO_THROW(args.add_tensor(make_tensor(static_cast<uint64_t>(0x1000 + i))));
     }
-    EXPECT_EQ(args.tensor_count(), 128);
+    EXPECT_EQ(args.tensor_count(), 256);
     EXPECT_EQ(args.tensor(0).buffer.addr, 0x1000u);
-    EXPECT_EQ(args.tensor(127).buffer.addr, 0x1000u + 127);
+    EXPECT_EQ(args.tensor(255).buffer.addr, 0x1000u + 255);
+}
+
+TEST(ChipMaxTensorArgs, ChipCallableAcceptsCapacity) {
+    std::vector<ArgDirection> signature(256, ArgDirection::IN);
+    auto buffer = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        signature.data(), static_cast<int32_t>(signature.size()), "composed", nullptr, 0, nullptr, nullptr, 0, ""
+    );
+
+    const auto &callable = *reinterpret_cast<const ChipCallable *>(buffer.data());
+    EXPECT_EQ(callable.sig_count(), 256);
+}
+
+TEST(ChipMaxTensorArgs, ChipCallableOverflowReportsRequestedAndSupportedCounts) {
+    const int32_t requested = CHIP_MAX_TENSOR_ARGS + 1;
+    std::vector<ArgDirection> signature(static_cast<size_t>(requested), ArgDirection::IN);
+
+    try {
+        (void)make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+            signature.data(), requested, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
+        );
+        FAIL() << "expected signature capacity validation to fail";
+    } catch (const std::invalid_argument &error) {
+        const std::string message = error.what();
+        EXPECT_NE(message.find(std::to_string(requested)), std::string::npos);
+        EXPECT_NE(message.find(std::to_string(CHIP_MAX_TENSOR_ARGS)), std::string::npos);
+    }
 }
 
 TEST(ChipMaxTensorArgs, ChipStorageRejectsOverflow) {

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -867,6 +867,24 @@ class TestChipCallable:
     def _make_child(self, sig, binary):
         return CoreCallable.build(signature=sig, binary=binary)
 
+    def test_signature_capacity(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN] * 256,
+            func_name="capacity",
+            binary=b"",
+            children=[],
+        )
+        assert chip.sig_count == 256
+
+    def test_signature_overflow_reports_counts(self):
+        with pytest.raises(ValueError, match=r"requested tensor count 257.*supported tensor count 256"):
+            ChipCallable.build(
+                signature=[ArgDirection.IN] * 257,
+                func_name="overflow",
+                binary=b"",
+                children=[],
+            )
+
     def test_build_with_children(self):
         child0 = self._make_child([ArgDirection.IN], b"\x01\x02\x03\x04")
         child1 = self._make_child([ArgDirection.OUT, ArgDirection.SCALAR], b"\x05\x06")


### PR DESCRIPTION
## Summary

- raise `CHIP_MAX_TENSOR_ARGS` from 128 to 256 across chip callables, task storage, and a2a3/a5 L2 runtime layouts
- expand each hierarchical mailbox frame from 32 KiB to 64 KiB so the maximum 256-tensor plus 128-scalar blob fits with callable and protocol metadata
- report requested and supported tensor counts on overflow, with boundary coverage for 256 accepted and 257 rejected

## Testing

- [x] post-rebase `pre-commit` checks
- [x] post-rebase targeted tests: Python task-interface 118 passed; C++ scheduler/capacity 2 passed
- [x] full Python unit tests: 1043 passed, 2 skipped
- [x] full C++ non-hardware unit tests: 74 passed
- [x] a2a3sim hierarchical PROCESS-mailbox end-to-end with 256 tensors
- [x] a5sim hierarchical PROCESS-mailbox end-to-end with 256 tensors
- [x] a2a3 onboard hierarchical PROCESS-mailbox end-to-end with 256 tensors (`task_20260803_011811_345264931358`, device 4)

Fixes #1645