### PR TITLE
Add device-free fake-chip-L3 harness, converge mock forks, eligibility cases

### DIFF
--- a/tests/ut/py/test_worker/__init__.py
+++ b/tests/ut/py/test_worker/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/ut/py/test_worker/_harness.py
+++ b/tests/ut/py/test_worker/_harness.py
@@ -1,0 +1,208 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Device-free chip-backed Worker trees for the Python worker unit tests.
+
+A chip child is forked, so the ``ChipWorker`` bound on ``simpler.worker`` at
+``Worker.init()`` time is the class the forked child instantiates. Replacing it
+with :class:`FakeChipWorker` yields an L3 that carries ``device_ids``, reaches
+READY, serves the CTRL_REGISTER / CTRL_UNREGISTER control path, and closes —
+with no NPU and no device runtime driven. ``platform="a2a3sim"`` is a
+construction-time requirement only: the parent reads the prebuilt sim runtime
+binaries to build the fork payload and never executes them, which is what
+:data:`requires_sim_binaries` gates on.
+
+A fake chip is the real dispatch target for its L3, so a broadcast that reaches
+it is observable from the parent: ``register_error`` makes the chip child's
+native register raise, and the failure surfaces to the caller of
+``Worker.register`` as REGISTER_PARTIAL_FAILURE.
+"""
+
+from __future__ import annotations
+
+import signal
+import time
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from functools import partial
+
+import pytest
+import simpler.worker as worker_mod
+from simpler.task_interface import ChipCallable
+from simpler.worker import Worker
+
+SIM_PLATFORM = "a2a3sim"
+SIM_RUNTIME = "tensormap_and_ringbuffer"
+
+#: Message raised by ``FakeChipWorker.init`` under the ``"raises"`` script.
+CHIP_INIT_FAILURE = "injected chip init failure"
+
+#: Wall budget for a single scenario — comfortably above the injected
+#: ``startup_timeout_s`` values, well under any real hang.
+TEST_WALL_BUDGET_S = 30.0
+
+#: Longer than any test budget, so the ``"hangs"`` script is only ever ended by
+#: the parent's startup deadline reaping the child.
+_HANG_S = 3600.0
+
+_SCRIPTS = ("ok", "raises", "hangs")
+
+
+@contextmanager
+def hard_timeout(seconds: float, msg: str = "startup did not return within the hard test budget"):
+    """Abort the body with TimeoutError if it runs longer than ``seconds``.
+
+    A backstop against a regression that reintroduces an unbounded startup
+    spin: instead of hanging CI, the test fails with TimeoutError. Uses SIGALRM
+    (pytest runs on the main thread), which interrupts the barrier's
+    ``time.sleep`` poll.
+
+    A single itimer backs this, so nesting two live ``hard_timeout`` scopes
+    leaves only the inner deadline armed.
+    """
+
+    def _handler(_signum, _frame):
+        raise TimeoutError(msg)
+
+    old = signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old)
+
+
+def sim_binaries_available() -> bool:
+    """True when the prebuilt ``a2a3sim`` runtime binaries a chip-carrying L3
+    reads at construction are present."""
+    try:
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        RuntimeBuilder(SIM_PLATFORM).get_binaries(SIM_RUNTIME)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+requires_sim_binaries = pytest.mark.skipif(
+    not sim_binaries_available(), reason=f"{SIM_PLATFORM} runtime binaries not built"
+)
+
+
+def chip_callable(func_name: str = "x", binary: bytes = b"\x00") -> ChipCallable:
+    """A minimal LOCAL_CHIP target; a fake chip never executes its payload."""
+    return ChipCallable.build(signature=[], func_name=func_name, binary=binary, children=[])
+
+
+class _FakeChipImpl:
+    """The native-handle half of :class:`FakeChipWorker` (``cw._impl``)."""
+
+    supports_concurrent_native_prepare = False
+
+    def __init__(self, register_error: str | None = None) -> None:
+        self._register_error = register_error
+
+    def register_callable_from_blob(self, cid: int, addr: int) -> None:
+        if self._register_error is not None:
+            raise RuntimeError(self._register_error)
+
+
+class FakeChipWorker:
+    """Stand-in for the native ChipWorker — no NPU touched.
+
+    ``script`` selects what ``init`` does: ``"ok"`` returns, ``"raises"`` raises
+    :data:`CHIP_INIT_FAILURE`, ``"hangs"`` blocks past any test budget.
+    ``register_error``, orthogonal to the script, makes the post-READY native
+    register raise that message on the chip child.
+
+    Build one with :func:`fake_chip_worker`; ``ChipWorker`` is constructed with
+    no arguments on both the L2 in-process and the forked chip-child paths.
+    """
+
+    pipeline_depth = 1
+    committed_device_memory = 0
+
+    def __init__(self, *, script: str = "ok", register_error: str | None = None) -> None:
+        if script not in _SCRIPTS:
+            raise ValueError(f"unknown fake-chip script {script!r}; expected one of {_SCRIPTS}")
+        self.script = script
+        self._impl = _FakeChipImpl(register_error)
+
+    def init(self, *_a, **_k) -> None:
+        if self.script == "raises":
+            raise RuntimeError(CHIP_INIT_FAILURE)
+        if self.script == "hangs":
+            time.sleep(_HANG_S)
+
+    def _register_callable_at_slot(self, _cid: int, _target) -> None:
+        pass
+
+    def _unregister_slot(self, _cid: int) -> None:
+        pass
+
+    def _run_slot(self, *_a, **_k) -> None:
+        pass
+
+    def finalize(self) -> None:
+        pass
+
+
+def fake_chip_worker(*, script: str = "ok", register_error: str | None = None):
+    """A zero-argument factory producing :class:`FakeChipWorker` instances."""
+    if script not in _SCRIPTS:
+        raise ValueError(f"unknown fake-chip script {script!r}; expected one of {_SCRIPTS}")
+    return partial(FakeChipWorker, script=script, register_error=register_error)
+
+
+def install_fake_chip(monkeypatch, *, script: str = "ok", register_error: str | None = None) -> None:
+    """Bind the fake as ``simpler.worker.ChipWorker`` for the rest of the test.
+
+    Must precede ``Worker.init()``: the chip child resolves the name at fork
+    time, and an L2 worker resolves it in-process during its own init.
+    """
+    monkeypatch.setattr(worker_mod, "ChipWorker", fake_chip_worker(script=script, register_error=register_error))
+
+
+@contextmanager
+def fake_chip_l3(
+    monkeypatch,
+    *,
+    script: str = "ok",
+    register_error: str | None = None,
+    device_ids: Sequence[int] = (0,),
+    num_sub_workers: int = 0,
+    startup_timeout_s: float = 10.0,
+    init: bool = True,
+    timeout_s: float = TEST_WALL_BUDGET_S,
+    **worker_kwargs,
+) -> Iterator[Worker]:
+    """Yield an L3 backed by ``len(device_ids)`` fake chips, closed on exit.
+
+    With ``init=False`` the worker is yielded NEW, for a body that registers
+    into the startup snapshot or asserts on ``init()`` itself. The whole body,
+    including ``close()``, runs under :func:`hard_timeout` — do not nest another
+    one inside it.
+    """
+    install_fake_chip(monkeypatch, script=script, register_error=register_error)
+    worker = Worker(
+        level=3,
+        device_ids=list(device_ids),
+        platform=SIM_PLATFORM,
+        runtime=SIM_RUNTIME,
+        num_sub_workers=num_sub_workers,
+        startup_timeout_s=startup_timeout_s,
+        **worker_kwargs,
+    )
+    with hard_timeout(timeout_s):
+        try:
+            if init:
+                worker.init()
+            yield worker
+        finally:
+            worker.close()

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -66,6 +66,8 @@ from simpler.worker import (
     _pack_py_callable_payload,
 )
 
+from ._harness import chip_callable, fake_chip_l3, requires_sim_binaries
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -335,6 +337,14 @@ class _FakeNativeRunImpl:
 
 
 class _FakeTwoFrameChipWorker:
+    """Collaborator double handed straight to ``_run_chip_main_loop`` in-process.
+
+    Distinct from ``_harness.FakeChipWorker``, which stands in for the class the
+    forked chip child instantiates: this one is never bound as
+    ``worker.ChipWorker`` and never init'd or finalized, so it implements only
+    the two-frame native-run surface the loop drives.
+    """
+
     pipeline_depth = 2
 
     def __init__(self, *, supports_concurrent_native_prepare: bool = False) -> None:
@@ -1394,20 +1404,28 @@ class TestLifecycle:
                 hw._hierarchical_start_cv.wait = original_wait
             hw.close()
 
-    def test_prepare_chip_callable_after_init_no_chips_succeeds(self):
-        # With no chip children (device_ids unset), the C++ broadcast is a
-        # no-op (next_level_threads_ is empty) — exercises the facade path
-        # (registry lock, cid allocation, broadcast call, return) end-to-end
-        # without needing an NPU.
-        hw = Worker(level=3, num_sub_workers=0)
-        hw.init()
-        try:
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-            handle = hw.register(callable_obj)
+    @requires_sim_binaries
+    def test_prepare_chip_callable_after_init_succeeds(self, monkeypatch):
+        # A post-init ChipCallable travels the whole dynamic-prepare path —
+        # registry lock, cid allocation, broadcast, chip-child CTRL_REGISTER,
+        # native register — and returns a handle bound to a live slot. The
+        # chipless counterpart is the opposite claim and lives with the rest of
+        # the eligibility rule, in
+        # test_startup_readiness.py::TestEligibleTargetPrecheck.
+        with fake_chip_l3(monkeypatch) as hw:
+            handle = hw.register(chip_callable())
             assert isinstance(handle, CallableHandle)
             assert _slot_for(hw, handle) >= 0
-        finally:
-            hw.close()
+
+    @requires_sim_binaries
+    def test_prepare_chip_callable_surfaces_chip_child_register_failure(self, monkeypatch):
+        # The broadcast reaches the chip child rather than terminating in the
+        # parent: a native register that raises on the child comes back to the
+        # caller as REGISTER_PARTIAL_FAILURE, and the handle is rolled back.
+        with fake_chip_l3(monkeypatch, register_error="injected chip register failure") as hw:
+            with pytest.raises(RuntimeError, match="REGISTER_PARTIAL_FAILURE"):
+                hw.register(chip_callable())
+            assert hw._callable_registry == {}
 
     def test_prepare_chip_callable_at_cid_overflow_raises(self):
         # cid budget is enforced under the new dynamic-prepare path too:
@@ -1415,14 +1433,19 @@ class TestLifecycle:
         # post-init ChipCallable prepare and observe the existing
         # MAX_REGISTERED_CALLABLE_IDS RuntimeError. A sub child gives the
         # pre-registered python callables an eligible dispatch target.
+        #
+        # This worker is chipless, so the ChipCallable is over the cid budget
+        # AND ineligible under the startup dispatch-target rule. Only the cid
+        # budget is asserted; the relative order of the two checks is unpinned
+        # here (see the b2 xfail in
+        # test_startup_readiness.py::TestEligibleTargetPrecheck).
         hw = Worker(level=3, num_sub_workers=1)
         try:
             for i in range(MAX_REGISTERED_CALLABLE_IDS):
                 hw.register(_unique_py_callable(i))
             hw.init()
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
             with pytest.raises(RuntimeError, match="MAX_REGISTERED_CALLABLE_IDS"):
-                hw.register(callable_obj)
+                hw.register(chip_callable())
         finally:
             hw.close()
 
@@ -1437,16 +1460,15 @@ class TestLifecycle:
         finally:
             hw.close()
 
-    def test_unregister_chip_callable_after_init_no_chips_succeeds(self):
-        # With zero chip mailboxes the C++ broadcast is a no-op, so the
-        # facade path (registry lock, broadcast, registry pop) is exercised
-        # end-to-end without an NPU. Also verifies slot reuse — unregistering
-        # frees the slot and the next register reuses the same slot via
-        # `_allocate_cid` (smallest-unused-integer).
-        hw = Worker(level=3, num_sub_workers=0)
-        hw.init()
-        try:
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+    @requires_sim_binaries
+    def test_unregister_chip_callable_after_init_succeeds(self, monkeypatch):
+        # Register and unregister both broadcast to a live chip child, which
+        # drops the digest from its identity table and releases the native
+        # slot. Also verifies slot reuse — unregistering frees the slot and the
+        # next register reuses the same slot via `_allocate_cid`
+        # (smallest-unused-integer).
+        with fake_chip_l3(monkeypatch) as hw:
+            callable_obj = chip_callable()
             handle_a = hw.register(callable_obj)
             slot_a = _slot_for(hw, handle_a)
             assert slot_a in hw._callable_registry
@@ -1454,8 +1476,6 @@ class TestLifecycle:
             assert slot_a not in hw._callable_registry
             handle_b = hw.register(callable_obj)
             assert _slot_for(hw, handle_b) == slot_a, "smallest-unused-cid policy should reuse the freed slot"
-        finally:
-            hw.close()
 
     def test_prepare_chip_callable_broadcast_runs_without_registry_lock(self):
         hw = Worker(level=3, num_sub_workers=0)

--- a/tests/ut/py/test_worker/test_l3_l2_orch_comm.py
+++ b/tests/ut/py/test_worker/test_l3_l2_orch_comm.py
@@ -148,6 +148,14 @@ class _NamedOnboardRegionExport:
 
 
 class _FakeChipWorkerForRegionCreate:
+    """Collaborator double for the in-process L3-L2 region-create handlers.
+
+    Distinct from ``_harness.FakeChipWorker``, which stands in for the class the
+    forked chip child instantiates: this one is never bound as
+    ``worker.ChipWorker``, so it implements only the device-memory surface a
+    region create touches.
+    """
+
     device_id = 2
 
     def __init__(self) -> None:

--- a/tests/ut/py/test_worker/test_l4_recursive.py
+++ b/tests/ut/py/test_worker/test_l4_recursive.py
@@ -12,8 +12,11 @@ L4 Worker dispatches to L3 Worker children (PROCESS mode). Each L3 Worker
 has its own SubWorkers. Verifies the full DAG completes and sub callables
 at L3 level see correct data.
 
-No NPU device required — L3 children use SubWorkers only (no ChipWorker).
+No NPU device required: the dataflow tests give their L3 children SubWorkers
+only, and the chip-callable cascade gives them a fake chip (``_harness``).
 """
