### PR TITLE
Fix: strip target triples from replayed compile commands

### DIFF
--- a/.github/workflows/ci-self-cpu.yml
+++ b/.github/workflows/ci-self-cpu.yml
@@ -15,7 +15,11 @@ run-name: CI Self CPU / PR ${{ inputs.pr_number || inputs.ref }}
 # bug that CI's 3.10 never did) with a pip cache; the venv isolates T1 from
 # any system/user python state. T3 (NPU) jobs keep their --system-site-packages
 # venvs (driver bindings). g++-15 is a symlink stand-in for the
-# ubuntu-toolchain ppa g++ — see below.
+# ubuntu-toolchain ppa g++ — see below. ci.yml lints with clang-tidy 18 while
+# HCE 2.0 packages only LLVM 12, so an agent also provides 18 on PATH under the
+# versioned name clang-tidy-18 (installed with its clang builtin headers,
+# without which it resolves no resource dir); the pre-commit job shadows the
+# distro clang-tidy with it when present.
 
 permissions:
   contents: read
@@ -179,6 +183,13 @@ jobs:
             ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
             echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           fi
+          if command -v clang-tidy-18 >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/bin"
+            ln -sf "$(command -v clang-tidy-18)" "$RUNNER_TEMP/bin/clang-tidy"
+            echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          fi
+          PATH="$RUNNER_TEMP/bin:$PATH" command -v clang-tidy
+          PATH="$RUNNER_TEMP/bin:$PATH" clang-tidy --version
       - name: Cache pip packages
         uses: actions/cache@v5
         with:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -161,7 +161,7 @@ queueing entirely:
   `[self-hosted, a2a3/a5]`. T2 (macOS) is intentionally absent. A lane-local
   `detect-changes` (same `NON_CODE` vocabulary and gates as `ci.yml` — keep the
   two copies in sync) skips jobs a diff cannot affect.
-- **cpu runner contract**: dnf-installed `cmake ninja-build gcc-c++ clang-tools-extra graphviz gtest-devel python3-devel`, plus a pip-installable torch aarch64 CPU wheel; `g++-15` is a symlink stand-in for the ubuntu-toolchain ppa g++.
+- **cpu runner contract**: dnf-installed `cmake ninja-build gcc-c++ clang-tools-extra graphviz gtest-devel python3-devel`, plus a pip-installable torch aarch64 CPU wheel; `g++-15` is a symlink stand-in for the ubuntu-toolchain ppa g++. On the agents `g++` resolves to a conda GCC 15 prefix rather than `/usr/bin/g++`, so the lane's sim artifacts are built with GCC 15 and `compile_commands.json` names that prefix's `<triple>-g++`; `tests/lint/clang_tidy.py` drops the triple before replaying a command, without which clang-tidy adopts it as a target and resolves no C++ standard library at all. `ci.yml` lints with clang-tidy 18 and HCE 2.0 packages only LLVM 12, so an agent additionally provides 18 on `PATH` as `clang-tidy-18`, installed together with its clang builtin headers — a clang-tidy whose prefix carries no `lib/clang/<major>/include` resolves no resource dir and fails every `#include <stddef.h>`. The `pre-commit` job shadows the distro `clang-tidy` with it when present.
 - The lane run is standalone — it attaches no checks to the PR; results are read from the run.
 
 ## Hardware Classification

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -19,6 +19,7 @@ If no sim build cache exists, the sim runtimes are built first:
 import json
 import os
 import platform
+import re
 import shlex
 import shutil
 import subprocess
