### PR TITLE
Fix: make profiler host-ready hand-off lossless

### DIFF
--- a/docs/dfx/profiling-framework.md
+++ b/docs/dfx/profiling-framework.md
@@ -138,7 +138,7 @@ Owns:
 
 Owns no threads. Every entry point is documented as one of:
 
-- lane-owned SPSC operations (`push_to_ready`, `push_recycled`,
+- lane-owned SPSC operations (`push_to_ready`, `wait_push_to_ready`, `push_recycled`,
   `pop_recycled`, `drain_done_into_recycled`),
 - collector producer operations (`notify_copy_done`, one shard per collector),
 - shared operations with narrow internal locking for blocking waits / mappings
@@ -173,7 +173,8 @@ Provides:
   returns finished buffers through the matching done shard.
 - `poll_and_collect_loop` — per-shard `wait_pop_ready` with a 100 ms cv
   tick, dispatches to `Derived::on_buffer_collected`, then calls
-  `manager_.notify_copy_done(...)` itself; idle-timeout hang detector.
+  `manager_.notify_copy_done(...)` itself; its idle-timeout detector reports
+  stalled traffic but keeps the consumer alive until execution completes.
 - `set_memory_context` / `clear_memory_context` so `Derived::init` can
   stash the alloc/reg/free callbacks before threads start; if init aborts
   before stashing, `start(tf)` becomes a no-op.
@@ -188,9 +189,10 @@ is where the unified algorithms live:
 - `process_entry` — resolve/copy the popped buffer, refill the originating
   free queue only from the current drain shard's local recycled lane, then
   push to the host ready shard. Runtime drain does not allocate and does not
-  consume done shards directly. If the host ready shard is full, the
-  undelivered buffer is retired rather than written to the done shard, keeping
-  the done shard's producer side collector-only.
+  consume done shards directly. If the host ready shard is full, the drain
+  thread retains the buffer and waits until its collector frees a slot. This
+  makes the device-ready pop to host-ready push a lossless hand-off while
+  keeping the done shard's producer side collector-only.
 - `proactive_replenish` — before worker threads start, top every
   (kind, instance) free queue up to `kSlotCount` and optionally warm
   recycled lanes. If recycled is dry while filling free queues it
@@ -326,7 +328,7 @@ Current users:
                               resolve_host_ptr
                               pop recycled[q]
                                 (top up originating free_queue)
-                              push_to_ready(shard q) ─────────► wait_pop_ready(q)
+                              wait_push_to_ready(shard q) ────► wait_pop_ready(q)
                                                                 Derived::on_buffer_collected
                                                                   (copy records out)
                                                                 notify_copy_done(q)

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -235,6 +235,12 @@ public:
         return tail == head;
     }
 
+    bool full() const {
+        uint64_t head = head_.load(std::memory_order_acquire);
+        uint64_t tail = tail_.load(std::memory_order_acquire);
+        return head - tail >= Capacity;
+    }
+
     size_t size() const {
         uint64_t tail = tail_.load(std::memory_order_acquire);
         uint64_t head = head_.load(std::memory_order_acquire);
@@ -602,28 +608,59 @@ public:
             LOG_ERROR("BufferPoolManager: ready queue full for shard=%d capacity=%zu", shard_index, kHostQueueCapacity);
             return false;
         }
-        shard.notify_epoch.fetch_add(1, std::memory_order_release);
+        shard.state_epoch.fetch_add(1, std::memory_order_release);
         shard.cv.notify_one();
         return true;
     }
 
