### PR TITLE
Fix: gate the device-phase timing buffer's per-run transfers on capture

### DIFF
--- a/docs/dfx/device-phases.md
+++ b/docs/dfx/device-phases.md
@@ -68,19 +68,24 @@ deep-dive — see [l2-timing.md](l2-timing.md).
   `[STRACE]` marker nested under `simpler_run.runner_run.device_wall`
   (see [host-trace.md](host-trace.md)).
 
-### Gating: `SIMPLER_DEVICE_STRACE_ENABLE` (host/device split)
+### Gating device-domain markers
 
 The device markers can be turned off independently of the host spans so a
 deployment can profile the two domains separately:
 
-* **Device** (`clk=dev` markers): the runtime env `SIMPLER_DEVICE_STRACE_ENABLE`,
-  read once by `emit_device_phase_markers` in the host `c_api_shared`. `=0`
-  suppresses the whole device-phase emit; any other value (or unset) keeps it on
-  (**default on**). It does not affect the on-device stamping cost (cheap plain
-  stores) — only whether the host re-emits the readback as markers.
+* **Device** (`clk=dev` markers): `SIMPLER_HOST_STRACE=1`, a visible
+  `LOG_TIMING` level, and the runtime env `SIMPLER_DEVICE_STRACE_ENABLE` must all
+  be enabled. The env is read once; `=0` disables the markers, while any other
+  value (or unset) keeps them on (**default on**). Onboard, the same predicate
+  controls buffer setup/reset, AICPU stamping, D2H readback, and marker
+  emission. A disabled predicate leaves the device base null, so stamping
+  no-ops and the marker-only H2D/D2H transfers are skipped.
 * **Host** (`simpler_run` / `bind` / `runner_run` / `validate` spans): no new
   knob — they ride the compile-time `SIMPLER_HOST_STRACE` macro and the log level
   (`LOG_TIMING`), so raising the log threshold drops them.
+
+The simulator still applies `SIMPLER_DEVICE_STRACE_ENABLE` at emission time;
+the transfer optimization above is specific to the onboard device buffer.
 
 `RunWall` is the whole on-NPU wall (the former `RunTiming.device_wall`); it is
 emitted as the `simpler_run.runner_run.device_wall` marker, not returned.

--- a/docs/dfx/profiling-config-naming.md
+++ b/docs/dfx/profiling-config-naming.md
@@ -45,8 +45,9 @@ Do not use "PROFILING" as a catch-all.
   profiling counters: `SIMPLER_ORCH_PROFILING` (orchestrator task/cycle
   counters), `SIMPLER_SCHED_PROFILING` (scheduler dispatch hit/miss + cycle),
   `SIMPLER_TENSORMAP_PROFILING` (tensor-map hash-table chain/overlap stats).
-- `SIMPLER_HOST_STRACE` gates **only** the host `[STRACE]` facility — so it is
-  `HOST_STRACE`, not `PROFILING`.
+- `SIMPLER_HOST_STRACE` gates the `[STRACE]` facility. Onboard, it also gates
+  capture work whose only consumer is a device-domain `[STRACE]` marker — so it
+  is `HOST_STRACE`, not `PROFILING`.
 
 ### 3. Runtime-subsystem-specific knobs carry an owner prefix; platform knobs do not
 
@@ -79,12 +80,11 @@ by **independent layers**:
 | Runtime emission (does it actually emit?) | env (`SIMPLER_DEVICE_STRACE_ENABLE`, log level) | on |
 | Runtime detail tier | `get_chip_swimlane_level()` | AICPU_TIMING |
 
-`SIMPLER_HOST_STRACE` (compile) gates whether the host `[STRACE]` macros
-exist at all; `SIMPLER_DEVICE_STRACE_ENABLE` (runtime env) gates whether the
-device-domain `[STRACE]` markers get emitted into the host log. They are an
-**asymmetric pair by design**: host-strace code lives in a header (natural
-compile-time gate), device-strace is emitted from already-compiled code based
-on runtime timing (natural runtime gate).
+`SIMPLER_HOST_STRACE` (compile) gates whether `[STRACE]` markers exist at all;
+`SIMPLER_DEVICE_STRACE_ENABLE` (runtime env) independently gates device-domain
+markers. Onboard device-phase capture also requires the `LOG_TIMING` level to
+be visible. The capture predicate is shared by buffer setup/reset, readback,
+and emission, so disabled markers do not leave marker-only transfers behind.
 
 ## Reference: the configuration surface
 
