### PR TITLE
Refactor: move comm-domain demos to scene tests

### DIFF
--- a/docs/capability-survey.md
+++ b/docs/capability-survey.md
@@ -217,7 +217,7 @@ values yield `PTO2_ERROR_ASYNC_COMPLETION_INVALID`.
 
 | Engine | a2a3 | a5 | Status |
 | ------ | ---- | -- | ------ |
-| COUNTER (default) | registered | registered | **Shipped** — `async_notify_demo` runs onboard on both arches and `deferred_notify_demo` runs in sim on both, through the `st-onboard-*` / `st-sim-*` jobs in `ci.yml`. Routed by `@pytest.mark.platforms`, no `skipif` |
+| COUNTER (default) | registered | registered | **Shipped** — `async_notify_demo` runs onboard on both arches and `deferred_notify_demo` runs in sim on both, through the `st-onboard-*` / `st-sim-*` jobs in `ci.yml`. Routed by `CASES[*]["platforms"]`, no `skipif` |
 | SDMA | build macro forced ON; runtime opt-in | `option(... OFF)` | a2a3 **Shipped** (the "SDMA pytest (a2a3)" step in `ci.yml`); a5 not built |
 | URMA | absent | full implementation | **Gated** — see below |
 | ROCE, CCU | enum only | enum only | **Name only** |

--- a/examples/a2a3/tensormap_and_ringbuffer/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/README.md
@@ -39,6 +39,10 @@ completion rather than on task end. All but `deferred_notify_demo`, which runs
 the simulator path, are **onboard-only**; every one except `prefetch_async_demo`
 needs two dies.
 
+These mechanism-focused examples use the scene-test lifecycle. For a complete
+direct `Worker` communication-domain walkthrough from construction through
+`close()`, see [`examples/workers/l3/allreduce/`](../../workers/l3/allreduce/).
+
 | Example | Mechanism | Devices |
 | ------- | --------- | ------- |
 | [`prefetch_async_demo/`](prefetch_async_demo/) | `TPREFETCH_ASYNC` over the runtime-injected SDMA workspace, provisioned once by `Worker(enable_sdma=True)` and injected into every kernel's `GlobalContext`. | 1 |

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -7,173 +7,106 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Notification counter + deferred completion smoke test for onboard a2a3."""
+"""Notification counter and deferred-completion smoke test for onboard a2a3."""
 
-from __future__ import annotations
-
-import argparse
-import os
-
-import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 
 
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
-
-
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel in [
-        (0, "kernels/aiv/kernel_producer_notify.cpp"),
-        (1, "kernels/aiv/kernel_consumer.cpp"),
-        (2, "kernels/aiv/kernel_notify_wait.cpp"),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
-        )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append(
-            (
-                func_id,
-                CoreCallable.build(
-                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-                    binary=kernel,
+def async_notify_orch_fn(orch, callables, task_args, config):
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(NRANKS)),
+        window_size=4 * 1024,
+        buffers=[CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+    ) as handle:
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"in_{rank}")), TensorArgType.INPUT)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"out_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["notify_counter"],
+                    shapes=(1,),
+                    dtype=DataType.INT32,
+                    child_memory=True,
                 ),
+                TensorArgType.INPUT,
             )
-        )
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/async_notify_orchestration.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="async_notify_orchestration",
-        binary=orch,
-        children=children,
-    )
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.async_notify, args, config, worker=rank)
 
 
-def run(
-    platform: str = "a2a3",
-    device_ids: list[int] | None = None,
-) -> int:
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"async_notify_demo needs exactly 2 devices, got {device_ids}")
-
-    inp = [
-        torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
-        for _ in range(nranks)
-    ]
-    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-    )
-    chip_handle = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            with orch.allocate_domain(
-                name="default",
-                workers=list(range(nranks)),
-                window_size=4 * 1024,
-                buffers=[CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
-            ) as handle:
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(make_tensor_arg(inp[rank]), TensorArgType.INPUT)
-                    args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["notify_counter"],
-                            shapes=(1,),
-                            dtype=DataType.INT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestAsyncNotifyDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": async_notify_orch_fn,
+        "callables": [
+            {
+                "name": "async_notify",
+                "orchestration": {
+                    "source": "kernels/orchestration/async_notify_orchestration.cpp",
+                    "function_name": "async_notify_orchestration",
+                    "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": func_id,
+                        "source": source,
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                    }
+                    for func_id, source in enumerate(
+                        [
+                            "kernels/aiv/kernel_producer_notify.cpp",
+                            "kernels/aiv/kernel_consumer.cpp",
+                            "kernels/aiv/kernel_notify_wait.cpp",
+                        ]
                     )
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_handle, args, cfg, worker=rank)
+                ],
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "notification_counter",
+            "platforms": ["a2a3"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-3
 
-        worker.run(orch_fn, args=None, config=CallConfig())
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            inp = torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32)
+            specs.extend(
+                [
+                    Tensor(f"in_{rank}", inp),
+                    Tensor(f"out_{rank}", torch.zeros(N, dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-        ok = True
-        for rank in range(nranks):
-            expected_out = inp[rank] * 2.0
-            expected_result = expected_out + 1.0
-            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
-            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
-            print(f"[async_notify_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
-            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
-        return 0 if ok else 1
-    finally:
-        worker.close()
-
-
-@pytest.mark.platforms(["a2a3"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
-def test_async_notify_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a2a3")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            expected_out = getattr(args, f"in_{rank}") * 2.0
+            getattr(args, f"out_{rank}").copy_(expected_out)
+            getattr(args, f"result_{rank}").copy_(expected_out + 1.0)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -7,185 +7,115 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""L2 deferred completion + two-chip comm smoke test for a2a3, onboard and sim."""
+"""Deferred-completion and two-chip communication smoke test for a2a3."""
 
