### PR TITLE
Refactor: centralize chip native run ownership

### DIFF
--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -51,6 +51,7 @@ target_compile_definitions(_task_interface PRIVATE
 
 target_sources(_task_interface PRIVATE
     ${CMAKE_SOURCE_DIR}/src/common/worker/chip_worker.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/worker/chip_run_lane.cpp
     # Host-side assert_impl / get_stacktrace for the unified Tensor's
     # always_assert (Tensor::make -> init_external). The binding does not link
     # the runtime orchestration/common.cpp that provides these for runtime .so.

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -53,6 +53,7 @@
 #include "arg_direction.h"
 #include "callable.h"
 #include "callable_protocol.h"
+#include "chip_run_lane.h"
 #include "chip_worker.h"
 #include "data_type.h"
 #include "dma_workspace.h"
@@ -2010,6 +2011,26 @@ NB_MODULE(_task_interface, m) {
         .def_ro("run_id", &ChipWorkerNativeRun::run_id)
         .def_ro("dispatch_id", &ChipWorkerNativeRun::dispatch_id);
 
+    nb::enum_<ChipRunPreparationDisposition>(m, "_ChipRunPreparationDisposition")
+        .value("VALIDATED_ONLY", ChipRunPreparationDisposition::VALIDATED_ONLY)
+        .value("NATIVE_PREPARED", ChipRunPreparationDisposition::NATIVE_PREPARED);
+
+    nb::class_<ChipRun>(m, "_ChipRun")
+        .def("done", &ChipRun::done)
+        .def("activate", &ChipRun::activate)
+        .def("abandon", &ChipRun::abandon, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("launched", &ChipRun::launched)
+        .def_prop_ro("lane_poisoned", &ChipRun::lane_poisoned)
+        .def_prop_ro("preparation_disposition", &ChipRun::preparation_disposition)
+        .def(
+            "_raise_if_failed",
+            [](ChipRun &self) {
+                if (!self.done()) throw std::logic_error("ChipRun is not terminal");
+                (void)self.wait_until(ChipRun::Deadline::max());
+            },
+            nb::call_guard<nb::gil_scoped_release>()
+        );
+
     // --- ChipWorker ---
     nb::class_<ChipWorker>(m, "_ChipWorker")
         .def(nb::init<>())
@@ -2093,6 +2114,25 @@ NB_MODULE(_task_interface, m) {
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::arg("slot_id"), nb::arg("generation"),
             nb::call_guard<nb::gil_scoped_release>(),
             "Prepare a native run from pre-encoded task args after lease admission."
+        )
+        .def(
+            "_submit_chip_run_materialized",
+            [](ChipWorker &self, int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config,
+               uint32_t slot_id, uint64_t generation, uint64_t run_id, uint64_t dispatch_id,
+               uint64_t accepted_state_addr, int32_t accepted_value, bool activated) {
+                return self.submit_chip_run(
+                    callable_id, args, config, PipelineSlotLease{slot_id, 0, generation}, run_id, dispatch_id,
+                    reinterpret_cast<volatile int32_t *>(accepted_state_addr), accepted_value, activated
+                );
+            },
+            nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::arg("slot_id"), nb::arg("generation"),
+            nb::arg("run_id"), nb::arg("dispatch_id"), nb::arg("accepted_state_addr"), nb::arg("accepted_value"),
+            nb::arg("activated"), nb::call_guard<nb::gil_scoped_release>(),
+            "Submit materialized task args to the chip native-run lane."
+        )
+        .def(
+            "_close_chip_run_lane", &ChipWorker::close_chip_run_lane, nb::call_guard<nb::gil_scoped_release>(),
+            "Drain active native ownership, abandon unlaunched work, and close the chip run lane."
         )
         .def(
             "_prepare_native_run_materialized",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -238,12 +238,15 @@ _OFF_TASK_ARGS_BLOB = _OFF_TASK_CALLABLE_HASH + CALLABLE_HASH_DIGEST_BYTES
 # clears it when it publishes the next task frame.
 _OFF_ACCEPTED = MAILBOX_FRAME_SIZE - MAILBOX_ERROR_MSG_SIZE - 8
 _TASK_ACCEPTED = 1
+_OFF_PREPARATION_DISPOSITION = _OFF_ACCEPTED + 4
+_VALIDATED_ONLY = 1
+_NATIVE_PREPARED = 2
 _OFF_FRAME_PROTOCOL = _OFF_ACCEPTED - 40
 _OFF_FRAME_RUN_ID = _OFF_ACCEPTED - 32
 _OFF_FRAME_SLOT_ID = _OFF_ACCEPTED - 24
 _OFF_FRAME_GENERATION = _OFF_ACCEPTED - 16
 _OFF_FRAME_DISPATCH_ID = _OFF_ACCEPTED - 8
-_TASK_PROTOCOL_VERSION = 2
+_TASK_PROTOCOL_VERSION = 3
 # Mirrors MAILBOX_OFF_SHUTDOWN / MAILBOX_SHUTDOWN_REQUESTED: termination is a
 # sticky one-way word on the control frame, not a MailboxState. _OFF_STATE has
 # three writers (parent CONTROL_REQUEST, child CONTROL_DONE, C++
@@ -2318,27 +2321,10 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             cid: int
             config: CallConfig
             activated: bool
-            native_run: Any = None
-            published: bool = False
+            chip_run: Any = None
+            launched_published: bool = False
 
-        supports_concurrent_native_prepare = bool(cw._impl.supports_concurrent_native_prepare)
         staged_frames: dict[int, _StagedFrame] = {}
-        active_frame: _StagedFrame | None = None
-        active_run: Any = None
-
-        def config_has_diagnostics(config: CallConfig) -> bool:
-            # Mirrors CallConfig::diagnostics_any(); these modes share native
-            # diagnostic state and therefore use the serial prepare fallback.
-            return bool(
-                config.enable_chip_swimlane
-                or config.enable_dump_args
-                or config.enable_pmu
-                or config.enable_dep_gen
-                or config.enable_scope_stats
-            )
-
-        def has_backend_prepared_frame() -> bool:
-            return any(frame.native_run is not None for frame in staged_frames.values())
 
         def read_identity(frame_buf: memoryview) -> tuple[int, int, int, int, int]:
             return (
@@ -2361,44 +2347,6 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
         def fail_frame(frame: _StagedFrame, message: str) -> None:
             _write_error(frame.frame_buf, 1, message)
             _mailbox_store_i32(frame.frame_addr + _OFF_STATE, _TASK_FAILED)
-
-        def publish_frame_staged(frame: _StagedFrame) -> None:
-            _write_error(frame.frame_buf, 0, "")
-            _mailbox_store_i32(frame.frame_addr + _OFF_STATE, _FRAME_STAGED)
-            frame.published = True
-
-        def prepare_frame_native_run(frame: _StagedFrame) -> Any:
-            if frame.native_run is not None:
-                return frame.native_run
-            _protocol, run_id, slot_id, generation, dispatch_id = frame.identity
-            # The frame carries the wire blob; the runtime reads the chip POD. Resolve each
-            # tensor's descriptor to a local base (map-once, cached by canonical identity) and
-            # rebuild at those bases, as the non-pipelined task path does. The native prepare
-            # copies the args into its own storage, so this POD need not outlive the call.
-            args_ptr = frame.frame_addr + _OFF_TASK_ARGS_BLOB
-            resolved = import_registry.materialize_blob(args_ptr, _MAILBOX_ARGS_CAPACITY)
-            chip_args = materialize_tensor_blob(args_ptr, _MAILBOX_ARGS_CAPACITY, resolved)
-            frame.native_run = cw._impl._prepare_native_run_materialized(
-                frame.cid,
-                chip_args,
-                frame.config,
-                slot_id,
-                generation,
-                run_id,
-                dispatch_id,
-                frame.frame_addr + _OFF_ACCEPTED,
-                _TASK_ACCEPTED,
-            )
-            return frame.native_run
-
-        def finalize_frame_native_run(frame: _StagedFrame) -> None:
-            native_run = frame.native_run
-            if native_run is None:
-                return
-            # Clearing ownership before the native call makes every unwind path
-            # attempt this token exactly once, including when finalization fails.
-            frame.native_run = None
-            cw._impl._finalize_native_run(native_run)
 
         def stage_frame(index: int, initial_state: int) -> _StagedFrame | None:
             frame_buf = frame_bufs[index]
@@ -2432,28 +2380,54 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                     raise RuntimeError(
                         f"cid {cid} not prepared before task frame publication (register via _CTRL_PREPARE first)"
                     )
-                config = _read_config_from_mailbox(frame_buf)
-                activation_required = initial_state != _TASK_READY
                 return _StagedFrame(
                     index=index,
                     frame_buf=frame_buf,
                     frame_addr=frame_addr,
                     identity=identity,
                     cid=int(cid),
-                    config=config,
-                    activated=not activation_required or initial_state == _ACTIVATE,
+                    config=_read_config_from_mailbox(frame_buf),
+                    activated=initial_state in (_TASK_READY, _ACTIVATE),
                 )
             except Exception as e:  # noqa: BLE001
                 _write_error(frame_buf, 1, _format_exc(f"chip_process dev={device_id} frame={index}", e))
                 _mailbox_store_i32(frame_addr + _OFF_STATE, _TASK_FAILED)
                 return None
 
+        def submit_frame(frame: _StagedFrame) -> None:
+            _protocol, run_id, slot_id, generation, dispatch_id = frame.identity
+            # The frame carries the wire blob; the runtime reads the chip POD. Resolve each
+            # tensor's descriptor to a local base (map-once, cached by canonical identity) and
+            # rebuild at those bases, as the non-pipelined task path does. The lane copies the
+            # args into its own storage, so this POD need not outlive the call.
+            args_ptr = frame.frame_addr + _OFF_TASK_ARGS_BLOB
+            resolved = import_registry.materialize_blob(args_ptr, _MAILBOX_ARGS_CAPACITY)
+            chip_args = materialize_tensor_blob(args_ptr, _MAILBOX_ARGS_CAPACITY, resolved)
+            frame.chip_run = cw._impl._submit_chip_run_materialized(
+                frame.cid,
+                chip_args,
+                frame.config,
+                slot_id,
+                generation,
+                run_id,
+                dispatch_id,
+                frame.frame_addr + _OFF_ACCEPTED,
+                _TASK_ACCEPTED,
+                False,
+            )
+            raw_disposition = frame.chip_run.preparation_disposition
+            disposition = int(getattr(raw_disposition, "value", raw_disposition))
+            if disposition not in (_VALIDATED_ONLY, _NATIVE_PREPARED):
+                raise RuntimeError(f"chip run lane returned invalid preparation disposition {disposition}")
+            _mailbox_store_i32(frame.frame_addr + _OFF_PREPARATION_DISPOSITION, disposition)
+            _write_error(frame.frame_buf, 0, "")
+            _mailbox_store_i32(frame.frame_addr + _OFF_STATE, _FRAME_STAGED)
+            if frame.activated:
+                frame.chip_run.activate()
+
         parent_pid = os.getppid()
         liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
         shutdown_message = f"chip_process dev={device_id}: task loop shut down"
-        # The sticky shutdown word outlives the _CONTROL_DONE this loop
-        # publishes for an in-flight control command, which overwrites a
-        # concurrent _SHUTDOWN store on the state word.
         shutdown_addr = _buffer_field_addr(buf, _OFF_SHUTDOWN)
         try:
             while True:
@@ -2463,8 +2437,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 if control_state == _CONTROL_REQUEST:
                     sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
                     registry_control = sub_cmd in (_CTRL_PREPARE, _CTRL_REGISTER, _CTRL_UNREGISTER)
-                    backend_prepared = has_backend_prepared_frame()
-                    defer_control = registry_control and (active_frame is not None or backend_prepared)
+                    defer_control = registry_control and bool(staged_frames)
                     if sub_cmd == _CTRL_UNREGISTER:
                         defer_control = defer_control or task_frame_references_digest(_read_control_digest(buf))
                     if not defer_control:
@@ -2472,7 +2445,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                         _write_error(buf, code, msg)
                         _mailbox_store_i32(state_addr, _CONTROL_DONE)
 
-                stop_after_frame_scan = False
+                new_frames: list[_StagedFrame] = []
                 for index in range(_TASK_FRAME_COUNT):
                     frame_state = _mailbox_load_i32(frame_addrs[index] + _OFF_STATE)
                     staged = staged_frames.get(index)
@@ -2480,204 +2453,92 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                         if frame_state in (_TASK_READY, _PREPARE_READY, _ACTIVATE):
                             staged = stage_frame(index, frame_state)
                             if staged is not None:
-                                staged_frames[index] = staged
+                                new_frames.append(staged)
                         continue
-                    if frame_state == _ACTIVATE:
+                    if frame_state == _ACTIVATE and not staged.activated:
                         if read_identity(staged.frame_buf) != staged.identity:
                             stale_message = f"chip_process dev={device_id}: stale activation identity"
-                            finalize_failed = False
                             try:
-                                finalize_frame_native_run(staged)
+                                staged.chip_run.abandon()
                             except Exception as e:  # noqa: BLE001
-                                finalize_failed = True
-                                stale_message += "; " + _format_exc("native finalize", e)
-                            fail_frame(staged, stale_message)
-                            if active_frame is not staged:
-                                staged_frames.pop(index, None)
-                            if finalize_failed:
+                                stale_message += "; " + _format_exc("chip run abandonment", e)
                                 shutdown_message = stale_message
-                                stop_after_frame_scan = True
                                 break
+                            fail_frame(staged, stale_message)
+                            staged_frames.pop(index, None)
                             continue
-                        staged.activated = True
-
-                if stop_after_frame_scan:
-                    break
-
-                next_active = None
-                if active_frame is None:
-                    activated_frames = [frame for frame in staged_frames.values() if frame.activated]
-                    if activated_frames:
-                        next_active = min(activated_frames, key=lambda frame: frame.identity[4])
-
-                for staged in sorted(staged_frames.values(), key=lambda frame: frame.identity[4]):
-                    # A frame published before any active claim is validation-only.
-                    # Keep considering it so activation or a later predecessor
-                    # claim can add the missing native token.
-                    native_prepare_now = (
-                        staged.native_run is None
-                        and supports_concurrent_native_prepare
-                        and not config_has_diagnostics(staged.config)
-                        and (
-                            (active_frame is None and staged is next_active)
-                            or (
-                                active_frame is not None
-                                and staged is not active_frame
-                                and not config_has_diagnostics(active_frame.config)
-                            )
-                        )
-                    )
-                    if staged.published and not native_prepare_now:
-                        continue
-                    try:
-                        if native_prepare_now:
-                            prepare_frame_native_run(staged)
-                        if not staged.published:
-                            publish_frame_staged(staged)
-                    except Exception as e:  # noqa: BLE001
-                        prepare_message = _format_exc(f"chip_process dev={device_id}: native prepare", e)
-                        finalize_failed = False
                         try:
-                            finalize_frame_native_run(staged)
-                        except Exception as finalize_error:  # noqa: BLE001
-                            finalize_failed = True
-                            prepare_message += "; " + _format_exc("native finalize", finalize_error)
-                        fail_frame(staged, prepare_message)
-                        staged_frames.pop(staged.index, None)
-                        if finalize_failed:
-                            shutdown_message = prepare_message
-                            stop_after_frame_scan = True
+                            staged.chip_run.activate()
+                            staged.activated = True
+                        except Exception as e:  # noqa: BLE001
+                            shutdown_message = _format_exc(f"chip_process dev={device_id}: native activation", e)
                             break
-
-                if stop_after_frame_scan:
-                    break
-
-                if active_frame is not None:
-                    try:
-                        run_complete = bool(cw._impl._poll_native_run(active_run))
-                    except Exception as e:  # noqa: BLE001
-                        poll_message = _format_exc(f"chip_process dev={device_id}: native poll", e)
+                else:
+                    for staged in sorted(new_frames, key=lambda frame: frame.identity[4]):
                         try:
-                            finalize_frame_native_run(active_frame)
-                        except Exception as finalize_error:  # noqa: BLE001
-                            poll_message += "; " + _format_exc("native finalize", finalize_error)
-                        fail_frame(active_frame, poll_message)
-                        staged_frames.pop(active_frame.index, None)
-                        active_frame = None
-                        active_run = None
-                        # A failed native progress/finalize fence cannot prove
-                        # that device state is reusable. Stop this endpoint so
-                        # an already-staged successor is failed, never launched
-                        # into potentially poisoned native state.
-                        shutdown_message = poll_message
-                        break
-                    else:
-                        if run_complete:
-                            completed_frame = active_frame
+                            submit_frame(staged)
+                        except Exception as e:  # noqa: BLE001
+                            fail_frame(staged, _format_exc(f"chip_process dev={device_id}: chip run submit", e))
+                        else:
+                            staged_frames[staged.index] = staged
+
+                    stop_progress = False
+                    for staged in sorted(staged_frames.values(), key=lambda frame: frame.identity[4]):
+                        try:
+                            if staged.chip_run.launched and not staged.launched_published:
+                                _mailbox_store_i32(staged.frame_addr + _OFF_STATE, _TASK_LAUNCHED)
+                                staged.launched_published = True
+                                continue
+                            run_complete = bool(staged.chip_run.done())
+                            if not run_complete and staged.chip_run.launched and not staged.launched_published:
+                                _mailbox_store_i32(staged.frame_addr + _OFF_STATE, _TASK_LAUNCHED)
+                                staged.launched_published = True
+                            if not run_complete:
+                                continue
+
                             code = 0
                             msg = ""
-                            finalize_failed = False
                             try:
-                                finalize_frame_native_run(active_frame)
+                                staged.chip_run._raise_if_failed()
                             except Exception as e:  # noqa: BLE001
                                 code = 1
-                                finalize_failed = True
-                                msg = _format_exc(f"chip_process dev={device_id}: native finalize", e)
-                            active_frame = None
-                            active_run = None
+                                msg = _format_exc(f"chip_process dev={device_id}: chip run", e)
                             if code == 0 and on_task_done_success is not None:
                                 try:
                                     code, msg = on_task_done_success()
                                 except Exception as e:  # noqa: BLE001
                                     code = 1
                                     msg = _format_exc(f"chip_process dev={device_id}: task completion hook", e)
-                            _write_error(completed_frame.frame_buf, code, msg)
+                            _write_error(staged.frame_buf, code, msg)
                             _mailbox_store_i32(
-                                completed_frame.frame_addr + _OFF_STATE,
+                                staged.frame_addr + _OFF_STATE,
                                 _TASK_DONE if code == 0 else _TASK_FAILED,
                             )
-                            staged_frames.pop(completed_frame.index, None)
-                            if finalize_failed:
-                                # Finalization is the native reuse fence. Its
-                                # failure terminalizes the endpoint before a
-                                # staged successor can cross the launch fence.
+                            staged_frames.pop(staged.index, None)
+                            if code != 0 and staged.chip_run.lane_poisoned:
                                 shutdown_message = msg
+                                stop_progress = True
                                 break
-
-                if active_frame is None:
-                    eligible = sorted(
-                        (frame for frame in staged_frames.values() if frame.activated and frame.published),
-                        key=lambda frame: frame.identity[4],
-                    )
-                    if eligible:
-                        next_frame = eligible[0]
-                        frame_state = _mailbox_load_i32(next_frame.frame_addr + _OFF_STATE)
-                        expected_states = (_FRAME_STAGED, _ACTIVATE)
-                        if (
-                            read_identity(next_frame.frame_buf) != next_frame.identity
-                            or frame_state not in expected_states
-                        ):
-                            launch_message = f"chip_process dev={device_id}: staged task frame changed before launch"
-                            finalize_failed = False
-                            try:
-                                finalize_frame_native_run(next_frame)
-                            except Exception as e:  # noqa: BLE001
-                                finalize_failed = True
-                                launch_message += "; " + _format_exc("native finalize", e)
-                            fail_frame(next_frame, launch_message)
-                            staged_frames.pop(next_frame.index, None)
-                            if finalize_failed:
-                                shutdown_message = launch_message
+                        except Exception as e:  # noqa: BLE001
+                            shutdown_message = _format_exc(f"chip_process dev={device_id}: chip run progress", e)
+                            stop_progress = True
+                            break
+                    if not stop_progress:
+                        liveness_countdown -= 1
+                        if liveness_countdown <= 0:
+                            liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
+                            if os.getppid() != parent_pid:
+                                shutdown_message = f"chip_process dev={device_id}: parent exited"
                                 break
-                        else:
-                            native_run = None
-                            try:
-                                native_run = prepare_frame_native_run(next_frame)
-                                cw._impl._launch_native_run(native_run)
-                            except Exception as e:  # noqa: BLE001
-                                launch_message = _format_exc(f"chip_process dev={device_id}: native launch", e)
-                                finalize_failed = False
-                                if native_run is not None:
-                                    try:
-                                        finalize_frame_native_run(next_frame)
-                                    except Exception as finalize_error:  # noqa: BLE001
-                                        finalize_failed = True
-                                        launch_message += "; " + _format_exc("native finalize", finalize_error)
-                                fail_frame(next_frame, launch_message)
-                                staged_frames.pop(next_frame.index, None)
-                                if finalize_failed:
-                                    # The launch cleanup did not establish the
-                                    # native reuse fence. Stop before any other
-                                    # staged frame can enter poisoned state.
-                                    shutdown_message = launch_message
-                                    break
-                            else:
-                                active_frame = next_frame
-                                active_run = native_run
-                                _mailbox_store_i32(next_frame.frame_addr + _OFF_STATE, _TASK_LAUNCHED)
-
-                liveness_countdown -= 1
-                if liveness_countdown <= 0:
-                    liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
-                    if os.getppid() != parent_pid:
-                        shutdown_message = f"chip_process dev={device_id}: parent exited"
-                        break
+                        continue
+                break
         finally:
-            if active_frame is not None:
-                active_message = shutdown_message
-                try:
-                    finalize_frame_native_run(active_frame)
-                except Exception as e:  # noqa: BLE001
-                    active_message += "; " + _format_exc("native finalize", e)
-                fail_frame(active_frame, active_message)
-                staged_frames.pop(active_frame.index, None)
+            try:
+                cw._impl._close_chip_run_lane()
+            except Exception as e:  # noqa: BLE001
+                shutdown_message += "; " + _format_exc("chip run lane close", e)
             for staged in staged_frames.values():
-                staged_message = shutdown_message
-                try:
-                    finalize_frame_native_run(staged)
-                except Exception as e:  # noqa: BLE001
-                    staged_message += "; " + _format_exc("native finalize", e)
-                fail_frame(staged, staged_message)
+                fail_frame(staged, shutdown_message)
             for index, frame_buf in enumerate(frame_bufs):
                 frame_state_addr = frame_addrs[index] + _OFF_STATE
                 if _mailbox_load_i32(frame_state_addr) in (

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -703,6 +703,8 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
     std::memcpy(frame + MAILBOX_OFF_ERROR, &zero_err, sizeof(zero_err));
     std::memset(frame + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
     clear_task_accepted(frame);
+    const int32_t no_disposition = static_cast<int32_t>(MailboxPreparationDisposition::NONE);
+    std::memcpy(frame + MAILBOX_OFF_PREPARATION_DISPOSITION, &no_disposition, sizeof(no_disposition));
     uint64_t reserved_callable = 0;
     std::memcpy(frame + MAILBOX_OFF_CALLABLE, &reserved_callable, sizeof(reserved_callable));
     std::memcpy(frame + MAILBOX_OFF_CONFIG, &state.config, sizeof(CallConfig));
@@ -793,6 +795,7 @@ WorkerCompletion LocalMailboxEndpoint::poisoned_completion(const FrameRecord &re
 
 bool LocalMailboxEndpoint::poll_progress(WorkerEndpointProgress &progress) {
     std::lock_guard<std::mutex> lk(progress_mu_);
+    progress.preparation_disposition = MailboxPreparationDisposition::NONE;
     bool any_occupied = false;
     for (const FrameRecord &record : frames_)
         any_occupied = any_occupied || record.occupied;
@@ -853,9 +856,18 @@ bool LocalMailboxEndpoint::poll_progress(WorkerEndpointProgress &progress) {
                 if (endpoint_poisoned_) break;
             }
             if (!record.staged_reported) {
+                int32_t disposition_value = 0;
+                std::memcpy(&disposition_value, frame + MAILBOX_OFF_PREPARATION_DISPOSITION, sizeof(disposition_value));
+                const auto disposition = static_cast<MailboxPreparationDisposition>(disposition_value);
+                if (disposition != MailboxPreparationDisposition::VALIDATED_ONLY &&
+                    disposition != MailboxPreparationDisposition::NATIVE_PREPARED) {
+                    poison_progress("invalid preparation disposition at endpoint staging");
+                    break;
+                }
                 record.staged_reported = true;
                 progress.kind = WorkerProgressKind::FRAME_STAGED;
                 progress.dispatch = record.dispatch;
+                progress.preparation_disposition = disposition;
                 poll_cursor_ = (index + 1) % task_frame_count_;
                 return true;
             }

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -84,6 +84,12 @@ enum class MailboxState : int32_t {
     PREPARE_READY = 12,
 };
 
+enum class MailboxPreparationDisposition : int32_t {
+    NONE = 0,
+    VALIDATED_ONLY = 1,
+    NATIVE_PREPARED = 2,
+};
+
 bool mailbox_compare_exchange_state(char *frame, MailboxState expected, MailboxState desired) noexcept;
 
 // Sized so the args region can hold any TaskArgs the runtime itself accepts
@@ -95,7 +101,7 @@ static constexpr size_t MAILBOX_TASK_FRAME_COUNT = 2;
 static constexpr size_t MAILBOX_CONTROL_FRAME = 0;
 static constexpr size_t MAILBOX_FIRST_TASK_FRAME = 1;
 static constexpr size_t MAILBOX_SIZE = MAILBOX_FRAME_SIZE * (1 + MAILBOX_TASK_FRAME_COUNT);
-static constexpr uint32_t MAILBOX_TASK_PROTOCOL_VERSION = 2;
+static constexpr uint32_t MAILBOX_TASK_PROTOCOL_VERSION = 3;
 
 // Error message region lives at the mailbox tail. 256 B of headroom is
 // enough for `<ExceptionType>: <short message>` produced by the child-side
@@ -137,6 +143,9 @@ static constexpr ptrdiff_t MAILBOX_OFF_ERROR_MSG =
 // that task frame, so nothing else can overwrite it in between.
 static constexpr int32_t MAILBOX_TASK_ACCEPTED = 1;
 static constexpr ptrdiff_t MAILBOX_OFF_ACCEPTED = MAILBOX_OFF_ERROR_MSG - 8;
+// Preparation disposition occupies the four bytes of trailer padding after
+// the sticky int32 launch ACK. It is independent of the phase state word.
+static constexpr ptrdiff_t MAILBOX_OFF_PREPARATION_DISPOSITION = MAILBOX_OFF_ACCEPTED + 4;
 static constexpr ptrdiff_t MAILBOX_OFF_FRAME_PROTOCOL = MAILBOX_OFF_ACCEPTED - 40;
 static constexpr ptrdiff_t MAILBOX_OFF_FRAME_RUN_ID = MAILBOX_OFF_ACCEPTED - 32;
 static constexpr ptrdiff_t MAILBOX_OFF_FRAME_SLOT_ID = MAILBOX_OFF_ACCEPTED - 24;
@@ -291,6 +300,7 @@ struct WorkerEndpointProgress {
     WorkerProgressKind kind{WorkerProgressKind::FRAME_STAGED};
     WorkerDispatch dispatch{};
     WorkerCompletion completion{};
+    MailboxPreparationDisposition preparation_disposition{MailboxPreparationDisposition::NONE};
 };
 
 enum class WorkerEndpointKind : int32_t {

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -208,6 +208,28 @@ struct ChipRunLaneState {
         }
     }
 
+    // Block on the device for the launched front, for waiters with no deadline
+    // to bound them. Only the front can be LAUNCHED, so its completion is what
+    // lets any waiter in the FIFO advance. Re-polling instead would hold a core
+    // for the whole run — the case codestyle rule 5 sends to a wakeup primitive
+    // rather than a busy loop. Reports whether it actually blocked, so a caller
+    // that cannot be unblocked this way does not spin on it.
+    bool block_on_front() noexcept {
+        if (fifo.empty()) return false;
+        const auto front = fifo.front();
+        if (front->phase != ChipRunState::Phase::LAUNCHED) return false;
+        try {
+            worker->wait_native_run(front->native_run);
+        } catch (...) {
+            const std::exception_ptr wait_error = std::current_exception();
+            if (front->error == nullptr) front->error = wait_error;
+            poison_with(front->error);
+        }
+        finish(front);
+        launch_front();
+        return true;
+    }
+
     ChipWorker *worker;
     mutable std::mutex mu;
     std::deque<std::shared_ptr<ChipRunState>> fifo;
@@ -229,6 +251,7 @@ bool ChipRun::done() {
 
 bool ChipRun::wait_until(Deadline deadline) {
     if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    const bool unbounded = deadline == Deadline::max();
     while (true) {
         {
             std::lock_guard<std::mutex> lk(lane_->mu);
@@ -236,6 +259,10 @@ bool ChipRun::wait_until(Deadline deadline) {
                 ChipRunLaneState::rethrow_run_error(run_);
                 return true;
             }
+            // An unbounded waiter has no deadline to end its loop, so polling
+            // here would spin for the whole run. Block on the device instead;
+            // if nothing is blockable yet the poll loop below still applies.
+            if (unbounded && lane_->block_on_front()) continue;
         }
         if (Clock::now() >= deadline) return false;
     }

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "chip_run_lane.h"
+
+#include "chip_worker.h"
+
+#include <algorithm>
+#include <deque>
+#include <exception>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+struct ChipRunState {
+    enum class Phase : uint8_t { QUEUED, PREPARED, LAUNCHED, TERMINAL };
+
+    int32_t callable_id{0};
+    ChipStorageTaskArgs args{};
+    CallConfig config{};
+    PipelineSlotLease lease{};
+    uint64_t run_id{0};
+    uint64_t dispatch_id{0};
+    volatile int32_t *accepted_state{nullptr};
+    int32_t accepted_value{0};
+    ChipWorkerNativeRun native_run{};
+    Phase phase{Phase::QUEUED};
+    ChipRunPreparationDisposition disposition{ChipRunPreparationDisposition::VALIDATED_ONLY};
+    bool pipeline_leased{true};
+    bool activated{false};
+    bool crossed_launch_fence{false};
+    std::exception_ptr error;
+};
+
+struct ChipRunLaneState {
+    explicit ChipRunLaneState(ChipWorker &worker) :
+        worker(&worker),
+        generations(worker.pipeline_depth(), 0) {}
+
+    void require_usable() const {
+        if (closed) throw std::runtime_error("chip run lane is closed");
+        if (poison != nullptr) {
+            try {
+                std::rethrow_exception(poison);
+            } catch (const std::exception &e) {
+                throw std::runtime_error(std::string("chip run lane is poisoned: ") + e.what());
+            } catch (...) {
+                throw std::runtime_error("chip run lane is poisoned by an unknown native failure");
+            }
+        }
+    }
+
+    static void rethrow_run_error(const std::shared_ptr<ChipRunState> &run) {
+        if (run->error != nullptr) std::rethrow_exception(run->error);
+    }
+
+    bool permits_native_successor(const ChipRunState &predecessor, const ChipRunState &successor) const {
+        return worker->supports_concurrent_native_prepare() && !predecessor.config.diagnostics_any() &&
+               !successor.config.diagnostics_any() && predecessor.phase == ChipRunState::Phase::LAUNCHED;
+    }
+
+    void prepare(const std::shared_ptr<ChipRunState> &run) {
+        run->native_run = worker->prepare_native_run_for_lane(
+            run->callable_id, &run->args, run->config, run->lease, run->run_id, run->dispatch_id, run->accepted_state,
+            run->accepted_value, run->pipeline_leased
+        );
+        run->phase = ChipRunState::Phase::PREPARED;
+        run->disposition = ChipRunPreparationDisposition::NATIVE_PREPARED;
+    }
+
+    void poison_with(std::exception_ptr error) {
+        if (poison == nullptr) poison = error;
+    }
+
+    void finish(const std::shared_ptr<ChipRunState> &run) noexcept {
+        try {
+            worker->finalize_native_run(run->native_run);
+        } catch (...) {
+            if (run->error == nullptr) run->error = std::current_exception();
+            poison_with(std::current_exception());
+        }
+        run->phase = ChipRunState::Phase::TERMINAL;
+        if (!fifo.empty() && fifo.front() == run) fifo.pop_front();
+    }
+
+    void fail_launch(const std::shared_ptr<ChipRunState> &run) noexcept {
+        run->error = std::current_exception();
+        finish(run);
+    }
+
+    void launch_front() noexcept {
+        if (fifo.empty()) return;
+        const auto run = fifo.front();
+        if (poison != nullptr) {
+            if (run->phase == ChipRunState::Phase::PREPARED) {
+                run->error = poison;
+                finish(run);
+            } else if (run->phase == ChipRunState::Phase::QUEUED) {
+                run->error = poison;
+                run->phase = ChipRunState::Phase::TERMINAL;
+                fifo.pop_front();
+            }
+            return;
+        }
+        if (!run->activated || run->phase == ChipRunState::Phase::LAUNCHED ||
+            run->phase == ChipRunState::Phase::TERMINAL) {
+            return;
+        }
+        if (run->phase == ChipRunState::Phase::QUEUED) {
+            try {
+                prepare(run);
+            } catch (...) {
+                run->error = std::current_exception();
+                run->phase = ChipRunState::Phase::TERMINAL;
+                fifo.pop_front();
+                return;
+            }
+        }
+        try {
+            worker->launch_native_run(run->native_run);
+            run->phase = ChipRunState::Phase::LAUNCHED;
+            run->crossed_launch_fence = true;
+        } catch (...) {
+            fail_launch(run);
+        }
+    }
+
+    void prepare_successor_if_eligible(const std::shared_ptr<ChipRunState> &run) {
+        if (fifo.size() != 2 || fifo.back() != run || fifo.front() == run) return;
+        if (run->phase != ChipRunState::Phase::QUEUED) return;
+        if (!permits_native_successor(*fifo.front(), *run)) return;
+        try {
+            prepare(run);
+        } catch (...) {
+            run->error = std::current_exception();
+            run->phase = ChipRunState::Phase::TERMINAL;
+            fifo.pop_back();
+        }
+    }
+
+    bool progress(const std::shared_ptr<ChipRunState> &target) {
+        if (target->phase == ChipRunState::Phase::TERMINAL) return true;
+        if (fifo.empty()) throw std::runtime_error("chip run lane lost a nonterminal run");
+        if (fifo.front() != target) return false;
+
+        launch_front();
+        if (fifo.size() == 2 && fifo.front() == target) prepare_successor_if_eligible(fifo.back());
+        if (target->phase == ChipRunState::Phase::TERMINAL) {
+            launch_front();
+            return true;
+        }
+        if (target->phase != ChipRunState::Phase::LAUNCHED) return false;
+
+        try {
+            if (!worker->poll_native_run(target->native_run)) return false;
+        } catch (...) {
+            const std::exception_ptr poll_error = std::current_exception();
+            finish(target);
+            if (target->error == nullptr) target->error = poll_error;
+            poison_with(target->error);
+            launch_front();
+            return true;
+        }
+        finish(target);
+        launch_front();
+        return true;
+    }
+
+    void drain_front() noexcept {
+        if (fifo.empty()) return;
+        const auto run = fifo.front();
+        if (poison != nullptr && run->phase == ChipRunState::Phase::QUEUED) {
+            run->error = poison;
+            run->phase = ChipRunState::Phase::TERMINAL;
+            fifo.pop_front();
+            return;
+        }
+        if (run->phase == ChipRunState::Phase::QUEUED && !run->activated) {
+            run->phase = ChipRunState::Phase::TERMINAL;
+            fifo.pop_front();
+            return;
+        }
+        launch_front();
+        if (run->phase == ChipRunState::Phase::TERMINAL) return;
+        if (run->phase == ChipRunState::Phase::PREPARED && (!run->activated || poison != nullptr)) {
+            if (poison != nullptr && run->error == nullptr) run->error = poison;
+            finish(run);
+            return;
+        }
+        if (run->phase == ChipRunState::Phase::LAUNCHED) {
+            try {
+                worker->wait_native_run(run->native_run);
+            } catch (...) {
+                run->error = std::current_exception();
+                poison_with(run->error);
+            }
+            finish(run);
+        }
+    }
+
+    ChipWorker *worker;
+    mutable std::mutex mu;
+    std::deque<std::shared_ptr<ChipRunState>> fifo;
+    std::vector<uint64_t> generations;
+    uint64_t direct_generation{0};
+    std::exception_ptr poison;
+    bool closed{false};
+};
+
+ChipRun::ChipRun(std::shared_ptr<ChipRunLaneState> lane, std::shared_ptr<ChipRunState> run) :
+    lane_(std::move(lane)),
+    run_(std::move(run)) {}
+
+bool ChipRun::done() {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    std::lock_guard<std::mutex> lk(lane_->mu);
+    return lane_->progress(run_);
+}
+
+bool ChipRun::wait_until(Deadline deadline) {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    while (true) {
+        {
+            std::lock_guard<std::mutex> lk(lane_->mu);
+            if (lane_->progress(run_)) {
+                ChipRunLaneState::rethrow_run_error(run_);
+                return true;
+            }
+        }
+        if (Clock::now() >= deadline) return false;
+    }
+}
+
+bool ChipRun::wait_until_launched(Deadline deadline) {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    while (true) {
+        {
+            std::lock_guard<std::mutex> lk(lane_->mu);
+            if (run_->crossed_launch_fence) return true;
+            if (run_->phase == ChipRunState::Phase::TERMINAL) {
+                ChipRunLaneState::rethrow_run_error(run_);
+                return false;
+            }
+            (void)lane_->progress(run_);
+        }
+        if (Clock::now() >= deadline) return false;
+    }
+}
+
+void ChipRun::activate() {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    std::lock_guard<std::mutex> lk(lane_->mu);
+    if (run_->phase == ChipRunState::Phase::TERMINAL) {
+        ChipRunLaneState::rethrow_run_error(run_);
+        return;
+    }
+    run_->activated = true;
+    lane_->launch_front();
+    if (lane_->fifo.size() == 2 && lane_->fifo.front() == run_) {
+        lane_->prepare_successor_if_eligible(lane_->fifo.back());
+    }
+}
+
+void ChipRun::abandon() {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    std::lock_guard<std::mutex> lk(lane_->mu);
+    if (run_->phase == ChipRunState::Phase::TERMINAL) return;
+    if (run_->phase == ChipRunState::Phase::LAUNCHED) {
+        throw std::runtime_error("cannot abandon a launched ChipRun");
+    }
+    auto it = std::find(lane_->fifo.begin(), lane_->fifo.end(), run_);
+    if (it == lane_->fifo.end()) throw std::runtime_error("chip run lane lost an unlaunched run");
+    if (run_->phase == ChipRunState::Phase::PREPARED) {
+        try {
+            lane_->worker->finalize_native_run(run_->native_run);
+        } catch (...) {
+            run_->error = std::current_exception();
+            lane_->poison_with(run_->error);
+        }
+    }
+    run_->phase = ChipRunState::Phase::TERMINAL;
+    lane_->fifo.erase(it);
+    if (run_->error != nullptr) std::rethrow_exception(run_->error);
+}
+
+bool ChipRun::launched() const {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    std::lock_guard<std::mutex> lk(lane_->mu);
+    return run_->crossed_launch_fence;
+}
+
+bool ChipRun::lane_poisoned() const {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    std::lock_guard<std::mutex> lk(lane_->mu);
+    return lane_->poison != nullptr;
+}
+
+ChipRunPreparationDisposition ChipRun::preparation_disposition() const {
+    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
+    std::lock_guard<std::mutex> lk(lane_->mu);
+    return run_->disposition;
+}
+
+ChipRunLane::ChipRunLane(ChipWorker &worker) :
+    state_(std::make_shared<ChipRunLaneState>(worker)) {}
+
+ChipRunLane::~ChipRunLane() {
+    try {
+        close();
+    } catch (...) {}
+}
+
+ChipRun ChipRunLane::submit(
+    int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config, const PipelineSlotLease &lease,
+    uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value, bool activated
+) {
+    std::lock_guard<std::mutex> lk(state_->mu);
+    state_->require_usable();
+    if (lease.reserved != 0 || lease.generation == 0 || lease.slot_id >= state_->generations.size()) {
+        throw std::runtime_error("chip run lane received an invalid pipeline lease");
+    }
+    if (lease.generation < state_->generations[lease.slot_id]) {
+        throw std::runtime_error("chip run lane pipeline lease generation is stale");
+    }
+    for (const auto &candidate : state_->fifo) {
+        if ((run_id != 0 && candidate->run_id == run_id) ||
+            (dispatch_id != 0 && candidate->dispatch_id == dispatch_id)) {
+            throw std::runtime_error("chip run lane received a duplicate run or dispatch identity");
+        }
+        if (candidate->lease.slot_id == lease.slot_id) {
+            throw std::runtime_error("chip run lane pipeline slot is already occupied");
+        }
+    }
+    if (state_->fifo.size() >= 2) {
+        throw std::runtime_error("chip run lane capacity exceeded before native preparation");
+    }
+    if (!state_->fifo.empty() && state_->fifo.front()->phase == ChipRunState::Phase::LAUNCHED &&
+        dispatch_id < state_->fifo.front()->dispatch_id) {
+        throw std::runtime_error("chip run lane cannot reorder before an active dispatch");
+    }
+    auto run = std::make_shared<ChipRunState>();
+    run->callable_id = callable_id;
+    run->args = args;
+    run->config = config;
+    run->lease = lease;
+    run->run_id = run_id;
+    run->dispatch_id = dispatch_id;
+    run->accepted_state = accepted_state;
+    run->accepted_value = accepted_value;
+    run->pipeline_leased = true;
+    run->activated = activated;
+    state_->generations[lease.slot_id] = lease.generation;
+    auto position = std::upper_bound(
+        state_->fifo.begin(), state_->fifo.end(), dispatch_id,
+        [](uint64_t id, const std::shared_ptr<ChipRunState> &candidate) {
+            return id < candidate->dispatch_id;
+        }
+    );
+    state_->fifo.insert(position, run);
+
+    try {
+        if (state_->fifo.front() == run) {
+            state_->launch_front();
+            if (state_->fifo.size() == 2) state_->prepare_successor_if_eligible(state_->fifo.back());
+        } else {
+            state_->prepare_successor_if_eligible(run);
+        }
+    } catch (...) {
+        run->error = std::current_exception();
+        run->phase = ChipRunState::Phase::TERMINAL;
+        auto it = std::find(state_->fifo.begin(), state_->fifo.end(), run);
+        if (it != state_->fifo.end()) state_->fifo.erase(it);
+    }
+    return ChipRun(state_, std::move(run));
+}
+
+ChipRun ChipRunLane::submit(
+    int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config, volatile int32_t *accepted_state,
+    int32_t accepted_value
+) {
+    std::lock_guard<std::mutex> lk(state_->mu);
+    state_->require_usable();
+    if (!state_->fifo.empty()) state_->drain_front();
+    state_->require_usable();
+    if (state_->generations.empty()) throw std::runtime_error("chip run lane has no runtime slots");
+    if (state_->direct_generation == std::numeric_limits<uint64_t>::max()) {
+        throw std::overflow_error("chip run lane exhausted its direct generation space");
+    }
+    ++state_->direct_generation;
+
+    auto run = std::make_shared<ChipRunState>();
+    run->callable_id = callable_id;
+    run->args = args;
+    run->config = config;
+    run->lease = PipelineSlotLease{0, 0, state_->direct_generation};
+    run->accepted_state = accepted_state;
+    run->accepted_value = accepted_value;
+    run->pipeline_leased = false;
+    run->activated = true;
+    state_->fifo.push_back(run);
+    state_->launch_front();
+    return ChipRun(state_, std::move(run));
+}
+
+void ChipRunLane::drain() {
+    std::lock_guard<std::mutex> lk(state_->mu);
+    while (!state_->fifo.empty())
+        state_->drain_front();
+    if (state_->poison != nullptr) std::rethrow_exception(state_->poison);
+}
+
+void ChipRunLane::close() {
+    std::lock_guard<std::mutex> lk(state_->mu);
+    if (state_->closed) {
+        if (state_->poison != nullptr) std::rethrow_exception(state_->poison);
+        return;
+    }
+    while (!state_->fifo.empty())
+        state_->drain_front();
+    state_->closed = true;
+    if (state_->poison != nullptr) std::rethrow_exception(state_->poison);
+}
+
+bool ChipRunLane::poisoned() const {
+    std::lock_guard<std::mutex> lk(state_->mu);
+    return state_->poison != nullptr;
+}

--- a/src/common/worker/chip_run_lane.h
+++ b/src/common/worker/chip_run_lane.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
+#include "../task_interface/call_config.h"
+#include "../task_interface/task_args.h"
+#include "pipeline_slot_pool.h"
+
+class ChipWorker;
+struct ChipRunLaneState;
+struct ChipRunState;
+
+enum class ChipRunPreparationDisposition : int32_t {
+    VALIDATED_ONLY = 1,
+    NATIVE_PREPARED = 2,
+};
+
+class ChipRun {
+public:
+    using Clock = std::chrono::steady_clock;
+    using Deadline = Clock::time_point;
+
+    ChipRun() = default;
+
+    bool done();
+    bool wait_until(Deadline deadline);
+    bool wait_until_launched(Deadline deadline);
+    void activate();
+    void abandon();
+
+    bool launched() const;
+    bool lane_poisoned() const;
+    ChipRunPreparationDisposition preparation_disposition() const;
+
+private:
+    friend class ChipRunLane;
+    ChipRun(std::shared_ptr<ChipRunLaneState> lane, std::shared_ptr<ChipRunState> run);
+
+    std::shared_ptr<ChipRunLaneState> lane_;
+    std::shared_ptr<ChipRunState> run_;
+};
+
+class ChipRunLane {
+public:
+    using Clock = ChipRun::Clock;
+    using Deadline = ChipRun::Deadline;
+
+    explicit ChipRunLane(ChipWorker &worker);
+    ~ChipRunLane();
+
+    ChipRunLane(const ChipRunLane &) = delete;
+    ChipRunLane &operator=(const ChipRunLane &) = delete;
+
+    ChipRun submit(
+        int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config, const PipelineSlotLease &lease,
+        uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0,
+        bool activated = true
+    );
+    ChipRun submit(
+        int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config,
+        volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0
+    );
+
+    void drain();
+    void close();
+    bool poisoned() const;
+
+private:
+    std::shared_ptr<ChipRunLaneState> state_;
+};

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -11,6 +11,7 @@
 
 #include "chip_worker.h"
 
+#include "chip_run_lane.h"
 #include "pipeline_contract.h"
 
 #include <dlfcn.h>
@@ -391,9 +392,19 @@ void ChipWorker::init(
             );
         }
     }
+    run_lane_ = std::make_unique<ChipRunLane>(*this);
 }
 
 void ChipWorker::finalize() {
+    if (run_lane_ != nullptr) {
+        try {
+            run_lane_->close();
+        } catch (...) {
+            // Final device teardown below is the last-resort reclamation path;
+            // destructors must not terminate while reporting a prior run error.
+        }
+        run_lane_.reset();
+    }
     cleanup_native_runs_noexcept();
     // Defensive: if the user never called comm_destroy, reclaim all owned
     // communicator handles and streams before tearing down the device context.
@@ -476,7 +487,10 @@ void ChipWorker::run(
     int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, volatile int32_t *accepted_state,
     int32_t accepted_value
 ) {
-    run_on_slot(callable_id, args, config, UNLEASED_SLOT, accepted_state, accepted_value);
+    if (args == nullptr) throw std::runtime_error("run requires task args");
+    if (run_lane_ == nullptr) throw std::runtime_error("ChipWorker run lane is not initialized");
+    ChipRun run = run_lane_->submit(callable_id, *args, config, accepted_state, accepted_value);
+    (void)run.wait_until(ChipRun::Deadline::max());
 }
 
 uint32_t ChipWorker::arena_bank_for_slot(uint32_t slot_id) const {
@@ -519,31 +533,12 @@ void ChipWorker::run_with_lease(
     if (lease.reserved != 0 || lease.generation == 0 || lease.slot_id >= pipeline_contract_.pipeline_depth) {
         throw std::runtime_error("run pipeline lease is outside the runtime PipelineContract");
     }
-    if (!pipeline_generations_.admit(lease)) {
-        throw std::runtime_error("run pipeline lease generation is stale");
-    }
-    run_on_slot(callable_id, args, config, lease.slot_id, accepted_state, accepted_value);
-}
-
-void ChipWorker::run_on_slot(
-    int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
-    volatile int32_t *accepted_state, int32_t accepted_value
-) {
-    config.validate();
-    if (!initialized_) {
-        throw std::runtime_error("ChipWorker not initialized; call init() first");
-    }
-
-    const NativeRunDescriptor descriptor{slot_id,       arena_bank_for_slot(slot_id), 0, 0, 0, 0, accepted_state,
-                                         accepted_value};
-    void *rt = runtime_bufs_[slot_id].data();
-    // Per-stage timing is emitted by the platform as `[STRACE]` log markers, not
-    // returned (see chip_worker.h::run). CallConfig is threaded through to the C
-    // ABI as a single pointer rather than unpacked into per-field args.
-    int rc = run_fn_(device_ctx_, rt, callable_id, args, &config, &descriptor);
-    if (rc != 0) {
-        throw std::runtime_error("run failed with code " + std::to_string(rc));
-    }
+    if (args == nullptr) throw std::runtime_error("run_with_lease requires task args");
+    if (run_lane_ == nullptr) throw std::runtime_error("ChipWorker run lane is not initialized");
+    ChipRun run = run_lane_->submit(
+        callable_id, *args, config, lease, /*run_id=*/0, /*dispatch_id=*/0, accepted_state, accepted_value, true
+    );
+    (void)run.wait_until(ChipRun::Deadline::max());
 }
 
 ChipWorkerNativeRun ChipWorker::prepare_native_run(
@@ -554,7 +549,19 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run(
         throw std::runtime_error("native-run pipeline lease is outside the runtime PipelineContract");
     }
     return prepare_native_run_on_slot(
-        callable_id, args, config, lease.slot_id, lease.generation, run_id, dispatch_id, accepted_state, accepted_value
+        callable_id, args, config, lease.slot_id, lease.generation, run_id, dispatch_id, accepted_state, accepted_value,
+        true
+    );
+}
+
+ChipWorkerNativeRun ChipWorker::prepare_native_run_for_lane(
+    int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, const PipelineSlotLease &lease,
+    uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value,
+    bool pipeline_leased
+) {
+    return prepare_native_run_on_slot(
+        callable_id, args, config, lease.slot_id, lease.generation, run_id, dispatch_id, accepted_state, accepted_value,
+        pipeline_leased
     );
 }
 
@@ -565,7 +572,8 @@ bool ChipWorker::supports_concurrent_native_prepare() const {
 
 ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
-    uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value
+    uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state,
+    int32_t accepted_value, bool admit_pipeline_generation
 ) {
     config.validate();
     if (!initialized_) {
@@ -601,14 +609,12 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
                 );
             }
         }
-        // The loop above already rejected every predecessor that may not carry a
-        // successor, so more than one survivor means a successor is staged.
         if (occupied > 1) {
             throw std::runtime_error(
                 "prepare_native_run already owns a prepared successor " + format_native_run_identity(run_identity)
             );
         }
-        if (!pipeline_generations_.admit(PipelineSlotLease{slot_id, 0, generation})) {
+        if (admit_pipeline_generation && !pipeline_generations_.admit(PipelineSlotLease{slot_id, 0, generation})) {
             throw std::runtime_error(
                 "native-run pipeline lease generation is stale " + format_native_run_identity(run_identity)
             );
@@ -657,6 +663,20 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
         state.phase = NativeRunPhase::PREPARED;
     }
     return run_identity;
+}
+
+ChipRun ChipWorker::submit_chip_run(
+    int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config, const PipelineSlotLease &lease,
+    uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value, bool activated
+) {
+    if (run_lane_ == nullptr) throw std::runtime_error("ChipWorker run lane is not initialized");
+    return run_lane_->submit(
+        callable_id, args, config, lease, run_id, dispatch_id, accepted_state, accepted_value, activated
+    );
+}
+
+void ChipWorker::close_chip_run_lane() {
+    if (run_lane_ != nullptr) run_lane_->close();
 }
 
 void ChipWorker::launch_native_run(const ChipWorkerNativeRun &run) {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -37,6 +38,10 @@ struct ChipWorkerNativeRun {
     uint64_t run_id{0};
     uint64_t dispatch_id{0};
 };
+
+class ChipRun;
+class ChipRunLane;
+struct ChipRunLaneState;
 
 class ChipWorker {
 public:
@@ -121,6 +126,13 @@ public:
     bool poll_native_run(const ChipWorkerNativeRun &run);
     void wait_native_run(const ChipWorkerNativeRun &run);
     void finalize_native_run(const ChipWorkerNativeRun &run);
+
+    ChipRun submit_chip_run(
+        int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config, const PipelineSlotLease &lease,
+        uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0,
+        bool activated = true
+    );
+    void close_chip_run_lane();
 
     // Per-callable_id preparation. Requires init() first and a callable_id
     // in [0, MAX_REGISTERED_CALLABLE_IDS) (cap 64).
@@ -315,14 +327,6 @@ private:
     std::unordered_map<uint64_t, size_t> comm_session_index_;
     uint64_t base_comm_handle_ = 0;
 
-    // Slot 0 with no generation bookkeeping: an unleased run is a caller that
-    // is not using the pipeline, and minting a generation for it here would
-    // advance the filter past the leases a real pool later presents.
-    static constexpr uint32_t UNLEASED_SLOT = 0;
-    void run_on_slot(
-        int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
-        volatile int32_t *accepted_state, int32_t accepted_value
-    );
     uint32_t arena_bank_for_slot(uint32_t slot_id) const;
 
     enum class NativeRunPhase : uint8_t { EMPTY, PREPARING, PREPARED, LAUNCHED, REAPED, FINALIZING };
@@ -336,9 +340,16 @@ private:
     ChipWorkerNativeRun prepare_native_run_on_slot(
         int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
         uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state,
-        int32_t accepted_value
+        int32_t accepted_value, bool admit_pipeline_generation
+    );
+    ChipWorkerNativeRun prepare_native_run_for_lane(
+        int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, const PipelineSlotLease &lease,
+        uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value,
+        bool pipeline_leased
     );
     void cleanup_native_runs_noexcept() noexcept;
+
+    friend struct ChipRunLaneState;
 
     class RuntimeStorage {
     public:
@@ -365,6 +376,7 @@ private:
     mutable std::mutex native_run_mu_;
     PipelineSlotGenerationFilter pipeline_generations_;
     PipelineContract pipeline_contract_{PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};
+    std::unique_ptr<ChipRunLane> run_lane_;
     // device_id_ is set once in init() and never modified afterward. All
     // ChipWorker callers run on the thread that called init() (the same
     // thread is the only one that subsequently calls malloc / copy_to /

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -212,6 +212,7 @@ add_library(hierarchical_objs OBJECT
     ${HIERARCHICAL_SRC_DIR}/worker_manager.cpp
     ${HIERARCHICAL_SRC_DIR}/scheduler.cpp
     ${HIERARCHICAL_SRC_DIR}/worker.cpp
+    ${WORKER_SRC_DIR}/chip_run_lane.cpp
     ${WORKER_SRC_DIR}/chip_worker.cpp
     # Host-side assert_impl / get_stacktrace for the unified Tensor's
     # always_assert (init_external, reached via make_tensor_external in
@@ -391,6 +392,7 @@ add_hierarchical_test(test_ring  hierarchical/test_ring.cpp)
 add_hierarchical_test(test_scope      hierarchical/test_scope.cpp)
 add_hierarchical_test(test_orchestrator hierarchical/test_orchestrator.cpp)
 add_hierarchical_test(test_scheduler  hierarchical/test_scheduler.cpp)
+add_hierarchical_test(test_chip_run_lane hierarchical/test_chip_run_lane.cpp)
 add_hierarchical_test(test_remote_wire hierarchical/test_remote_wire.cpp)
 add_hierarchical_test(test_remote_endpoint hierarchical/test_remote_endpoint.cpp)
 add_hierarchical_test(test_pipeline_contract hierarchical/test_pipeline_contract.cpp)

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "call_config.h"
+#include "pipeline_slot_pool.h"
+#include "pto_runtime_c_api.h"
+#include "task_args.h"
+#include "types.h"
+
+#define private public
+#include "chip_worker.h"
+#undef private
+#include "chip_run_lane.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+std::unordered_map<void *, uint32_t> g_slots;
+std::array<bool, 2> g_complete{};
+std::array<int, 2> g_prepare_rc{};
+std::array<int, 2> g_launch_rc{};
+std::array<int, 2> g_poll_rc{};
+std::array<int, 2> g_wait_rc{};
+std::array<int, 2> g_finalize_rc{};
+size_t g_poll_count{0};
+std::vector<std::string> g_events;
+
+uint32_t slot_of(void *runtime) { return g_slots.at(runtime); }
+
+int prepare_run(
+    void *, void *runtime, int32_t, const void *, const CallConfig *, const NativeRunDescriptor *descriptor
+) {
+    EXPECT_EQ(slot_of(runtime), descriptor->pipeline_slot);
+    g_complete[descriptor->pipeline_slot] = false;
+    g_events.push_back("prepare" + std::to_string(descriptor->pipeline_slot));
+    return g_prepare_rc[descriptor->pipeline_slot];
+}
+
+int launch_run(void *, void *runtime) {
+    const uint32_t slot = slot_of(runtime);
+    g_events.push_back("launch" + std::to_string(slot));
+    return g_launch_rc[slot];
+}
+
+int poll_run(void *, void *runtime) {
+    ++g_poll_count;
+    const uint32_t slot = slot_of(runtime);
+    if (g_poll_rc[slot] != 0) return g_poll_rc[slot];
+    return g_complete[slot] ? SIMPLER_NATIVE_RUN_POLL_COMPLETE : SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+}
+
+int wait_run(void *, void *runtime) {
+    const uint32_t slot = slot_of(runtime);
+    g_events.push_back("wait" + std::to_string(slot));
+    g_complete[slot] = true;
+    return g_wait_rc[slot];
+}
+
+int finalize_run(void *, void *runtime) {
+    const uint32_t slot = slot_of(runtime);
+    g_events.push_back("finalize" + std::to_string(slot));
+    return g_finalize_rc[slot];
+}
+
+int supports_successor(void *) { return 1; }
+
+void prime_worker(ChipWorker &worker) {
+    g_slots.clear();
+    g_complete = {};
+    g_prepare_rc = {};
+    g_launch_rc = {};
+    g_poll_rc = {};
+    g_wait_rc = {};
+    g_finalize_rc = {};
+    g_poll_count = 0;
+    g_events.clear();
+    worker.initialized_ = true;
+    worker.pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 2, {}};
+    worker.runtime_bufs_.emplace_back(64, alignof(std::max_align_t));
+    worker.runtime_bufs_.emplace_back(64, alignof(std::max_align_t));
+    for (uint32_t slot = 0; slot < worker.runtime_bufs_.size(); ++slot) {
+        g_slots.emplace(worker.runtime_bufs_[slot].data(), slot);
+    }
+    worker.prepare_run_fn_ = prepare_run;
+    worker.launch_run_fn_ = launch_run;
+    worker.poll_run_fn_ = poll_run;
+    worker.wait_run_fn_ = wait_run;
+    worker.finalize_run_fn_ = finalize_run;
+    worker.supports_concurrent_native_prepare_fn_ = supports_successor;
+}
+
+ChipRun submit(ChipRunLane &lane, uint64_t run_id, uint32_t slot, bool activate = true) {
+    ChipStorageTaskArgs args{};
+    return lane.submit(1, args, CallConfig{}, PipelineSlotLease{slot, 0, run_id}, run_id, run_id, nullptr, 0, activate);
+}
+
+}  // namespace
+
+TEST(ChipRunLaneTest, OwnsFifoPreparationAndLaunch) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+
+    ChipRun first = submit(lane, 101, 0);
+    ChipRun second = submit(lane, 102, 1, false);
+    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::NATIVE_PREPARED);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1"}));
+
+    second.activate();
+    EXPECT_FALSE(second.done());
+    g_complete[0] = true;
+    EXPECT_TRUE(first.done());
+    EXPECT_FALSE(second.done());
+    EXPECT_TRUE(second.launched());
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1", "finalize0", "launch1"}));
+
+    g_complete[1] = true;
+    EXPECT_TRUE(second.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, ValidationOnlySuccessorPreparesAfterPromotion) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipStorageTaskArgs args{};
+    CallConfig diagnostic;
+    diagnostic.enable_pmu = true;
+    diagnostic.output_prefix[0] = 'x';
+
+    ChipRun first = submit(lane, 101, 0);
+    ChipRun second = lane.submit(1, args, diagnostic, PipelineSlotLease{1, 0, 102}, 102, 102, nullptr, 0, false);
+    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::VALIDATED_ONLY);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0"}));
+
+    second.activate();
+    g_complete[0] = true;
+    EXPECT_TRUE(first.done());
+    EXPECT_FALSE(second.done());
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "finalize0", "prepare1", "launch1"}));
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, EarlierActiveDispatchOrdersBeforeAnAlreadyStagedSuccessor) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+
+    ChipRun successor = submit(lane, 102, 1, false);
+    EXPECT_EQ(successor.preparation_disposition(), ChipRunPreparationDisposition::VALIDATED_ONLY);
+    ChipRun active = submit(lane, 101, 0, true);
+    EXPECT_TRUE(active.launched());
+    EXPECT_EQ(successor.preparation_disposition(), ChipRunPreparationDisposition::NATIVE_PREPARED);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1"}));
+
+    successor.activate();
+    g_complete[0] = true;
+    EXPECT_TRUE(active.done());
+    EXPECT_TRUE(successor.launched());
+    g_complete[1] = true;
+    EXPECT_TRUE(successor.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, AcceptsCurrentLeaseGenerationAndRejectsOlderOne) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun first = submit(lane, 101, 0);
+    g_complete[0] = true;
+    ASSERT_TRUE(first.done());
+
+    ChipStorageTaskArgs args{};
+    ChipRun repeated = lane.submit(1, args, CallConfig{}, PipelineSlotLease{0, 0, 101}, 102, 102, nullptr, 0, true);
+    g_complete[0] = true;
+    ASSERT_TRUE(repeated.done());
+    EXPECT_THROW(
+        lane.submit(1, args, CallConfig{}, PipelineSlotLease{0, 0, 100}, 103, 103, nullptr, 0, true), std::runtime_error
+    );
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, ActivateStopsAtTheLaunchFenceBeforePolling) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun run = submit(lane, 101, 0, false);
+
+    run.activate();
+    EXPECT_TRUE(run.launched());
+    EXPECT_EQ(g_poll_count, 0);
+    g_complete[0] = true;
+    EXPECT_TRUE(run.done());
+    EXPECT_EQ(g_poll_count, 1);
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, DirectGenerationDoesNotConsumeTheFirstPipelineLease) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipStorageTaskArgs args{};
+
+    ChipRun direct = lane.submit(1, args, CallConfig{});
+    g_complete[0] = true;
+    ASSERT_TRUE(direct.done());
+
+    ChipRun leased = submit(lane, 1, 0);
+    EXPECT_TRUE(leased.launched());
+    g_complete[0] = true;
+    EXPECT_TRUE(leased.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, PrepareFailureIsTerminalWithoutPoisoningTheLane) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    g_prepare_rc[0] = -5;
+
+    ChipRun failed = submit(lane, 101, 0);
+    EXPECT_TRUE(failed.done());
+    EXPECT_THROW(failed.wait_until(ChipRunLane::Deadline::max()), std::runtime_error);
+    EXPECT_FALSE(lane.poisoned());
+
+    ChipRun successor = submit(lane, 102, 1);
+    EXPECT_TRUE(successor.launched());
+    g_complete[1] = true;
+    EXPECT_TRUE(successor.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, ReclaimedLaunchFailureDoesNotPoisonTheLane) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    g_launch_rc[0] = -6;
+
+    ChipRun failed = submit(lane, 101, 0);
+    EXPECT_TRUE(failed.done());
+    EXPECT_THROW(failed.wait_until(ChipRunLane::Deadline::max()), std::runtime_error);
+    EXPECT_FALSE(lane.poisoned());
+
+    ChipRun successor = submit(lane, 102, 1);
+    EXPECT_TRUE(successor.launched());
+    g_complete[1] = true;
+    EXPECT_TRUE(successor.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, ExpiredWaitLeavesTheRunLive) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun run = submit(lane, 101, 0);
+
+    EXPECT_FALSE(run.wait_until(ChipRunLane::Clock::now()));
+    EXPECT_FALSE(run.done());
+    g_complete[0] = true;
+    EXPECT_TRUE(run.wait_until(ChipRunLane::Deadline::max()));
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, FinalizeFailurePoisonsAdmissionAndCloseReportsIt) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun first = submit(lane, 101, 0);
+    g_complete[0] = true;
+    g_finalize_rc[0] = -7;
+    EXPECT_TRUE(first.done());
+    EXPECT_THROW(first.wait_until(ChipRunLane::Clock::time_point::max()), std::runtime_error);
+    EXPECT_TRUE(lane.poisoned());
+
+    ChipStorageTaskArgs args{};
+    EXPECT_THROW(
+        lane.submit(1, args, CallConfig{}, PipelineSlotLease{1, 0, 102}, 102, 102, nullptr, 0, true), std::runtime_error
+    );
+    EXPECT_THROW(lane.close(), std::runtime_error);
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, PollFailureReportsTheTerminalNativeError) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun run = submit(lane, 101, 0);
+    g_poll_rc[0] = SIMPLER_NATIVE_RUN_POLL_ERROR;
+    g_wait_rc[0] = 507015;
+
+    EXPECT_TRUE(run.done());
+    EXPECT_THROW(run.wait_until(ChipRunLane::Deadline::max()), std::runtime_error);
+    try {
+        run.wait_until(ChipRunLane::Deadline::max());
+        FAIL() << "expected the terminal native error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_NE(std::string(e.what()).find("finalize_native_run failed with code 507015"), std::string::npos);
+    }
+    EXPECT_TRUE(lane.poisoned());
+    EXPECT_THROW(lane.close(), std::runtime_error);
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, CloseDrainsAndRejectsNewSubmissions) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun first = submit(lane, 101, 0);
+    lane.close();
+    EXPECT_TRUE(first.done());
+
+    ChipStorageTaskArgs args{};
+    EXPECT_THROW(
+        lane.submit(1, args, CallConfig{}, PipelineSlotLease{1, 0, 102}, 102, 102, nullptr, 0, true), std::runtime_error
+    );
+    worker.finalize();
+}

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -1225,10 +1225,13 @@ TEST(WorkerManagerTest, TwoFrameLeaseSlotsDoNotDefineFifoOrAcceptance) {
     WorkerEndpointProgress progress;
     EXPECT_FALSE(endpoint.poll_progress(progress));
 
+    const int32_t native_prepared = static_cast<int32_t>(MailboxPreparationDisposition::NATIVE_PREPARED);
+    std::memcpy(lower_frame + MAILBOX_OFF_PREPARATION_DISPOSITION, &native_prepared, sizeof(native_prepared));
     set_test_frame_state(lower_frame, MailboxState::FRAME_STAGED);
     ASSERT_TRUE(endpoint.poll_progress(progress));
     EXPECT_EQ(progress.kind, WorkerProgressKind::FRAME_STAGED);
     EXPECT_EQ(progress.dispatch.dispatch_id, 42u);
+    EXPECT_EQ(progress.preparation_disposition, MailboxPreparationDisposition::NATIVE_PREPARED);
     EXPECT_EQ(test_frame_state(lower_frame), MailboxState::ACTIVATE);
 
     set_test_frame_state(lower_frame, MailboxState::TASK_LAUNCHED);

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -255,6 +255,48 @@ def test_start_hierarchical_passes_each_chip_its_negotiated_frame_count(monkeypa
     assert fake_parent.initialized
 
 
+class _FakeChipRun:
+    def __init__(self, lane, submission) -> None:
+        self._lane = lane
+        self.submission = submission
+        self.token = None
+        self.activated = False
+        self._launched = False
+        self.terminal = False
+        self.error: Optional[BaseException] = None
+        self._disposition = worker_mod._VALIDATED_ONLY
+
+    @property
+    def launched(self) -> bool:
+        return self._launched
+
+    @property
+    def lane_poisoned(self) -> bool:
+        return self._lane._lane_poisoned
+
+    @property
+    def preparation_disposition(self):
+        return SimpleNamespace(value=self._disposition)
+
+    def activate(self) -> None:
+        self.activated = True
+        self._lane._launch_front()
+        self._lane._prepare_successor()
+
+    def abandon(self) -> None:
+        if self._launched:
+            raise RuntimeError("cannot abandon a launched fake ChipRun")
+        self._lane._finish(self)
+
+    def done(self) -> bool:
+        return self._lane._progress(self)
+
+    def _raise_if_failed(self) -> None:
+        assert self.terminal
+        if self.error is not None:
+            raise self.error
+
+
 class _FakeNativeRunImpl:
     def __init__(self, *, supports_concurrent_native_prepare: bool = False) -> None:
         self.supports_concurrent_native_prepare = supports_concurrent_native_prepare
@@ -268,10 +310,13 @@ class _FakeNativeRunImpl:
         self.poll_errors: dict[tuple[int, int], BaseException] = {}
         self.finalize_errors: dict[tuple[int, int], BaseException] = {}
         self.prepare_identities: list[tuple[int, int, int, int]] = []
+        self.poll_states: list[tuple[int, int]] = []
         self.register_calls: list[tuple[int, int]] = []
         self.register_called = threading.Event()
         self._finalized_runs: set[tuple[int, int]] = set()
         self._polled_slots: set[int] = set()
+        self._runs: list[_FakeChipRun] = []
+        self._lane_poisoned = False
 
     def register_callable_from_blob(self, cid: int, blob_addr: int) -> None:
         self.register_calls.append((int(cid), int(blob_addr)))
@@ -327,6 +372,8 @@ class _FakeNativeRunImpl:
 
     def _poll_native_run(self, token) -> bool:
         slot = int(token.slot_id)
+        state_addr = int(token.accepted_addr) - worker_mod._OFF_ACCEPTED
+        self.poll_states.append((slot, _mailbox_load_i32(state_addr)))
         error = self.poll_errors.get((slot, int(token.generation)))
         if error is not None:
             raise error
@@ -345,6 +392,149 @@ class _FakeNativeRunImpl:
         error = self.finalize_errors.get(run_key)
         if error is not None:
             raise error
+
+    @staticmethod
+    def _has_diagnostics(config) -> bool:
+        return bool(
+            config.enable_chip_swimlane
+            or config.enable_dump_args
+            or config.enable_pmu
+            or config.enable_dep_gen
+            or config.enable_scope_stats
+        )
+
+    def _prepare(self, run: _FakeChipRun) -> None:
+        s = run.submission
+        run.token = self._prepare_native_run_materialized(
+            s.cid,
+            s.args,
+            s.config,
+            s.slot_id,
+            s.generation,
+            s.run_id,
+            s.dispatch_id,
+            s.accepted_addr,
+            s.accepted_value,
+        )
+        run._disposition = worker_mod._NATIVE_PREPARED
+
+    def _finish(self, run: _FakeChipRun) -> None:
+        try:
+            if run.token is not None:
+                self._finalize_native_run(run.token)
+        except BaseException as error:  # noqa: BLE001
+            run.error = run.error or error
+            self._lane_poisoned = True
+        run.terminal = True
+        if run in self._runs:
+            self._runs.remove(run)
+
+    def _launch_front(self) -> None:
+        if not self._runs:
+            return
+        run = self._runs[0]
+        if self._lane_poisoned:
+            run.error = run.error or RuntimeError("fake chip run lane is poisoned")
+            self._finish(run)
+            return
+        if not run.activated or run._launched or run.terminal:
+            return
+        if run.token is None:
+            try:
+                self._prepare(run)
+            except BaseException as error:  # noqa: BLE001
+                run.error = error
+                run.terminal = True
+                self._runs.remove(run)
+                return
+        try:
+            self._launch_native_run(run.token)
+            run._launched = True
+        except BaseException as error:  # noqa: BLE001
+            run.error = error
+            self._finish(run)
+
+    def _prepare_successor(self) -> None:
+        if len(self._runs) != 2:
+            return
+        predecessor, successor = self._runs
+        if (
+            predecessor._launched
+            and successor.token is None
+            and self.supports_concurrent_native_prepare
+            and not self._has_diagnostics(predecessor.submission.config)
+            and not self._has_diagnostics(successor.submission.config)
+        ):
+            try:
+                self._prepare(successor)
+            except BaseException as error:  # noqa: BLE001
+                successor.error = error
+                successor.terminal = True
+                self._runs.remove(successor)
+
+    def _progress(self, target: _FakeChipRun) -> bool:
+        if target.terminal:
+            return True
+        if not self._runs or self._runs[0] is not target:
+            return False
+        self._launch_front()
+        self._prepare_successor()
+        if target.terminal:
+            self._launch_front()
+            return True
+        if not target._launched:
+            return False
+        try:
+            if not self._poll_native_run(target.token):
+                return False
+        except BaseException as error:  # noqa: BLE001
+            target.error = error
+            self._lane_poisoned = True
+        self._finish(target)
+        self._launch_front()
+        self._prepare_successor()
+        return True
+
+    def _submit_chip_run_materialized(  # noqa: PLR0913 -- mirrors the production binding
+        self,
+        cid,
+        args,
+        config,
+        slot_id,
+        generation,
+        run_id,
+        dispatch_id,
+        accepted_addr,
+        accepted_value,
+        activated,
+    ):
+        submission = SimpleNamespace(
+            cid=cid,
+            args=args,
+            config=config,
+            slot_id=int(slot_id),
+            generation=int(generation),
+            run_id=int(run_id),
+            dispatch_id=int(dispatch_id),
+            accepted_addr=int(accepted_addr),
+            accepted_value=int(accepted_value),
+        )
+        run = _FakeChipRun(self, submission)
+        run.activated = bool(activated)
+        self._runs.append(run)
+        self._runs.sort(key=lambda candidate: candidate.submission.dispatch_id)
+        self._launch_front()
+        self._prepare_successor()
+        return run
+
+    def _close_chip_run_lane(self) -> None:
+        while self._runs:
+            run = self._runs[0]
+            if run._launched:
+                self.completed[run.submission.slot_id].set()
+            self._finish(run)
+        if self._lane_poisoned:
+            raise RuntimeError("fake chip run lane is poisoned")
 
 
 class _FakeTwoFrameChipWorker:
@@ -422,6 +612,11 @@ class _TwoFrameLoopHarness:
 
     def accepted_addr(self, index: int) -> int:
         return self.mailbox_addr + self._frame_offset(index) + worker_mod._OFF_ACCEPTED
+
+    def preparation_disposition(self, index: int) -> int:
+        return _mailbox_load_i32(
+            self.mailbox_addr + self._frame_offset(index) + worker_mod._OFF_PREPARATION_DISPOSITION
+        )
 
     def publish(
         self,
@@ -512,6 +707,7 @@ def test_two_frame_stages_b_without_native_prepare_until_a_finalizes():
 
         harness.publish(1, 2)
         harness.wait_state(1, worker_mod._FRAME_STAGED)
+        assert harness.preparation_disposition(1) == worker_mod._VALIDATED_ONLY
         assert not harness.cw._impl.prepared[1].is_set()
         assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
 
@@ -540,6 +736,19 @@ def test_two_frame_stages_b_without_native_prepare_until_a_finalizes():
         harness.close()
 
 
+def test_two_frame_publishes_launch_before_polling_immediate_completion():
+    harness = _TwoFrameLoopHarness()
+    try:
+        harness.cw._impl.completed[0].set()
+        harness.publish(0, 1)
+        harness.start()
+        harness.wait_state(0, worker_mod._TASK_DONE)
+
+        assert harness.cw._impl.poll_states[0] == (0, worker_mod._TASK_LAUNCHED)
+    finally:
+        harness.close()
+
+
 def test_two_frame_hbg_prepares_b_while_a_runs_but_accepts_only_after_launch():
     harness = _TwoFrameLoopHarness(
         supports_concurrent_native_prepare=True,
@@ -552,6 +761,7 @@ def test_two_frame_hbg_prepares_b_while_a_runs_but_accepts_only_after_launch():
 
         harness.publish(1, 2, state=worker_mod._PREPARE_READY)
         harness.wait_state(1, worker_mod._FRAME_STAGED)
+        assert harness.preparation_disposition(1) == worker_mod._NATIVE_PREPARED
         assert harness.cw._impl.prepared[1].is_set()
         assert not harness.cw._impl.finalized[0].is_set()
         assert not harness.cw._impl.launched[1].is_set()
@@ -751,6 +961,7 @@ def test_two_frame_prepare_ready_waits_for_sticky_activation():
         harness.publish(0, 1, state=worker_mod._PREPARE_READY)
         harness.start()
         harness.wait_state(0, worker_mod._FRAME_STAGED)
+        assert harness.preparation_disposition(0) == worker_mod._VALIDATED_ONLY
         assert not harness.cw._impl.prepared[0].is_set()
 
         _mailbox_store_i32(harness.state_addr(0), worker_mod._ACTIVATE)


### PR DESCRIPTION
## Summary
- add `ChipRunLane` / `ChipRun` as the C++ owner of native FIFO admission, generation, prepare/launch/poll/finalize, terminal state, poison, drain, and close
- route both the direct adapter and local endpoint child loop through that lane while keeping public direct `Worker.submit()` blocking
- split mailbox phase from preparation disposition (`VALIDATED_ONLY` / `NATIVE_PREPARED`) and bump the task protocol to v3
- remove native run policy from Python; Python retains frame validation, activation publication, registry control deferral, and mailbox state publication

## Scope
This is W1a + E2 only. It does not add public asynchronous submit, W1d cleanup/folding, B5 compatibility, or W1b.

## Testing
- all pre-commit hooks passed, including clang-tidy, cpplint, Ruff, and Pyright
- Python no-hardware UT: 1175 passed, 13 skipped, 14 deselected
- C++ no-hardware UT: 91/91 passed
- targeted `ChipRunLane`: 12/12 passed; scheduler: 63/63 passed
- same-lease repeated dispatch regression: current generation accepted, older generation rejected
- a2a3sim and a5sim consecutive group reservation passed; all CI cases that previously reported stale lease generation passed on both relevant sim paths
- a2a3sim native lifecycle and A2/A3 + A5 wide-dispatch/vector simulation passed
- A2/A3 queue architecture probe: `task_20260807_044537_40856118009`
- A2/A3 endpoint, whole-run FIFO, and native lifecycle: `task_20260807_050221_7162399608` passed
- A2/A3 launch-seam and stale-generation onboard regressions: `task_20260807_061626_126859527092` passed
- A2/A3 SDMA/AICore fault terminal error propagation: `task_20260807_064449_306323420340` passed