### PR TITLE
Add: declare A5 TMR pipeline contract

### DIFF
--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -265,9 +265,10 @@ One memcpy of a few KB per task; negligible.
 
 #### Pipeline resource leases
 
-A2/A3 host runtimes declare `pipeline_depth = 2` as resource capacity. The
-contract determines the concrete copy count rather than permitting concurrent
-device execution by itself:
+A2/A3 host runtimes and the A5 tensor-map-and-ring-buffer runtime declare
+`pipeline_depth = 2` as resource capacity. The contract determines the
+concrete copy count rather than permitting concurrent device execution by
+itself:
 
 | Resource class | Copies | Selection |
 | -------------- | -----: | --------- |
@@ -310,10 +311,16 @@ run N+1:   PREPARED
 run N+2:   blocked in begin_run before its graph callback
 ```
 
-Where a backend publishes depth one — A5, or any runtime without a depth-two
-contract — the *second* submission is the one that blocks in `begin_run`, and
-there is no prepared successor at all. Code that relies on a later callback to
-unblock an earlier run deadlocks on such a backend.
+Where a backend publishes depth one, the *second* submission is the one that
+blocks in `begin_run`, and there is no prepared successor at all. Code that
+relies on a later callback to unblock an earlier run deadlocks on such a
+backend.
+
+A5 tensor-map-and-ring-buffer publishes depth two for whole-run admission, but
+its local endpoint still has one mailbox frame and device execution remains
+serial. The second reservation may build and become `PREPARED`; it does not
+gain a second concurrently executable device frame. A5 host-build-graph
+publishes no contract and stays at depth one.
 
 `begin_run` acquires a generation-safe lease before invoking the callback.
 The FIFO head may enter `EXECUTING` while its callback is still building, which

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -8187,10 +8187,13 @@ class Worker:
         the depth this worker's backends negotiated, not a constant: at the
         negotiated depth two, one active plus one prepared run are permitted and
         a third submission blocks before invoking its graph callback; where a
-        backend publishes depth one — A5, or any runtime without a depth-two
-        contract — the *second* submission already blocks there. A caller whose
-        first run only completes because a later callback runs would deadlock on
-        such a backend. Completion and cleanup stay attached to each handle.
+        backend publishes depth one, the *second* submission already blocks
+        there. A5 tensor-map-and-ring-buffer publishes depth two, while its
+        local endpoint retains one mailbox frame and serial device execution;
+        A5 host-build-graph publishes no contract and stays at depth one. A
+        caller whose first run only completes because a later callback runs
+        would deadlock on a depth-one backend. Completion and cleanup stay
+        attached to each handle.
         """
         with self._operation_lease("submit"):
             return self._submit_locked(callable, args, config)

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -63,7 +63,24 @@ static_assert(
 );
 
 extern "C" const PipelineContract *get_pipeline_contract(void) {
-    static const PipelineContract contract = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};
+    // Orchestration runs on the device, so this run's own content is confined to
+    // its task args. The three pooled regions are built and uploaded once per
+    // callable sizing and then served from the prebuilt-arena cache
+    // (build_and_cache_prebuilt_arena runs only on a miss), so a run reuses the
+    // instance the previous run left behind.
+    static const PipelineContract contract = {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        2,
+        {
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        },
+    };
     return &contract;
 }
 

--- a/tests/st/a5/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Exercise both slots in the A5 tensor-map-and-ring-buffer pipeline.
+
+TMR classifies its GM heap, GM shared memory, and runtime image as
+`DEVICE_SCRATCH`, so every slot shares arena bank 0. The host `Runtime` staging
+buffer and retained temporary buffer remain per-slot resources.
+"""
+
+import itertools
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
+
+_VECTOR_KERNELS = "../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestPipelineSlotsTmr(SceneTestCase):
+    """A leased run on slot 1 must not disturb slot 0's per-run state."""
+
+    RTOL = 1e-5
+    ATOL = 1e-5
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{_VECTOR_KERNELS}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{_VECTOR_KERNELS}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{_VECTOR_KERNELS}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{_VECTOR_KERNELS}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "slot_topology",
+            "platforms": ["a5", "a5sim"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    # Shared st_worker means a shared per-slot high-water mark; draw from one
+    # increasing counter so tests do not depend on pytest's ordering.
+    _generation_counter = itertools.count(1)
+
+    def generate_args(self, params):
+        size = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((size,), 2.0, dtype=torch.float32)),
+            Tensor("b", torch.full((size,), 3.0, dtype=torch.float32)),
+            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        a, b = args.a, args.b
+        args.f[:] = (a + b + 1) * (a + b + 2) + (a + b)
+
+    def _run(self, worker, handle, *, slot_id=None):
+        """Run normally or through a lease, then check the result."""
+        test_args = self.generate_args({})
+        golden = test_args.clone()
+        self.compute_golden(golden, {})
+        chip_args, output_names = _build_chip_task_args(test_args, self.CALLABLE["orchestration"]["signature"])
+        config = self._build_config(self.CASES[0]["config"])
+        if slot_id is None:
+            worker.run(handle, chip_args, config=config)
+        else:
+            state = worker._resolve_handle(handle)
+            worker._chip_worker._run_slot_with_pipeline_lease(
+                state.slot_id, chip_args, slot_id, next(self._generation_counter), config=config
+            )
+        _compare_outputs(test_args, golden, output_names, self.RTOL, self.ATOL)
+
+    def test_slot_one_keeps_tmr_per_run_state_separate(self, st_platform, st_worker):
+        chip_worker = st_worker._chip_worker
+        assert chip_worker.pipeline_depth == 2
+        assert chip_worker.runtime_slot_count == 2
+
+        addrs = chip_worker.runtime_buffer_addrs
+        assert len(addrs) == 2, addrs
+        assert addrs[0] != addrs[1], f"both slots stage into one host Runtime: {addrs}"
+
+        handle = st_worker.register(self.build_callable(st_platform))
+        try:
+            # Switching back catches per-slot state overwritten by slot 1.
+            self._run(st_worker, handle)
+            self._run(st_worker, handle, slot_id=1)
+            self._run(st_worker, handle)
+            self._run(st_worker, handle, slot_id=1)
+
+            temp0 = chip_worker.retained_temp_addr(0)
+            temp1 = chip_worker.retained_temp_addr(1)
+            assert temp0 != 0 and temp1 != 0, f"a slot that ran staged nothing: slot0={temp0:#x}, slot1={temp1:#x}"
+            assert temp0 != temp1, f"both slots stage through one retained buffer: {temp0:#x}"
+
+            bank0 = chip_worker.arena_bank_gm_heap_base(0)
+            bank1 = chip_worker.arena_bank_gm_heap_base(1)
+            assert bank0 != 0, "the shared device-scratch bank was never committed"
+            assert bank1 == 0, f"slot 1 committed a second device-scratch bank: {bank1:#x}"
+        finally:
+            st_worker.unregister(handle)

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -192,6 +192,8 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
         ("a2a3", "host_build_graph", 1, 1),
         ("a2a3", "tensormap_and_ringbuffer", 2, 2),
         ("a5", "host_build_graph", 2, 1),
+        ("a5", "tensormap_and_ringbuffer", 2, 1),
+        ("a5sim", "tensormap_and_ringbuffer", 2, 1),
         ("a2a3sim", "host_build_graph", 2, 1),
     ],
 )


### PR DESCRIPTION
## Summary

Declare the complete pipeline contract for the A5 tensor-map and ring-buffer runtime instead of relying on the conservative single-slot declaration.

The runtime now reports a pipeline depth of two and classifies all six resources it uses:

- task arguments as `HOST_PER_RUN`
- GM heap, GM shared memory, and the runtime image as shared `DEVICE_SCRATCH`
- AICPU and AICore streams as per-run `EXEC_HANDLE` resources

## Why

The previous A5 TMR declaration exposed no resources and a pipeline depth of one. As a result, `ChipWorker` could only provision the legacy single-slot path even though the runtime's resource lifetimes support two pipeline slots.

The explicit contract lets the worker allocate independent host runtime buffers and execution handles for each in-flight slot while continuing to reuse the pooled device arenas. Device operations remain serialized, so the arena resources do not require per-slot copies.

## Implementation

- Add a shared A5 TMR pipeline-contract definition used by the runtime export and tests.
- Return the complete declaration from `get_pipeline_contract()`.
- Validate the ABI version, pipeline depth, arena topology, resource count, kinds, and resource classes in the C++ unit tests.

## Validation

- `test_pipeline_contract`: 22/22 tests passed locally.
- A5 simulation `libhost_runtime.so` built successfully.
- Confirmed that `get_pipeline_contract` is exported from the generated runtime library.
- Formatting and pre-commit checks passed.

Related to #1582.