+    /**
+     * Publish one ready buffer, waiting for the collector to free a slot when
+     * the host hand-off ring is full. The caller retains ownership until this
+     * method returns, so a buffer already removed from the device ready queue
+     * can never be retired merely because the host consumer is temporarily
+     * slower than the drain thread.
+     *
+     * The timed tick bounds the impact of a condition-variable lost wakeup
+     * without putting a mutex on the SPSC pop hot path: a missed notification
+     * delays a retry by at most one tick, while every successful pop normally
+     * wakes the producer immediately.
+     */
+    void wait_push_to_ready(const ReadyBufferInfo &info, int shard_index = 0) {
+        auto &shard = ready_shards_[normalize_shard(shard_index)];
+        constexpr auto kRetryTick = std::chrono::milliseconds(100);
+
+        while (!shard.queue.push(info)) {
+            uint64_t seen = shard.state_epoch.load(std::memory_order_acquire);
+            std::unique_lock<std::mutex> lock(shard.wait_mutex);
+            (void)shard.cv.wait_for(lock, kRetryTick, [&shard, seen] {
+                return shard.state_epoch.load(std::memory_order_acquire) != seen || !shard.queue.full();
+            });
+        }
+
+        shard.state_epoch.fetch_add(1, std::memory_order_release);
+        shard.cv.notify_one();
+    }
+
     bool try_pop_ready(ReadyBufferInfo &out, int shard_index = 0) {
         auto &shard = ready_shards_[normalize_shard(shard_index)];
-        return shard.queue.pop(out);
+        if (!shard.queue.pop(out)) return false;
+        shard.state_epoch.fetch_add(1, std::memory_order_release);
+        shard.cv.notify_one();
+        return true;
     }
 
     bool wait_pop_ready(ReadyBufferInfo &out, std::chrono::milliseconds timeout, int shard_index = 0) {
         auto &shard = ready_shards_[normalize_shard(shard_index)];
-        if (shard.queue.pop(out)) return true;
+        if (try_pop_ready(out, shard_index)) return true;
 
-        uint64_t seen = shard.notify_epoch.load(std::memory_order_acquire);
+        uint64_t seen = shard.state_epoch.load(std::memory_order_acquire);
         std::unique_lock<std::mutex> lock(shard.wait_mutex);
         if (!shard.cv.wait_for(lock, timeout, [&shard, seen] {
-                return shard.notify_epoch.load(std::memory_order_acquire) != seen || !shard.queue.empty();
+                return shard.state_epoch.load(std::memory_order_acquire) != seen || !shard.queue.empty();
             })) {
             return false;
         }
-        return shard.queue.pop(out);
+        return try_pop_ready(out, shard_index);
     }
 
     // -------------------------------------------------------------------------
@@ -972,7 +1009,10 @@ private:
         ReadyRing queue;
         std::mutex wait_mutex;
         std::condition_variable cv;
-        std::atomic<uint64_t> notify_epoch{0};
+        // Incremented after every successful push or pop. Both sides use the
+        // epoch to distinguish a real queue-state transition from a spurious
+        // condition-variable wakeup.
+        std::atomic<uint64_t> state_epoch{0};
     };
 
     struct DoneQueueShard {

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -177,8 +177,9 @@
  *
  *   static constexpr int          kIdleTimeoutSec;
  *       Bound on how long the loop sits with no buffers AND no
- *       `execution_complete_` signal before logging an error and exiting
- *       (use the subsystem's PLATFORM_*_TIMEOUT_SECONDS).
+ *       `execution_complete_` signal before logging an error. The collector
+ *       remains alive until execution completes so a blocked drain producer
+ *       always has a consumer (use the subsystem's PLATFORM_*_TIMEOUT_SECONDS).
  *
  *   static constexpr const char*  kSubsystemName;
  *       Used in the idle-timeout log line (e.g. "L2Swimlane", "PMU", "ArgsDump").
@@ -451,9 +452,11 @@ struct ProfilerAlgorithms {
             (void)top_up_free_queue(mgr, site.kind, *site.free_queue, site.buffer_size, q);
         }
 
-        if (!mgr.push_to_ready(site.info, q)) {
-            (void)mgr.retire_unqueued_buffer(site.kind, site.info.dev_buffer_ptr, q);
-        }
+        // The device ready entry was already acknowledged by
+        // try_pop_aicpu_entry(). Keep ownership here until the collector frees
+        // a host-ring slot; retiring on transient host backpressure would make
+        // the buffer unreachable to Derived::on_buffer_collected().
+        mgr.wait_push_to_ready(site.info, q);
     }
 
     // Top up every (kind, instance) free_queue to kSlotCount before worker
@@ -1178,15 +1181,15 @@ private:
     /**
      * Main collector loop. Blocks on one manager ready-queue shard with a 100 ms
      * cv-wait tick. On each hit it dispatches the buffer to Derived via
-     * on_buffer_collected() and recycles the buffer. Exits in two cases:
+     * on_buffer_collected() and recycles the buffer. Exits only after:
      *
-     *   1. execution_complete_ was set (by stop()) and this ready_queue shard is
-     *      empty, after a final non-blocking drain pass.
-     *   2. No buffer arrived for `Derived::kIdleTimeoutSec` consecutive
-     *      seconds AND execution_complete_ has not been signalled — this
-     *      is a hang detector that logs an error and bails out. Multi-shard
-     *      collectors arm this only after a shard has seen traffic, because
-     *      an empty shard can be a valid run shape.
+     *   execution_complete_ was set (by stop()) and this ready_queue shard is
+     *   empty, after a final non-blocking drain pass.
+     *
+     * No buffer for `Derived::kIdleTimeoutSec` after traffic is still reported
+     * as a hang warning, but the consumer stays alive. A later final-drain push
+     * may be blocked on this shard, so exiting before execution_complete_ would
+     * leave the management thread waiting forever.
      */
     void poll_and_collect_loop(int shard_index) {
         const auto wait_tick = std::chrono::milliseconds(100);
@@ -1222,10 +1225,13 @@ private:
             }
             if (std::chrono::steady_clock::now() - idle_start.value() >= idle_timeout) {
                 LOG_ERROR(
-                    "%s collector idle timeout after %d seconds — giving up", Derived::kSubsystemName,
-                    Derived::kIdleTimeoutSec
+                    "%s collector idle timeout after %d seconds — staying alive until execution completes",
+                    Derived::kSubsystemName, Derived::kIdleTimeoutSec
                 );
-                break;
+                // Report once per traffic burst. A newly consumed buffer sets
+                // has_seen_buffer again and re-arms the detector.
+                has_seen_buffer = false;
+                idle_start.reset();
             }
         }
     }

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <future>
 #include <set>
 #include <thread>
 #include <utility>
