### PR TITLE
Add: protect args dump arena reuse with backpressure

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -379,7 +379,9 @@ DumpBufferState[num_dump_threads]               (per-thread)
 ├── current_buf_ptr            (AICPU active DumpMetaBuffer*)
 ├── current_buf_seq
 ├── arena_base / arena_size    (per-thread arena pointers)
-├── arena_write_offset         (AICPU monotonic cursor)
+├── arena_write_offset         (AICPU cursor in the current arena reuse cycle)
+├── published_payload_count    (payloads committed to Host through RQ entries)
+├── completed_payload_count    (published watermark acknowledged by Host)
 └── dropped_record_count
 
 DumpMetaBuffer pool (rotated)                   (BUFFERS_PER_THREAD per thread)
@@ -581,21 +583,19 @@ deviation from §5.4 is the **transport channel**: a5 has no
 host-shadow `malloc()` and the mgmt loop synchronizes the two via
 `profiling_copy.h` (`rtMemcpy` onboard, `memcpy` in sim).
 `MemoryOps` therefore carries five callbacks (`alloc` / `reg` /
-`free_` / `copy_to_device` / `copy_from_device`); the mgmt loop
-mirrors the entire shm region (`DumpDataHeader` + per-thread
-`DumpBufferState`) device → host at the top of every tick, then
-pushes back only the fields host modified (advanced
-`queue_heads[q]`, refilled `free_queue.tail` and
-`buffer_ptrs[slot]`) via `BufferPoolManager::write_range_to_device`.
-The bulk `mirror_shm_to_device` is **not** called from the mgmt
-loop: it would race with AICPU writes to device-only fields
-(`current_buf_ptr`, `total/dropped` counters, `queue_tails`,
-`free_queue.head`) and roll them back. Each popped
-`DumpMetaBuffer` is still pulled on demand inside
-`ProfilerAlgorithms::process_entry`. The per-thread arena lives
-outside the shm region, so `on_buffer_collected` issues an
-additional `copy_from_device` for the arena bytes referenced by
-the buffer's records.
+`free_` / `copy_to_device` / `copy_from_device`). The mgmt threads
+pull queue indices and ready entries on demand, then push back only
+the fields host modified (advanced `queue_heads[q]`, refilled
+`free_queue.tail` and `buffer_ptrs[slot]`) via
+`BufferPoolManager::write_range_to_device`. Each popped
+`DumpMetaBuffer` is pulled inside `ProfilerAlgorithms::process_entry`.
+The per-thread arena lives outside the shm region, so
+`on_buffer_collected` separately refreshes `arena_write_offset` and
+copies the arena bytes. The freeze-release predicate refreshes each
+thread's `published_payload_count` before comparing their sum with the
+single host writer's completed payload count. Once equal, Host writes each
+thread's published watermark back as `completed_payload_count`; AICPU requires
+this acknowledgement before reusing that thread's arena.
 
 ```text
         HOST                                         DEVICE
@@ -614,8 +614,8 @@ the buffer's records.
 │   split mgmt starts      │               │   wait FIN               │
 │   collector shards start │               │   AFTER_COMPLETION       │
 │                          │               │     dump_arg_record()    │
-│ mgmt every 10us tick:    │               │   if buffer full:        │
-│   copy_from_device(shm)  │<──memcpy─────<│     push ready entry,    │
+│ mgmt polling:            │               │   if buffer full:        │
+│   refresh queue fields   │<──memcpy─────<│     push ready entry,    │
 │   for each ready entry:  │               │     pop next from free_q │
 │     copy buf from device │<──memcpy─────<│                          │
 │     resolve host ptr     │               │ dump_args_flush():       │
@@ -720,9 +720,10 @@ device.
 
 ## 7. Limitations
 
-Three failure modes exist when dump buffers run out of space. All
-three surface in the JSON manifest plus the `dump_args_flush`
-log line so users can detect and diagnose them.
+Three pressure or failure conditions exist when dump buffers run out
+of space. Successful arena backpressure preserves payload; truncation
+and record discard surface in the JSON manifest plus the
+`dump_args_flush` log line so users can detect and diagnose them.
 
 ### 7.1 Truncation (`truncated = true`)
 
@@ -750,73 +751,32 @@ contiguous), enough for statistical sampling.
 proportionally) so the arena is at least as large as the biggest
 tensor you need to inspect.
 
-### 7.2 Overwrite (`overwritten = true`)
+### 7.2 Arena payload freeze release
 
-**Trigger:** the circular arena wraps around and AICPU writes new
-payload data over a region whose metadata record has already been
-emitted but whose payload has not yet been consumed by the host.
+`arena_write_offset` remains monotonic and physical writes use `% arena_size`.
+Before reserving an offset or copying payload bytes, AICPU checks whether the
+arena is already one full physical cycle deep or whether the new payload would
+cross the physical end. If so, it seals/publishes the current metadata buffer
+and opens the existing freeze.
 
-**a2a3 mechanism:** the arena is a monotonic-offset circular buffer.
-`arena_write_offset` grows without bound; the actual write position
-is `offset % arena_size`. When the host processes a record it
-compares the record's `payload_offset` against a high-water mark:
-
-```text
-high_water = max payload_offset seen so far (maintained per-thread)
-if high_water > arena_size:
-    oldest_valid = high_water − arena_size
-    if record.payload_offset < oldest_valid:
-        overwritten = true
-```
-
-Because a2a3 uses shared memory and a background reader, the host
-can drain arena data while the kernel is still running. Overwrite
-happens only when AICPU writes faster than the host can read —
-many large tensors arrive in rapid succession without the host
-keeping up.
-
-**a5 mechanism:** same arithmetic, but detection happens in
-`collect_all()` after `rtStreamSynchronize`:
-
-```text
-write_offset = arena_header.write_offset   (total bytes ever written)
-if write_offset > arena_size:
-    oldest_valid = write_offset − arena_size
-    if record.payload_offset < oldest_valid:
-        overwritten = true
-```
-
-a5 collects only after the stream finishes, so the entire execution
-window's data must fit in the arena. If total payload bytes written
-across all tasks exceed `arena_size`, the earliest payloads are
-overwritten.
-
-**Effect:** overwritten records appear with `"overwritten": true`
-and zero payload bytes in the binary file. Metadata (shape, dtype,
-task_id) is preserved — only the raw data is lost.
-
-**Tuning:** raise `PLATFORM_DUMP_BUFFERS_PER_THREAD` (arena grows
-proportionally) so total payload fits, or reduce the number of
-tasks being dumped.
+At each existing RQ publish point, AICPU counts the non-empty tensor payload
+records in that metadata buffer. The host's single writer increments one global
+completion count only after `args.bin` accepts a payload.
+`backpressure_release_ready()` therefore holds an existing queue freeze until
+the completed count reaches the sum of all threads' published counts. The common
+framework still independently requires all RQs drained and FQs refilled. Host
+also acknowledges each completed per-thread watermark. The triggering thread
+requires that acknowledgement, even if the common queue freeze has already
+released, before aligning its monotonic logical offset to the next physical
+arena boundary and writing the pending payload from the arena start.
+The cursor is never reset and no reclaimed/published arena offset is needed.
 
 ### 7.3 Record discard (`dropped_count` / `dropped_records`)
 
 **Trigger:** the metadata record buffer (not the payload arena) is
 full and no replacement buffer is available.
 
-**a5 mechanism (simple):** each thread has a single `DumpBuffer`
-with `capacity = RECORDS_PER_BUFFER` (default 256). When `count >=
-capacity`, subsequent `dump_arg_record()` calls increment
-`dropped_count` and return immediately — no metadata, no payload
-is stored for that tensor.
-
-```text
-if buf.count >= buf.capacity:
-    buf.dropped_count++
-    return              ← tensor silently skipped
-```
-
-**a2a3 mechanism (rotating buffers):** each thread rotates through
+**Mechanism (identical on a2a3 and a5):** each thread rotates through
 multiple metadata buffers via an SPSC free queue. When a buffer
 fills (256 records), AICPU tries to:
 
@@ -824,10 +784,11 @@ fills (256 records), AICPU tries to:
    host mgmt thread to pick up).
 2. Pop a fresh buffer from the free queue.
 
-If the ready queue is full or the free queue is empty, AICPU
-spin-waits up to `DUMP_SPIN_WAIT_LIMIT` (1 000 000 iterations) to
-give the host mgmt thread (driving `BufferPoolManager<DumpModule>`)
-time to replenish. If the wait expires:
+If the ready queue is full or the free queue is empty, AICPU raises
+the corresponding DFX contention signal and waits at the existing
+bounded freeze gate while the host drains/refills the queues. If the
+host-crash timeout expires, the current records are accounted as
+dropped.
 
 ```text
 // Overwrite current buffer — account for lost records