-from __future__ import annotations
-
-import argparse
-import os
-
-import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 DTYPE_NBYTES = 4
 
 
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
-
-
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel in [
-        (0, "kernels/aiv/kernel_producer.cpp"),
-        (1, "kernels/aiv/kernel_consumer.cpp"),
-        (2, "kernels/aiv/kernel_notify_wait.cpp"),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
-        )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append(
-            (
-                func_id,
-                CoreCallable.build(
-                    signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
-                    binary=kernel,
-                ),
-            )
-        )
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/deferred_notify_orch.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="deferred_notify_orchestration",
-        binary=orch,
-        children=children,
-    )
-
-
-def run(
-    platform: str = "a2a3sim",
-    device_ids: list[int] | None = None,
-) -> int:
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"deferred_notify_demo needs exactly 2 devices, got {device_ids}")
-
+def deferred_notify_orch_fn(orch, callables, task_args, config):
     mailbox_nbytes = N * DTYPE_NBYTES
-    counter_nbytes = 4
-    window_size = max(mailbox_nbytes + counter_nbytes, 4 * 1024)
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(NRANKS)),
+        window_size=max(mailbox_nbytes + DTYPE_NBYTES, 4 * 1024),
+        buffers=[
+            CommBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+            CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=DTYPE_NBYTES),
+        ],
+    ) as handle:
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"partial_{rank}")), TensorArgType.INPUT)
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["mailbox"],
+                    shapes=(N,),
+                    dtype=DataType.FLOAT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INOUT,
+            )
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["notify_counter"],
+                    shapes=(1,),
+                    dtype=DataType.INT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INPUT,
+            )
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.deferred_notify, args, config, worker=rank)
 
-    partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-    )
-    chip_handle = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            # `notify_counter` must start at 0; allocate_domain zero-initializes
-            # the whole window, so no explicit host seed is needed.
-            with orch.allocate_domain(
-                name="default",
-                workers=list(range(nranks)),
-                window_size=window_size,
-                buffers=[
-                    CommBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                    CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=counter_nbytes),
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestDeferredNotifyDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": deferred_notify_orch_fn,
+        "callables": [
+            {
+                "name": "deferred_notify",
+                "orchestration": {
+                    "source": "kernels/orchestration/deferred_notify_orch.cpp",
+                    "function_name": "deferred_notify_orchestration",
+                    "signature": [D.IN, D.INOUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": func_id,
+                        "source": source,
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.INOUT, D.OUT, D.IN],
+                    }
+                    for func_id, source in enumerate(
+                        [
+                            "kernels/aiv/kernel_producer.cpp",
+                            "kernels/aiv/kernel_consumer.cpp",
+                            "kernels/aiv/kernel_notify_wait.cpp",
+                        ]
+                    )
                 ],
-            ) as handle:
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(make_tensor_arg(partial[rank]), TensorArgType.INPUT)
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["mailbox"],
-                            shapes=(N,),
-                            dtype=DataType.FLOAT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INOUT,
-                    )
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["notify_counter"],
-                            shapes=(1,),
-                            dtype=DataType.INT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
-                    )
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_handle, args, cfg, worker=rank)
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "peer_notification",
+            "platforms": ["a2a3", "a2a3sim"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-6
 
-        worker.run(orch_fn, args=None, config=CallConfig())
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            specs.extend(
+                [
+                    Tensor(f"partial_{rank}", torch.full((N,), float(rank + 1), dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-        ok = True
-        for rank in range(nranks):
-            expected = partial[(rank + 1) % nranks]
-            max_diff = float(torch.max(torch.abs(result[rank] - expected)))
-            print(f"[deferred_notify_demo] rank {rank}: max_diff={max_diff:.3e}")
-            ok = ok and max_diff <= 1e-6
-        return 0 if ok else 1
-    finally:
-        worker.close()
-
-
-@pytest.mark.platforms(["a2a3", "a2a3sim"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
-def test_deferred_notify_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a2a3sim")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            getattr(args, f"result_{rank}").copy_(getattr(args, f"partial_{(rank + 1) % NRANKS}"))
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -7,203 +7,120 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""SDMA deferred completion smoke test for onboard a2a3.
+"""SDMA deferred-completion smoke test for onboard a2a3.
 
-Each rank stages its input inside the HCCL window.  The deferred producer
-TGET_ASYNCs the peer rank's input into local ``out`` and registers the PTO
-AsyncEvent through ``defer_pto_async_event``.  The consumer depends on the
-producer output and writes ``result = out + 1``.  Correct ``out`` and
-``result`` therefore validate both the SDMA completion polling and the
-deferred-release dependency path.
+Each rank stages its input inside the HCCL window. The deferred producer fetches
+the peer rank's input into local ``out`` and registers its async event. The
+consumer depends on that output and writes ``result = out + 1``.
 """
-
-from __future__ import annotations
-
-import argparse
-import os
 
 import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 DTYPE_NBYTES = 4
 
 
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
-
-
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel in [
-        (0, "kernels/aiv/kernel_sdma_tget_async.cpp"),
-        (1, "kernels/aiv/kernel_consumer.cpp"),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
-        )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append(
-            (
-                func_id,
-                CoreCallable.build(
-                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-                    binary=kernel,
-                ),
-            )
-        )
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/sdma_async_completion_orch.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="sdma_async_completion_orchestration",
-        binary=orch,
-        children=children,
-    )
-
-
-def run(
-    platform: str = "a2a3",
-    device_ids: list[int] | None = None,
-) -> int:
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"sdma_async_completion_demo needs exactly 2 devices, got {device_ids}")
-    if platform.endswith("sim"):
-        raise ValueError("sdma_async_completion_demo requires onboard a2a3 hardware")
-
+def sdma_async_completion_orch_fn(orch, callables, task_args, config):
     input_nbytes = N * DTYPE_NBYTES
-    window_size = max(input_nbytes, 4 * 1024)
-
-    # `inputs` must live in shared memory: `orch.copy_to` stages each rank's
-    # data into its HCCL window from the forked chip child, which reads `src`
-    # out of its own address space.
-    inputs = [
-        torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
-        for rank in range(nranks)
-    ]
-    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-        enable_sdma=True,
-    )
-    chip_handle = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            with orch.allocate_domain(
-                name="default",
-                workers=list(range(nranks)),
-                window_size=window_size,
-                buffers=[
-                    CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes),
-                ],
-            ) as handle:
-                # Stage every rank's input window before submitting any kernel:
-                # each producer TGET_ASYNCs the *peer* rank's window, so all
-                # windows must hold real data before execution begins.
-                for rank in range(nranks):
-                    orch.copy_to(
-                        rank,
-                        dst=handle[rank].buffer_ptrs["input_window"],
-                        src=inputs[rank].data_ptr(),
-                        size=input_nbytes,
-                    )
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["input_window"],
-                            shapes=(N,),
-                            dtype=DataType.FLOAT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
-                    )
-                    args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_handle, args, cfg, worker=rank)
-
-        worker.run(orch_fn, args=None, config=CallConfig())
-
-        ok = True
-        for rank in range(nranks):
-            peer = 1 - rank
-            expected_out = inputs[peer]
-            expected_result = expected_out + 1.0
-            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
-            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
-            print(f"[sdma_async_completion_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
-            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
-        return 0 if ok else 1
-    finally:
-        worker.close()
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(NRANKS)),
+        window_size=max(input_nbytes, 4 * 1024),
+        buffers=[CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes)],
+    ) as handle:
+        for rank in range(NRANKS):
+            orch.copy_to(
+                rank,
+                dst=handle[rank].buffer_ptrs["input_window"],
+                src=getattr(task_args, f"in_{rank}").data_ptr(),
+                size=input_nbytes,
+            )
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["input_window"],
+                    shapes=(N,),
+                    dtype=DataType.FLOAT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INPUT,
+            )
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"out_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.sdma_async_completion, args, config, worker=rank)
 
 
 @pytest.mark.sdma
