### PR TITLE
Resolve host-orchestrator tensor access through a host view

### DIFF
--- a/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Host-side tensor access for the host orchestrator. See
+ * runtime/host_tensor_access.h for the contract.
+ */
+
+#include "host_tensor_access.h"
+
+#include <string.h>
+
+#include <vector>
+
+namespace {
+
+struct HostTensorRegion {
+    uint64_t dev_base;
+    uint64_t size;
+    unsigned char *host_view;
+    // The host view is a copy of the device bytes rather than the device bytes
+    // themselves, so a write reaches the device only once pushed back.
+    bool mirrored;
+};
+
+// One entry per tensor staged for the run being orchestrated. A run stages a
+// handful of tensors and orchestration reads are cold-path, so a linear scan
+// costs less than the map that would replace it.
+std::vector<HostTensorRegion> g_regions;
+
+int (*g_copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size) = nullptr;
+
+// The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
+// `*offset` is the span's distance from that region's base.
+const HostTensorRegion *find_region(uint64_t dev_addr, uint64_t bytes, uint64_t *offset) {
+    for (const HostTensorRegion &region : g_regions) {
+        if (dev_addr < region.dev_base) {
+            continue;
+        }
+        uint64_t off = dev_addr - region.dev_base;
+        if (off > region.size || bytes > region.size - off) {
+            continue;
+        }
+        *offset = off;
+        return &region;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
+    uint64_t offset = 0;
+    const HostTensorRegion *region = find_region(dev_addr, bytes, &offset);
+    if (region == nullptr) {
+        return false;
+    }
+    memcpy(dst, region->host_view + offset, bytes);
+    return true;
+}
+
+bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
+    uint64_t offset = 0;
+    const HostTensorRegion *region = find_region(dev_addr, bytes, &offset);
+    if (region == nullptr) {
+        return false;
+    }
+    unsigned char *dst = region->host_view + offset;
+    memcpy(dst, src, bytes);
+    if (!region->mirrored) {
+        return true;
+    }
+    if (g_copy_to_device == nullptr) {
+        return false;
+    }
+    return g_copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
+}
+
+void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size)) {
+    g_regions.clear();
+    g_copy_to_device = copy_to_device;
+}
+
+bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view) {
+    if (host_view == nullptr || size == 0) {
+        return false;
+    }
+    HostTensorRegion region;
+    region.dev_base = dev_base;
+    region.size = size;
+    region.host_view = static_cast<unsigned char *>(host_view);
+    region.mirrored = reinterpret_cast<uintptr_t>(host_view) != static_cast<uintptr_t>(dev_base);
+    g_regions.push_back(region);
+    return true;
+}

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -50,6 +50,7 @@
 #include "../common/pto_runtime_status.h"
 #include "../runtime/common.h"
 #include "../runtime/dep_gen_host_graph.h"
+#include "../runtime/host_tensor_access.h"
 #include "../runtime/pto_orchestrator.h"
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
@@ -488,11 +489,11 @@ int32_t run_host_orchestration(
         rt, block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM, block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM
     );
     rt->mode = PTO2_MODE_EXECUTE;
-    // get_tensor_data/set_tensor_data dereference buffer.addr directly: the
-    // input tensors were mapped into host address space at staging time
-    // (HostApi::register_device_memory_to_host), so the host orchestrator can
-    // read control tensors (e.g. paged_attention's context_lens/block_table) in
-    // place.
+    // get_tensor_data/set_tensor_data resolve buffer.addr through the host
+    // views registered at staging time (runtime/host_tensor_access.h), so the
+    // host orchestrator can read control tensors (e.g. paged_attention's
+    // context_lens/block_table) whether or not the platform maps device memory
+    // into the host address space.
 
     // Bind both framework_current_runtime instances: the host library's (used by
     // rt_scope_* / rt_orchestration_done) and the orch .so's own copy (used by