@@ -96,13 +96,13 @@ on runtime timing (natural runtime gate).
 | `SIMPLER_ORCH_PROFILING` | 0 | orchestrator-phase counters (requires `SIMPLER_DFX`) |
 | `SIMPLER_SCHED_PROFILING` | 0 | scheduler hot-path counters (requires `SIMPLER_DFX`) |
 | `SIMPLER_TENSORMAP_PROFILING` | 0 | tensor-map hash-table counters (requires `SIMPLER_ORCH_PROFILING`) |
-| `SIMPLER_HOST_STRACE` | 1 | host `[STRACE]` RAII macros (`strace.h`); independent of `SIMPLER_DFX` |
+| `SIMPLER_HOST_STRACE` | 1 | `[STRACE]` macros (`strace.h`) and onboard capture used only by device-domain markers; independent of `SIMPLER_DFX` |
 
 ### Env vars
 
 | Env | Layer | Value | Gates |
 | --- | ----- | ----- | ----- |
-| `SIMPLER_DEVICE_STRACE_ENABLE` | host general | bool | device-domain `[STRACE]` emission to host log |
+| `SIMPLER_DEVICE_STRACE_ENABLE` | host general | bool | device-domain `[STRACE]` capture/emission onboard; emission in sim |
 | `SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE` | host runtime | bool | serial orch→scheduler transition (TMR subsystem) |
 | `SIMPLER_PMU_EVENT_TYPE` | host platform | enum | which PMU event the PMU collector samples |
 | `SIMPLER_OP_EXECUTE_TIMEOUT_US` | host platform | µs | op-execute timeout (overrides the `platform_config.h` compile default) |

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/c_api_shared.cpp"
 )

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -78,6 +78,7 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/c_api_shared.cpp"
 )

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -483,28 +483,14 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
     }
 }
 
-// Runtime gate for device-domain phase emission. SIMPLER_DEVICE_STRACE_ENABLE=0
-// suppresses the device (clk=dev) markers so a deployment can profile host and
-// device independently; any other value (or unset) keeps them on. Host-side
-// [STRACE] spans are unaffected — they ride SIMPLER_HOST_STRACE + the log level.
-// Read once and cached: getenv is not thread-safe against setenv, and the value
-// is a process-lifetime config knob.
-static bool device_profiling_enabled() {
-    static const bool enabled = [] {
-        const char *v = std::getenv("SIMPLER_DEVICE_STRACE_ENABLE");
-        return v == nullptr || std::strcmp(v, "0") != 0;
-    }();
-    return enabled;
-}
-
 // Emit device-domain trace markers for the AICPU phases. RunWall (the whole
 // on-NPU wall, i.e. the former RunTiming.device_wall) is emitted at depth 2
 // under runner_run; its preamble/so_load/graph_build/post_orch subdivisions are
 // emitted at depth 3 beneath it. Phases never stamped (0 ns) are skipped.
