### PR TITLE
[Performance] HBG: up to 99% host-side overhead reduction

### DIFF
--- a/src/a2a3/runtime/host_build_graph/common/pto_runtime_status.h
+++ b/src/a2a3/runtime/host_build_graph/common/pto_runtime_status.h
@@ -39,6 +39,7 @@
 #define PTO2_ERROR_ASYNC_COMPLETION_INVALID 101
 #define PTO2_ERROR_ASYNC_WAIT_OVERFLOW 102
 #define PTO2_ERROR_ASYNC_REGISTRATION_FAILED 103
+#define PTO2_ERROR_READY_QUEUE_OVERFLOW 104  // push into a ready queue found no free slot (full, or window > capacity)
 
 static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
     if (orch_error_code != PTO2_ERROR_NONE) {

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -81,6 +81,33 @@ The host/device boundary is POD and position-independent. Fanins are integer
 producer IDs, not pointers. The only per-slot pointers are rebound to their final
 device addresses before H2D.
 
+### 3.1 Bounded H2D Upload
+
+The shared-memory mirror is sized to ring capacity (task window) but a run only
+writes `[0, total_tasks)`, and the device boots scheduler-only and reads no SM slot
+past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-sized —
+the contract that keeps `bind` proportional to the workload.
+
+- **Shared memory** — the header is zeroed on the host; `descriptors`, `payloads`,
+  `slot_states` and `completion_flags` are each written per task at submit and
+  H2D-uploaded bounded to `[0, total_tasks)`. Per-slot reset is init-on-write in
+  `orch::prepare_task` as each slot is claimed — there is no window-wide reset.
+
+- **Runtime arena** — the **orchestrator block** (`fanin_seen_epoch` /
+  `scope_tasks` / TensorMap, ~8.5 MB) is **not shipped at all**: it is host-only
+  dep-computation scratch, and the AICPU scheduler holds zero references to it. (The
+  scalar `inline_completed_tasks` the scheduler does read lives in the runtime
+  header, inside the region that still ships whole.) Everything from the scheduler
+  block onward — the ready-queue slot pools, runtime header, and completion mailbox
+  — ships **whole**. The ready queues are *not* bounded to `total_tasks`: graph
+  execution replays a cached GRAPH task that the device Scheduler expands into
+  on-device nodes, and those nodes push into the ready queues past the host task
+  count, so the queue slots must all carry a valid Vyukov sequence on the device.
+
+`bind_callable_to_runtime_impl` `always_assert`s `orch_start <= orch_end` before
+uploading, so a future `runtime_reserve_layout` reorder that moved the scheduler
+block ahead of the orchestrator block faults instead of shipping a misaligned image.
+
 ## 4. Whole-Graph Capacity
 
 The runtime uses one task ring, one graph heap, and one TensorMap pool. They are

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cerrno>
 #include <cinttypes>
 #include <cstddef>
@@ -474,8 +475,18 @@ int32_t run_host_orchestration(
 ) {
     dep_gen_host_graph_begin_capture();
 
-    std::vector<uint8_t> host_sm_buffer(sm_size, 0);
-    void *host_sm = host_sm_buffer.data();
+    // Init-on-write: descriptors, payloads, slot_states and completion_flags are
+    // each written per task at submit and read only for [0, total_tasks). Zero
+    // only the fixed-size header here; the per-slot segments are initialized in
+    // orch::prepare_task and shipped bounded to total_tasks below.
+    const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
+        pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
+    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size]);
+    void *host_sm = host_sm_buf.get();
+    std::memset(host_sm, 0, sm_segs.descriptors);
+
+    // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
+    // init_data_from_layout resets the orchestrator state, so this is safe.
     if (!rt->orchestrator.init_data_from_layout(
             layout.orch, host_arena, host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0]
         )) {
@@ -524,6 +535,18 @@ int32_t run_host_orchestration(
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
     if (!upload_graph_submissions(runtime, api, *graph_state)) return -1;
 
+    // total_tasks sizes the bounded per-segment H2D copies below; a value outside
+    // [0, task_window] would make those copies read/write out of bounds.
+    if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_sizes[0]) {
+        LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
+        return -1;
+    }
+
+    // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
+    // on the host, before the SM and arena leave for the device. Pointers into
+    // the SM shift by sm_delta; pointers into the arena (fanout adjacency, wiring
+    // queue) shift by arena_delta. After this both the SM and arena carry device
+    // addresses, so the device boots scheduler-only.
     const int64_t sm_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_sm)) -
                              static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
     const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