@@ -693,6 +694,11 @@ extern "C" int bind_callable_to_runtime_impl(
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
 
+    // Open this run's host-view window. It closes once the orchestrator has
+    // finished, so no host view outlives the point at which a task could make
+    // it stale.
+    host_tensor_access_reset(api->copy_to_device);
+
     int64_t t_args_start = _now_ms();
     for (int i = 0; i < tensor_count; i++) {
         Tensor t = orch_args->tensor(i);
@@ -737,23 +743,20 @@ extern "C" int bind_callable_to_runtime_impl(
 
         // host_build_graph runs the orchestrator on the host, which may read
         // control tensors (e.g. paged_attention's context_lens/block_table) via
-        // get_tensor_data to shape the graph. Map this device buffer into the
-        // host address space so the host can dereference buffer.addr directly.
-        // Released in validate_runtime_impl before device_free.
-        //
-        // The host then reads/writes buffer.addr (== dev_ptr) directly, so this
-        // path REQUIRES an identity mapping (host VA == dev_ptr). a2a3
-        // halHostRegister(DEV_SVM_MAP_HOST) returns identity and sim is already a
-        // host pointer, but the HAL contract permits a non-identity VA — verify
-        // it here and fail the prepare rather than letting the host dereference a
-        // device address (segfault / silent corruption) on a future HAL.
-        void *host_va = api->register_device_memory_to_host(dev_ptr, size);
-        if (host_va != nullptr && host_va != dev_ptr) {
-            LOG_ERROR(
-                "host-orch: SVM map returned non-identity host VA %p for dev_ptr %p; the host orchestrator "
-                "dereferences buffer.addr directly and assumes identity mapping",
-                host_va, dev_ptr
-            );
+        // get_tensor_data to shape the graph. Give it a host view of this
+        // buffer: the device buffer itself where the platform can map it into
+        // the host address space (released in validate_runtime_impl before
+        // device_free), otherwise the staging copy, which holds the same bytes
+        // for the whole orchestration window and whose writes are pushed back
+        // to the device. A tensor with neither is not host-accessible, so the
+        // prepare fails here rather than the orchestrator dereferencing a
+        // device address.
+        void *host_view = api->register_device_memory_to_host(dev_ptr, size);
+        if (host_view == nullptr) {
+            host_view = host_ptr;
+        }
+        if (!host_tensor_access_add(reinterpret_cast<uint64_t>(dev_ptr), size, host_view)) {
+            LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
             return -1;
         }
 
@@ -858,6 +861,9 @@ extern "C" int bind_callable_to_runtime_impl(
             runtime, api, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
             eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
+        // The orchestrator is the only host-view reader; from here the device
+        // owns these buffers, so drop the window on both exits.
+        host_tensor_access_reset(nullptr);
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;

--- a/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file host_tensor_access.h
+ * @brief Tensor-byte access for the host orchestrator, over device buffers.
+ *
+ * `Tensor::buffer.addr` is a device address. host_build_graph runs the
+ * orchestrator on the host, so `get_tensor_data` / `set_tensor_data` cannot
+ * assume the CPU executing them can load that address — whether it can is a
+ * platform capability, not a property of the runtime. This is the seam where
+ * that capability is resolved, so the orchestrator core never dereferences a
+ * device address itself.
+ *
+ * A region is registered per staged tensor with the host address serving it:
+ *
+ *   - `host_view == dev_base`  — the device buffer is mapped into the host
+ *     address space (a2a3 `halHostRegister(DEV_SVM_MAP_HOST)`; sim, where a
+ *     device pointer is already a host pointer). Reads and writes land on the
+ *     device bytes directly.
+ *   - `host_view != dev_base`  — no host mapping exists. The region is served
+ *     from the staging buffer holding the same bytes, and a write is pushed
+ *     back through the device-copy hook so the device observes it.
+ *
+ * An address no registered region covers is a failure, never a raw
+ * dereference: only tensors the runtime staged have a host view at all, so a
+ * GM-heap tensor or a pass-through child-memory buffer resolves to nothing.
+ *
+ * Registrations are valid only for one orchestration run — the window between
+ * staging and the first dispatched task. A mirror is a copy, and nothing has
+ * executed yet to make it stale; once tasks run, a stale mirror would be
+ * indistinguishable from live device memory. `host_tensor_access_reset` bounds
+ * that window at both ends.
+ *
+ * The read/write pair carries weak fallbacks in the runtime translation unit
+ * (`orchestrator_core/pto_runtime2.cpp`) that dereference `dev_addr` directly,
+ * so the AICPU build — which compiles this path but never runs an
+ * orchestrator — resolves without this .cpp. libhost_runtime.so links the
+ * strong definitions from `host/host_tensor_access.cpp`.
+ */
+
+#ifndef SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_HOST_TENSOR_ACCESS_H_
+#define SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_HOST_TENSOR_ACCESS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Read `bytes` at device address `dev_addr` into `dst`.
+ *
+ * @return false when no registered region covers the whole span; `dst` is
+ *         untouched.
+ */
+bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
+
+/**
+ * Write `bytes` from `src` to device address `dev_addr`, leaving the bytes
+ * visible to the device.
+ *
+ * @return false when no registered region covers the whole span, or when the
+ *         push-back to the device fails.
+ */
+bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes);
+
+/**
+ * Drop every registration and latch the hook used to push mirror-mode writes
+ * to the device (`HostApi::copy_to_device`; null when no write can need one).
+ *
+ * Called around one orchestration run: before the first
+ * `host_tensor_access_add`, and again once the run has finished, after which
+ * every access fails until the next run registers its own tensors.
+ */
+void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size));
+
+/**
+ * Register `[dev_base, dev_base + size)` as reachable from the host at
+ * `host_view`.
+ *
+ * @return false for an empty region or a null `host_view`.
+ */
+bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view);
+
+#endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_HOST_TENSOR_ACCESS_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -30,9 +30,26 @@
 #include "aicpu/device_time.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "host_tensor_access.h"
 #if SIMPLER_DFX
 #include "aicpu/scope_stats_collector_aicpu.h"
 #endif
+
+// Tensor-byte access for a caller that can load a device address directly.
+// The AICPU build compiles this translation unit and links these; the host
+// build overrides them with host/host_tensor_access.cpp, where a device
+// address is not loadable in general. Visibility is hidden so the host .so
+// does not export them into the global dynamic symbol table (same pattern as
+// get_sys_cnt_aicpu above and the dep_gen stubs in pto_orchestrator.cpp).
+__attribute__((weak, visibility("hidden"))) bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
+    memcpy(dst, reinterpret_cast<const void *>(dev_addr), bytes);
+    return true;
+}
+
+__attribute__((weak, visibility("hidden"))) bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
+    memcpy(reinterpret_cast<void *>(dev_addr), src, bytes);
+    return true;
+}
 
 // Host fallback for the host-orchestration path. The AICPU cycle counter is a
 // device register unavailable on the host, so return a monotonic wall-clock
