### PR TITLE
Fix: parallelize A5 dummy task resolution

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1018,13 +1018,15 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             continue;
         }
 
-        // Phase 3: Drain dummy ready queue (thread 0 only).
+        // Phase 3: Drain dummy ready queue (S0/S1/S2/S3).
         //
         // Dependency-only tasks bypass AICore dispatch: they go through the
         // scheduler so fanin/fanout edges stay consistent, but completion is
-        // signalled inline here. Pinned to thread 0 to avoid cross-thread races.
-        if (thread_idx == 0) {
-            constexpr int DUMMY_DRAIN_BATCH = 16;
+        // signalled inline here. The ready queue is MPMC, and the fanout path
+        // uses per-slot locks/atomics, so multiple scheduler threads can share
+        // the dependency-only resolve work.
+        if (thread_idx < 4) {
+            constexpr int DUMMY_DRAIN_BATCH = 8;
             PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
 #if SIMPLER_DFX


### PR DESCRIPTION
## Summary

- let all four default A5 scheduler threads drain dependency-only tasks
- reduce the per-thread dummy batch from 16 to 8 to distribute queue work
- rely on the MPMC ready queue and per-slot atomic fanout path for safe concurrent resolution

## Performance

Measured sequentially on the same Ascend950PR device through `task-submit`; both variants use batch 8, default `aicpu_thread_num=5`, independent worktrees/venvs, and 100 rounds per workload.

| Workload | Metric | 1 scheduler | 4 schedulers | Change |
| --- | ---: | ---: | ---: | ---: |
| 4096 dummy, shared producer | Effective | 4369.7 us | 4254.3 us | -2.64% |
| 4096 dummy, shared producer | Sched | 4363.7 us | 4247.0 us | -2.67% |
| 4096 immediately-ready dummy | Effective | 4558.5 us | 4533.4 us | -0.55% |
| 4096 immediately-ready dummy | Sched | 4551.6 us | 4526.4 us | -0.55% |

The shared-producer workload shows a modest improvement. The immediately-ready result is within the +/-2% noise margin; shared queue and per-slot atomic contention limit scaling.

## Testing

- targeted pre-commit on `scheduler_dispatch.cpp`: passed
- A5Sim dummy scene test after rebasing to latest main: passed
- Ascend950PR onboard dummy scene test through `task-submit`: passed
- two 4096-dummy hardware benchmarks, 100 rounds per single/four-scheduler variant

Addresses A3 of #1582.