### PR TITLE
Fix: align hbg docs/comments with the polling runtime model

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -260,44 +260,34 @@ This back-pressure is essential for correctness with small ring sizes — for ex
 
 ### 4.5 Deadlock Detection
 
-A ring that is **too small** can cause a **deadlock**. The root cause is the scope mechanism: each task's `fanout_count` includes a reference from its owning scope. The scope reference is only released when `scope_end()` runs — but `scope_end()` is called by the orchestrator, which is blocked waiting for ring space. This creates a circular dependency:
+A ring that is **too small** stalls the allocator permanently. host_build_graph is whole-graph-resident: the orchestrator runs to completion on the host and there is no on-device slot reclaim, so `last_task_alive` is never advanced at runtime (see Section 8.4). The task-ring gate is `local_task_id - last_alive + 1 < window_size`; with `last_alive` pinned at 0 it reduces to `local_task_id + 1 < window_size`, so the ring commits `window_size - 1` tasks (one slot is reserved to tell full from empty) and blocks on the next. The window must therefore hold the **whole graph's task count**, not just one scope — e.g. with `task_window=16` the allocator commits 15 tasks and blocks on the 16th, and because `last_alive` stays 0 the reclaim it waits on never comes.
+
+`PTO2TaskAllocator::alloc` spins on this condition and backstops it two ways (cold path, checked every 1024 spins):
+
+- **Structural head-of-line test** (`head_blocked_on_scope_end`) — inert for host_build_graph, since tasks cannot complete during host-side graph construction.
+- **Wall-clock backstop** — `PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES` (500 ms). After 500 ms with no reclaim progress it calls `report_deadlock()`, latches a fatal, and the failed alloc unwinds.
+
+While blocked it emits periodic warnings (every `PTO2_BLOCK_NOTIFY_INTERVAL` = 10000 spins):
 
 ```text
-Orchestrator blocked on task_ring_alloc (ring full)
-    → needs scheduler to advance last_task_alive
-    → needs tasks to reach CONSUMED state (fanout_count == 0)
-    → needs scope_end() to release scope reference
-    → needs orchestrator to continue
-    → DEADLOCK
+[TaskAllocator] BLOCKED: tasks=15/16, heap=65536/65536, on=task, spins=100000
 ```
 
-The runtime detects this automatically by counting spin iterations in the allocation functions:
-
-**Periodic BLOCKED warnings** (every 10,000 spins):
+and on the backstop logs to the device log:
 
 ```text
-[TaskRing] BLOCKED (Flow Control): current=208, last_alive=192, active=16/16 (100.0%), spins=10000
-[HeapRing] BLOCKED: requesting 4096 bytes, available=0, top=65536, tail=0, spins=10000
+========================================
+FATAL: Task Allocator Deadlock - Task Ring Full!
+========================================
+No reclaim progress for ~500 ms (<N> cycles wall clock).
+  Task ring:  current=15, last_alive=0, active=15/16 (93.8%)
+  Heap ring:  top=..., tail=..., size=..., available=...
+  Head task 0: state=0, last_consumer=...
 ```
 
-**Deadlock detection** (after 100,000 spins with no progress):
+(`... - Heap Exhausted!` plus a `Requested: N bytes` line when the heap ring, not the task ring, is the blocked resource.)
 
-```text
-FATAL: Flow Control Deadlock Detected!
-Task Ring is FULL and no progress after 100000 spins.
-  - Active tasks:  16
-  - Window size:   16
-Root Cause:
-  Tasks cannot transition to CONSUMED state because fanout_count
-  includes 1 for the owning scope, and scope_end() requires the
-  orchestrator to continue — creating a circular dependency.
-Solution:
-  Recommended: 32 (at least 2x current active tasks)
-```
-
-The FATAL message is logged to the device log and the process exits. The solution is to increase the ring size so that it can hold at least all tasks within the largest parallel scope. For example, if a scope submits 13 tasks, `task_window >= 14` is required (13 + 1 to distinguish full from empty).
-
-**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `PTO2_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
+**Sizing guideline**: because the whole graph is resident, `task_window_size` must exceed the graph's **total task count** — `task_window_size > total_tasks` (the `+1` distinguishes full from empty). The default `#define PTO2_TASK_WINDOW_SIZE 16384` covers up to ~16k tasks per ring; raise it for larger graphs. Sizing by a single scope's task count under-sizes the window for any multi-scope graph and trips the backstop above.
 
 ---
 
@@ -359,7 +349,7 @@ This forms a back-pressure mechanism analogous to the Task Ring's flow control.
 | Periodic Cleanup | Every 64 retired tasks | Walk per-task chains, free entries | Pool capacity reclaimed in bounded time |
 | Pool Back-Pressure | Pool exhausted | Block until scheduler advances watermark | Hard capacity bound, no OOM |
 