@@ -247,12 +264,17 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, 
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    void *ptr = reinterpret_cast<void *>(tensor.buffer.addr + flat_offset * elem_size);
-    // buffer.addr is mapped into host address space at staging time
-    // (runtime_maker HostApi::register_device_memory_to_host), so the host
-    // orchestrator reads it directly — same as set_tensor_data's write below.
+    uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     uint64_t result = 0;
-    memcpy(&result, ptr, elem_size);
+    if (!host_tensor_read(elem_addr, &result, elem_size)) {
+        rt->orchestrator.report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
+            "no host view for device address %#llx (%llu bytes): during host orchestration only tensors the "
+            "runtime staged are readable, not runtime-created or child-memory buffers",
+            (unsigned long long)elem_addr, (unsigned long long)elem_size
+        );
+        return 0;
+    }
     return result;
 }
 
@@ -272,8 +294,15 @@ void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, cons
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    void *ptr = reinterpret_cast<void *>(tensor.buffer.addr + flat_offset * elem_size);
-    memcpy(ptr, &value, elem_size);
+    uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
+    if (!host_tensor_write(elem_addr, &value, elem_size)) {
+        rt->orchestrator.report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
+            "no writable host view for device address %#llx (%llu bytes): during host orchestration only tensors "
+            "the runtime staged are writable, not runtime-created or child-memory buffers",
+            (unsigned long long)elem_addr, (unsigned long long)elem_size
+        );
+    }
 }
 
 // Ops-table entry that hands the call-site captured by PTO2ScopeGuard to the

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -682,6 +682,7 @@ add_a2a3_runtime_test(test_scope_deadlock_detection common/test_scope_deadlock_d
 add_a2a3_hbg_runtime_test(test_hbg_task_allocator a2a3/test_task_allocator.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensormap a2a3/test_hbg_tensormap.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_dep_gen_host_graph a2a3/test_dep_gen_host_graph.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp)
 # PTO2TensorMap's out-of-line members (reserve_layout / init / valid_count) live
 # in this .cpp; no other add_a2a3_hbg_runtime_test target needs them.
 target_sources(test_hbg_tensormap PRIVATE
@@ -689,6 +690,9 @@ target_sources(test_hbg_tensormap PRIVATE
 )
 target_sources(test_hbg_dep_gen_host_graph PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/host/dep_gen_host_graph.cpp
+)
+target_sources(test_hbg_tensor_access PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
 )
 add_a2a3_runtime_test(test_dep_list_pool    a2a3/test_dep_list_pool.cpp)
 add_a2a3_runtime_test(test_scheduler_state  a2a3/test_scheduler_state.cpp)

--- a/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Host-view resolution for the host orchestrator's tensor reads and writes.
+ *
+ * The mirror path (a platform that cannot map device memory into the host
+ * address space) has no reachable call site on a2a3, whose SVM map always
+ * succeeds, so these tests are the only place it executes.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "host_tensor_access.h"
+
+namespace {
+
+// Stands in for a device address range that no host load can reach. Only its
+// arithmetic is exercised — nothing dereferences it.
+constexpr uint64_t kFakeDeviceBase = 0x7000'0000'0000ull;
+
+struct CopyCall {
+    void *dev_ptr;
+    const void *host_ptr;
+    size_t size;
+};
+
+std::vector<CopyCall> g_copies;
+int g_copy_result = 0;
+
+int record_copy(void *dev_ptr, const void *host_ptr, size_t size) {
+    g_copies.push_back({dev_ptr, host_ptr, size});
+    return g_copy_result;
+}
+
+class HostTensorAccessTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_copies.clear();
+        g_copy_result = 0;
+        host_tensor_access_reset(&record_copy);
+    }
+    void TearDown() override { host_tensor_access_reset(nullptr); }
+};
+
+// A buffer the host can load directly: the device address IS a host address,
+// as on a2a3 after halHostRegister and on sim.
+TEST_F(HostTensorAccessTest, DirectRegionReadsAndWritesInPlace) {
+    int32_t buffer[4] = {10, 20, 30, 40};
+    const uint64_t base = reinterpret_cast<uint64_t>(buffer);
+    ASSERT_TRUE(host_tensor_access_add(base, sizeof(buffer), buffer));
+
+    int32_t value = 0;
+    ASSERT_TRUE(host_tensor_read(base + 2 * sizeof(int32_t), &value, sizeof(value)));
+    EXPECT_EQ(value, 30);
+
+    const int32_t written = 99;
+    ASSERT_TRUE(host_tensor_write(base + sizeof(int32_t), &written, sizeof(written)));
+    EXPECT_EQ(buffer[1], 99);
+    // The bytes are already the device's, so no push-back is issued.
+    EXPECT_TRUE(g_copies.empty());
+}
+
+// A buffer the host reaches only through the staging copy.
+TEST_F(HostTensorAccessTest, MirroredRegionReadsFromTheHostView) {
+    int32_t mirror[4] = {1, 2, 3, 4};
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    int32_t value = 0;
+    ASSERT_TRUE(host_tensor_read(kFakeDeviceBase + 3 * sizeof(int32_t), &value, sizeof(value)));
+    EXPECT_EQ(value, 4);
+}
+
+TEST_F(HostTensorAccessTest, MirroredWritePushesTheTouchedBytesToTheDevice) {
+    int32_t mirror[4] = {1, 2, 3, 4};
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    const int32_t written = 77;
+    const uint64_t dev_addr = kFakeDeviceBase + 2 * sizeof(int32_t);
+    ASSERT_TRUE(host_tensor_write(dev_addr, &written, sizeof(written)));
+
+    EXPECT_EQ(mirror[2], 77);
+    ASSERT_EQ(g_copies.size(), 1u);
+    EXPECT_EQ(g_copies[0].dev_ptr, reinterpret_cast<void *>(dev_addr));
+    EXPECT_EQ(g_copies[0].host_ptr, static_cast<const void *>(&mirror[2]));
+    EXPECT_EQ(g_copies[0].size, sizeof(int32_t));
+}
+
+TEST_F(HostTensorAccessTest, MirroredWriteFailsWhenThePushBackFails) {
+    int32_t mirror[2] = {1, 2};
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    g_copy_result = -1;
+    const int32_t written = 5;
+    EXPECT_FALSE(host_tensor_write(kFakeDeviceBase, &written, sizeof(written)));
+}
+
+TEST_F(HostTensorAccessTest, MirroredWriteFailsWithNoCopyHook) {
+    int32_t mirror[2] = {1, 2};
+    host_tensor_access_reset(nullptr);
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    const int32_t written = 5;
+    EXPECT_FALSE(host_tensor_write(kFakeDeviceBase, &written, sizeof(written)));
+}
+
+// The fail-closed contract: an address outside every registered region — a
+// GM-heap tensor the orchestrator created, or a pass-through child-memory
+// buffer — resolves to nothing instead of being dereferenced.
+TEST_F(HostTensorAccessTest, UnregisteredAddressFailsAndLeavesTheDestination) {
+    int32_t mirror[2] = {1, 2};
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    int32_t value = 0xABCD;
+    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase + 0x100000, &value, sizeof(value)));
+    EXPECT_EQ(value, 0xABCD);
+
+    const int32_t written = 5;
+    EXPECT_FALSE(host_tensor_write(kFakeDeviceBase + 0x100000, &written, sizeof(written)));
+    EXPECT_TRUE(g_copies.empty());
+}
+
+TEST_F(HostTensorAccessTest, SpanRunningPastTheRegionEndFails) {
+    int32_t mirror[2] = {1, 2};
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    int64_t value = 0;
+    // Starts inside the region, ends past it.
+    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase + sizeof(int32_t), &value, sizeof(value)));
+    // Starts before it.
+    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase - sizeof(int32_t), &value, sizeof(int32_t)));
+}
+
+TEST_F(HostTensorAccessTest, ResetDropsEveryRegistration) {
+    int32_t mirror[2] = {1, 2};
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    int32_t value = 0;
+    ASSERT_TRUE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
+
+    host_tensor_access_reset(&record_copy);
+    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
+}
+
+TEST_F(HostTensorAccessTest, EmptyOrNullRegionIsRejected) {
+    int32_t mirror[2] = {1, 2};
+    EXPECT_FALSE(host_tensor_access_add(kFakeDeviceBase, 0, mirror));
+    EXPECT_FALSE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), nullptr));
+}
+
+// Several tensors are staged per run and each resolves against its own region.
+TEST_F(HostTensorAccessTest, RegionsAreResolvedIndependently) {
+    int32_t first[2] = {1, 2};
+    int32_t second[2] = {3, 4};
+    const uint64_t second_base = kFakeDeviceBase + 0x10000;
+    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(first), first));
+    ASSERT_TRUE(host_tensor_access_add(second_base, sizeof(second), second));
+
+    int32_t value = 0;
+    ASSERT_TRUE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
+    EXPECT_EQ(value, 1);
+    ASSERT_TRUE(host_tensor_read(second_base + sizeof(int32_t), &value, sizeof(value)));
+    EXPECT_EQ(value, 4);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