-// STRACE_DEV_SPAN_AT self-compiles to nothing when profiling is off, so no extra
-// gate is needed here.
+// Capture and emission share one gate, so a gated-off run performs no transfers
+// for markers that cannot reach the log.
 static void emit_device_phase_markers(DeviceRunnerBase *runner) {
-    if (!device_profiling_enabled()) return;
+    if (!device_phase_capture_enabled()) return;
     const uint64_t run_wall_ns = runner->last_device_phase_ns(AicpuPhase::RunWall);
     if (run_wall_ns != 0) {
         STRACE_DEV_SPAN_AT("simpler_run.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);

--- a/src/common/platform/onboard/host/device_phase_capture.cpp
+++ b/src/common/platform/onboard/host/device_phase_capture.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "device_phase_capture.h"
+
+#include <cstdlib>
+#include <cstring>
+
+#include "host_log.h"
+#include "profiling_config.h"
+
+bool device_phase_capture_enabled() {
+#if SIMPLER_HOST_STRACE
+    static const bool enabled = [] {
+        const char *v = std::getenv("SIMPLER_DEVICE_STRACE_ENABLE");
+        return v == nullptr || std::strcmp(v, "0") != 0;
+    }();
+    return enabled && HostLogger::get_instance().is_enabled(simpler::log::LogLevel::TIMING);
+#else
+    return false;
+#endif
+}

--- a/src/common/platform/onboard/host/device_phase_capture.h
+++ b/src/common/platform/onboard/host/device_phase_capture.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_PHASE_CAPTURE_H
+#define SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_PHASE_CAPTURE_H
+
+bool device_phase_capture_enabled();
+
+#endif  // SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_PHASE_CAPTURE_H

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1121,7 +1121,7 @@ int DeviceRunnerBase::finalize_common() {
 
     clear_temporary_buffer();
 
-    // Free the 8-byte device_wall buffer (allocated lazily in run()) while
+    // Free the device-phase/task-timing buffer (allocated lazily in run()) while
     // mem_alloc_ and the device context are still live. free_tensor() routes
     // through mem_alloc_.free(), so it must run before mem_alloc_.finalize()
     // and before the subclass's `rtDeviceReset()` tears down the device runtime.
@@ -1228,6 +1228,12 @@ int DeviceRunnerBase::resolve_aicpu_thread_num(int requested, int usable, int ar
 }
 
 void DeviceRunnerBase::ensure_device_wall_buffer() {
+    if (!device_phase_capture_enabled()) {
+        // A null base makes the AICPU stamping helpers no-op.
+        kernel_args_.args.device_wall_data_base = 0;
+        return;
+    }
+
     // Per-thread fixed AICPU phase records (thread-major:
     // AicpuPhaseRecord[NUM_AICPU_PHASES] per launched AICPU thread). Slot
     // AicpuPhase::RunWall keeps the original whole-run wall; the rest subdivide
@@ -1245,11 +1251,9 @@ void DeviceRunnerBase::ensure_device_wall_buffer() {
     constexpr size_t kBytes = device_phase_buffer_bytes(kThreads);
     if (device_wall_dev_ptr_ == nullptr) {
         device_wall_dev_ptr_ = allocate_tensor(kBytes);
-        if (device_wall_dev_ptr_ != nullptr) {
-            kernel_args_.args.device_wall_data_base = reinterpret_cast<uint64_t>(device_wall_dev_ptr_);
-        }
     }
     if (device_wall_dev_ptr_ != nullptr) {
+        kernel_args_.args.device_wall_data_base = reinterpret_cast<uint64_t>(device_wall_dev_ptr_);
         AicpuPhaseRecord init[kRecords];
         for (int i = 0; i < kRecords; ++i) {
             init[i].start_cycle = kPhaseUnset;  // start/dispatch: sentinel so min()/unset-check ignore unused slots
@@ -1381,6 +1385,7 @@ void DeviceRunnerBase::read_device_wall_ns() {
         task_slot_dispatch_ns_[s] = 0;
         task_slot_finish_ns_[s] = 0;
     }
+    if (!device_phase_capture_enabled()) return;
     if (device_wall_dev_ptr_ == nullptr) return;
 
     constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -58,6 +58,7 @@
 #include "common/dma_workspace.h"
 #include "common/chip_swimlane_profiling.h"
 #include "utils/device_arena.h"
+#include "device_phase_capture.h"
 #include "device_runner_helpers.h"
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
@@ -736,13 +737,10 @@ protected:
     int resolve_aicpu_thread_num(int requested, int usable, int arch_default);
 
     /**
-     * Lazy-allocate the 8-byte device-resident buffer that AICPU writes
-     * the run wall (ns) into and that `read_device_wall_ns()` pulls
-     * back after stream sync. Idempotent: a no-op once
-     * `device_wall_dev_ptr_` is non-null. Routes the alloc through
-     * `mem_alloc_`; the pointer is freed by `finalize_common()`.
-     * Failure to alloc is non-fatal (`device_wall_data_base` stays 0,
-     * subsequent `last_device_wall_ns()` reads 0).
+     * Prepare the device-phase/task-timing buffer for one run. Capture-disabled
+     * runs publish a null device base. Capture-enabled runs allocate lazily,
+     * reset every record, and publish the base for AICPU stamping. Allocation or
+     * reset failure is non-fatal; the base stays null and timing reads as 0.
      */
     void ensure_device_wall_buffer();
 
@@ -782,11 +780,9 @@ protected:
     int sync_stream_pair(rtStream_t aicpu_stream, rtStream_t aicore_stream);
 
     /**
-     * Pull the device wall (ns) back from `device_wall_dev_ptr_` and
-     * cache it on `device_wall_ns_`. D2H copy failure is a soft warn —
-     * `device_wall_ns_` stays at 0 so `last_device_wall_ns()` returns 0
-     * to callers. No-op if `device_wall_dev_ptr_` is null (lazy alloc
-     * may have failed silently).
+     * Read and reduce the device-phase/task-timing records after stream sync.
+     * Capture-disabled runs and missing buffers leave all cached timings at 0.
+     * A D2H failure is a soft warning and also leaves timing at 0.
      */
     void read_device_wall_ns();
 
@@ -1047,8 +1043,8 @@ protected:
     // stamps raw sys-counter cycles per phase through that pointer; subclass
     // drain pulls it back via `read_device_wall_ns()` after stream sync and
     // caches the per-phase ns spans for `last_device_phase_ns()` (and RunWall
-    // for `last_device_wall_ns()`). Allocated once at simpler_init, freed in the
-    // subclass `finalize()`.
+    // for `last_device_wall_ns()`). Allocated lazily on the first capture-enabled
+    // run and freed in the subclass `finalize()`.
     void *device_wall_dev_ptr_{nullptr};
     uint64_t device_wall_ns_{0};
     uint64_t device_phase_ns_[NUM_AICPU_PHASES] = {0};

--- a/src/common/task_interface/profiling_config.h
+++ b/src/common/task_interface/profiling_config.h
@@ -16,10 +16,8 @@
 #define SIMPLER_DFX 1
 #endif
 
-// Gate for the host-side `[STRACE]` run-timing trace facility
-// (src/common/log/include/common/strace.h). Separate from SIMPLER_DFX (which
-// gates the device orch/sched markers) so the host trace can be toggled
-// independently; default on, mirroring SIMPLER_DFX.
+// Gate for `[STRACE]` markers and the onboard capture work that exclusively
+// backs device-domain markers. Independent of the SIMPLER_DFX collectors.
 #ifndef SIMPLER_HOST_STRACE
 #define SIMPLER_HOST_STRACE 1
 #endif

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -813,10 +813,43 @@ target_link_libraries(test_host_log_off PRIVATE
 )
 add_test(NAME test_host_log_off COMMAND test_host_log_off)
 
+set(COMMON_PLATFORM_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
+function(add_device_phase_capture_test name host_strace device_strace expected)
+    add_executable(${name}
+        common/test_device_phase_capture.cpp
+        ${COMMON_PLATFORM_DIR}/onboard/host/device_phase_capture.cpp
+        ${SIMPLER_LOG_DIR}/host_log.cpp
+    )
+    target_compile_definitions(${name} PRIVATE
+        SIMPLER_HOST_STRACE=${host_strace}
+        EXPECT_CAPTURE_ENABLED=${expected}
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${COMMON_PLATFORM_DIR}/onboard/host
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+        ${SIMPLER_LOG_DIR}
+        ${SIMPLER_LOG_DIR}/include
+    )
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES
+        ENVIRONMENT "SIMPLER_DEVICE_STRACE_ENABLE=${device_strace}"
+        LABELS "no_hardware"
+    )
+endfunction()
+
+add_device_phase_capture_test(test_device_phase_capture 1 1 1)
+add_device_phase_capture_test(test_device_phase_capture_env_off 1 0 0)
+add_device_phase_capture_test(test_device_phase_capture_compile_off 0 1 0)
+
 # Onboard uses CANN for DEBUG/INFO/WARN/ERROR but keeps TIMING on simpler's
 # finer threshold. The dlog stub makes the CANN levels available without SDK
 # headers or hardware.
-set(COMMON_PLATFORM_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
 add_executable(test_onboard_device_log_level
     common/test_onboard_device_log_level.cpp
     ${COMMON_PLATFORM_DIR}/onboard/aicpu/device_log.cpp

--- a/tests/ut/cpp/common/test_device_phase_capture.cpp
+++ b/tests/ut/cpp/common/test_device_phase_capture.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "device_phase_capture.h"
+#include "host_log.h"
+
+using simpler::log::LogLevel;
+
+namespace {
+
+class DevicePhaseCaptureTest : public testing::Test {
+protected:
+    void TearDown() override { HostLogger::get_instance().set_level(LogLevel::TIMING); }
+};
+
+}  // namespace
+
+TEST_F(DevicePhaseCaptureTest, FollowsTraceGatesAndTimingMarkerVisibility) {
+    HostLogger::get_instance().set_level(LogLevel::TIMING);
+    EXPECT_EQ(device_phase_capture_enabled(), EXPECT_CAPTURE_ENABLED != 0);
+
+    HostLogger::get_instance().set_level(LogLevel::INFO);
+    EXPECT_EQ(device_phase_capture_enabled(), EXPECT_CAPTURE_ENABLED != 0);
+
+    HostLogger::get_instance().set_level(LogLevel::WARN);
+    EXPECT_FALSE(device_phase_capture_enabled());
+
+    HostLogger::get_instance().set_level(LogLevel::ERROR);
+    EXPECT_FALSE(device_phase_capture_enabled());
+
+    HostLogger::get_instance().set_level(LogLevel::NUL);
+    EXPECT_FALSE(device_phase_capture_enabled());
+}


### PR DESCRIPTION
Fixes #1642.

## Problem

Every `simpler_run` performed **three device↔host transfers** around the AICPU device-phase / task-timing buffer, all unconditional:

| # | Op | Dir | a2a3 / a5 |
| - | -- | --- | --------- |
| 1 | `ensure_device_wall_buffer()` H2D reset | H→D | 2496 B / 5824 B |
| 2 | `read_device_wall_ns()` phase-region D2H | D→H | 960 B / 2240 B |
| 3 | `read_device_wall_ns()` task-timing tail D2H | D→H | 1536 B / 3584 B |

The only consumer of the readback is `emit_device_phase_markers()`, which is double-gated (compile-time `SIMPLER_HOST_STRACE` — `STRACE_DEV_SPAN_AT` compiles to nothing when off — and runtime `SIMPLER_DEVICE_STRACE_ENABLE`). The producers were **not** gated: the only guard was "is the buffer allocated", which the lazy allocator makes true for the process lifetime after the first run. No other code reads `last_device_wall_ns` / `last_device_phase_ns` / `last_task_slot_*`. So with device strace disabled, all three transfers ran every run and the data was discarded — per-run latency on the dispatch/decode hot path.

## Fix

Gate the producer on the same condition as the consumer. `device_phase_capture_enabled()` (compile gate ∧ runtime env) is now the **single** predicate both sides share:

- `ensure_device_wall_buffer()` early-returns when capture is off → no allocation, no H2D reset (transfer #1). The buffer stays unallocated, so `KernelArgs::device_wall_data_base` stays `0` and the AICPU stamps nothing — `device_phase_aicpu.h` no-ops at base 0, so **no device-side write is stranded and the chip cannot hang**.
- `read_device_wall_ns()` early-returns when capture is off → no D2H readbacks (transfers #2, #3).
- `emit_device_phase_markers()` now calls the shared predicate instead of its own local `device_profiling_enabled()` env read (single source of truth; also drops the now-unused `<cstdlib>` include).

When capture is **on**, the code path is byte-identical to before (allocate + reset + read + emit).

## Scope

- **Onboard only.** The sim path keeps its own separate gate (its "transfers" are in-process memory writes, not device DMA).
- **Observation 1 of the issue only.** The task-timing tail is still copied when capture is on but no task is tagged (observation 2). That needs a device-written "any task tagged" marker across all four runtime trees + a wire-layout change; split out as #1656.

## Verification

- **Compile:** full from-scratch rebuild of both `a2a3` and `a5` onboard runtimes (host_build_graph + tensormap_and_ringbuffer) — clean. Pre-commit clang-format / clang-tidy / cpplint pass.
- **Onboard hardware:** this box currently reports no detectable silicon (`npu-smi` returns no chip), so the device-behavior check (markers still emitted with capture on; absent with capture off; no regression) is left to CI's `st-onboard-a2a3` / `st-onboard-a5` jobs. The change is correct by construction: with capture on the path is unchanged, and the AICPU null-base no-op is an existing, documented guarantee.