### PR TITLE
Fix host-build-graph validation and teardown defects

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -188,7 +188,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 // already invalidated src's lines, so tensor_count/scalar_count/
                 // scalars read coherently with the orchestrator's submit writes.
                 // args[SPMD_LOCAL_CONTEXT_INDEX]/[SPMD_GLOBAL_CONTEXT_INDEX] are
-                // still written by the AICPU (num_args <= 48 never reaches them).
+                // pre-filled once at init() and never changed; tensor and scalar
+                // counts are set by the orchestrator, so num_args never reaches them.
                 __gm__ char *src = reinterpret_cast<__gm__ char *>(exec_payload->src_payload);
                 int32_t tensor_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
                 int32_t scalar_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -42,6 +42,7 @@
 #include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
+#include "utils/thread_completion_gate.h"
 
 // Core type definitions
 #include "common/core_type.h"
@@ -82,7 +83,6 @@ struct AicpuExecutor {
     std::atomic<int32_t> thread_idx_{0};
     std::atomic<bool> init_done_{false};
     std::atomic<bool> init_failed_{false};
-    std::atomic<bool> finished_{false};
 
     // Parallel-handshake coordination (see AicpuExecutor::init). hs_setup_done_
     // is published by the leader once the shared pre-handshake setup is visible;
@@ -106,7 +106,7 @@ struct AicpuExecutor {
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
-    std::atomic<int32_t> finished_count_{0};
+    simpler::ThreadCompletionGate completion_gate_;
     std::atomic<bool> runtime_init_ready_{false};
 
     // Per-Worker arena backing the PTO2Runtime + sm_handle + orch/sched/mailbox
@@ -194,7 +194,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     hs_arrived_.fetch_add(1, std::memory_order_acq_rel);
     if (is_leader) {
         while (hs_arrived_.load(std::memory_order_acquire) < nthreads) {}
-        finished_count_.store(0, std::memory_order_release);
+        completion_gate_.reset();
         if (sched_ctx_.post_handshake_init(runtime) != 0) {
             init_failed_.store(true, std::memory_order_release);
             init_done_.store(true, std::memory_order_release);
@@ -244,8 +244,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // run() — it must NOT return early. This thread owns a core slice
         // (handshake_partition assigns [lo, total) to the last thread), so an
         // early return would skip shutdown(thread_idx) — leaving its AICore
-        // cores spinning on an unclosed register window — and finished_count_,
-        // so finished_ never publishes and the host hangs into the op-execute
+        // cores spinning on an unclosed register window — and the completion
+        // gate never opens, so the host hangs into the op-execute
         // timeout (507018) instead of seeing the failure. On failure: record it
         // in run_rc, leave rt null so the dispatch block below skips, and still
         // publish runtime_init_ready_ (single point at the block's end) so the
@@ -358,19 +358,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     LOG_INFO("Thread %d: Completed", thread_idx);
 
-    // Check if this is the last thread to finish
-    int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
-    if (prev_finished + 1 == aicpu_thread_num_) {
-        finished_.store(true, std::memory_order_release);
-        // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
-        // always tear them down here.
+    completion_gate_.arrive_and_finalize_if_last(aicpu_thread_num_, [&] {
+        // Destroy the host_build_graph runtime. sm_handle / rt are recreated
+        // every run, so always tear them down here.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO before destroying rt.
             framework_bind_runtime(nullptr);
             runtime_destroy(rt, runtime_arena_);
             rt = nullptr;
         }
-    }
+    });
 
     return run_rc;
 }
@@ -384,12 +381,12 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();
 
-    finished_count_.store(0, std::memory_order_release);
+    completion_gate_.reset();
     runtime_init_ready_.store(false, std::memory_order_release);
 
     aicpu_thread_num_ = 0;
 
-    // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
+    // Clear the file-scope runtime pointer (freed by the last scheduler thread before deinit).
     rt = nullptr;
 
     LOG_INFO("DeInit: Runtime execution state reset");
@@ -402,7 +399,6 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     classify_ready_.store(false, std::memory_order_release);
     classify_arrived_.store(0, std::memory_order_release);
     thread_idx_.store(0, std::memory_order_release);
-    finished_.store(false, std::memory_order_release);
 
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
@@ -457,9 +453,9 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
 
     int32_t runtime_rc = read_pto2_runtime_status(runtime);
 
-    // Last thread cleans up
-    if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
-        LOG_INFO("aicpu_execute: Last thread finished, cleaning up");
+    // The finalizer publishes cleanup eligibility only after runtime destruction.
+    if (g_aicpu_executor.completion_gate_.claim_cleanup()) {
+        LOG_INFO("aicpu_execute: All threads finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
     }
 

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -1,843 +1,227 @@
-# PTO2 Runtime System Design (host_build_graph)
+# `host_build_graph` Runtime Design
 
-## Overview
+## 1. Execution Model
 
-host_build_graph is the **host-orchestration** variant of the PTO2 runtime: it
-shares tensormap_and_ringbuffer's scheduler, ring buffers, and shared-memory
-layout, and differs only in **when** the orchestrator runs. The host runs the
-orchestrator to completion — building the whole task graph, populating shared
-memory and the prebuilt arena — then H2Ds that image to the device, where the
-AICPU boots scheduler-only (no on-device orchestrator thread). It coordinates
-four layers of execution:
-
-- **Host** (x86/ARM CPU): compiles kernels, allocates device memory, **runs the orchestrator to build the task graph**, H2Ds the populated SM + arena, and launches AICPU/AICore threads.
-- **AICPU** (device ARM cores): runs scheduler threads only — it attaches the host-populated shared memory (already device-addressed by the host) and dispatches the already-built graph.
-- **AICore** (AI compute cores): executes kernel functions dispatched by the scheduler.
-- **Shared Memory** (Global Memory): ring buffers, task descriptors, heap, and TensorMap — built on host, attached read-mostly by the schedulers.
+`host_build_graph` separates graph construction from device execution:
 
 ```text
-┌───────────────────────────────────────────────────────────────────────┐
-│                            Host (CPU)                                 │
-│  test_*.py (SceneTestCase) → compile kernels → init Runtime           │
-│  → run orchestrator (build graph) → H2D populated SM + arena          │
-│  → upload binaries → launch AICPU/AICore → collect results            │
-└───────────────────────────┬───────────────────────────────────────────┘
-                            │ device memory / GM (populated graph image)
-┌───────────────────────────▼───────────────────────────────────────────┐
-│                     AICPU (N threads)                                  │
-│  All threads: Schedulers (attach + dispatch to AICore)                │
-│  (no on-device orchestrator thread — host already built the graph)    │
-│                                                                       │
-│  ┌─────────────────────────────────────────────────────────────────┐  │
-│  │                   Shared Memory (GM)                             │  │
-│  │  SharedMemoryHeader │ TaskDescriptors[] │ Payloads[] │ SlotStates[] │
-│  │  GM Heap (output buffers)                                       │  │
-│  └─────────────────────────────────────────────────────────────────┘  │
-│                                                                       │
-│  Scheduler ──Handshake/Registers──► AICore workers (AIC + AIV)        │
-└───────────────────────────────────────────────────────────────────────┘
+host register: materialize + dlopen orchestration SO
+        ↓
+host run/bind: stage external tensors, execute orchestration to completion
+        ↓
+host: relocate the prebuilt graph image and copy it to device memory
+        ↓
+device: attach the image, classify tasks, dispatch with AICPU schedulers
+        ↓
+host: collect outputs and destroy/reset per-run state
 ```
 
-> **Where the orchestrator runs (host_build_graph vs tensormap).** The data
-> structures and scheduler mechanics described in the sections below — the
-> orchestrator state, ring buffers, TensorMap dependency tracking, and the
-> dispatch handshake — are **shared** with `tensormap_and_ringbuffer`. Two
-> things differ, both following from **when and where the orchestrator runs**:
->
-> - **host_build_graph (this runtime):** the **host** dlopens the orchestration
->   `.so` and runs it to completion, populating shared memory + the prebuilt
->   arena. Dependencies are recorded as **position-independent integer fanin**:
->   each task's payload stores its producers' local-ids (`fanin_local_ids`) and
->   each producer records its highest consumer id (`last_consumer_local_id`).
->   There is no fanout adjacency, dep-pool, or per-task lock. Because fanin is
->   integer ids, the host→device relocation (`relocate_host_orch_image`)
->   collapses to fixing up only the per-slot `task` / `payload` pointers before
->   the H2D copy. The device boots **scheduler-only**: no on-device orchestrator
->   thread and no fanout wiring; on boot it scans the submitted tasks and
->   classifies each (fanin-free → ready queue; otherwise register on its first
->   unmet producer's wake list — see §8), then dispatches.
-> - **tensormap_and_ringbuffer:** the orchestrator runs **on-device** on AICPU
->   thread N-1, concurrently with the scheduler threads, recording the same
->   integer fanin during submit.
->
-> Where a section below says "the orchestrator runs on AICPU Thread 3" or
-> "Thread 3 dlopens the SO", read that as the **tensormap (device-orch)
-> mechanics this runtime inherits** — under host_build_graph that same work
-> happens on the **host** before launch.
+The device has no orchestration thread. Every launched AICPU thread participates
+in scheduling its assigned AICore workers; the highest-index thread first
+attaches the prebuilt runtime and publishes the boot barrier.
 
----
+This ordering is the defining constraint of the runtime. The host constructs the
+whole graph before any device task can complete.
 
-## 1. Runtime Variants
+## 2. Callable and Run Lifecycle
 
-Two runtime backends exist under `src/runtime/`, each representing a different orchestration and scheduling strategy.
+### 2.1 Registration
 
-### 1.1 host_build_graph
+`register_callable_impl` materializes the orchestration bytes as a temporary
+shared object, opens it with `dlopen(RTLD_LOCAL)`, and resolves:
 
-The host-orchestration variant of `tensormap_and_ringbuffer`: it shares the same
-ring-buffer task storage, GM heap, and TensorMap dependency tracking, and runs
-the orchestration SO **on the host CPU** to build the complete task graph before
-launching device execution. The device then boots scheduler-only.
+- `aicpu_orchestration_config`;
+- `aicpu_orchestration_entry`; and
+- `framework_bind_runtime`.
 
-- **Task storage**: `PTO2TaskDescriptor[]` in shared memory ring buffer (same as 1.2)
-- **Dependencies**: automatically derived from tensor read/write patterns via TensorMap (same as 1.2)
-- **Scheduling**: AICPU attaches the host-populated, already-device-addressed SM and dispatches the pre-built graph
-- **Use case**: host-side graph construction; device runs no orchestrator thread
+The resolved handle and entry points belong to the registered callable and stay
+alive across prepared runs. Unregister/context teardown closes the handle and
+removes its temporary file.
 
-### 1.2 tensormap_and_ringbuffer (PTO2)
+Child AIC/AIV callables are uploaded separately. Their resolved device function
+addresses populate the per-run dispatch table.
 
-The primary production runtime. Uses ring buffers for task slots and output memory, with a TensorMap for automatic dependency tracking.
+### 2.2 Host Graph Construction
 
-- **Task storage**: `PTO2TaskDescriptor[]` in shared memory ring buffer
-- **Memory**: GM Heap ring for output buffer allocation
-- **Dependencies**: automatically derived from tensor read/write patterns via TensorMap
-- **Thread model**: 3 scheduler threads + 1 orchestrator thread on AICPU
-- **Single ring**: host_build_graph builds the whole graph on the host with no
-  execution-time reclaim, so HeapRing and TaskRing are single
-  whole-graph-resident instances (`PTO2_MAX_RING_DEPTH == 1`); all scope depths
-  map to ring 0.
-- **Use case**: production workloads; supports streaming, flow control, and large batch sizes
+For each run, the host:
 
----
+1. validates and stages external tensors, registering their host views;
+2. reserves one backing arena for runtime/shared-memory subregions;
+3. binds the runtime to the orchestration DSO;
+4. calls the orchestration entry synchronously;
+5. finalizes task counts and the graph image;
+6. rewrites per-slot task/payload pointers to device addresses; and
+7. copies the shared-memory image and arena to the device.
 
-## 2. Platform Abstraction
+An orchestration fatal stops this sequence and is propagated through
+`orch_error_code`.
 
-Two platform implementations exist under `src/platform/`, sharing a common interface.
+### 2.3 Device Execution and Teardown
 
-### 2.1 a2a3 (Real Ascend Hardware)
+The boot thread attaches the already-populated arena without resetting it. All
+threads classify/dispatch their core partitions and then shut those cores down.
+The last arriving thread destroys the attached runtime before publishing cleanup
+eligibility. Exactly one returning AICPU thread claims that eligibility and
+resets executor/scheduler state for the next run.
 
-| Component | Description |
-| --------- | ----------- |
-| `device_runner.cpp` | Uses CANN APIs: `rtMalloc`, `rtMemcpy`, `rtLaunchKernel` |
-| `memory_allocator.cpp` | Wraps `rtMalloc`/`rtFree` with allocation tracking |
-| `aicore/kernel.cpp` | `KERNEL_ENTRY(aicore_kernel)` → `aicore_execute` |
-| `aicpu/kernel.cpp` | `DynTileFwkBackendKernelServer` entry → `aicpu_execute` |
-| `spin_hint.h` | ARM `wfe`/`yield` instructions for efficient spinning |
+Publishing cleanup only after destruction prevents `deinit()` from racing the
+runtime arena or its file-scope binding.
 
-### 2.2 a2a3sim (Thread Simulation)
+## 3. Prebuilt Graph Image
 
-| Component | Description |
-| --------- | ----------- |
-| `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
-| `memory_allocator.cpp` | Wraps `malloc`/`free` |
-| `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
-| `upload_chip_callable_buffer` | Copy ChipCallable bytes to a host scratch, `dlopen` each child SO, `dlsym` "kernel_entry", patch the scratch's `resolved_addr_` with the function pointer |
+The shared image uses three per-slot structures:
 
-### 2.3 Platform Constants (`platform_config.h`)
+| Structure | Purpose |
+| --------- | ------- |
+| `PTO2TaskDescriptor` | Full task ID, kernel IDs, packed-buffer addresses |
+| `PTO2TaskPayload` | Tensors, scalars, predicate, local-ID fanins, dispatch metadata |
+| `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
-| Constant | Value | Description |
-| -------- | ----- | ----------- |
-| `PLATFORM_MAX_BLOCKDIM` | 24 | Maximum blocks (each = 1 AIC + 2 AIV) |
-| `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (all schedulers; the highest-index thread also runs the host-orch boot) |
-| `PLATFORM_MAX_AIC_PER_THREAD` | 24 | Max AIC cores per scheduler thread |
-| `PLATFORM_MAX_AIV_PER_THREAD` | 48 | Max AIV cores per scheduler thread |
-| `PLATFORM_PROF_SYS_CNT_FREQ` | 50 MHz | System counter frequency for profiling |
+The host/device boundary is POD and position-independent. Fanins are integer
+producer IDs, not pointers. The only per-slot pointers are rebound to their final
+device addresses before H2D.
 
----
+## 4. Whole-Graph Capacity
 
-## 3. Shared Memory Layout
+The runtime uses one task ring, one graph heap, and one TensorMap pool. They are
+capacity-bounded storage, not streaming flow-control buffers:
 
-The orchestrator and schedulers communicate through a contiguous shared memory region in Global Memory (GM). The single ring's TaskDescriptor, TaskPayload, and TaskSlotState sections (plus the per-slot `completion_flags`) are laid out by `pto2_sm_layout::ring_segment_offsets`.
+- `last_task_alive` does not advance during a run;
+- `heap_tail` does not retire task output buffers during a run;
+- task slots and heap bytes are never recycled mid-run; and
+- TensorMap entries are not reclaimed while host construction is active.
+
+`completed_watermark` records the contiguous prefix of completed device tasks.
+It supports completion/consumer metadata only; it does not reclaim the task ring
+or heap.
+
+There is no post-run sweep that makes graph space reusable. Runtime destruction
+releases the complete arena, and the next run starts from a newly initialized
+image.
+
+### 4.1 Allocation Failure
+
+The graph must fit the configured task window, heap, fanin capacity, and
+TensorMap pool. When an allocation cannot progress, a wall-clock backstop
+latches a fatal instead of waiting for a scheduler that has not started.
+
+Representative allocator output is:
 
 ```text
-┌─────────────────────────────┐  offset 0
-│  PTO2SharedMemoryHeader     │  (per-ring flow control + layout, global flags)
-├─────────────────────────────┤  aligned
-│  Per-ring regions ×4:       │
-│    PTO2TaskDescriptor[N]    │  N = task_window_size per ring
-│    PTO2TaskPayload[N]       │
-│    PTO2TaskSlotState[N]     │
-└─────────────────────────────┘
-```
-
-### 3.1 SharedMemoryHeader Fields
-
-| Field | Writer | Reader | Purpose |
-| ----- | ------ | ------ | ------- |
-| `current_task_index` | Orchestrator | Scheduler | Next task ID to allocate (task ring head) |
-| `last_task_alive` | Scheduler | Orchestrator | Oldest still-active task (task ring tail) |
-| `heap_top` | Orchestrator | Scheduler | Heap ring allocation pointer |
-| `heap_tail` | Scheduler | Orchestrator | Heap ring reclamation pointer |
-| `orchestrator_done` | Orchestrator | Scheduler | Signals orchestration completion |
-| `task_window_size` | Init | Both | Number of task slots (per-ring, in `PTO2SharedMemoryRingHeader`) |
-| `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
-| `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
-| `total_size` | Init | Both | Total shared memory size |
-
-### 3.2 Size Calculation
-
-```text
-total = ALIGN(Header)
-      + Σ_ring [ ALIGN(window_size * sizeof(TaskDescriptor))
-               + ALIGN(window_size * sizeof(TaskPayload))
-               + ALIGN(window_size * sizeof(TaskSlotState)) ]
-```
-
-Alignment is 64 bytes (`PTO2_ALIGN_SIZE`).
-
----
-
-## 4. Ring Buffer Mechanisms
-
-> **Single ring**: TaskRing and HeapRing are single whole-graph instances
-> (`PTO2_MAX_RING_DEPTH == 1`). The host builds the entire graph before the
-> device boots and there is no execution-time reclaim, so a per-scope-depth
-> ring split would buy nothing — every scope depth maps to ring 0.
-
-### 4.1 Task Ring
-
-The task ring manages task slot allocation with back-pressure flow control.
-
-**Structure** (`PTO2TaskRing`):
-
-- `descriptors`: pointer to `TaskDescriptor[]` in shared memory
-- `window_size`: number of slots (power of 2)
-- `current_index`: next task ID to allocate (monotonically increasing)
-- `last_alive_ptr`: pointer to `header->last_task_alive`
-
-**Slot mapping**: `slot = task_id & (window_size - 1)`
-
-**Allocation** (`PTO2TaskAllocator::alloc`):
-
-```text
-active_count = current_index - *last_alive_ptr
-if active_count < window_size - 1:
-    allocate slot, advance current_index
-else:
-    spin-wait (back-pressure from scheduler)
-```
-
-**Reclamation**: Scheduler threads advance `last_task_alive` via lock-free CAS when the oldest task reaches state CONSUMED (4). This frees slots for reuse.
-
-**Flow control**: When the ring is full, the orchestrator blocks until the scheduler advances `last_task_alive`. With `PTO2_RING_TASK_WINDOW=16` and 208 tasks, slots are recycled ~13 times each.
-
-### 4.2 Heap Ring
-
-The heap ring manages output buffer allocation from a circular GM heap.
-
-**Structure** (`PTO2HeapRing`):
-
-- `base`: GM heap base address
-- `size`: total heap size (default 1 GB)
-- `top`: allocation pointer (local to orchestrator)
-- `tail_ptr`: pointer to `header->heap_tail` (updated by scheduler)
-
-**Allocation**: Buffers are allocated contiguously from `top`. When reaching the end, allocation wraps to the beginning if `tail` has advanced far enough. Buffers never straddle the wrap-around boundary.
-
-**Reclamation**: When `last_task_alive` advances past a task, its `packed_buffer_end` is used to advance `heap_tail`, freeing the memory region.
-
-When an empty ring is parked at a non-zero offset and neither free arc can hold a request that fits the full
-capacity, allocation restarts at offset zero: `heap_tail` resets to zero and `heap_top` advances past the new
-allocation. Reclaim markers from tasks in the preceding coordinate space are ignored until the first post-rebase
-allocation retires.
-
-### 4.3 Dependency Representation (polling completion)
-
-There is no dependency-list pool or fanout adjacency. A task's dependencies are
-stored inline on its payload as a flat array of position-independent producer
-local-ids:
-
-- `fanin_local_ids[fanin_count]` — the local-ids of this task's direct producers
-  (`fanin_count <= PTO2_MAX_FANIN`; there is no spill, so an overflow is fatal).
-- A per-slot `completion_flags[id]` byte in the ring header is the device-side
-  readiness truth: a task is ready iff every id in its `fanin_local_ids` has its
-  `completion_flags` byte set (see §8.2).
-
-Because the fanin is integer ids rather than pointers, the host→device image
-needs no fanout/dep-pool relocation — only the per-slot `task` / `payload`
-pointers are relocated (see §7.3).
-
-### 4.4 Flow Control and Back-Pressure
-
-The ring buffer mechanism provides **flow control** between the orchestrator (producer) and the scheduler (consumer). When a ring is exhausted, the orchestrator **blocks** — it cannot submit new tasks or allocate more output memory until the scheduler reclaims slots/space by advancing the watermarks.
-
-**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `PTO2TaskAllocator::alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
-
-**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `PTO2TaskAllocator::alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
-
-**TensorMap pool back-pressure**: Before STEP 4 registers a task's outputs, the orchestrator's `ensure_tensormap_capacity` reserves pool space for the inserts. When the shared entry pool is exhausted, it reclaims retired entries across all rings and spin-waits until reclaim actually frees entries, with a 500 ms wall-clock deadlock backstop (see Section 5.4).
-
-This back-pressure is essential for correctness with small ring sizes — for example, with `PTO2_RING_TASK_WINDOW=16` and 208 tasks, the orchestrator blocks ~192 times, each time waiting for the scheduler to drain completed tasks before continuing.
-
-### 4.5 Deadlock Detection
-
-A ring that is **too small** stalls the allocator permanently. host_build_graph is whole-graph-resident: the orchestrator runs to completion on the host and there is no on-device slot reclaim, so `last_task_alive` is never advanced at runtime (see Section 8.4). The task-ring gate is `local_task_id - last_alive + 1 < window_size`; with `last_alive` pinned at 0 it reduces to `local_task_id + 1 < window_size`, so the ring commits `window_size - 1` tasks (one slot is reserved to tell full from empty) and blocks on the next. The window must therefore hold the **whole graph's task count**, not just one scope — e.g. with `task_window=16` the allocator commits 15 tasks and blocks on the 16th, and because `last_alive` stays 0 the reclaim it waits on never comes.
-
-`PTO2TaskAllocator::alloc` spins on this condition and backstops it two ways (cold path, checked every 1024 spins):
-
-- **Structural head-of-line test** (`head_blocked_on_scope_end`) — inert for host_build_graph, since tasks cannot complete during host-side graph construction.
-- **Wall-clock backstop** — `PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES` (500 ms). After 500 ms with no reclaim progress it calls `report_deadlock()`, latches a fatal, and the failed alloc unwinds.
-
-While blocked it emits periodic warnings (every `PTO2_BLOCK_NOTIFY_INTERVAL` = 10000 spins):
-
-```text
-[TaskAllocator] BLOCKED: tasks=15/16, heap=65536/65536, on=task, spins=100000
-```
-
-and on the backstop logs to the device log:
-
-```text
-========================================
-FATAL: Task Allocator Deadlock - Task Ring Full!
-========================================
-No reclaim progress for ~500 ms (<N> cycles wall clock).
-  Task ring:  current=15, last_alive=0, active=15/16 (93.8%)
+FATAL: Task Allocator Deadlock - Heap Exhausted!
+  Task ring:  current=..., last_alive=..., active=.../...
   Heap ring:  top=..., tail=..., size=..., available=...
-  Head task 0: state=0, last_consumer=...
+  Requested:  ... bytes
 ```
 
-(`... - Heap Exhausted!` plus a `Requested: N bytes` line when the heap ring, not the task ring, is the blocked resource.)
+This is host-orchestration logging. The allocator records the corresponding
+runtime error and unwinds; it does not terminate the process directly.
 
-**Sizing guideline**: because the whole graph is resident, `task_window_size` must exceed the graph's **total task count** — `task_window_size > total_tasks` (the `+1` distinguishes full from empty). The default `#define PTO2_TASK_WINDOW_SIZE 16384` covers up to ~16k tasks per ring; raise it for larger graphs. Sizing by a single scope's task count under-sizes the window for any multi-scope graph and trips the backstop above.
+## 5. Submission and Dependencies
 
----
+### 5.1 Mixed Tasks and Logical Blocks
 
-## 5. TensorMap and Automatic Dependency Tracking
+An active mask selects AIC, AIV0, and AIV1 lanes. `block_num` is a logical SPMD
+width and may exceed the physical device width when sync-start is not requested;
+the scheduler dispatches those blocks in waves.
 
-### 5.1 Purpose
-
-TensorMap maintains a mapping from tensor memory regions to their producer task IDs. When a new task reads a tensor (INPUT/INOUT), TensorMap automatically discovers the producer and establishes a dependency edge.
-
-### 5.2 Hash Table Design
-
-- **Key**: tensor base address (`buffer.addr`)
-- **Value**: producer task ID, with overlap detection for sub-regions
-- **Overlap**: `COVERED` (new region fully contains old) or `OTHER` (partial overlap)
-- Sub-tensors of the same base tensor hash to the same bucket, enabling overlap detection
-
-### 5.3 Entry Pool Management
-
-Unlike the Task Ring and Heap Ring, TensorMap entries are **not** managed by a ring buffer. Instead, a **fixed-size pool + free list** is used:
-
-1. **Free list first**: `free_entry_list[]` stores pointers to released entries. Allocation pops from here (O(1)).
-2. **Bump allocation**: if free list is empty, `entry_pool[next_entry_idx++]` allocates from the end of the pool.
-3. **Blocking reclaim**: if the pool is short of the inserts a task needs, the orchestrator's `ensure_tensormap_capacity` reads the latest `last_task_alive` for every ring and calls `reclaim_retired_all` (`cleanup_retired` per ring) to batch-free entries belonging to retired tasks, returning them to the free list, before the inserts proceed.
-
-This design avoids the complexity of ring-based wrapping while still being bounded by `PTO2_TENSORMAP_POOL_SIZE` (default 65536 entries).
-
-### 5.4 Stale Entry Cleanup: Three-Layer Defense
-
-TensorMap must ensure entries for retired tasks (`producer_task_id < last_task_alive`) are removed, so that:
-
-- The pool does not grow unboundedly (capacity is finite)
-- Lookup performance does not degrade as stale entries accumulate in bucket chains
-
-Three complementary mechanisms achieve this:
-
-**Layer 1 — Chain Truncation during Lookup** (lazy, per-bucket):
-
-Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `PTO2TensorMap::lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
-
-This guarantees lookup only traverses valid entries — O(valid_entries_in_bucket), not O(total_entries).
-
-**Layer 2 — Periodic Batch Cleanup** (`cleanup_retired`, per-task):
-
-Every time the orchestrator submits a task (Step 0 of `PTO2OrchestratorState::submit_task`), it calls `PTO2TensorMap::sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `PTO2TensorMap::cleanup_retired` runs:
-
-This uses the **per-task entry chain** (`task_entry_head[task_slot]`) — each task's entries are doubly-linked together at insert time via `next_in_task`/`prev_in_task`. A slot's chain can hold more than one task's entries: a task at `local_id + N * window` reuses the slot and prepends to the chain already there, and cleanup can lag that reuse. Cleanup therefore walks the chain and frees only the entries whose `producer_task_id` matches the retiring task, unlinking each and leaving the rest linked — O(entries_in_slot), with no scan of the entire pool or all buckets. Freed entries are returned to `free_entry_list` for immediate reuse.
-
-**Layer 3 — Back-Pressure on Pool Exhaustion** (blocking):
-
-Before STEP 4 inserts a task's outputs, `ensure_tensormap_capacity` checks the free list + bump region against the task's needed entry count. If short, it reclaims retired entries across all rings and blocks until reclaim frees enough entries. Progress is measured by entries actually freed, not by watermark movement — a ring can retire zero-output tasks, advancing `last_task_alive` without freeing any entry. A pool that frees nothing for a 500 ms wall-clock timeout is a genuine deadlock: it latches `PTO2_ERROR_TENSORMAP_OVERFLOW` and unwinds, matching the task allocator and fanin spill pool.
-
-This forms a back-pressure mechanism analogous to the Task Ring's flow control.
-
-**Summary**:
-
-| Layer | Trigger | Method | Guarantees |
-| ----- | ------- | ------ | ---------- |
-| Chain Truncation | Every lookup | Truncate stale tail of bucket chain | Lookup only visits valid entries |
-| Periodic Cleanup | Every 64 retired tasks | Walk per-task chains, free entries | Pool capacity reclaimed in bounded time |
-| Pool Back-Pressure | Pool exhausted | Block until scheduler advances watermark | Hard capacity bound, no OOM |
-
-Because host_build_graph is whole-graph-resident and `last_task_alive` never advances, no TensorMap entry is reclaimed during the run: the valid-entry count grows to `total_tasks × avg_outputs_per_task` and stays there. The default `pool_size=65536` bounds that; a graph whose total output-entry count exceeds the pool trips the pool back-pressure backstop (Section 5.4) rather than being reclaimed.
-
-### 5.5 Dependency Discovery Flow
-
-When `PTO2OrchestratorState::submit_task` processes parameters:
-
-1. **INPUT/INOUT**: `PTO2TensorMap::lookup` searches for overlapping producers (with chain truncation)
-2. For each producer found: `append_fanin_or_fail` adds the dependency
-3. **OUTPUT/INOUT**: `PTO2TensorMap::insert` registers the current task as the new producer at bucket head
-4. Stale entries are pruned lazily during lookup (Layer 1) and periodically by cleanup (Layer 2)
-
----
-
-## 6. Task Descriptor and States
-
-### 6.1 PTO2TaskDescriptor (Hot Path)
-
-| Field | Description |
-| ----- | ----------- |
-| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 \| local_id`; `ring_id` is always 0 in this single-ring runtime). |
-| `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
-| `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
-| `completed_subtasks` | Atomic counter; each subtask increments on completion. Trigger condition: `completed_subtasks == total_required_subtasks` |
-| `packed_buffer_base` | Start of packed buffer in GM Heap |
-| `packed_buffer_end` | End of packed buffer (for heap reclamation) |
-
-Fanin/fanout are not on the descriptor: producer ids live on the payload
-(`fanin_local_ids`, §6.1b) and consumers are reached at completion via the
-per-slot wake list (§8.2), not a fanout adjacency list.
-
-### 6.1b PTO2TaskPayload (Cold Path)
-
-| Field | Description |
-| ----- | ----------- |
-| `tensors[16]` | Tensor descriptors for parameters |
-| `scalar_value[16]` | Scalar parameter values |
-| `is_tensor[16]` | Whether each parameter is tensor or scalar |
-| `param_count` | Number of valid parameters |
-| `fanin_local_ids[fanin_count]` | Producer local-ids (position-independent; readiness = all their `completion_flags` set) |
-| `fanin_count` | Number of producer dependencies (`<= PTO2_MAX_FANIN`, no spill) |
-| `predicate` | Dispatch predicate (`DispatchPredicate`, cache line 9 / byte 576); evaluated by the scheduler at the ready point (see §8.3) |
-
-`last_consumer_local_id` (the highest consumer id of this task) lives on the
-slot state, not the payload; the host consumer-wait gates on it (§8.4).
-
-### 6.2 Task State Machine
-
-`task_state` is the **host-visible mirror** of completion; the device-side
-readiness truth is the per-slot `completion_flags` byte (§8.2). The host polls
-`task_state` in `wait_for_tensor_ready`, the allocator deadlock detector, and
-the cold-path stall dump.
+Before a slot is allocated or published, submission requires:
 
 ```text
-  [0] PENDING ──worker(s) done, on_mixed_task_complete──► [1] COMPLETED
+block_num >= 1
+block_num * popcount(active_mask) <= INT16_MAX
 ```
 
-- **0 (PENDING)**: slot allocated; remains PENDING while waiting on producers,
-  queued, or dispatched.
-- **1 (COMPLETED)**: all subtasks done. `on_mixed_task_complete` sets this
-  (host mirror) and, in the same step, sets `completion_flags[id]` (device
-  readiness) and advances `completed_watermark`.
+The product is stored in the 16-bit `total_required_subtasks` field. Sync-start
+adds a separate co-residency limit: AIV tasks use the available AIV count, while
+AIC/MIX tasks use the available cluster count.
 
-There is no runtime CONSUMED flip and no slot recycle: host_build_graph is
-whole-graph-resident (§8.4).
+### 5.2 TensorMap and Fanins
 
----
+TensorMap maps tensor regions to producer task IDs. For every task:
 
-## 7. Orchestrator
+1. INPUT/INOUT regions look up overlapping producers.
+2. Explicit and discovered producers are deduplicated into
+   `fanin_local_ids[]`.
+3. OUTPUT/INOUT regions register the new task as producer.
+4. Each producer tracks its highest consumer local ID for completion metadata.
 
-### 7.1 PTO2OrchestratorState
+There is no fanout adjacency or dependency pool. A per-slot completion flag is
+the readiness truth on device.
 
-The orchestrator builds the task graph by calling the user-provided
-orchestration function. In host_build_graph it runs **on the host** (see the
-divergence note in the Overview); the `PTO2OrchestratorState` below is the same
-structure tensormap drives on AICPU thread N-1.
+## 6. Boot Classification and Wake Lists
 
-Key members:
+Submit does not push tasks into ready queues. After the graph arrives on device,
+boot classification scans every submitted task exactly once:
 
-- `ring`: the single `PTO2RingSet` (HeapRing + TaskRing).
-- `tensor_map`, `tensor_pool`: dependency tracking
-- `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
-- `scheduler`: pointer to scheduler state (for seeding zero-fanin tasks into the ready queue)
-- `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
+- a task whose fanins are all complete is routed to its shape queue;
+- otherwise it registers on the first unmet producer's intrusive wake list; and
+- producer completion reclassifies every detached waiter.
 
-### 7.2 Task Submission Flow (`PTO2OrchestratorState::submit_task`)
+Completion flags are monotonic, so this consumer-pull scheme cannot miss a
+producer transition and does not require periodic dependency polling.
 
-| Step | Operation |
-| ---- | --------- |
-| 0 | `PTO2TensorMap::sync_tensormap` — prune stale TensorMap entries |
-| 1 | `PTO2TaskAllocator::alloc` — allocate task slot (may block on flow control) |
-| 2 | Initialize task descriptor + slot state, copy parameters |
-| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer ids in `PTO2FaninBuilder` |
-| 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
-| 5 | **Record fanin**: `append_fanin_or_fail` dedups producers and writes their local-ids into `payload->fanin_local_ids[]`; each producer's `last_consumer_local_id` is bumped to this task's id. `payload.fanin_count` is set from the builder. |
-| 6 | **Seed readiness**: a task with zero fanin (`fanin_count == 0`) is pushed straight to the ready queue via `push_ready_routed`. A task with fanin is left for the device boot classify (§8) — the host does not pre-register wake lists. |
+The dispatchable shapes are `AIC`, `AIV`, and `MIX`; dependency-only `DUMMY`
+tasks use a dedicated queue and complete without AICore dispatch.
 
-> **Note**: There is no fanout adjacency, dep-pool, or per-producer lock. A
-> producer inline-completed on the host (e.g. a hidden-alloc task) pre-sets its
-> own `completion_flags[id] = 1` in the H2D image so device consumers see it as
-> already satisfied. The only cross-task pointers the image carries are the
-> per-slot `task` / `payload` pointers, which `relocate_host_orch_image` shifts
-> to device addresses before H2D.
+Early producer propagation is currently disabled in HBG. The shared scheduler
+retains early-staging code for parity with `tensormap_and_ringbuffer`, but HBG's
+boot classifier and wake lists are the active readiness path.
 
-### 7.3 Dependency Recording and Relocation
+## 7. Dispatch and Completion
 
-`append_fanin_or_fail` records, per consumer, the deduped list of producer
-local-ids into `payload->fanin_local_ids[]` and bumps `fanin_count`; it also
-raises each producer's `last_consumer_local_id` to the consumer's id. An
-overflow past `PTO2_MAX_FANIN` is fatal (`PTO2_ERROR_...`), since there is no
-spill.
+- AIC/AIV dispatch claims ranges of logical block indices from
+  `next_block_idx` and requeues unfinished wide tasks.
+- MIX dispatch selects cluster offsets whose used lanes share one valid
+  placement. The tracker uses a 128-bit bitset because the flattened offset is
+  `cluster * 3`, reaching above bit 63 on supported devices.
+- Sync-start cohorts stage locally when possible; wider ownership spans use a
+  generation-tagged global drain before launch.
+- Every lane completion increments `completed_subtasks`. The task completes once
+  that count equals `block_num * popcount(active_mask)`.
+- Completion sets the task's flag, advances the contiguous
+  `completed_watermark`, and reclassifies its wake-list consumers.
 
-`relocate_host_orch_image` runs on the host before H2D. Because fanin is
-position-independent integer ids, the only pointers needing fixup are the
-per-slot `task` and `payload` pointers (SM-region delta); the fanout adjacency,
-dep-pool, and ready-queue pointer relocation of the wiring model are gone.
+The drain's `pending_task` stays valid for the complete attempt: all participant
+threads load it before the coordinator can pass the stage-done barrier and clear
+it. A recovery return for a null pointer would describe an unreachable state and
+could strand the drain protocol, so the active path relies on that invariant.
 
-Readiness and completion are handled entirely device-side by the scheduler:
-the boot classify seeds the ready queue and registers wake lists (§8.2), and
-`on_mixed_task_complete` publishes each producer's `completion_flags` and drains
-its wake list. See §8.2 for the completion protocol.
+## 8. Scalar Access During Construction
 
-### 7.4 Scope Mechanism (`PTO2_SCOPE`)
+`get_tensor_data` and `set_tensor_data` operate on registered host views of
+external tensors. They cannot wait for a submitted device producer because the
+device scheduler starts only after orchestration returns. Runtime-created graph-
+heap outputs also have no host view.
 
-Scopes control the lifetime of intermediate buffers. Each scope:
+Producer references are checked against the complete bound descriptor ID before
+a slot is used, preventing masked-slot aliasing. See
+[SCALAR_DATA_ACCESS.md](SCALAR_DATA_ACCESS.md) for the supported contract.
 
-- Tracks tasks submitted within it via a flat `scope_tasks[]` buffer partitioned by `scope_begins[]`
-- Scopes bound intermediate-buffer lifetime **structurally** (the orchestration function that built the graph). host_build_graph is whole-graph-resident, so `scope_end` performs no runtime buffer reclaim — there is no `fanout_refcount`.
+## 9. Errors and Diagnostics
 
-```cpp
-PTO2_SCOPE(rt) {
-    // Tasks submitted here belong to this scope
-    rt_submit_aic_task(FUNC_QK, args);
-    rt_submit_aiv_task(FUNC_SF, args);
-}
-// scope_end: scope reference released from all tasks above
+The runtime latches orchestration and scheduler errors in shared memory and maps
+them to the negative run status observed by the host. Important validation paths
+include:
+
+- invalid arguments (`-5`);
+- sync-start residency violations (`-7`);
+- tensor wait timeout (`-8`); and
+- scheduler timeout (`-100`).
+
+Device logs contain scheduler records only. Host graph-construction diagnostics
+remain host-side. See [device_log_profiling.md](device_log_profiling.md).
+
+## 10. Verification
+
+Runtime C++ changes require rebuilding the editable package, then running both
+simulation variants:
+
+```bash
+pip install --no-build-isolation -e .
+pytest examples tests/st --platform a2a3sim --runtime host_build_graph
+pytest examples tests/st --platform a5sim --runtime host_build_graph
 ```
 
-**Output tensor lifetime — single-scope only.** `submit_task` returns a
-`TaskOutputTensors`, and `get_ref(i)` hands back a `const Tensor&`. Both are
-backed by pointers into the submitting task's `PTO2TaskPayload::tensors[]`,
-which lives in a ring-buffer slot. host_build_graph does not recycle slots
-within a run (whole-graph-resident, no execution-time reclaim), so the storage
-is not overwritten mid-run; the constraint is instead structural — the
-`TaskOutputTensors` and the refs it returns are scoped to the orchestration
-function that built the graph and must not be retained past it.
-
-Therefore the `TaskOutputTensors` instance, the references it returns, and
-any pointer derived from them MUST NOT outlive the `PTO2_SCOPE` in which
-submit was called. The typical safe pattern is:
-
-```cpp
-PTO2_SCOPE() {
-    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
-    const Tensor &y = outs.get_ref(0);
-    // Use y here and in subsequent submits within the same scope.
-}   // outs and y both go out of scope; no dangling references can escape.
-```
-
-Anti-patterns that compile but silently break:
-
-```cpp
-const Tensor *kept = nullptr;
-PTO2_SCOPE() {
-    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
-    kept = &outs.get_ref(0);          // escapes the scope
-}
-// `kept` still points at a payload slot. After enough submits in later
-// scopes, the slot is reused and `*kept` aliases an unrelated task's
-// tensor — a wrong-tensor read with no runtime diagnostic.
-
-TaskOutputTensors outs;               // declared in outer scope
-PTO2_SCOPE() {
-    outs = rt_submit_aic_task(FUNC_QK, args);
-}
-const Tensor &t = outs.get_ref(0);    // same hazard: outs survives scope
-```
-
-This invariant is intentionally not runtime-checked. A reused slot carries
-a different but valid `owner_task_id`, so an assertion based on
-`owner_task_id` cannot distinguish "still the original task" from
-"silently aliased to a newer task". Treat the rule as a static contract,
-verified by review.
-
----
-
-## 8. Scheduler
-
-### 8.1 Thread Model
-
-With `aicpu_thread_num=4` and `block_dim=24`, the AICPU runs 4 scheduler
-threads (thread 3 also performs the one-time host-orch boot before it starts
-dispatching):
-
-| Thread | Role | Cores |
-| ------ | ---- | ----- |
-| 0 | Scheduler | 6 AIC + 12 AIV |
-| 1 | Scheduler | 6 AIC + 12 AIV |
-| 2 | Scheduler | 6 AIC + 12 AIV |
-| 3 | Scheduler (+ host-orch boot) | 6 AIC + 12 AIV |
-
-Core assignment: clusters (1 AIC + 2 AIV) are divided equally among all 4
-scheduler threads.
-
-### 8.2 Scheduler Main Loop
-
-Each scheduler thread runs a tight loop with two main phases:
-
-**Phase 1 — Completion Handling (polling)**:
-
-- Poll register `COND` on each managed core.
-- When `TASK_FIN_STATE` detected: call `on_subtask_complete`; when
-  `completed_subtasks == total_required_subtasks`, call `on_mixed_task_complete`,
-  which:
-  1. mirrors `task_state = COMPLETED` (host-visible) and sets the device
-     readiness truth `completion_flags[my_id] = 1` (release);
-  2. drains this task's intrusive **wake list** — `wake_list_head.exchange(SENTINEL)`
-     — reclassifying each waiter: a waiter whose remaining fanin is now all met
-     is pushed via `push_ready_routed`; otherwise it re-registers on its next
-     unmet producer. After the exchange the head is `SENTINEL`, so a consumer
-     registering concurrently re-checks the flags instead of being lost;
-  3. CAS-advances `completed_watermark` over the contiguous completed prefix
-     (§8.4).
-
-**Readiness / wake registration.** A task is ready iff every id in its
-`fanin_local_ids` has its `completion_flags` byte set (`fanin_satisfied` /
-`classify_fanin_state`, acquire loads). A not-yet-ready task registers itself on
-its **first unmet** producer's wake list (`register_wake`); that producer's
-completion re-drives the classification. The decision is terminal — tasks are
-never re-polled — because `completion_flags` are monotonic. This wake machinery
-is seeded by the device **boot classify** (`on_orchestration_done`), which scans
-the submitted tasks once and either pushes the fanin-free ones to the ready
-queue or registers each remaining task on its first unmet producer.
-
-**Early staging status.** Early producer propagation is currently disabled in
-HBG: `propagate_dispatch_fanin` is a stub, so the polling path does not populate
-`early_dispatch_queues` or `early_sync_start_queue`. The scheduler retains the
-early-staging machinery as a dormant mirror of the TMR runtime for a future
-consumer-pull publication path. If that path populates the queues, a
-`sync_start` cohort that fits one scheduler's idle and pending slots stages
-locally; larger cohorts use the generation-tagged global drain. This is not an
-active end-to-end HBG fast path today.
-
-**Phase 2 — Dispatch**:
-
-- For each idle core: pop a task from the matching shape-based ready queue (lock-free MPMC Vyukov queue, one per resource shape)
-- Build `PTO2DispatchPayload` from `TaskDescriptor` with `task_id`, `subslot`, `kernel_id`, and `core_type`
-- Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE`
-
-After these phases, the scheduler updates profiling headers and checks for termination (all tasks completed and orchestrator done).
-
-### 8.3 Ready Queue Design
-
-Ready queues use a lock-free bounded MPMC (Vyukov) design:
-
-- One `PTO2ReadyQueue` per resource shape (5 shapes: `AIC_ONLY`, `AIV_X1`, `AIV_X2`, `AIC_AIV_X1`, `AIC_AIV_X2`)
-- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `task->active_mask.to_shape()`
-- **Pop**: scheduler threads pop from the queue matching the idle core's resource shape
-- Per-slot sequence counters prevent ABA problems
-- `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing
-
-### 8.4 Completion Watermark (host consumer-wait gate)
-
-`completed_watermark` is the highest id such that every task in
-`[0, completed_watermark]` has its `completion_flags` byte set. The tail of
-`on_mixed_task_complete` CAS-advances it over the **full contiguous completed
-prefix** (bounded by `current_task_index`, not by the completing task's own id)
-— capping at `my_id` would make the final value completion-order-dependent and
-strand it below the true prefix.
-
-It is **load-bearing**: the host `wait_for_tensor_ready(..., wait_for_consumers)`
-gates on `completed_watermark >= producer.last_consumer_local_id` to observe
-"every consumer of this producer has retired" — replacing the wiring model's
-`fanout_refcount == fanout_count` check.
-
-Slot reclaim is inert: host_build_graph is whole-graph-resident, so
-`last_task_alive` is never advanced at runtime and there is no
-`advance_ring_pointers` step. `reset_for_reuse()` runs **once at init**
-(`pto_shared_memory.cpp`) to zero each slot before the host orchestrator
-populates it — it is not a runtime recycle hook.
-
-### 8.5 SchedulerContext
-
-All scheduler-side state and methods live in `SchedulerContext` (`runtime/scheduler/scheduler_context.h`). It is held as a `sched_ctx_` member of `AicpuExecutor`; `AicpuExecutor` is a thin wrapper that owns the lifecycle atomics and delegates everything else to `SchedulerContext`.
-
-Public surface (called from `AicpuExecutor::init/run/deinit`):
-
-| Method | Phase | Purpose |
-| ------ | ----- | ------- |
-| `init(runtime, aicpu_thread_num, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
-| `bind_runtime(rt)` | boot thread | Wire `sched_` to `rt->scheduler` once the boot thread attaches the host-built `rt` |
-| `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
-| `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled |
-| `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | boot thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_` (or `emergency_shutdown` on fatal) |
-| `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
-| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` |
-
-Private internals are split across three .cpp files by responsibility:
-
-- `scheduler_completion.cpp` — completion polling, drain protocol
-- `scheduler_dispatch.cpp` — task dispatch loop and helpers
-- `scheduler_cold_path.cpp` — exit checks, stall diagnostics, profiling, lifecycle (`init/deinit`), core management (`handshake_all_cores` / `assign_cores_to_threads` / `reassign_cores_for_all_threads` / `emergency_shutdown`), and `on_orchestration_done`
-
-`AicpuExecutor` calls neither `handshake_*`, `assign_*`, `reassign_*`, nor `emergency_shutdown` directly — they are private, invoked only by `init` and `on_orchestration_done`.
-
----
-
-## 9. AICore Worker Interaction
-
-### 9.1 Handshake Protocol
-
-Each AICore worker has a `Handshake` struct in shared memory:
-
-| Field | Direction | Purpose |
-| ----- | --------- | ------- |
-| `task` | AICPU→AICore | Pointer to `PTO2DispatchPayload` |
-| `control` | AICPU→AICore | 0=normal, 1=shutdown |
-| `perf_records_addr` | AICPU→AICore | Performance buffer address |
-
-### 9.2 Register-Based Dispatch
-
-Instead of polling a shared-memory status flag, the production protocol uses hardware registers.
-
-> **Note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions.
-
-| Register | Direction | Usage |
-| -------- | --------- | ----- |
-| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id` to dispatch (idle=0x7FFFFFFD); `EXIT_SIGNAL` to shut down |
-| `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
-
-**AICore execution loop**:
-
-1. Poll `DATA_MAIN_BASE` for value != AICPU_IDLE_TASK_ID
-2. Read payload from `Handshake.task`
-3. Write ACK to `COND`
-4. Execute kernel function via `func_id_to_addr` lookup
-5. Write FIN to `COND`
-
-### 9.3 PTO2DispatchPayload
-
-Built by the scheduler from `PTO2TaskDescriptor`:
-
-| Field | Description |
-| ----- | ----------- |
-| `task_id` | Mixed-task identifier (for completion aggregation) |
-| `subslot` | Which subtask slot this dispatch represents (`AIC`, `AIV0`, or `AIV1`) |
-| `kernel_id` | Function ID for this subtask slot |
-| `core_type` | AIC or AIV |
-| `function_bin_addr` | GM address of compiled kernel binary |
-| `num_args` | Number of arguments |
-| `args[]` | Tensor addresses and scalar values |
-
----
-
-## 10. Kernel and Orchestration Loading
-
-### 10.1 Kernel Binary Loading
-
-1. **Host** compiles each kernel source (`.cpp`) into a binary (`.o` or `.so`)
-   and packs all children into a single `ChipCallable` buffer alongside the
-   orchestration SO.
-2. `host_api.upload_chip_callable_buffer(callable)` H2Ds the whole buffer
-   once and returns the device address of the ChipCallable header.
-3. For each child, host computes
-   `chip_dev + offsetof(ChipCallable, storage_) + callable->child_offset(i)`
-   and stores it in `Runtime.func_id_to_addr_[child_func_id(i)]`.
-4. When dispatching, the scheduler reads `func_id_to_addr_[fid]`, casts to
-   `const CoreCallable*`, reads `resolved_addr_`, and copies that into
-   `PTO2DispatchPayload.function_bin_addr`.
-
-### 10.2 Orchestration SO Loading
-
-1. **Host** compiles the orchestration source into a shared library (`.so`)
-2. The SO binary is embedded into `Runtime.device_orch_so_storage_[]` and copied to device
-3. **AICPU Thread 3** writes the SO to a temp file, calls `dlopen`
-4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
-5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. Thread 3 creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
-7. After orchestration completes: `dlclose`, delete temp file
-
-### 10.3 Thread Startup Synchronization
-
-| Flag | Set by | Waited by | Purpose |
-| ---- | ------ | --------- | ------- |
-| `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
-
-Profiling-subsystem init (`dump_args` / `pmu` / `l2_swimlane`) runs once in
-`SchedulerContext::init()` on the single-threaded cold path, before any
-scheduler/orchestrator thread starts — so it needs no cross-thread init
-handshake. `dep_gen` is not among them: it captures the graph on the host while
-the orchestrator builds it (see [docs/dfx/dep-gen.md](../../../../../docs/dfx/dep-gen.md)
-§2.2), so nothing about it is device-side.
-
-Startup sequence:
-
-1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
-2. Scheduler threads: wait for `runtime_init_ready_` → enter main loop
-3. Thread 3: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
-
----
-
-## 11. PTO2 Orchestration API
-
-The orchestration API is defined in `pto_orchestration_api.h`. Orchestration code depends only on this header.
-
-### 11.1 Core API
-
-| Function/Macro | Purpose |
-| -------------- | ------- |
-| `rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
-| `rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
-| `rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
-| `PTO2_SCOPE() { ... }` | RAII scope for buffer lifetime |
-| `rt_orchestration_done()` | Signal orchestration complete |
-
-### 11.2 Parameter Construction
-
-| Function | Description |
-| -------- | ----------- |
-| `make_tensor_external(ptr, shapes, ndim, dtype)` | Wrap an existing device pointer as a tensor |
-| `TensorCreateInfo(shapes, ndim, dtype)` | Describe a runtime-created output buffer |
-| `Arg::add_input(tensor)` | INPUT parameter — read by the task |
-| `Arg::add_output(create_info)` | OUTPUT parameter — runtime allocates and returns a Tensor |
-| `Arg::add_inout(tensor)` | INOUT parameter — existing tensor read then written |
-| `Arg::add_scalar(value)` | 64-bit scalar parameter |
-
-### 11.3 Resource Shapes
-
-Tasks are queued by resource shape, which is derived from the `active_mask` in the `MixedKernels` struct:
-
-| Shape | Active Mask | Description |
-| ----- | ----------- | ----------- |
-| `AIC_ONLY` | AIC only | AIC cores (matrix multiplication) |
-| `AIV_X1` | AIV0 or AIV1 only | Single AIV core (vector operations) |
-| `AIV_X2` | AIV0 + AIV1 | Two AIV cores |
-| `AIC_AIV_X1` | AIC + one AIV | AIC + single AIV core |
-| `AIC_AIV_X2` | AIC + AIV0 + AIV1 | Full cluster (AIC + two AIV cores) |
-
-### 11.4 Orchestration Export Interface
-
-Each orchestration `.so` must export:
-
-```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
-extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
-```
-
----
-
-## 12. Example: Batch Paged Attention
-
-### 12.1 Kernel Configuration (`kernel_config.py`)
-
-```python
-KERNELS = [
-    {"func_id": 0, "name": "QK",      "source": "aic/aic_qk_matmul.cpp",       "core_type": "aic"},
-    {"func_id": 1, "name": "SF",      "source": "aiv/aiv_softmax_prepare.cpp", "core_type": "aiv"},
-    {"func_id": 2, "name": "PV",      "source": "aic/aic_pv_matmul.cpp",       "core_type": "aic"},
-    {"func_id": 3, "name": "UP",      "source": "aiv/aiv_online_update.cpp",   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": "aiv/aiv_hub.cpp",            "core_type": "aiv"},
-]
-
-ORCHESTRATION = {
-    "source": "orchestration/paged_attention_orch.cpp",
-    "function_name": "aicpu_orchestration_entry",
-}
-
-RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
-    "block_dim": 24,
-}
-```
-
-### 12.2 Orchestration Structure
-
-```cpp
-void aicpu_orchestration_entry(uint64_t* args, int arg_count) {
-    // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
-    for (q_idx = 0; q_idx < q_loop; q_idx++) {
-        for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {
-            PTO2_SCOPE() {
-                // Describe accumulator tensors (oi, li, mi) with TensorCreateInfo
-                // Submit AIV_HUB to initialize accumulators
-                for (bn = 0; bn < max_bn; bn++) {
-                    // Allocate intermediate tensors (sij, pij, mij, lij, oi_new)
-                    // Submit QK (CUBE) → SF (VECTOR) → PV (CUBE) → UP (VECTOR)
-                }
-            }
-        }
-    }
-}
-```
+Pure scheduler/core-tracker and lifecycle primitives also have C++ unit tests
+under `tests/ut/cpp`.

--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -1,143 +1,73 @@
-# Scalar Data Access — get/set_tensor_data Design
+# Scalar Data Access During Host Graph Construction
 
-## 1. Overview
+`host_build_graph` runs the orchestration function synchronously on the host,
+before any AICPU scheduler or AICore kernel starts. `get_tensor_data` and
+`set_tensor_data` therefore access the host view used to stage the graph's
+external tensors; they do not interleave host code with device execution.
 
-During task graph construction, orchestration sometimes needs to read tensor contents (e.g. InCore kernel results for control-flow decisions) or write initial values into tensors. `get_tensor_data` / `set_tensor_data` provide **blocking** cross-layer data access, allowing orchestration to safely read and write tensor data — subject to the host_build_graph restriction noted below.
+## Supported Uses
 
-**Core design principle**: Reuse the existing TensorMap dependency tracking mechanism — no new synchronization infrastructure.
+| Tensor state | `get_tensor_data` | `set_tensor_data` |
+| ------------ | ----------------- | ----------------- |
+| External tensor with no submitted producer | Reads the staged host value | Updates the staged host value |
+| External control/output tensor not referenced by a task | Reads immediately | Writes immediately |
+| Runtime-created output | Unsupported: no registered host view | Unsupported: no registered host view |
+| Tensor owned by a submitted device task | Unsupported during graph construction | Unsupported during graph construction |
+| Tensor with an invalid or stale owner task ID | Fails with `INVALID_ARGS` | Fails with `INVALID_ARGS` |
 
-**host_build_graph restriction**: the orchestrator runs to completion on the host before any device task executes (`run_host_orchestration()` populates the SM, `copy_to_device()` uploads it, and only then does the AICPU boot scheduler-only). No device task has run during orchestration, so a producer's `task_state` can never reach `PTO2_TASK_COMPLETED` at that point. `get_tensor_data` / `set_tensor_data` are therefore safe only on tensors with **no producing task** — external tensors (`make_tensor_external`) and initial-value writes. Reading an InCore kernel result mid-graph (for control-flow decisions) is a `tensormap_and_ringbuffer` capability, whose orchestrator runs on the AICPU alongside the schedulers; here it spins to `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` (15 s) and fails with `PTO2_ERROR_TENSOR_WAIT_TIMEOUT`.
+The supported write changes the data that will be copied to the device. Every
+task in the graph observes that final staged value; submit order does not turn
+the write into a barrier between kernels.
 
-## 2. API
-
-```cpp
-// Blocking read: returns value at the given indices (default: raw uint64_t bits)
-// Specify T for typed read: float val = get_tensor_data<float>(tensor, 1, idx);
-template<typename T = uint64_t>
-T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
-
-// Blocking write: stores value at the given indices (type deduced from argument)
-// Typed write: set_tensor_data(tensor, 1, idx, 42.0f);
-template<typename T = uint64_t>
-void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], T value);
-```
-
-Both call into the runtime through the ops table — orchestration .so needs no runtime symbol linkage.
-
-## 3. Blocking Interface Design
-
-### 3.1 get_tensor_data Flow
-
-```text
-addr null-check → TensorMap lookup → spin-wait producer COMPLETED → compute flat offset → memcpy read
-```
-
-- **addr null-check**: `buffer.addr == 0` means unallocated — log error, return 0
-- **TensorMap lookup**: find producer task by `buffer.addr`
-- **spin-wait**: wait until producer `task_state >= PTO2_TASK_COMPLETED`
-- **No producer** (lookup callback never fires): skip waiting, read immediately
-
-### 3.2 set_tensor_data Flow
-
-```text
-addr null-check → TensorMap lookup → spin-wait producer COMPLETED → spin-wait consumers done → memcpy write
-```
-
-One extra step versus get_tensor_data: wait for all consumers to finish (per-ring `completed_watermark >= producer's last_consumer_local_id`).
-
-### 3.3 Timeout
-
-- Uses cycle counter (`get_sys_cnt_aicpu()`), checked every 1024 spins
-- Threshold: `PTO2_TENSOR_DATA_TIMEOUT_MS` (15 s), scaled to
-  `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` via `PLATFORM_PROF_SYS_CNT_FREQ` so it reaps
-  at the same wall-clock on every arch
-- On timeout: sets `orch.fatal = true`, preventing further task submission
-
-## 4. add_output with Initial Value
+## API
 
 ```cpp
-TensorCreateInfo ci(shapes, ndims, dtype);
-ci.set_initial_value(initial_value);
-args.add_output(ci);
+uint32_t index[1] = {0};
+
+int32_t value = get_tensor_data<int32_t>(control, 1, index);
+set_tensor_data<int32_t>(layout, 1, index, value + 1);
 ```
 
-**Mechanism**:
+Both tensors in this example must be external tensors staged by the host. A
+common use is to read an input control value or publish runtime geometry into an
+external layout tensor that no submitted task owns.
 
-1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
-2. `add_output(ci)` stores a pointer to `ci` in `L0TaskArgs` (the original must remain valid until submit)
-3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
-4. Fill strategy:
-   - Small buffer (< 64 B): element-by-element memcpy directly into dst
-   - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
+## Why Device-Produced Values Cannot Be Read Here
 
-**Constraint**: existing tensors are write targets only through `add_inout()`.
+The execution order is:
 
-## 5. Scalar Dependencies via 1-Element Tensors
+1. The host loads and calls the orchestration shared object.
+2. Orchestration builds the entire task graph and returns.
+3. The host relocates and copies the graph image to device memory.
+4. AICPU schedulers boot and dispatch the graph.
 
-Traditional scalars (`L0TaskArgs::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
+A producer submitted in step 1 cannot become `COMPLETED` until step 4. Waiting
+for that producer from the orchestration call cannot make progress. The runtime
+keeps a timeout as a defensive failure backstop, but it is not a supported
+synchronization mechanism.
 
-> **Not usable as-is in host_build_graph.** The example below submits a producing task and then reads its result with `get_tensor_data`, which waits for kernel completion. Per the §1 restriction, no device task has run during host_build_graph orchestration, so this read spins to `PTO2_ERROR_TENSOR_WAIT_TIMEOUT`. Reading a kernel-produced scalar mid-graph is a `tensormap_and_ringbuffer` capability; in host_build_graph the carrier works only in the producer-less direction (seed it with `set_initial_value` / an external tensor, no producing task).
+Runtime-created output buffers also live in the graph heap and have no host-view
+registration. Even if their address is nonzero, host orchestration must not
+dereference or modify them.
 
-```cpp
-uint32_t shapes[1] = {1};
-TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
+## Ownership Validation
 
-// Submit with initial value and keep the returned tensor
-scalar_ci.set_initial_value(float_to_u64(77.0f));
-L0TaskArgs args;
-args.add_output(scalar_ci);
-TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
-const Tensor& scalar_tensor = outs.get_ref(0);
+Before a wait slot is used, the runtime verifies:
 
-// Orchestration-side blocking read (waits for kernel completion)
-uint32_t idx[1] = {0};
-float val = get_tensor_data<float>(scalar_tensor, 1, idx);
-```
+- the task ID is valid and belongs to the single HBG ring;
+- the selected ring slot has a bound task descriptor; and
+- the descriptor's full task ID matches the tensor's owner/producer ID.
 
-**Advantage**: Fully reuses existing TensorMap (producer tracking, fanin/fanout dependencies) — no new infrastructure needed.
+The full-ID check prevents a masked ring-slot lookup from aliasing an unused or
+different task. A failure latches `PTO2_ERROR_INVALID_ARGS` and the run returns
+status `-5`; reads return zero and writes stop only after that fatal status is
+recorded.
 
-## 6. Data Hazard Analysis
+## Practical Rules
 
-Three actors:
-
-- **Kernel**: InCore task submitted via add_input/add_output/add_inout (asynchronous execution)
-- **Orch Read**: orchestration calls `get_tensor_data` (blocking read)
-- **Orch Write**: orchestration calls `set_tensor_data` (blocking write)
-
-### Hazard Matrix (earlier operation → later operation)
-
-| # | Earlier Op | Later Op | Hazard | Guarantee | Safe? |
-| - | ---------- | -------- | ------ | --------- | ----- |
-| 1 | Kernel write (OUTPUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
-| 2 | Kernel write (OUTPUT) | Orch Write | WAW | spin-wait producer COMPLETED | Yes |
-| 3 | Kernel read (INPUT) | Orch Write | WAR | spin-wait completed_watermark | **Needs INOUT** |
-| 4 | Kernel read-write (INOUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
-| 5 | Kernel read-write (INOUT) | Orch Write | WAW+WAR | spin-wait producer + consumers | Yes |
-| 6 | Orch Write | Kernel read (INPUT) | RAW | blocking completes before next submit | Yes |
-| 7 | Orch Write | Kernel write (OUTPUT) | WAW | same — serial guarantee | Yes |
-| 8 | Orch Read | Kernel write (OUTPUT) | WAR | same — serial guarantee | Yes |
-| 9–12 | Orch ↔ Orch | — | — | same-thread serial execution | Yes |
-
-### Key Design Points
-
-**Scenario #3 is the only case requiring special attention**:
-
-TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` finds no matching producer (the lookup callback never fires) and returns immediately — but the kernel may still be reading → **WAR data race**.
-
-**Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through the ring's `completed_watermark`.
-
-**Scenarios #6–8 serial guarantee**:
-
-get/set_tensor_data are blocking calls, and orchestration is single-threaded serial submission. After a blocking operation completes, subsequent code (including task submissions) executes strictly afterward.
-
-## 7. External Tensor Behavior
-
-`make_tensor_external()` creates tensors with a pre-set `buffer.addr` (pointing to host-allocated device memory).
-
-| Scenario | Behavior |
-| -------- | -------- |
-| External tensor never submitted as OUTPUT/INOUT | No TensorMap entry — get/set execute immediately |
-| External tensor previously submitted as OUTPUT/INOUT | TensorMap has producer entry — get/set spin-wait |
-| External tensor submitted as INPUT, then set_tensor_data | **WAR risk** — must use INOUT instead (same as scenario #3) |
-
-**Key rule**: If an external tensor will later be written via `set_tensor_data`, all prior kernel accesses must use `add_inout()`, not `add_input()`.
+- Use scalar access only on external, host-staged tensors with no device
+  producer or outstanding device consumer.
+- Use tensor dependencies to order device tasks; do not use host scalar access
+  as a device synchronization barrier.
+- Pass values needed for graph construction as orchestration inputs or scalars.
+- Keep device-produced values on the device or return them after the run.

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -1,222 +1,124 @@
-# Submit by Cluster - Requirements and Main-Branch-Aligned Design
+# Cluster-Aware Submission in `host_build_graph`
 
-## 1. Goal
+## Contract
 
-Define a single, main-branch-aligned specification for PTO2 cluster submission that combines:
-
-1. Product requirements (what must be true).
-2. Runtime design (how it is implemented on current main baseline).
-
-The target model is: one submitted graph node is one `MixedTask`, and dispatch/completion is mixed-task-granular.
-
-## 2. Background and Motivation
-
-Future Ascend hardware is expected to provide stronger locality within an AICore cluster (`1 AIC + 2 AIV`).
-The runtime therefore needs a "submit together, run together" model for related AIC/AIV kernels.
-
-Legacy per-task submit (`kernel_id + worker_type`) cannot express atomic co-dispatch of multiple kernels to one cluster.
-
-## 3. Scope
-
-### In Scope
-
-1. New orchestration-facing submit API for cluster-aware mixed submission.
-2. Runtime/backend scheduler and executor changes to treat a mixed submit as one atomic scheduling unit.
-3. Dependency gating, readiness, dispatch, completion, and reclamation at mixed-task granularity.
-4. AIV slot equivalence (`AIV0` and `AIV1` are equivalent execution targets).
-
-### Out of Scope
-
-1. User-facing cluster pinning (`allocate_cluster/free_cluster`-style APIs).
-2. New worker types beyond AIC/AIV.
-3. Cross-cluster user placement policies.
-4. Hardware topology changes beyond `1 AIC + 2 AIV` per cluster.
-
-## 4. Main-Branch Baseline Constraints
-
-Design must preserve the current main runtime architecture:
-
-1. Executor threading split (orchestrator thread vs scheduler threads), and post-orchestrator transition (`transition_requested_` + `reassign_cores_for_all_threads()`).
-2. Shared-memory hot/cold split (`PTO2TaskDescriptor` hot + `PTO2TaskPayload` cold).
-
-## 5. Terminology
-
-1. `cluster`: one physical unit with `1 AIC + 2 AIV`.
-2. `MixedKernels`: 3 submit slots (`AIC`, `AIV0`, `AIV1`) with `INVALID_KERNEL_ID` for inactive slots.
-3. `MixedTask`: one runtime graph node created by one submit call.
-4. `active_mask`: bitmask of active subtask slots.
-5. `resource shape`: normalized lane demand class of a mixed task.
-
-## 6. API Contract
+One call to `rt_submit_task` creates one mixed graph task. The task may use any
+nonempty combination of the physical cluster's `AIC`, `AIV0`, and `AIV1`
+lanes; all active lanes share one argument payload, dependency set, logical
+block count, and completion record.
 
 ```cpp
-inline constexpr int32_t INVALID_KERNEL_ID = -1;
+MixedKernels kernels;
+kernels.aic_kernel_id = aic_func_id;
+kernels.aiv0_kernel_id = aiv0_func_id;
+kernels.aiv1_kernel_id = aiv1_func_id;
 
-struct MixedKernels {
-    int32_t aic_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv0_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
-};
-
-static inline void rt_submit_task(PTO2Runtime* rt,
-                                       const MixedKernels& mixed_kernels,
-                                       Arg* args,
-                                       int32_t num_args);
-
-static inline void rt_submit_aic_task(PTO2Runtime* rt,
-                                           int32_t kernel_id,
-                                           Arg* args,
-                                           int32_t num_args);
-
-static inline void rt_submit_aiv_task(PTO2Runtime* rt,
-                                           int32_t kernel_id,
-                                           Arg* args,
-                                           int32_t num_args);
+L0TaskArgs args;
+args.add_inout(output);
+args.launch_spec.set_block_num(block_num);
+TaskOutputTensors result = rt_submit_task(kernels, args);
 ```
 
-Rules:
+`rt_submit_aic_task` and `rt_submit_aiv_task` are convenience wrappers over the
+same mixed-task contract.
 
-1. One submit call creates one `MixedTask`.
-2. All active slots share the same `args` and `num_args`.
-3. At least one slot must be active.
-4. `aiv0_kernel_id` and `aiv1_kernel_id` are semantically equivalent.
-5. Wrappers are orchestration sugar only (inline in orchestration API); no dedicated runtime ops entries.
-6. Submit-contract types are defined once in a shared header-only submit-types surface consumed by orchestration and runtime headers.
-7. Invalid submits follow existing PTO2 behavior (`always_assert`), not a new recoverable return-code API.
+## Task Representation
 
-## 7. Data Model (Requirements + Design)
+The shared graph image separates stable task identity from scheduling state:
 
-`PTO2TaskDescriptor` (hot path) carries mixed-task identity/state:
+- `PTO2TaskDescriptor` contains the task ID, kernel IDs, and packed-buffer
+  addresses.
+- `PTO2TaskPayload` contains tensors, scalars, predicates, and position-
+  independent `fanin_local_ids[]`.
+- `PTO2TaskSlotState` contains the active mask, task attributes, logical block
+  count, subtask counters, completion state, and descriptor/payload bindings.
 
-1. `task_id`
-2. `active_mask`
-3. `completed_subtasks` (atomic counter, incremented per subtask completion)
-4. `kernel_id[3]` for `(AIC, AIV0, AIV1)`
-5. dependency heads/counters and packed-buffer metadata
+This image is built on the host, relocated once, and copied to the device. It
+contains no fanout adjacency or dependency-pool pointers.
 
-`PTO2TaskPayload` (cold path) carries:
+## Resource Shapes
 
-1. shared args/tensors/scalars copied once per mixed submit
-2. fanin mixed-task IDs
-3. other cold-path submit metadata
+`ActiveMask::to_shape()` maps a task to one of four shapes:
 
-Producer identity in TensorMap is mixed-task ID end-to-end.
+| Shape | Meaning |
+| ----- | ------- |
+| `AIC` | One AIC lane per logical block |
+| `AIV` | One AIV lane per logical block |
+| `MIX` | Two or three active lanes in one physical cluster |
+| `DUMMY` | Dependency-only task with no AICore dispatch |
 
-## 8. Scheduling Model
+A single-AIV task is normalized to the AIV0 submit slot. MIX dispatch still
+uses the full active mask so unused lanes do not block placement.
 
-### 8.1 Resource Shapes
+## Logical Blocks and Validation
 
-Runtime uses shape-based ready queues (not worker-type queues):
+`block_num` is the number of logical SPMD blocks, not the number of physical
+clusters. Non-sync tasks may be wider than the device and dispatch in waves.
 
-1. `AIC_ONLY`
-2. `AIV_X1`
-3. `AIV_X2`
-4. `AIC_AIV_X1`
-5. `AIC_AIV_X2`
+Submission validates before allocating or publishing a slot:
 
-Queueing key is normalized resource shape (not raw slot label).
+```text
+block_num >= 1
+block_num * popcount(active_mask) <= INT16_MAX
+```
 
-### 8.2 Atomic Cluster Dispatch
+The product is the number stored in the 16-bit completion counter. Invalid
+values latch `PTO2_ERROR_INVALID_ARGS`; they are not capped at the device's
+physical cluster count.
 
-1. Dispatch decision unit is one mixed task.
-2. For multi-slot mixed tasks, partial launch is forbidden.
-3. A mixed task is dispatchable only when one local owned cluster can satisfy all required lanes.
-4. Compatible mixed tasks may co-reside over time if they use disjoint free lanes.
+`require_sync_start` adds a separate residency constraint because every block
+must launch as one cohort:
 
-### 8.3 Dependency and Completion
+- AIV-only: `block_num <= rt_available_aiv_count()`
+- AIC or MIX: `block_num <= rt_available_cluster_count()`
 
-1. Fanin release/readiness remains dependency-correct and graph-level.
-2. Two-stage completion:
-   - `on_subtask_complete(task_id, subslot)`
-   - `on_task_complete(task_id)` only when `completed_subtasks == total_required_subtasks`
-3. Downstream release is triggered once per mixed task completion, not once per subslot.
+## Dependency and Readiness Flow
 
-## 9. Executor Ownership and Numbering
+1. Host orchestration allocates a task slot and builds its payload.
+2. TensorMap and explicit dependencies append producer local IDs to
+   `fanin_local_ids[]`.
+3. Submit publishes only the finished graph data; it does not push ready tasks.
+4. After H2D, device boot scans every submitted task exactly once.
+5. A task with every fanin complete is routed to its ready queue; otherwise it
+   registers on its first unmet producer's wake list.
+6. Producer completion reclassifies wake-list consumers until they become ready.
 
-### 9.1 Canonical Flattened Numbering (Unchanged)
+Completion flags are monotonic, so a task never needs periodic fanin polling.
 
-Given `block_dim` clusters:
+## Dispatch and Completion
 
-1. AIC IDs: `[0, block_dim)`
-2. AIV IDs: `[block_dim, 3 * block_dim)`
-3. Cluster `i`: `{i, block_dim + i, 2 * block_dim + i}`
+- AIC and AIV tasks claim as many free cores as the current scheduler owns and
+  requeue remaining logical blocks for later waves.
+- MIX placement selects whole clusters whose used lanes can all accept the
+  task. High cluster offsets are represented by the runtime's 128-bit bitset.
+- `require_sync_start` uses local staging when possible and a generation-tagged
+  global drain when the cohort spans scheduler ownership domains.
+- Each completed lane increments `completed_subtasks`; the mixed task completes
+  exactly once when it reaches `block_num * popcount(active_mask)`.
 
-This project-defined flattened numbering is kept unchanged.
+## Executor Model
 
-### 9.2 Cluster Ownership
+The host loads and executes the orchestration shared object synchronously. The
+device has no orchestration thread: every launched AICPU thread participates in
+scheduling its assigned cores after the boot thread attaches the prebuilt graph.
+Cluster ownership is assigned during the AICore handshake and remains stable for
+the run.
 
-1. One cluster must be owned by one scheduler domain/thread at a time.
-2. No split-cluster ownership in either:
-   - initial `assign_cores_to_threads()`
-   - post-orchestrator `reassign_cores_for_all_threads()`
-3. Lane occupancy bookkeeping must remain consistent with ownership after reassignment.
+## Capacity
 
-## 10. Functional Requirements
+`host_build_graph` is whole-graph-resident. Task slots, heap bytes, fanin IDs,
+and TensorMap entries are not reclaimed while the graph is executing. The graph
+must fit the configured task window, heap, and TensorMap pool before launch.
 
-### 10.1 Valid Mixed Shapes
+## Validation
 
-1. AIC only
-2. AIV only (1 or 2 AIV lanes)
-3. AIC + 1 AIV
-4. AIC + 2 AIV
-
-### 10.2 Runtime Behavior per Submit
-
-1. Validate submit arguments.
-2. Allocate mixed-task ID and initialize descriptor/payload/slot_state once.
-3. Lookup producers via TensorMap; collect fanin metadata and increment producers' `fanout_count`.
-4. Wire fanout edges and determine readiness **inline in submit**: link each live producer's `fanout_head` via `dep_pool` entries and seed readiness directly — `push_ready_routed` for zero-fanin tasks, `route_ready_once` once a producer's fanin resolves. No device-side wiring queue is involved.
-5. Dispatch all active lanes atomically when resources allow.
-6. Aggregate completion and release downstream once.
-
-## 11. Non-Functional Requirements
-
-1. Correctness: no dependency violation, no partial mixed-task dispatch.
-2. Determinism: dependency-correct ordering preserved; AIV lane choice may vary but remains semantically equivalent.
-3. Fairness: resource-aware polling heuristic is allowed; strict starvation-free guarantee across all shapes is not required.
-4. Performance: no obvious regression for non-cluster workflows.
-5. Observability: lifecycle visibility for submit/ready/dispatch/block/complete.
-
-## 12. Acceptance Criteria
-
-Feature is accepted when:
-
-1. Orchestration compiles and submits via `MixedKernels` API/wrappers.
-2. Scheduler dispatches each mixed task as one cluster scheduling decision.
-3. Dependencies gate mixed-task readiness correctly.
-4. AIV execution remains cluster-local and semantically equivalent across lanes.
-5. Existing non-cluster workflows continue to pass without behavior regression.
-6. Cluster ownership is never split across scheduler domains before/after transition.
-
-## 13. Verification Matrix
-
-Recommended validation coverage:
-
-1. Mapping correctness for cluster-to-core ID relation.
-2. Atomic dispatch for multi-slot shapes.
-3. Dependency gating and completion aggregation (`done_mask == active_mask`).
-4. Lane-occupancy co-residency behavior for compatible shapes.
-5. Core-transition ownership stability.
-6. Invalid submit handling (`always_assert` path).
-7. Regression coverage for existing examples/tests.
-
-Milestone command (device):
+Run the HBG runtime simulation sweep after runtime changes:
 
 ```bash
-python tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py \
-  -p a2a3 -d 9
+pytest examples tests/st --platform a2a3sim --runtime host_build_graph
+pytest examples tests/st --platform a5sim --runtime host_build_graph
 ```
 
-Final validation:
-
-```bash
-pytest examples tests/st -m "not sdma" --platform a2a3   # SDMA cases quarantined by marker; run them with -m sdma
-```
-
-## 14. Resolved Decisions
-
-1. Legacy orchestration-facing single-task submit is replaced by mixed submit contract.
-2. Invalid mixed submits fail with existing submit-time assert behavior.
-3. Per-cluster concurrent capacity is lane-occupancy-driven, not a fixed constant.
-4. Submit-contract types live in one shared header-only surface.
-5. Resource-aware dispatch heuristics are allowed without a strict starvation-free guarantee.
+The `host_build_graph_wide_dispatch` scene specifically covers wide AIV work,
+sync-start MIX placement, normal MIX placement, and bit offsets above 63 with
+`aicpu_thread_num=2`.

--- a/src/a2a3/runtime/host_build_graph/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/host_build_graph/docs/device_log_profiling.md
@@ -1,175 +1,90 @@
-# PTO2 Device Log Profiling Guide
+# `host_build_graph` Device-Log Profiling
 
-## How to Find Device Logs
+## Execution Boundary
 
-AICPU logs (via `LOG_INFO`) are written by CANN's **dlog** subsystem and do **not** appear in the `python test_*.py` / pytest terminal output. They are written to CANN's device log directory:
+`host_build_graph` runs its orchestration shared object on the host before the
+device launch. The device boots scheduler-only, so its device log contains no
+orchestrator-thread block and no device-side `dlopen` timing.
+
+Host graph-construction timing belongs in host-side diagnostics. This guide is
+only for the AICPU scheduler portion of a run.
+
+## Finding the Log
+
+On hardware, AICPU `LOG_INFO` records are written by CANN's dlog subsystem:
 
 ```text
 $HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
 ```
 
-Each run produces a new log file (or appends to an existing one). Find the most recent file by modification time:
+Find the newest file and filter the current scheduler records:
 
 ```bash
-ls -lt $HOME/ascend/log/debug/device-<device_id>/ | head -5
+ls -t "$HOME/ascend/log/debug/device-<device_id>"/device-*.log | head -1
+grep -E "sched_start=|Scheduler summary|Scheduler Phase Breakdown" <logfile>
 ```
 
-## Log Structure Overview
+## Scheduler Summary
 
-A single run produces two profiling blocks in the device log:
-
-| Block | Emitted by | Function | Content |
-| ----- | ---------- | -------- | ------- |
-| **Orchestrator Profiling** | Thread 3 (orchestrator) | `aicpu_orchestration_entry` | Time breakdown of graph construction on device |
-| **PTO2 Scheduler Summary** | Threads 0/1/2 (schedulers) | `SchedulerContext::resolve_and_dispatch` | Per-thread scheduling statistics, phase timing, and lock contention |
-
-All timing values are in microseconds (us), converted from AICPU cycle counters.
-
-> **host_build_graph (host-orch) note.** The **Orchestrator Profiling** block
-> below only appears in the **device** log under the device-orchestration that
-> `tensormap_and_ringbuffer` runs. In host_build_graph the orchestrator runs on
-> the **host** and the device boots scheduler-only — `aicpu_executor.cpp`
-> carries no on-device orchestrator path — so the device log for a
-> host_build_graph run contains **only Block 2 (the Scheduler Summary)**.
-> Orchestrator graph-construction timing for host_build_graph is a host-side
-> measurement, not a device-log line.
-
----
-
-## Block 1: Orchestrator Profiling
-
-Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_entry`, and prints a profiling summary after it returns.
-
-### Example (from a real run: batch=64, 16704 tasks)
+With `SIMPLER_DFX` enabled, each scheduler thread emits timing bounds and a
+summary when its dispatch loop completes:
 
 ```text
-Thread 3: Calling aicpu_orchestration_entry from SO
-Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
-Thread 3: === Orchestrator Profiling: 16704 tasks, total=14601.580us ===
-Thread 3:   sync_tensormap : 286.300us (2.0%)
-Thread 3:   task_ring_alloc: 380.400us (2.6%)
-Thread 3:   param_copy     : 2147.800us (14.7%)
-Thread 3:   lookup+dep     : 7290.300us (49.9%)
-Thread 3:   heap_alloc     : 701.500us (4.8%)
-Thread 3:   tensormap_ins  : 1890.380us (12.9%)
-Thread 3:   fanin+ready    : 1207.400us (8.3%)
-Thread 3:   finalize+SM    : 697.500us (4.8%)
-Thread 3:   scope_end      : 364.080us
-Thread 3:   avg/task       : 0.874us
-Thread 3: PTO2 total submitted tasks = 16704
+Thread 0: sched_start=... sched_end=... sched_cost=3477.420us
+Thread 0: Scheduler summary: total_time=3460.100us, loops=147, tasks_scheduled=352
 ```
 
-### Field Reference
+| Field | Meaning |
+| ----- | ------- |
+| `sched_cost` | Wall time from scheduler-loop entry to exit |
+| `total_time` | Accounted complete + dispatch + idle cycles |
+| `loops` | Scheduler-loop iterations |
+| `tasks_scheduled` | Mixed tasks this thread completed |
 
-| Field | Source (`pto_orchestrator.cpp`) | Description |
-| ----- | ------------------------------- | ----------- |
-| **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
-| **total** | Sum of all sub-steps below | Accumulated time inside `submit_task` across all tasks |
-| **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
-| **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
-| **param_copy** | `g_orch_args_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
-| **lookup+dep** | `g_orch_lookup_cycle` | TensorMap lookup for inputs/inouts + building fanin/fanout dependency edges |
-| **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
-| **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
-| **fanin+ready** | `g_orch_fanin_cycle` | Building the fanin list + checking if task is already ready (Step 5/5b) |
-| **scope_end** | `g_orch_scope_end_cycle` | `end_scope` overhead (notifying scheduler of scope completion) |
-| **avg/task** | `total / submit_count` | Average orchestrator time per task submission |
+All launched AICPU threads participate in scheduling their assigned cores. The
+highest-index thread performs one-time prebuilt-runtime attachment before it
+enters the same scheduler path; it is not an orchestrator thread.
 
-### Interpreting the Numbers
+## Optional Phase Breakdown
 
-- **cost > total**: The difference is overhead outside `submit_task` (the orchestration user code itself, scope_begin/end, TensorCreateInfo construction, etc.).
-- **lookup+dep** is typically the dominant cost (~50%) because it involves TensorMap hash lookups and building dependency edges with spinlock-protected fanout list insertions.
-- **param_copy** scales with the number of parameters per task.
-- **avg/task < 1us** indicates efficient graph construction.
-
----
-
-## Block 2: PTO2 Scheduler Summary
-
-Each scheduler thread (Thread 0–3 at `aicpu_thread_num=4`) prints its own summary after completing all tasks. The output has two sub-sections: **summary** and **phase breakdown**.
-
-### Example (Thread 0, from a different run: batch=1, 1044 tasks)
+When `SIMPLER_SCHED_PROFILING` is also enabled, the summary includes:
 
 ```text
-Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
-Thread 0: --- Phase Breakdown ---
-Thread 0:   complete:    1485.020us (42.7%)
-Thread 0:   scan:        14.400us (0.4%)
-Thread 0:   dispatch:    1973.060us (56.7%)
-Thread 0:   idle:        4.940us (0.1%)
+Thread 0: === Scheduler Phase Breakdown: total=3460.100us, 352 tasks ===
+Thread 0:   complete       : ...
+Thread 0:     poll         : ... hit=... miss=... hit_rate=...%
+Thread 0:   dispatch       : ...
+Thread 0:     pop          : ... work=... wait=... atomics=...
+Thread 0:     setup        : ...
+Thread 0:   idle           : ...
+Thread 0:   avg/complete   : ...
 ```
 
-### Summary Line
+- `complete` polls core completion and retires mixed tasks.
+- `dispatch` selects ready work, builds payloads, and publishes core commands.
+- `pop` separates ready-queue work from contention wait.
+- `setup` covers payload/MMIO preparation.
+- `idle` is accounted time when the loop made no progress.
+
+Dependency fanout/fanin aggregates are derived from `deps.json` by the DFX
+analysis tools; current HBG device logs do not print the obsolete adjacency-list
+statistics described by older guides.
+
+## Timeout Record
+
+A scheduler timeout uses an explicit end marker:
 
 ```text
-Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
+Thread 0: sched_start=... sched_end(timeout)=... sched_cost=...
 ```
 
-| Field | Description |
-| ----- | ----------- |
-| **completed** | Number of tasks this thread processed to completion |
-| **Y us** | Total scheduler loop time (sum of all phase cycles) |
-| **Z loops** | Number of scheduler loop iterations |
-| **W tasks/loop** | Average tasks completed per loop iteration; higher = better throughput |
+Use the accompanying runtime-status and stall-classification records to identify
+the failure. Do not infer an orchestration stall from a missing Thread-3 block;
+that block never exists in this runtime.
 
-### Phase Breakdown
+## Related Tools
 
-The scheduler loop runs four phases each iteration. Each phase's time is accumulated across all loop iterations.
-
-| Phase | What it does | Inline stats |
-| ----- | ------------ | ------------ |
-| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to increment the completion counter; when `completed_subtasks == total_required_subtasks`, triggers `on_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
-| **scan** | Updates the perf profiling header with latest scheduler state | — |
-| **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
-| **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |
-
-**Interpreting phase percentages:**
-
-- **dispatch** is typically the largest (~55-60%) because it includes ready-queue pops (with spinlock), payload construction, and cache flush (`dc cvac` + `dsb sy`).
-- **complete** is the second largest (~40-45%) because it traverses both fanout (CAS-based fanin decrement, conditional ready-queue push) and fanin (release_producer, check_consumed, ring pointer advancement).
-- **scan** is small (<1%) — only updates the perf header.
-- **idle** is negligible when tasks are flowing; high idle% indicates the scheduler is starved.
-
-**Interpreting pop hit_rate:**
-
-- **High hit_rate (>50%)**: Ready queue is well-supplied; dispatch is efficient.
-- **Low hit_rate (<10%)**: Ready queue is mostly empty when cores become idle. The bottleneck is upstream (orchestrator submission speed or fanout resolution latency), not dispatch itself.
-
-### Per-Task Averages
-
-Divide each thread's phase times by its `completed` count to get per-task scheduling cost:
-
-| Metric | Formula | Typical value |
-| ------ | ------- | ------------- |
-| Scheduling overhead per task | total_time / completed | ~5-10 us/task |
-| Dispatch per task | dispatch_time / completed | ~3-6 us/task |
-| Complete per task | complete_time / completed | ~2-4 us/task |
-
----
-
-## Cross-Referencing with Host Profiling
-
-When `--enable-l2-swimlane` is used, the host terminal prints a **Task Statistics by Function** table with `Total_Exec` (total AICore kernel execution time). Combined with device log data:
-
-| Metric | Source | Description |
-| ------ | ------ | ----------- |
-| Avg kernel exec time | `Total_Exec / total_tasks` (host) | Time AICore spends executing each kernel |
-| Avg scheduling overhead | `sum(thread_total) / total_tasks` (device log) | Time AICPU spends scheduling each task |
-| Sched/Exec ratio | scheduling / execution | Scheduling overhead relative to kernel execution |
-
-A high sched/exec ratio (e.g., >3x) indicates that scheduling overhead dominates, and optimizations should target the scheduler's dispatch hot path (cache flush, payload construction) or upstream task flow.
-
----
-
-## Quick Reference: Extracting Profiling Data
-
-```bash
-# Find the latest device log for device 2
-ls -t $HOME/ascend/log/debug/device-2/device-*.log | head -1
-
-# Extract orchestrator profiling (Thread 3)
-grep "Thread 3:" <logfile>
-
-# Extract scheduler profiling (Threads 0/1/2)
-grep -E "Thread [012]:" <logfile>
-```
+- `python -m simpler_setup.tools.strace_timing` summarizes host/device run markers.
+- `simpler_setup.tools.l0_swimlane` reconstructs intra-core execution from dumps.
+- The repository's DFX analysis workflow combines scheduler timing with
+  dependency and task records.

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -389,11 +389,11 @@ Pass compile definitions through the build command or CI `CXXFLAGS`.
 This overrides the defaults in `profiling_config.h` without changing source.
 
 ```bash
-# Example: disable all profiling code
-CXXFLAGS="-DPTO2_PROFILING=0" pip install --no-build-isolation -e .
+# Example: disable all device profiling code
+CXXFLAGS="-DSIMPLER_DFX=0" pip install --no-build-isolation -e .
 
 # Example: enable orchestrator and tensormap profiling
-CXXFLAGS="-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1" \
+CXXFLAGS="-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_TENSORMAP_PROFILING=1" \
     pip install --no-build-isolation -e .
 ```
 

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -276,9 +276,11 @@ static inline bool rt_is_fatal() {
  *   uint64_t raw = get_tensor_data(tensor, 1, idx);       // old usage unchanged
  *   float val = get_tensor_data<float>(tensor, 1, idx);   // typed read
  *
- * If the tensor has a producer in TensorMap, spin-waits until the producer
- * task completes before reading. External tensors (make_tensor_external)
- * are read immediately without waiting.
+ * This API reads the registered host view used to stage an external tensor.
+ * It is valid while host orchestration is building the graph, before device
+ * scheduling starts. A tensor produced by a submitted task cannot become
+ * readable during graph construction, and a runtime-created output has no
+ * registered host view; either use is reported as an invalid argument.
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
@@ -297,24 +299,11 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
  *   set_tensor_data(tensor, 1, idx, raw_u64);     // old usage unchanged
  *   set_tensor_data(tensor, 1, idx, 42.0f);       // typed write (T = float)
  *
- * If the tensor has a producer in TensorMap, spin-waits until the producer
- * and all its consumers complete before writing (WAW + WAR safety).
- * External tensors (make_tensor_external) with no TensorMap entry are
- * written immediately without waiting.
- *
- * Limitation: TensorMap only tracks producers (OUTPUT/INOUT), not consumers
- * that used the tensor as INPUT. If a kernel reads this tensor as INPUT
- * (not INOUT) and the tensor has no TensorMap producer entry, set_tensor_data
- * cannot detect the reader and may cause a data race.
- *
- * To ensure WAR safety for all access patterns, use add_inout() instead of
- * add_input() for kernel parameters that may later be written via
- * set_tensor_data. INOUT creates a TensorMap entry that enables automatic
- * consumer tracking via the ring's completed_watermark.
- *
- * The tensor must already have an allocated buffer (addr != 0).
- * For runtime-created outputs, call this only on the Tensor returned by
- * add_output(TensorCreateInfo) after submit returns.
+ * This API updates the registered host view used to stage an external tensor.
+ * The updated value becomes part of the graph's initial device data. It is not
+ * a synchronization barrier for submitted readers or writers. A tensor with a
+ * submitted producer, or a runtime-created output with no registered host view,
+ * is rejected as an invalid argument.
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Orchestrator Implementation
+ * host_build_graph orchestrator implementation
  *
  * Implements orchestrator state management, scope handling, and task submission.
  *
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <limits>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -387,6 +388,18 @@ static bool prepare_task(
     uint8_t ring_id = 0;
     auto &allocator = orch->ring.task_allocator;
 
+    int16_t block_num = args.launch_spec.block_num();
+    int32_t active_subtasks_per_block = __builtin_popcount(active_mask.core_mask());
+    int32_t total_required_subtasks = static_cast<int32_t>(block_num) * active_subtasks_per_block;
+    if (block_num <= 0 || total_required_subtasks > std::numeric_limits<int16_t>::max()) {
+        orch->report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
+            "block_num=%d with %d active slots requires %d subtasks; expected block_num >= 1 and total <= %d",
+            block_num, active_subtasks_per_block, total_required_subtasks, std::numeric_limits<int16_t>::max()
+        );
+        return false;
+    }
+
     if (!check_scope_can_accept_task(orch, allocator, ring_id)) {
         return false;
     }
@@ -427,9 +440,7 @@ static bool prepare_task(
     // (host_build_graph does not recycle slots at runtime, so there is no
     // post-CONSUMED reset path).
     out->slot_state->task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-    int16_t block_num = args.launch_spec.block_num();
-    out->slot_state->total_required_subtasks =
-        static_cast<int16_t>(block_num * __builtin_popcount(active_mask.core_mask()));
+    out->slot_state->total_required_subtasks = static_cast<int16_t>(total_required_subtasks);
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
     out->slot_state->task_attrs = task_attrs;
@@ -891,7 +902,6 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
 
     int16_t block_num = args.launch_spec.block_num();
-    always_assert(block_num >= 1 && "block_num must be >= 1");
 
     // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
     // it to the aiv0 slot.  This guarantees the dispatch path can always use

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Main Implementation
+ * host_build_graph runtime implementation
  *
  * Implements the unified runtime API that combines orchestrator and scheduler.
  *
@@ -120,13 +120,12 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
     va_end(args);
 }
 
-// Wait for all producers of this tensor to be safe for data access.
-// Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
-// For reads: wait until each producer COMPLETED (done writing).
-// For writes: also wait until all consumers done reading
-//   (per-ring completed_watermark >= the producer's last_consumer_local_id).
-// Uses cycle-based timeout (checked every 1024 spins).
-// Returns false on timeout (sets orch.fatal).
+// Validate every producer reference before waiting on its slot. The host builds
+// the complete graph before device scheduling starts, so a live device producer
+// cannot complete during this call; the timeout remains a defensive failure
+// backstop rather than a synchronization mechanism for orchestration code.
+// For writes, completed_watermark additionally protects against overwriting a
+// producer while one of its submitted consumers is still live.
 MAYBE_UNINITIALIZED_BEGIN
 static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
     PTO2TaskId owner = tensor.owner_task_id;
@@ -142,6 +141,33 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     const PTO2TaskSlotState *seg[kSegmentCap];
     int seg_count = 0;
     bool failed = false;
+
+    auto resolve_producer = [&](PTO2TaskId producer) -> const PTO2TaskSlotState * {
+        if (!producer.is_valid() || producer.ring() != 0) {
+            orch.report_fatal(
+                PTO2_ERROR_INVALID_ARGS, caller,
+                "tensor producer task %#llx has invalid ring %u; host_build_graph uses ring 0",
+                static_cast<unsigned long long>(producer.raw), static_cast<unsigned int>(producer.ring())
+            );
+            failed = true;
+            return nullptr;
+        }
+
+        auto &ring = orch.sm_header->ring;
+        int32_t local_id = static_cast<int32_t>(producer.local());
+        int32_t slot_index = ring.get_slot_by_task_id(local_id);
+        auto &slot = ring.get_slot_state_by_slot(slot_index);
+        if (slot.task == nullptr || slot.task->task_id != producer) {
+            orch.report_fatal(
+                PTO2_ERROR_INVALID_ARGS, caller,
+                "tensor producer task %#llx does not match the descriptor bound to slot %d",
+                static_cast<unsigned long long>(producer.raw), slot_index
+            );
+            failed = true;
+            return nullptr;
+        }
+        return &slot;
+    };
 
     auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
         uint8_t ring_id = 0;
@@ -227,16 +253,17 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     auto do_wait = [&]() {
         // Step A: creator retention — read owner directly from tensor metadata
         if (owner.is_valid()) {
-            auto &s = orch.sm_header->ring.get_slot_state_by_task_id(owner.local());
-            try_push(s);
+            const auto *slot = resolve_producer(owner);
             if (failed) return;
+            try_push(*slot);
         }
 
         // Step B: modifier writer lookup (OverlapMap), direct callback
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
             PTO2TaskId pid = entry.producer_task_id;
-            auto &s = orch.sm_header->ring.get_slot_state_by_task_id(pid.local());
-            try_push(s);
+            const auto *slot = resolve_producer(pid);
+            if (failed) return false;
+            try_push(*slot);
             return !failed;
         });
         if (failed) return;

--- a/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -20,9 +20,10 @@
  * GlobalContext (sub_block_id) is initialized once at runtime startup via
  * init_global_context() and never modified afterwards.
  *
- * LocalContext (block_idx, block_num) and args[] are rebuilt by build_payload()
- * before each dispatch.  Both context struct pointers are written into the
- * args[] suffix on every dispatch (since args[] is rebuilt entirely each time).
+ * build_payload() refreshes the function address, LocalContext's hot fields,
+ * and either the ready-path argument prefix or the gated-path source pointer.
+ * Context pointers, GlobalContext, and the async-completion slab metadata are
+ * initialized once per core and payload buffer.
  *
  * AICore caches a pointer to its per-core slot at startup and reads from
  * it on each dispatch.  The struct is cache-line aligned to avoid false

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -392,15 +392,9 @@ void SchedulerContext::dispatch_shape(
             CoreTracker::BitStates selected_mix_clusters(0ULL);
 
             if (is_mix) {
-                auto candidates = cores;
                 uint8_t cmask = slot_state->active_mask.core_mask();
                 auto wanted = is_pending ? CoreTracker::MixPlacement::PENDING : CoreTracker::MixPlacement::RUNNING;
-                while (candidates.has_value()) {
-                    int32_t cluster_offset = candidates.pop_first();
-                    if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
-                        selected_mix_clusters |= CoreTracker::BitStates(1ULL << cluster_offset);
-                    }
-                }
+                selected_mix_clusters = tracker.get_mix_cluster_offset_states(cmask, wanted) & cores;
                 if (!selected_mix_clusters.has_value()) {
                     disp_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
@@ -745,13 +739,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         if (is_mix) {
             auto wanted = is_idle ? CoreTracker::MixPlacement::RUNNING : CoreTracker::MixPlacement::PENDING;
             uint8_t cmask = c->active_mask.core_mask();
-            CoreTracker::BitStates candidates = tracker.get_cluster_offset_states();
-            while (candidates.has_value()) {
-                int32_t cluster_offset = candidates.pop_first();
-                if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
-                    bucket |= CoreTracker::BitStates(1ULL << cluster_offset);
-                }
-            }
+            bucket = tracker.get_mix_cluster_offset_states(cmask, wanted);
         } else {
             bucket = tracker.get_dispatchable_cores(shape, phase);
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -8,8 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#ifndef SCHEDULER_TYPES_H
-#define SCHEDULER_TYPES_H
+#pragma once
 
 #include <atomic>
 #include <cstddef>
@@ -391,6 +390,18 @@ public:
         return MixPlacement::PENDING;
     }
 
+    BitStates get_mix_cluster_offset_states(uint8_t core_mask, MixPlacement placement) const {
+        BitStates result;
+        BitStates candidates = get_cluster_offset_states();
+        while (candidates.has_value()) {
+            int32_t cluster_offset = candidates.pop_first();
+            if (classify_mix_cluster(cluster_offset, core_mask) == placement) {
+                result |= BitStates::bit(cluster_offset);
+            }
+        }
+        return result;
+    }
+
     // --- Gated MIX split placement ---
     // A gated MIX block can place each of its cores INDEPENDENTLY (idle core -> gated
     // running slot; busy core with a free pending slot -> gated pending slot), because
@@ -439,15 +450,7 @@ public:
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result;
-        BitStates candidates = get_cluster_offset_states();
-        while (candidates.has_value()) {
-            int32_t cluster_offset = candidates.pop_first();
-            if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
-                result |= BitStates::bit(cluster_offset);
-            }
-        }
-        return result;
+        return get_mix_cluster_offset_states(core_mask, MixPlacement::RUNNING);
     }
 
     int32_t count_mix_running_clusters(uint8_t core_mask) const {
@@ -510,7 +513,7 @@ public:
     int32_t core_num() const { return cluster_count_ * 3; }
 
 private:
-    int32_t cluster_count_;
+    int32_t cluster_count_{0};
     BitStates aic_mask_;
     BitStates aiv_mask_;
     BitStates core_states_;
@@ -604,5 +607,3 @@ inline uint64_t sync_start_drain_next_attempt(uint64_t attempt) {
 inline uint64_t sync_start_drain_ack_subtree_token(uint64_t attempt) {
     return attempt | SYNC_START_DRAIN_ACK_SUBTREE_READY;
 }
-
-#endif  // SCHEDULER_TYPES_H

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -188,7 +188,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 // already invalidated src's lines, so tensor_count/scalar_count/
                 // scalars read coherently with the orchestrator's submit writes.
                 // args[SPMD_LOCAL_CONTEXT_INDEX]/[SPMD_GLOBAL_CONTEXT_INDEX] are
-                // still written by the AICPU (num_args <= 48 never reaches them).
+                // pre-filled once at init() and never changed; tensor and scalar
+                // counts are set by the orchestrator, so num_args never reaches them.
                 __gm__ char *src = reinterpret_cast<__gm__ char *>(exec_payload->src_payload);
                 int32_t tensor_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
                 int32_t scalar_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -42,6 +42,7 @@
 #include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
+#include "utils/thread_completion_gate.h"
 
 // Core type definitions
 #include "common/core_type.h"
@@ -82,7 +83,6 @@ struct AicpuExecutor {
     std::atomic<int32_t> thread_idx_{0};
     std::atomic<bool> init_done_{false};
     std::atomic<bool> init_failed_{false};
-    std::atomic<bool> finished_{false};
 
     // Parallel-handshake coordination (see AicpuExecutor::init). hs_setup_done_
     // is published by the leader once the shared pre-handshake setup is visible;
@@ -106,7 +106,7 @@ struct AicpuExecutor {
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
-    std::atomic<int32_t> finished_count_{0};
+    simpler::ThreadCompletionGate completion_gate_;
     std::atomic<bool> runtime_init_ready_{false};
 
     // Per-Worker arena backing the PTO2Runtime + sm_handle + orch/sched/mailbox
@@ -194,7 +194,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     hs_arrived_.fetch_add(1, std::memory_order_acq_rel);
     if (is_leader) {
         while (hs_arrived_.load(std::memory_order_acquire) < nthreads) {}
-        finished_count_.store(0, std::memory_order_release);
+        completion_gate_.reset();
         if (sched_ctx_.post_handshake_init(runtime) != 0) {
             init_failed_.store(true, std::memory_order_release);
             init_done_.store(true, std::memory_order_release);
@@ -244,8 +244,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // run() — it must NOT return early. This thread owns a core slice
         // (handshake_partition assigns [lo, total) to the last thread), so an
         // early return would skip shutdown(thread_idx) — leaving its AICore
-        // cores spinning on an unclosed register window — and finished_count_,
-        // so finished_ never publishes and the host hangs into the op-execute
+        // cores spinning on an unclosed register window — and the completion
+        // gate never opens, so the host hangs into the op-execute
         // timeout (507018) instead of seeing the failure. On failure: record it
         // in run_rc, leave rt null so the dispatch block below skips, and still
         // publish runtime_init_ready_ (single point at the block's end) so the
@@ -358,19 +358,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     LOG_INFO("Thread %d: Completed", thread_idx);
 
-    // Check if this is the last thread to finish
-    int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
-    if (prev_finished + 1 == aicpu_thread_num_) {
-        finished_.store(true, std::memory_order_release);
-        // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
-        // always tear them down here.
+    completion_gate_.arrive_and_finalize_if_last(aicpu_thread_num_, [&] {
+        // Destroy the host_build_graph runtime. sm_handle / rt are recreated
+        // every run, so always tear them down here.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO before destroying rt.
             framework_bind_runtime(nullptr);
             runtime_destroy(rt, runtime_arena_);
             rt = nullptr;
         }
-    }
+    });
 
     return run_rc;
 }
@@ -384,12 +381,12 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();
 
-    finished_count_.store(0, std::memory_order_release);
+    completion_gate_.reset();
     runtime_init_ready_.store(false, std::memory_order_release);
 
     aicpu_thread_num_ = 0;
 
-    // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
+    // Clear the file-scope runtime pointer (freed by the last scheduler thread before deinit).
     rt = nullptr;
 
     LOG_INFO("DeInit: Runtime execution state reset");
@@ -402,7 +399,6 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     classify_ready_.store(false, std::memory_order_release);
     classify_arrived_.store(0, std::memory_order_release);
     thread_idx_.store(0, std::memory_order_release);
-    finished_.store(false, std::memory_order_release);
 
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
@@ -457,9 +453,9 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
 
     int32_t runtime_rc = read_pto2_runtime_status(runtime);
 
-    // Last thread cleans up
-    if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
-        LOG_INFO("aicpu_execute: Last thread finished, cleaning up");
+    // The finalizer publishes cleanup eligibility only after runtime destruction.
+    if (g_aicpu_executor.completion_gate_.claim_cleanup()) {
+        LOG_INFO("aicpu_execute: All threads finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
     }
 

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -1,853 +1,227 @@
-# PTO2 Runtime System Design (host_build_graph)
+# `host_build_graph` Runtime Design
 
-## Overview
+## 1. Execution Model
 
-host_build_graph is the **host-orchestration** variant of the PTO2 runtime: it
-shares tensormap_and_ringbuffer's scheduler, ring buffers, and shared-memory
-layout, and differs only in **when** the orchestrator runs. The host runs the
-orchestrator to completion — building the whole task graph, populating shared
-memory and the prebuilt arena — then H2Ds that image to the device, where the
-AICPU boots scheduler-only (no on-device orchestrator thread). It coordinates
-four layers of execution:
-
-- **Host** (x86/ARM CPU): compiles kernels, allocates device memory, **runs the orchestrator to build the task graph**, H2Ds the populated SM + arena, and launches AICPU/AICore threads.
-- **AICPU** (device ARM cores): runs scheduler threads only — it attaches the host-populated shared memory (already device-addressed by the host) and dispatches the already-built graph.
-- **AICore** (AI compute cores): executes kernel functions dispatched by the scheduler.
-- **Shared Memory** (Global Memory): ring buffers, task descriptors, heap, and TensorMap — built on host, attached read-mostly by the schedulers.
+`host_build_graph` separates graph construction from device execution:
 
 ```text
-┌───────────────────────────────────────────────────────────────────────┐
-│                            Host (CPU)                                 │
-│  test_*.py (SceneTestCase) → compile kernels → init Runtime           │
-│  → run orchestrator (build graph) → H2D populated SM + arena          │
-│  → upload binaries → launch AICPU/AICore → collect results            │
-└───────────────────────────┬───────────────────────────────────────────┘
-                            │ device memory / GM (populated graph image)
-┌───────────────────────────▼───────────────────────────────────────────┐
-│                     AICPU (N threads)                                  │
-│  All threads: Schedulers (attach + dispatch to AICore)                │
-│  (no on-device orchestrator thread — host already built the graph)    │
-│                                                                       │
-│  ┌─────────────────────────────────────────────────────────────────┐  │
-│  │                   Shared Memory (GM)                             │  │
-│  │  SharedMemoryHeader │ TaskDescriptors[] │ Payloads[] │ SlotStates[] │
-│  │  GM Heap (output buffers)                                       │  │
-│  └─────────────────────────────────────────────────────────────────┘  │
-│                                                                       │
-│  Scheduler ──Handshake/Registers──► AICore workers (AIC + AIV)        │
-└───────────────────────────────────────────────────────────────────────┘
+host register: materialize + dlopen orchestration SO
+        ↓
+host run/bind: stage external tensors, execute orchestration to completion
+        ↓
+host: relocate the prebuilt graph image and copy it to device memory
+        ↓
+device: attach the image, classify tasks, dispatch with AICPU schedulers
+        ↓
+host: collect outputs and destroy/reset per-run state
 ```
 
-> **Where the orchestrator runs (host_build_graph vs tensormap).** The data
-> structures and scheduler mechanics described in the sections below — the
-> orchestrator state, ring buffers, TensorMap dependency tracking, and the
-> dispatch handshake — are **shared** with `tensormap_and_ringbuffer`. Two
-> things differ, both following from **when and where the orchestrator runs**:
->
-> - **host_build_graph (this runtime):** the **host** dlopens the orchestration
->   `.so` and runs it to completion, populating shared memory + the prebuilt
->   arena. Dependencies are recorded as **position-independent integer fanin**:
->   each task's payload stores its producers' local-ids (`fanin_local_ids`) and
->   each producer records its highest consumer id (`last_consumer_local_id`).
->   There is no fanout adjacency, dep-pool, or per-task lock. Because fanin is
->   integer ids, the host→device relocation (`relocate_host_orch_image`)
->   collapses to fixing up only the per-slot `task` / `payload` pointers before
->   the H2D copy. The device boots **scheduler-only**: no on-device orchestrator
->   thread and no fanout wiring; on boot it scans the submitted tasks and
->   classifies each (fanin-free → ready queue; otherwise register on its first
->   unmet producer's wake list — see §8), then dispatches.
-> - **tensormap_and_ringbuffer:** the orchestrator runs **on-device** on AICPU
->   thread N-1, concurrently with the scheduler threads, recording the same
->   integer fanin during submit.
->
-> Where a section below says "the orchestrator runs on AICPU Thread 3" or
-> "Thread 3 dlopens the SO", read that as the **tensormap (device-orch)
-> mechanics this runtime inherits** — under host_build_graph that same work
-> happens on the **host** before launch.
+The device has no orchestration thread. Every launched AICPU thread participates
+in scheduling its assigned AICore workers; the highest-index thread first
+attaches the prebuilt runtime and publishes the boot barrier.
 
----
+This ordering is the defining constraint of the runtime. The host constructs the
+whole graph before any device task can complete.
 
-## 1. Runtime Variants
+## 2. Callable and Run Lifecycle
 
-Two runtime backends exist under `src/runtime/`, each representing a different orchestration and scheduling strategy.
+### 2.1 Registration
 
-### 1.1 host_build_graph
+`register_callable_impl` materializes the orchestration bytes as a temporary
+shared object, opens it with `dlopen(RTLD_LOCAL)`, and resolves:
 
-The host-orchestration variant of `tensormap_and_ringbuffer`: it shares the same
-ring-buffer task storage, GM heap, and TensorMap dependency tracking, and runs
-the orchestration SO **on the host CPU** to build the complete task graph before
-launching device execution. The device then boots scheduler-only.
+- `aicpu_orchestration_config`;
+- `aicpu_orchestration_entry`; and
+- `framework_bind_runtime`.
 
-- **Task storage**: `PTO2TaskDescriptor[]` in shared memory ring buffer (same as 1.2)
-- **Dependencies**: automatically derived from tensor read/write patterns via TensorMap (same as 1.2)
-- **Scheduling**: AICPU attaches the host-populated, already-device-addressed SM and dispatches the pre-built graph
-- **Use case**: host-side graph construction; device runs no orchestrator thread
+The resolved handle and entry points belong to the registered callable and stay
+alive across prepared runs. Unregister/context teardown closes the handle and
+removes its temporary file.
 
-### 1.2 tensormap_and_ringbuffer (PTO2)
+Child AIC/AIV callables are uploaded separately. Their resolved device function
+addresses populate the per-run dispatch table.
 
-The primary production runtime. Uses ring buffers for task slots and output memory, with a TensorMap for automatic dependency tracking.
+### 2.2 Host Graph Construction
 
-- **Task storage**: `PTO2TaskDescriptor[]` in shared memory ring buffer
-- **Memory**: GM Heap ring for output buffer allocation
-- **Dependencies**: automatically derived from tensor read/write patterns via TensorMap
-- **Thread model**: 3 scheduler threads + 1 orchestrator thread on AICPU
-- **Single ring**: host_build_graph builds the whole graph on the host with no
-  execution-time reclaim, so HeapRing and TaskRing are single
-  whole-graph-resident instances (`PTO2_MAX_RING_DEPTH == 1`); all scope depths
-  map to ring 0.
-- **Use case**: production workloads; supports streaming, flow control, and large batch sizes
+For each run, the host:
 
----
+1. validates and stages external tensors, registering their host views;
+2. reserves one backing arena for runtime/shared-memory subregions;
+3. binds the runtime to the orchestration DSO;
+4. calls the orchestration entry synchronously;
+5. finalizes task counts and the graph image;
+6. rewrites per-slot task/payload pointers to device addresses; and
+7. copies the shared-memory image and arena to the device.
 
-## 2. Platform Abstraction
+An orchestration fatal stops this sequence and is propagated through
+`orch_error_code`.
 
-Two platform implementations exist under `src/platform/`, sharing a common interface.
+### 2.3 Device Execution and Teardown
 
-### 2.1 a2a3 (Real Ascend Hardware)
+The boot thread attaches the already-populated arena without resetting it. All
+threads classify/dispatch their core partitions and then shut those cores down.
+The last arriving thread destroys the attached runtime before publishing cleanup
+eligibility. Exactly one returning AICPU thread claims that eligibility and
+resets executor/scheduler state for the next run.
 
-| Component | Description |
-| --------- | ----------- |
-| `device_runner.cpp` | Uses CANN APIs: `rtMalloc`, `rtMemcpy`, `rtLaunchKernel` |
-| `memory_allocator.cpp` | Wraps `rtMalloc`/`rtFree` with allocation tracking |
-| `aicore/kernel.cpp` | `KERNEL_ENTRY(aicore_kernel)` → `aicore_execute` |
-| `aicpu/kernel.cpp` | `DynTileFwkBackendKernelServer` entry → `aicpu_execute` |
-| `spin_hint.h` | ARM `wfe`/`yield` instructions for efficient spinning |
+Publishing cleanup only after destruction prevents `deinit()` from racing the
+runtime arena or its file-scope binding.
 
-### 2.2 a2a3sim (Thread Simulation)
+## 3. Prebuilt Graph Image
 
-| Component | Description |
-| --------- | ----------- |
-| `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
-| `memory_allocator.cpp` | Wraps `malloc`/`free` |
-| `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
-| `upload_chip_callable_buffer` | Copy ChipCallable bytes to a host scratch, `dlopen` each child SO, `dlsym` "kernel_entry", patch the scratch's `resolved_addr_` with the function pointer |
+The shared image uses three per-slot structures:
 
-### 2.3 Platform Constants (`platform_config.h`)
+| Structure | Purpose |
+| --------- | ------- |
+| `PTO2TaskDescriptor` | Full task ID, kernel IDs, packed-buffer addresses |
+| `PTO2TaskPayload` | Tensors, scalars, predicate, local-ID fanins, dispatch metadata |
+| `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
-| Constant | Value | Description |
-| -------- | ----- | ----------- |
-| `PLATFORM_MAX_BLOCKDIM` | 24 | Maximum blocks (each = 1 AIC + 2 AIV) |
-| `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (all schedulers; the highest-index thread also runs the host-orch boot) |
-| `PLATFORM_MAX_AIC_PER_THREAD` | 24 | Max AIC cores per scheduler thread |
-| `PLATFORM_MAX_AIV_PER_THREAD` | 48 | Max AIV cores per scheduler thread |
-| `PLATFORM_PROF_SYS_CNT_FREQ` | 50 MHz | System counter frequency for profiling |
+The host/device boundary is POD and position-independent. Fanins are integer
+producer IDs, not pointers. The only per-slot pointers are rebound to their final
+device addresses before H2D.
 
----
+## 4. Whole-Graph Capacity
 
-## 3. Shared Memory Layout
+The runtime uses one task ring, one graph heap, and one TensorMap pool. They are
+capacity-bounded storage, not streaming flow-control buffers:
 
-The orchestrator and schedulers communicate through a contiguous shared memory region in Global Memory (GM). The single ring's TaskDescriptor, TaskPayload, and TaskSlotState sections (plus the per-slot `completion_flags`) are laid out by `pto2_sm_layout::ring_segment_offsets`.
+- `last_task_alive` does not advance during a run;
+- `heap_tail` does not retire task output buffers during a run;
+- task slots and heap bytes are never recycled mid-run; and
+- TensorMap entries are not reclaimed while host construction is active.
+
+`completed_watermark` records the contiguous prefix of completed device tasks.
+It supports completion/consumer metadata only; it does not reclaim the task ring
+or heap.
+
+There is no post-run sweep that makes graph space reusable. Runtime destruction
+releases the complete arena, and the next run starts from a newly initialized
+image.
+
+### 4.1 Allocation Failure
+
+The graph must fit the configured task window, heap, fanin capacity, and
+TensorMap pool. When an allocation cannot progress, a wall-clock backstop
+latches a fatal instead of waiting for a scheduler that has not started.
+
+Representative allocator output is:
 
 ```text
-┌─────────────────────────────┐  offset 0
-│  PTO2SharedMemoryHeader     │  (per-ring flow control + layout, global flags)
-├─────────────────────────────┤  aligned
-│  Per-ring regions ×4:       │
-│    PTO2TaskDescriptor[N]    │  N = task_window_size per ring
-│    PTO2TaskPayload[N]       │
-│    PTO2TaskSlotState[N]     │
-└─────────────────────────────┘
+FATAL: Task Allocator Deadlock - Heap Exhausted!
+  Task ring:  current=..., last_alive=..., active=.../...
+  Heap ring:  top=..., tail=..., size=..., available=...
+  Requested:  ... bytes
 ```
 
-### 3.1 SharedMemoryHeader Fields
+This is host-orchestration logging. The allocator records the corresponding
+runtime error and unwinds; it does not terminate the process directly.
 
-| Field | Writer | Reader | Purpose |
-| ----- | ------ | ------ | ------- |
-| `current_task_index` | Orchestrator | Scheduler | Next task ID to allocate (task ring head) |
-| `last_task_alive` | Scheduler | Orchestrator | Oldest still-active task (task ring tail) |
-| `heap_top` | Orchestrator | Scheduler | Heap ring allocation pointer |
-| `heap_tail` | Scheduler | Orchestrator | Heap ring reclamation pointer |
-| `orchestrator_done` | Orchestrator | Scheduler | Signals orchestration completion |
-| `task_window_size` | Init | Both | Number of task slots (per-ring, in `PTO2SharedMemoryRingHeader`) |
-| `heap_size` | Init | Both | Heap total size (per-ring, in `PTO2SharedMemoryRingHeader`) |
-| `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM (per-ring) |
-| `total_size` | Init | Both | Total shared memory size |
+## 5. Submission and Dependencies
 
-### 3.2 Size Calculation
+### 5.1 Mixed Tasks and Logical Blocks
+
+An active mask selects AIC, AIV0, and AIV1 lanes. `block_num` is a logical SPMD
+width and may exceed the physical device width when sync-start is not requested;
+the scheduler dispatches those blocks in waves.
+
+Before a slot is allocated or published, submission requires:
 
 ```text
-total = ALIGN(Header)
-      + Σ_ring [ ALIGN(window_size * sizeof(TaskDescriptor))
-               + ALIGN(window_size * sizeof(TaskPayload))
-               + ALIGN(window_size * sizeof(TaskSlotState)) ]
+block_num >= 1
+block_num * popcount(active_mask) <= INT16_MAX
 ```
 
-Alignment is 64 bytes (`PTO2_ALIGN_SIZE`).
+The product is stored in the 16-bit `total_required_subtasks` field. Sync-start
+adds a separate co-residency limit: AIV tasks use the available AIV count, while
+AIC/MIX tasks use the available cluster count.
 
----
+### 5.2 TensorMap and Fanins
 
-## 4. Ring Buffer Mechanisms
+TensorMap maps tensor regions to producer task IDs. For every task:
 
-> **Single ring**: TaskRing and HeapRing are single whole-graph instances
-> (`PTO2_MAX_RING_DEPTH == 1`). The host builds the entire graph before the
-> device boots and there is no execution-time reclaim, so a per-scope-depth
-> ring split would buy nothing — every scope depth maps to ring 0.
+1. INPUT/INOUT regions look up overlapping producers.
+2. Explicit and discovered producers are deduplicated into
+   `fanin_local_ids[]`.
+3. OUTPUT/INOUT regions register the new task as producer.
+4. Each producer tracks its highest consumer local ID for completion metadata.
 
-### 4.1 Task Ring
+There is no fanout adjacency or dependency pool. A per-slot completion flag is
+the readiness truth on device.
 
-The task ring manages task slot allocation with back-pressure flow control.
+## 6. Boot Classification and Wake Lists
 
-**Structure** (`PTO2TaskRing`):
+Submit does not push tasks into ready queues. After the graph arrives on device,
+boot classification scans every submitted task exactly once:
 
-- `descriptors`: pointer to `TaskDescriptor[]` in shared memory
-- `window_size`: number of slots (power of 2)
-- `current_index`: next task ID to allocate (monotonically increasing)
-- `last_alive_ptr`: pointer to `header->last_task_alive`
+- a task whose fanins are all complete is routed to its shape queue;
+- otherwise it registers on the first unmet producer's intrusive wake list; and
+- producer completion reclassifies every detached waiter.
 
-**Slot mapping**: `slot = task_id & (window_size - 1)`
+Completion flags are monotonic, so this consumer-pull scheme cannot miss a
+producer transition and does not require periodic dependency polling.
 
-**Allocation** (`PTO2TaskAllocator::alloc`):
+The dispatchable shapes are `AIC`, `AIV`, and `MIX`; dependency-only `DUMMY`
+tasks use a dedicated queue and complete without AICore dispatch.
 
-```text
-active_count = current_index - *last_alive_ptr
-if active_count < window_size - 1:
-    allocate slot, advance current_index
-else:
-    spin-wait (back-pressure from scheduler)
+Early producer propagation is currently disabled in HBG. The shared scheduler
+retains early-staging code for parity with `tensormap_and_ringbuffer`, but HBG's
+boot classifier and wake lists are the active readiness path.
+
+## 7. Dispatch and Completion
+
+- AIC/AIV dispatch claims ranges of logical block indices from
+  `next_block_idx` and requeues unfinished wide tasks.
+- MIX dispatch selects cluster offsets whose used lanes share one valid
+  placement. The tracker uses a 128-bit bitset because the flattened offset is
+  `cluster * 3`, reaching above bit 63 on supported devices.
+- Sync-start cohorts stage locally when possible; wider ownership spans use a
+  generation-tagged global drain before launch.
+- Every lane completion increments `completed_subtasks`. The task completes once
+  that count equals `block_num * popcount(active_mask)`.
+- Completion sets the task's flag, advances the contiguous
+  `completed_watermark`, and reclassifies its wake-list consumers.
+
+The drain's `pending_task` stays valid for the complete attempt: all participant
+threads load it before the coordinator can pass the stage-done barrier and clear
+it. A recovery return for a null pointer would describe an unreachable state and
+could strand the drain protocol, so the active path relies on that invariant.
+
+## 8. Scalar Access During Construction
+
+`get_tensor_data` and `set_tensor_data` operate on registered host views of
+external tensors. They cannot wait for a submitted device producer because the
+device scheduler starts only after orchestration returns. Runtime-created graph-
+heap outputs also have no host view.
+
+Producer references are checked against the complete bound descriptor ID before
+a slot is used, preventing masked-slot aliasing. See
+[SCALAR_DATA_ACCESS.md](SCALAR_DATA_ACCESS.md) for the supported contract.
+
+## 9. Errors and Diagnostics
+
+The runtime latches orchestration and scheduler errors in shared memory and maps
+them to the negative run status observed by the host. Important validation paths
+include:
+
+- invalid arguments (`-5`);
+- sync-start residency violations (`-7`);
+- tensor wait timeout (`-8`); and
+- scheduler timeout (`-100`).
+
+Device logs contain scheduler records only. Host graph-construction diagnostics
+remain host-side. See [device_log_profiling.md](device_log_profiling.md).
+
+## 10. Verification
+
+Runtime C++ changes require rebuilding the editable package, then running both
+simulation variants:
+
+```bash
+pip install --no-build-isolation -e .
+pytest examples tests/st --platform a2a3sim --runtime host_build_graph
+pytest examples tests/st --platform a5sim --runtime host_build_graph
 ```
 
-**Reclamation**: Scheduler threads advance `last_task_alive` via lock-free CAS when the oldest task reaches state CONSUMED (4). This frees slots for reuse.
-
-**Flow control**: When the ring is full, the orchestrator blocks until the scheduler advances `last_task_alive`. With `PTO2_RING_TASK_WINDOW=16` and 208 tasks, slots are recycled ~13 times each.
-
-### 4.2 Heap Ring
-
-The heap ring manages output buffer allocation from a circular GM heap.
-
-**Structure** (`PTO2HeapRing`):
-
-- `base`: GM heap base address
-- `size`: total heap size (default 1 GB)
-- `top`: allocation pointer (local to orchestrator)
-- `tail_ptr`: pointer to `header->heap_tail` (updated by scheduler)
-
-**Allocation**: Buffers are allocated contiguously from `top`. When reaching the end, allocation wraps to the beginning if `tail` has advanced far enough. Buffers never straddle the wrap-around boundary.
-
-**Reclamation**: When `last_task_alive` advances past a task, its `packed_buffer_end` is used to advance `heap_tail`, freeing the memory region.
-
-When an empty ring is parked at a non-zero offset and neither free arc can hold a request that fits the full
-capacity, allocation restarts at offset zero: `heap_tail` resets to zero and `heap_top` advances past the new
-allocation. Reclaim markers from tasks in the preceding coordinate space are ignored until the first post-rebase
-allocation retires.
-
-### 4.3 Dependency Representation (polling completion)
-
-There is no dependency-list pool or fanout adjacency. A task's dependencies are
-stored inline on its payload as a flat array of position-independent producer
-local-ids:
-
-- `fanin_local_ids[fanin_count]` — the local-ids of this task's direct producers
-  (`fanin_count <= PTO2_MAX_FANIN`; there is no spill, so an overflow is fatal).
-- A per-slot `completion_flags[id]` byte in the ring header is the device-side
-  readiness truth: a task is ready iff every id in its `fanin_local_ids` has its
-  `completion_flags` byte set (see §8.2).
-
-Because the fanin is integer ids rather than pointers, the host→device image
-needs no fanout/dep-pool relocation — only the per-slot `task` / `payload`
-pointers are relocated (see §7.3).
-
-### 4.4 Flow Control and Back-Pressure
-
-The ring buffer mechanism provides **flow control** between the orchestrator (producer) and the scheduler (consumer). When a ring is exhausted, the orchestrator **blocks** — it cannot submit new tasks or allocate more output memory until the scheduler reclaims slots/space by advancing the watermarks.
-
-**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `PTO2TaskAllocator::alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
-
-**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `PTO2TaskAllocator::alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
-
-**TensorMap pool back-pressure**: Before STEP 4 registers a task's outputs, the orchestrator's `ensure_tensormap_capacity` reserves pool space for the inserts. When the shared entry pool is exhausted, it reclaims retired entries across all rings and spin-waits until reclaim actually frees entries, with a 500 ms wall-clock deadlock backstop (see Section 5.4).
-
-This back-pressure is essential for correctness with small ring sizes — for example, with `PTO2_RING_TASK_WINDOW=16` and 208 tasks, the orchestrator blocks ~192 times, each time waiting for the scheduler to drain completed tasks before continuing.
-
-### 4.5 Deadlock Detection
-
-A ring that is **too small** can cause a **deadlock**. The root cause is the scope mechanism: each task's `fanout_count` includes a reference from its owning scope. The scope reference is only released when `scope_end()` runs — but `scope_end()` is called by the orchestrator, which is blocked waiting for ring space. This creates a circular dependency:
-
-```text
-Orchestrator blocked on task_ring_alloc (ring full)
-    → needs scheduler to advance last_task_alive
-    → needs tasks to reach CONSUMED state (fanout_count == 0)
-    → needs scope_end() to release scope reference
-    → needs orchestrator to continue
-    → DEADLOCK
-```
-
-The runtime detects this automatically by counting spin iterations in the allocation functions:
-
-**Periodic BLOCKED warnings** (every 10,000 spins):
-
-```text
-[TaskRing] BLOCKED (Flow Control): current=208, last_alive=192, active=16/16 (100.0%), spins=10000
-[HeapRing] BLOCKED: requesting 4096 bytes, available=0, top=65536, tail=0, spins=10000
-```
-
-**Deadlock detection** (after 100,000 spins with no progress):
-
-```text
-FATAL: Flow Control Deadlock Detected!
-Task Ring is FULL and no progress after 100000 spins.
-  - Active tasks:  16
-  - Window size:   16
-Root Cause:
-  Tasks cannot transition to CONSUMED state because fanout_count
-  includes 1 for the owning scope, and scope_end() requires the
-  orchestrator to continue — creating a circular dependency.
-Solution:
-  Recommended: 32 (at least 2x current active tasks)
-```
-
-The FATAL message is logged to the device log and the process exits. The solution is to increase the ring size so that it can hold at least all tasks within the largest parallel scope. For example, if a scope submits 13 tasks, `task_window >= 14` is required (13 + 1 to distinguish full from empty).
-
-**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `PTO2_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
-
----
-
-## 5. TensorMap and Automatic Dependency Tracking
-
-### 5.1 Purpose
-
-TensorMap maintains a mapping from tensor memory regions to their producer task IDs. When a new task reads a tensor (INPUT/INOUT), TensorMap automatically discovers the producer and establishes a dependency edge.
-
-### 5.2 Hash Table Design
-
-- **Key**: tensor base address (`buffer.addr`)
-- **Value**: producer task ID, with overlap detection for sub-regions
-- **Overlap**: `COVERED` (new region fully contains old) or `OTHER` (partial overlap)
-- Sub-tensors of the same base tensor hash to the same bucket, enabling overlap detection
-
-### 5.3 Entry Pool Management
-
-Unlike the Task Ring and Heap Ring, TensorMap entries are **not** managed by a ring buffer. Instead, a **fixed-size pool + free list** is used:
-
-1. **Free list first**: `free_entry_list[]` stores pointers to released entries. Allocation pops from here (O(1)).
-2. **Bump allocation**: if free list is empty, `entry_pool[next_entry_idx++]` allocates from the end of the pool.
-3. **Blocking reclaim**: if the pool is short of the inserts a task needs, the orchestrator's `ensure_tensormap_capacity` reads the latest `last_task_alive` for every ring and calls `reclaim_retired_all` (`cleanup_retired` per ring) to batch-free entries belonging to retired tasks, returning them to the free list, before the inserts proceed.
-
-This design avoids the complexity of ring-based wrapping while still being bounded by `PTO2_TENSORMAP_POOL_SIZE` (default 65536 entries).
-
-### 5.4 Stale Entry Cleanup: Three-Layer Defense
-
-TensorMap must ensure entries for retired tasks (`producer_task_id < last_task_alive`) are removed, so that:
-
-- The pool does not grow unboundedly (capacity is finite)
-- Lookup performance does not degrade as stale entries accumulate in bucket chains
-
-Three complementary mechanisms achieve this:
-
-**Layer 1 — Chain Truncation during Lookup** (lazy, per-bucket):
-
-Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `PTO2TensorMap::lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
-
-This guarantees lookup only traverses valid entries — O(valid_entries_in_bucket), not O(total_entries).
-
-**Layer 2 — Periodic Batch Cleanup** (`cleanup_retired`, per-task):
-
-Every time the orchestrator submits a task (Step 0 of `PTO2OrchestratorState::submit_task`), it calls `PTO2TensorMap::sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `PTO2TensorMap::cleanup_retired` runs:
-
-This uses the **per-task entry chain** (`task_entry_head[task_slot]`) — each task's entries are doubly-linked together at insert time via `next_in_task`/`prev_in_task`. A slot's chain can hold more than one task's entries: a task at `local_id + N * window` reuses the slot and prepends to the chain already there, and cleanup can lag that reuse. Cleanup therefore walks the chain and frees only the entries whose `producer_task_id` matches the retiring task, unlinking each and leaving the rest linked — O(entries_in_slot), with no scan of the entire pool or all buckets. Freed entries are returned to `free_entry_list` for immediate reuse.
-
-**Layer 3 — Back-Pressure on Pool Exhaustion** (blocking):
-
-Before STEP 4 inserts a task's outputs, `ensure_tensormap_capacity` checks the free list + bump region against the task's needed entry count. If short, it reclaims retired entries across all rings and blocks until reclaim frees enough entries. Progress is measured by entries actually freed, not by watermark movement — a ring can retire zero-output tasks, advancing `last_task_alive` without freeing any entry. A pool that frees nothing for a 500 ms wall-clock timeout is a genuine deadlock: it latches `PTO2_ERROR_TENSORMAP_OVERFLOW` and unwinds, matching the task allocator and fanin spill pool.
-
-This forms a back-pressure mechanism analogous to the Task Ring's flow control.
-
-**Summary**:
-
-| Layer | Trigger | Method | Guarantees |
-| ----- | ------- | ------ | ---------- |
-| Chain Truncation | Every lookup | Truncate stale tail of bucket chain | Lookup only visits valid entries |
-| Periodic Cleanup | Every 64 retired tasks | Walk per-task chains, free entries | Pool capacity reclaimed in bounded time |
-| Pool Back-Pressure | Pool exhausted | Block until scheduler advances watermark | Hard capacity bound, no OOM |
-
-In steady state, the number of valid TensorMap entries ≈ `active_tasks × avg_outputs_per_task`. With the default `task_window=65536` and `pool_size=65536`, this is well within bounds. With small windows (e.g., `task_window=16`), active entries are even fewer (~16 × a few), and cleanup runs frequently.
-
-### 5.5 Dependency Discovery Flow
-
-When `PTO2OrchestratorState::submit_task` processes parameters:
-
-1. **INPUT/INOUT**: `PTO2TensorMap::lookup` searches for overlapping producers (with chain truncation)
-2. For each producer found: `append_fanin_or_fail` adds the dependency
-3. **OUTPUT/INOUT**: `PTO2TensorMap::insert` registers the current task as the new producer at bucket head
-4. Stale entries are pruned lazily during lookup (Layer 1) and periodically by cleanup (Layer 2)
-
----
-
-## 6. Task Descriptor and States
-
-### 6.1 PTO2TaskDescriptor (Hot Path)
-
-| Field | Description |
-| ----- | ----------- |
-| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 \| local_id`; `ring_id` is always 0 in this single-ring runtime). |
-| `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
-| `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
-| `completed_subtasks` | Atomic counter; each subtask increments on completion. Trigger condition: `completed_subtasks == total_required_subtasks` |
-| `packed_buffer_base` | Start of packed buffer in GM Heap |
-| `packed_buffer_end` | End of packed buffer (for heap reclamation) |
-
-Fanin/fanout are not on the descriptor: producer ids live on the payload
-(`fanin_local_ids`, §6.1b) and consumers are reached at completion via the
-per-slot wake list (§8.2), not a fanout adjacency list.
-
-### 6.1b PTO2TaskPayload (Cold Path)
-
-| Field | Description |
-| ----- | ----------- |
-| `tensors[16]` | Tensor descriptors for parameters |
-| `scalar_value[16]` | Scalar parameter values |
-| `is_tensor[16]` | Whether each parameter is tensor or scalar |
-| `param_count` | Number of valid parameters |
-| `fanin_local_ids[fanin_count]` | Producer local-ids (position-independent; readiness = all their `completion_flags` set) |
-| `fanin_count` | Number of producer dependencies (`<= PTO2_MAX_FANIN`, no spill) |
-| `predicate` | Dispatch predicate (`DispatchPredicate`, cache line 9 / byte 576); evaluated by the scheduler at the ready point (see §8.3) |
-
-`last_consumer_local_id` (the highest consumer id of this task) lives on the
-slot state, not the payload; the host consumer-wait gates on it (§8.4).
-
-### 6.2 Task State Machine
-
-`task_state` is the **host-visible mirror** of completion; the device-side
-readiness truth is the per-slot `completion_flags` byte (§8.2). The host polls
-`task_state` in `wait_for_tensor_ready`, the allocator deadlock detector, and
-the cold-path stall dump.
-
-```text
-  [0] PENDING ──worker(s) done, on_mixed_task_complete──► [1] COMPLETED
-```
-
-- **0 (PENDING)**: slot allocated; remains PENDING while waiting on producers,
-  queued, or dispatched.
-- **1 (COMPLETED)**: all subtasks done. `on_mixed_task_complete` sets this
-  (host mirror) and, in the same step, sets `completion_flags[id]` (device
-  readiness) and advances `completed_watermark`.
-
-There is no runtime CONSUMED flip and no slot recycle: host_build_graph is
-whole-graph-resident (§8.4).
-
----
-
-## 7. Orchestrator
-
-### 7.1 PTO2OrchestratorState
-
-The orchestrator builds the task graph by calling the user-provided
-orchestration function. In host_build_graph it runs **on the host** (see the
-divergence note in the Overview); the `PTO2OrchestratorState` below is the same
-structure tensormap drives on AICPU thread N-1.
-
-Key members:
-
-- `ring`: the single `PTO2RingSet` (HeapRing + TaskRing).
-- `tensor_map`, `tensor_pool`: dependency tracking
-- `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
-- `scheduler`: pointer to scheduler state (for seeding zero-fanin tasks into the ready queue)
-- `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
-
-### 7.2 Task Submission Flow (`PTO2OrchestratorState::submit_task`)
-
-| Step | Operation |
-| ---- | --------- |
-| 0 | `PTO2TensorMap::sync_tensormap` — prune stale TensorMap entries |
-| 1 | `PTO2TaskAllocator::alloc` — allocate task slot (may block on flow control) |
-| 2 | Initialize task descriptor + slot state, copy parameters |
-| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer ids in `PTO2FaninBuilder` |
-| 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
-| 5 | **Record fanin**: `append_fanin_or_fail` dedups producers and writes their local-ids into `payload->fanin_local_ids[]`; each producer's `last_consumer_local_id` is bumped to this task's id. `payload.fanin_count` is set from the builder. |
-| 6 | **Seed readiness**: a task with zero fanin (`fanin_count == 0`) is pushed straight to the ready queue via `push_ready_routed`. A task with fanin is left for the device boot classify (§8) — the host does not pre-register wake lists. |
-
-> **Note**: There is no fanout adjacency, dep-pool, or per-producer lock. A
-> producer inline-completed on the host (e.g. a hidden-alloc task) pre-sets its
-> own `completion_flags[id] = 1` in the H2D image so device consumers see it as
-> already satisfied. The only cross-task pointers the image carries are the
-> per-slot `task` / `payload` pointers, which `relocate_host_orch_image` shifts
-> to device addresses before H2D.
-
-### 7.3 Dependency Recording and Relocation
-
-`append_fanin_or_fail` records, per consumer, the deduped list of producer
-local-ids into `payload->fanin_local_ids[]` and bumps `fanin_count`; it also
-raises each producer's `last_consumer_local_id` to the consumer's id. An
-overflow past `PTO2_MAX_FANIN` is fatal (`PTO2_ERROR_...`), since there is no
-spill.
-
-`relocate_host_orch_image` runs on the host before H2D. Because fanin is
-position-independent integer ids, the only pointers needing fixup are the
-per-slot `task` and `payload` pointers (SM-region delta); the fanout adjacency,
-dep-pool, and ready-queue pointer relocation of the wiring model are gone.
-
-Readiness and completion are handled entirely device-side by the scheduler:
-the boot classify seeds the ready queue and registers wake lists (§8.2), and
-`on_mixed_task_complete` publishes each producer's `completion_flags` and drains
-its wake list. See §8.2 for the completion protocol.
-
-### 7.4 Scope Mechanism (`PTO2_SCOPE`)
-
-Scopes control the lifetime of intermediate buffers. Each scope:
-
-- Tracks tasks submitted within it via a flat `scope_tasks[]` buffer partitioned by `scope_begins[]`
-- Scopes bound intermediate-buffer lifetime **structurally** (the orchestration function that built the graph). host_build_graph is whole-graph-resident, so `scope_end` performs no runtime buffer reclaim — there is no `fanout_refcount`.
-
-```cpp
-PTO2_SCOPE(rt) {
-    // Tasks submitted here belong to this scope
-    rt_submit_aic_task(FUNC_QK, args);
-    rt_submit_aiv_task(FUNC_SF, args);
-}
-// scope_end: scope reference released from all tasks above
-```
-
-**Output tensor lifetime — single-scope only.** `submit_task` returns a
-`TaskOutputTensors`, and `get_ref(i)` hands back a `const Tensor&`. Both are
-backed by pointers into the submitting task's `PTO2TaskPayload::tensors[]`,
-which lives in a ring-buffer slot. host_build_graph does not recycle slots
-within a run (whole-graph-resident, no execution-time reclaim), so the storage
-is not overwritten mid-run; the constraint is instead structural — the
-`TaskOutputTensors` and the refs it returns are scoped to the orchestration
-function that built the graph and must not be retained past it.
-
-Therefore the `TaskOutputTensors` instance, the references it returns, and
-any pointer derived from them MUST NOT outlive the `PTO2_SCOPE` in which
-submit was called. The typical safe pattern is:
-
-```cpp
-PTO2_SCOPE() {
-    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
-    const Tensor &y = outs.get_ref(0);
-    // Use y here and in subsequent submits within the same scope.
-}   // outs and y both go out of scope; no dangling references can escape.
-```
-
-Anti-patterns that compile but silently break:
-
-```cpp
-const Tensor *kept = nullptr;
-PTO2_SCOPE() {
-    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
-    kept = &outs.get_ref(0);          // escapes the scope
-}
-// `kept` still points at a payload slot. After enough submits in later
-// scopes, the slot is reused and `*kept` aliases an unrelated task's
-// tensor — a wrong-tensor read with no runtime diagnostic.
-
-TaskOutputTensors outs;               // declared in outer scope
-PTO2_SCOPE() {
-    outs = rt_submit_aic_task(FUNC_QK, args);
-}
-const Tensor &t = outs.get_ref(0);    // same hazard: outs survives scope
-```
-
-This invariant is intentionally not runtime-checked. A reused slot carries
-a different but valid `owner_task_id`, so an assertion based on
-`owner_task_id` cannot distinguish "still the original task" from
-"silently aliased to a newer task". Treat the rule as a static contract,
-verified by review.
-
----
-
-## 8. Scheduler
-
-### 8.1 Thread Model
-
-With `aicpu_thread_num=4` and `block_dim=24`, the AICPU runs 4 scheduler
-threads (thread 3 also performs the one-time host-orch boot before it starts
-dispatching):
-
-| Thread | Role | Cores |
-| ------ | ---- | ----- |
-| 0 | Scheduler | 6 AIC + 12 AIV |
-| 1 | Scheduler | 6 AIC + 12 AIV |
-| 2 | Scheduler | 6 AIC + 12 AIV |
-| 3 | Scheduler (+ host-orch boot) | 6 AIC + 12 AIV |
-
-Core assignment: clusters (1 AIC + 2 AIV) are divided equally among all 4
-scheduler threads.
-
-### 8.2 Scheduler Main Loop
-
-Each scheduler thread runs a tight loop with two main phases:
-
-**Phase 1 — Completion Handling (polling)**:
-
-- Poll register `COND` on each managed core.
-- When `TASK_FIN_STATE` detected: call `on_subtask_complete`; when
-  `completed_subtasks == total_required_subtasks`, call `on_mixed_task_complete`,
-  which:
-  1. mirrors `task_state = COMPLETED` (host-visible) and sets the device
-     readiness truth `completion_flags[my_id] = 1` (release);
-  2. drains this task's intrusive **wake list** — `wake_list_head.exchange(SENTINEL)`
-     — reclassifying each waiter: a waiter whose remaining fanin is now all met
-     is pushed via `push_ready_routed`; otherwise it re-registers on its next
-     unmet producer. After the exchange the head is `SENTINEL`, so a consumer
-     registering concurrently re-checks the flags instead of being lost;
-  3. CAS-advances `completed_watermark` over the contiguous completed prefix
-     (§8.4).
-
-**Readiness / wake registration.** A task is ready iff every id in its
-`fanin_local_ids` has its `completion_flags` byte set (`fanin_satisfied` /
-`classify_fanin_state`, acquire loads). A not-yet-ready task registers itself on
-its **first unmet** producer's wake list (`register_wake`); that producer's
-completion re-drives the classification. The decision is terminal — tasks are
-never re-polled — because `completion_flags` are monotonic. This wake machinery
-is seeded by the device **boot classify** (`on_orchestration_done`), which scans
-the submitted tasks once and either pushes the fanin-free ones to the ready
-queue or registers each remaining task on its first unmet producer.
-
-**Early staging status.** Early producer propagation is currently disabled in
-HBG: `propagate_dispatch_fanin` is a stub, so the polling path does not populate
-`early_dispatch_queues` or `early_sync_start_queue`. The scheduler retains the
-early-staging machinery as a dormant mirror of the TMR runtime for a future
-consumer-pull publication path. If that path populates the queues, a
-`sync_start` cohort that fits one scheduler's idle and pending slots stages
-locally; larger cohorts use the generation-tagged global drain. This is not an
-active end-to-end HBG fast path today.
-
-**Phase 2 — Dispatch**:
-
-- For each idle core: pop a task from the matching shape-based ready queue (lock-free MPMC Vyukov queue, one per resource shape)
-- Build `PTO2DispatchPayload` from `TaskDescriptor` with `task_id`, `subslot`, `kernel_id`, and `core_type`
-- Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE`
-
-After these phases, the scheduler updates profiling headers and checks for termination (all tasks completed and orchestrator done).
-
-### 8.3 Ready Queue Design
-
-Ready queues use a lock-free bounded MPMC (Vyukov) design:
-
-- One `PTO2ReadyQueue` per resource shape (5 shapes: `AIC_ONLY`, `AIV_X1`, `AIV_X2`, `AIC_AIV_X1`, `AIC_AIV_X2`)
-- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `task->active_mask.to_shape()`
-- **Pop**: scheduler threads pop from the queue matching the idle core's resource shape
-- Per-slot sequence counters prevent ABA problems
-- `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing
-
-### 8.4 Completion Watermark (host consumer-wait gate)
-
-`completed_watermark` is the highest id such that every task in
-`[0, completed_watermark]` has its `completion_flags` byte set. The tail of
-`on_mixed_task_complete` CAS-advances it over the **full contiguous completed
-prefix** (bounded by `current_task_index`, not by the completing task's own id)
-— capping at `my_id` would make the final value completion-order-dependent and
-strand it below the true prefix.
-
-It is **load-bearing**: the host `wait_for_tensor_ready(..., wait_for_consumers)`
-gates on `completed_watermark >= producer.last_consumer_local_id` to observe
-"every consumer of this producer has retired" — replacing the wiring model's
-`fanout_refcount == fanout_count` check.
-
-Slot reclaim is inert: host_build_graph is whole-graph-resident, so
-`last_task_alive` is never advanced at runtime and there is no
-`advance_ring_pointers` step. `reset_for_reuse()` runs **once at init**
-(`pto_shared_memory.cpp`) to zero each slot before the host orchestrator
-populates it — it is not a runtime recycle hook.
-
-### 8.5 SchedulerContext
-
-All scheduler-side state and methods live in `SchedulerContext` (`runtime/scheduler/scheduler_context.h`). It is held as a `sched_ctx_` member of `AicpuExecutor`; `AicpuExecutor` is a thin wrapper that owns the lifecycle atomics and delegates everything else to `SchedulerContext`.
-
-Public surface (called from `AicpuExecutor::init/run/deinit`):
-
-| Method | Phase | Purpose |
-| ------ | ----- | ------- |
-| `init(runtime, aicpu_thread_num, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
-| `bind_runtime(rt)` | boot thread | Wire `sched_` to `rt->scheduler` once the boot thread attaches the host-built `rt` |
-| `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
-| `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled |
-| `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | boot thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_` (or `emergency_shutdown` on fatal) |
-| `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
-| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` |
-
-Private internals are split across three .cpp files by responsibility:
-
-- `scheduler_completion.cpp` — completion polling, drain protocol
-- `scheduler_dispatch.cpp` — task dispatch loop and helpers
-- `scheduler_cold_path.cpp` — exit checks, stall diagnostics, profiling, lifecycle (`init/deinit`), core management (`handshake_all_cores` / `assign_cores_to_threads` / `reassign_cores_for_all_threads` / `emergency_shutdown`), and `on_orchestration_done`
-
-`AicpuExecutor` calls neither `handshake_*`, `assign_*`, `reassign_*`, nor `emergency_shutdown` directly — they are private, invoked only by `init` and `on_orchestration_done`.
-
----
-
-## 9. AICore Worker Interaction
-
-### 9.1 Handshake Protocol
-
-Each AICore worker has a `Handshake` struct in shared memory:
-
-| Field | Direction | Purpose |
-| ----- | --------- | ------- |
-| `task` | AICPU→AICore | Pointer to `PTO2DispatchPayload` |
-| `control` | AICPU→AICore | 0=normal, 1=shutdown |
-| `perf_records_addr` | AICPU→AICore | Performance buffer address |
-
-### 9.2 Register-Based Dispatch
-
-Instead of polling a shared-memory status flag, the production protocol uses hardware registers.
-
-> **Note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions.
-
-| Register | Direction | Usage |
-| -------- | --------- | ----- |
-| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id` to dispatch (idle=0x7FFFFFFD); `EXIT_SIGNAL` to shut down |
-| `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
-
-**AICore execution loop**:
-
-1. Poll `DATA_MAIN_BASE` for value != AICPU_IDLE_TASK_ID
-2. Read payload from `Handshake.task`
-3. Write ACK to `COND`
-4. Execute kernel function via `func_id_to_addr` lookup
-5. Write FIN to `COND`
-
-### 9.3 PTO2DispatchPayload
-
-Built by the scheduler from `PTO2TaskDescriptor`:
-
-| Field | Description |
-| ----- | ----------- |
-| `task_id` | Mixed-task identifier (for completion aggregation) |
-| `subslot` | Which subtask slot this dispatch represents (`AIC`, `AIV0`, or `AIV1`) |
-| `kernel_id` | Function ID for this subtask slot |
-| `core_type` | AIC or AIV |
-| `function_bin_addr` | GM address of compiled kernel binary |
-| `num_args` | Number of arguments |
-| `args[]` | Tensor addresses and scalar values |
-
----
-
-## 10. Kernel and Orchestration Loading
-
-### 10.1 Kernel Binary Loading
-
-1. **Host** compiles each kernel source (`.cpp`) into a binary (`.o` or `.so`)
-   and packs all children into a single `ChipCallable` buffer alongside the
-   orchestration SO.
-2. `host_api.upload_chip_callable_buffer(callable)` H2Ds the whole buffer
-   once and returns the device address of the ChipCallable header.
-3. For each child, host computes
-   `chip_dev + offsetof(ChipCallable, storage_) + callable->child_offset(i)`
-   and stores it in `Runtime.func_id_to_addr_[child_func_id(i)]`.
-4. When dispatching, the scheduler reads `func_id_to_addr_[fid]`, casts to
-   `const CoreCallable*`, reads `resolved_addr_`, and copies that into
-   `PTO2DispatchPayload.function_bin_addr`.
-
-### 10.2 Orchestration SO Loading
-
-1. **Host** compiles the orchestration source into a shared library (`.so`)
-2. The SO binary is embedded into `Runtime.device_orch_so_storage_[]` and copied to device
-3. **AICPU Thread 3** writes the SO to a temp file, calls `dlopen`
-4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
-5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. Thread 3 creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
-7. After orchestration completes: `dlclose`, delete temp file
-
-### 10.3 Thread Startup Synchronization
-
-| Flag | Set by | Waited by | Purpose |
-| ---- | ------ | --------- | ------- |
-| `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
-
-Profiling-subsystem init (`dump_args` / `pmu` / `l2_swimlane`) runs once in
-`SchedulerContext::init()` on the single-threaded cold path, before any
-scheduler/orchestrator thread starts — so it needs no cross-thread init
-handshake. `dep_gen` is not among them: it captures the graph on the host while
-the orchestrator builds it (see [docs/dfx/dep-gen.md](../../../../../docs/dfx/dep-gen.md)
-§2.2), so nothing about it is device-side.
-
-Startup sequence:
-
-1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
-2. Scheduler threads: wait for `runtime_init_ready_` → enter main loop
-3. Thread 3: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
-
----
-
-## 11. PTO2 Orchestration API
-
-The orchestration API is defined in `pto_orchestration_api.h`. Orchestration code depends only on this header.
-
-### 11.1 Core API
-
-| Function/Macro | Purpose |
-| -------------- | ------- |
-| `rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
-| `rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
-| `rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
-| `PTO2_SCOPE() { ... }` | RAII scope for buffer lifetime |
-| `rt_orchestration_done()` | Signal orchestration complete |
-
-### 11.2 Parameter Construction
-
-| Function | Description |
-| -------- | ----------- |
-| `make_tensor_external(ptr, shapes, ndim, dtype)` | Wrap an existing device pointer as a tensor |
-| `TensorCreateInfo(shapes, ndim, dtype)` | Describe a runtime-created output buffer |
-| `Arg::add_input(tensor)` | INPUT parameter — read by the task |
-| `Arg::add_output(create_info)` | OUTPUT parameter — runtime allocates and returns a Tensor |
-| `Arg::add_inout(tensor)` | INOUT parameter — existing tensor read then written |
-| `Arg::add_scalar(value)` | 64-bit scalar parameter |
-
-### 11.3 Resource Shapes
-
-Tasks are queued by resource shape, which is derived from the `active_mask` in the `MixedKernels` struct:
-
-| Shape | Active Mask | Description |
-| ----- | ----------- | ----------- |
-| `AIC_ONLY` | AIC only | AIC cores (matrix multiplication) |
-| `AIV_X1` | AIV0 or AIV1 only | Single AIV core (vector operations) |
-| `AIV_X2` | AIV0 + AIV1 | Two AIV cores |
-| `AIC_AIV_X1` | AIC + one AIV | AIC + single AIV core |
-| `AIC_AIV_X2` | AIC + AIV0 + AIV1 | Full cluster (AIC + two AIV cores) |
-
-### 11.4 Orchestration Export Interface
-
-Each orchestration `.so` must export:
-
-```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
-extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
-```
-
----
-
-## 12. Example: Batch Paged Attention
-
-### 12.1 Kernel Configuration (`kernel_config.py`)
-
-```python
-KERNELS = [
-    {"func_id": 0, "name": "QK",      "source": "aic/aic_qk_matmul.cpp",       "core_type": "aic"},
-    {"func_id": 1, "name": "SF",      "source": "aiv/aiv_softmax_prepare.cpp", "core_type": "aiv"},
-    {"func_id": 2, "name": "PV",      "source": "aic/aic_pv_matmul.cpp",       "core_type": "aic"},
-    {"func_id": 3, "name": "UP",      "source": "aiv/aiv_online_update.cpp",   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": "aiv/aiv_hub.cpp",            "core_type": "aiv"},
-]
-
-ORCHESTRATION = {
-    "source": "orchestration/paged_attention_orch.cpp",
-    "function_name": "aicpu_orchestration_entry",
-}
-
-RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
-    "block_dim": 24,
-}
-```
-
-### 12.2 Orchestration Structure
-
-```cpp
-void aicpu_orchestration_entry(uint64_t* args, int arg_count) {
-    // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
-    for (q_idx = 0; q_idx < q_loop; q_idx++) {
-        for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {
-            PTO2_SCOPE() {
-                // Describe accumulator tensors (oi, li, mi) with TensorCreateInfo
-                // Submit AIV_HUB to initialize accumulators
-                for (bn = 0; bn < max_bn; bn++) {
-                    // Allocate intermediate tensors (sij, pij, mij, lij, oi_new)
-                    // Submit QK (CUBE) → SF (VECTOR) → PV (CUBE) → UP (VECTOR)
-                }
-            }
-        }
-    }
-}
-```
+Pure scheduler/core-tracker and lifecycle primitives also have C++ unit tests
+under `tests/ut/cpp`.

--- a/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -1,139 +1,73 @@
-# Scalar Data Access — get/set_tensor_data Design
+# Scalar Data Access During Host Graph Construction
 
-## 1. Overview
+`host_build_graph` runs the orchestration function synchronously on the host,
+before any AICPU scheduler or AICore kernel starts. `get_tensor_data` and
+`set_tensor_data` therefore access the host view used to stage the graph's
+external tensors; they do not interleave host code with device execution.
 
-During task graph construction, orchestration sometimes needs to read InCore kernel results (for control-flow decisions) or write initial values into tensors. `get_tensor_data` / `set_tensor_data` provide **blocking** cross-layer data access, allowing orchestration to safely read and write tensor data.
+## Supported Uses
 
-**Core design principle**: Reuse the existing TensorMap dependency tracking mechanism — no new synchronization infrastructure.
+| Tensor state | `get_tensor_data` | `set_tensor_data` |
+| ------------ | ----------------- | ----------------- |
+| External tensor with no submitted producer | Reads the staged host value | Updates the staged host value |
+| External control/output tensor not referenced by a task | Reads immediately | Writes immediately |
+| Runtime-created output | Unsupported: no registered host view | Unsupported: no registered host view |
+| Tensor owned by a submitted device task | Unsupported during graph construction | Unsupported during graph construction |
+| Tensor with an invalid or stale owner task ID | Fails with `INVALID_ARGS` | Fails with `INVALID_ARGS` |
 
-## 2. API
+The supported write changes the data that will be copied to the device. Every
+task in the graph observes that final staged value; submit order does not turn
+the write into a barrier between kernels.
 
-```cpp
-// Blocking read: returns value at the given indices (default: raw uint64_t bits)
-// Specify T for typed read: float val = get_tensor_data<float>(tensor, 1, idx);
-template<typename T = uint64_t>
-T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
-
-// Blocking write: stores value at the given indices (type deduced from argument)
-// Typed write: set_tensor_data(tensor, 1, idx, 42.0f);
-template<typename T = uint64_t>
-void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], T value);
-```
-
-Both call into the runtime through the ops table — orchestration .so needs no runtime symbol linkage.
-
-## 3. Blocking Interface Design
-
-### 3.1 get_tensor_data Flow
-
-```text
-addr null-check → TensorMap lookup → spin-wait producer COMPLETED → compute flat offset → memcpy read
-```
-
-- **addr null-check**: `buffer.addr == 0` means unallocated — log error, return 0
-- **TensorMap lookup**: find producer task by `buffer.addr`
-- **spin-wait**: wait until producer `task_state >= PTO2_TASK_COMPLETED`
-- **No producer** (lookup callback never fires): skip waiting, read immediately
-
-### 3.2 set_tensor_data Flow
-
-```text
-addr null-check → TensorMap lookup → spin-wait producer COMPLETED → spin-wait consumers done → memcpy write
-```
-
-One extra step versus get_tensor_data: wait for all consumers to finish (`fanout_refcount >= fanout_count - 1`, excluding the scope reference).
-
-### 3.3 Timeout
-
-- Uses cycle counter (`get_sys_cnt_aicpu()`), checked every 1024 spins
-- Threshold: `PTO2_TENSOR_DATA_TIMEOUT_MS` (15 s), scaled to
-  `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` via `PLATFORM_PROF_SYS_CNT_FREQ` so it reaps
-  at the same wall-clock on every arch
-- On timeout: sets `orch.fatal = true`, preventing further task submission
-
-## 4. add_output with Initial Value
+## API
 
 ```cpp
-TensorCreateInfo ci(shapes, ndims, dtype);
-ci.set_initial_value(initial_value);
-args.add_output(ci);
+uint32_t index[1] = {0};
+
+int32_t value = get_tensor_data<int32_t>(control, 1, index);
+set_tensor_data<int32_t>(layout, 1, index, value + 1);
 ```
 
-**Mechanism**:
+Both tensors in this example must be external tensors staged by the host. A
+common use is to read an input control value or publish runtime geometry into an
+external layout tensor that no submitted task owns.
 
-1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
-2. `add_output(ci)` stores a pointer to `ci` in `L0TaskArgs` (the original must remain valid until submit)
-3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
-4. Fill strategy:
-   - Small buffer (< 64 B): element-by-element memcpy directly into dst
-   - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
+## Why Device-Produced Values Cannot Be Read Here
 
-**Constraint**: existing tensors are write targets only through `add_inout()`.
+The execution order is:
 
-## 5. Scalar Dependencies via 1-Element Tensors
+1. The host loads and calls the orchestration shared object.
+2. Orchestration builds the entire task graph and returns.
+3. The host relocates and copies the graph image to device memory.
+4. AICPU schedulers boot and dispatch the graph.
 
-Traditional scalars (`L0TaskArgs::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
+A producer submitted in step 1 cannot become `COMPLETED` until step 4. Waiting
+for that producer from the orchestration call cannot make progress. The runtime
+keeps a timeout as a defensive failure backstop, but it is not a supported
+synchronization mechanism.
 
-```cpp
-uint32_t shapes[1] = {1};
-TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
+Runtime-created output buffers also live in the graph heap and have no host-view
+registration. Even if their address is nonzero, host orchestration must not
+dereference or modify them.
 
-// Submit with initial value and keep the returned tensor
-scalar_ci.set_initial_value(float_to_u64(77.0f));
-L0TaskArgs args;
-args.add_output(scalar_ci);
-TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
-const Tensor& scalar_tensor = outs.get_ref(0);
+## Ownership Validation
 
-// Orchestration-side blocking read (waits for kernel completion)
-uint32_t idx[1] = {0};
-float val = get_tensor_data<float>(scalar_tensor, 1, idx);
-```
+Before a wait slot is used, the runtime verifies:
 
-**Advantage**: Fully reuses existing TensorMap (producer tracking, fanin/fanout dependencies) — no new infrastructure needed.
+- the task ID is valid and belongs to the single HBG ring;
+- the selected ring slot has a bound task descriptor; and
+- the descriptor's full task ID matches the tensor's owner/producer ID.
 
-## 6. Data Hazard Analysis
+The full-ID check prevents a masked ring-slot lookup from aliasing an unused or
+different task. A failure latches `PTO2_ERROR_INVALID_ARGS` and the run returns
+status `-5`; reads return zero and writes stop only after that fatal status is
+recorded.
 
-Three actors:
+## Practical Rules
 
-- **Kernel**: InCore task submitted via add_input/add_output/add_inout (asynchronous execution)
-- **Orch Read**: orchestration calls `get_tensor_data` (blocking read)
-- **Orch Write**: orchestration calls `set_tensor_data` (blocking write)
-
-### Hazard Matrix (earlier operation → later operation)
-
-| # | Earlier Op | Later Op | Hazard | Guarantee | Safe? |
-| - | ---------- | -------- | ------ | --------- | ----- |
-| 1 | Kernel write (OUTPUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
-| 2 | Kernel write (OUTPUT) | Orch Write | WAW | spin-wait producer COMPLETED | Yes |
-| 3 | Kernel read (INPUT) | Orch Write | WAR | spin-wait fanout_refcount | **Needs INOUT** |
-| 4 | Kernel read-write (INOUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
-| 5 | Kernel read-write (INOUT) | Orch Write | WAW+WAR | spin-wait producer + consumers | Yes |
-| 6 | Orch Write | Kernel read (INPUT) | RAW | blocking completes before next submit | Yes |
-| 7 | Orch Write | Kernel write (OUTPUT) | WAW | same — serial guarantee | Yes |
-| 8 | Orch Read | Kernel write (OUTPUT) | WAR | same — serial guarantee | Yes |
-| 9–12 | Orch ↔ Orch | — | — | same-thread serial execution | Yes |
-
-### Key Design Points
-
-**Scenario #3 is the only case requiring special attention**:
-
-TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` finds no matching producer (the lookup callback never fires) and returns immediately — but the kernel may still be reading → **WAR data race**.
-
-**Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through `fanout_refcount`.
-
-**Scenarios #6–8 serial guarantee**:
-
-get/set_tensor_data are blocking calls, and orchestration is single-threaded serial submission. After a blocking operation completes, subsequent code (including task submissions) executes strictly afterward.
-
-## 7. External Tensor Behavior
-
-`make_tensor_external()` creates tensors with a pre-set `buffer.addr` (pointing to host-allocated device memory).
-
-| Scenario | Behavior |
-| -------- | -------- |
-| External tensor never submitted as OUTPUT/INOUT | No TensorMap entry — get/set execute immediately |
-| External tensor previously submitted as OUTPUT/INOUT | TensorMap has producer entry — get/set spin-wait |
-| External tensor submitted as INPUT, then set_tensor_data | **WAR risk** — must use INOUT instead (same as scenario #3) |
-
-**Key rule**: If an external tensor will later be written via `set_tensor_data`, all prior kernel accesses must use `add_inout()`, not `add_input()`.
+- Use scalar access only on external, host-staged tensors with no device
+  producer or outstanding device consumer.
+- Use tensor dependencies to order device tasks; do not use host scalar access
+  as a device synchronization barrier.
+- Pass values needed for graph construction as orchestration inputs or scalars.
+- Keep device-produced values on the device or return them after the run.

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -1,222 +1,124 @@
-# Submit by Cluster - Requirements and Main-Branch-Aligned Design
+# Cluster-Aware Submission in `host_build_graph`
 
-## 1. Goal
+## Contract
 
-Define a single, main-branch-aligned specification for PTO2 cluster submission that combines:
-
-1. Product requirements (what must be true).
-2. Runtime design (how it is implemented on current main baseline).
-
-The target model is: one submitted graph node is one `MixedTask`, and dispatch/completion is mixed-task-granular.
-
-## 2. Background and Motivation
-
-Future Ascend hardware is expected to provide stronger locality within an AICore cluster (`1 AIC + 2 AIV`).
-The runtime therefore needs a "submit together, run together" model for related AIC/AIV kernels.
-
-Legacy per-task submit (`kernel_id + worker_type`) cannot express atomic co-dispatch of multiple kernels to one cluster.
-
-## 3. Scope
-
-### In Scope
-
-1. New orchestration-facing submit API for cluster-aware mixed submission.
-2. Runtime/backend scheduler and executor changes to treat a mixed submit as one atomic scheduling unit.
-3. Dependency gating, readiness, dispatch, completion, and reclamation at mixed-task granularity.
-4. AIV slot equivalence (`AIV0` and `AIV1` are equivalent execution targets).
-
-### Out of Scope
-
-1. User-facing cluster pinning (`allocate_cluster/free_cluster`-style APIs).
-2. New worker types beyond AIC/AIV.
-3. Cross-cluster user placement policies.
-4. Hardware topology changes beyond `1 AIC + 2 AIV` per cluster.
-
-## 4. Main-Branch Baseline Constraints
-
-Design must preserve the current main runtime architecture:
-
-1. Executor threading split (orchestrator thread vs scheduler threads), and post-orchestrator transition (`transition_requested_` + `reassign_cores_for_all_threads()`).
-2. Shared-memory hot/cold split (`PTO2TaskDescriptor` hot + `PTO2TaskPayload` cold).
-
-## 5. Terminology
-
-1. `cluster`: one physical unit with `1 AIC + 2 AIV`.
-2. `MixedKernels`: 3 submit slots (`AIC`, `AIV0`, `AIV1`) with `INVALID_KERNEL_ID` for inactive slots.
-3. `MixedTask`: one runtime graph node created by one submit call.
-4. `active_mask`: bitmask of active subtask slots.
-5. `resource shape`: normalized lane demand class of a mixed task.
-
-## 6. API Contract
+One call to `rt_submit_task` creates one mixed graph task. The task may use any
+nonempty combination of the physical cluster's `AIC`, `AIV0`, and `AIV1`
+lanes; all active lanes share one argument payload, dependency set, logical
+block count, and completion record.
 
 ```cpp
-inline constexpr int32_t INVALID_KERNEL_ID = -1;
+MixedKernels kernels;
+kernels.aic_kernel_id = aic_func_id;
+kernels.aiv0_kernel_id = aiv0_func_id;
+kernels.aiv1_kernel_id = aiv1_func_id;
 
-struct MixedKernels {
-    int32_t aic_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv0_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
-};
-
-static inline void rt_submit_task(PTO2Runtime* rt,
-                                       const MixedKernels& mixed_kernels,
-                                       Arg* args,
-                                       int32_t num_args);
-
-static inline void rt_submit_aic_task(PTO2Runtime* rt,
-                                           int32_t kernel_id,
-                                           Arg* args,
-                                           int32_t num_args);
-
-static inline void rt_submit_aiv_task(PTO2Runtime* rt,
-                                           int32_t kernel_id,
-                                           Arg* args,
-                                           int32_t num_args);
+L0TaskArgs args;
+args.add_inout(output);
+args.launch_spec.set_block_num(block_num);
+TaskOutputTensors result = rt_submit_task(kernels, args);
 ```
 
-Rules:
+`rt_submit_aic_task` and `rt_submit_aiv_task` are convenience wrappers over the
+same mixed-task contract.
 
-1. One submit call creates one `MixedTask`.
-2. All active slots share the same `args` and `num_args`.
-3. At least one slot must be active.
-4. `aiv0_kernel_id` and `aiv1_kernel_id` are semantically equivalent.
-5. Wrappers are orchestration sugar only (inline in orchestration API); no dedicated runtime ops entries.
-6. Submit-contract types are defined once in a shared header-only submit-types surface consumed by orchestration and runtime headers.
-7. Invalid submits follow existing PTO2 behavior (`always_assert`), not a new recoverable return-code API.
+## Task Representation
 
-## 7. Data Model (Requirements + Design)
+The shared graph image separates stable task identity from scheduling state:
 
-`PTO2TaskDescriptor` (hot path) carries mixed-task identity/state:
+- `PTO2TaskDescriptor` contains the task ID, kernel IDs, and packed-buffer
+  addresses.
+- `PTO2TaskPayload` contains tensors, scalars, predicates, and position-
+  independent `fanin_local_ids[]`.
+- `PTO2TaskSlotState` contains the active mask, task attributes, logical block
+  count, subtask counters, completion state, and descriptor/payload bindings.
 
-1. `task_id`
-2. `active_mask`
-3. `completed_subtasks` (atomic counter, incremented per subtask completion)
-4. `kernel_id[3]` for `(AIC, AIV0, AIV1)`
-5. dependency heads/counters and packed-buffer metadata
+This image is built on the host, relocated once, and copied to the device. It
+contains no fanout adjacency or dependency-pool pointers.
 
-`PTO2TaskPayload` (cold path) carries:
+## Resource Shapes
 
-1. shared args/tensors/scalars copied once per mixed submit
-2. fanin mixed-task IDs
-3. other cold-path submit metadata
+`ActiveMask::to_shape()` maps a task to one of four shapes:
 
-Producer identity in TensorMap is mixed-task ID end-to-end.
+| Shape | Meaning |
+| ----- | ------- |
+| `AIC` | One AIC lane per logical block |
+| `AIV` | One AIV lane per logical block |
+| `MIX` | Two or three active lanes in one physical cluster |
+| `DUMMY` | Dependency-only task with no AICore dispatch |
 
-## 8. Scheduling Model
+A single-AIV task is normalized to the AIV0 submit slot. MIX dispatch still
+uses the full active mask so unused lanes do not block placement.
 
-### 8.1 Resource Shapes
+## Logical Blocks and Validation
 
-Runtime uses shape-based ready queues (not worker-type queues):
+`block_num` is the number of logical SPMD blocks, not the number of physical
+clusters. Non-sync tasks may be wider than the device and dispatch in waves.
 
-1. `AIC_ONLY`
-2. `AIV_X1`
-3. `AIV_X2`
-4. `AIC_AIV_X1`
-5. `AIC_AIV_X2`
+Submission validates before allocating or publishing a slot:
 
-Queueing key is normalized resource shape (not raw slot label).
+```text
+block_num >= 1
+block_num * popcount(active_mask) <= INT16_MAX
+```
 
-### 8.2 Atomic Cluster Dispatch
+The product is the number stored in the 16-bit completion counter. Invalid
+values latch `PTO2_ERROR_INVALID_ARGS`; they are not capped at the device's
+physical cluster count.
 
-1. Dispatch decision unit is one mixed task.
-2. For multi-slot mixed tasks, partial launch is forbidden.
-3. A mixed task is dispatchable only when one local owned cluster can satisfy all required lanes.
-4. Compatible mixed tasks may co-reside over time if they use disjoint free lanes.
+`require_sync_start` adds a separate residency constraint because every block
+must launch as one cohort:
 
-### 8.3 Dependency and Completion
+- AIV-only: `block_num <= rt_available_aiv_count()`
+- AIC or MIX: `block_num <= rt_available_cluster_count()`
 
-1. Fanin release/readiness remains dependency-correct and graph-level.
-2. Two-stage completion:
-   - `on_subtask_complete(task_id, subslot)`
-   - `on_task_complete(task_id)` only when `completed_subtasks == total_required_subtasks`
-3. Downstream release is triggered once per mixed task completion, not once per subslot.
+## Dependency and Readiness Flow
 
-## 9. Executor Ownership and Numbering
+1. Host orchestration allocates a task slot and builds its payload.
+2. TensorMap and explicit dependencies append producer local IDs to
+   `fanin_local_ids[]`.
+3. Submit publishes only the finished graph data; it does not push ready tasks.
+4. After H2D, device boot scans every submitted task exactly once.
+5. A task with every fanin complete is routed to its ready queue; otherwise it
+   registers on its first unmet producer's wake list.
+6. Producer completion reclassifies wake-list consumers until they become ready.
 
-### 9.1 Canonical Flattened Numbering (Unchanged)
+Completion flags are monotonic, so a task never needs periodic fanin polling.
 
-Given `block_dim` clusters:
+## Dispatch and Completion
 
-1. AIC IDs: `[0, block_dim)`
-2. AIV IDs: `[block_dim, 3 * block_dim)`
-3. Cluster `i`: `{i, block_dim + i, 2 * block_dim + i}`
+- AIC and AIV tasks claim as many free cores as the current scheduler owns and
+  requeue remaining logical blocks for later waves.
+- MIX placement selects whole clusters whose used lanes can all accept the
+  task. High cluster offsets are represented by the runtime's 128-bit bitset.
+- `require_sync_start` uses local staging when possible and a generation-tagged
+  global drain when the cohort spans scheduler ownership domains.
+- Each completed lane increments `completed_subtasks`; the mixed task completes
+  exactly once when it reaches `block_num * popcount(active_mask)`.
 
-This project-defined flattened numbering is kept unchanged.
+## Executor Model
 
-### 9.2 Cluster Ownership
+The host loads and executes the orchestration shared object synchronously. The
+device has no orchestration thread: every launched AICPU thread participates in
+scheduling its assigned cores after the boot thread attaches the prebuilt graph.
+Cluster ownership is assigned during the AICore handshake and remains stable for
+the run.
 
-1. One cluster must be owned by one scheduler domain/thread at a time.
-2. No split-cluster ownership in either:
-   - initial `assign_cores_to_threads()`
-   - post-orchestrator `reassign_cores_for_all_threads()`
-3. Lane occupancy bookkeeping must remain consistent with ownership after reassignment.
+## Capacity
 
-## 10. Functional Requirements
+`host_build_graph` is whole-graph-resident. Task slots, heap bytes, fanin IDs,
+and TensorMap entries are not reclaimed while the graph is executing. The graph
+must fit the configured task window, heap, and TensorMap pool before launch.
 
-### 10.1 Valid Mixed Shapes
+## Validation
 
-1. AIC only
-2. AIV only (1 or 2 AIV lanes)
-3. AIC + 1 AIV
-4. AIC + 2 AIV
-
-### 10.2 Runtime Behavior per Submit
-
-1. Validate submit arguments.
-2. Allocate mixed-task ID and initialize descriptor/payload/slot_state once.
-3. Lookup producers via TensorMap; collect fanin metadata and increment producers' `fanout_count`.
-4. Wire fanout edges and determine readiness **inline in submit**: link each live producer's `fanout_head` via `dep_pool` entries and seed readiness directly — `push_ready_routed` for zero-fanin tasks, `route_ready_once` once a producer's fanin resolves. No device-side wiring queue is involved.
-5. Dispatch all active lanes atomically when resources allow.
-6. Aggregate completion and release downstream once.
-
-## 11. Non-Functional Requirements
-
-1. Correctness: no dependency violation, no partial mixed-task dispatch.
-2. Determinism: dependency-correct ordering preserved; AIV lane choice may vary but remains semantically equivalent.
-3. Fairness: resource-aware polling heuristic is allowed; strict starvation-free guarantee across all shapes is not required.
-4. Performance: no obvious regression for non-cluster workflows.
-5. Observability: lifecycle visibility for submit/ready/dispatch/block/complete.
-
-## 12. Acceptance Criteria
-
-Feature is accepted when:
-
-1. Orchestration compiles and submits via `MixedKernels` API/wrappers.
-2. Scheduler dispatches each mixed task as one cluster scheduling decision.
-3. Dependencies gate mixed-task readiness correctly.
-4. AIV execution remains cluster-local and semantically equivalent across lanes.
-5. Existing non-cluster workflows continue to pass without behavior regression.
-6. Cluster ownership is never split across scheduler domains before/after transition.
-
-## 13. Verification Matrix
-
-Recommended validation coverage:
-
-1. Mapping correctness for cluster-to-core ID relation.
-2. Atomic dispatch for multi-slot shapes.
-3. Dependency gating and completion aggregation (`done_mask == active_mask`).
-4. Lane-occupancy co-residency behavior for compatible shapes.
-5. Core-transition ownership stability.
-6. Invalid submit handling (`always_assert` path).
-7. Regression coverage for existing examples/tests.
-
-Milestone command (device):
+Run the HBG runtime simulation sweep after runtime changes:
 
 ```bash
-python tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py \
-  -p a2a3 -d 9
+pytest examples tests/st --platform a2a3sim --runtime host_build_graph
+pytest examples tests/st --platform a5sim --runtime host_build_graph
 ```
 
-Final validation:
-
-```bash
-pytest examples tests/st -m "not sdma" --platform a2a3   # SDMA cases quarantined by marker; run them with -m sdma
-```
-
-## 14. Resolved Decisions
-
-1. Legacy orchestration-facing single-task submit is replaced by mixed submit contract.
-2. Invalid mixed submits fail with existing submit-time assert behavior.
-3. Per-cluster concurrent capacity is lane-occupancy-driven, not a fixed constant.
-4. Submit-contract types live in one shared header-only surface.
-5. Resource-aware dispatch heuristics are allowed without a strict starvation-free guarantee.
+The `host_build_graph_wide_dispatch` scene specifically covers wide AIV work,
+sync-start MIX placement, normal MIX placement, and bit offsets above 63 with
+`aicpu_thread_num=2`.

--- a/src/a5/runtime/host_build_graph/docs/device_log_profiling.md
+++ b/src/a5/runtime/host_build_graph/docs/device_log_profiling.md
@@ -1,175 +1,90 @@
-# PTO2 Device Log Profiling Guide
+# `host_build_graph` Device-Log Profiling
 
-## How to Find Device Logs
+## Execution Boundary
 
-AICPU logs (via `LOG_INFO`) are written by CANN's **dlog** subsystem and do **not** appear in the `python test_*.py` / pytest terminal output. They are written to CANN's device log directory:
+`host_build_graph` runs its orchestration shared object on the host before the
+device launch. The device boots scheduler-only, so its device log contains no
+orchestrator-thread block and no device-side `dlopen` timing.
+
+Host graph-construction timing belongs in host-side diagnostics. This guide is
+only for the AICPU scheduler portion of a run.
+
+## Finding the Log
+
+On hardware, AICPU `LOG_INFO` records are written by CANN's dlog subsystem:
 
 ```text
 $HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
 ```
 
-Each run produces a new log file (or appends to an existing one). Find the most recent file by modification time:
+Find the newest file and filter the current scheduler records:
 
 ```bash
-ls -lt $HOME/ascend/log/debug/device-<device_id>/ | head -5
+ls -t "$HOME/ascend/log/debug/device-<device_id>"/device-*.log | head -1
+grep -E "sched_start=|Scheduler summary|Scheduler Phase Breakdown" <logfile>
 ```
 
-## Log Structure Overview
+## Scheduler Summary
 
-A single run produces two profiling blocks in the device log:
-
-| Block | Emitted by | Function | Content |
-| ----- | ---------- | -------- | ------- |
-| **Orchestrator Profiling** | Thread 3 (orchestrator) | `aicpu_orchestration_entry` | Time breakdown of graph construction on device |
-| **PTO2 Scheduler Summary** | Threads 0/1/2 (schedulers) | `SchedulerContext::resolve_and_dispatch` | Per-thread scheduling statistics, phase timing, and lock contention |
-
-All timing values are in microseconds (us), converted from AICPU cycle counters.
-
-> **host_build_graph (host-orch) note.** The **Orchestrator Profiling** block
-> below only appears in the **device** log under the device-orchestration that
-> `tensormap_and_ringbuffer` runs. In host_build_graph the orchestrator runs on
-> the **host** and the device boots scheduler-only — `aicpu_executor.cpp`
-> carries no on-device orchestrator path — so the device log for a
-> host_build_graph run contains **only Block 2 (the Scheduler Summary)**.
-> Orchestrator graph-construction timing for host_build_graph is a host-side
-> measurement, not a device-log line.
-
----
-
-## Block 1: Orchestrator Profiling
-
-Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_entry`, and prints a profiling summary after it returns.
-
-### Example (from a real run: batch=64, 16704 tasks)
+With `SIMPLER_DFX` enabled, each scheduler thread emits timing bounds and a
+summary when its dispatch loop completes:
 
 ```text
-Thread 3: Calling aicpu_orchestration_entry from SO
-Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
-Thread 3: === Orchestrator Profiling: 16704 tasks, total=14601.580us ===
-Thread 3:   sync_tensormap : 286.300us (2.0%)
-Thread 3:   task_ring_alloc: 380.400us (2.6%)
-Thread 3:   param_copy     : 2147.800us (14.7%)
-Thread 3:   lookup+dep     : 7290.300us (49.9%)
-Thread 3:   heap_alloc     : 701.500us (4.8%)
-Thread 3:   tensormap_ins  : 1890.380us (12.9%)
-Thread 3:   fanin+ready    : 1207.400us (8.3%)
-Thread 3:   finalize+SM    : 697.500us (4.8%)
-Thread 3:   scope_end      : 364.080us
-Thread 3:   avg/task       : 0.874us
-Thread 3: PTO2 total submitted tasks = 16704
+Thread 0: sched_start=... sched_end=... sched_cost=3477.420us
+Thread 0: Scheduler summary: total_time=3460.100us, loops=147, tasks_scheduled=352
 ```
 
-### Field Reference
+| Field | Meaning |
+| ----- | ------- |
+| `sched_cost` | Wall time from scheduler-loop entry to exit |
+| `total_time` | Accounted complete + dispatch + idle cycles |
+| `loops` | Scheduler-loop iterations |
+| `tasks_scheduled` | Mixed tasks this thread completed |
 
-| Field | Source (`pto_orchestrator.cpp`) | Description |
-| ----- | ------------------------------- | ----------- |
-| **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
-| **total** | Sum of all sub-steps below | Accumulated time inside `submit_task` across all tasks |
-| **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
-| **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
-| **param_copy** | `g_orch_args_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
-| **lookup+dep** | `g_orch_lookup_cycle` | TensorMap lookup for inputs/inouts + building fanin/fanout dependency edges |
-| **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
-| **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
-| **fanin+ready** | `g_orch_fanin_cycle` | Building the fanin list + checking if task is already ready (Step 5/5b) |
-| **scope_end** | `g_orch_scope_end_cycle` | `end_scope` overhead (notifying scheduler of scope completion) |
-| **avg/task** | `total / submit_count` | Average orchestrator time per task submission |
+All launched AICPU threads participate in scheduling their assigned cores. The
+highest-index thread performs one-time prebuilt-runtime attachment before it
+enters the same scheduler path; it is not an orchestrator thread.
 
-### Interpreting the Numbers
+## Optional Phase Breakdown
 
-- **cost > total**: The difference is overhead outside `submit_task` (the orchestration user code itself, scope_begin/end, TensorCreateInfo construction, etc.).
-- **lookup+dep** is typically the dominant cost (~50%) because it involves TensorMap hash lookups and building dependency edges with spinlock-protected fanout list insertions.
-- **param_copy** scales with the number of parameters per task.
-- **avg/task < 1us** indicates efficient graph construction.
-
----
-
-## Block 2: PTO2 Scheduler Summary
-
-Each scheduler thread (Thread 0–3 at `aicpu_thread_num=4`) prints its own summary after completing all tasks. The output has two sub-sections: **summary** and **phase breakdown**.
-
-### Example (Thread 0, from a different run: batch=1, 1044 tasks)
+When `SIMPLER_SCHED_PROFILING` is also enabled, the summary includes:
 
 ```text
-Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
-Thread 0: --- Phase Breakdown ---
-Thread 0:   complete:    1485.020us (42.7%)
-Thread 0:   scan:        14.400us (0.4%)
-Thread 0:   dispatch:    1973.060us (56.7%)
-Thread 0:   idle:        4.940us (0.1%)
+Thread 0: === Scheduler Phase Breakdown: total=3460.100us, 352 tasks ===
+Thread 0:   complete       : ...
+Thread 0:     poll         : ... hit=... miss=... hit_rate=...%
+Thread 0:   dispatch       : ...
+Thread 0:     pop          : ... work=... wait=... atomics=...
+Thread 0:     setup        : ...
+Thread 0:   idle           : ...
+Thread 0:   avg/complete   : ...
 ```
 
-### Summary Line
+- `complete` polls core completion and retires mixed tasks.
+- `dispatch` selects ready work, builds payloads, and publishes core commands.
+- `pop` separates ready-queue work from contention wait.
+- `setup` covers payload/MMIO preparation.
+- `idle` is accounted time when the loop made no progress.
+
+Dependency fanout/fanin aggregates are derived from `deps.json` by the DFX
+analysis tools; current HBG device logs do not print the obsolete adjacency-list
+statistics described by older guides.
+
+## Timeout Record
+
+A scheduler timeout uses an explicit end marker:
 
 ```text
-Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
+Thread 0: sched_start=... sched_end(timeout)=... sched_cost=...
 ```
 
-| Field | Description |
-| ----- | ----------- |
-| **completed** | Number of tasks this thread processed to completion |
-| **Y us** | Total scheduler loop time (sum of all phase cycles) |
-| **Z loops** | Number of scheduler loop iterations |
-| **W tasks/loop** | Average tasks completed per loop iteration; higher = better throughput |
+Use the accompanying runtime-status and stall-classification records to identify
+the failure. Do not infer an orchestration stall from a missing Thread-3 block;
+that block never exists in this runtime.
 
-### Phase Breakdown
+## Related Tools
 
-The scheduler loop runs four phases each iteration. Each phase's time is accumulated across all loop iterations.
-
-| Phase | What it does | Inline stats |
-| ----- | ------------ | ------------ |
-| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to increment the completion counter; when `completed_subtasks == total_required_subtasks`, triggers `on_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
-| **scan** | Updates the perf profiling header with latest scheduler state | — |
-| **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
-| **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |
-
-**Interpreting phase percentages:**
-
-- **dispatch** is typically the largest (~55-60%) because it includes ready-queue pops (with spinlock), payload construction, and cache flush (`dc cvac` + `dsb sy`).
-- **complete** is the second largest (~40-45%) because it traverses both fanout (CAS-based fanin decrement, conditional ready-queue push) and fanin (release_producer, check_consumed, ring pointer advancement).
-- **scan** is small (<1%) — only updates the perf header.
-- **idle** is negligible when tasks are flowing; high idle% indicates the scheduler is starved.
-
-**Interpreting pop hit_rate:**
-
-- **High hit_rate (>50%)**: Ready queue is well-supplied; dispatch is efficient.
-- **Low hit_rate (<10%)**: Ready queue is mostly empty when cores become idle. The bottleneck is upstream (orchestrator submission speed or fanout resolution latency), not dispatch itself.
-
-### Per-Task Averages
-
-Divide each thread's phase times by its `completed` count to get per-task scheduling cost:
-
-| Metric | Formula | Typical value |
-| ------ | ------- | ------------- |
-| Scheduling overhead per task | total_time / completed | ~5-10 us/task |
-| Dispatch per task | dispatch_time / completed | ~3-6 us/task |
-| Complete per task | complete_time / completed | ~2-4 us/task |
-
----
-
-## Cross-Referencing with Host Profiling
-
-When `--enable-l2-swimlane` is used, the host terminal prints a **Task Statistics by Function** table with `Total_Exec` (total AICore kernel execution time). Combined with device log data:
-
-| Metric | Source | Description |
-| ------ | ------ | ----------- |
-| Avg kernel exec time | `Total_Exec / total_tasks` (host) | Time AICore spends executing each kernel |
-| Avg scheduling overhead | `sum(thread_total) / total_tasks` (device log) | Time AICPU spends scheduling each task |
-| Sched/Exec ratio | scheduling / execution | Scheduling overhead relative to kernel execution |
-
-A high sched/exec ratio (e.g., >3x) indicates that scheduling overhead dominates, and optimizations should target the scheduler's dispatch hot path (cache flush, payload construction) or upstream task flow.
-
----
-
-## Quick Reference: Extracting Profiling Data
-
-```bash
-# Find the latest device log for device 2
-ls -t $HOME/ascend/log/debug/device-2/device-*.log | head -1
-
-# Extract orchestrator profiling (Thread 3)
-grep "Thread 3:" <logfile>
-
-# Extract scheduler profiling (Threads 0/1/2)
-grep -E "Thread [012]:" <logfile>
-```
+- `python -m simpler_setup.tools.strace_timing` summarizes host/device run markers.
+- `simpler_setup.tools.l0_swimlane` reconstructs intra-core execution from dumps.
+- The repository's DFX analysis workflow combines scheduler timing with
+  dependency and task records.

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -389,11 +389,11 @@ Pass compile definitions through the build command or CI `CXXFLAGS`.
 This overrides the defaults in `profiling_config.h` without changing source.
 
 ```bash
-# Example: disable all profiling code
-CXXFLAGS="-DPTO2_PROFILING=0" pip install --no-build-isolation -e .
+# Example: disable all device profiling code
+CXXFLAGS="-DSIMPLER_DFX=0" pip install --no-build-isolation -e .
 
 # Example: enable orchestrator and tensormap profiling
-CXXFLAGS="-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1" \
+CXXFLAGS="-DSIMPLER_ORCH_PROFILING=1 -DSIMPLER_TENSORMAP_PROFILING=1" \
     pip install --no-build-isolation -e .
 ```
 

--- a/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -276,9 +276,11 @@ static inline bool rt_is_fatal() {
  *   uint64_t raw = get_tensor_data(tensor, 1, idx);       // old usage unchanged
  *   float val = get_tensor_data<float>(tensor, 1, idx);   // typed read
  *
- * If the tensor has a producer in TensorMap, spin-waits until the producer
- * task completes before reading. External tensors (make_tensor_external)
- * are read immediately without waiting.
+ * This API reads the registered host view used to stage an external tensor.
+ * It is valid while host orchestration is building the graph, before device
+ * scheduling starts. A tensor produced by a submitted task cannot become
+ * readable during graph construction, and a runtime-created output has no
+ * registered host view; either use is reported as an invalid argument.
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
@@ -297,24 +299,11 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
  *   set_tensor_data(tensor, 1, idx, raw_u64);     // old usage unchanged
  *   set_tensor_data(tensor, 1, idx, 42.0f);       // typed write (T = float)
  *
- * If the tensor has a producer in TensorMap, spin-waits until the producer
- * and all its consumers complete before writing (WAW + WAR safety).
- * External tensors (make_tensor_external) with no TensorMap entry are
- * written immediately without waiting.
- *
- * Limitation: TensorMap only tracks producers (OUTPUT/INOUT), not consumers
- * that used the tensor as INPUT. If a kernel reads this tensor as INPUT
- * (not INOUT) and the tensor has no TensorMap producer entry, set_tensor_data
- * cannot detect the reader and may cause a data race.
- *
- * To ensure WAR safety for all access patterns, use add_inout() instead of
- * add_input() for kernel parameters that may later be written via
- * set_tensor_data. INOUT creates a TensorMap entry that enables automatic
- * consumer tracking via fanout_refcount.
- *
- * The tensor must already have an allocated buffer (addr != 0).
- * For runtime-created outputs, call this only on the Tensor returned by
- * add_output(TensorCreateInfo) after submit returns.
+ * This API updates the registered host view used to stage an external tensor.
+ * The updated value becomes part of the graph's initial device data. It is not
+ * a synchronization barrier for submitted readers or writers. A tensor with a
+ * submitted producer, or a runtime-created output with no registered host view,
+ * is rejected as an invalid argument.
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Orchestrator Implementation
+ * host_build_graph orchestrator implementation
  *
  * Implements orchestrator state management, scope handling, and task submission.
  *
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <limits>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -387,6 +388,18 @@ static bool prepare_task(
     uint8_t ring_id = 0;
     auto &allocator = orch->ring.task_allocator;
 
+    int16_t block_num = args.launch_spec.block_num();
+    int32_t active_subtasks_per_block = __builtin_popcount(active_mask.core_mask());
+    int32_t total_required_subtasks = static_cast<int32_t>(block_num) * active_subtasks_per_block;
+    if (block_num <= 0 || total_required_subtasks > std::numeric_limits<int16_t>::max()) {
+        orch->report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
+            "block_num=%d with %d active slots requires %d subtasks; expected block_num >= 1 and total <= %d",
+            block_num, active_subtasks_per_block, total_required_subtasks, std::numeric_limits<int16_t>::max()
+        );
+        return false;
+    }
+
     if (!check_scope_can_accept_task(orch, allocator, ring_id)) {
         return false;
     }
@@ -419,17 +432,15 @@ static bool prepare_task(
     // single payload-init point, which runs before Orch-side wiring publish.
 
     // Fields already zeroed by reset_for_reuse() at slot init:
-    //   fanout_lock=0, fanout_count=PTO2_FANOUT_SCOPE_BIT, fanout_head=nullptr,
-    //   fanin_refcount=0, fanout_refcount=0, completed_subtasks=0, next_block_idx=0
+    //   wake_list_head=nullptr, next_in_wake_list=nullptr,
+    //   any_subtask_deferred=false, completed_subtasks=0, next_block_idx=0
     // Fields immutable after RingSchedState::init():
     //   ring_id
     // task_state is set to PENDING here as the orchestrator populates the slot
     // (host_build_graph does not recycle slots at runtime, so there is no
     // post-CONSUMED reset path).
     out->slot_state->task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-    int16_t block_num = args.launch_spec.block_num();
-    out->slot_state->total_required_subtasks =
-        static_cast<int16_t>(block_num * __builtin_popcount(active_mask.core_mask()));
+    out->slot_state->total_required_subtasks = static_cast<int16_t>(total_required_subtasks);
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
     out->slot_state->task_attrs = task_attrs;
@@ -891,7 +902,6 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
 
     int16_t block_num = args.launch_spec.block_num();
-    always_assert(block_num >= 1 && "block_num must be >= 1");
 
     // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
     // it to the aiv0 slot.  This guarantees the dispatch path can always use

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Main Implementation
+ * host_build_graph runtime implementation
  *
  * Implements the unified runtime API that combines orchestrator and scheduler.
  *
@@ -120,14 +120,12 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
     va_end(args);
 }
 
-// Wait for all producers of this tensor to be safe for data access.
-// Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
-// For reads: wait until each producer COMPLETED (done writing).
-// For writes: also wait until all consumers done reading
-//   (consumer low bits of fanout_refcount >= consumer count, excluding the
-//    bit31 scope reference).
-// Uses cycle-based timeout (checked every 1024 spins).
-// Returns false on timeout (sets orch.fatal).
+// Validate every producer reference before waiting on its slot. The host builds
+// the complete graph before device scheduling starts, so a live device producer
+// cannot complete during this call; the timeout remains a defensive failure
+// backstop rather than a synchronization mechanism for orchestration code.
+// For writes, completed_watermark additionally protects against overwriting a
+// producer while one of its submitted consumers is still live.
 MAYBE_UNINITIALIZED_BEGIN
 static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
     PTO2TaskId owner = tensor.owner_task_id;
@@ -143,6 +141,33 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     const PTO2TaskSlotState *seg[kSegmentCap];
     int seg_count = 0;
     bool failed = false;
+
+    auto resolve_producer = [&](PTO2TaskId producer) -> const PTO2TaskSlotState * {
+        if (!producer.is_valid() || producer.ring() != 0) {
+            orch.report_fatal(
+                PTO2_ERROR_INVALID_ARGS, caller,
+                "tensor producer task %#llx has invalid ring %u; host_build_graph uses ring 0",
+                static_cast<unsigned long long>(producer.raw), static_cast<unsigned int>(producer.ring())
+            );
+            failed = true;
+            return nullptr;
+        }
+
+        auto &ring = orch.sm_header->ring;
+        int32_t local_id = static_cast<int32_t>(producer.local());
+        int32_t slot_index = ring.get_slot_by_task_id(local_id);
+        auto &slot = ring.get_slot_state_by_slot(slot_index);
+        if (slot.task == nullptr || slot.task->task_id != producer) {
+            orch.report_fatal(
+                PTO2_ERROR_INVALID_ARGS, caller,
+                "tensor producer task %#llx does not match the descriptor bound to slot %d",
+                static_cast<unsigned long long>(producer.raw), slot_index
+            );
+            failed = true;
+            return nullptr;
+        }
+        return &slot;
+    };
 
     auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
         uint8_t ring_id = 0;
@@ -228,16 +253,17 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     auto do_wait = [&]() {
         // Step A: creator retention — read owner directly from tensor metadata
         if (owner.is_valid()) {
-            auto &s = orch.sm_header->ring.get_slot_state_by_task_id(owner.local());
-            try_push(s);
+            const auto *slot = resolve_producer(owner);
             if (failed) return;
+            try_push(*slot);
         }
 
         // Step B: modifier writer lookup (OverlapMap), direct callback
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
             PTO2TaskId pid = entry.producer_task_id;
-            auto &s = orch.sm_header->ring.get_slot_state_by_task_id(pid.local());
-            try_push(s);
+            const auto *slot = resolve_producer(pid);
+            if (failed) return false;
+            try_push(*slot);
             return !failed;
         });
         if (failed) return;

--- a/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -20,9 +20,10 @@
  * GlobalContext (sub_block_id) is initialized once at runtime startup via
  * init_global_context() and never modified afterwards.
  *
- * LocalContext (block_idx, block_num) and args[] are rebuilt by build_payload()
- * before each dispatch.  Both context struct pointers are written into the
- * args[] suffix on every dispatch (since args[] is rebuilt entirely each time).
+ * build_payload() refreshes the function address, LocalContext's hot fields,
+ * and either the ready-path argument prefix or the gated-path source pointer.
+ * Context pointers, GlobalContext, and the async-completion slab metadata are
+ * initialized once per core and payload buffer.
  *
  * AICore caches a pointer to its per-core slot at startup and reads from
  * it on each dispatch.  The struct is cache-line aligned to avoid false

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -144,7 +144,7 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  * Conditions:
  *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
  *                         hidden alloc completed inline by the orchestrator
- *   COMPLETED->CONSUMED:  fanout_refcount == fanout_count && state == COMPLETED
+ *   COMPLETED->CONSUMED:  per-ring completed_watermark >= last_consumer_local_id
  */
 typedef enum {
     PTO2_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -392,15 +392,9 @@ void SchedulerContext::dispatch_shape(
             CoreTracker::BitStates selected_mix_clusters(0ULL);
 
             if (is_mix) {
-                auto candidates = cores;
                 uint8_t cmask = slot_state->active_mask.core_mask();
                 auto wanted = is_pending ? CoreTracker::MixPlacement::PENDING : CoreTracker::MixPlacement::RUNNING;
-                while (candidates.has_value()) {
-                    int32_t cluster_offset = candidates.pop_first();
-                    if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
-                        selected_mix_clusters |= CoreTracker::BitStates(1ULL << cluster_offset);
-                    }
-                }
+                selected_mix_clusters = tracker.get_mix_cluster_offset_states(cmask, wanted) & cores;
                 if (!selected_mix_clusters.has_value()) {
                     disp_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
@@ -745,13 +739,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         if (is_mix) {
             auto wanted = is_idle ? CoreTracker::MixPlacement::RUNNING : CoreTracker::MixPlacement::PENDING;
             uint8_t cmask = c->active_mask.core_mask();
-            CoreTracker::BitStates candidates = tracker.get_cluster_offset_states();
-            while (candidates.has_value()) {
-                int32_t cluster_offset = candidates.pop_first();
-                if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
-                    bucket |= CoreTracker::BitStates(1ULL << cluster_offset);
-                }
-            }
+            bucket = tracker.get_mix_cluster_offset_states(cmask, wanted);
         } else {
             bucket = tracker.get_dispatchable_cores(shape, phase);
         }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -8,8 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#ifndef SCHEDULER_TYPES_H
-#define SCHEDULER_TYPES_H
+#pragma once
 
 #include <atomic>
 #include <cstddef>
@@ -391,6 +390,18 @@ public:
         return MixPlacement::PENDING;
     }
 
+    BitStates get_mix_cluster_offset_states(uint8_t core_mask, MixPlacement placement) const {
+        BitStates result;
+        BitStates candidates = get_cluster_offset_states();
+        while (candidates.has_value()) {
+            int32_t cluster_offset = candidates.pop_first();
+            if (classify_mix_cluster(cluster_offset, core_mask) == placement) {
+                result |= BitStates::bit(cluster_offset);
+            }
+        }
+        return result;
+    }
+
     // --- Gated MIX split placement ---
     // A gated MIX block can place each of its cores INDEPENDENTLY (idle core -> gated
     // running slot; busy core with a free pending slot -> gated pending slot), because
@@ -439,15 +450,7 @@ public:
     }
 
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result;
-        BitStates candidates = get_cluster_offset_states();
-        while (candidates.has_value()) {
-            int32_t cluster_offset = candidates.pop_first();
-            if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
-                result |= BitStates::bit(cluster_offset);
-            }
-        }
-        return result;
+        return get_mix_cluster_offset_states(core_mask, MixPlacement::RUNNING);
     }
 
     int32_t count_mix_running_clusters(uint8_t core_mask) const {
@@ -510,7 +513,7 @@ public:
     int32_t core_num() const { return cluster_count_ * 3; }
 
 private:
-    int32_t cluster_count_;
+    int32_t cluster_count_{0};
     BitStates aic_mask_;
     BitStates aiv_mask_;
     BitStates core_states_;
@@ -604,5 +607,3 @@ inline uint64_t sync_start_drain_next_attempt(uint64_t attempt) {
 inline uint64_t sync_start_drain_ack_subtree_token(uint64_t attempt) {
     return attempt | SYNC_START_DRAIN_ACK_SUBTREE_READY;
 }
-
-#endif  // SCHEDULER_TYPES_H

--- a/src/common/utils/thread_completion_gate.h
+++ b/src/common/utils/thread_completion_gate.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace simpler {
+
+class ThreadCompletionGate {
+public:
+    template <typename Finalize>
+    void arrive_and_finalize_if_last(int32_t thread_count, Finalize finalize) {
+        int32_t previous = arrived_.fetch_add(1, std::memory_order_acq_rel);
+        if (previous + 1 != thread_count) {
+            return;
+        }
+
+        finalize();
+        cleanup_ready_.store(true, std::memory_order_release);
+    }
+
+    bool claim_cleanup() {
+        bool expected = true;
+        return cleanup_ready_.compare_exchange_strong(
+            expected, false, std::memory_order_acquire, std::memory_order_relaxed
+        );
+    }
+
+    void reset() {
+        arrived_.store(0, std::memory_order_release);
+        cleanup_ready_.store(false, std::memory_order_release);
+    }
+
+private:
+    std::atomic<int32_t> arrived_{0};
+    std::atomic<bool> cleanup_ready_{false};
+};
+
+}  // namespace simpler

--- a/tests/st/host_build_graph_validation/kernels/core/kernel_noop.cpp
+++ b/tests/st/host_build_graph_validation/kernels/core/kernel_noop.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }

--- a/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
+++ b/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <limits>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_NOOP_AIC 0
+#define FUNC_NOOP_AIV0 1
+#define FUNC_NOOP_AIV1 2
+
+namespace {
+
+void submit_zero_block_task() {
+    L0TaskArgs args;
+    args.launch_spec.set_block_num(0);
+    rt_submit_aiv_task(FUNC_NOOP_AIV0, args);
+}
+
+void submit_overflowing_mix_task() {
+    MixedKernels kernels;
+    kernels.aic_kernel_id = FUNC_NOOP_AIC;
+    kernels.aiv0_kernel_id = FUNC_NOOP_AIV0;
+    kernels.aiv1_kernel_id = FUNC_NOOP_AIV1;
+
+    L0TaskArgs args;
+    constexpr int16_t kOverflowingBlockCount = std::numeric_limits<int16_t>::max() / 3 + 1;
+    args.launch_spec.set_block_num(kOverflowingBlockCount);
+    rt_submit_task(kernels, args);
+}
+
+Tensor tensor_with_unbound_owner(const Tensor &external) {
+    Tensor forged = external;
+    forged.owner_task_id = PTO2TaskId::make(0, 17);
+    return forged;
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 2};
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &external = orch_args.tensor(0).ref();
+    uint64_t case_id = orch_args.scalar(0);
+    uint32_t index[1] = {0};
+
+    switch (case_id) {
+    case 0:
+        submit_zero_block_task();
+        return;
+    case 1:
+        submit_overflowing_mix_task();
+        return;
+    case 2:
+        (void)get_tensor_data<int32_t>(tensor_with_unbound_owner(external), 1, index);
+        return;
+    case 3:
+        set_tensor_data<int32_t>(tensor_with_unbound_owner(external), 1, index, 7);
+        return;
+    default:
+        rt_report_fatal(
+            PTO2_ERROR_INVALID_ARGS, "unknown validation case %llu", static_cast<unsigned long long>(case_id)
+        );
+        return;
+    }
+}
+
+}  // extern "C"

--- a/tests/st/host_build_graph_validation/test_host_build_graph_validation.py
+++ b/tests/st/host_build_graph_validation/test_host_build_graph_validation.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Invalid host-build-graph inputs fail with the documented invalid-argument status."""
+
+import functools
+import os
+
+import pytest
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    ChipStorageTaskArgs,
+    CoreCallable,
+    DataType,
+    Tensor,
+)
+from simpler.worker import Worker
+
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RUNTIME = "host_build_graph"
+ORCHESTRATION_SOURCE = os.path.join(HERE, "kernels", "orchestration", "validation_orch.cpp")
+CORE_SOURCE = os.path.join(HERE, "kernels", "core", "kernel_noop.cpp")
+
+CASES = {
+    "zero_block_num": 0,
+    "mixed_subtask_overflow": 1,
+    "unbound_owner_read": 2,
+    "unbound_owner_write": 3,
+}
+
+
+@functools.cache
+def _build_callable(platform: str) -> ChipCallable:
+    compiler = KernelCompiler(platform=platform)
+    pto_isa_root = ensure_pto_isa_root()
+    include_dirs = list(compiler.get_orchestration_include_dirs(RUNTIME)) + [
+        str(compiler.project_root / "src" / "common")
+    ]
+
+    aic_binary = compiler.compile_incore(
+        source_path=CORE_SOURCE,
+        core_type="aic",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=include_dirs,
+    )
+    aiv_binary = compiler.compile_incore(
+        source_path=CORE_SOURCE,
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=include_dirs,
+    )
+    orchestration = compiler.compile_orchestration(runtime_name=RUNTIME, source_path=ORCHESTRATION_SOURCE)
+    return ChipCallable.build(
+        signature=[ArgDirection.INOUT],
+        func_name="aicpu_orchestration_entry",
+        binary=orchestration,
+        children=[
+            (0, CoreCallable.build(signature=[], binary=aic_binary)),
+            (1, CoreCallable.build(signature=[], binary=aiv_binary)),
+            (2, CoreCallable.build(signature=[], binary=aiv_binary)),
+        ],
+    )
+
+
+@pytest.mark.platforms(["a2a3sim", "a5sim"])
+@pytest.mark.device_count(1)
+@pytest.mark.runtime(RUNTIME)
+@pytest.mark.parametrize("case_name", list(CASES))
+def test_invalid_input_reports_code_five(st_platform, st_device_ids, case_name, capfd):
+    worker = Worker(level=2, platform=st_platform, runtime=RUNTIME, device_id=int(st_device_ids[0]))
+    buffer = None
+    try:
+        handle = worker.register(_build_callable(st_platform))
+        worker.init()
+
+        host_value = torch.zeros(1, dtype=torch.int32)
+        buffer = worker.malloc(host_value.nbytes)
+        worker.copy_to(buffer, host_value.data_ptr(), host_value.nbytes)
+
+        args = ChipStorageTaskArgs()
+        args.add_tensor(Tensor.make(buffer, (1,), DataType.INT32))
+        args.add_scalar(CASES[case_name])
+
+        config = CallConfig()
+        config.aicpu_thread_num = 2
+        with pytest.raises(RuntimeError, match=r"(run_runtime|run) failed with code -5\b"):
+            worker.run(handle, args, config)
+
+        captured = capfd.readouterr()
+        log = captured.err + captured.out
+        assert "orch_error_code=5" in log
+        assert "INVALID_ARGS" in log
+    finally:
+        if buffer is not None:
+            worker.free(buffer)
+        worker.close()

--- a/tests/st/host_build_graph_wide_dispatch/kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp
+++ b/tests/st/host_build_graph_wide_dispatch/kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include "pto_arg_with_deps.h"      // NOLINT(build/include_subdir)
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_SPMD_MIX_AIC 0
+#define FUNC_SPMD_MIX_AIV0 1
+#define FUNC_SPMD_MIX_AIV1 2
+#define FUNC_SPMD_WRITE_AIV 3
+
+namespace {
+
+MixedKernels mix_kernels() {
+    MixedKernels kernels;
+    kernels.aic_kernel_id = FUNC_SPMD_MIX_AIC;
+    kernels.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
+    kernels.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
+    return kernels;
+}
+
+PTO2TaskId submit_aiv(const Tensor &output, int16_t block_num) {
+    L0TaskArgs args;
+    args.add_inout(output);
+    args.add_scalar(0);
+    args.add_scalar(0);
+    args.launch_spec.set_block_num(block_num);
+    return rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args).task_id();
+}
+
+PTO2TaskId submit_sync_mix(const Tensor &output, int16_t block_num, int64_t base, PTO2TaskId producer) {
+    L0TaskArgsWithDeps<1> args;
+    args.add_inout(output);
+    args.add_scalar(base);
+    args.add_scalar(0);
+    args.launch_spec.set_block_num(block_num);
+    args.launch_spec.set_require_sync_start(true);
+    args.add_dep(producer);
+    return rt_submit_task(mix_kernels(), args).task_id();
+}
+
+void submit_normal_mix(const Tensor &output, int16_t block_num, int64_t base, PTO2TaskId producer) {
+    L0TaskArgsWithDeps<1> args;
+    args.add_inout(output);
+    args.add_scalar(base);
+    args.add_scalar(0);
+    args.launch_spec.set_block_num(block_num);
+    args.add_dep(producer);
+    rt_submit_task(mix_kernels(), args);
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 2};
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &output = orch_args.tensor(0).ref();
+    const Tensor &layout = orch_args.tensor(1).ref();
+    int16_t aiv_blocks = static_cast<int16_t>(rt_available_aiv_count());
+    int16_t mix_blocks = static_cast<int16_t>(rt_available_cluster_count());
+
+    PTO2TaskId aiv = submit_aiv(output, aiv_blocks);
+    PTO2TaskId sync_mix = submit_sync_mix(output, mix_blocks, aiv_blocks, aiv);
+    int64_t normal_base = aiv_blocks + 3 * mix_blocks;
+    submit_normal_mix(output, mix_blocks, normal_base, sync_mix);
+
+    uint32_t index[1] = {0};
+    set_tensor_data<int32_t>(layout, 1, index, aiv_blocks);
+    index[0] = 1;
+    set_tensor_data<int32_t>(layout, 1, index, mix_blocks);
+}
+
+}  // extern "C"

--- a/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
+++ b/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Wide host-build-graph dispatch across the high half of the 128-bit core mask."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_MIX_BLOCK = 3
+MAX_CLUSTERS = 36
+MAX_AIV = MAX_CLUSTERS * 2
+MAX_TOTAL_CL = MAX_AIV + 2 * MAX_CLUSTERS * SLOTS_PER_MIX_BLOCK
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestHostBuildGraphWideDispatch(SceneTestCase):
+    """Exercise wide AIV plus sync-start and normal MIX placement with one scheduler."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SPMD_MIX_AIC",
+                "source": "../a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/"
+                "kernels/aic/kernel_spmd_mix_slow.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SPMD_MIX_AIV0",
+                "source": "../a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/"
+                "kernels/aiv/kernel_spmd_mix_slow.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "SPMD_MIX_AIV1",
+                "source": "../a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/"
+                "kernels/aiv/kernel_spmd_mix_slow.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 3,
+                "name": "SPMD_WRITE_AIV",
+                "source": "../a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/"
+                "kernels/aiv/kernel_spmd_write_slow.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "TwoThreads",
+            "platforms": ["a2a3sim", "a5sim"],
+            "config": {"aicpu_thread_num": 2},
+            "params": {},
+        }
+    ]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            Tensor("layout", torch.zeros(2, dtype=torch.int32)),
+        )
+
+    def compute_golden(self, args, params):
+        pass
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        aiv_blocks, mix_blocks = (int(value) for value in test_args.layout)
+        assert aiv_blocks == mix_blocks * 2
+        used_cache_lines = aiv_blocks + 2 * mix_blocks * SLOTS_PER_MIX_BLOCK
+        assert used_cache_lines <= MAX_TOTAL_CL
+
+        expected = torch.zeros(MAX_TOTAL_CL, dtype=torch.float32)
+        for block_idx in range(aiv_blocks):
+            expected[block_idx] = float(block_idx)
+
+        sync_base = aiv_blocks
+        normal_base = sync_base + mix_blocks * SLOTS_PER_MIX_BLOCK
+        for base in (sync_base, normal_base):
+            for block_idx in range(mix_blocks):
+                for slot in range(SLOTS_PER_MIX_BLOCK):
+                    expected[base + block_idx * SLOTS_PER_MIX_BLOCK + slot] = float(block_idx)
+
+        actual = test_args.output.reshape(MAX_TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        assert torch.equal(actual, expected)
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -146,6 +146,33 @@ function(add_a2a3_hbg_runtime_test name src)
     set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
 endfunction()
 
+function(add_a5_hbg_runtime_test name src)
+    add_executable(${name}
+        ${src}
+        ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/orchestration
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/common
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/aicpu
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common
+    )
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
+endfunction()
+
 function(add_a2a3_orchestrator_runtime_test name src)
     add_executable(${name}
         ${src}
@@ -430,6 +457,7 @@ target_include_directories(test_runtime_orch_so PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
 )
 add_common_utils_test(test_device_arena common/test_device_arena.cpp)
+add_common_utils_test(test_thread_completion_gate common/test_thread_completion_gate.cpp)
 add_common_utils_test(test_buffer_pool_manager common/test_buffer_pool_manager.cpp)
 target_sources(test_buffer_pool_manager PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp
@@ -700,6 +728,8 @@ add_a2a3_hbg_runtime_test(test_hbg_task_allocator a2a3/test_task_allocator.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensormap a2a3/test_hbg_tensormap.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_dep_gen_host_graph a2a3/test_dep_gen_host_graph.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 # PTO2TensorMap's out-of-line members (reserve_layout / init / valid_count) live
 # in this .cpp; no other add_a2a3_hbg_runtime_test target needs them.
 target_sources(test_hbg_tensormap PRIVATE

--- a/tests/ut/cpp/common/test_hbg_core_tracker.cpp
+++ b/tests/ut/cpp/common/test_hbg_core_tracker.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "scheduler/scheduler_types.h"
+
+TEST(HostBuildGraphCoreTrackerTest, MixPlacementSelectionPreservesClustersAboveBit63) {
+    CoreTracker tracker;
+    tracker.init(CoreTracker::MAX_CLUSTERS);
+    for (int32_t cluster = 0; cluster < CoreTracker::MAX_CLUSTERS; ++cluster) {
+        int32_t offset = cluster * 3;
+        tracker.set_cluster(cluster, offset, offset + 1, offset + 2);
+    }
+
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0 | PTO2_SUBTASK_MASK_AIV1;
+    int32_t high_offset = (CoreTracker::MAX_CLUSTERS - 1) * 3;
+    auto running = tracker.get_mix_cluster_offset_states(used_mask, CoreTracker::MixPlacement::RUNNING);
+    EXPECT_EQ(running.count(), CoreTracker::MAX_CLUSTERS);
+    EXPECT_TRUE((running & CoreTracker::BitStates::bit(high_offset)).has_value());
+
+    for (int32_t offset = 0; offset < CoreTracker::MAX_CLUSTERS * 3; ++offset) {
+        tracker.change_core_state(offset);
+    }
+    auto pending = tracker.get_mix_cluster_offset_states(used_mask, CoreTracker::MixPlacement::PENDING);
+    EXPECT_EQ(pending.count(), CoreTracker::MAX_CLUSTERS);
+    EXPECT_TRUE((pending & CoreTracker::BitStates::bit(high_offset)).has_value());
+}

--- a/tests/ut/cpp/common/test_thread_completion_gate.cpp
+++ b/tests/ut/cpp/common/test_thread_completion_gate.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include "utils/thread_completion_gate.h"
+
+TEST(ThreadCompletionGateTest, CleanupCannotBeClaimedWhileFinalizerIsRunning) {
+    simpler::ThreadCompletionGate gate;
+    gate.arrive_and_finalize_if_last(2, [] {});
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool finalizer_started = false;
+    bool allow_finalizer_to_finish = false;
+
+    std::thread last_thread([&] {
+        gate.arrive_and_finalize_if_last(2, [&] {
+            std::unique_lock<std::mutex> lock(mutex);
+            finalizer_started = true;
+            condition.notify_one();
+            condition.wait(lock, [&] {
+                return allow_finalizer_to_finish;
+            });
+        });
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        condition.wait(lock, [&] {
+            return finalizer_started;
+        });
+    }
+    EXPECT_FALSE(gate.claim_cleanup());
+
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        allow_finalizer_to_finish = true;
+    }
+    condition.notify_one();
+    last_thread.join();
+
+    EXPECT_TRUE(gate.claim_cleanup());
+    EXPECT_FALSE(gate.claim_cleanup());
+}
+
+TEST(ThreadCompletionGateTest, ResetAllowsAnotherRun) {
+    simpler::ThreadCompletionGate gate;
+    int finalized = 0;
+
+    gate.arrive_and_finalize_if_last(1, [&] {
+        ++finalized;
+    });
+    ASSERT_TRUE(gate.claim_cleanup());
+
+    gate.reset();
+    gate.arrive_and_finalize_if_last(1, [&] {
+        ++finalized;
+    });
+    EXPECT_TRUE(gate.claim_cleanup());
+    EXPECT_EQ(finalized, 2);
+}


### PR DESCRIPTION
## Summary

- Preserve 128-bit MIX placement across every a2a3/a5 cluster and initialize
  scheduler tracker state deterministically.
- Publish executor cleanup only after the last scheduler thread destroys the
  per-run runtime, then grant one thread the exclusive `deinit()` claim.
- Reject zero/overflowing block-subtask totals and forged tensor producer IDs
  with `INVALID_ARGS` instead of asserting or dereferencing an unbound slot.
- Correct the host-graph scalar-access, dispatch-payload, profiling, and runtime
  lifecycle documentation in both architecture trees.
- Add architecture-parity unit tests plus simulation regressions for teardown
  ordering, invalid inputs, and dispatch above bit 63.

The prior `pending_task == nullptr` drain guard was removed. Its CodeRabbit
finding was withdrawn after confirming that incomplete drain state is
intentionally reset by `deinit()` and the guard only made an unreachable state
look recoverable.

## Testing

- Editable runtime rebuild: a2a3sim and a5sim runtime binaries compiled.
- C++ UT: `test_thread_completion_gate`, `test_hbg_core_tracker`, and
  `test_a5_hbg_core_tracker` passed.
- a2a3sim HBG sweep: 23 passed, 5 skipped.
- a5sim HBG sweep: 14 passed, 1 skipped.
- Targeted validation and wide-dispatch scenes passed again on both simulators
  after formatting.
- Full staged-file pre-commit gate passed, including clang-format, clang-tidy,
  cpplint, markdownlint, Ruff, and Pyright.

Hardware tests were not run locally because this host has no `npu-smi` device.