-In steady state, the number of valid TensorMap entries ≈ `active_tasks × avg_outputs_per_task`. With the default `task_window=65536` and `pool_size=65536`, this is well within bounds. With small windows (e.g., `task_window=16`), active entries are even fewer (~16 × a few), and cleanup runs frequently.
+Because host_build_graph is whole-graph-resident and `last_task_alive` never advances, no TensorMap entry is reclaimed during the run: the valid-entry count grows to `total_tasks × avg_outputs_per_task` and stays there. The default `pool_size=65536` bounds that; a graph whose total output-entry count exceeds the pool trips the pool back-pressure backstop (Section 5.4) rather than being reclaimed.
 
 ### 5.5 Dependency Discovery Flow
 

--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -2,9 +2,11 @@
 
 ## 1. Overview
 
-During task graph construction, orchestration sometimes needs to read InCore kernel results (for control-flow decisions) or write initial values into tensors. `get_tensor_data` / `set_tensor_data` provide **blocking** cross-layer data access, allowing orchestration to safely read and write tensor data.
+During task graph construction, orchestration sometimes needs to read tensor contents (e.g. InCore kernel results for control-flow decisions) or write initial values into tensors. `get_tensor_data` / `set_tensor_data` provide **blocking** cross-layer data access, allowing orchestration to safely read and write tensor data — subject to the host_build_graph restriction noted below.
 
 **Core design principle**: Reuse the existing TensorMap dependency tracking mechanism — no new synchronization infrastructure.
+
+**host_build_graph restriction**: the orchestrator runs to completion on the host before any device task executes (`run_host_orchestration()` populates the SM, `copy_to_device()` uploads it, and only then does the AICPU boot scheduler-only). No device task has run during orchestration, so a producer's `task_state` can never reach `PTO2_TASK_COMPLETED` at that point. `get_tensor_data` / `set_tensor_data` are therefore safe only on tensors with **no producing task** — external tensors (`make_tensor_external`) and initial-value writes. Reading an InCore kernel result mid-graph (for control-flow decisions) is a `tensormap_and_ringbuffer` capability, whose orchestrator runs on the AICPU alongside the schedulers; here it spins to `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` (15 s) and fails with `PTO2_ERROR_TENSOR_WAIT_TIMEOUT`.
 
 ## 2. API
 
@@ -41,7 +43,7 @@ addr null-check → TensorMap lookup → spin-wait producer COMPLETED → comput
 addr null-check → TensorMap lookup → spin-wait producer COMPLETED → spin-wait consumers done → memcpy write
 ```
 
-One extra step versus get_tensor_data: wait for all consumers to finish (`fanout_refcount >= fanout_count - 1`, excluding the scope reference).
+One extra step versus get_tensor_data: wait for all consumers to finish (per-ring `completed_watermark >= producer's last_consumer_local_id`).
 
 ### 3.3 Timeout
 
