### PR TITLE
Add: cooperative init cancellation and retryable resource cleanup journal

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -249,6 +249,21 @@ def _local_task_frame_count(platform: str, _runtime: str, pipeline_depth: int) -
     return 1
 
 
+def _shm_name(token: str, suffix: str):
+    """Deterministic POSIX shm name from the root token and a per-child suffix.
+    Returns None (random name) when token is empty. Truncates the token to
+    8 hex characters so the full name fits within macOS's 30-character
+    POSIX-shm-name limit (PSHMNAMLEN=31 including NUL).
+
+    Each Worker generates its own token, so a name identifies one mailbox of
+    one startup epoch. Being a fixed name rather than a random one, a segment
+    left behind by a crashed prior run makes ``SharedMemory(create=True)`` fail
+    with ``FileExistsError`` instead of being silently bypassed."""
+    if not token:
+        return None
+    return f"sp-{token[:8]}-{suffix}"
+
+
 # Startup readiness bound. A child that neither reports INIT_READY/INIT_FAILED
 # nor exits within this window is treated as hung and startup is aborted.
 # Generous by default so a legitimately slow device/runtime init (large
@@ -271,6 +286,13 @@ _ROLLBACK_GRACEFUL_TIMEOUT_S = 10.0
 # joiner still re-observes `done` within this interval instead of blocking
 # forever.
 _CLOSE_JOIN_RECHECK_S = 1.0
+# Upper bound on how long close() waits for a cancelled init() to unwind.
+# The cancel token is only observed at cooperative points (the child-readiness
+# poll and the READY commit gate), so an init blocked inside a native segment
+# — ChipWorker.init(), the fork phase — reaches none of them. Past this bound
+# close() raises rather than blocking forever; the init epoch is left to
+# complete on its own thread.
+_CLOSE_CANCEL_UNWIND_TIMEOUT_S = 60.0
 # Bounded re-check interval for a RunHandle waiter parked behind the elected
 # waiter. Same backstop role as _CLOSE_JOIN_RECHECK_S: if the elected waiter's
 # notify_all() is skipped (an async BaseException landing between publishing the
@@ -3025,6 +3047,47 @@ def _child_worker_loop(
     )
 
 
