### PR TITLE
Support: persist scene-test kernel compilation cache

### DIFF
--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -42,6 +42,14 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
+      - name: Restore scene-test kernel cache (a2a3)
+        uses: actions/cache@v5
+        with:
+          path: build/cache/kernels
+          key: scene-kernels-a2a3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pto_isa.pin') }}-${{ inputs.ref || github.sha }}
+          restore-keys: |
+            scene-kernels-a2a3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pto_isa.pin') }}-
+
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
@@ -56,6 +64,13 @@ jobs:
           if ! command -v dot >/dev/null 2>&1; then
             echo "::warning::graphviz 'dot' not found on PATH; deps_viewer tool smoke will skip. Install graphviz on this self-hosted runner to restore coverage."
           fi
+
+      - name: Compile scene-test kernels (a2a3)
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          source .venv/bin/activate
+          python -m simpler_setup.tools.scene_test_compile examples tests/st \
+            --platform a2a3 --require-pto-isa --compile-workers 8 -q
 
       - name: Run pytest scene tests (a2a3)
         if: inputs.a2a3_sdma_mode == 'marker'

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -37,6 +37,14 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
+      - name: Restore scene-test kernel cache (a5)
+        uses: actions/cache@v5
+        with:
+          path: build/cache/kernels
+          key: scene-kernels-a5-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pto_isa.pin') }}-${{ inputs.ref || github.sha }}
+          restore-keys: |
+            scene-kernels-a5-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pto_isa.pin') }}-
+
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
@@ -48,6 +56,8 @@ jobs:
       - name: Run pytest scene tests (a5)
         run: |
           source .venv/bin/activate
+          python -m simpler_setup.tools.scene_test_compile examples tests/st \
+            --platform a5 --require-pto-isa --compile-workers 8 -q
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa"
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 1200"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -206,6 +206,40 @@ a5 runners are ARM64-only and always use `task-submit`. Steps that only build
 arch. The same device-lock rule applies to local onboard work — see
 [.claude/rules/running-onboard.md](../.claude/rules/running-onboard.md).
 
+The two onboard scene-test jobs (`st-onboard-a2a3`, `st-onboard-a5`) compile
+their selected test batch before entering `task-submit`. The lock-free warm-up
+populates the `build/cache/kernels/` cache; the subsequent pytest invocation
+keeps the existing batch-level device allocation and reconstructs each
+`ChipCallable` from that cache. The warm-up does not acquire one lock per case,
+and runners with exclusive devices continue to execute pytest directly.
+Compilation is serial by default; both onboard jobs pass `--compile-workers 8`,
+which assumes the runner's CPU is theirs alone — it starts eight `ccec`
+processes at once. The sim jobs run on ephemeral GitHub-hosted runners with no
+restored cache, so they compile cold every time and get no warm-up step.
+
+A warm-up that cannot compile a class reports it and keeps going: the pass only
+fills a cache, so the locked pytest run that follows is what recompiles the
+class and attributes the failure to the case that owns it, instead of one
+unbuildable kernel costing the whole batch its results.
+
+`actions/checkout` cleans ignored files before each job, so the onboard jobs
+restore and save `build/cache/kernels/` through `actions/cache`. Cache keys are
+partitioned by target architecture, runner OS/architecture, and PTO-ISA pin.
+The artifact's own key covers the contents of its orchestration, incore, and
+transitively included sources, the compiler identities and effective fixed
+flags, a digest of the modules that decide artifact bytes
+(`kernel_compiler.py`, `toolchain.py`, `elf_parser.py`), the binding's
+serialized-callable ABI, and a manual schema constant. It also carries the
+owning test class's qualified name, so two scene tests built from identical
+sources keep separate entries rather than sharing one.
+
+Entries are content-addressed and therefore never overwritten, so a run prunes
+entries whose last use is more than 14 days old before it exits. Without that,
+the directory grows by one entry per kernel change forever and the saved
+`actions/cache` archive — one new entry per push, restored by prefix — would
+crowd the repository's 10 GB cache budget and evict the pip and cmake caches
+the other jobs depend on.
+
 ## Test Sources
 
 ### `tests/ut/` — Python unit tests (ut-py)

--- a/docs/investigations/2026-07-qwen-scene-test-406s-decomposition.md
+++ b/docs/investigations/2026-07-qwen-scene-test-406s-decomposition.md
@@ -109,6 +109,25 @@ Compilation breaks down as ~1.1–1.3 s per ordinary incore, 6.6 s for the
 orchestration, and 8.4 s for the vendor FAI kernel's AIV variant (1330 KiB) —
 the single outlier.
 
+### Post-cache lock boundary
+
+Local a2a3 validation of the #1604 persistent compile cache on 2026-08-03 used
+the same `StressBatch16Seq3500` case and split the invocation at the CI lock
+boundary:
+
+| Phase | Wall | Device lock |
+| ----- | ---- | ----------- |
+| cold `scene_test_compile` warm-up (37 compilation units) | 75.24 s | not held |
+| `task-submit` invocation after warm-up | 53.87 s | held after allocation |
+| device `runner_run.device_wall` marker inside that invocation | 35.416 ms | held |
+
+The cache artifact was written before `task-submit`, remained unchanged during
+the device run, and the case passed. This confirms that compilation no longer
+consumes card time. Fixture construction and golden computation still execute
+inside the locked pytest process; moving them would require a same-job data
+handoff or a delayed-lock interface rather than the long-lived golden cache
+rejected below.
+
 ### The root cause
 
 None of the golden's 359 s was arithmetic. Its reference walks **3584 small