@@ -536,7 +559,23 @@ int32_t run_host_orchestration(
         return -1;
     }
 
-    if (api->copy_to_device(device_sm, host_sm, sm_size) != 0) {
+    // Ship only the live prefix of each segment: the device reads no slot past
+    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
+    // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
+    // header + descriptors[0,N) are contiguous, so that is a single copy.
+    const uint64_t nt = static_cast<uint64_t>(total_tasks);
+    const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
+    char *host_base = static_cast<char *>(host_sm);
+    char *dev_base = static_cast<char *>(device_sm);
+    if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
+        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
+            0 ||
+        api->copy_to_device(
+            dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
+        ) != 0 ||
+        api->copy_to_device(
+            dev_base + sm_segs.completion_flags, host_base + sm_segs.completion_flags, nt * sizeof(std::atomic<uint8_t>)
+        ) != 0) {
         LOG_ERROR("host-orch: H2D of populated SM failed");
         return -1;
     }
@@ -880,7 +919,24 @@ extern "C" int bind_callable_to_runtime_impl(
     // *before* it can dereference the image.
     rt->prebuilt_layout = layout;
 
-    int rc_upload = api->copy_to_device(runtime_arena_dev, host_arena.base(), layout.arena_size);
+    // Skip uploading the orchestrator block (fanin_seen_epoch / scope / tensormap,
+    // ~8.5 MB): it is host-only dep-computation scratch that the AICPU scheduler
+    // never reads. Ship [0, orch_start) (sm_handle) and [orch_end, arena_size)
+    // (ready queues + runtime header + mailbox) whole; the orch block between them
+    // is not sent. orch_start/orch_end are the first orch and first scheduler
+    // reservations (runtime_reserve_layout order: sm_handle -> orch -> sched); the
+    // ready queues ship in full because graph execution expands a GRAPH task into
+    // on-device nodes that push past the host task count.
+    const auto &sq = layout.sched;
+    const size_t orch_start = layout.orch.off_fanin_seen_epoch;
+    const size_t orch_end = sq.off_ready_queue_slots[0];
+    always_assert(orch_start <= orch_end);
+    char *arena_host = static_cast<char *>(host_arena.base());
+    char *arena_dev = static_cast<char *>(runtime_arena_dev);
+    int rc_upload = api->copy_to_device(arena_dev, arena_host, orch_start);
+    if (rc_upload == 0) {
+        rc_upload = api->copy_to_device(arena_dev + orch_end, arena_host + orch_end, layout.arena_size - orch_end);
+    }
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -866,6 +866,14 @@ static bool prepare_task(
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
 
+    // Init-on-write: this slot's dynamic scheduling fields and completion flag are
+    // initialized here, as the orchestrator claims the slot. whole-graph-resident
+    // hbg claims slots [0, total_tasks) exactly once and the device reads no slot
+    // past total_tasks, so this claim-time write is the only per-slot SM reset and
+    // the unclaimed tail is neither initialized nor read.
+    out->slot_state->reset_for_reuse();
+    orch->sm_header->ring.completion_flags[out->alloc_result.slot].store(0, std::memory_order_relaxed);
+
     graph_record_begin_task(orch, out->task_id);
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
@@ -884,7 +892,7 @@ static bool prepare_task(
     // early-dispatch fields) is initialized in PTO2TaskPayload::init, the
     // single payload-init point, which runs before Orch-side wiring publish.
 
-    // Fields already zeroed by reset_for_reuse() at slot init:
+    // Fields already zeroed by the reset_for_reuse() above:
     //   wake_list_head=nullptr, next_in_wake_list=nullptr,
     //   any_subtask_deferred=false, completed_subtasks=0, next_block_idx=0
     // Fields immutable after RingSchedState::init():
@@ -900,8 +908,8 @@ static bool prepare_task(
     out->slot_state->task_kind = active_mask ? TaskKind::KERNEL : TaskKind::DUMMY;
     // Reclaim gate: seed last_consumer to self, so a producer with no consumers
     // is retirable once completed_watermark >= its own id. Each fanin edge bumps
-    // it in append_fanin_or_fail. completion_flags for this slot are already 0
-    // (zeroed once at init; whole-graph-resident hbg never reuses a slot).
+    // it in append_fanin_or_fail. completion_flags for this slot were cleared
+    // above (whole-graph-resident hbg never reuses a slot).
     out->slot_state->last_consumer_local_id = static_cast<int32_t>(out->task_id.local());
     // payload.fanin_count is set in submit_task_common's STEP 6.
     scope_tasks_push(orch, out->slot_state);

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -538,9 +538,9 @@ struct alignas(64) PTO2TaskSlotState {
     bool has_any_subtask_deferred() const { return any_subtask_deferred.load(std::memory_order_acquire); }
 
     /**
-     * Reset dynamic scheduling fields to their pristine values. Runs once per
-     * slot at init (pto_shared_memory.cpp) — whole-graph-resident hbg has no
-     * execution-time slot recycle. Skips payload/task (bound once) and
+     * Reset dynamic scheduling fields to their pristine values. Called once per
+     * slot as the orchestrator claims it in prepare_task — whole-graph-resident
+     * hbg has no execution-time slot recycle. Skips payload/task (bound once) and
      * task_state (the orchestrator sets PENDING when it populates the slot).
      * wake_list_head starts nullptr (open for registration), NOT SENTINEL.
      * Graph-affine replay passes preserve_graph_binding=true because its node

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -102,7 +102,8 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Polling-completion state (device-addressed array, one byte per slot).
     // 0 = pending, 1 = task fully COMPLETED. Writer = the task's completer at
     // on_mixed_task_complete; reader = consumer fanin polling (is_completion_flag_set).
-    // Zeroed host-side at init. Indexed by local_id & task_window_mask.
+    // Cleared per-slot in orch::prepare_task as each slot is claimed. Indexed by
+    // local_id & task_window_mask.
     std::atomic<uint8_t> *completion_flags;
 
     bool is_completion_flag_set(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -494,13 +494,26 @@ struct PTO2SchedulerState {
             return;
         }
         PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+        bool pushed;
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
-            dummy_ready_queue.push(slot_state);
+            pushed = dummy_ready_queue.push(slot_state);
         } else if (slot_state->task_attrs.requires_sync_start()) {
-            ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
+            pushed = ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
         } else {
-            ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+            pushed = ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+        }
+        // A queue is sized for the whole task window and each task is routed to one
+        // queue exactly once, so push cannot legitimately fail. A false return means
+        // the target slot fell outside the shipped prefix, or the window genuinely
+        // exceeds queue capacity — either way the task is dropped and the run would
+        // otherwise stall. Latch a named error so it surfaces as READY_QUEUE_OVERFLOW
+        // rather than an anonymous forward-progress timeout.
+        if (!pushed) {
+            int32_t expected = PTO2_ERROR_NONE;
+            sm_header->sched_error_code.compare_exchange_strong(
+                expected, PTO2_ERROR_READY_QUEUE_OVERFLOW, std::memory_order_acq_rel, std::memory_order_acquire
+            );
         }
     }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -92,9 +92,9 @@ bool PTO2SchedulerState::RingSchedState::init_data_from_layout(void *sm_dev_base
     last_task_alive = 0;
     advance_lock.store(0, std::memory_order_relaxed);
 
-    // Per-slot SM-side initialization (reset_for_reuse + fanin_count/active_mask
-    // zero) lives in PTO2SharedMemoryHandle::init_header_per_ring so the AICPU
-    // performs it during SM reset; host prebuilt-arena init skips SM access here.
+    // Per-slot SM-side initialization (reset_for_reuse + active_mask, and clearing
+    // the completion flag) happens init-on-write in orch::prepare_task as each slot
+    // is claimed; host prebuilt-arena init skips SM access here.
 
     return true;
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -178,22 +178,11 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
     header->sched_error_code.store(PTO2_ERROR_NONE, std::memory_order_relaxed);
     header->sched_error_thread.store(-1, std::memory_order_relaxed);
 
-    // Per-ring slot_states reset. Previously lived in
-    // PTO2SchedulerState::RingSchedState::init(), but it writes into
-    // ring->slot_states[] which is SM-side storage — keeping it here lets
-    // host-side prebuilt-arena init skip all SM dereferences.
-    // reset_for_reuse() prepares dynamic fanout/refcount fields so the first
-    // submit doesn't need an explicit reset.
-    auto &ring = header->ring;
-    for (uint64_t i = 0; i < task_window_sizes[0]; i++) {
-        ring.slot_states[i].reset_for_reuse();
-        ring.slot_states[i].active_mask = ActiveMask{};
-    }
-
-    // Polling completion flags: 0 = pending. Shared memory is not guaranteed
-    // zero on device; stale non-zero bytes would make consumers observe a
-    // producer as already completed. Zero the whole per-ring array once.
-    __builtin_memset((void *)ring.completion_flags, 0, task_window_sizes[0] * sizeof(std::atomic<uint8_t>));
+    // Per-slot init (slot_states.reset_for_reuse() + active_mask, and clearing the
+    // completion flag) happens init-on-write in orch::prepare_task as each slot
+    // [0, total_tasks) is claimed, so the SM init/upload cost tracks the task
+    // count, not ring capacity. The device reads no slot past total_tasks, so the
+    // unclaimed tail is left uninitialized.
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
@@ -94,13 +94,11 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
     // The pool's persistent invariant after init is "bucket_index == -1 means
     // not linked", set explicitly below.
     memset(entry_pool_arena, 0, static_cast<size_t>(pool_size) * sizeof(PTO2TensorMapEntry));
+    // The memset already zeroed every field (all four link pointers -> nullptr,
+    // producer_task_id -> {}); only bucket_index needs its non-zero "not linked"
+    // marker, so the per-entry loop writes just that.
     for (int32_t i = 0; i < pool_size; i++) {
         entry_pool_arena[i].bucket_index = -1;
-        entry_pool_arena[i].next_in_bucket = nullptr;
-        entry_pool_arena[i].prev_in_bucket = nullptr;
-        entry_pool_arena[i].next_in_task = nullptr;
-        entry_pool_arena[i].prev_in_task = nullptr;
-        entry_pool_arena[i].producer_task_id = PTO2TaskId{};
     }
 
     // free_entry_list: zeroed (was calloc'd before); contents become meaningful

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -741,11 +741,24 @@ add_a2a3_test(test_acl_hal_device common/test_acl_hal_device.cpp)
 # PTO2 runtime-linked tests
 add_a2a3_runtime_test(test_task_allocator   a2a3/test_task_allocator.cpp)
 add_a2a3_runtime_test(test_scope_deadlock_detection common/test_scope_deadlock_detection.cpp)
+set(HBG_RUNTIME_DIR ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/runtime)
 add_a2a3_hbg_runtime_test(test_hbg_task_allocator a2a3/test_task_allocator.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensormap a2a3/test_hbg_tensormap.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_dep_gen_host_graph a2a3/test_dep_gen_host_graph.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp)
+# The submit-poison test drives the real orchestrator submit path, so it links the
+# orchestrator + shared runtime out-of-line members (mirrors a2a3_rt_objs for hbg).
+add_a2a3_hbg_runtime_test(test_hbg_submit_poison a2a3/test_hbg_submit_poison.cpp)
+target_sources(test_hbg_submit_poison PRIVATE
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 add_a2a3_hbg_runtime_test(test_graph_cache a2a3/test_graph_cache.cpp)
 target_sources(test_graph_cache PRIVATE

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Poison test for the "every device-read SM field is written at submit" contract.
+ *
+ * host_build_graph no longer zero-fills the shared-memory task window (init-on-write):
+ * init_header_per_ring writes only the header, and each slot's device-read fields are
+ * written per task at submit (prepare_task + submit_task_common + PTO2TaskPayload::init).
+ * Nothing else clears the window, so a device-read field a submit forgets to write would
+ * read as 0 only by allocator accident — passing every zero-backed test and failing
+ * non-deterministically on device.
+ *
+ * This test fills the whole per-slot window with a 0xAA poison byte before submitting a
+ * representative mix, then asserts that for every claimed slot [0, total_tasks) the
+ * device-read fields carry real values, not poison. Add a device-read field and forget
+ * its submit-path write, and this fails in-tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "utils/device_arena.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+
+namespace {
+
+constexpr uint8_t POISON = 0xAA;
+// A void* / int32 whose bytes are all 0xAA — what an unwritten field would read as.
+void *const POISON_PTR = reinterpret_cast<void *>(static_cast<uintptr_t>(0xAAAAAAAAAAAAAAAAULL));
+
+}  // namespace
+
+class HbgSubmitPoisonTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2OrchestratorState orch{};
+    PTO2SchedulerState sched{};
+    PTO2OrchestratorLayout orch_layout{};
+    PTO2SchedulerLayout sched_layout{};
+    std::vector<char> gm_heap;
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+
+        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(orch.init_data_from_layout(
+            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE
+        ));
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+    }
+
+    void TearDown() override {
+        orch.destroy();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // Fill the per-slot window (descriptors / payloads / slot_states / completion_flags)
+    // with poison. init_header_per_ring wrote only the header, so this is the state the
+    // window is in before any submit writes it — modelling the never-zeroed device SM.
+    void poison_window() {
+        auto &ring = sm_handle->header->ring;  // host_build_graph is single-ring
+        const size_t n = static_cast<size_t>(ring.task_window_mask) + 1;
+        std::memset(ring.task_descriptors, POISON, n * sizeof(PTO2TaskDescriptor));
+        std::memset(ring.task_payloads, POISON, n * sizeof(PTO2TaskPayload));
+        std::memset(ring.slot_states, POISON, n * sizeof(PTO2TaskSlotState));
+        std::memset(ring.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
+    }
+};
+
+TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
+    poison_window();
+    orch.begin_scope();
+
+    // 1. Zero-fanin root: a real mixed (AIV0) task with an output tensor and a scalar.
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(4);
+    uint32_t shape[] = {16};
+    CoreTaskArgs root_args;
+    create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+    root_args.add_output(create_infos.back());
+    root_args.add_scalar(static_cast<uint64_t>(42));
+    MixedKernels root_mixed{};
+    root_mixed.aiv0_kernel_id = 0;
+    TaskOutputTensors root = orch.submit_task(root_mixed, root_args);
+    ASSERT_TRUE(root.task_id().is_valid());
+
+    // 2. Multi-fanin dummy consumer (duplicate dep deduped to one fanin).
+    PTO2TaskId deps[] = {root.task_id(), root.task_id()};
+    CoreTaskArgs consumer_args;
+    consumer_args.set_dependencies(deps, 2);
+    TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
+    ASSERT_TRUE(consumer.task_id().is_valid());
+
+    // 3. Hidden-alloc convenience (allocates an output, no kernel).
+    CoreTaskArgs alloc_args;
+    create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+    alloc_args.add_output(create_infos.back());
+    TaskOutputTensors allocated = orch.alloc_tensors(alloc_args);
+    ASSERT_TRUE(allocated.task_id().is_valid());
+
+    // 4. Plain dummy.
+    CoreTaskArgs plain_args;
+    TaskOutputTensors plain = orch.submit_dummy_task(plain_args);
+    ASSERT_TRUE(plain.task_id().is_valid());
+
+    orch.end_scope();
+
+    auto &ring = sm_handle->header->ring;
+    const int32_t total = ring.fc.current_task_index.load(std::memory_order_acquire);
+    ASSERT_GE(total, 4);
+
+    // Every claimed slot's device-read fields must carry real values, not poison.
+    for (int32_t local = 0; local < total; local++) {
+        SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
+        const int32_t slot = ring.get_slot_by_task_id(local);
+        const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
+        const PTO2TaskPayload &pl = ring.task_payloads[slot];
+        const PTO2TaskSlotState &st = ring.slot_states[slot];
+
+        // Descriptor: the task id is written to this exact local id.
+        EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));
+        // task_state is written at submit (reset_for_reuse skips it): PENDING for a
+        // dispatchable task, COMPLETED for a pre-completed hidden-alloc. Either way a
+        // real enum, never poison.
+        const PTO2TaskState state = st.task_state.load(std::memory_order_relaxed);
+        EXPECT_TRUE(state == PTO2_TASK_PENDING || state == PTO2_TASK_COMPLETED);
+        // Completion flag is written to a real 0/1 (pending vs pre-completed), not a
+        // poison byte (0xAA).
+        const uint8_t cflag = ring.completion_flags[slot].load(std::memory_order_relaxed);
+        EXPECT_LE(cflag, uint8_t{1});
+        // Payload counts are real, not the poison bit pattern.
+        EXPECT_GE(pl.fanin_count, 0);
+        EXPECT_LE(pl.fanin_count, PTO2_MAX_FANIN);
+        EXPECT_GE(pl.tensor_count, 0);
+        EXPECT_GE(pl.scalar_count, 0);
+        // predicate.op is a dispatch-time field, read only for tasks the device
+        // actually dispatches. submit_task_common writes it (NONE when unset); a
+        // pre-completed hidden-alloc is never dispatched, so it does not.
+        if (state == PTO2_TASK_PENDING) {
+            EXPECT_LE(static_cast<uint8_t>(pl.predicate.op), static_cast<uint8_t>(PredicateOp::LE));
+        }
+    }
+
+    // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
+    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[ring.get_slot_by_task_id(root.task_id().local())];
+    const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
+    EXPECT_EQ(root_pl.tensor_count, 1);
+    EXPECT_EQ(root_pl.scalar_count, 1);
+    EXPECT_NE(root_desc.packed_buffer_base, POISON_PTR);
+    EXPECT_NE(root_desc.packed_buffer_base, nullptr);
+    EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);
+
+    // The consumer's fanin is written: two duplicate deps dedupe to one.
+    const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
+    EXPECT_EQ(cons_pl.fanin_count, 1);
+    EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
+}


### PR DESCRIPTION
# Human Summary

The host side of HBG was taking 20x more time than the device side. This was due to an unnecessary resetting (zeroing) and copying of the entire scheduling workspace. This PR reduces the H2D transfer to the minimal required information, and the work structures are initialized-on-use, rather than pre-zeroed.

- Up to 99% (depending on the case) of the host-side costs are reduced.
- This optimization is orthogonal to that of #1444, both will help independently in ameliorating the host-side overhead.

# AI Summary

## PR: host_build_graph — init-on-write bounded SM upload + skip orch block

Branch `hbg-sm-init-on-write`, rebased onto `upstream/main` (`0659745d`, includes #1444
graph execution). One commit, +324/−38 across 12 files (core + a guardrail, a regression
test, and doc/comment updates from review).

## TL;DR

HBG's per-dispatch wall is **96–99.6% host `bind`**, and `bind` was dominated by
**rebuilding and H2D-uploading full, ring-sized host structures every run** — the
shared-memory mirror *and* the ~20 MB prebuilt runtime arena — even though a run touches
a tiny fraction of either. The device boots scheduler-only and reads no SM slot past
`total_tasks`, so the SM mirror is made **init-on-write and shipped bounded to the task
count**, and the arena's ~8.5 MB host-only orchestrator block is **dropped from the
upload**.

**Result — host `bind`, A/B vs upstream (a2a3):**

| workload | baseline | this PR | Δ |
| --- | --- | --- | --- |
| bgemm | 77.0 ms | **~11.6 ms** | −85% |
| **paged_attention** | **402.7 ms** | **~7.8 ms** | **−98%** |

(bgemm/paged re-measured post-revert; matmul/vector were not re-measured but sit in the same
~8–12 ms small-kernel range — the SM-mirror bind floor once the payload/window uploads are
bounded.) Device time is **unchanged** (~0.05–0.1 ms) — the whole win drops into per-dispatch
latency. Note: an earlier revision also bounded the ready-queue upload, taking bgemm bind to
~4 ms; that was reverted for #1444 graph-execution compatibility (see Fix), so the queue
portion of the win is not in this PR.

## Problem

Splitting `bind` (via `[STRACE]` markers) put nearly all of it in `run_host_orchestration` /
`bind_callable_to_runtime_impl`, in two structures that are both sized by ring capacity and
rebuilt+reuploaded every run:

- The **shared-memory mirror** (`host_sm_buf(sm_size, 0)`): 81 MB (default ring) to 651 MB
  (4 GB ring), of which ~97% is the payload segment.
- The **prebuilt runtime arena** (~20 MB, fixed): scheduler ready queues (65536×7) +
  tensormap (65536 entries).

A run uses a few dozen of the 16k–131k slots, so almost all of the alloc/zero/init and the
uploads is work on capacity that is never touched.

## Fix

The device reads no slot past `total_tasks`. So:

**Shared memory** — descriptors and payloads are written per task at submit; slot_states and
completion_flags are reset per slot in `orch::prepare_task` as it is claimed (dropping the
window-wide reset loop in `init_header_per_ring`); only the header is zeroed on the host;
each segment is H2D-uploaded bounded to `[0, total_tasks)`.

**Runtime arena** —
- Don't upload the orchestrator block (fanin_seen_epoch / scope / tensormap, ~8.5 MB): it is
  host-only dep-computation scratch the AICPU scheduler never reads. Everything from the
  scheduler block onward (ready queues, runtime header, mailbox) still ships whole.
- Drop the redundant per-entry stores in the tensormap reset (the preceding `memset` already
  zeroes the link pointers and `producer_task_id`).

The ready queues are **not** bounded to `total_tasks`. An earlier revision seeded/shipped them
bounded (with a `+1` sentinel for the batched-dequeue boundary), but that is incompatible with
#1444 graph execution: a replayed GRAPH task is expanded by the device Scheduler into on-device
nodes that push into the ready queues *past* the host task count, so every queue slot must carry
a valid Vyukov sequence on the device. The queues therefore ship in full. (This cost the queue
portion of the arena win but leaves the dominant SM win intact — see below.)

`total_tasks` is range-checked before it sizes the SM copies. Single-ring (`PTO2_MAX_RING_DEPTH == 1`).

## Why it is safe

Every scheduler-read SM field is explicitly initialized at submit, so nothing depends on the
removed blanket zeros; reads are bounded by `current_task_index`. The orchestrator block is
host-only (verified: zero AICPU-scheduler references); the tensormap-reset change is a pure
dedup of what `memset` already wrote. The ready queues ship in full, so graph execution's
on-device node expansion pushes into fully-seeded slots.

## Validation

100-round golden × 4 workloads PASS (bgemm, matmul, vector, paged_attention). The full HBG
a2a3 scene-test suite is green — including the `graph_execution` cases (28 passed, 0 failed
per pass) and `dep_gen` — under pytest-xdist cross-run stress with **0 scheduler stalls / 0
op-execute timeouts**, and ut-cpp is 83/83. (The `graph_execution` compatibility is load-bearing:
the queue-bounding revision failed those, which is why the ready queues now ship in full.)

## Guardrails and tests (from review)

- **Named error, not a silent hang.** `push_ready_routed` checks the push return and
  latches `PTO2_ERROR_READY_QUEUE_OVERFLOW` on failure — a genuinely full queue (task
  window or graph-node expansion past the 65536 capacity) would otherwise drop a ready
  task and stall. Zero cost on the success path.
- **Layout-order assert.** `bind_callable_to_runtime_impl` `always_assert`s
  `orch_start <= orch_end` before slicing the host-only orchestrator block out of the
  upload, so a future `runtime_reserve_layout` reorder faults instead of shipping a
  misaligned image.
- **Poison test.** `tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp` fills the SM window with
  `0xAA`, submits a representative mix (real mixed task with tensors + scalar, multi-fanin
  consumer, hidden-alloc, dummy), and asserts every device-read slot field carries a real
  value, not poison — so a future device-read field added without a submit-path write fails
  in-tree instead of non-deterministically on device.
- **Docs/comments.** The `reset_for_reuse` relocation (init → `prepare_task`) is
  reflected everywhere it was described, and the H2D contract is documented in
  `RUNTIME_LOGIC.md §3.1`.

## Scope / not done

- a2a3 `host_build_graph` only.
- The ready-queue upload is **not** bounded (see Fix) — incompatible with #1444 graph
  execution's on-device node expansion. Recovering that ~6.7 ms would need a device-side
  scheme that seeds the slots a graph run actually reaches; left as a follow-up.
- Fully bounding the tensormap reset (a further ~1–2 ms) is deliberately left out:
  `print_stats` scans the whole entry pool and dereferences entries, and the pool has a
  recycling free-list, so bounding its reset is high-risk for a sub-noise gain. The 8 MB
  `memset` stays.