+def _journal_child_survivors(journal, sub_shms, sub_pids, chip_shms, chip_pids, next_shms, next_pids, reaped):
+    """Register unreaped child processes and their paired shms in the cleanup
+    journal so a subsequent close() can retry."""
+    for shms, pids, kind in (
+        (sub_shms, sub_pids, "sub"),
+        (chip_shms, chip_pids, "chip"),
+        (next_shms, next_pids, "next"),
+    ):
+        for i in range(min(len(shms), len(pids))):
+            pid = pids[i]
+            if pid in reaped:
+                continue
+            shm = shms[i]
+
+            def _make_cleanup(_shm=shm, _pid=pid, _kind=kind):
+                def _cleanup_child():
+                    try:
+                        wpid, _status = os.waitpid(_pid, os.WNOHANG)
+                    except OSError:
+                        wpid = 0
+                    if wpid == 0:
+                        raise RuntimeError(f"child {_kind} pid {_pid} still alive; shm not freed")
+                    cleanup_error = None
+                    try:
+                        _shm.close()
+                    except BaseException as exc:  # noqa: BLE001
+                        cleanup_error = exc
+                    try:
+                        _shm.unlink()
+                    except FileNotFoundError:
+                        pass
+                    except BaseException as exc:  # noqa: BLE001
+                        cleanup_error = cleanup_error or exc
+                    if cleanup_error is not None:
+                        raise cleanup_error
+
+                return _cleanup_child
+
+            journal.add("child", f"{kind} pid {pid} (shm unreclaimed)", _make_cleanup())
+
+
 class _Lifecycle(enum.Enum):
     """The single authoritative *public-admission* lifecycle of a Worker (5
     states), guarded by ``_hierarchical_start_cv``.
@@ -3032,8 +3095,8 @@ class _Lifecycle(enum.Enum):
     ``NEW → INITIALIZING → READY | FAILED → CLOSED``. Every level uses this
     machine: an L2 worker inits synchronously (no child barrier) but still claims
     INITIALIZING so two concurrent ``init()`` calls serialize on the same epoch.
-    close() while INITIALIZING fails fast (this worker does not support
-    cancelling an in-progress init); a caller must wait for READY or FAILED.
+    close() while INITIALIZING cooperatively cancels the in-progress init and
+    ultimately reaches CLOSED.
 
     Admission is decided solely by this state: CLOSED rejects every public
     live-tree API, permanently (close() is a commitment, not a reversible
@@ -3056,6 +3119,43 @@ class _CloseOutcome:
 
     error: BaseException | None
     incomplete: bool
+
+
+class CleanupJournal:
+    """Post-success resource cleanup journal shared by _teardown_ready_tree
+    and _abort_hierarchical. Entries removed only after native free succeeds."""
+
+    def __init__(self):
+        self._entries = []
+        self._errors = []
+
+    def add(self, kind, identity, cleanup_fn):
+        self._entries.append((kind, identity, cleanup_fn))
+
+    def extend(self, entries):
+        self._entries.extend(entries)
+
+    @property
+    def empty(self):
+        return len(self._entries) == 0
+
+    @property
+    def errors(self):
+        return list(self._errors)
+
+    def drive(self):
+        errors = []
+        remaining = []
+        for kind, identity, cleanup_fn in self._entries:
+            try:
+                cleanup_fn()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+                remaining.append((kind, identity, cleanup_fn))
+        self._entries = remaining
+        if errors:
+            self._errors.extend(errors)
+        return errors[0] if errors else None
 
 
 class _CloseAttempt:
@@ -3128,8 +3228,18 @@ class _StartupCancelled(BaseException):
     startup (SIGTERM). Unwinds the child's own ``setup`` — recursively rolling
     back any grandchildren it already forked — before it exits.
 
-    Only the forked-child SIGTERM path raises this: the startup *root* is not
-    cancellable (``close()`` fails fast while INITIALIZING)."""
+    Derives from ``BaseException`` because it is delivered from a signal
+    handler and must not be absorbed by the child's own ``except Exception``
+    handlers. Root-thread cancellation uses ``InitCancelled`` instead."""
+
+
+class InitCancelled(RuntimeError):
+    """Raised from ``Worker.init()`` when a concurrent ``close()`` cancelled the
+    startup epoch before it committed READY.
+
+    An ordinary ``RuntimeError`` — the init-owner thread is a normal caller, so
+    the cancellation must be catchable by ``except Exception``. Distinct from
+    ``_StartupCancelled``, which is signal-delivered inside a forked child."""
 
 
 @dataclass(eq=False)
@@ -3693,6 +3803,7 @@ class Worker:
         self._live_handles: dict[int, bytes] = {}
         self._next_handle_id: int = 0
         self._owner_id = uuid.uuid4().hex
+        self._shm_token: str = ""
         self._uncertain_hashids: set[bytes] = set()
         # Single authoritative lifecycle state (see _Lifecycle). All reads and
         # writes hold _hierarchical_start_cv. `_initialized` / `_hierarchical_
@@ -3711,6 +3822,8 @@ class Worker:
         # tree (un-reclaimed resources leak). Only a drain-timeout, which leaves
         # this False, permits a later close() to drive drain+teardown once.
         self._teardown_attempted: bool = False
+        self._cancel_token: bool = False
+        self._cleanup_journal = CleanupJournal()
         # Count of in-flight admitted operations (run / buffer / remote-memory)
         # that passed the READY gate and hold a lease. close() publishes CLOSED
         # (blocking new leases) and drains this to zero before teardown; if it
@@ -3729,9 +3842,9 @@ class Worker:
         # run on this thread: a non-owner close() of a READY tree is always
         # rejected — even after the owner thread has exited, because thread
         # affinity does not transfer (a foreign finalize would run against the
-        # wrong / unbound device context). A close() while INITIALIZING fails
-        # fast (this worker does not cancel an in-progress init); any thread may
-        # join an in-flight close().
+        # wrong / unbound device context). A close() while INITIALIZING is served
+        # by cooperative cancellation on a non-owner thread and rejected on the
+        # init-owner thread itself; any thread may join an in-flight close().
         self._init_owner_thread: threading.Thread | None = None
 
         # Narrow lock around `_callable_registry` mutation so concurrent
@@ -6040,7 +6153,9 @@ class Worker:
                     f"has no eligible dispatch target (needs {need})"
                 )
 
-    def init(self, prewarm_config: CallConfig | None = None, *, _startup_deadline: float | None = None) -> None:
+    def init(  # noqa: PLR0912, PLR0915
+        self, prewarm_config: CallConfig | None = None, *, _startup_deadline: float | None = None
+    ) -> None:
         """Initialize the worker and bring its whole subtree to READY.
 
         For an L3+ worker ``init`` is the single startup submission point: it
@@ -6097,6 +6212,9 @@ class Worker:
             self._prewarm_config = prewarm_config
             self._startup_error = None
             self._init_owner_thread = threading.current_thread()