@@ -324,6 +325,48 @@ TEST(BufferPoolManagerShardingTest, WaitPopReadyWakesOnProducer) {
     EXPECT_EQ(out.dev_buffer_ptr, ptr(0x7000));
     EXPECT_EQ(out.shard_marker, 7u);
     producer.join();
+}
+
+TEST(BufferPoolManagerShardingTest, WaitPushReadyWakesOnConsumerAndPreservesFifo) {
+    using namespace std::chrono_literals;
+    using Manager = profiling_common::BufferPoolManager<TestModule>;
+
+    Manager manager;
+    for (uintptr_t i = 0; i < Manager::kHostQueueCapacity; i++) {
+        ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x1000 + i), static_cast<uint32_t>(i)}, 0));
+    }
+
+    std::promise<void> started_promise;
+    std::future<void> started = started_promise.get_future();
+    std::promise<void> done_promise;
+    std::future<void> done = done_promise.get_future();
+    std::thread producer([&]() {
+        started_promise.set_value();
+        manager.wait_push_to_ready(TestReadyBufferInfo{ptr(0x2000), 99}, 0);
+        done_promise.set_value();
+    });
+
+    EXPECT_EQ(started.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(done.wait_for(20ms), std::future_status::timeout);
+
+    TestReadyBufferInfo first{};
+    EXPECT_TRUE(manager.wait_pop_ready(first, 500ms, 0));
+    EXPECT_EQ(first.dev_buffer_ptr, ptr(0x1000));
+    EXPECT_EQ(first.shard_marker, 0u);
+
+    EXPECT_EQ(done.wait_for(500ms), std::future_status::ready);
+    producer.join();
+
+    TestReadyBufferInfo out{};
+    for (uintptr_t i = 1; i < Manager::kHostQueueCapacity; i++) {
+        ASSERT_TRUE(manager.try_pop_ready(out, 0));
+        EXPECT_EQ(out.dev_buffer_ptr, ptr(0x1000 + i));
+        EXPECT_EQ(out.shard_marker, static_cast<uint32_t>(i));
+    }
+    ASSERT_TRUE(manager.try_pop_ready(out, 0));
+    EXPECT_EQ(out.dev_buffer_ptr, ptr(0x2000));
+    EXPECT_EQ(out.shard_marker, 99u);
+    EXPECT_FALSE(manager.try_pop_ready(out, 0));
 }
 
 TEST(BufferPoolManagerShardingTest, DoneShardsRecycleByKind) {
@@ -804,33 +847,61 @@ TEST(BufferPoolManagerShardingTest, ReplenishRecycledPoolsUsesSlotSizedBatchForS
     manager.clear_mappings();
 }
 
-TEST(BufferPoolManagerShardingTest, ProcessEntryReadyFullDoesNotPublishDoneFromDrainThread) {
+TEST(BufferPoolManagerShardingTest, ProcessEntryWaitsForReadySpaceInsteadOfRetiringBuffer) {
     using Manager = profiling_common::BufferPoolManager<AlgorithmModule>;
+    using namespace std::chrono_literals;
 
     Manager manager;
     AlgorithmHeader header{};
     void *dev_ptr = ptr(0x7000);
     manager.register_mapping(dev_ptr, dev_ptr);
 
+    std::promise<void> copied_promise;
+    std::future<void> copied = copied_promise.get_future();
+    std::atomic<bool> copied_signalled{false};
+    profiling_common::MemoryOps ops;
+    ops.copy_from_device = [&](void * /*host_dst*/, const void *dev_src, size_t /*size*/) {
+        if (dev_src == dev_ptr && !copied_signalled.exchange(true, std::memory_order_acq_rel)) {
+            copied_promise.set_value();
+        }
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, &header, sizeof(header), 0);
+
     ASSERT_TRUE(manager.push_to_ready(AlgorithmReadyBufferInfo{ptr(0x1111), ptr(0x1111)}, 0));
 
-    profiling_common::ProfilerAlgorithms<AlgorithmModule>::process_entry(
-        manager, &header, 0, AlgorithmReadyEntry{reinterpret_cast<uint64_t>(dev_ptr)}
-    );
+    std::promise<void> process_done_promise;
+    std::future<void> process_done = process_done_promise.get_future();
+    std::thread management([&]() {
+        profiling_common::ProfilerAlgorithms<AlgorithmModule>::process_entry(
+            manager, &header, 0, AlgorithmReadyEntry{reinterpret_cast<uint64_t>(dev_ptr)}
+        );
+        process_done_promise.set_value();
+    });
+
+    EXPECT_EQ(copied.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(process_done.wait_for(20ms), std::future_status::timeout);
+
+    AlgorithmReadyBufferInfo first{};
+    EXPECT_TRUE(manager.wait_pop_ready(first, 500ms, 0));
+    EXPECT_EQ(first.dev_buffer_ptr, ptr(0x1111));
+
+    EXPECT_EQ(process_done.wait_for(500ms), std::future_status::ready);
+    management.join();
 
     profiling_common::DoneInfo done{};
     EXPECT_FALSE(manager.try_pop_done(done, 0));
 
     AlgorithmReadyBufferInfo ready{};
     ASSERT_TRUE(manager.try_pop_ready(ready, 0));
-    EXPECT_EQ(ready.dev_buffer_ptr, ptr(0x1111));
+    EXPECT_EQ(ready.dev_buffer_ptr, dev_ptr);
     EXPECT_FALSE(manager.try_pop_ready(ready, 0));
 
     std::vector<void *> released;
     manager.release_owned_buffers([&](void *p) {
         released.push_back(p);
     });
-    EXPECT_EQ(released, (std::vector<void *>{dev_ptr}));
+    EXPECT_TRUE(released.empty());
 }
 
 TEST(BufferPoolManagerShardingTest, BlockBatchCarvesRangeMappingsAndReleasesBaseOnce) {

--- a/tests/ut/cpp/common/test_profiler_base.cpp
+++ b/tests/ut/cpp/common/test_profiler_base.cpp
@@ -107,15 +107,15 @@ using PerThreadModule = TestModuleBase<PLATFORM_MAX_AICPU_THREADS>;
 // many AICPU threads run.
 using SingleShardModule = TestModuleBase<1>;
 
-template <typename Module>
-class TestCollector : public profiling_common::ProfilerBase<TestCollector<Module>, Module> {
+template <typename Module, int IdleTimeoutSeconds = 2>
+class TestCollector : public profiling_common::ProfilerBase<TestCollector<Module, IdleTimeoutSeconds>, Module> {
 public:
-    using Base = profiling_common::ProfilerBase<TestCollector<Module>, Module>;
+    using Base = profiling_common::ProfilerBase<TestCollector<Module, IdleTimeoutSeconds>, Module>;
     using ReadyBufferInfo = typename Module::ReadyBufferInfo;
 
     // Deliberately short: a false-positive idle timeout must fail the test fast
     // rather than stall it.
-    static constexpr int kIdleTimeoutSec = 2;
+    static constexpr int kIdleTimeoutSec = IdleTimeoutSeconds;
     static constexpr const char *kSubsystemName = "TestCollector";
 
     void on_buffer_collected(const ReadyBufferInfo &info, int collector_shard) {
@@ -258,4 +258,28 @@ TEST(ProfilerBaseTest, SilentRunDoesNotTripIdleTimeout) {
 
     collector.stop();
     EXPECT_EQ(collector.collected(), 1);
+}
+
+TEST(ProfilerBaseTest, CollectorStaysAliveAfterArmedIdleTimeout) {
+    using namespace std::chrono_literals;
+
+    TestHeader header{};
+    TestCollector<SingleShardModule, 0> collector;
+    collector.init(2, &header);
+    collector.start(nullptr);
+
+    uint64_t first_buffer = 0;
+    publish(collector, header, 1, &first_buffer);
+    EXPECT_TRUE(wait_for_collected(collector, 1, 5s));
+
+    // Once traffic has armed the idle detector, a zero-second timeout fires on
+    // the next empty poll. The collector must report it without exiting.
+    std::this_thread::sleep_for(250ms);
+
+    uint64_t late_buffer = 0;
+    publish(collector, header, 1, &late_buffer);
+    EXPECT_TRUE(wait_for_collected(collector, 2, 5s));
+
+    collector.stop();
+    EXPECT_EQ(collector.collected(), 2);
 }


### PR DESCRIPTION
## Summary

问题发生在 management thread 向 collector 的 Host ready ring 交接处。旧实现遇到满队列时会 retire 尚未收集的 buffer，导致 dep-gen reconciliation 不完整；新实现保留 buffer 所有权，等待 collector 腾出空位后重试，从而保证交接不丢数据。

### 修改前

```mermaid
flowchart LR
    A["management: process_entry()"] --> B["push_to_ready()"]
    B --> C{"Host ready ring 满？"}
    C -->|否| D["Host ready ring"]
    D --> E["collector 收集"]
    E --> F["reconciliation"]
    F --> G["生成 deps.json"]
    C -->|是| H["retire buffer"]
    H --> I["reconciliation 不完整"]
    I --> J["不生成 deps.json"]
```

### 修改后

```mermaid
flowchart LR
    A["management: process_entry()"] --> B["wait_push_to_ready()"]
    B --> C{"Host ready ring 满？"}
    C -->|否| D["Host ready ring"]
    C -->|是| H["保留 buffer 并等待"]
    H -->|"collector pop 后唤醒并重试"| B
    D --> E["collector 收集"]
    E --> F["reconciliation"]
    F --> G["生成 deps.json"]
```

## 问题

management thread 从 device ready queue 中 pop 并确认一个 entry 后，`process_entry()` 持有该 buffer 唯一仍可访问的副本。旧实现使用非阻塞的 `push_to_ready()`；如果 management 到 collector 之间的 Host ready ring 已满，这个 buffer 会在 `on_buffer_collected()` 收集之前被 retire。

对于 dep-gen，这会导致采集计数无法完成 reconciliation，并在结束阶段阻止 `deps.json` 生成。

## 具体修改

Host ready ring 位于 `src/common/platform/include/host/buffer_pool_manager.h`：

- `BufferPoolManager::ready_shards_` 是 management 到 collector 的全部 Host ready shard 数组。
- 每个 shard 真正的 ring 是 `ready_shards_[normalize_shard(shard_index)].queue`。
- `.queue` 的类型是 `ReadyRing`，即 `SpscRing<ReadyBufferInfo, kReadyQueueCapacity>`。
- 对 dep-gen，`kReadyQueueCapacity` 来自 `DepGenModule::kReadyQueueSize`，当前为 `PLATFORM_DEP_GEN_READYQUEUE_SIZE = 4 * 2 = 8`。
- 本 PR 不扩大这个 ring，而是在 ring 满时等待。

### 1. 增加 Host ready ring 满状态查询

位置：`SpscRing::full()`，文件 `buffer_pool_manager.h`。

- 为什么改：阻塞等待的 predicate 需要在不修改队列的情况下判断 collector 是否已经腾出空位。
- 怎么改：读取 SPSC ring 的 `head_` 和 `tail_`；当 `head - tail >= Capacity` 时返回满。

### 2. 增加阻塞式 publish 和双向唤醒

位置：`BufferPoolManager::wait_push_to_ready()`、`try_pop_ready()` 和 `wait_pop_ready()`，文件 `buffer_pool_manager.h`。

- 为什么改：原来的 `push_to_ready()` 在 ring 满时立即返回 `false`，无法保证已经从 device ready queue 取出的 buffer 最终交给 collector。
- 怎么改：新增 `wait_push_to_ready()`。它循环调用 `shard.queue.push(info)`；失败时保留 `info` 的所有权，并在 `shard.cv` 上等待，直到 ring 状态变化或 `queue.full()` 变为 false，然后重试。
- 将原来的 `notify_epoch` 改为 `state_epoch`。每次成功 push 或 pop 都执行 `state_epoch++` 和 `notify_one()`，因此 producer 与 consumer 都能唤醒对方。
- `try_pop_ready()` 在 collector 成功 pop 后通知等待空间的 producer；`wait_pop_ready()` 统一复用 `try_pop_ready()`，避免遗漏 pop 侧通知。
- 保留 100 ms 定时重试，作为 condition variable 通知丢失时的兜底。

### 3. 删除 `process_entry()` 的丢弃路径

位置：`ProfilerAlgorithms::process_entry()`，文件 `src/common/platform/include/host/profiler_base.h`。

修改前：

```cpp
if (!mgr.push_to_ready(site.info, q)) {
    (void)mgr.retire_unqueued_buffer(site.kind, site.info.dev_buffer_ptr, q);
}
```

修改后：

```cpp
mgr.wait_push_to_ready(site.info, q);
```

- 为什么改：执行到这里时 device ready entry 已经被 `try_pop_aicpu_entry()` pop 并确认。此时 `site.info` 是这个 buffer 唯一仍可到达的所有权路径；retire 会让 collector 永远看不到它。
- 怎么改：management thread 必须等到 Host ready ring 有空间并成功 publish 后，`process_entry()` 才返回。

### 4. collector idle timeout 后继续存活

位置：`ProfilerBase::poll_and_collect_loop()`，文件 `profiler_base.h`。

- 为什么改：如果 collector 因 idle timeout 提前 `break`，后续 final drain 可能在满 Host ready ring 上永久等待，因为已经没有 consumer 负责 pop。
- 怎么改：idle timeout 仍然记录错误，但不再退出循环；它重置本轮 timeout 状态并继续等待。collector 只在 `execution_complete_ == true` 且最终 ready queue 排空后退出。

### 5. 增加回归测试

- `WaitPushReadyWakesOnConsumerAndPreservesFifo`：填满 `ready_shards_[0].queue`，验证 producer 阻塞；collector pop 后 producer 被唤醒，并验证 FIFO 顺序。
- `ProcessEntryWaitsForReadySpaceInsteadOfRetiringBuffer`：验证 `process_entry()` 在满 ring 上等待，新 buffer 最终进入 ready ring，没有进入 done queue，也没有被 release。
- `CollectorStaysAliveAfterArmedIdleTimeout`：验证 collector 报告 idle timeout 后仍能收集晚到的 buffer。
- 同步更新 `docs/dfx/profiling-framework.md` 中的所有权说明和 end-to-end 数据流。

## 为什么选择等待

已关闭的 #1594 使用扩大容量的方案，但这只能推迟溢出发生的时机。Host ring 的容量并不是 final flush 突发量的正确性上界。

保留 buffer 所有权并施加 backpressure，可以确保 device-ready 到 host-ready 的交接不会丢失数据；只要 collector 最终能够继续消费，任意有限突发都可以被完整处理。因此，本 PR 取代 #1594 中基于扩大容量的方案。

## 测试

- `pre-commit run --from-ref origin/main --to-ref HEAD`：通过。
- 完成 C++ 构建，并运行 `ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure`：rebase 到最新 `origin/main` 后 74/74 通过。
- `python -m simpler_setup.build_runtimes --platforms a2a3`：在最终无冲突 rebase 前，`host_build_graph` 和 `tensormap_and_ringbuffer` 均构建通过。
- A2A3 四卡 PyPTO-lib DeepSeek L3 decode：任务 `task_20260803_021153_200471219670`，设备 `0,2,4,6`，EP=4，TP=4，结果为 `[RUN] PASS`。
  - 使用了 `--enable-l2-swimlane`，没有使用 `--enable-dep-gen 0`。
  - 按预期生成 4/4 个非空且可解析的 `rank0..3/d0/deps.json`，合计包含 26,440 个 task 和 92,067 条 edge。
  - 四个 rank 均成功生成 downstream merged swimlane。
  - 观察到 4 次 backpressure trigger 和对应的 4 次 release；未发现 `silent_loss`、队列满导致的 retire、record count mismatch、reconciliation failure 或 fatal error。
  - 本次运行验证 execution 和 DFX 产物完整性；未配置 golden numerical data。

硬件日志没有直接记录是否进入 `wait_push_to_ready()`；该阻塞分支由 C++ 回归测试直接覆盖。