+
+from __future__ import annotations
 
 import struct
 from multiprocessing.shared_memory import SharedMemory
@@ -22,6 +25,16 @@ import pytest
 from simpler.callable_identity import CallableHandle
 from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import Worker
+
+from ._harness import (
+    SIM_PLATFORM,
+    SIM_RUNTIME,
+    TEST_WALL_BUDGET_S,
+    chip_callable,
+    hard_timeout,
+    install_fake_chip,
+    requires_sim_binaries,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -151,52 +164,72 @@ class TestL4Validation:
             w4.close()
 
 
+@requires_sim_binaries
 class TestL4DynamicRegister:
     """Cascade of CTRL_REGISTER / CTRL_UNREGISTER through an L4 → L3 worker tree.
 
-    The L3 child is sub-only (no chip device) so the cascade hits zero
-    chip mailboxes inside the L3 child — but exercises the full path
-    from L4 parent → next_level mailbox → ``_child_worker_loop`` CONTROL
-    handler → ``inner_worker._register_child_chip`` recursively. NPU not required.
+    The L3 child carries a fake chip, so the cascade runs the whole path from
+    L4 parent → next_level mailbox → ``_child_worker_loop`` CONTROL handler →
+    ``inner_worker._register_child_chip`` → the L3's own chip mailbox → the
+    chip child's native register. The fake crosses both forks, so no NPU is
+    required.
     """
 
-    def test_l4_register_chip_callable_after_init_succeeds(self):
-        from simpler.task_interface import ChipCallable  # noqa: PLC0415
-
-        l3 = Worker(level=3, num_sub_workers=1)
+    @staticmethod
+    def _l4_over_chip_backed_l3(monkeypatch, *, register_error: str | None = None) -> Worker:
+        install_fake_chip(monkeypatch, register_error=register_error)
+        l3 = Worker(
+            level=3,
+            device_ids=[0],
+            platform=SIM_PLATFORM,
+            runtime=SIM_RUNTIME,
+            num_sub_workers=1,
+            startup_timeout_s=10.0,
+        )
         l3.register(lambda args: None)  # at least one registered callable so L3 init is happy
 
-        w4 = Worker(level=4, num_sub_workers=0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0)
         w4.register(lambda orch, args, config: None)
         w4.add_worker(l3)
-        w4.init()
+        return w4
+
+    def test_l4_register_chip_callable_after_init_succeeds(self, monkeypatch):
+        w4 = self._l4_over_chip_backed_l3(monkeypatch)
         try:
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-            handle = w4.register(callable_obj)
-            assert isinstance(handle, CallableHandle)
-            assert _slot_for(w4, handle) >= 0
+            with hard_timeout(TEST_WALL_BUDGET_S):
+                w4.init()
+                handle = w4.register(chip_callable())
+                assert isinstance(handle, CallableHandle)
+                assert _slot_for(w4, handle) >= 0
         finally:
             w4.close()
 
-    def test_l4_register_then_unregister_recycles_cid(self):
-        from simpler.task_interface import ChipCallable  # noqa: PLC0415
-
-        l3 = Worker(level=3, num_sub_workers=1)
-        l3.register(lambda args: None)
-
-        w4 = Worker(level=4, num_sub_workers=0)
-        w4.register(lambda orch, args, config: None)
-        w4.add_worker(l3)
-        w4.init()
+    def test_l4_register_then_unregister_recycles_cid(self, monkeypatch):
+        w4 = self._l4_over_chip_backed_l3(monkeypatch)
         try:
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-            handle_a = w4.register(callable_obj)
-            slot_a = _slot_for(w4, handle_a)
-            w4.unregister(handle_a)
-            assert slot_a not in w4._callable_registry
-            # Slot is freed; the next register reuses it.
-            handle_b = w4.register(callable_obj)
-            assert _slot_for(w4, handle_b) == slot_a
+            with hard_timeout(TEST_WALL_BUDGET_S):
+                w4.init()
+                callable_obj = chip_callable()
+                handle_a = w4.register(callable_obj)
+                slot_a = _slot_for(w4, handle_a)
+                w4.unregister(handle_a)
+                assert slot_a not in w4._callable_registry
+                # Slot is freed; the next register reuses it.
+                handle_b = w4.register(callable_obj)
+                assert _slot_for(w4, handle_b) == slot_a
+        finally:
+            w4.close()
+
+    def test_l4_register_surfaces_grandchild_chip_register_failure(self, monkeypatch):
+        # The cascade terminates at the chip child two forks down, not at the
+        # L3 child: a native register that raises there travels back up as the
+        # L4's REGISTER_PARTIAL_FAILURE.
+        w4 = self._l4_over_chip_backed_l3(monkeypatch, register_error="injected chip register failure")
+        try:
+            with hard_timeout(TEST_WALL_BUDGET_S):
+                w4.init()
+                with pytest.raises(RuntimeError, match="REGISTER_PARTIAL_FAILURE"):
+                    w4.register(chip_callable())
         finally:
             w4.close()
 

--- a/tests/ut/py/test_worker/test_startup_readiness.py
+++ b/tests/ut/py/test_worker/test_startup_readiness.py
@@ -30,42 +30,27 @@ instead of hanging CI.
 """
 
 import os
-import signal
 import struct
 import threading
 import time
-from contextlib import contextmanager
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
 from simpler.task_interface import CallConfig, TaskArgs
-from simpler.worker import RunHandle, Worker
+from simpler.worker import RemoteCallable, RemoteWorkerSpec, RunHandle, Worker
 
-# Hard wall budget for a single failure scenario — comfortably above the
-# injected startup_timeout_s values below, well under any real hang.
-_TEST_WALL_BUDGET_S = 30.0
+from ._harness import (
+    CHIP_INIT_FAILURE,
+    TEST_WALL_BUDGET_S,
+    chip_callable,
+    fake_chip_l3,
+    hard_timeout,
+    install_fake_chip,
+    requires_sim_binaries,
+)
 
-
-@contextmanager
-def _hard_timeout(seconds: float, msg: str = "startup did not return within the hard test budget"):
-    """Abort the body with TimeoutError if it runs longer than ``seconds``.
-
-    A backstop against a regression that reintroduces an unbounded startup
-    spin: instead of hanging CI, the test fails with TimeoutError. Uses SIGALRM
-    (pytest runs on the main thread), which interrupts the barrier's
-    ``time.sleep`` poll.
-    """
-
-    def _handler(_signum, _frame):
-        raise TimeoutError(msg)
-
-    old = signal.signal(signal.SIGALRM, _handler)
-    signal.setitimer(signal.ITIMER_REAL, seconds)
-    try:
-        yield
-    finally:
-        signal.setitimer(signal.ITIMER_REAL, 0)
-        signal.signal(signal.SIGALRM, old)
+_TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+_hard_timeout = hard_timeout
 
 
 def _run_catch(fn):
@@ -686,22 +671,6 @@ class TestApiLinearizationDuringInit:
             it.join(10.0)
 
 
-class _FakeChipOk:
-    """Stand-in for a ChipWorker whose init succeeds — no NPU touched."""
-
-    def init(self, *_a, **_k):
-        pass
-
-    def _register_callable_at_slot(self, *_a, **_k):  # pragma: no cover
-        pass
-
-    def _run_slot(self, *_a, **_k):
-        pass
-
-    def finalize(self):
-        pass
-
-
 # Module-level (picklable-by-reference) probe for the callable-__del__-reenters-
 # close regression: the callable must not hold a Worker ref (register pickles it),
 # so it reaches the worker via this module global at __del__ time only.
@@ -734,8 +703,6 @@ class TestLevel2Lifecycle:
     """
 
     def _make_l2(self, monkeypatch):
-        import simpler.worker as worker_mod  # noqa: PLC0415
-
         import simpler_setup.runtime_builder as rb_mod  # noqa: PLC0415
 
         class _FakeBuilder:
@@ -747,7 +714,7 @@ class TestLevel2Lifecycle:
 
         # Mock the device/runtime layer so this stays device-free (no sim
         # binaries required) — the regression is purely the lifecycle state.
-        monkeypatch.setattr(worker_mod, "ChipWorker", _FakeChipOk)
+        install_fake_chip(monkeypatch)
         monkeypatch.setattr(rb_mod, "RuntimeBuilder", _FakeBuilder)
         return Worker(level=2, device_id=0, platform="a2a3sim", runtime="tensormap_and_ringbuffer")
 
@@ -1426,35 +1393,7 @@ class TestLevel2Lifecycle:
             t1.join(5.0)
 
 
-class _FakeChipRaises:
-    """Stand-in for ChipWorker whose init raises — no NPU touched."""
-
-    def init(self, *_a, **_k):
-        raise RuntimeError("injected chip init failure")
-
-    def finalize(self):  # pragma: no cover - never reached (init raises)
-        pass
-
-
-class _FakeChipHangs:
-    def init(self, *_a, **_k):
-        time.sleep(3600)
-
-    def finalize(self):  # pragma: no cover
-        pass
-
-
-def _sim_binaries_available() -> bool:
-    try:
-        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
-
-        RuntimeBuilder("a2a3sim").get_binaries("tensormap_and_ringbuffer")
-        return True
-    except Exception:  # noqa: BLE001
-        return False
-
-
-@pytest.mark.skipif(not _sim_binaries_available(), reason="a2a3sim runtime binaries not built")
+@requires_sim_binaries
 class TestChipStartupFailure:
     """Chip (L2) startup failure — device-free via a faked ChipWorker on a2a3sim.
 
@@ -1466,41 +1405,18 @@ class TestChipStartupFailure:
     the former ``while ... != INIT_DONE`` was on this chip path).
     """
 
-    def _make_l3(self, timeout_s):
-        return Worker(
-            level=3,
-            device_ids=[0],
-            platform="a2a3sim",
-            runtime="tensormap_and_ringbuffer",
-            num_sub_workers=0,
-            startup_timeout_s=timeout_s,
-        )
-
     def test_chip_init_failure_raises_bounded(self, monkeypatch):
-        import simpler.worker as worker_mod  # noqa: PLC0415
-
-        monkeypatch.setattr(worker_mod, "ChipWorker", _FakeChipRaises)
-        l3 = self._make_l3(timeout_s=10.0)  # chip-only; the chip forks from device_ids
-        try:
-            with _hard_timeout(_TEST_WALL_BUDGET_S):
-                with pytest.raises(RuntimeError, match="injected chip init failure"):
-                    l3.init()
-        finally:
-            l3.close()
+        # chip-only L3; the chip forks from device_ids
+        with fake_chip_l3(monkeypatch, script="raises", init=False, startup_timeout_s=10.0) as l3:
+            with pytest.raises(RuntimeError, match=CHIP_INIT_FAILURE):
+                l3.init()
 
     def test_chip_init_hang_trips_deadline(self, monkeypatch):
-        import simpler.worker as worker_mod  # noqa: PLC0415
-
-        monkeypatch.setattr(worker_mod, "ChipWorker", _FakeChipHangs)
-        l3 = self._make_l3(timeout_s=1.5)  # chip-only; the chip forks from device_ids
         start = time.monotonic()
-        try:
-            with _hard_timeout(_TEST_WALL_BUDGET_S):
-                with pytest.raises(RuntimeError, match="deadline"):
-                    l3.init()
+        with fake_chip_l3(monkeypatch, script="hangs", init=False, startup_timeout_s=1.5) as l3:
+            with pytest.raises(RuntimeError, match="deadline"):
+                l3.init()
             assert 1.5 <= time.monotonic() - start < _TEST_WALL_BUDGET_S
-        finally:
-            l3.close()
 
 
 class TestEligibleTargetPrecheck:
@@ -1559,6 +1475,87 @@ class TestEligibleTargetPrecheck:
         with _hard_timeout(_TEST_WALL_BUDGET_S):
             w.init()
             assert w._initialized is True
+            w.close()
+
+    @requires_sim_binaries
+    def test_chip_backed_l3_with_chip_callable_inits(self, monkeypatch):
+        # LOCAL_CHIP positive: the chip child resolves the ChipCallable and
+        # prepares it before publishing INIT_READY, so the tree comes up READY.
+        with fake_chip_l3(monkeypatch, init=False) as w:
+            w.register(chip_callable())
+            w.init()
+            assert w._initialized is True
+
+    def test_chipless_l3_with_chip_callable_rejected_at_init(self):
+        # LOCAL_CHIP negative: a ChipCallable is installed only into chip child
+        # loops, so a sub-backed but chipless L3 has no resolver for it.
+        w = Worker(level=3, num_sub_workers=1)
+        w.register(chip_callable())
+        try:
+            with _hard_timeout(_TEST_WALL_BUDGET_S):
+                with pytest.raises(
+                    RuntimeError, match=r"LOCAL_CHIP callable .* \(needs a chip device \(device_ids\)\)"
+                ):
+                    w.init()
+                assert w._chip_pids == []
+        finally:
+            w.close()
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="P0.2-b2: post-init register does not re-apply the startup eligibility rule",
+    )
+    def test_post_init_chip_callable_on_chipless_l3_rejected(self):
+        # The same LOCAL_CHIP rule, one epoch later: an L3 that came up without
+        # a chip child cannot resolve a ChipCallable handed to it post-init
+        # either, so register() must reject it instead of returning an inert
+        # handle.
+        w = Worker(level=3, num_sub_workers=1)
+        try:
+            with _hard_timeout(_TEST_WALL_BUDGET_S):
+                w.init()
+                with pytest.raises(RuntimeError, match=r"\(needs a chip device \(device_ids\)\)"):
+                    w.register(chip_callable())
+        finally:
+            w.close()
+
+    def test_remote_callable_naming_its_own_remote_passes_init_gate(self):
+        # REMOTE_TASK_DISPATCHER positive: the callable names a worker id that
+        # add_remote_worker returned, so the gate init() runs over the startup
+        # snapshot accepts it. Driven directly rather than through init(), which
+        # would additionally attach a live remote L3 session.
+        w = Worker(level=4, num_sub_workers=0)
+        worker_id = w.add_remote_worker(RemoteWorkerSpec(endpoint="127.0.0.1:19073", platform="a2a3sim"))
+        handle = w.register(RemoteCallable("pkg.remote:orch"), workers=[worker_id])
+        try:
+            assert w._resolve_handle(handle).target_namespace == "REMOTE_TASK_DISPATCHER"
+            w._validate_eligible_targets()
+        finally:
+            w.close()
+
+    def test_remote_callable_naming_unknown_worker_is_rejected(self):
+        # REMOTE_TASK_DISPATCHER negative: naming an id that add_remote_worker
+        # never returned is refused at register, i.e. before the registration
+        # can reach the startup snapshot that _validate_eligible_targets scans.
+        w = Worker(level=4, num_sub_workers=0)
+        worker_id = w.add_remote_worker(RemoteWorkerSpec(endpoint="127.0.0.1:19073", platform="a2a3sim"))
+        try:
+            with pytest.raises(ValueError, match="workers must name remote worker ids"):
+                w.register(RemoteCallable("pkg.remote:orch"), workers=[worker_id + 1])
+        finally:
+            w.close()
+
+    def test_remote_need_is_the_unmet_named_workers(self):
+        # The init-time rule behind both cases above: a REMOTE_TASK_DISPATCHER
+        # registration is eligible exactly when every id it names is a live
+        # remote worker. Driven directly because register() refuses to build the
+        # ineligible registration in the first place.
+        w = Worker(level=4, num_sub_workers=0)
+        worker_id = w.add_remote_worker(RemoteWorkerSpec(endpoint="127.0.0.1:19073", platform="a2a3sim"))
+        try:
+            assert w._eligible_target_need("REMOTE_TASK_DISPATCHER", (worker_id,)) is None
+            assert "add_remote_worker" in w._eligible_target_need("REMOTE_TASK_DISPATCHER", (worker_id + 1,))
+        finally:
             w.close()
 
 