@@ -73,6 +75,8 @@ args.add_output(ci);
 ## 5. Scalar Dependencies via 1-Element Tensors
 
 Traditional scalars (`L0TaskArgs::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
+
+> **Not usable as-is in host_build_graph.** The example below submits a producing task and then reads its result with `get_tensor_data`, which waits for kernel completion. Per the §1 restriction, no device task has run during host_build_graph orchestration, so this read spins to `PTO2_ERROR_TENSOR_WAIT_TIMEOUT`. Reading a kernel-produced scalar mid-graph is a `tensormap_and_ringbuffer` capability; in host_build_graph the carrier works only in the producer-less direction (seed it with `set_initial_value` / an external tensor, no producing task).
 
 ```cpp
 uint32_t shapes[1] = {1};
@@ -106,7 +110,7 @@ Three actors:
 | - | ---------- | -------- | ------ | --------- | ----- |
 | 1 | Kernel write (OUTPUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
 | 2 | Kernel write (OUTPUT) | Orch Write | WAW | spin-wait producer COMPLETED | Yes |
-| 3 | Kernel read (INPUT) | Orch Write | WAR | spin-wait fanout_refcount | **Needs INOUT** |
+| 3 | Kernel read (INPUT) | Orch Write | WAR | spin-wait completed_watermark | **Needs INOUT** |
 | 4 | Kernel read-write (INOUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
 | 5 | Kernel read-write (INOUT) | Orch Write | WAW+WAR | spin-wait producer + consumers | Yes |
 | 6 | Orch Write | Kernel read (INPUT) | RAW | blocking completes before next submit | Yes |
@@ -120,7 +124,7 @@ Three actors:
 
 TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` finds no matching producer (the lookup callback never fires) and returns immediately — but the kernel may still be reading → **WAR data race**.
 
-**Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through `fanout_refcount`.
+**Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through the ring's `completed_watermark`.
 
 **Scenarios #6–8 serial guarantee**:
 

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -310,7 +310,7 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
  * To ensure WAR safety for all access patterns, use add_inout() instead of
  * add_input() for kernel parameters that may later be written via
  * set_tensor_data. INOUT creates a TensorMap entry that enables automatic
- * consumer tracking via fanout_refcount.
+ * consumer tracking via the ring's completed_watermark.
  *
  * The tensor must already have an allocated buffer (addr != 0).
  * For runtime-created outputs, call this only on the Tensor returned by

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -419,8 +419,8 @@ static bool prepare_task(
     // single payload-init point, which runs before Orch-side wiring publish.
 
     // Fields already zeroed by reset_for_reuse() at slot init:
-    //   fanout_lock=0, fanout_count=PTO2_FANOUT_SCOPE_BIT, fanout_head=nullptr,
-    //   fanin_refcount=0, fanout_refcount=0, completed_subtasks=0, next_block_idx=0
+    //   wake_list_head=nullptr, next_in_wake_list=nullptr,
+    //   any_subtask_deferred=false, completed_subtasks=0, next_block_idx=0
     // Fields immutable after RingSchedState::init():
     //   ring_id
     // task_state is set to PENDING here as the orchestrator populates the slot

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -124,8 +124,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 // Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
 // For reads: wait until each producer COMPLETED (done writing).
 // For writes: also wait until all consumers done reading
-//   (consumer low bits of fanout_refcount >= consumer count, excluding the
-//    bit31 scope reference).
+//   (per-ring completed_watermark >= the producer's last_consumer_local_id).
 // Uses cycle-based timeout (checked every 1024 spins).
 // Returns false on timeout (sets orch.fatal).
 MAYBE_UNINITIALIZED_BEGIN

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -145,7 +145,7 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  * Conditions:
  *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
  *                         hidden alloc completed inline by the orchestrator
- *   COMPLETED->CONSUMED:  fanout_refcount == fanout_count && state == COMPLETED
+ *   COMPLETED->CONSUMED:  per-ring completed_watermark >= last_consumer_local_id
  */
 typedef enum {
     PTO2_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched


### PR DESCRIPTION
## Summary

`host_build_graph`'s dependency model was migrated from the wiring/refcount model (`fanout_refcount` + scope refcount + `CONSUMED`-via-refcount) to the polling model (`completion_flags` + per-ring `completed_watermark`), and the runtime is whole-graph-resident (the orchestrator runs to completion on the host; `last_task_alive` is never advanced at runtime). Several docs and load-bearing comments still described the removed model. **Documentation/comment-only — no behavior change.** All replacement facts were verified against the current source, not taken from the issue text.

Three facets from #1646, all confined to `src/a2a3/runtime/host_build_graph/`:

1. **Removed refcount mechanism presented as current** — retarget the seven present-tense references from `fanout_refcount`/`fanout_count` to the real consumer-retirement signal: per-ring `completed_watermark >= producer's last_consumer_local_id` (`SCALAR_DATA_ACCESS.md` §3.2/§4/§5, `RUNTIME_LOGIC.md` state machine, `pto_orchestration_api.h`, `pto_runtime2_types.h`, `pto_runtime2.cpp`). Correct the `prepare_task` zeroed-fields comment to the fields `reset_for_reuse()` actually clears (`wake_list_head` / `next_in_wake_list` / `any_subtask_deferred` / `completed_subtasks` / `next_block_idx`). The correct historical/contrast notes are left intact.
2. **`SCALAR_DATA_ACCESS.md` §1 claimed a capability hbg lacks** — scope it: the orchestrator finishes on the host before any device task runs, so a producer's `task_state` can never reach `COMPLETED` during orchestration; get/set_tensor_data are safe only on producer-less tensors (external / initial-value), and reading a produced result mid-graph is a `tensormap_and_ringbuffer` capability that times out here.
3. **`RUNTIME_LOGIC.md` §4.5 sizing guidance + default** — rewrite the deadlock section to the current model: whole-graph residency means the window must hold the whole graph's task count (not the largest scope), and a too-small window trips the 500 ms wall-clock backstop (`report_deadlock`); replace the stale `Flow Control Deadlock` FATAL/BLOCKED sample text the code no longer emits, and fix the `task_window` default (`65536` → `16384`, matching `#define PTO2_TASK_WINDOW_SIZE 16384`). This aligns §4.5 with the already-correct §8.4.

## Scope

Per agreement on the issue, facet 3 fixes the sizing guidance **and** reconciles §4.5's stale root-cause/FATAL text (one coherent unit). §4.1–§4.4's broader `last_task_alive` reclaim narrative (L209–259) is intentionally left for a follow-up, as is the residue outside `host_build_graph` (`tensormap_and_ringbuffer`, top-level `docs/`, `a5`) that #1646 did not sweep.

## Testing

Documentation and comment-only; no compiled behavior changes.
- [x] All pre-commit hooks pass (check-headers, clang-format, clang-tidy, cpplint, markdownlint)
- [x] Residue probe confirms the seven fixed refs are gone and the historical notes remain
- [x] Edited docs cross-checked against §8.4 for internal consistency

Fixes #1646