@@ -852,8 +813,9 @@ host hand-off queue).
 | Condition | Flag | Metadata | Payload | a2a3 | a5 |
 | --------- | ---- | -------- | ------- | ---- | -- |
 | Tensor > arena | `truncated` | Preserved | Partial (`arena/2` bytes) | Same | Same |
-| Arena wraps, old data overwritten | `overwritten` | Preserved | Lost (zero bytes in bin) | Rare (concurrent drain) | Likely if total data > arena |
-| Record buffer full, no free buffer | `dropped_count` | Lost | Lost | After spin-wait fallback | Immediate when count ≥ capacity |
+| Arena host writer falls behind | none on success | Preserved | Preserved after bounded freeze | Same | Same |
+| Arena collection/write fails | `overwritten` or run error | Preserved | May be lost | Same | Same |
+| Record buffer full, no free buffer | `dropped_count` | Lost | Lost | After freeze timeout | Same |
 
 ### 7.5 Configuration knobs
 
@@ -863,8 +825,8 @@ and match between `a2a3` and `a5`:
 
 | Constant | Default | Effect |
 | -------- | ------- | ------ |
-| `PLATFORM_DUMP_RECORDS_PER_BUFFER` | 256 | Max records per DumpBuffer (a2a3: per metadata buffer) |
-| `PLATFORM_DUMP_BUFFERS_PER_THREAD` | 8 | Arena size multiplier (a2a3: also SPSC free queue depth) |
+| `PLATFORM_DUMP_RECORDS_PER_BUFFER` | 256 | Max records per metadata buffer |
+| `PLATFORM_DUMP_BUFFERS_PER_THREAD` | 8 | Arena size multiplier and SPSC free queue depth |
 | `PLATFORM_DUMP_AVG_TENSOR_BYTES` | 64 KiB | Arena size multiplier |
 | `PLATFORM_DUMP_MAX_DIMS` | 5 | Upper bound on shape / offset arrays |
 | `PLATFORM_MAX_AICPU_THREADS` | 7 | Number of dump-producing threads |

--- a/src/common/platform/include/common/args_dump.h
+++ b/src/common/platform/include/common/args_dump.h
@@ -180,27 +180,30 @@ static_assert(sizeof(DumpFreeQueue) == 128, "DumpFreeQueue must be 128 bytes");
  * - free_queue.head: Device writes (pops buffers)
  * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
  * - current_buf_seq: Device writes (monotonic counter)
- * - arena_write_offset: Device writes (monotonic), Host reads (for overwrite detection)
+ * - arena_write_offset: Device writes (monotonic), Host reads for overwrite detection
+ * - published_payload_count: Device counts payload records committed to the ready queue
+ * - completed_payload_count: Host acknowledges payloads after writer completion
  * - dropped_record_count: Device writes (records lost before host export)
  */
 struct DumpBufferState {
-    DumpFreeQueue free_queue;                // SPSC queue of free DumpMetaBuffer addresses
-    volatile uint64_t current_buf_ptr;       // Current active DumpMetaBuffer (0 = none)
-    volatile uint32_t current_buf_seq;       // Sequence number for ordering
-    uint32_t pad0;                           // Alignment
-    volatile uint64_t arena_base;            // Device pointer to this thread's arena
-    volatile uint64_t arena_size;            // Arena size in bytes
-    volatile uint64_t arena_write_offset;    // Monotonic write cursor (host computes % arena_size)
-    volatile uint32_t dropped_record_count;  // Records dropped before host export
-    uint8_t pad1[84];                        // Pad to 256 bytes (172 + 84 = 256)
+    DumpFreeQueue free_queue;                   // SPSC queue of free DumpMetaBuffer addresses
+    volatile uint64_t current_buf_ptr;          // Current active DumpMetaBuffer (0 = none)
+    volatile uint32_t current_buf_seq;          // Sequence number for ordering
+    uint32_t pad0;                              // Alignment
+    volatile uint64_t arena_base;               // Device pointer to this thread's arena
+    volatile uint64_t arena_size;               // Arena size in bytes
+    volatile uint64_t arena_write_offset;       // Monotonic write cursor (host computes % arena_size)
+    volatile uint64_t published_payload_count;  // Payload records committed to the ready queue
+    volatile uint64_t completed_payload_count;  // Host-acknowledged published payload count
+    volatile uint32_t dropped_record_count;     // Records dropped before host export
+    uint8_t pad1[68];                           // Pad to 256 bytes (188 + 68 = 256)
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(DumpBufferState) == 256, "DumpBufferState must be 256 bytes");
 static_assert(offsetof(DumpBufferState, current_buf_ptr) == 128, "DumpBufferState current_buf_ptr offset changed");
 static_assert(offsetof(DumpBufferState, arena_base) == 144, "DumpBufferState arena_base offset changed");