-@pytest.mark.platforms(["a2a3"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
-def test_sdma_async_completion_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestSdmaAsyncCompletionDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": sdma_async_completion_orch_fn,
+        "callables": [
+            {
+                "name": "sdma_async_completion",
+                "orchestration": {
+                    "source": "kernels/orchestration/sdma_async_completion_orch.cpp",
+                    "function_name": "sdma_async_completion_orchestration",
+                    "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": func_id,
+                        "source": source,
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                    }
+                    for func_id, source in enumerate(
+                        [
+                            "kernels/aiv/kernel_sdma_tget_async.cpp",
+                            "kernels/aiv/kernel_consumer.cpp",
+                        ]
+                    )
+                ],
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "peer_fetch",
+            "platforms": ["a2a3"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-3
 
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            inp = torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32)
+            specs.extend(
+                [
+                    Tensor(f"in_{rank}", inp),
+                    Tensor(f"out_{rank}", torch.zeros(N, dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a2a3")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            expected_out = getattr(args, f"in_{1 - rank}")
+            getattr(args, f"out_{rank}").copy_(expected_out)
+            getattr(args, f"result_{rank}").copy_(expected_out + 1.0)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)

--- a/examples/a5/tensormap_and_ringbuffer/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/README.md
@@ -31,6 +31,10 @@ For the `Worker` API underneath the framework, see
 Each registers an async event and lets the consumer wait on deferred completion
 rather than on task end. All need two dies.
 
+These mechanism-focused examples use the scene-test lifecycle. For a complete
+direct `Worker` communication-domain walkthrough from construction through
+`close()`, see [`examples/workers/l3/allreduce/`](../../workers/l3/allreduce/).
+
 | Example | Mechanism |
 | ------- | --------- |
 | [`sdma_async_completion_demo/`](sdma_async_completion_demo/) | `TGET_ASYNC` from a peer's window slot over SDMA, completion registered via `defer_pto_async_event`. Needs `SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON` at build **and** run time; skipped otherwise. |

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -7,170 +7,106 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Notification counter + deferred completion smoke test for onboard a5."""
+"""Notification counter and deferred-completion smoke test for onboard a5."""
 
-from __future__ import annotations
-
-import argparse
-import os
-
-import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 
 
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
-
-
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel in [
-        (0, "kernels/aiv/kernel_producer_notify.cpp"),
-        (1, "kernels/aiv/kernel_consumer.cpp"),
-        (2, "kernels/aiv/kernel_notify_wait.cpp"),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
-        )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append(
-            (
-                func_id,
-                CoreCallable.build(
-                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-                    binary=kernel,
+def async_notify_orch_fn(orch, callables, task_args, config):
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(NRANKS)),
+        window_size=4 * 1024,
+        buffers=[CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+    ) as handle:
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"in_{rank}")), TensorArgType.INPUT)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"out_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["notify_counter"],
+                    shapes=(1,),
+                    dtype=DataType.INT32,
+                    child_memory=True,
                 ),
+                TensorArgType.INPUT,
             )
-        )
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/async_notify_orchestration.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="async_notify_orchestration",
-        binary=orch,
-        children=children,
-    )
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.async_notify, args, config, worker=rank)
 
 
-def run(platform: str = "a5", device_ids: list[int] | None = None) -> int:
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"async_notify_demo needs exactly 2 devices, got {device_ids}")
-
-    inp = [
-        torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
-        for _ in range(nranks)
-    ]
-    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-    )
-    chip_handle = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            with orch.allocate_domain(
-                name="default",
-                workers=list(range(nranks)),
-                window_size=4 * 1024,
-                buffers=[CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
-            ) as handle:
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(make_tensor_arg(inp[rank]), TensorArgType.INPUT)
-                    args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["notify_counter"],
-                            shapes=(1,),
-                            dtype=DataType.INT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestAsyncNotifyDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": async_notify_orch_fn,
+        "callables": [
+            {
+                "name": "async_notify",
+                "orchestration": {
+                    "source": "kernels/orchestration/async_notify_orchestration.cpp",
+                    "function_name": "async_notify_orchestration",
+                    "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": func_id,
+                        "source": source,
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                    }
+                    for func_id, source in enumerate(
+                        [
+                            "kernels/aiv/kernel_producer_notify.cpp",
+                            "kernels/aiv/kernel_consumer.cpp",
+                            "kernels/aiv/kernel_notify_wait.cpp",
+                        ]
                     )
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_handle, args, cfg, worker=rank)
+                ],
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "notification_counter",
+            "platforms": ["a5"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-3
 
-        worker.run(orch_fn, args=None, config=CallConfig())
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            inp = torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32)
+            specs.extend(
+                [
+                    Tensor(f"in_{rank}", inp),
+                    Tensor(f"out_{rank}", torch.zeros(N, dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-        ok = True
-        for rank in range(nranks):
-            expected_out = inp[rank] * 2.0
-            expected_result = expected_out + 1.0
-            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
-            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
-            print(f"[async_notify_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
-            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
-        return 0 if ok else 1
-    finally:
-        worker.close()
-
-
-@pytest.mark.platforms(["a5"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
-def test_async_notify_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a5")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            expected_out = getattr(args, f"in_{rank}") * 2.0
+            getattr(args, f"out_{rank}").copy_(expected_out)
+            getattr(args, f"result_{rank}").copy_(expected_out + 1.0)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -7,185 +7,115 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""L2 deferred completion + two-chip comm smoke test for a5sim."""
+"""Deferred-completion and two-chip communication smoke test for a5sim."""
 
-from __future__ import annotations
-
-import argparse
-import os
-
-import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 DTYPE_NBYTES = 4
 
 
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
-
-
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel in [
-        (0, "kernels/aiv/kernel_producer.cpp"),
-        (1, "kernels/aiv/kernel_consumer.cpp"),
-        (2, "kernels/aiv/kernel_notify_wait.cpp"),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
-        )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append(
-            (
-                func_id,
-                CoreCallable.build(
-                    signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
-                    binary=kernel,
-                ),
-            )
-        )
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/deferred_notify_orch.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="deferred_notify_orchestration",
-        binary=orch,
-        children=children,
-    )
-
-
-def run(
-    platform: str = "a5sim",
-    device_ids: list[int] | None = None,
-) -> int:
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"deferred_notify_demo needs exactly 2 devices, got {device_ids}")
-
+def deferred_notify_orch_fn(orch, callables, task_args, config):
     mailbox_nbytes = N * DTYPE_NBYTES
-    counter_nbytes = 4
-    window_size = max(mailbox_nbytes + counter_nbytes, 4 * 1024)
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(NRANKS)),
+        window_size=max(mailbox_nbytes + DTYPE_NBYTES, 4 * 1024),
+        buffers=[
+            CommBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+            CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=DTYPE_NBYTES),
+        ],
+    ) as handle:
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"partial_{rank}")), TensorArgType.INPUT)
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["mailbox"],
+                    shapes=(N,),
+                    dtype=DataType.FLOAT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INOUT,
+            )
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["notify_counter"],
+                    shapes=(1,),
+                    dtype=DataType.INT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INPUT,
+            )
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.deferred_notify, args, config, worker=rank)
 