+            self._cancel_token = False
+            if self._is_startup_root or _startup_deadline is None:
+                self._shm_token = uuid.uuid4().hex
             self._lifecycle = _Lifecycle.INITIALIZING
             if self.level >= 3:
                 self._is_startup_root = _startup_deadline is None
@@ -6128,6 +6246,8 @@ class Worker:
                 # startup this deadline also bounds.
                 if self.level >= 3 and time.monotonic() >= self._startup_deadline:
                     raise RuntimeError("hierarchical startup: startup deadline exceeded before READY")
+                if self._cancel_token:
+                    raise InitCancelled("init cancelled by close() before READY commit")
                 self._lifecycle = _Lifecycle.READY
                 self._hierarchical_start_cv.notify_all()
         except BaseException as exc:
@@ -6142,9 +6262,8 @@ class Worker:
                 self._cleanup_partial_init()
             finally:
                 with self._hierarchical_start_cv:
-                    # Only an INITIALIZING epoch commits FAILED. This thread is
-                    # the sole writer of the INITIALIZING -> FAILED edge (close()
-                    # fails fast while INITIALIZING and never advances it).
+                    # Only an INITIALIZING epoch commits FAILED. FAILED is only
+                    # written by the init thread. CLOSED is absorbing.
                     if self._lifecycle is _Lifecycle.INITIALIZING:
                         self._lifecycle = _Lifecycle.FAILED
                     self._hierarchical_start_cv.notify_all()
@@ -6195,9 +6314,11 @@ class Worker:
         if self._remote_worker_specs:
             self._remote_session_timeout_s()
 
+        for inner in self._next_level_workers:
+            inner._shm_token = self._shm_token
         # 1. Allocate sub-worker mailboxes (unified layout, MAILBOX_SIZE each).
-        for _ in range(n_sub):
-            shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+        for i in range(n_sub):
+            shm = SharedMemory(create=True, size=MAILBOX_SIZE, name=_shm_name(self._shm_token, f"sub-{i}"))
             assert shm.buf is not None
             _mailbox_store_i32(_buffer_field_addr(shm.buf, _OFF_STATE), _IDLE)
             self._sub_shms.append(shm)
@@ -6219,15 +6340,15 @@ class Worker:
             self._l3_bins = binaries
 
             # Allocate chip mailboxes (unified layout, MAILBOX_SIZE each).
-            for _ in device_ids:
-                shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+            for i, _dev_id in enumerate(device_ids):
+                shm = SharedMemory(create=True, size=MAILBOX_SIZE, name=_shm_name(self._shm_token, f"chip-{i}"))
                 assert shm.buf is not None
                 _mailbox_store_i32(_buffer_field_addr(shm.buf, _OFF_STATE), _IDLE)
                 self._chip_shms.append(shm)
 
         # 3. Allocate next-level Worker child mailboxes (L4+ only).
-        for _ in self._next_level_workers:
-            shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+        for i, _inner in enumerate(self._next_level_workers):
+            shm = SharedMemory(create=True, size=MAILBOX_SIZE, name=_shm_name(self._shm_token, f"next-{i}"))
             assert shm.buf is not None
             _mailbox_store_i32(_buffer_field_addr(shm.buf, _OFF_STATE), _IDLE)
             self._next_level_shms.append(shm)
@@ -6568,6 +6689,8 @@ class Worker:
                 still_pending.append(i)
             pending = still_pending
             if pending:
+                if self._cancel_token:
+                    raise InitCancelled(f"{kind} worker readiness wait cancelled by close()")
                 if time.monotonic() > deadline:
                     raise RuntimeError(
                         f"{kind} worker(s) {pending} did not become ready within "
@@ -6738,6 +6861,22 @@ class Worker:
         self._worker = None
         self._orch = None
 
+        # Survivors (children not reaped within the deadline) are registered in
+        # the journal so a subsequent close() can retry. Children that were
+        # SIGKILL'd are excluded — they should die imminently and be reaped
+        # by init; if they survive past SIGKILL they are in an un-recoverable
+        # D-state and journal retry would endlessly fail.
+        _reaped_or_killed = reaped | set(killed)
+        _journal_child_survivors(
+            self._cleanup_journal,
+            self._sub_shms,
+            self._sub_pids,
+            self._chip_shms,
+            self._chip_pids,
+            self._next_level_shms,
+            self._next_level_pids,
+            _reaped_or_killed,
+        )
         self._chip_pids.clear()
         self._sub_pids.clear()
         self._next_level_pids.clear()
@@ -8626,6 +8765,7 @@ class Worker:
             or bool(self._live_domains)
             or bool(self._host_buf_registry)
             or bool(self._pending_remote_buffer_frees or self._pending_remote_import_releases)
+            or not self._cleanup_journal.empty
         )
 
     def _describe_live_resources(self) -> str:
@@ -8660,8 +8800,13 @@ class Worker:
         never closed keeps its device held.
 
         - Reentrant ``close()`` from inside a leased operation is rejected.
-        - ``close()`` during an in-progress ``init()`` fails fast; this worker
-          does not cancel initialization. Wait for READY or FAILED.
+        - ``close()`` during an in-progress ``init()`` on another thread
+          cooperatively cancels it: the init epoch unwinds and this call
+          proceeds to teardown. Cancellation is observed only at cooperative
+          points, so an init blocked inside a native segment is not
+          interrupted — this call raises after
+          ``_CLOSE_CANCEL_UNWIND_TIMEOUT_S`` rather than blocking forever.
+          Closing from the init-owner thread itself is rejected.
         - A concurrent ``close()`` joins the in-flight attempt and observes its
           result; teardown never runs twice at once.
         - Teardown is single-shot. Once it runs, a later ``close()`` re-raises
@@ -8677,8 +8822,9 @@ class Worker:
         # fence — the leased live-tree APIs are rejected once CLOSED) and NEVER
         # reverts to READY. Contract:
         #   - reentrant close() (from inside a leased op) is rejected;
-        #   - close() while init() is INITIALIZING fails fast — this worker does
-        #     not cancel an in-progress init; wait for READY or FAILED;
+        #   - close() while init() is INITIALIZING latches a cancel token and
+        #     waits (bounded) for the init thread to unwind the epoch;
+        #     closing from the init-owner thread is rejected;
         #   - a concurrent close() joins the in-flight attempt and observes its
         #     result; the same worker's teardown never runs twice at once;
         #   - teardown is single-shot and TERMINAL: once it runs, an un-reclaimed
@@ -8717,10 +8863,20 @@ class Worker:
                         "register() / unregister() or other leased Worker operation on this thread"
                     )
                 if self._lifecycle is _Lifecycle.INITIALIZING:
-                    raise RuntimeError(
-                        "Worker.close(): cannot close while init() is in progress; "
-                        "wait for the worker to reach READY or FAILED first"
-                    )
+                    if self._init_owner_thread is threading.current_thread():
+                        raise RuntimeError("Worker.close(): cannot cancel init() from the init-owner thread")
+                    self._cancel_token = True
+                    self._hierarchical_start_cv.notify_all()
+                    _cancel_deadline = time.monotonic() + _CLOSE_CANCEL_UNWIND_TIMEOUT_S
+                    while self._lifecycle is _Lifecycle.INITIALIZING:
+                        _remaining = _cancel_deadline - time.monotonic()
+                        if _remaining <= 0:
+                            raise RuntimeError(
+                                "Worker.close(): cancelled init() did not unwind within "
+                                f"{_CLOSE_CANCEL_UNWIND_TIMEOUT_S}s; the init thread is blocked in a "
+                                "native segment past every cooperative cancellation point"
+                            )
+                        self._hierarchical_start_cv.wait(timeout=min(_remaining, _CLOSE_JOIN_RECHECK_S))
                 # A caller that WAITS on an in-flight attempt must always resolve
                 # against THAT attempt — never re-read _close_completion (a
                 # successor may already be installed) and never start a retry
@@ -8741,7 +8897,12 @@ class Worker:
                 # replays; only a drain-timeout — teardown un-attempted, tree
                 # intact — may be retried by this call.
                 prior = self._close_completion
-                if prior is not None and prior.done and (self._teardown_attempted or prior.error is None):
+                if (
+                    prior is not None
+                    and prior.done
+                    and self._cleanup_journal.empty
+                    and (self._teardown_attempted or prior.error is None)
+                ):
                     deferred_native_cleanup_error = self._consume_l3_host_mapped_cleanup_error_locked("close")
                     if prior.error is not None:
                         raise prior.error
@@ -8848,11 +9009,8 @@ class Worker:
                         if result is None and retained_error is not None:
                             result = retained_error
                     had_live = self._has_live_resources()
