### PR TITLE
Fix: drain SUB workers during scheduler test teardown

### DIFF
--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -2370,6 +2370,8 @@ struct GroupSchedulerFixture : public ::testing::Test {
         worker_a.drain();
         worker_b.drain();
         worker_c.drain();
+        sub_worker_a.drain();
+        sub_worker_b.drain();
         sched.stop();
         manager.stop();
         allocator.shutdown();
@@ -2842,8 +2844,8 @@ TEST_F(GroupSchedulerFixture, ConsecutiveGroupsReserveOnlyBlockedHeadTargets) {
 
 TEST_F(GroupSchedulerFixture, TearDownDrainsCurrentAndQueuedDispatches) {
     // The verification is the teardown itself: work is left deliberately in
-    // both states — running and queued-but-undispatched — so teardown drains
-    // a worker mid-task and one whose dispatch has not happened yet.
+    // both states — running and queued-but-undispatched — across NEXT_LEVEL
+    // and SUB workers, so every registered worker type must drain cleanly.
     {
         std::lock_guard<std::mutex> scheduler_pause(sched.loop_mutex());
         (void)orch.submit_next_level_group(
@@ -2856,12 +2858,19 @@ TEST_F(GroupSchedulerFixture, TearDownDrainsCurrentAndQueuedDispatches) {
         );
         (void)orch.submit_next_level(C(86), single_tensor_args(0x10A, TensorArgType::OUTPUT), cfg, 0);
         (void)orch.submit_next_level(C(87), single_tensor_args(0x10B, TensorArgType::OUTPUT), cfg, 2);
+        (void)orch.submit_sub_group(
+            C(88), {single_tensor_args(0x10C, TensorArgType::OUTPUT), single_tensor_args(0x10D, TensorArgType::OUTPUT)}
+        );
     }
 
     worker_a.wait_running();
     worker_b.wait_running();
+    sub_worker_a.wait_running();
+    sub_worker_b.wait_running();
     EXPECT_TRUE(worker_a.is_running.load(std::memory_order_acquire));
     EXPECT_TRUE(worker_b.is_running.load(std::memory_order_acquire));
+    EXPECT_TRUE(sub_worker_a.is_running.load(std::memory_order_acquire));
+    EXPECT_TRUE(sub_worker_b.is_running.load(std::memory_order_acquire));
 }
 
 // The shape that hangs when the idle edge is missing: a second task queued for


### PR DESCRIPTION
## Summary

- Drain both registered SUB mock workers before stopping the scheduler in
  `GroupSchedulerFixture`.
- Extend the teardown regression test to leave an in-flight SUB group alongside
  running and queued NEXT_LEVEL work.

## Why

`GroupSchedulerFixture` registers `sub_worker_a` and `sub_worker_b`, but its
teardown previously drained only the NEXT_LEVEL workers. `Scheduler::stop()`
waits for `WorkerManager::any_busy()`, which includes SUB workers, so an
unfinished SUB dispatch could hang fixture teardown.

This is a follow-up to #1611 and addresses:
https://github.com/hw-native-sys/simpler/pull/1611#discussion_r3698805373

## Testing

- Before the fix, the extended teardown test timed out after 5 seconds.
- `TearDownDrainsCurrentAndQueuedDispatches`: 100 iterations passed.
- Full `test_scheduler`: 62 tests passed.
- All 76 non-hardware CTest entries passed; 75 ran inside the sandbox, and
  `test_remote_endpoint` passed when rerun outside because socket creation is
  restricted inside the Codex sandbox.
- `clang-format --dry-run --Werror` passed.