@@ -75,6 +76,18 @@ _SUPPRESS_ARGS = [
 # GCC-only flags to strip from compile_commands.json before passing to clang-tidy.
 _GCC_ONLY_FLAGS = {"-fno-gnu-unique"}
 
+# A compiler whose program name carries a target-triple prefix — conda-forge and
+# crosstool GCC ship `<triple>-g++` with `g++` as a symlink to it, and CMake
+# records the resolved name. clang-tidy reads that prefix as its target triple,
+# then matches no installed GCC and receives no C++ standard library include
+# dirs: every `#include <cstdint>` fails, and statements that fail to build are
+# dropped from the AST, which turns non-trivial constructors into
+# modernize-use-equals-default reports. Every target in a sim database is
+# host-compiled, so the prefix names nothing clang-tidy needs.
+_TRIPLE_PREFIXED_DRIVER = re.compile(
+    r"^(?:[A-Za-z0-9_]+-)+(?P<driver>gcc|g\+\+|cc|c\+\+|clang|clang\+\+)(?P<suffix>-[0-9.]+)?$"
+)
+
 
 def _ensure_sim_cache() -> None:
     """Build all detectable sim runtimes if no sim compile databases exist."""
@@ -90,16 +103,37 @@ def _ensure_sim_cache() -> None:
         sys.exit(result.returncode)
 
 
-def _strip_gcc_flags(command: str) -> str:
-    """Remove GCC-only flags that clang/clang-tidy does not understand."""
-    parts = shlex.split(command)
-    filtered_parts = [p for p in parts if p not in _GCC_ONLY_FLAGS]
-    return shlex.join(filtered_parts)
+def _strip_target_triple(compiler: str) -> str:
+    """Return the compiler path with any target-triple prefix dropped from its name."""
+    path = Path(compiler)
+    match = _TRIPLE_PREFIXED_DRIVER.match(path.name)
+    if match is None:
+        return compiler
+    return str(path.with_name(match["driver"] + (match["suffix"] or "")))
 
 
-def _strip_gcc_flags_from_args(arguments: list[str]) -> list[str]:
-    """Remove GCC-only flags from an argv-style compile command."""
-    return [arg for arg in arguments if arg not in _GCC_ONLY_FLAGS]
+def _rewrite_argv(argv: list[str]) -> list[str]:
+    """Drop GCC-only flags and any target-triple prefix from a compile command."""
+    if not argv:
+        return argv
+    return [_strip_target_triple(argv[0])] + [arg for arg in argv[1:] if arg not in _GCC_ONLY_FLAGS]
+
+
+def _rewrite_entry(entry: dict) -> bool:
+    """Rewrite one compile database entry in place; return True when it changed."""
+    changed = False
+    if "command" in entry:
+        argv = shlex.split(entry["command"])
+        rewritten = _rewrite_argv(argv)
+        if rewritten != argv:
+            entry["command"] = shlex.join(rewritten)
+            changed = True
+    if "arguments" in entry:
+        rewritten = _rewrite_argv(entry["arguments"])
+        if rewritten != entry["arguments"]:
+            entry["arguments"] = rewritten
+            changed = True
+    return changed
 
 
 def _resolve_target_dirs(config_dir: Path, build_config: dict, target: str) -> tuple[list[str], list[str]]:
@@ -162,32 +196,33 @@ def _parse_compile_database(raw: str, db_file: Path) -> list[dict]:
     entries = json.loads(raw)
     if not isinstance(entries, list):
         raise ValueError(f"compile database is not a JSON array: {db_file}")
+    for entry in entries:
+        if not isinstance(entry, dict) or "file" not in entry:
+            raise ValueError(f"compile database entry is not an object naming a file: {db_file}")
     return entries
 
 
-def _load_compile_database(db_file: Path) -> tuple[str, list[dict]]:
+def _load_compile_database(db_file: Path) -> list[dict]:
     """Load a compile database, rebuilding its target cache dir when it is broken."""
     if not db_file.is_file():
         print(f"WARNING: compile database disappeared, skipping: {db_file}", file=sys.stderr)
-        return "", []
+        return []
 
-    raw = db_file.read_text()
     try:
-        return raw, _parse_compile_database(raw, db_file)
+        return _parse_compile_database(db_file.read_text(), db_file)
     except (ValueError, json.JSONDecodeError) as exc:
         print(f"WARNING: invalid compile database detected: {exc}", file=sys.stderr)
         _reconfigure_compile_database(db_file)
 
     if not db_file.is_file():
         print(f"WARNING: compile database recovery produced no file, skipping: {db_file}", file=sys.stderr)
-        return "", []
+        return []
 
-    rebuilt_raw = db_file.read_text()
     try:
-        return rebuilt_raw, _parse_compile_database(rebuilt_raw, db_file)
+        return _parse_compile_database(db_file.read_text(), db_file)
     except (ValueError, json.JSONDecodeError) as exc:
         print(f"WARNING: recovered compile database is still invalid, skipping: {exc}", file=sys.stderr)
-        return "", []
+        return []
 
 
 def _build_file_index() -> dict[str, list[Path]]:
@@ -197,19 +232,17 @@ def _build_file_index() -> dict[str, list[Path]]:
     folder that contains a compile_commands.json covering the file.
     Only sim variant databases are used (avoids cross-compiler sysroot issues).
 
-    When the compile database contains GCC-only flags, it is modified
-    in-place to remove them so that clang-tidy can parse the commands.
+    When a compile command carries GCC-only flags or a target-triple-prefixed
+    compiler name, the database is modified in-place so that clang-tidy can
+    replay it.
     """
     index: dict[str, list[Path]] = {}
     for db_file in sorted(_CACHE_DIR.glob("*/sim/*/*/compile_commands.json")):
-        raw, entries = _load_compile_database(db_file)
-        needs_filter = any(flag in raw for flag in _GCC_ONLY_FLAGS)
-        if needs_filter:
-            for entry in entries:
-                if "command" in entry:
-                    entry["command"] = _strip_gcc_flags(entry["command"])
-                if "arguments" in entry:
-                    entry["arguments"] = _strip_gcc_flags_from_args(entry["arguments"])
+        entries = _load_compile_database(db_file)
+        changed = False
+        for entry in entries:
+            changed |= _rewrite_entry(entry)
+        if changed:
             db_file.write_text(json.dumps(entries, indent=2))
         for entry in entries:
             filepath = entry["file"]


### PR DESCRIPTION
## Summary

`tests/lint/clang_tidy.py` replays each changed file's compile command through
clang-tidy. clang-tidy does not run the compiler — it drives its own clang
frontend, and clang's driver reads **the program name in argv[0] as a target
triple** when that name carries one (`ToolChain::getTargetAndModeFromProgramName`,
the mechanism behind `aarch64-linux-gnu-gcc`).

conda-forge and crosstool GCC install `<triple>-g++` and make `g++` a symlink to
it; CMake records the resolved name. So a database entry reads
`.../bin/aarch64-conda-linux-gnu-g++ …`, clang-tidy takes
`aarch64-conda-linux-gnu` as its target, matches no installed GCC (the box has
`/usr/lib/gcc/aarch64-linux-gnu/10.3.1` — different vendor segment), and is left
with **no C++ standard library include dirs at all**. Every `#include <cerrno>` /
`<cstdint>` fails, and because Sema drops statements that fail to build, a
constructor with a real body is additionally reported as
`modernize-use-equals-default`. One toolchain mismatch, presented as lint errors
naming real files and real checks.

Every target in a sim compile database is host-compiled, so the triple prefix
names nothing clang-tidy needs. This drops it while rewriting each command —
next to the GCC-only flags already stripped there — and writes the database back
whenever a rewrite changed something, rather than only when a `-fno-gnu-unique`
was present. Directory and all other arguments are untouched.

`ci-self-cpu.yml`'s `pre-commit` job additionally prefers a `clang-tidy-18` when
an agent provides one, so the emergency lane lints with the same clang-tidy
major as `ci.yml` (ubuntu ships 18; HCE 2.0 packages only LLVM 12).

## Where it fires

The self-hosted `cpu` lane. Its agents resolve `g++` to a conda GCC 15 prefix,
and their `clang-tidy` is the distro LLVM 12 — which, unlike 18, does not fall
back to a compatible triple. It stayed latent because every earlier lane run
reported `clang-tidy … (no files to check) Skipped`; #1587 was the first
C++-touching PR through the lane, and its lane `pre-commit` failed on those
phantom diagnostics while the GitHub-hosted `pre-commit` for the same commit
passed.

## Testing

Run on a `cpu` agent, against the changed-file set of #1587, restoring the
triple-prefixed database before each case:

| clang-tidy | hook | result |
| ---------- | ---- | ------ |
| 12 (distro) | before | exit 1 — `'cstdint' file not found` + phantom `modernize-use-equals-default` |
| 12 (distro) | after | exit 0 |
| 18 | before | exit 0 (18 tolerates the prefix) |
| 18 | after | exit 0 |

- [x] `ruff check` / `ruff format` / `pyright` clean on the hook
- [x] Rewrite verified idempotent, and a no-op for untouched spellings
      (`/usr/bin/g++`, `g++-15`, `/opt/llvm/bin/clang++`)
- [ ] Simulation tests pass — not run; no product code changes
- [ ] Hardware tests pass — not applicable