-                    # Terminal teardown is single-shot and best-effort: a resource
-                    # it could not reclaim LEAKS. Never return success with a
-                    # residual — if teardown ran and left something behind without
-                    # itself raising, synthesize a terminal error.
-                    if teardown_tree and result is None and had_live:
+                    journal_pending = not self._cleanup_journal.empty
+                    if teardown_tree and result is None and had_live and not journal_pending:
                         result = RuntimeError(
                             "Worker.close(): teardown left resources un-reclaimed (leaked): "
                             f"{self._describe_live_resources()}"
@@ -9027,6 +9185,9 @@ class Worker:
             except BaseException as exc:  # noqa: BLE001
                 errors.append(exc)
 
+        journal_err = self._cleanup_journal.drive()
+        if journal_err is not None:
+            errors.append(journal_err)
         # Release any orch-allocated CommDomain handles before tearing down the
         # C++ scheduler: once `dw.close()` runs the chip mailboxes are unusable
         # and we can no longer drive CTRL_RELEASE_DOMAIN.

--- a/tests/ut/py/test_worker/test_cancellation_journal.py
+++ b/tests/ut/py/test_worker/test_cancellation_journal.py
@@ -1,0 +1,325 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""P0.2-c cooperative init cancellation and retryable resource cleanup journal."""
+
+import threading
+import time
+
+import pytest
+import simpler.worker as worker_mod
+from simpler.worker import CleanupJournal, Worker, _Lifecycle, _shm_name
+
+from ._harness import TEST_WALL_BUDGET_S, hard_timeout
+
+_TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+_hard_timeout = hard_timeout
+
+
+def _run_catch(fn):
+    try:
+        fn()
+        return None
+    except BaseException as e:
+        return e
+
+
+def _init_hangs(*_a, **_k):
+    time.sleep(3600)
+
+
+def _init_raises(*_a, **_k):
+    raise RuntimeError("injected inner init failure")
+
+
+def _l3_child(sub_fn=None, num_sub_workers=1):
+    l3 = Worker(level=3, num_sub_workers=num_sub_workers)
+    l3.register(sub_fn if sub_fn is not None else (lambda args: None))
+    return l3
+
+
+def _trivial_orch(orch, args, config):
+    return None
+
+
+class TestCleanupJournal:
+    def test_empty_drive_returns_none(self):
+        j = CleanupJournal()
+        assert j.empty
+        assert j.drive() is None
+
+    def test_success_removes_entry(self):
+        j = CleanupJournal()
+        called = []
+        j.add("child", "test", lambda: called.append(1))
+        assert not j.empty
+        assert j.drive() is None
+        assert j.empty
+        assert called == [1]
+
+    def test_failure_keeps_entry(self):
+        j = CleanupJournal()
+        j.add("child", "test", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        err = j.drive()
+        assert err is not None
+        assert "boom" in str(err)
+        assert not j.empty
+
+    def test_failed_entry_retryable(self):
+        j = CleanupJournal()
+        attempts = []
+
+        def fail_then_ok():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise RuntimeError("first attempt fails")
+
+        j.add("child", "test", fail_then_ok)
+        assert j.drive() is not None
+        assert not j.empty
+        assert j.drive() is None
+        assert j.empty
+        assert attempts == [1, 1]
+
+    def test_all_entries_attempted_on_failure(self):
+        j = CleanupJournal()
+        called = []
+        j.add("child", "a", lambda: called.append("ok"))
+        j.add("child", "b", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        j.add("child", "c", lambda: called.append("also_ok"))
+        err = j.drive()
+        assert err is not None
+        assert called == ["ok", "also_ok"]
+        assert not j.empty
+        assert len(j._entries) == 1
+
+    def test_errors_accumulated(self):
+        j = CleanupJournal()
+        j.add("child", "a", lambda: (_ for _ in ()).throw(ValueError("a")))
+        j.add("child", "b", lambda: (_ for _ in ()).throw(TypeError("b")))
+        j.drive()
+        assert len(j.errors) == 2
+
+    def test_extend(self):
+        j = CleanupJournal()
+        called = []
+        j.extend([("child", "a", lambda: called.append("a")), ("child", "b", lambda: called.append("b"))])
+        j.drive()
+        assert j.empty
+        assert called == ["a", "b"]
+
+
+class TestCloseDuringInitializing:
+    def test_close_cancels_init_reaches_closed(self, monkeypatch):
+        entered = threading.Event()
+        release = threading.Event()
+        orig = Worker._start_hierarchical
+
+        def paused_start(self):
+            entered.set()
+            assert release.wait(10.0)
+            return orig(self)
+
+        monkeypatch.setattr(Worker, "_start_hierarchical", paused_start)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w.register(lambda args: None)
+
+        def owner_body():
+            _run_catch(w.init)
+
+        it = threading.Thread(target=owner_body)
+        it.start()
+        try:
+            with _hard_timeout(_TEST_WALL_BUDGET_S):
+                assert entered.wait(3.0)
+                close_result: list = []
+                ct = threading.Thread(target=lambda: close_result.append(_run_catch(w.close)))
+                ct.start()
+                while not w._cancel_token:
+                    time.sleep(0.001)
+                release.set()
+                ct.join(10.0)
+                it.join(10.0)
+                assert close_result == [None]
+                assert w._lifecycle is worker_mod._Lifecycle.CLOSED
+        finally:
+            release.set()
+            it.join(10.0)
+
+    def test_uncooperative_init_bounds_the_close_wait(self, monkeypatch):
+        """An init blocked past every cooperative point makes close() raise on
+        its unwind deadline instead of blocking forever."""
+        entered = threading.Event()
+        release = threading.Event()
+        orig = Worker._start_hierarchical
+
+        def paused_start(self):
+            entered.set()
+            assert release.wait(30.0)
+            return orig(self)
+
+        monkeypatch.setattr(Worker, "_start_hierarchical", paused_start)
+        monkeypatch.setattr(worker_mod, "_CLOSE_CANCEL_UNWIND_TIMEOUT_S", 0.5)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w.register(lambda args: None)
+
+        def owner_body():
+            _run_catch(w.init)
+
+        it = threading.Thread(target=owner_body)
+        it.start()
+        try:
+            with _hard_timeout(_TEST_WALL_BUDGET_S):
+                assert entered.wait(3.0)
+                err = _run_catch(w.close)
+                assert isinstance(err, RuntimeError)
+                assert "did not unwind" in str(err)
+                assert w._lifecycle is worker_mod._Lifecycle.INITIALIZING
+        finally:
+            release.set()
+            it.join(10.0)
+
+    def test_same_thread_close_during_init_rejected(self, monkeypatch):
+        entered = threading.Event()
+        release = threading.Event()
+        orig = Worker._start_hierarchical
+
+        def paused_start(self):
+            entered.set()
+            err = _run_catch(self.close)
+            assert isinstance(err, RuntimeError)
+            assert "init-owner" in str(err)
+            assert release.wait(10.0)
+            return orig(self)
+
+        monkeypatch.setattr(Worker, "_start_hierarchical", paused_start)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w.register(lambda args: None)
+        try:
+            with _hard_timeout(_TEST_WALL_BUDGET_S):
+                release.set()
+                w.init()
+                assert w._lifecycle is worker_mod._Lifecycle.READY
+        finally:
+            w.close()
+
+
+class TestClosedAbsorption:
+    def test_closed_absorbing(self):
+        w = Worker(level=3, num_sub_workers=1)
+        w.register(lambda args: None)
+        with w._hierarchical_start_cv:
+            w._lifecycle = _Lifecycle.INITIALIZING
+        with w._hierarchical_start_cv:
+            w._lifecycle = _Lifecycle.CLOSED
+        with w._hierarchical_start_cv:
+            if w._lifecycle is _Lifecycle.INITIALIZING:
+                w._lifecycle = _Lifecycle.FAILED
+        assert w._lifecycle is worker_mod._Lifecycle.CLOSED
+        w.close()
+
+
+class TestJournalInAbortHierarchical:
+    def test_journal_persists_after_close_failure(self):
+        """A journal entry added before close() persists through a failed
+        close() and is retried by a second close()."""
+        w = Worker(level=3, num_sub_workers=1)
+        w.register(lambda args: None)
+        attempts = []
+
+        def fail_then_ok():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise RuntimeError("transient journal failure")
+
+        w._cleanup_journal.add("child", "test", fail_then_ok)
+        # First close: journal drive fails, entry stays.
+        err1 = _run_catch(w.close)
+        assert err1 is not None
+        assert "transient journal failure" in str(err1)
+        assert not w._cleanup_journal.empty
+        assert w._lifecycle is worker_mod._Lifecycle.CLOSED
+        # The attempt is incomplete — journal still has entries.
+        assert w._close_completion is not None
+        assert w._close_completion.incomplete
+        assert w._close_completion.done
+        # Second close: retries the journal, succeeds.
+        err2 = _run_catch(w.close)
+        assert err2 is None
+        assert w._cleanup_journal.empty
+        assert attempts == [1, 1]
+
+    def test_fully_reaped_abort_leaves_empty_journal(self, monkeypatch):
+        l3 = _l3_child()
+        l3.init = _init_raises
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0)
+        w4.register(_trivial_orch)
+        w4.add_worker(l3)
+        try:
+            with _hard_timeout(_TEST_WALL_BUDGET_S):
+                with pytest.raises(RuntimeError, match="injected inner init failure"):
+                    w4.init()
+            assert w4._cleanup_journal.empty
+            assert w4._next_level_pids == []
+        finally:
+            w4.close()
+
+
+class TestJournalRetryOnClose:
+    def test_journal_driven_before_teardown(self):
+        """When the journal has entries, _teardown_ready_tree drives them
+        and they are removed on success."""
+        w = Worker(level=3, num_sub_workers=1)
+        w.register(lambda args: None)
+        driven = []
+        w._cleanup_journal.add("child", "test", lambda: driven.append("journal"))
+        # close() invokes _teardown_ready_tree which drives the journal.
+        w.close()
+        assert driven == ["journal"], f"journal entry was not driven: {driven}"
+        assert w._cleanup_journal.empty
+
+    def test_journal_retry_on_close(self):
+        """A journal entry that fails on first close stays in the journal
+        and is retried by a second close()."""
+        w = Worker(level=3, num_sub_workers=1)
+        w.register(lambda args: None)
+        attempts = []
+
+        def fail_then_ok():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise RuntimeError("transient failure")
+
+        w._cleanup_journal.add("child", "test", fail_then_ok)
+        # First close: journal drive fails, entry stays, error surfaces.
+        err1 = _run_catch(w.close)
+        assert err1 is not None
+        assert "transient failure" in str(err1)
+        assert not w._cleanup_journal.empty
+        assert w._lifecycle is worker_mod._Lifecycle.CLOSED
+        # Second close: retries the journal entry, succeeds.
+        err2 = _run_catch(w.close)
+        assert err2 is None
+        assert w._cleanup_journal.empty
+        assert attempts == [1, 1]
+
+
+class TestShmNames:
+    def test_shm_name_with_token(self):
+        assert _shm_name("abc123456789", "sub-0") == "sp-abc12345-sub-0"
+
+    def test_shm_name_without_token(self):
+        assert _shm_name("", "sub-0") is None
+
+
+class TestNewWorkerClose:
+    def test_new_worker_close_journal_empty(self):
+        w = Worker(level=3, num_sub_workers=1)
+        w.close()
+        assert w._cleanup_journal.empty
+        assert w._lifecycle is worker_mod._Lifecycle.CLOSED

--- a/tests/ut/py/test_worker/test_startup_readiness.py
+++ b/tests/ut/py/test_worker/test_startup_readiness.py
@@ -636,10 +636,10 @@ class TestApiLinearizationDuringInit:
             proceed.set()
             it.join(10.0)
 
-    def test_close_during_initializing_fails_fast(self, monkeypatch):
-        # close() does not cancel an in-progress init: it fails fast so the
-        # INITIALIZING epoch is never torn down under its owner. The owner
-        # completes init and closes the READY tree itself.
+    def test_close_during_initializing_cancels_init(self, monkeypatch):
+        # close() on a non-owner thread during INITIALIZING cooperatively
+        # cancels the in-progress init and reaches CLOSED. Run close() in
+        # a thread so release.set() can fire while close() awaits init unwind.
         import simpler.worker as worker_mod  # noqa: PLC0415
 
         entered = threading.Event()
@@ -648,26 +648,29 @@ class TestApiLinearizationDuringInit:
 
         w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
         w.register(lambda args: None)
-        proceed = threading.Event()
 
         def owner_body():
             _run_catch(w.init)
-            proceed.wait(10.0)
-            _run_catch(w.close)  # owner closes the READY tree
 
         it = threading.Thread(target=owner_body)
         it.start()
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 assert entered.wait(3.0)
-                # A concurrent close() while INITIALIZING is rejected outright.
-                with pytest.raises(RuntimeError, match="in progress"):
-                    w.close()
-                assert w._lifecycle is worker_mod._Lifecycle.INITIALIZING
-                release.set()  # let init finish -> READY
+
+                close_result: list = []
+                ct = threading.Thread(target=lambda: close_result.append(_run_catch(w.close)))
+                ct.start()
+                # Wait for cancel token to latch, then release the init thread.
+                while not w._cancel_token:
+                    time.sleep(0.001)
+                release.set()
+                ct.join(10.0)
+                it.join(10.0)
+                assert close_result == [None]
+                assert w._lifecycle is worker_mod._Lifecycle.CLOSED
         finally:
             release.set()
-            proceed.set()
             it.join(10.0)
 
 
@@ -1343,16 +1346,16 @@ class TestLevel2Lifecycle:
             proceed.set()
             t1.join(5.0)
 
-    def test_l2_close_during_initializing_fails_fast(self, monkeypatch):
-        # close() cannot cancel an in-progress L2 init: it fails fast, the owner
-        # finishes init to READY, and the owner then finalizes the device
-        # same-thread. No cross-thread finalize, no resurrected epoch.
+    def test_l2_close_during_initializing_cancels_init(self, monkeypatch):
+        # close() on a non-owner thread during an L2 INITIALIZING cooperatively
+        # cancels the in-progress ChipWorker.init. The device is finalized by
+        # init's cleanup, and close reaches CLOSED. Run close() in a thread so
+        # release.set() fires while close() awaits init unwind.
         import simpler.worker as worker_mod  # noqa: PLC0415
 
         entered = threading.Event()
         release = threading.Event()
         finalized = {"n": 0}
-        proceed = threading.Event()
 
         class _PausingChip:
             def init(self, *_a, **_k):
@@ -1370,26 +1373,27 @@ class TestLevel2Lifecycle:
 
         def owner_body():
             init_err.append(_run_catch(w.init))
-            proceed.wait(10.0)
-            _run_catch(w.close)  # owner finalizes the device same-thread
 
         t1 = threading.Thread(target=owner_body)
         t1.start()
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 assert entered.wait(3.0)
-                with pytest.raises(RuntimeError, match="in progress"):
-                    w.close()
-                assert w._lifecycle is worker_mod._Lifecycle.INITIALIZING
-                release.set()  # init completes -> READY
-                proceed.set()  # owner then closes
+
+                close_result: list = []
+                ct = threading.Thread(target=lambda: close_result.append(_run_catch(w.close)))
+                ct.start()
+                # Wait for cancel token to latch, then release init.
+                while not w._cancel_token:
+                    time.sleep(0.001)
+                release.set()
+                ct.join(10.0)
                 t1.join(10.0)
-                assert init_err[0] is None
+                assert close_result == [None]
                 assert w._lifecycle is worker_mod._Lifecycle.CLOSED
-                assert finalized["n"] == 1  # device finalized once, same-thread
+                assert finalized["n"] == 1  # device finalized by init cleanup
         finally:
             release.set()
-            proceed.set()
             t1.join(5.0)
 
 


### PR DESCRIPTION
## Summary

close() during INITIALIZING now cooperatively cancels the in-flight init
and ultimately reaches CLOSED, instead of failing fast. A latching cancel
token is observed at cooperative points (the child-readiness poll and the
READY commit gate); native segments run to completion uninterrupted.
Because an init blocked inside a native segment reaches no cooperative
point, the wait is bounded by `_CLOSE_CANCEL_UNWIND_TIMEOUT_S` — close()
raises rather than blocking forever. CLOSED is absorbing: a late init
rollback cannot resurrect FAILED.

Root cancellation raises `InitCancelled`, an ordinary `RuntimeError`, so
the init-owner thread can catch it with `except Exception`.
`_StartupCancelled` remains the signal-delivered `BaseException` used only
on the forked-child SIGTERM path.

A CleanupJournal tracks resources whose native free can fail. Entries are
removed only after successful cleanup (post-success), and a subsequent
close() retries any that remain. The journal is shared by both teardown
paths (_teardown_ready_tree and _abort_hierarchical). Unreaped children
from startup rollback are registered in the journal rather than
unconditionally discarded.

Mailbox shm names are now deterministic — `sp-<token[:8]>-<suffix>`, where
each Worker generates its own token. Because the name is fixed rather than
random, a segment left behind by a crashed prior run surfaces as a
`FileExistsError` on create instead of being silently bypassed. Zero wire
delta.

close() replay and residual-synthesis checks are journal-aware: a
non-empty journal permits retry; an empty journal with live resources is
poison.

## Changes

- worker.py: cancel token with bounded unwind wait, `InitCancelled`
  exception type, CleanupJournal class, journal integration in both
  teardown paths, deterministic shm naming, journal-aware close()
  terminal checks
- 18 new tests covering journal semantics, cooperative cancellation, the
  uncooperative-init bound, CLOSED absorption, shm naming, and
  retry-on-close
- 2 old fail-fast tests updated to match cooperative cancellation

## Not in scope

Deterministic naming is a **precondition** for prefix-based orphan
recovery, not the recovery itself: nothing in this PR enumerates
`/dev/shm`. Reclaiming segments left by a hard-killed process tree is
follow-up work.

## Verification

- `tests/ut/py/test_worker/`: 534 passed, 3 skipped
- Full `tests/ut/py`: 1029 passed, 14 skipped (5 `TestTorchInterop`
  failures are a local missing-`torch` artifact, green in CI)
- `test_uncooperative_init_bounds_the_close_wait` confirmed to fail
  pre-fix (hangs to the test wall budget) and pass post-fix
