### PR TITLE
Fix: state the post-B4 runner geometry, stream, and TLS contracts

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -259,8 +259,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // Latch this run's diagnostic enables onto the runner before the collector
     // paths below read them; block_dim/aicpu_thread_num are consumed locally.
     apply_call_config(config);
-    // prepare_launch_shape() resolved block_dim before the graph was built, so
-    // the geometry this run launches with is already on the runner.
+    // activate_launch_shape() latches this run's geometry onto the runner on the
+    // executor thread immediately before run(), so block_dim_ is this run's.
     const int block_dim = block_dim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
@@ -291,7 +291,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     ensure_device_wall_buffer();
 
     if (block_dim < 1) {
-        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
+        LOG_ERROR("run() reached with unresolved block_dim; activate_launch_shape must run first");
         return -1;
     }
     int num_aicore = block_dim * cores_per_blockdim_;

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -141,8 +141,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // Latch this run's diagnostic enables onto the runner before the collector
     // paths below read them; block_dim/aicpu_thread_num are consumed locally.
     apply_call_config(config);
-    // prepare_launch_shape() resolved block_dim before the graph was built, so
-    // the geometry this run launches with is already on the runner.
+    // activate_launch_shape() latches this run's geometry onto the runner on the
+    // executor thread immediately before run(), so block_dim_ is this run's.
     const int block_dim = block_dim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
@@ -175,7 +175,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     ensure_device_wall_buffer();
 
     if (block_dim < 1) {
-        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
+        LOG_ERROR("run() reached with unresolved block_dim; activate_launch_shape must run first");
         return -1;
     }
     int num_aicore = block_dim * cores_per_blockdim_;

--- a/src/common/platform/include/host/run_stream_slots.h
+++ b/src/common/platform/include/host/run_stream_slots.h
@@ -13,6 +13,7 @@
 #define SRC_COMMON_PLATFORM_INCLUDE_HOST_RUN_STREAM_SLOTS_H_
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <functional>
 
@@ -33,6 +34,15 @@
  * than hand it a fresh stream beside a live one, and teardown needs the handle
  * to retry. Stream creation and destruction are injected so this state machine
  * is exercisable without a device.
+ *
+ * Threading: a `Slot` is touched only by the thread that owns that slot's run,
+ * and admission gives at most one owner per slot, so the per-slot handles need
+ * no synchronization. Two slots are therefore serviced concurrently — a native
+ * prepare acquires the successor's slot while the executor retires the
+ * predecessor's. `created_count_` is the one field shared across those owners
+ * and is additionally readable from an unrelated thread through
+ * `get_run_stream_set_create_count`, so it is atomic. `destroy_all()` walks
+ * every slot and requires all runs to be quiesced.
  */
 class RunStreamSlots {
 public:
@@ -64,7 +74,7 @@ public:
             s.aicore = nullptr;
             return rc;
         }
-        ++created_count_;
+        created_count_.fetch_add(1, std::memory_order_relaxed);
         return 0;
     }
 
@@ -99,7 +109,7 @@ public:
     void *aicpu(unsigned slot) const { return slot < slots_.size() ? slots_[slot].aicpu : nullptr; }
     void *aicore(unsigned slot) const { return slot < slots_.size() ? slots_[slot].aicore : nullptr; }
     bool ready(unsigned slot) const { return aicpu(slot) != nullptr && aicore(slot) != nullptr; }
-    size_t created_count() const { return created_count_; }
+    size_t created_count() const { return created_count_.load(std::memory_order_relaxed); }
     static constexpr size_t capacity() { return PTO_PIPELINE_MAX_DEPTH; }
 
 private:
@@ -111,7 +121,7 @@ private:
     CreateFn create_;
     DestroyFn destroy_;
     std::array<Slot, PTO_PIPELINE_MAX_DEPTH> slots_{};
-    size_t created_count_{0};
+    std::atomic<size_t> created_count_{0};
 };
 
 #endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_RUN_STREAM_SLOTS_H_

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -86,22 +86,29 @@ void create_run_selection_key() {
     g_run_selection_key_error = pthread_key_create(&g_run_selection_key, std::free);
 }
 