`host_build_graph` runs the orchestrator on the host, where `Tensor::buffer.addr` is a device address. `get_tensor_data` / `set_tensor_data` dereferenced it directly, which is only valid because a2a3 maps device buffers into the host address space and returns an identity VA. That made a platform capability an unstated precondition of the runtime.

Staging now registers a **host view** per tensor and the orchestrator resolves addresses through it:

| Platform reports | Host view | Write path |
| ---------------- | --------- | ---------- |
| a host map (a2a3 SVM, sim) | the device buffer itself | in place, as before |
| no host map | the staging copy | mirror + `copy_to_device` push-back |
| nothing covers the address | *fatal* | *fatal* |

- **Fail closed.** A `nullptr` from `register_device_memory_to_host` previously passed the staging check, and the orchestrator then dereferenced a raw device address — a segfault or silent corruption instead of a failed prepare. An address in no registered region is now a fatal that names the tensor kinds with no host view (runtime-created, child memory).
- **A non-identity host VA is now usable** rather than a hard prepare failure, since nothing assumes `buffer.addr` is the host address.
- **The AICPU build is unchanged.** The read/write pair carries weak+hidden fallbacks in the runtime translation unit that dereference the address directly, so the AICPU build — which compiles this path but never runs an orchestrator — links without the host `.cpp`. This is the same idiom `pto_orchestrator.cpp` already uses for the dep_gen and scope-stats hooks. Verified by `objdump`: the host `.so` carries the registry body, the AICPU `.so` carries the two-line `memcpy`.