-static_assert(
-    offsetof(DumpBufferState, dropped_record_count) == 168, "DumpBufferState dropped_record_count offset changed"
-);
+static_assert(offsetof(DumpBufferState, completed_payload_count) == 176, "completed payload offset changed");
+static_assert(offsetof(DumpBufferState, dropped_record_count) == 184, "dropped record offset changed");
 
 // =============================================================================
 // DumpReadyQueueEntry - Ready Queue Entry

--- a/src/common/platform/include/common/dfx_backpressure_device.h
+++ b/src/common/platform/include/common/dfx_backpressure_device.h
@@ -141,22 +141,28 @@ inline void mark_fq_contended(Header *header, bool *signalled) {
 }
 
 // Leader park for a lane whose own reclaim depends on the host completing an
-// open→drain→release cycle on the FREE-queue (pop) side — only tensor_dump's
+// open→drain→release cycle on the FREE-queue (pop) side — only args_dump's
 // arena barrier today (engine-gate leaders instead spin on a real free slot).
 // Blocks until the host has both opened fq_freeze covering this contention AND
 // released it. Uses the DISJUNCTION (fq_contended || fq_freeze_active): the host
 // opens fq_freeze before consuming fq_contended, so the predicate stays
 // continuously true from mark_fq_contended() to release — no (0,0) escape
-// window. Relaxes via SPIN_WAIT_HINT() (platform-tiered). Null-safe.
+// window. Relaxes via SPIN_WAIT_HINT() (platform-tiered). Null-safe. The caller
+// supplies the start time so this wait and any follow-up acknowledgement wait
+// can share one timeout budget.
 template <typename Header>
-inline void wait_for_release(const Header *header) {
+inline bool wait_for_release(const Header *header, uint64_t wait_start, uint64_t timeout_cycles) {
     if (header == nullptr) {
-        return;
+        return true;
     }
     while (header->backpressure.fq_contended != 0 || header->backpressure.fq_freeze_active != 0) {
+        if (get_sys_cnt_aicpu() - wait_start >= timeout_cycles) {
+            return false;
+        }
         SPIN_WAIT_HINT();
     }
     rmb();  // acquire: order host's pre-release writes before the leader's post-release reads
+    return true;
 }
 
 }  // namespace dfx_backpressure

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -31,6 +31,7 @@
 #ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_ARGS_DUMP_COLLECTOR_H_
 #define SRC_COMMON_PLATFORM_INCLUDE_HOST_ARGS_DUMP_COLLECTOR_H_
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -275,6 +276,9 @@ public:
      */
     void *get_dump_shm_device_ptr() const { return dump_shared_mem_dev_; }
 