### PR DESCRIPTION
## Summary

A shared device-free fake-chip-L3 test harness in `tests/ut/py/test_worker/_harness.py`
that makes it one call — `fake_chip_l3(monkeypatch)` — to stand up a `device_ids`-carrying
L3 that reaches READY, serves the full CTRL_REGISTER / CTRL_UNREGISTER control path,
and closes cleanly with no NPU.

### b1-1 — converge four independent mock ChipWorker forks

Three fakes that were three forks of the same `monkeypatch.setattr(worker_mod, "ChipWorker", …)`
substitution point (`_FakeChipOk` / `_FakeChipRaises` / `_FakeChipHangs`) converge into one
`FakeChipWorker` with `script="ok"|"raises"|"hangs"` and an orthogonal `register_error` knob.

`_TwoFrameLoopHarness` was out of scope per the task doc.

**Two fakes deliberately stay** (`_FakeTwoFrameChipWorker`, `_FakeChipWorkerForRegionCreate`),
each now carrying a docstring stating why: they are collaborator doubles handed directly to
in-process functions (`_run_chip_main_loop`, the region-create handlers), never bound as
`worker.ChipWorker` and never forked. Folding them into a startup fake would hand them an
`init`/`finalize` surface they never use.

### b1-2 — eligibility pos/neg cases for all three dispatch-target namespaces