@@ -197,11 +216,12 @@ with nothing checking it was right.
   already exists (`l3_compile_cache_key()` composes a stable key) and only ever
   reaches an in-memory dict. Tracked with the device-lock question in
   [#1604](https://github.com/hw-native-sys/simpler/issues/1604).
-- **The device lock.** All ~115 s of the case is CPU work performed while
-  holding a card, because `ci.yml` wraps the whole pytest session in
-  `task-submit`. Also [#1604](https://github.com/hw-native-sys/simpler/issues/1604);
-  note it pulls against the competing idea of holding **one** lock for the whole
-  job, which would reclaim the 210 s of re-queueing but lengthen the hold.
+- **The device lock.** The #1604 warm-up keeps kernel compilation outside
+  `task-submit`; fixture construction and golden computation remain inside the
+  locked pytest process. Moving those phases requires a same-job handoff or a
+  delayed-lock interface. It still pulls against the competing idea of holding
+  **one** lock for the whole job, which would reclaim the 210 s of re-queueing
+  but lengthen the hold.
 
 ## References
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,10 @@ pytest examples tests/st --platform a2a3sim       # specific sim
 pytest examples tests/st -m "not sdma" --platform a2a3          # hardware
 pytest examples tests/st -m "not sdma" --platform a2a3 --device 4-7  # hardware with device pool
 
+# Compile the selected hardware batch without creating a Worker or using an NPU
+python -m simpler_setup.tools.scene_test_compile examples tests/st \
+    -m "not sdma" --platform a2a3 --require-pto-isa --compile-workers 8
+
 # SDMA cases run separately, as they do in CI: they are quarantined by
 # @pytest.mark.sdma so no fault-injection case shares a device with a
 # provisioned SDMA workspace (issue #1425)
@@ -86,6 +90,32 @@ If a module is exposed via nanobind (used by both C++ and Python), test in **ut-
 If a module is pure C++ with no Python binding, test in **ut-cpp** (`tests/ut/cpp/`).
 
 ## Scene Test CLI Options
+
+### Lock-free kernel warm-up
+
+`python -m simpler_setup.tools.scene_test_compile` accepts the same pytest
+paths and selection arguments as the subsequent scene-test command. It runs
+pytest collection, compiles each selected `SceneTestCase` class once, and
+stores the resulting `ChipCallable` under `build/cache/kernels/`. It does not
+create a `Worker` or access an NPU. Compilation is serial by default so callers
+with large models do not unexpectedly overload the host. Pass
+`--compile-workers N` to opt into compiling up to `N` test classes concurrently
+— each worker starts its own compiler process, so only raise it on a host whose
+CPU is yours. simpler's two onboard CI jobs (a2a3, a5) use eight; the sim jobs
+have no warm-up step.
+
+A class that fails to compile is reported and skipped rather than aborting the
+pass, so the run that follows still recompiles it and reports the error against
+the case that owns it.
+
+Pass the same paths, `-m`, `--platform`, `--runtime`, and `--level` selections
+to warm-up and execution. A normal pytest or standalone run loads matching
+artifacts from the persistent cache; changed orchestration, incore, or included
+source content, compiler identity, fixed compilation flags, compilation logic,
+or compilation schema produces a new cache entry automatically. Entries unused
+for 14 days are pruned. When `build/` is not writable — a wheel installed into
+a read-only `site-packages` — the cache is skipped with a warning and every
+callable is compiled in-process, exactly as before the cache existed.
 
 Scene tests support advanced CLI options for benchmarking, profiling, and runtime control. These work identically in both pytest and standalone mode.
 

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -6,12 +6,14 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+import hashlib
 import importlib.util
 import logging
 import os
 import subprocess
 import sys
 import tempfile
+from functools import cache
 from pathlib import Path
 from typing import Optional, Union
 
@@ -27,6 +29,54 @@ from .toolchain import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Covers the part of the persistent scene-test cache key that nothing else
+# fingerprints: how ``scene_test._compile_chip_callable_from_spec`` assembles
+# compiled binaries into a ``ChipCallable``. The modules that decide the bytes
+# of a single compiled artifact carry their own digest (see
+# ``_artifact_logic_token``), and the binding layout carries an ABI token, so a
+# manual bump here is only owed for a change in that assembly step.
+_COMPILE_CACHE_SCHEMA = 1
+
+# Modules whose logic turns kernel sources into artifact bytes: compiler
+# invocation and flags, toolchain selection, and the ELF section extraction
+# applied to every onboard incore.
+_ARTIFACT_LOGIC_MODULES = ("kernel_compiler.py", "toolchain.py", "elf_parser.py")
+
+
+@cache
+def _artifact_logic_token() -> str:
+    """Digest the modules that decide a compiled artifact's bytes.
+
+    Source content, compiler identity and compile flags are keyed separately;
+    this token is what invalidates a cached artifact when the compilation logic
+    itself changes, so editing one of these modules takes effect without a
+    manual ``_COMPILE_CACHE_SCHEMA`` bump.
+    """
+    digest = hashlib.sha256()
+    module_dir = Path(__file__).resolve().parent
+    for name in _ARTIFACT_LOGIC_MODULES:
+        digest.update(name.encode())
+        try:
+            digest.update(hashlib.sha256((module_dir / name).read_bytes()).digest())
+        except OSError:
+            digest.update(b"unreadable")
+    return digest.hexdigest()
+
+
+@cache
+def _executable_cache_identity(executable: str) -> dict[str, object]:
+    """Return stable compiler identity without embedding runner-local paths."""
+    try:
+        result = subprocess.run([executable, "--version"], check=False, capture_output=True, text=True, timeout=5)
+        return {
+            "name": os.path.basename(executable),
+            "returncode": result.returncode,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+        }
+    except (OSError, subprocess.SubprocessError) as error:
+        return {"name": os.path.basename(executable), "error": type(error).__name__}
 
 
 class KernelCompiler:
@@ -225,6 +275,86 @@ class KernelCompiler:
             str(source_dir / "cache_ops.cpp"),
             str(source_dir / "device_time.cpp"),
         ]
+
+    def get_orchestration_cache_inputs(self, runtime_name: str) -> tuple[list[str], list[str]]:
+        """Return the include directories and extra sources used by orchestration compilation.
+
+        Keeping this calculation beside ``compile_orchestration`` ensures the
+        persistent scene-test cache hashes the same inputs the compiler sees.
+        """
+        include_dirs = self.get_orchestration_include_dirs(runtime_name)
+        config_include_dirs, config_sources = self._get_orchestration_config(runtime_name)
+        return (
+            [*include_dirs, *config_include_dirs],
+            [*config_sources, *self._get_orchestration_platform_sources()],
+        )
+
+    def _orchestration_toolchain(self, runtime_name: str) -> Union[GxxToolchain, Aarch64GxxToolchain]:
+        if runtime_name == "host_build_graph":
+            return self.host_gxx
+        if runtime_name == "tensormap_and_ringbuffer":
+            if self.platform.endswith("sim"):
+                return self.host_gxx
+            assert self.aarch64 is not None, "aarch64 toolchain is only available for hardware platforms"
+            return self.aarch64
+        raise ValueError(f"Unknown runtime_name: {runtime_name!r}")
+
+    def _orchestration_compile_flags(self, toolchain: Union[GxxToolchain, Aarch64GxxToolchain]) -> list[str]:
+        return [*toolchain.get_compile_flags(), *self._sanitizer_flags(toolchain)]
+
+    @staticmethod
+    def _orchestration_link_flags() -> list[str]:
+        """Return the link flags every orchestration ``.so`` carries on this host.
+
+        macOS/clang resolves the runtime's symbols at dlopen time, so undefined
+        symbols must be allowed. Elsewhere a deterministic ELF GNU Build-ID is
+        forced in: the host-side DeviceRunner reads ``.note.gnu.build-id`` to
+        recognize a callable it has already uploaded, and passing the flag
+        explicitly keeps that id stable across toolchain versions even though
+        the compiler default already injects one.
+        """
+        if sys.platform == "darwin":
+            return ["-undefined", "dynamic_lookup"]
+        return ["-Wl,--build-id=sha1"]
+
+    def compile_cache_token(self, runtime_name: str, core_types: list[str]) -> dict[str, object]:
+        """Describe every compiler and fixed flag that affects kernel artifacts."""
+        orchestration = self._orchestration_toolchain(runtime_name)
+        if self.platform.endswith("sim"):
+            incore = self.gxx15
+            incore_entries = [
+                {
+                    "core_type": core_type,
+                    "flags": [*incore.get_compile_flags(core_type=core_type), *self._sanitizer_flags(incore)],
+                }
+                for core_type in sorted(set(core_types))
+            ]
+            linker = None
+        else:
+            assert self.ccec is not None, "ccec toolchain is only available for hardware platforms"
+            incore = self.ccec
+            incore_entries = [
+                {"core_type": core_type, "flags": incore.get_compile_flags(core_type=core_type)}
+                for core_type in sorted(set(core_types))
+            ]
+            linker = {
+                "identity": _executable_cache_identity(self.ccec.linker_path),
+                "flags": ["-e", "kernel_entry"],
+            }
+        return {
+            "schema": _COMPILE_CACHE_SCHEMA,
+            "logic": _artifact_logic_token(),
+            "orchestration": {
+                "identity": _executable_cache_identity(orchestration.cxx_path),
+                "compile_flags": self._orchestration_compile_flags(orchestration),
+                "link_flags": self._orchestration_link_flags(),
+            },
+            "incore": {
+                "identity": _executable_cache_identity(incore.cxx_path),
+                "variants": incore_entries,
+                "linker": linker,
+            },
+        }
 
     def _run_subprocess(
         self, cmd: list[str], label: str, error_hint: str = "Compiler not found"
@@ -462,39 +592,15 @@ class KernelCompiler:
             RuntimeError: If compilation fails
             ValueError: If runtime_name is unknown
         """
-        include_dirs = self.get_orchestration_include_dirs(runtime_name)
+        include_dirs, orch_sources = self.get_orchestration_cache_inputs(runtime_name)
         if extra_include_dirs:
             include_dirs = include_dirs + list(extra_include_dirs)
-
-        # Load optional orchestration config for extra sources/includes
-        orch_includes, orch_sources = self._get_orchestration_config(runtime_name)
-        if orch_includes:
-            include_dirs = include_dirs + orch_includes
-        orch_sources = list(orch_sources) + self._get_orchestration_platform_sources()
 
         # host_build_graph dlopens the orchestration .so on the host, so it
         # compiles with the host g++ (x86_64) regardless of platform.
         # tensormap_and_ringbuffer dlopens it on the aarch64 AICPU onboard, so
         # it cross-compiles there and uses the host g++ only for sim.
-        if runtime_name == "host_build_graph":
-            toolchain_type = ToolchainType.HOST_GXX
-        elif runtime_name == "tensormap_and_ringbuffer":
-            toolchain_type = self._get_toolchain(
-                {
-                    "a2a3": ToolchainType.AARCH64_GXX,
-                    "a2a3sim": ToolchainType.HOST_GXX,
-                    "a5": ToolchainType.AARCH64_GXX,
-                    "a5sim": ToolchainType.HOST_GXX,
-                },
-            )
-        else:
-            raise ValueError(f"Unknown runtime_name: {runtime_name!r}")
-        toolchain: Union[GxxToolchain, Aarch64GxxToolchain]
-        if toolchain_type == ToolchainType.AARCH64_GXX:
-            assert self.aarch64 is not None, "aarch64 toolchain is only available for hardware platforms"
-            toolchain = self.aarch64
-        else:
-            toolchain = self.host_gxx
+        toolchain = self._orchestration_toolchain(runtime_name)
 
         # HOST_GXX: simulation build (host execution)
         # AARCH64_GXX: cross-compilation for supported runtimes
@@ -538,17 +644,7 @@ class KernelCompiler:
             prefix=f"{os.path.basename(source_path)}.orch_", suffix=".so", build_dir=build_dir
         )
 
-        cmd = [toolchain.cxx_path] + toolchain.get_compile_flags()
-        cmd += self._sanitizer_flags(toolchain)
-
-        # Force a deterministic ELF GNU Build-ID into every orchestration .so.
-        # The host-side DeviceRunner reads `.note.gnu.build-id` to detect when
-        # the same callable is being re-run (cache hit → skip device upload +
-        # device dlopen). The compiler default already injects a Build-ID,
-        # but pass it explicitly so the cache key remains stable across
-        # toolchain versions. macOS/clang ld silently ignores this flag.
-        if sys.platform != "darwin":
-            cmd.append("-Wl,--build-id=sha1")
+        cmd = [toolchain.cxx_path, *self._orchestration_compile_flags(toolchain), *self._orchestration_link_flags()]
 
         if extra_sources:
             for src in extra_sources:
@@ -556,11 +652,6 @@ class KernelCompiler:
                 if os.path.isfile(src):
                     cmd.append(src)
                     logger.debug(f"  Including extra source: {os.path.basename(src)}")
-
-        # On macOS, allow undefined symbols to be resolved at dlopen time
-        if sys.platform == "darwin":
-            cmd.append("-undefined")
-            cmd.append("dynamic_lookup")
 
         # Add include dirs
         if extra_include_dirs:

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -26,6 +26,7 @@ import gc
 import inspect
 import logging
 import os
+import platform as host_platform
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -33,6 +34,7 @@ from typing import Any, NamedTuple
 
 from .log_config import DEFAULT_LOG_LEVEL, LOG_LEVEL_CHOICES, configure_logging
 from .pto_isa import ensure_pto_isa_root
+from .scene_test_cache import compile_artifact_key, get_or_compile
 
 logger = logging.getLogger(__name__)
 
@@ -989,7 +991,7 @@ def _compare_outputs(test_args, golden_args, output_names, rtol, atol):
 
 
 def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
-    """Compile a chip entry spec (orchestration + incores) -> ChipCallable. Session-cached."""
+    """Compile a chip entry spec into a memory- and disk-cached ``ChipCallable``."""
     if cache_key in _compile_cache:
         return _compile_cache[cache_key]
 
@@ -1005,36 +1007,83 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
     pto_isa_root = ensure_pto_isa_root()
     kc = KernelCompiler(platform=platform)
     is_sim = platform.endswith("sim")
-
-    orch_binary = kc.compile_orchestration(runtime, orch["source"])
     inc_dirs = kc.get_orchestration_include_dirs(runtime)
-
-    kernel_binaries = []
+    orch_include_dirs, orch_sources = kc.get_orchestration_cache_inputs(runtime)
+    orch_units = [orch["source"], *orch_sources]
+    compilation_units: list[tuple[str | Path, list[str | Path]]] = [
+        (source, orch_include_dirs) for source in orch_units
+    ]
+    resolved_extra_dirs = []
     for k in incores:
-        signature = k.get("signature", [])
         extra = _resolve_incore_include_dirs(k["extra_include_dirs"], k) if k.get("extra_include_dirs") else []
-        incore = kc.compile_incore(
-            k["source"],
-            core_type=k["core_type"],
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=inc_dirs + extra,
-        )
-        if not is_sim:
-            incore = extract_text_section(incore)
-        kernel_binaries.append(
+        resolved_extra_dirs.append(extra)
+        compilation_units.append(
             (
-                k["func_id"],
-                CoreCallable.build(signature=signature, binary=incore),
+                k["source"],
+                [
+                    Path(pto_isa_root) / "include",
+                    Path(pto_isa_root) / "include" / "pto",
+                    *kc.get_incore_include_dirs(),
+                    *inc_dirs,
+                    *extra,
+                ],
             )
         )
-
-    chip_callable = ChipCallable.build(
-        signature=orch.get("signature", []),
-        func_name=orch["function_name"],
-        binary=orch_binary,
-        children=kernel_binaries,
-        config_name=orch.get("config_name", ""),
+    artifact_key = compile_artifact_key(
+        {
+            "cache_key": cache_key,
+            "platform": platform,
+            "runtime": runtime,
+            "host_platform": sys.platform,
+            "host_machine": host_platform.machine(),
+            "sanitizers": KernelCompiler._sanitizers,
+            "compiler": kc.compile_cache_token(runtime, [k["core_type"] for k in incores]),
+            "orchestration": {
+                "function_name": orch["function_name"],
+                "config_name": orch.get("config_name", ""),
+                "signature": orch.get("signature", []),
+            },
+            "incores": [
+                {
+                    "func_id": k["func_id"],
+                    "core_type": k["core_type"],
+                    "signature": k.get("signature", []),
+                }
+                for k in incores
+            ],
+        },
+        compilation_units,
     )
+
+    def compile_callable():
+        orch_binary = kc.compile_orchestration(runtime, orch["source"])
+        kernel_binaries = []
+        for k, extra in zip(incores, resolved_extra_dirs, strict=True):
+            signature = k.get("signature", [])
+            incore = kc.compile_incore(
+                k["source"],
+                core_type=k["core_type"],
+                pto_isa_root=pto_isa_root,
+                extra_include_dirs=inc_dirs + extra,
+            )
+            if not is_sim:
+                incore = extract_text_section(incore)
+            kernel_binaries.append(
+                (
+                    k["func_id"],
+                    CoreCallable.build(signature=signature, binary=incore),
+                )
+            )
+
+        return ChipCallable.build(
+            signature=orch.get("signature", []),
+            func_name=orch["function_name"],
+            binary=orch_binary,
+            children=kernel_binaries,
+            config_name=orch.get("config_name", ""),
+        )
+
+    chip_callable = get_or_compile(artifact_key, compile_callable)
     _compile_cache[cache_key] = chip_callable
     return chip_callable
 

--- a/simpler_setup/scene_test_cache.py
+++ b/simpler_setup/scene_test_cache.py
@@ -1,0 +1,355 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Persistent cache for compiled scene-test ``ChipCallable`` blobs."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+from .environment import PROJECT_ROOT
+
+logger = logging.getLogger(__name__)
+
+KERNEL_CACHE_DIR = PROJECT_ROOT / "build" / "cache" / "kernels"
+
+_CACHE_VERSION = 1
+_BINARY_FILE = "callable.bin"
+_MANIFEST_FILE = "manifest.json"
+_LOCK_DIR = ".locks"
+_INCLUDE_RE = re.compile(rb"^\s*#\s*include\s*([<\"])([^>\"]+)[>\"]", re.MULTILINE)
+
+# Entries are content-addressed, so a source change strands the old entry
+# forever. Every hit refreshes its mtime, so this window is time-since-last-use
+# and an entry still in service is never reclaimed regardless of its age.
+_ENTRY_RETENTION_S = 14 * 24 * 3600
+
+
+@cache
+def _chip_callable_abi_token() -> str:
+    """Return a fingerprint of the binding's serialized callable layout."""
+    from simpler.task_interface import ArgDirection, ChipCallable, CoreCallable  # noqa: PLC0415
+
+    child = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT],
+        binary=b"scene-test-cache-core-abi",
+    )
+    callable_obj = ChipCallable.build(
+        signature=[ArgDirection.INOUT],
+        func_name="scene_test_cache_abi",
+        binary=b"scene-test-cache-chip-abi",
+        children=[(17, child)],
+        config_name="scene_test_cache_config",
+    )
+    raw = ctypes.string_at(int(callable_obj.buffer_ptr()), int(callable_obj.buffer_size()))
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _stable_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _stable_value(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (list, tuple)):
+        return [_stable_value(item) for item in value]
+    enum_value = getattr(value, "value", None)
+    if isinstance(enum_value, (bool, int, float, str)):
+        return enum_value
+    raise TypeError(f"unsupported compile-cache key value: {type(value).__name__}")
+
+
+def _resolve_include(name: str, quoted: bool, including_file: Path, include_dirs: tuple[Path, ...]) -> Path | None:
+    candidates = ((including_file.parent,) if quoted else ()) + include_dirs
+    for directory in candidates:
+        candidate = directory / name
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+_scan_cache: dict[tuple[Path, int, int], tuple[bytes, tuple[tuple[str, bool], ...]]] = {}
+
+
+def _scan_source(path: Path) -> tuple[bytes, tuple[tuple[str, bool], ...]]:
+    """Return one file's digest and its ``#include`` directives as ``(name, quoted)``.
+
+    Memoized on ``(path, mtime_ns, size)`` because the compilation units of one
+    scene test share most of their include closure — the pto-isa headers alone
+    are reached from every incore — and both the read and the digest are
+    otherwise repeated once per unit.
+    """
+    try:
+        stat = path.stat()
+        token = (path, stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        token = None
+    if token is not None:
+        memoized = _scan_cache.get(token)
+        if memoized is not None:
+            return memoized
+
+    data = path.read_bytes()
+    directives = []
+    for match in _INCLUDE_RE.finditer(data):
+        delimiter, raw_name = match.groups()
+        try:
+            name = raw_name.decode()
+        except UnicodeDecodeError:
+            continue
+        directives.append((name, delimiter == b'"'))
+    scanned = (hashlib.sha256(data).digest(), tuple(directives))
+    if token is not None:
+        _scan_cache[token] = scanned
+    return scanned
+
+
+def _source_closure(
+    source: str | Path, include_dirs: Iterable[str | Path]
+) -> tuple[Path, dict[Path, bytes], list[tuple[Path, str, Path]]]:
+    """Return the root path, the digest of every file in its include closure, and the closure's edges.
+
+    The closure holds only includes that resolve within ``include_dirs`` — or,
+    for a quoted include, beside the including file — mirroring the search order
+    the compiler applies to the same ``-I`` list. Headers the toolchain supplies
+    from its own search path (ccec builtins, CANN headers under
+    ``ASCEND_HOME_PATH``) resolve outside that list and are absent from the key;
+    the compiler ``--version`` identity carried in the key metadata is what
+    covers those. ``#if`` conditions are not evaluated, so the closure is an
+    over-approximation of what any single build compiles.
+    """
+    roots = tuple(Path(directory).resolve() for directory in include_dirs if Path(directory).is_dir())
+    source_path = Path(source).resolve()
+    pending = [source_path]
+    files: dict[Path, bytes] = {}
+    edges = []
+    while pending:
+        path = pending.pop()
+        if path in files:
+            continue
+        file_digest, directives = _scan_source(path)
+        files[path] = file_digest
+        for name, quoted in directives:
+            dependency = _resolve_include(name, quoted, path, roots)
+            if dependency is not None:
+                edges.append((path, name, dependency))
+                if dependency not in files:
+                    pending.append(dependency)
+    return source_path, files, edges
+
+
+def compile_artifact_key(
+    metadata: Mapping[str, Any], compilation_units: Iterable[tuple[str | Path, Iterable[str | Path]]]
+) -> str:
+    """Return a content key for callable metadata and source include closures."""
+    digest = hashlib.sha256()
+    abi_token = _chip_callable_abi_token().encode()
+    digest.update(len(abi_token).to_bytes(8, "little"))
+    digest.update(abi_token)
+    encoded_metadata = json.dumps(_stable_value(metadata), sort_keys=True, separators=(",", ":")).encode()
+    digest.update(len(encoded_metadata).to_bytes(8, "little"))
+    digest.update(encoded_metadata)
+
+    for source, include_dirs in compilation_units:
+        source_path, file_digests, edges = _source_closure(source, include_dirs)
+        digest.update(b"unit")
+        digest.update(file_digests[source_path])
+        for file_digest in sorted(file_digests.values()):
+            digest.update(b"file")
+            digest.update(file_digest)
+        edge_records = sorted(
+            (file_digests[parent], name.encode(), file_digests[dependency]) for parent, name, dependency in edges
+        )
+        for parent_digest, name, dependency_digest in edge_records:
+            digest.update(b"edge")
+            digest.update(parent_digest)
+            digest.update(len(name).to_bytes(8, "little"))
+            digest.update(name)
+            digest.update(dependency_digest)
+    return digest.hexdigest()
+
+
+def _entry_paths(key: str) -> tuple[Path, Path, Path]:
+    entry = KERNEL_CACHE_DIR / key
+    return entry, entry / _BINARY_FILE, entry / _MANIFEST_FILE
+
+
+def _touch(key: str) -> None:
+    entry, _binary_path, _manifest_path = _entry_paths(key)
+    with contextlib.suppress(OSError):
+        os.utime(entry)
+
+
+def _load(key: str):
+    _entry, binary_path, manifest_path = _entry_paths(key)
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        raw = binary_path.read_bytes()
+    except (OSError, json.JSONDecodeError):
+        return None
+    if manifest != {
+        "version": _CACHE_VERSION,
+        "key": key,
+        "size": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }:
+        return None
+
+    from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+    try:
+        callable_obj = ChipCallable.from_bytes(raw)
+        callable_obj.buffer_size()
+    except (RuntimeError, ValueError):
+        return None
+    return callable_obj
+
+
+def _publish(key: str, callable_obj) -> None:
+    entry, binary_path, manifest_path = _entry_paths(key)
+    entry.mkdir(parents=True, exist_ok=True)
+    raw = ctypes.string_at(int(callable_obj.buffer_ptr()), int(callable_obj.buffer_size()))
+    manifest = {
+        "version": _CACHE_VERSION,
+        "key": key,
+        "size": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+    suffix = f".{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    binary_tmp = entry / f"{_BINARY_FILE}{suffix}"
+    manifest_tmp = entry / f"{_MANIFEST_FILE}{suffix}"
+    try:
+        binary_tmp.write_bytes(raw)
+        manifest_tmp.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        os.replace(binary_tmp, binary_path)
+        os.replace(manifest_tmp, manifest_path)
+    finally:
+        binary_tmp.unlink(missing_ok=True)
+        manifest_tmp.unlink(missing_ok=True)
+
+
+_pruned_dirs: set[Path] = set()
+
+
+def prune_stale_entries() -> int:
+    """Delete cache entries and lock files untouched for ``_ENTRY_RETENTION_S``.
+
+    Runs at most once per cache directory per process, after a publish has
+    already proved the directory writable. Returns the number of entries removed.
+    """
+    if KERNEL_CACHE_DIR in _pruned_dirs:
+        return 0
+    _pruned_dirs.add(KERNEL_CACHE_DIR)
+
+    cutoff = time.time() - _ENTRY_RETENTION_S
+    removed = 0
+    try:
+        entries = list(KERNEL_CACHE_DIR.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        if entry.name == _LOCK_DIR:
+            continue
+        try:
+            if entry.stat().st_mtime >= cutoff:
+                continue
+        except OSError:
+            continue
+        if entry.is_dir():
+            shutil.rmtree(entry, ignore_errors=True)
+        else:
+            with contextlib.suppress(OSError):
+                entry.unlink()
+        removed += 1
+
+    for lock_path in (KERNEL_CACHE_DIR / _LOCK_DIR).glob("*.lock"):
+        with contextlib.suppress(OSError):
+            if lock_path.stat().st_mtime < cutoff:
+                lock_path.unlink()
+    if removed:
+        logger.info("[SceneTestCache] pruned %d stale entr(ies) from %s", removed, KERNEL_CACHE_DIR)
+    return removed
+
+
+@contextlib.contextmanager
+def _entry_lock(key: str):
+    """Hold an exclusive lock for ``key``, or yield ``None`` when the cache directory is unusable.
+
+    A read-only install (a wheel whose ``PROJECT_ROOT`` is inside
+    ``site-packages``) or a filesystem without ``flock`` yields ``None``, which
+    degrades the caller to plain compilation instead of failing a scene test
+    that used to pass.
+    """
+    lock_file = None
+    try:
+        lock_dir = KERNEL_CACHE_DIR / _LOCK_DIR
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = (lock_dir / f"{key}.lock").open("w")
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+    except OSError as error:
+        if lock_file is not None:
+            lock_file.close()
+            lock_file = None
+        logger.warning(
+            "[SceneTestCache] disabled: %s is not usable (%s: %s); compiling without a cache",
+            KERNEL_CACHE_DIR,
+            type(error).__name__,
+            error,
+        )
+    try:
+        yield lock_file
+    finally:
+        if lock_file is not None:
+            lock_file.close()
+
+
+def get_or_compile(key: str, compile_fn: Callable[[], Any]):
+    """Load one ``ChipCallable`` or compile and atomically publish it."""
+    cached = _load(key)
+    if cached is not None:
+        _touch(key)
+        logger.info("[SceneTestCache] hit: %s", key[:12])
+        return cached
+
+    with _entry_lock(key) as lock_file:
+        if lock_file is None:
+            return compile_fn()
+        cached = _load(key)
+        if cached is not None:
+            _touch(key)
+            logger.info("[SceneTestCache] hit after wait: %s", key[:12])
+            return cached
+        logger.info("[SceneTestCache] miss: %s", key[:12])
+        callable_obj = compile_fn()
+        try:
+            _publish(key, callable_obj)
+        except OSError as error:
+            logger.warning(
+                "[SceneTestCache] publish failed for %s (%s: %s); artifact not cached",
+                key[:12],
+                type(error).__name__,
+                error,
+            )
+        else:
+            prune_stale_entries()
+        return callable_obj

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -1,6 +1,6 @@
-# Profiling & Debug Tools (shipped in the wheel)
+# Tools shipped in the wheel
 
-End-user CLIs for analyzing simpler profiling data and args dumps.
+End-user CLIs for preparing scene tests and analyzing profiling data or args dumps.
 All are invokable as Python modules once the `simpler` wheel is installed —
 no repo checkout required.
 
@@ -9,6 +9,7 @@ no repo checkout required.
 
 ## Tool list
 
+- **[scene_test_compile](#scene_test_compile)** — collect and compile selected Scene Test callables without an NPU
 - **[swimlane_converter](#swimlane_converter)** — perf JSON → Chrome Trace Event (Perfetto)
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
 - **[critical_path](#critical_path)** — chip swimlane critical-path compute/stall analysis
@@ -21,6 +22,29 @@ For CLIs that allow an omitted input, auto-detection paths
 relative to the **current working directory** — run these from the directory
 that holds your `outputs/`. Each test case writes into its own
 `outputs/<case>_<ts>/` directory; those tools auto-pick the latest by mtime.
+
+---
+
+## scene_test_compile
+
+Populate the persistent Scene Test kernel cache without creating a `Worker` or
+accessing an NPU. Arguments after the module name are passed to pytest
+collection, so the warm-up can use the same paths and selection filters as the
+later device run.
+
+```bash
+python -m simpler_setup.tools.scene_test_compile examples tests/st \
+    -m "not sdma" --platform a2a3 --require-pto-isa --compile-workers 8
+```
+
+Compiled `ChipCallable` blobs are stored under `build/cache/kernels/`. A normal
+pytest or standalone scene-test run loads a matching blob from that directory;
+source, transitive-include, compiler, or compilation-logic changes produce a
+different content key, and entries unused for 14 days are pruned. Cache misses
+compile serially by default; pass `--compile-workers N` to opt into compiling
+up to `N` test classes concurrently, one compiler process per worker. A class
+that fails to compile is reported without aborting the rest of the pass. The
+warm-up does not inspect or access NPU devices.
 
 ---
 

--- a/simpler_setup/tools/scene_test_compile.py
+++ b/simpler_setup/tools/scene_test_compile.py
@@ -1,0 +1,126 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Compile selected scene-test callables without creating a device worker."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+
+try:
+    from _pytest.skipping import evaluate_skip_marks
+except ImportError:
+    evaluate_skip_marks = None
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COMPILE_WORKERS = 1
+
+
+def _is_skipped(item) -> bool:
+    """Report whether pytest already knows it will skip ``item``.
+
+    ``evaluate_skip_marks`` is pytest-internal and absent on a pytest whose
+    layout has moved; the warm-up then compiles the skipped class too, which
+    costs compile time but cannot change what the later pytest run does.
+    """
+    if evaluate_skip_marks is None:
+        return False
+    return evaluate_skip_marks(item) is not None
+
+
+def _compile_scene_test_class(cls, platform: str) -> None:
+    if cls._st_level == 2:
+        cls.compile_chip_callable(platform)
+    elif cls._st_level == 3:
+        cls._compile_l3_callables(platform)
+
+
+def compile_collected_scene_tests(
+    items, platform: str, *, max_workers: int = _DEFAULT_COMPILE_WORKERS
+) -> tuple[int, list[tuple[str, Exception]]]:
+    """Compile each non-skipped scene-test class represented by ``items``.
+
+    Returns ``(compiled_count, failures)`` with one ``(class_name, error)`` per
+    class that raised. A compilation error is reported rather than propagated
+    because this pass only populates a cache: the pytest run that follows
+    recompiles what is missing and attributes the error to the case it belongs
+    to, so one unbuildable kernel does not cost the whole batch its results.
+    """
+    selected_classes = []
+    seen_classes = set()
+    for item in items:
+        cls = getattr(item, "cls", None)
+        if cls is None or cls in seen_classes or not hasattr(cls, "_st_level"):
+            continue
+        if _is_skipped(item):
+            continue
+        if cls._st_level not in (2, 3):
+            continue
+        seen_classes.add(cls)
+        selected_classes.append(cls)
+
+    def compile_one(cls) -> tuple[str, Exception] | None:
+        try:
+            _compile_scene_test_class(cls, platform)
+        except Exception as error:
+            logger.warning("[SceneTestCompile] %s failed to compile: %r", cls.__name__, error)
+            return (cls.__name__, error)
+        return None
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        results = list(executor.map(compile_one, selected_classes))
+    failures = [result for result in results if result is not None]
+    return len(selected_classes) - len(failures), failures
+
+
+class _CompilePlugin:
+    def pytest_addoption(self, parser):
+        group = parser.getgroup("scene-test compilation")
+        group.addoption(
+            "--compile-workers",
+            action="store",
+            type=int,
+            default=_DEFAULT_COMPILE_WORKERS,
+            help="Maximum concurrent SceneTestCase compilations (default: 1)",
+        )
+
+    def pytest_collection_finish(self, session):
+        platform = session.config.getoption("--platform")
+        if not platform:
+            import pytest  # noqa: PLC0415
+
+            raise pytest.UsageError("--platform is required for scene-test compilation")
+        max_workers = session.config.getoption("--compile-workers")
+        if max_workers < 1:
+            import pytest  # noqa: PLC0415
+
+            raise pytest.UsageError("--compile-workers must be at least 1")
+        count, failures = compile_collected_scene_tests(session.items, platform, max_workers=max_workers)
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is not None:
+            reporter.write_line(f"compiled scene-test cache for {count} class(es)")
+            for name, error in failures:
+                reporter.write_line(f"::warning::scene-test cache warm-up failed for {name}: {error!r}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run pytest collection and populate the persistent scene-test cache."""
+    import pytest  # noqa: PLC0415
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if "--collect-only" not in args:
+        args.append("--collect-only")
+    return int(pytest.main(args, plugins=[_CompilePlugin()]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ut/py/test_scene_test_cache.py
+++ b/tests/ut/py/test_scene_test_cache.py
@@ -21,15 +21,23 @@ instances die while the extension is still live.
 from __future__ import annotations
 
 import importlib
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier, Lock
 
+import pytest
 from _task_interface import ArgDirection, ChipCallable  # pyright: ignore[reportMissingImports]
 
 # ``simpler_setup/__init__.py`` re-exports the ``scene_test`` *decorator*,
 # which shadows the submodule attribute when accessed via ``simpler_setup``.
 # Importing the names directly from the submodule avoids that ambiguity.
+from simpler_setup import scene_test_cache
 from simpler_setup.scene_test import (
     SceneTestCase,
     _compile_cache,
+    _compile_chip_callable_from_spec,
     _pto_isa_compile_cache_token,
     clear_compile_cache,
     l3_compile_cache_key,
@@ -95,3 +103,271 @@ def test_compile_cache_keys_include_module(monkeypatch):
     assert l3_compile_cache_key("tests.first", "TestScene", "child", "a5", "a5") != l3_compile_cache_key(
         "tests.second", "TestScene", "child", "a5", "a5"
     )
+
+
+class _FakeKernelCompiler:
+    _sanitizers = ""
+    cache_schema = 1
+    orchestration_compiles = 0
+    incore_compiles = 0
+
+    def __init__(self, platform):
+        self.platform = platform
+
+    def get_orchestration_include_dirs(self, runtime):
+        return []
+
+    def get_incore_include_dirs(self):
+        return []
+
+    def get_orchestration_cache_inputs(self, runtime):
+        return [], []
+
+    def compile_cache_token(self, runtime, core_types):
+        return {"schema": self.cache_schema}
+
+    def compile_orchestration(self, runtime, source):
+        type(self).orchestration_compiles += 1
+        return Path(source).read_bytes()
+
+    def compile_incore(self, source, **kwargs):
+        type(self).incore_compiles += 1
+        return Path(source).read_bytes()
+
+
+def _cacheable_spec(tmp_path):
+    header = tmp_path / "shared.h"
+    header.write_text("constexpr int VALUE = 1;\n")
+    orchestration = tmp_path / "orchestration.cpp"
+    orchestration.write_text('#include "shared.h"\nextern "C" void orchestration() {}\n')
+    incore = tmp_path / "kernel.cpp"
+    incore.write_text('#include "shared.h"\nextern "C" void kernel_entry() {}\n')
+    spec = {
+        "orchestration": {
+            "source": str(orchestration),
+            "function_name": "orchestration",
+            "signature": [ArgDirection.IN],
+        },
+        "incores": [
+            {
+                "source": str(incore),
+                "func_id": 0,
+                "core_type": "aiv",
+                "signature": [ArgDirection.IN],
+                "extra_include_dirs": [str(tmp_path)],
+            }
+        ],
+    }
+    return spec, header
+
+
+def _configure_fake_compilation(monkeypatch, tmp_path):
+    pto_isa_root = tmp_path / "pto-isa"
+    (pto_isa_root / "include" / "pto").mkdir(parents=True)
+    monkeypatch.setattr("simpler_setup.kernel_compiler.KernelCompiler", _FakeKernelCompiler)
+    monkeypatch.setattr("simpler_setup.pto_isa.ensure_pto_isa_root", lambda: str(pto_isa_root))
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", tmp_path / "cache")
+    _FakeKernelCompiler.cache_schema = 1
+    _FakeKernelCompiler.orchestration_compiles = 0
+    _FakeKernelCompiler.incore_compiles = 0
+    clear_compile_cache()
+
+
+def test_compile_cache_survives_session_cache_clear(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    first = _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    assert _FakeKernelCompiler.orchestration_compiles == 1
+    assert _FakeKernelCompiler.incore_compiles == 1
+
+    clear_compile_cache()
+    second = _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 1
+    assert _FakeKernelCompiler.incore_compiles == 1
+    assert second.func_name == first.func_name
+    assert second.binary_size == first.binary_size
+    assert second.child_count == first.child_count
+
+
+def test_compile_cache_invalidates_transitive_include(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    clear_compile_cache()
+    header.write_text("constexpr int VALUE = 2;\n")
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 2
+
+
+def test_compile_cache_invalidates_compiler_schema(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    _FakeKernelCompiler.cache_schema = 1
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    clear_compile_cache()
+    _FakeKernelCompiler.cache_schema = 2
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 2
+
+
+def test_compile_cache_rebuilds_incomplete_entry(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    binary_path = next((tmp_path / "cache").glob("*/callable.bin"))
+    binary_path.write_bytes(b"incomplete")
+    clear_compile_cache()
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 2
+
+
+def test_compile_artifact_key_is_independent_of_checkout_path(tmp_path):
+    keys = []
+    for root_name in ("runner-a", "runner-b"):
+        root = tmp_path / root_name
+        root.mkdir()
+        (root / "shared.h").write_text("constexpr int VALUE = 1;\n")
+        source = root / "kernel.cpp"
+        source.write_text('#include "shared.h"\nextern "C" void kernel_entry() {}\n')
+        keys.append(scene_test_cache.compile_artifact_key({"platform": "a2a3"}, [(source, [root])]))
+
+    assert keys[0] == keys[1]
+
+
+def test_compile_artifact_key_includes_callable_abi(monkeypatch, tmp_path):
+    source = tmp_path / "kernel.cpp"
+    source.write_text('extern "C" void kernel_entry() {}\n')
+
+    monkeypatch.setattr(scene_test_cache, "_chip_callable_abi_token", lambda: "abi-a")
+    first = scene_test_cache.compile_artifact_key({}, [(source, [])])
+    monkeypatch.setattr(scene_test_cache, "_chip_callable_abi_token", lambda: "abi-b")
+    second = scene_test_cache.compile_artifact_key({}, [(source, [])])
+
+    assert first != second
+
+
+def test_concurrent_cache_misses_compile_once(monkeypatch, tmp_path):
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", tmp_path / "cache")
+    start = Barrier(2)
+    count_lock = Lock()
+    compile_count = 0
+
+    def compile_callable():
+        nonlocal compile_count
+        with count_lock:
+            compile_count += 1
+        return _build_chip_callable("shared")
+
+    def load_or_compile():
+        start.wait()
+        return scene_test_cache.get_or_compile("a" * 64, compile_callable)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        callables = list(executor.map(lambda _: load_or_compile(), range(2)))
+
+    assert compile_count == 1
+    assert [callable_obj.func_name for callable_obj in callables] == ["shared", "shared"]
+
+
+def test_artifact_logic_token_covers_the_compilation_modules(monkeypatch):
+    from simpler_setup import kernel_compiler
+
+    assert set(kernel_compiler._ARTIFACT_LOGIC_MODULES) == {"kernel_compiler.py", "toolchain.py", "elf_parser.py"}
+
+    def token_over(modules):
+        monkeypatch.setattr(kernel_compiler, "_ARTIFACT_LOGIC_MODULES", modules)
+        kernel_compiler._artifact_logic_token.cache_clear()
+        return kernel_compiler._artifact_logic_token()
+
+    over_compiler = token_over(("kernel_compiler.py",))
+    over_toolchain = token_over(("toolchain.py",))
+    over_both = token_over(("kernel_compiler.py", "toolchain.py"))
+    kernel_compiler._artifact_logic_token.cache_clear()
+
+    assert len({over_compiler, over_toolchain, over_both}) == 3
+
+
+def test_publish_prunes_entries_past_the_retention_window(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", cache_dir)
+
+    stale = cache_dir / ("b" * 64)
+    stale.mkdir(parents=True)
+    (stale / "callable.bin").write_bytes(b"stale")
+    stale_lock = cache_dir / ".locks" / "old.lock"
+    stale_lock.parent.mkdir(parents=True)
+    stale_lock.write_text("")
+    expired = time.time() - scene_test_cache._ENTRY_RETENTION_S - 60
+    for path in (stale, stale_lock):
+        os.utime(path, (expired, expired))
+
+    scene_test_cache.get_or_compile("c" * 64, lambda: _build_chip_callable("fresh"))
+
+    assert not stale.exists()
+    assert not stale_lock.exists()
+    assert (cache_dir / ("c" * 64) / "callable.bin").is_file()
+
+
+def test_cache_hit_refreshes_entry_mtime(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", cache_dir)
+
+    key = "d" * 64
+    scene_test_cache.get_or_compile(key, lambda: _build_chip_callable("kept"))
+    entry = cache_dir / key
+    aged = time.time() - scene_test_cache._ENTRY_RETENTION_S - 60
+    os.utime(entry, (aged, aged))
+
+    scene_test_cache.get_or_compile(key, lambda: pytest.fail("cached entry should not recompile"))
+
+    assert entry.stat().st_mtime > aged
+
+
+def test_unwritable_cache_dir_falls_back_to_plain_compilation(monkeypatch, tmp_path):
+    read_only = tmp_path / "read-only"
+    read_only.mkdir(mode=0o500)
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", read_only / "kernels")
+
+    compiled = scene_test_cache.get_or_compile("e" * 64, lambda: _build_chip_callable("uncached"))
+
+    assert compiled.func_name == "uncached"
+    assert not (read_only / "kernels").exists()
+
+
+def test_source_scan_is_memoized_per_file(monkeypatch, tmp_path):
+    scene_test_cache._scan_cache.clear()
+    header = tmp_path / "shared.h"
+    header.write_text("constexpr int VALUE = 1;\n")
+    sources = []
+    for index in range(3):
+        source = tmp_path / f"kernel{index}.cpp"
+        source.write_text(f'#include "shared.h"\nextern "C" void kernel_entry{index}() {{}}\n')
+        sources.append((source, [tmp_path]))
+
+    reads = []
+    original_read_bytes = Path.read_bytes
+
+    def counting_read_bytes(self):
+        reads.append(self)
+        return original_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+    scene_test_cache.compile_artifact_key({}, sources)
+
+    assert reads.count(header.resolve()) == 1
+    assert len(reads) == 4

--- a/tests/ut/py/test_scene_test_compile.py
+++ b/tests/ut/py/test_scene_test_compile.py
@@ -1,0 +1,218 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from threading import Barrier
+
+import pytest
+
+from simpler_setup.tools import scene_test_compile
+
+
+class _Item:
+    def __init__(self, cls, markers=()):
+        self.cls = cls
+        self._markers = markers
+
+    def iter_markers(self, name=None):
+        return (marker for marker in self._markers if name is None or marker.name == name)
+
+
+def test_compile_collected_scene_tests_deduplicates_classes_and_skips_marked_items():
+    calls = []
+
+    class L2:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            calls.append((cls.__name__, platform))
+
+    class L3:
+        _st_level = 3
+
+        @classmethod
+        def _compile_l3_callables(cls, platform):
+            calls.append((cls.__name__, platform))
+
+    class Skipped:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            calls.append((cls.__name__, platform))
+
+    count, failures = scene_test_compile.compile_collected_scene_tests(
+        [
+            _Item(L2),
+            _Item(L2),
+            _Item(L3),
+            _Item(Skipped, [pytest.mark.skip(reason="not selected").mark]),
+            _Item(None),
+        ],
+        "a2a3",
+    )
+
+    assert count == 2
+    assert failures == []
+    assert set(calls) == {("L2", "a2a3"), ("L3", "a2a3")}
+
+
+def test_compile_collected_scene_tests_evaluates_skipif():
+    calls = []
+
+    class ActiveSkip:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            calls.append(cls.__name__)
+
+    class InactiveSkip:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            calls.append(cls.__name__)
+
+    count, failures = scene_test_compile.compile_collected_scene_tests(
+        [
+            _Item(ActiveSkip, [pytest.mark.skipif(True, reason="active").mark]),
+            _Item(InactiveSkip, [pytest.mark.skipif(False, reason="inactive").mark]),
+        ],
+        "a2a3",
+    )
+
+    assert count == 1
+    assert failures == []
+    assert calls == ["InactiveSkip"]
+
+
+def test_compile_collected_scene_tests_runs_classes_concurrently():
+    started = Barrier(2, timeout=1)
+
+    class First:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            started.wait()
+
+    class Second:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            started.wait()
+
+    assert scene_test_compile.compile_collected_scene_tests([_Item(First), _Item(Second)], "a2a3", max_workers=2) == (
+        2,
+        [],
+    )
+
+
+@pytest.mark.parametrize(("max_workers", "expected"), [(None, 1), (8, 8)])
+def test_compile_collected_scene_tests_uses_configured_workers(monkeypatch, max_workers, expected):
+    captured = {}
+
+    class RecordingExecutor:
+        def __init__(self, max_workers):
+            captured["max_workers"] = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def map(self, fn, values):
+            return map(fn, values)
+
+    class Scene:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            return None
+
+    monkeypatch.setattr(scene_test_compile, "ThreadPoolExecutor", RecordingExecutor, raising=False)
+
+    kwargs = {} if max_workers is None else {"max_workers": max_workers}
+    assert scene_test_compile.compile_collected_scene_tests([_Item(Scene)], "a2a3", **kwargs) == (1, [])
+    assert captured == {"max_workers": expected}
+
+
+def test_compile_collected_scene_tests_reports_failures_without_raising():
+    compiled = []
+
+    class Broken:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            raise RuntimeError("ccec exploded")
+
+    class Healthy:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            compiled.append(cls.__name__)
+
+    count, failures = scene_test_compile.compile_collected_scene_tests([_Item(Broken), _Item(Healthy)], "a2a3")
+
+    assert count == 1
+    assert compiled == ["Healthy"]
+    assert [name for name, _error in failures] == ["Broken"]
+    assert isinstance(failures[0][1], RuntimeError)
+
+
+def test_compile_collected_scene_tests_without_pytest_skip_helper(monkeypatch):
+    calls = []
+
+    class Skipped:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            calls.append(cls.__name__)
+
+    monkeypatch.setattr(scene_test_compile, "evaluate_skip_marks", None)
+
+    count, failures = scene_test_compile.compile_collected_scene_tests(
+        [_Item(Skipped, [pytest.mark.skip(reason="ignored without the helper").mark])],
+        "a2a3",
+    )
+
+    assert (count, failures, calls) == (1, [], ["Skipped"])
+
+
+def test_main_runs_pytest_collection_only(monkeypatch):
+    captured = {}
+
+    def fake_pytest_main(args, plugins):
+        captured["args"] = args
+        captured["plugins"] = plugins
+        return 0
+
+    monkeypatch.setattr("pytest.main", fake_pytest_main)
+
+    result = scene_test_compile.main(["examples", "-m", "not sdma", "--platform", "a2a3"])
+
+    assert result == 0
+    assert captured["args"] == [
+        "examples",
+        "-m",
+        "not sdma",
+        "--platform",
+        "a2a3",
+        "--collect-only",
+    ]
+    assert len(captured["plugins"]) == 1


### PR DESCRIPTION
## Summary

- persist content-addressed `ChipCallable` artifacts under `build/cache/kernels`, with source/include-closure, compiler identity/flags/schema, and ABI invalidation, plus integrity validation, atomic publication, and per-key locking
- add a collection-only scene-test compile command that defaults to serial compilation; simpler CI explicitly uses `--compile-workers 8` before `task-submit` without acquiring an NPU
- restore and save kernel artifacts with `actions/cache`, while keeping the existing batch-level device acquisition and separate SDMA execution
- honor active pytest skip conditions and cover cache reuse, invalidation, corruption, concurrency, and configurable warm-up parallelism

## Lock-boundary measurement

`qwen3_14b_decode::StressBatch16Seq3500` on a2a3, with both device jobs acquiring immediately:

| Path | Lock-free warm-up | `task-submit` wall | Total wall |
| --- | ---: | ---: | ---: |
| baseline: full pytest under lock | — | 131.62 s | 131.62 s |
| current: cold cache | 80.16 s | 54.20 s | 134.36 s |
| current: warm cache | 17.23 s | 54.20 s | 71.43 s |

The cold-cache path moves compilation out of the device allocation rather than shortening first-run wall time. Device-lock wall falls by 77.42 s (58.8%); restored caches also reduce total wall time.

Fixture construction and golden computation remain inside the locked pytest invocation and are intentionally outside this PR's scope.

## Testing

- full Python UT: 1076 passed, 19 skipped, 1 xfailed
- focused cache/warm-up UT after rebase: 15 passed
- local a2a3sim cold-cache warm-up repeated successfully; a full eight-class run observed eight concurrent compiler child processes
- real CLI validation covered `--compile-workers 8` and rejection of zero workers
- all commit hooks passed: headers, English-only, YAML, Markdown, Ruff, and Pyright
- a2a3 onboard `qwen3_14b_decode::StressBatch16Seq3500`: baseline, cold warm-up, cached device run, and hot warm-up all passed

Close #1604