-    partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-    )
-    chip_handle = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            # `notify_counter` must start at 0; allocate_domain zero-initializes
-            # the whole window, so no explicit host seed is needed.
-            with orch.allocate_domain(
-                name="default",
-                workers=list(range(nranks)),
-                window_size=window_size,
-                buffers=[
-                    CommBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                    CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=counter_nbytes),
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestDeferredNotifyDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": deferred_notify_orch_fn,
+        "callables": [
+            {
+                "name": "deferred_notify",
+                "orchestration": {
+                    "source": "kernels/orchestration/deferred_notify_orch.cpp",
+                    "function_name": "deferred_notify_orchestration",
+                    "signature": [D.IN, D.INOUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": func_id,
+                        "source": source,
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.INOUT, D.OUT, D.IN],
+                    }
+                    for func_id, source in enumerate(
+                        [
+                            "kernels/aiv/kernel_producer.cpp",
+                            "kernels/aiv/kernel_consumer.cpp",
+                            "kernels/aiv/kernel_notify_wait.cpp",
+                        ]
+                    )
                 ],
-            ) as handle:
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(make_tensor_arg(partial[rank]), TensorArgType.INPUT)
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["mailbox"],
-                            shapes=(N,),
-                            dtype=DataType.FLOAT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INOUT,
-                    )
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["notify_counter"],
-                            shapes=(1,),
-                            dtype=DataType.INT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
-                    )
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_handle, args, cfg, worker=rank)
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "peer_notification",
+            "platforms": ["a5sim"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-6
 
-        worker.run(orch_fn, args=None, config=CallConfig())
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            specs.extend(
+                [
+                    Tensor(f"partial_{rank}", torch.full((N,), float(rank + 1), dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-        ok = True
-        for rank in range(nranks):
-            expected = partial[(rank + 1) % nranks]
-            max_diff = float(torch.max(torch.abs(result[rank] - expected)))
-            print(f"[deferred_notify_demo] rank {rank}: max_diff={max_diff:.3e}")
-            ok = ok and max_diff <= 1e-6
-        return 0 if ok else 1
-    finally:
-        worker.close()
-
-
-@pytest.mark.platforms(["a5sim"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
-def test_deferred_notify_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a5sim")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            getattr(args, f"result_{rank}").copy_(getattr(args, f"partial_{(rank + 1) % NRANKS}"))
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/README.md
@@ -25,8 +25,8 @@ compiled into the host runtime:
 
 | Gate | Effect |
 | ---- | ------ |
-| `@pytest.mark.platforms(["a5"])` | deselected on any other `--platform` |
-| `@pytest.mark.device_count(2)` | needs two dies |
+| `CASES[*]["platforms"] = ["a5"]` | deselected on any other `--platform` |
+| `CASES[*]["config"]["device_count"] = 2` | needs two dies |
 | `@pytest.mark.skipif(...)` | skipped unless `SIMPLER_ENABLE_PTO_SDMA_WORKSPACE` is `1` / `ON` / `TRUE` / `YES` |
 
 The CMake option defaults `OFF`, so a stock build skips this test even on a5

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -7,206 +7,133 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""SDMA deferred completion smoke test for onboard a5.
+"""SDMA deferred-completion smoke test for onboard a5.
 
-Each rank stages its input inside the HCCL window.  The deferred producer
-TGET_ASYNCs the peer rank's input into local ``out`` and registers the PTO
-AsyncEvent through ``defer_pto_async_event``.  The consumer depends on the
-producer output and writes ``result = out + 1``.  Correct ``out`` and
-``result`` therefore validate both the SDMA completion polling and the
-deferred-release dependency path.
+Each rank stages its input inside the communication window. The deferred
+producer fetches the peer rank's input into local ``out`` and registers its
+async event. The consumer depends on that output and writes
+``result = out + 1``.
 """
 
-from __future__ import annotations
-
-import argparse
 import os
 
 import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 DTYPE_NBYTES = 4
+_SDMA_WORKSPACE_ENV = "SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"
+_WORKSPACE_TRUTHY = {"1", "ON", "TRUE", "YES"}
 
 
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
+def _sdma_workspace_enabled():
+    return os.environ.get(_SDMA_WORKSPACE_ENV, "").upper() in _WORKSPACE_TRUTHY
 
 
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel in [
-        (0, "kernels/aiv/kernel_sdma_tget_async.cpp"),
-        (1, "kernels/aiv/kernel_consumer.cpp"),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
-        )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append(
-            (
-                func_id,
-                CoreCallable.build(
-                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-                    binary=kernel,
-                ),
-            )
-        )
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/sdma_async_completion_orch.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="sdma_async_completion_orchestration",
-        binary=orch,
-        children=children,
-    )
-
-
-def run(
-    platform: str = "a5",
-    device_ids: list[int] | None = None,
-) -> int:
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"sdma_async_completion_demo needs exactly 2 devices, got {device_ids}")
-    if platform.endswith("sim"):
-        raise ValueError("sdma_async_completion_demo requires onboard a5 hardware")
-
+def sdma_async_completion_orch_fn(orch, callables, task_args, config):
     input_nbytes = N * DTYPE_NBYTES
-    window_size = max(input_nbytes, 4 * 1024)
-
-    # `inputs` must live in shared memory: `orch.copy_to` stages each rank's
-    # data into its HCCL window from the forked chip child, which reads `src`
-    # out of its own address space.
-    inputs = [
-        torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
-        for rank in range(nranks)
-    ]
-    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-    )
-    chip_cid = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            with orch.allocate_domain(
-                name="default",
-                workers=list(range(nranks)),
-                window_size=window_size,
-                buffers=[
-                    CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes),
-                ],
-            ) as handle:
-                # Stage every rank's input window before submitting any kernel:
-                # each producer TGET_ASYNCs the *peer* rank's window, so all
-                # windows must hold real data before execution begins.
-                for rank in range(nranks):
-                    orch.copy_to(
-                        rank,
-                        dst=handle[rank].buffer_ptrs["input_window"],
-                        src=inputs[rank].data_ptr(),
-                        size=input_nbytes,
-                    )
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["input_window"],
-                            shapes=(N,),
-                            dtype=DataType.FLOAT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
-                    )
-                    args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_cid, args, cfg, worker=rank)
-
-        worker.run(orch_fn, args=None, config=CallConfig())
-
-        ok = True
-        for rank in range(nranks):
-            peer = 1 - rank
-            expected_out = inputs[peer]
-            expected_result = expected_out + 1.0
-            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
-            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
-            print(f"[sdma_async_completion_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
-            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
-        return 0 if ok else 1
-    finally:
-        worker.close()
+    with orch.allocate_domain(
+        name="default",
+        workers=list(range(NRANKS)),
+        window_size=max(input_nbytes, 4 * 1024),
+        buffers=[CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes)],
+    ) as handle:
+        for rank in range(NRANKS):
+            orch.copy_to(
+                rank,
+                dst=handle[rank].buffer_ptrs["input_window"],
+                src=getattr(task_args, f"in_{rank}").data_ptr(),
+                size=input_nbytes,
+            )
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["input_window"],
+                    shapes=(N,),
+                    dtype=DataType.FLOAT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INPUT,
+            )
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"out_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.sdma_async_completion, args, config, worker=rank)
 
 
-@pytest.mark.platforms(["a5"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
 @pytest.mark.skipif(
-    os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() not in {"1", "ON", "TRUE", "YES"},
+    not _sdma_workspace_enabled(),
     reason="SDMA workspace overlay not enabled (set SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON to run). "
     "See docs/a5-sdma-overlay.md (#1315).",
 )
-def test_sdma_async_completion_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestSdmaAsyncCompletionDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": sdma_async_completion_orch_fn,
+        "callables": [
+            {
+                "name": "sdma_async_completion",
+                "orchestration": {
+                    "source": "kernels/orchestration/sdma_async_completion_orch.cpp",
+                    "function_name": "sdma_async_completion_orchestration",
+                    "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": func_id,
+                        "source": source,
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                    }
+                    for func_id, source in enumerate(
+                        [
+                            "kernels/aiv/kernel_sdma_tget_async.cpp",
+                            "kernels/aiv/kernel_consumer.cpp",
+                        ]
+                    )
+                ],
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "peer_fetch",
+            "platforms": ["a5"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-3
 
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            inp = torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32)
+            specs.extend(
+                [
+                    Tensor(f"in_{rank}", inp),
+                    Tensor(f"out_{rank}", torch.zeros(N, dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a5")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            expected_out = getattr(args, f"in_{1 - rank}")
+            getattr(args, f"out_{rank}").copy_(expected_out)
+            getattr(args, f"result_{rank}").copy_(expected_out + 1.0)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)

--- a/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/README.md
@@ -54,8 +54,8 @@ was not built in.
 
 | Gate | Effect |
 | ---- | ------ |
-| `@pytest.mark.platforms(["a5"])` | deselected on any other `--platform` |
-| `@pytest.mark.device_count(2)` | needs two dies |
+| `CASES[*]["platforms"] = ["a5"]` | deselected on any other `--platform` |
+| `CASES[*]["config"]["device_count"] = 2` | needs two dies |
 | `@pytest.mark.skipif(not _urma_workspace_enabled())` | skipped unless `SIMPLER_ENABLE_PTO_URMA_WORKSPACE` is one of `1` / `ON` / `TRUE` / `YES` in the environment |
 | `run()` raises | if `platform != "a5"` or the device count is not 2, and re-checks the env var before doing any work |
 

--- a/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/test_urma_deferred_completion_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/test_urma_deferred_completion_demo.py
@@ -7,227 +7,151 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""URMA deferred completion smoke test for onboard a5.
+"""URMA deferred-completion smoke test for onboard a5.
 
-Each rank stages its input inside the HCCL/URMA communication window. The
-producer TGET_ASYNCs the peer rank's input into local ``out`` and registers the
-URMA AsyncEvent through the deferred completion path. The consumer depends on
-that producer output and writes ``result = out + 1``. Correct ``out`` and
-``result`` validate both URMA completion polling and deferred-release dependency
-handling.
+Each rank stages its input inside the communication window. The producer
+fetches the peer rank's input into local ``out`` and registers the URMA async
+event. The consumer depends on that output and writes ``result = out + 1``.
 """
 
-from __future__ import annotations
-
-import argparse
 import os
 
 import pytest
 import torch
-from simpler.task_interface import (
-    ArgDirection,
-    CallConfig,
-    ChipCallable,
-    CommBufferSpec,
-    CoreCallable,
-    DataType,
-    TaskArgs,
-    Tensor,
-    TensorArgType,
-)
-from simpler.worker import Worker
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
+from simpler.task_interface import Tensor as DeviceTensor
 
-from simpler_setup.elf_parser import extract_text_section
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.torch_interop import make_tensor_arg
 
-HERE = os.path.dirname(os.path.abspath(__file__))
 N = 128 * 128
+NRANKS = 2
 DTYPE_NBYTES = 4
-URMA_DATA_OFFSET_NBYTES = 64 * 4
+URMA_DATA_OFFSET_NBYTES = 64 * DTYPE_NBYTES
 _URMA_WORKSPACE_ENV = "SIMPLER_ENABLE_PTO_URMA_WORKSPACE"
 _WORKSPACE_TRUTHY = {"1", "ON", "TRUE", "YES"}
 
 
-def _urma_workspace_enabled() -> bool:
+def _urma_workspace_enabled():
     return os.environ.get(_URMA_WORKSPACE_ENV, "").upper() in _WORKSPACE_TRUTHY
 
 
-def _require_urma_workspace_enabled() -> None:
-    if _urma_workspace_enabled():
-        return
-    raise RuntimeError(
-        "urma_deferred_completion_demo requires host runtime built with "
-        f"{_URMA_WORKSPACE_ENV}=ON; set it before rebuilding simpler."
-    )
-
-
-def parse_device_range(spec: str) -> list[int]:
-    if "," in spec:
-        return [int(x) for x in spec.split(",") if x]
-    if "-" in spec:
-        lo, hi = (int(x) for x in spec.split("-"))
-        return list(range(lo, hi + 1))
-    return [int(spec)]
-
-
-def build_chip_callable(platform: str) -> ChipCallable:
-    kc = KernelCompiler(platform=platform)
-    runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root()
-    include_dirs = kc.get_orchestration_include_dirs(runtime)
-    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
-
-    children = []
-    for func_id, rel, signature in [
-        (
-            0,
-            "kernels/aiv/kernel_urma_tget_async.cpp",
-            [ArgDirection.IN, ArgDirection.OUT, ArgDirection.IN],
-        ),
-        (
-            1,
-            "kernels/aiv/kernel_consumer.cpp",
-            [ArgDirection.IN, ArgDirection.OUT],
-        ),
-    ]:
-        kernel = kc.compile_incore(
-            source_path=os.path.join(HERE, rel),
-            core_type="aiv",
-            pto_isa_root=pto_isa_root,
-            extra_include_dirs=extra_includes,
+def _require_urma_workspace_enabled():
+    if not _urma_workspace_enabled():
+        raise RuntimeError(
+            "urma_deferred_completion_demo requires host runtime built with "
+            f"{_URMA_WORKSPACE_ENV}=ON; set it before rebuilding simpler."
         )
-        if not platform.endswith("sim"):
-            kernel = extract_text_section(kernel)
-        children.append((func_id, CoreCallable.build(signature=signature, binary=kernel)))
-
-    orch = kc.compile_orchestration(
-        runtime_name=runtime,
-        source_path=os.path.join(HERE, "kernels/orchestration/urma_deferred_completion_orch.cpp"),
-        extra_include_dirs=[str(kc.project_root / "src" / "common")],
-    )
-    return ChipCallable.build(
-        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
-        func_name="urma_deferred_completion_orchestration",
-        config_name="urma_deferred_completion_orchestration_config",
-        binary=orch,
-        children=children,
-    )
 
 
-def run(platform: str = "a5", device_ids: list[int] | None = None) -> int:
+def urma_deferred_completion_orch_fn(orch, callables, task_args, config):
     _require_urma_workspace_enabled()
-    if device_ids is None:
-        device_ids = [0, 1]
-    nranks = len(device_ids)
-    if nranks != 2:
-        raise ValueError(f"urma_deferred_completion_demo needs exactly 2 devices, got {device_ids}")
-    if platform != "a5":
-        raise ValueError("urma_deferred_completion_demo requires onboard a5 hardware")
-
     input_nbytes = N * DTYPE_NBYTES
-    window_size = max(URMA_DATA_OFFSET_NBYTES + input_nbytes, 4 * 1024 * 1024)
-
-    # `inputs` must live in shared memory: `orch.copy_to` stages each rank's
-    # data into its HCCL window from the forked chip child, which reads `src`
-    # out of its own address space.
-    inputs = [
-        torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
-        for rank in range(nranks)
-    ]
-    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
-
-    chip_callable = build_chip_callable(platform)
-    worker = Worker(
-        level=3,
-        platform=platform,
-        runtime="tensormap_and_ringbuffer",
-        device_ids=device_ids,
-        num_sub_workers=0,
-    )
-    chip_cid = worker.register(chip_callable)
-    try:
-        worker.init()
-
-        def orch_fn(orch, _args, cfg):
-            with orch.allocate_domain(
-                name="urma_deferred_completion",
-                workers=list(range(nranks)),
-                window_size=window_size,
-                buffers=[
-                    CommBufferSpec(
-                        name="urma_reserved",
-                        dtype="int32",
-                        count=URMA_DATA_OFFSET_NBYTES // 4,
-                        nbytes=URMA_DATA_OFFSET_NBYTES,
-                    ),
-                    CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes),
-                ],
-            ) as handle:
-                # Stage every rank's input window before submitting any kernel:
-                # each producer TGET_ASYNCs the *peer* rank's window, so all
-                # windows must hold real data before execution begins.
-                for rank in range(nranks):
-                    orch.copy_to(
-                        rank,
-                        dst=handle[rank].buffer_ptrs["input_window"],
-                        src=inputs[rank].data_ptr(),
-                        size=input_nbytes,
-                    )
-                for rank in range(nranks):
-                    domain = handle[rank]
-                    args = TaskArgs()
-                    args.add_tensor(
-                        Tensor.make(
-                            data=domain.buffer_ptrs["input_window"],
-                            shapes=(N,),
-                            dtype=DataType.FLOAT32,
-                            child_memory=True,
-                        ),
-                        TensorArgType.INPUT,
-                    )
-                    args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                    args.add_scalar(domain.device_ctx)
-                    orch.submit_next_level(chip_cid, args, cfg, worker=rank)
-
-        worker.run(orch_fn, args=None, config=CallConfig())
-
-        ok = True
-        for rank in range(nranks):
-            peer = 1 - rank
-            expected_out = inputs[peer]
-            expected_result = expected_out + 1.0
-            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
-            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
-            print(f"[urma_deferred_completion_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
-            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
-        return 0 if ok else 1
-    finally:
-        worker.close()
+    with orch.allocate_domain(
+        name="urma_deferred_completion",
+        workers=list(range(NRANKS)),
+        window_size=max(URMA_DATA_OFFSET_NBYTES + input_nbytes, 4 * 1024 * 1024),
+        buffers=[
+            CommBufferSpec(
+                name="urma_reserved",
+                dtype="int32",
+                count=URMA_DATA_OFFSET_NBYTES // DTYPE_NBYTES,
+                nbytes=URMA_DATA_OFFSET_NBYTES,
+            ),
+            CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes),
+        ],
+    ) as handle:
+        for rank in range(NRANKS):
+            orch.copy_to(
+                rank,
+                dst=handle[rank].buffer_ptrs["input_window"],
+                src=getattr(task_args, f"in_{rank}").data_ptr(),
+                size=input_nbytes,
+            )
+        for rank in range(NRANKS):
+            domain = handle[rank]
+            args = TaskArgs()
+            args.add_tensor(
+                DeviceTensor.make(
+                    data=domain.buffer_ptrs["input_window"],
+                    shapes=(N,),
+                    dtype=DataType.FLOAT32,
+                    child_memory=True,
+                ),
+                TensorArgType.INPUT,
+            )
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"out_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_tensor(make_tensor_arg(getattr(task_args, f"result_{rank}")), TensorArgType.OUTPUT_EXISTING)
+            args.add_scalar(domain.device_ctx)
+            orch.submit_next_level(callables.urma_deferred_completion, args, config, worker=rank)
 
 
-@pytest.mark.platforms(["a5"])
-@pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
 @pytest.mark.skipif(
     not _urma_workspace_enabled(),
     reason="URMA workspace overlay not enabled (set SIMPLER_ENABLE_PTO_URMA_WORKSPACE=ON to run). "
     "See docs/a5-sdma-overlay.md (#1315).",
 )
-def test_urma_deferred_completion_demo(st_device_ids, st_platform) -> None:
-    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestUrmaDeferredCompletionDemo(SceneTestCase):
+    CALLABLE = {
+        "orchestration": urma_deferred_completion_orch_fn,
+        "callables": [
+            {
+                "name": "urma_deferred_completion",
+                "orchestration": {
+                    "source": "kernels/orchestration/urma_deferred_completion_orch.cpp",
+                    "function_name": "urma_deferred_completion_orchestration",
+                    "config_name": "urma_deferred_completion_orchestration_config",
+                    "signature": [D.IN, D.OUT, D.OUT, D.IN],
+                },
+                "incores": [
+                    {
+                        "func_id": 0,
+                        "source": "kernels/aiv/kernel_urma_tget_async.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT, D.IN],
+                    },
+                    {
+                        "func_id": 1,
+                        "source": "kernels/aiv/kernel_consumer.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT],
+                    },
+                ],
+            }
+        ],
+    }
+    CASES = [
+        {
+            "name": "peer_fetch",
+            "platforms": ["a5"],
+            "config": {"device_count": NRANKS, "num_sub_workers": 0},
+            "params": {},
+        }
+    ]
+    RTOL = 0.0
+    ATOL = 1e-3
 
+    def generate_args(self, params):
+        specs = []
+        for rank in range(NRANKS):
+            inp = torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32)
+            specs.extend(
+                [
+                    Tensor(f"in_{rank}", inp),
+                    Tensor(f"out_{rank}", torch.zeros(N, dtype=torch.float32)),
+                    Tensor(f"result_{rank}", torch.zeros(N, dtype=torch.float32)),
+                ]
+            )
+        return TaskArgsBuilder(*specs)
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", default="a5")
-    parser.add_argument("-d", "--device", default="0-1")
-    args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device))
+    def compute_golden(self, args, params):
+        for rank in range(NRANKS):
+            expected_out = getattr(args, f"in_{1 - rank}")
+            getattr(args, f"out_{rank}").copy_(expected_out)
+            getattr(args, f"result_{rank}").copy_(expected_out + 1.0)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary
- convert seven L3 communication-domain demos from hand-built Workers to scene-test cases and goldens
- keep each domain orchestration beside its kernels so the communication API remains readable
- point readers who need the complete direct Worker lifecycle to the L3 allreduce walkthrough

## Testing
- [x] pre-commit hooks
- [x] pytest collection for a2a3, a2a3sim, a5, and a5sim variants
- [x] standalone deferred-notify on a2a3sim and a5sim
- [x] a2a3sim deferred-notify with `--rounds 2`
- [x] offline callable compilation for all onboard-only a2a3/a5 classes
- [ ] onboard execution (blocked: `onboard-arch-precheck` cannot identify silicon because `npu-smi` DCMI initialization fails with `-8005`)

Fixes #1616