-DeviceRunnerBase::NativeRunThreadSelection &run_selection() {
+/** This thread's selection storage, or nullptr when it cannot be installed. */
+NativeRunThreadSelection *try_run_selection() noexcept {
     int once_rc = pthread_once(&g_run_selection_once, create_run_selection_key);
-    if (once_rc != 0 || g_run_selection_key_error != 0) {
-        throw std::runtime_error("failed to create native-run pthread TLS key");
-    }
+    if (once_rc != 0 || g_run_selection_key_error != 0) return nullptr;
     auto *selection = static_cast<NativeRunThreadSelection *>(pthread_getspecific(g_run_selection_key));
     if (selection == nullptr) {
         void *storage = std::malloc(sizeof(NativeRunThreadSelection));
-        if (storage == nullptr) throw std::bad_alloc();
+        if (storage == nullptr) return nullptr;
         selection = new (storage) NativeRunThreadSelection{};
         int set_rc = pthread_setspecific(g_run_selection_key, selection);
         if (set_rc != 0) {
             selection->~NativeRunThreadSelection();
             std::free(storage);
-            throw std::runtime_error("failed to install native-run pthread TLS state");
+            return nullptr;
         }
+    }
+    return selection;
+}
+
+DeviceRunnerBase::NativeRunThreadSelection &run_selection() {
+    NativeRunThreadSelection *selection = try_run_selection();
+    if (selection == nullptr) {
+        throw std::runtime_error("failed to install native-run pthread TLS state");
     }
     return *selection;
 }
@@ -196,7 +203,15 @@ DeviceRunnerBase::NativeRunThreadSelection DeviceRunnerBase::capture_native_run_
 }
 
 void DeviceRunnerBase::restore_native_run_thread_selection(const NativeRunThreadSelection &selection) noexcept {
-    run_selection() = selection;
+    NativeRunThreadSelection *target = try_run_selection();
+    if (target == nullptr) {
+        // Returning would leave this thread on the default slot and bank, so a
+        // run would address storage another run's lease owns. There is no
+        // caller-visible channel for the failure on a freshly started thread.
+        LOG_ERROR("native-run thread selection storage could not be installed");
+        std::abort();
+    }
+    *target = selection;
 }
 
 uint64_t DeviceRunnerBase::arena_bank_gm_heap_base(uint32_t bank_id) const {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -137,6 +137,12 @@ public:
     uint32_t pipeline_slot() const;
     uint32_t selected_arena_bank() const;
     NativeRunThreadSelection capture_native_run_thread_selection() const;
+    /**
+     * Install `selection` on the calling thread. Aborts if the per-thread
+     * storage cannot be created: every caller either runs inside a scope guard
+     * or on a thread that has not started its run yet, so proceeding on the
+     * default slot and bank would silently address another lease's storage.
+     */
     void restore_native_run_thread_selection(const NativeRunThreadSelection &selection) noexcept;
 
     /**

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -785,6 +785,11 @@ int set_task_accepted_state_ctx(DeviceContextHandle ctx, volatile int32_t *state
     }
 }
 
+/**
+ * Simulation keeps no per-thread run selection, so the identity is carried only
+ * by the onboard runner's trace attributes and is discarded here. Accepting it
+ * keeps the pipeline symbol set uniform across every host runtime.
+ */
 int set_native_run_identity_ctx(DeviceContextHandle ctx, uint64_t, uint64_t, uint64_t, uint64_t) {
     return ctx == NULL ? -1 : 0;
 }

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -38,6 +38,7 @@ T load_symbol(void *handle, const char *name) {
         msg += name;
         msg += "': ";
         msg += err;
+        msg += "; every host runtime built from this source tree exports it, so rebuild the runtime";
         throw std::runtime_error(msg);
     }
     return reinterpret_cast<T>(sym);
@@ -668,7 +669,9 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
                 );
             }
         }
-        if (occupied != 0 && occupied != 1) {
+        // The loop above already rejected every predecessor that may not carry a
+        // successor, so more than one survivor means a successor is staged.
+        if (occupied > 1) {
             throw std::runtime_error(
                 "prepare_native_run already owns a prepared successor " + format_native_run_identity(run_identity)
             );


### PR DESCRIPTION
## Summary

Follow-up to #1587. It moved three contracts without moving the text that described them, and left one failure mode expressed as a `noexcept` violation.

**Geometry.** `resolve_block_dim()` and `prepare_launch_shape()` no longer write `block_dim_` / `worker_count_`; `activate_launch_shape()` latches both on the executor thread immediately before `run()`. Both onboard `run()` bodies still carried a comment and a `LOG_ERROR` naming `prepare_launch_shape`, so the one diagnostic a future reader greps pointed at a function that latches nothing. #1521 later edited the line directly below that comment and left it standing.

The simulation runners are deliberately untouched: `SimDeviceRunnerBase::prepare_launch_shape` does still assign `block_dim_`, so their wording is correct. The two remaining references — `call_config.h` and the HBG `runtime_maker.cpp` — are also correct, since `prepare_launch_shape` still publishes `worker_count` onto the `Runtime`.

**Streams.** `RunStreamSlots` became a two-thread class when native prepare started provisioning the successor's slot while the executor retires the predecessor's. Per-slot handles are safe — admission gives each slot one owner — but `created_count_` is shared across owners and is also read from an unrelated thread through `get_run_stream_set_create_count` (and asserted by `run_stream_reuse`). It is now `std::atomic<size_t>`, and the ownership rule is stated on the class.

**Thread selection.** `restore_native_run_thread_selection` was `noexcept` while `run_selection()` could throw: on a thread created by `create_thread` the per-thread block does not exist yet, so installation allocates. Split out a non-throwing `try_run_selection()` and let restore abort with a message on the unrecoverable path. Returning instead would leave the thread on the default slot and bank, addressing storage another lease owns, and a freshly started thread has no channel to report the failure through.

**Symbol loading.** Since every required pipeline symbol became a strict load in #1587, the dominant cause of a `dlsym` failure is a host runtime out of sync with the tree that consumes it. The error now says so instead of reporting only the missing name.

Two readability items alongside: `occupied != 0 && occupied != 1` becomes `occupied > 1` (the loop above it has already rejected every predecessor that may not carry a successor), and the simulation `set_native_run_identity_ctx` records that it discards identity by design.

No behavior change outside the abort path. `B6c` in the pipeline plan removes the TLS mechanism outright; until then the failure is diagnosable rather than a bare terminate.

## Testing

- [x] `pre-commit` on every changed file — all hooks pass (clang-format, clang-tidy, cpplint, headers, English-only)
- [x] Editable rebuild: all 2 arch x 2 platform x 2 runtime host DSOs
- [x] C++ unit tests: 74/74 passed
- [x] Python unit tests: 1050 passed, 13 skipped
- [x] a2a3sim `tests/st/a2a3`: HBG 17 passed / 4 skipped, TMR 38 passed, L3 resource phase all PASS
- [x] a2a3 onboard via `task-submit`, devices 3+5: 7 passed across `worker_async_fifo`, `worker_async_endpoint`, `native_run_lifecycle`, and `run_stream_reuse` — the last is the direct consumer of `created_count`
- [x] a5 onboard — covered by CI `st-onboard-a5` (the local a5 pool was unavailable); the a5 change is a comment and a log string in a path a5 shares with a2a3