| namespace | positive | negative |
|-----------|----------|----------|
| `LOCAL_CHIP` | chip-backed L3 with pre-registered `ChipCallable` reaches READY | sub-only L3 with `ChipCallable` rejected at `init()` |
| `LOCAL_PYTHON` | existing (sub-backed L3 with lambda inits) | existing (childless L3 with lambda rejected) |
| `REMOTE_TASK_DISPATCHER` | `_validate_eligible_targets` accepts a registration naming its own `add_remote_worker` id | `register` refuses an unknown id (plus a direct unit test of the `_eligible_target_need` backstop) |

All init-time cases are green. The **post-init `LOCAL_CHIP` negative is `xfail(strict=True)`**
with a P0.2-b2 reference — it fails `DID NOT RAISE` because the post-init path does not yet
re-apply the startup eligibility rule. b2 makes it pass and removes the xfail.

### b1-3 — migrate facade tests to the real path

Four chipless-facade tests now exercise the chip child:

- `test_prepare_chip_callable_after_init_succeeds` (was `…no_chips_succeeds`) — real chip, still succeeds
- `test_unregister_chip_callable_after_init_succeeds` (was `…no_chips_succeeds`) — real chip, unregister+recycle
- `test_l4_register_chip_callable_after_init_succeeds` (was sub-only L3) — chip-backed L3, cascade verified
- `test_l4_register_then_unregister_recycles_cid` (was sub-only L3) — chip-backed L3