Registrations are valid only for the orchestration window — between staging and the first dispatched task, so a mirror cannot be stale. `host_tensor_access_reset` bounds it at both ends.

New files: `runtime/host_tensor_access.h`, `host/host_tensor_access.cpp`, `tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp`.

## Why

This is a prerequisite for giving a5 the host-orchestrated `host_build_graph`: a5 has no host-map path, so `DeviceRunnerBase::register_device_memory_to_host` returns `nullptr` there and the current code would fault inside the orchestrator. It also closes the latent failure on a2a3 should `halHostRegister` ever fail at runtime.

Note that a per-access `rtMemcpy` is deliberately *not* how the no-host-map case is served — that was the earlier `host_d2h_read` hook, and `paged_attention` re-reads `block_table` inside its `q_loop`, so its large cases issue on the order of 10^4–10^5 element reads.

## Testing

The mirror path has no reachable call site on a2a3, so it was exercised two ways: the new unit tests, and a temporary experiment forcing `DeviceRunner::register_device_memory_to_host` to return `nullptr`, under which `paged_attention` (control-tensor reads) and `available_aicore_counts` (writes with push-back) **both pass on hardware**. That experiment is not part of this branch.

- [x] a2a3 onboard sweep (`tests/st/a2a3` + `examples/a2a3`, both runtimes, `-m "not sdma"`) — 51 passed
- [x] — of which `host_build_graph` — 21 passed, 1 skipped
- [x] a2a3sim `host_build_graph` — 17 passed, 4 skipped
- [x] cpput — 75 passed (10 new `test_hbg_tensor_access` cases, the only place the mirror path runs in CI)
- [x] ut-py — 1034 passed, 9 skipped
- [x] pre-commit — clang-format / clang-tidy / cpplint / check-headers all pass

All suites re-run after rebasing onto #1587.