+    /** Return whether an active args-dump freeze may release. An idle call returns false. */
+    bool backpressure_release_ready() const;
+
 private:
     struct alignas(64) CollectorShardCounters {
         uint64_t total_collected{0};
@@ -313,6 +317,7 @@ private:
     std::atomic<uint32_t> total_dropped_record_count_{0};
     std::atomic<uint32_t> total_truncated_count_{0};
     std::atomic<uint32_t> total_overwrite_count_{0};
+    std::array<std::atomic<uint64_t>, PLATFORM_MAX_AICPU_THREADS> written_payload_counts_{};
 
     // Run-scoped state for the writer thread (lazily started on first
     // on_buffer_collected and joined by export_dump_files).
@@ -327,11 +332,15 @@ private:
     void start_writer_thread_once();
 
     // Writer thread: streams arg payloads to a single args.bin
+    struct PayloadWriteRequest {
+        uint32_t thread_index;
+        std::vector<uint8_t> bytes;
+    };
     std::thread writer_thread_;
     std::mutex writer_start_mutex_;
     std::mutex write_mutex_;
     std::condition_variable write_cv_;
-    std::queue<DumpedArg> write_queue_;
+    std::queue<PayloadWriteRequest> write_queue_;
     std::atomic<bool> writer_done_{false};
 
     // Resolved dump level; FULL_JSON_ONLY suppresses the .bin file entirely.

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -531,7 +531,7 @@ struct ProfilerAlgorithms {
     // extra_release_ready is the per-subsystem release predicate
     // (Derived::backpressure_release_ready(), default true). The caller
     // (mgmt_replenish_loop) evaluates it because this static has no Derived.
-    // tensor_dump uses it to hold the release until its collector has pulled all
+    // args_dump uses it to hold the release until its collector has pulled all
     // arena bytes (RQ-empty alone does not imply that — see buffer_pool_manager).
     template <typename Mgr>
     static void update_backpressure_freeze(Mgr &mgr, DataHeader *header, bool extra_release_ready = true) {
@@ -571,8 +571,8 @@ struct ProfilerAlgorithms {
             header->backpressure.fq_contended = 0;
             mgr.write_range_to_device(&header->backpressure.fq_contended, sizeof(header->backpressure.fq_contended));
             LOG_WARN(
-                "%s DFX backpressure TRIGGERED: free-queue-empty, pop-gate freeze OPENED — all AICPU lanes parked at "
-                "their pop gate",
+                "%s DFX backpressure TRIGGERED: free-queue-empty, pop-gate freeze OPENED — lanes park as they "
+                "reach an empty free queue",
                 Module::kSubsystemName
             );
         }
@@ -753,11 +753,12 @@ public:
     // DFX backpressure per-subsystem release predicate (CRTP hook). Default:
     // the freeze may release as soon as the framework's RQ-empty + FQ-full hold.
     // A subsystem whose collector owns a separate, independently-overwritten
-    // region (only tensor_dump today: the payload arena) MUST override this to
+    // region (only args_dump today: the payload arena) MUST override this to
     // return false until its collector has drained that region, else the device
-    // resumes and overwrites not-yet-pulled data. Called on the mgmt_replenish
-    // thread inside the freeze loop — overrides must be cheap, non-blocking, and
-    // read only atomics.
+    // resumes and overwrites not-yet-pulled data. Called once per mgmt tick
+    // before the state-machine update. The idle path must use only local state;
+    // an active-freeze check may refresh device state but must return without
+    // waiting for asynchronous work.
     bool backpressure_release_ready() const { return true; }
 
 private:
@@ -1163,9 +1164,10 @@ private:
             // for freeze_active. Always active (block-on-contention is the only
             // behavior); idle at zero cost until a lane raises `contended`.
             // Per-subsystem release predicate (CRTP): default true, only
-            // tensor_dump overrides it (gate release on collector-quiesce);
+            // args_dump overrides it (gate release on collector-quiesce);
             // evaluated here because update_backpressure_freeze is a static with
-            // no Derived, and must be cheap + non-blocking (freeze hot loop).
+            // no Derived. Its idle path must be local; an active-freeze check
+            // returns false rather than waiting for collector work.
             const bool extra_release_ready = static_cast<const Derived *>(this)->backpressure_release_ready();
             Alg::update_backpressure_freeze(manager_, header, extra_release_ready);
 

--- a/src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/args_dump_aicpu.cpp
@@ -356,6 +356,21 @@ struct DumpDeviceModule {
     static void set_count(Buffer *buffer, uint32_t count) { buffer->count = count; }
 
     static void write_ready_entry(Context ctx, uint32_t tail, uint64_t buffer_ptr, uint32_t buffer_seq) {
+        DumpBufferState *state = s_dump_states[ctx.thread_idx];
+        auto *buffer = reinterpret_cast<DumpMetaBuffer *>(buffer_ptr);
+        uint64_t payload_count = 0;
+        uint32_t record_count = buffer->count;
+        if (record_count > PLATFORM_DUMP_RECORDS_PER_BUFFER) {
+            record_count = PLATFORM_DUMP_RECORDS_PER_BUFFER;
+        }
+        for (uint32_t i = 0; i < record_count; i++) {
+            const ArgsDumpRecord &record = buffer->records[i];
+            if (record.kind == static_cast<uint8_t>(ArgsDumpKind::TENSOR) && record.payload_size > 0) {
+                payload_count++;
+            }
+        }
+        state->published_payload_count += payload_count;
+        wmb();
         ctx.header->queues[ctx.thread_idx][tail].thread_index = static_cast<uint32_t>(ctx.thread_idx);
         ctx.header->queues[ctx.thread_idx][tail].buffer_ptr = buffer_ptr;
         ctx.header->queues[ctx.thread_idx][tail].buffer_seq = buffer_seq;
@@ -424,6 +439,49 @@ static int switch_dump_meta_buffer(int thread_idx) {
     }
     DumpEngine::switch_buffer(dump_context(thread_idx), state);
     return 0;
+}
+
+static bool ensure_dump_arena_capacity(int thread_idx, DumpBufferState *state, uint64_t copy_bytes) {
+    if (copy_bytes == 0) {
+        return true;
+    }
+    if (state == nullptr || copy_bytes > state->arena_size) {
+        return false;
+    }
+
+    const uint64_t physical_offset = state->arena_write_offset % state->arena_size;
+    const bool arena_full = state->arena_write_offset != 0 && physical_offset == 0;
+    const bool crosses_arena_end = copy_bytes > state->arena_size - physical_offset;
+    if (!arena_full && !crosses_arena_end) {
+        return true;
+    }
+
+    DumpMetaBuffer *buf = s_current_dump_buf[thread_idx];
+    if (buf != nullptr && buf->count > 0) {
+        uint32_t seq = state->current_buf_seq;
+        if (switch_dump_meta_buffer(thread_idx) != 0 || state->current_buf_seq == seq) {
+            return false;
+        }
+    }
+
+    const uint64_t target_payload_count = state->published_payload_count;
+    const uint64_t wait_start = get_sys_cnt_aicpu();
+    bool signalled = false;
+    dfx_backpressure::mark_fq_contended(s_dump_header, &signalled);
+    if (!dfx_backpressure::wait_for_release(s_dump_header, wait_start, kDumpQueueBackpressureWaitCycles)) {
+        return false;
+    }
+    while (state->completed_payload_count < target_payload_count) {
+        if (get_sys_cnt_aicpu() - wait_start >= kDumpQueueBackpressureWaitCycles) {
+            return false;
+        }
+        SPIN_WAIT_HINT();
+    }
+    rmb();
+    if (physical_offset != 0) {
+        state->arena_write_offset += state->arena_size - physical_offset;
+    }
+    return true;
 }
 
 struct CircularArenaWriter {
@@ -626,6 +684,19 @@ int dump_arg_record(int thread_idx, const ArgsDumpInfo &info) {
         // Tensor larger than entire arena — copy a partial sample
         copy_bytes = state->arena_size / 2;
         truncated = true;
+    }
+
+    if (!ensure_dump_arena_capacity(thread_idx, state, copy_bytes)) {
+        account_dropped_records(state, 1);
+        return -1;
+    }
+    buf = s_current_dump_buf[thread_idx];
+    if (buf == nullptr) {
+        buf = try_pop_dump_meta_buffer(thread_idx, state, state->current_buf_seq);
+        if (buf == nullptr) {
+            account_dropped_records(state, 1);
+            return -1;
+        }
     }
 
     uint64_t offset = state->arena_write_offset;

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -19,10 +19,9 @@
  *        export.
  *
  * a5 specifics: device↔host transfers go through profiling_copy.h. The
- * framework's mgmt loop mirrors the shm region per tick and pulls each
- * popped DumpMetaBuffer's contents on demand. on_buffer_collected pulls
- * the relevant portion of the originating thread's arena before reading
- * args records (arena buffers live outside the shm region).
+ * framework pulls queue fields and each popped DumpMetaBuffer on demand.
+ * on_buffer_collected separately refreshes the originating thread's arena
+ * write cursor and payload bytes because arenas live outside the shm region.
  */
 
 #include "host/args_dump_collector.h"
@@ -117,6 +116,9 @@ int ArgsDumpCollector::initialize(
     total_truncated_count_.store(0, std::memory_order_relaxed);
     total_overwrite_count_.store(0, std::memory_order_relaxed);
     last_progress_ms_.store(0, std::memory_order_relaxed);
+    for (auto &count : written_payload_counts_) {
+        count.store(0, std::memory_order_relaxed);
+    }
 
     // Stash the memory context on the base up-front so alloc_paired_buffer
     // (which reads alloc_cb_/register_cb_/free_cb_/device_id_)
@@ -170,6 +172,8 @@ int ArgsDumpCollector::initialize(
         state->arena_base = reinterpret_cast<uint64_t>(ai.dev_ptr);
         state->arena_size = arena_size;
         state->arena_write_offset = 0;
+        state->published_payload_count = 0;
+        state->completed_payload_count = 0;
         state->dropped_record_count = 0;
 
         LOG_INFO(
@@ -275,12 +279,16 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info, int
     uint64_t records_appended = 0;
 
     // a5: pull the relevant portion of the originating thread's arena from
-    // device. arena_write_offset was mirrored into shm_host_ at the top of
-    // the mgmt tick that produced this entry, so it is safe to read here.
+    // device. The arena lives outside the shared-memory region, so refresh
+    // its write cursor explicitly before copying the payload bytes.
     int thread_idx = static_cast<int>(info.thread_index);
     if (thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
         ArenaInfo &ai = arenas_[thread_idx];
         DumpBufferState *state = get_dump_buffer_state(shm_host_, thread_idx);
+        DumpBufferState *device_state = get_dump_buffer_state(dump_shared_mem_dev_, thread_idx);
+        profiling_copy_from_device(
+            &state->arena_write_offset, &device_state->arena_write_offset, sizeof(state->arena_write_offset)
+        );
         uint64_t write_offset = state->arena_write_offset;
         uint64_t bytes_to_copy = (write_offset < ai.size) ? write_offset : ai.size;
         if (bytes_to_copy > 0) {
@@ -290,7 +298,6 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info, int
 
     for (uint32_t i = 0; i < count; i++) {
         const ArgsDumpRecord &rec = buf->records[i];
-
         DumpedArg dt{};
         dt.task_id = rec.task_id;
         // rec is read from device shared memory (untrusted): clamp func_count so a
@@ -370,16 +377,12 @@ void ArgsDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info, int
         }
 
         dt.payload_size = dt.bytes.size();
-
         bool has_payload = dt.kind == ArgsDumpKind::TENSOR && !dt.overwritten && !dt.bytes.empty();
         if (has_payload) {
-            std::vector<uint8_t> payload = std::move(dt.bytes);
-            DumpedArg writer_item = dt;
-            writer_item.bytes = std::move(payload);
+            PayloadWriteRequest writer_item{info.thread_index, std::move(dt.bytes)};
             {
                 std::scoped_lock<std::mutex> lock(write_mutex_);
                 dt.bin_offset = next_bin_offset_;
-                writer_item.bin_offset = next_bin_offset_;
                 next_bin_offset_ += dt.payload_size;
                 write_queue_.push(std::move(writer_item));
             }
@@ -584,7 +587,7 @@ static uint64_t get_num_elements(const DumpedArg &dt) {
 
 void ArgsDumpCollector::writer_loop() {
     while (true) {
-        DumpedArg dt;
+        PayloadWriteRequest request;
         {
             std::unique_lock<std::mutex> lock(write_mutex_);
             write_cv_.wait(lock, [this] {
@@ -593,18 +596,64 @@ void ArgsDumpCollector::writer_loop() {
             if (write_queue_.empty() && writer_done_.load()) {
                 break;
             }
-            dt = std::move(write_queue_.front());
+            request = std::move(write_queue_.front());
             write_queue_.pop();
         }
 
-        if (!dt.bytes.empty()) {
+        if (!request.bytes.empty()) {
             bin_file_.write(
-                reinterpret_cast<const char *>(dt.bytes.data()), static_cast<std::streamsize>(dt.bytes.size())
+                reinterpret_cast<const char *>(request.bytes.data()), static_cast<std::streamsize>(request.bytes.size())
             );
+            written_payload_counts_[request.thread_index].fetch_add(1, std::memory_order_release);
         }
 
-        bytes_written_ += dt.bytes.size();
+        bytes_written_ += request.bytes.size();
     }
+}
+
+bool ArgsDumpCollector::backpressure_release_ready() const {
+    if (shm_host_ == nullptr || dump_shared_mem_dev_ == nullptr) {
+        return true;
+    }
+    const DumpDataHeader *header = get_dump_header(shm_host_);
+    // A freeze opened later in this management tick remains active until the
+    // next tick evaluates the payload counts.
+    if (header->backpressure.rq_freeze_active == 0 && header->backpressure.fq_freeze_active == 0) {
+        return false;
+    }
+    std::array<uint64_t, PLATFORM_MAX_AICPU_THREADS> published_payload_counts{};
+    for (int t = 0; t < num_dump_threads_; t++) {
+        DumpBufferState *host_state = get_dump_buffer_state(shm_host_, t);
+        DumpBufferState *device_state = get_dump_buffer_state(dump_shared_mem_dev_, t);
+        if (profiling_copy_from_device(
+                &host_state->published_payload_count, &device_state->published_payload_count,
+                sizeof(host_state->published_payload_count)
+            ) != 0) {
+            return false;
+        }
+        published_payload_counts[t] = host_state->published_payload_count;
+    }
+    for (int t = 0; t < num_dump_threads_; t++) {
+        if (written_payload_counts_[t].load(std::memory_order_acquire) != published_payload_counts[t]) {
+            return false;
+        }
+    }
+    for (int t = 0; t < num_dump_threads_; t++) {
+        DumpBufferState *host_state = get_dump_buffer_state(shm_host_, t);
+        DumpBufferState *device_state = get_dump_buffer_state(dump_shared_mem_dev_, t);
+        const uint64_t completed_payload_count = published_payload_counts[t];
+        if (host_state->completed_payload_count == completed_payload_count) {
+            continue;
+        }
+        if (profiling_copy_to_device(
+                &device_state->completed_payload_count, &completed_payload_count, sizeof(completed_payload_count)
+            ) != 0) {
+            return false;
+        }
+        host_state->completed_payload_count = completed_payload_count;
+        wmb();
+    }
+    return true;
 }
 
 int ArgsDumpCollector::export_dump_files() {
@@ -881,6 +930,9 @@ int ArgsDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const Dump
     total_overwrite_count_.store(0, std::memory_order_relaxed);
     writer_started_ = false;
     clear_memory_context();
+    for (auto &count : written_payload_counts_) {
+        count.store(0, std::memory_order_relaxed);
+    }
 
     return 0;
 }

--- a/tests/ut/cpp/a2a3/test_args_dump.cpp
+++ b/tests/ut/cpp/a2a3/test_args_dump.cpp
@@ -11,8 +11,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <thread>
 
 #include "aicpu/args_dump_aicpu.h"
 
@@ -187,6 +189,76 @@ TEST_F(ArgsDumpTest, DumpRecordCorrectness) {
     EXPECT_EQ(srec.dtype, static_cast<uint8_t>(DataType::UINT64));
     EXPECT_EQ(srec.func_ids[0], 7u);
     EXPECT_EQ(meta_buf.count, 2u);
+
+    dump_args_flush(0);
+    EXPECT_EQ(state->published_payload_count, 1u);
+
+    set_platform_dump_base(0);
+}
+
+TEST_F(ArgsDumpTest, ArenaBackpressureChecksBeforePayloadOverwrite) {
+    constexpr size_t kDumpMemSize = sizeof(DumpDataHeader) + sizeof(DumpBufferState);
+    alignas(64) uint8_t dump_mem[kDumpMemSize] = {};
+    alignas(64) DumpMetaBuffer meta_buffers[2]{};
+    constexpr size_t kArenaSize = 32;
+    alignas(uint64_t) uint8_t arena[kArenaSize] = {};
+    uint64_t first_data[4] = {1, 2, 3, 4};
+    uint64_t second_data[4] = {5, 6, 7, 8};
+
+    DumpDataHeader *header = get_dump_header(dump_mem);
+    header->magic = ARGS_DUMP_MAGIC;
+    header->dump_args_level = static_cast<uint32_t>(DumpArgsLevel::FULL);
+    header->num_dump_threads = 1;
+    DumpBufferState *state = get_dump_buffer_state(dump_mem, 0);
+    state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&meta_buffers[0]);
+    state->free_queue.buffer_ptrs[1] = reinterpret_cast<uint64_t>(&meta_buffers[1]);
+    state->free_queue.tail = 2;
+    state->arena_base = reinterpret_cast<uint64_t>(arena);
+    state->arena_size = kArenaSize;
+
+    set_platform_dump_base(reinterpret_cast<uint64_t>(dump_mem));
+    dump_args_init(1);
+
+    ArgsDumpInfo info{};
+    info.role = ArgsDumpRole::INPUT;
+    info.stage = ArgsDumpStage::BEFORE_DISPATCH;
+    info.dtype = static_cast<uint8_t>(DataType::UINT64);
+    info.ndims = 1;
+    info.shapes[0] = 4;
+    info.strides[0] = 1;
+    info.kind = static_cast<uint8_t>(ArgsDumpKind::TENSOR);
+    info.func_count = 1;
+    info.func_ids[0] = 1;
+    info.buffer_addr = reinterpret_cast<uint64_t>(first_data);
+    ASSERT_EQ(dump_arg_record(0, info), 0);
+
+    std::atomic<bool> payload_preserved_before_ack{false};
+    std::thread host([header, state, &arena, first_data, &payload_preserved_before_ack] {
+        while (header->backpressure.fq_contended == 0) {
+            std::this_thread::yield();
+        }
+        header->backpressure.fq_freeze_active = 1;
+        wmb();
+        header->backpressure.fq_contended = 0;
+        header->backpressure.fq_freeze_active = 0;
+        wmb();
+        payload_preserved_before_ack.store(
+            *reinterpret_cast<const uint64_t *>(arena) == first_data[0], std::memory_order_release
+        );
+        state->completed_payload_count = state->published_payload_count;
+    });
+
+    info.task_id = 1;
+    info.buffer_addr = reinterpret_cast<uint64_t>(second_data);
+    EXPECT_EQ(dump_arg_record(0, info), 0);
+    host.join();
+
+    EXPECT_TRUE(payload_preserved_before_ack.load(std::memory_order_acquire));
+    EXPECT_EQ(state->published_payload_count, 1u);
+    EXPECT_EQ(state->completed_payload_count, 1u);
+    EXPECT_EQ(state->arena_write_offset, 2 * kArenaSize);
+    EXPECT_EQ(meta_buffers[1].records[0].payload_offset, kArenaSize);
+    EXPECT_EQ(*reinterpret_cast<uint64_t *>(arena), second_data[0]);
 
     set_platform_dump_base(0);
 }

--- a/tests/ut/cpp/a5/test_args_dump.cpp
+++ b/tests/ut/cpp/a5/test_args_dump.cpp
@@ -11,8 +11,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <thread>
 
 #include "aicpu/args_dump_aicpu.h"
 
@@ -187,6 +189,76 @@ TEST_F(ArgsDumpTest, DumpRecordCorrectness) {
     EXPECT_EQ(srec.dtype, static_cast<uint8_t>(DataType::UINT64));
     EXPECT_EQ(srec.func_ids[0], 7u);
     EXPECT_EQ(meta_buf.count, 2u);
+
+    dump_args_flush(0);
+    EXPECT_EQ(state->published_payload_count, 1u);
+
+    set_platform_dump_base(0);
+}
+
+TEST_F(ArgsDumpTest, ArenaBackpressureChecksBeforePayloadOverwrite) {
+    constexpr size_t kDumpMemSize = sizeof(DumpDataHeader) + sizeof(DumpBufferState);
+    alignas(64) uint8_t dump_mem[kDumpMemSize] = {};
+    alignas(64) DumpMetaBuffer meta_buffers[2]{};
+    constexpr size_t kArenaSize = 32;
+    alignas(uint64_t) uint8_t arena[kArenaSize] = {};
+    uint64_t first_data[4] = {1, 2, 3, 4};
+    uint64_t second_data[4] = {5, 6, 7, 8};
+
+    DumpDataHeader *header = get_dump_header(dump_mem);
+    header->magic = ARGS_DUMP_MAGIC;
+    header->dump_args_level = static_cast<uint32_t>(DumpArgsLevel::FULL);
+    header->num_dump_threads = 1;
+    DumpBufferState *state = get_dump_buffer_state(dump_mem, 0);
+    state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&meta_buffers[0]);
+    state->free_queue.buffer_ptrs[1] = reinterpret_cast<uint64_t>(&meta_buffers[1]);
+    state->free_queue.tail = 2;
+    state->arena_base = reinterpret_cast<uint64_t>(arena);
+    state->arena_size = kArenaSize;
+
+    set_platform_dump_base(reinterpret_cast<uint64_t>(dump_mem));
+    dump_args_init(1);
+
+    ArgsDumpInfo info{};
+    info.role = ArgsDumpRole::INPUT;
+    info.stage = ArgsDumpStage::BEFORE_DISPATCH;
+    info.dtype = static_cast<uint8_t>(DataType::UINT64);
+    info.ndims = 1;
+    info.shapes[0] = 4;
+    info.strides[0] = 1;
+    info.kind = static_cast<uint8_t>(ArgsDumpKind::TENSOR);
+    info.func_count = 1;
+    info.func_ids[0] = 1;
+    info.buffer_addr = reinterpret_cast<uint64_t>(first_data);
+    ASSERT_EQ(dump_arg_record(0, info), 0);
+
+    std::atomic<bool> payload_preserved_before_ack{false};
+    std::thread host([header, state, &arena, first_data, &payload_preserved_before_ack] {
+        while (header->backpressure.fq_contended == 0) {
+            std::this_thread::yield();
+        }
+        header->backpressure.fq_freeze_active = 1;
+        wmb();
+        header->backpressure.fq_contended = 0;
+        header->backpressure.fq_freeze_active = 0;
+        wmb();
+        payload_preserved_before_ack.store(
+            *reinterpret_cast<const uint64_t *>(arena) == first_data[0], std::memory_order_release
+        );
+        state->completed_payload_count = state->published_payload_count;
+    });
+
+    info.task_id = 1;
+    info.buffer_addr = reinterpret_cast<uint64_t>(second_data);
+    EXPECT_EQ(dump_arg_record(0, info), 0);
+    host.join();
+
+    EXPECT_TRUE(payload_preserved_before_ack.load(std::memory_order_acquire));
+    EXPECT_EQ(state->published_payload_count, 1u);
+    EXPECT_EQ(state->completed_payload_count, 1u);
+    EXPECT_EQ(state->arena_write_offset, 2 * kArenaSize);
+    EXPECT_EQ(meta_buffers[1].records[0].payload_offset, kArenaSize);
+    EXPECT_EQ(*reinterpret_cast<uint64_t *>(arena), second_data[0]);
 
     set_platform_dump_base(0);
 }

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -32,6 +32,11 @@ int test_free(void *ptr) {
     return 0;
 }
 
+class TestArgsDumpCollector : public ArgsDumpCollector {
+public:
+    void *get_dump_shm_host_ptr() const { return shm_host_; }
+};
+
 }  // namespace
 
 TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
@@ -90,6 +95,131 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     ASSERT_TRUE(manifest_file.is_open());
     const std::string manifest{std::istreambuf_iterator<char>(manifest_file), std::istreambuf_iterator<char>()};
     EXPECT_NE(manifest.find("\"total_args\": " + std::to_string(kShardCount * kRecordsPerShard)), std::string::npos);
+
+    collector.finalize(nullptr, test_free);
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST(ArgsDumpCollectorTest, BackpressureReleaseWaitsForAllPublishedPayloads) {
+    const std::filesystem::path test_dir =
+        std::filesystem::temp_directory_path() / ("args_dump_count_test_" + std::to_string(::getpid()));
+    std::filesystem::remove_all(test_dir);
+    ASSERT_TRUE(std::filesystem::create_directories(test_dir));
+
+    constexpr int kArenaCount = 2;
+    constexpr uint64_t kPayloadSize = sizeof(uint64_t);
+    TestArgsDumpCollector collector;
+    ASSERT_EQ(
+        collector.initialize(kArenaCount, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL), 0
+    );
+
+    auto *device_base = collector.get_dump_shm_device_ptr();
+    ASSERT_NE(device_base, nullptr);
+    auto *host_base = collector.get_dump_shm_host_ptr();
+    ASSERT_NE(host_base, nullptr);
+    DumpDataHeader *header = get_dump_header(host_base);
+    ASSERT_NE(header, nullptr);
+    EXPECT_FALSE(collector.backpressure_release_ready());
+    header->backpressure.fq_freeze_active = 1;
+    std::vector<DumpMetaBuffer> buffers(kArenaCount);
+    for (int arena_index = 0; arena_index < kArenaCount; arena_index++) {
+        DumpBufferState *state = get_dump_buffer_state(device_base, arena_index);
+        ASSERT_NE(state, nullptr);
+        auto *arena = reinterpret_cast<uint64_t *>(state->arena_base);
+        ASSERT_NE(arena, nullptr);
+        arena[0] = static_cast<uint64_t>(arena_index + 1);
+        state->arena_write_offset = kPayloadSize;
+        state->published_payload_count = 1;
+
+        DumpMetaBuffer &buffer = buffers[arena_index];
+        buffer.count = 1;
+        ArgsDumpRecord &record = buffer.records[0];
+        record.task_id = static_cast<uint64_t>(arena_index);
+        record.role = static_cast<uint8_t>(ArgsDumpRole::INPUT);
+        record.stage = static_cast<uint8_t>(ArgsDumpStage::BEFORE_DISPATCH);
+        record.kind = static_cast<uint8_t>(ArgsDumpKind::TENSOR);
+        record.dtype = static_cast<uint8_t>(DataType::UINT64);
+        record.ndims = 1;
+        record.shapes[0] = 1;
+        record.strides[0] = 1;
+        record.payload_offset = 0;
+        record.payload_size = kPayloadSize;
+    }
+
+    EXPECT_FALSE(collector.backpressure_release_ready());
+
+    DumpReadyBufferInfo first{};
+    first.thread_index = 0;
+    first.host_buffer_ptr = &buffers[0];
+    collector.on_buffer_collected(first, 0);
+    EXPECT_FALSE(collector.backpressure_release_ready());
+
+    DumpReadyBufferInfo second{};
+    second.thread_index = 1;
+    second.host_buffer_ptr = &buffers[1];
+    collector.on_buffer_collected(second, 1);
+    ASSERT_EQ(collector.export_dump_files(), 0);
+    EXPECT_TRUE(collector.backpressure_release_ready());
+    for (int arena_index = 0; arena_index < kArenaCount; arena_index++) {
+        DumpBufferState *state = get_dump_buffer_state(device_base, arena_index);
+        EXPECT_EQ(state->completed_payload_count, state->published_payload_count);
+    }
+
+    collector.finalize(nullptr, test_free);
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST(ArgsDumpCollectorTest, BackpressureReleaseDoesNotOffsetPayloadsAcrossThreads) {
+    const std::filesystem::path test_dir =
+        std::filesystem::temp_directory_path() / ("args_dump_thread_count_test_" + std::to_string(::getpid()));
+    std::filesystem::remove_all(test_dir);
+    ASSERT_TRUE(std::filesystem::create_directories(test_dir));
+
+    TestArgsDumpCollector collector;
+    ASSERT_EQ(collector.initialize(2, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL), 0);
+
+    auto *device_base = collector.get_dump_shm_device_ptr();
+    ASSERT_NE(device_base, nullptr);
+    auto *host_base = collector.get_dump_shm_host_ptr();
+    ASSERT_NE(host_base, nullptr);
+    DumpDataHeader *header = get_dump_header(host_base);
+    ASSERT_NE(header, nullptr);
+    header->backpressure.fq_freeze_active = 1;
+    DumpBufferState *thread0_state = get_dump_buffer_state(device_base, 0);
+    DumpBufferState *thread1_state = get_dump_buffer_state(device_base, 1);
+    ASSERT_NE(thread0_state, nullptr);
+    ASSERT_NE(thread1_state, nullptr);
+
+    constexpr uint64_t kPayloadSize = sizeof(uint64_t);
+    auto *arena = reinterpret_cast<uint64_t *>(thread0_state->arena_base);
+    ASSERT_NE(arena, nullptr);
+    arena[0] = 1;
+    thread0_state->arena_write_offset = kPayloadSize;
+
+    DumpMetaBuffer buffer{};
+    buffer.count = 1;
+    ArgsDumpRecord &record = buffer.records[0];
+    record.kind = static_cast<uint8_t>(ArgsDumpKind::TENSOR);
+    record.dtype = static_cast<uint8_t>(DataType::UINT64);
+    record.ndims = 1;
+    record.shapes[0] = 1;
+    record.strides[0] = 1;
+    record.payload_size = kPayloadSize;
+
+    DumpReadyBufferInfo info{};
+    info.thread_index = 0;
+    info.host_buffer_ptr = &buffer;
+    collector.on_buffer_collected(info, 0);
+    ASSERT_EQ(collector.export_dump_files(), 0);
+
+    // Model a skewed global snapshot: one payload was written for thread 0,
+    // while the sampled publication belongs to thread 1. Equal totals must
+    // not acknowledge either thread.
+    thread0_state->published_payload_count = 0;
+    thread1_state->published_payload_count = 1;
+    EXPECT_FALSE(collector.backpressure_release_ready());
+    EXPECT_EQ(thread0_state->completed_payload_count, 0u);
+    EXPECT_EQ(thread1_state->completed_payload_count, 0u);
 
     collector.finalize(nullptr, test_free);
     std::filesystem::remove_all(test_dir);

--- a/tests/ut/cpp/common/test_profiler_device_engine.cpp
+++ b/tests/ut/cpp/common/test_profiler_device_engine.cpp
@@ -153,6 +153,32 @@ TEST(ProfilerDeviceEngineTest, PopFreeSupportsRecoveryAfterSwitchFailure) {
     EXPECT_EQ(new_buffer.count, 0u);
 }
 
+TEST(ProfilerDeviceEngineTest, PopFreeDoesNotParkWhileAFreeSlotIsAvailable) {
+    FakeHeader header;
+    FakeState state;
+    FakeBuffer new_buffer;
+    FakeBuffer *current = nullptr;
+    header.backpressure.fq_freeze_active = 1;
+    state.free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&new_buffer);
+    state.free_queue.tail = 1;
+
+    auto buffer = Engine::pop_free(context(&header, &current), &state, 0);
+
+    EXPECT_EQ(buffer, &new_buffer);
+    EXPECT_EQ(state.free_queue.head, 1u);
+}
+
+TEST(ProfilerDeviceEngineTest, WaitForReleaseUsesCallerTimeoutBudget) {
+    FakeHeader header;
+    header.backpressure.fq_contended = 1;
+
+    EXPECT_FALSE(dfx_backpressure::wait_for_release(&header, get_sys_cnt_aicpu(), 0));
+
+    header.backpressure.fq_contended = 0;
+    EXPECT_TRUE(dfx_backpressure::wait_for_release(&header, get_sys_cnt_aicpu(), 0));
+    EXPECT_TRUE(dfx_backpressure::wait_for_release<FakeHeader>(nullptr, get_sys_cnt_aicpu(), 0));
+}
+
 TEST(ProfilerDeviceEngineTest, TryPopFreeReturnsImmediatelyWhenStartupQueueIsEmpty) {
     FakeHeader header;
     FakeState state;


### PR DESCRIPTION
## Summary

- Protect args-dump payload arenas from wrapping over records that are still in the host collector/writer pipeline.
- Publish a per-AICPU-thread payload watermark before ready-queue handoff, track writer completion per source thread, and acknowledge all threads together only when every `written[t] == published[t]`.
- Reuse the shared DFX freeze/release state machine so arena reuse remains globally coordinated without adding device shared-memory fields or a parked-thread epoch protocol.
- Bound the freeze-release wait and the subsequent payload acknowledgement wait with one existing DFX timeout budget.
- Cover both a2a3 and a5 device/collector paths, including cross-thread count compensation and pop-gate behavior.

## Core flow

```text
Device publishes per-thread payload watermarks
                    ↓
Host freezes arena reuse and drains collector/writer work
                    ↓
Every thread satisfies written[t] == published[t]
                    ↓
Host ACKs all thread watermarks and releases the global freeze
```

## Testing

- [x] Full non-hardware C++ suite: 76/76 passed.
- [x] a2a3sim args-dump scene test passed.
- [x] a5sim args-dump scene test passed.
- [x] Ascend910_9392 onboard page-unroll through `task-submit`, with `--dump-args 2`, temporary 256 MiB/thread arena, and batch 32:
  - 1 test passed in 61.34 s.
  - Exported 1,024 args and 4.35 GB of payload data.
  - `truncated_args=0`, `dropped_records=0`, and `dropped_overwrite=0`.
- [x] Pre-commit hooks passed, including clang-format, clang-tidy, cpplint, and markdownlint.

## Known capacity/throughput limit

With the default 128 MiB/thread arena and the full page-unroll batch 256 workload, the host completed 46 trigger/release pairs with no dropped or overwritten records, but cumulative dump/write waits exceeded the outer 45-second AICPU op-execute timeout. Increasing the arena to 256 MiB/thread and using batch 32 produced a complete passing run. The backpressure protocol protects correctness; very large dump workloads still need enough arena capacity and host write throughput to finish within the outer op timeout.