A new test at each level feeds `register_error` and asserts `REGISTER_PARTIAL_FAILURE` —
proof the broadcast reaches the chip child and is not terminated by an empty mailbox set
in the parent.

### Two expectation changes the task doc asked to flag

| test | change |
|------|--------|
| `test_prepare_chip_callable_after_init_no_chips_succeeds` | renamed `…_after_init_succeeds`, given a real chip. The chipless counterpart is the **b2 xfail** in `test_startup_readiness.py::TestEligibleTargetPrecheck`. |
| `test_prepare_chip_callable_at_cid_overflow_raises` | **check order untouched.** The worker is chipless, so the callable is over the cid budget AND ineligible under the dispatch-target rule. Only the cid budget is asserted; the relative order of the two checks is unpinned here — b2 decides. |

### Placement choice

The harness lives in `tests/ut/py/test_worker/_harness.py` (a package-private module imported
with `from ._harness import …`), following the same pattern as `tests/st/worker/collectives/_helpers.py`
(a `_`-prefixed module in a package directory with `__init__.py` and relative imports).
Not a conftest fixture: the harness exports classes, a context manager, and a skip marker,
not fixtures.

## Testing

- [x] `pytest tests/ut -m "not requires_hardware"` → 1051 passed, 7 skipped, 1 xfailed
- [x] `pytest tests/ut/py/test_worker` run 3× consecutively → identical (514/2/1) each time
- [x] `pytest tests/ut -m requires_hardware --platform a2a3` on locked a2a3 → 6 passed
- [x] `pre-commit` on all six touched files → clean (ruff check/format, pyright, headers)
- [x] `python/` and `src/` are zero-diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)