### PR TITLE
Refactor: split device enqueue from completion drain

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -106,7 +106,7 @@ DeviceRunner runner;
 void *ptr = runner.allocate_tensor(bytes);
 runner.copy_to_device(dev_ptr, host_ptr, bytes);
 runner.set_executors(aicpu_binary, aicore_binary);   // once, at init time
-runner.run(runtime, config);                         // config carries aicpu_thread_num, diagnostics
+runner.run(runtime, config);                         // compatibility composition: enqueue + drain
 runner.finalize();
 ```
 

--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -90,9 +90,9 @@ nothing to capture-then-reconstruct.
   shared-memory ring, and the drain thread are all skipped
   (`dep_gen_host_graph_active()` tells the runner). Nothing is dropped under
   back-pressure because nothing is streamed.
-- **Output.** The same `deps.json`, written at run teardown. After prepare's
-  host orchestration builds the graph, the phased runtime moves it into
-  run-owned storage and the executor adopts it before execution.
+- **Output.** The same `deps.json`, written during the device-runner drain.
+  After prepare's host orchestration builds the graph, the phased runtime moves
+  it into run-owned storage and the executor adopts it before enqueue.
 
 ---
 

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -1,8 +1,9 @@
 # Host runtime trace markers — `[STRACE]`
 
 `simpler_run()` spans several host-side stages (`bind`, `runner_run`,
-`validate`) plus, inside `runner_run`'s blocking wait, an on-NPU AICPU window
-that itself subdivides into preamble / SO-load / graph-build / post-orch. The
+`validate`) plus, inside `runner_run`'s enqueue-through-drain lifetime, an
+on-NPU AICPU window that itself subdivides into preamble / SO-load /
+graph-build / post-orch. The
 two headline walls (`host_wall` / `device_wall`, see
 [l2-timing.md](l2-timing.md)) cannot show *where* the time goes.
 
@@ -46,7 +47,7 @@ simpler_run                                   (= host_wall)
 ├─ simpler_run.bind
 │  ├─ simpler_run.bind.args        (ntensor=N: per-tensor device_malloc + H2D)
 │  └─ simpler_run.bind.prebuilt    (prebuilt runtime-arena cache hit or build + upload)
-├─ simpler_run.runner_run          (launch + blocking sync on the AICPU)
+├─ simpler_run.runner_run          (device enqueue + completion drain)
 │  └─ simpler_run.runner_run.device_wall      (whole on-NPU AICPU wall)
 │     └─ .{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}
 │           device-domain (clk=dev): AICPU subdivision of the on-NPU wall
@@ -64,10 +65,11 @@ device-log lines. A phase that was never stamped
 [device-phases.md](device-phases.md) for the device-side mechanism.
 
 The phased native-run interface preserves this same marker contract. Prepare
-allocates one `inv` and records the host-wall start; prepare, the blocking
-executor thread, and finalize temporarily bind that `(inv, hid)` while emitting
-their spans. Finalize releases the runner claim, destroys the per-run state, and
-then emits the stored `simpler_run` wall, so the root includes that cleanup tail.
+allocates one `inv` and records the host-wall start; prepare, the executor's
+enqueue/drain lifecycle, and finalize temporarily bind that `(inv, hid)` while
+emitting their spans. Finalize releases the runner claim, destroys the per-run
+state, and then emits the stored `simpler_run` wall, so the root includes that
+cleanup tail.
 No trace scope or synthetic nesting remains active between C API calls. For
 direct phased use the host wall is the full prepare-to-finalize lifetime,
 including time the caller spends polling or doing other host work; blocking

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -249,8 +249,8 @@ Applies to all 4 runtime executors: a2a3 (hbg, tmr), a5 (hbg, tmr).
 | SO | Caching | Lifecycle |
 | -- | ------- | --------- |
 | Host runtime | `ChipWorker::lib_handle_` | Per-init: dlopen in `init()`, dlclose in `finalize()` |
-| AICPU | `DeviceRunner::aicpu_so_handle_` | Per-run: loaded in `ensure_binaries_loaded()`, closed in `unload_executor_binaries()` at end of `run()` |
-| AICore | `DeviceRunner::aicore_so_handle_` | Same as AICPU |
+| AICPU | `DeviceRunner::aicpu_so_handle_` | Per-init: loaded lazily by the first `enqueue_run()`, retained across runs, closed by `finalize()` |
+| AICore | `DeviceRunner::aicore_so_handle_` | Per-run: reloaded for the run's kernel binary, closed after a successful `drain_run()` (or by final cleanup) |
 | Kernel | `DeviceRunner::func_id_to_addr_` (map by func_id) | Per-task: uploaded in `init_runtime_impl()`, removed in `validate_runtime_impl()` |
 | Orchestration | `AicpuExecutor::orch_so_handle_` | Per-run: loaded by orchestrator thread, closed by last thread in `deinit()` |
 
@@ -271,9 +271,10 @@ Applies to all 4 runtime executors: a2a3 (hbg, tmr), a5 (hbg, tmr).
 Onboard caches more aggressively. The `DeviceRunner` persists across tasks
 within a runtime group, the runtime AICPU SO is preinstalled once through the
 dispatcher bootstrap, and per-task launches reuse cached `rtFuncHandle`s.
-Simulation re-loads AICPU/AICore SOs every `run()` call because the SO's
-internal static state (`g_aicpu_executor`) must be fresh for each task when
-different tasks have different configurations.
+Simulation also retains the AICPU SO across runs so `g_aicpu_executor` can
+reuse its orchestration-SO cache; `AicpuExecutor::deinit()` resets its per-run
+state. The AICore SO is reloaded for each run because its kernel binary varies
+per callable.
 
 Onboard per-task launches pass the front-less `KernelArgs` payload directly to
 `rtsLaunchCpuKernel` with no CANN launch front: runtime state flows through
@@ -315,12 +316,16 @@ ChipWorker.run(handle, args, config)                   # public wrapper path
       new (buf) NativeRunState()             owns Runtime + executor state
       DeviceRunner::bind_callable_to_runtime(r, cid, api, args, rings)
     simpler_launch_run(...)
-      executor thread: DeviceRunner::run(r, config)
+      executor thread: DeviceRunner::enqueue_run(r, config)
         clear_cpu_sim_shared_storage()
-        ensure_binaries_loaded()             dlopen aicpu/aicore SOs once
+        ensure_binaries_loaded()             lazily dlopen AICPU; reload AICore for this run
         launch AICPU + AICore threads
+        publish launch fence                 simpler_launch_run may return
+      executor thread: DeviceRunner::drain_run()
         join all threads
-        unload_executor_binaries()           dlclose aicpu/aicore SOs
+        dlclose AICore SO                     AICPU stays loaded across runs
+    simpler_poll_run(...)                    caller thread, concurrent with drain
+      DeviceRunner::poll_run()                nonblocking completion query
     simpler_wait_run(...)
     simpler_finalize_run(...)
       validate_runtime_impl(r)               copy results, remove kernels
@@ -328,6 +333,7 @@ ChipWorker.run(handle, args, config)                   # public wrapper path
 
 ChipWorker.finalize()
   finalize_device(ctx)
+    unload_executor_binaries()               dlclose AICPU and any residual AICore SO
   destroy_device_context(ctx)
   dlclose(host_runtime.so)                   -fno-gnu-unique ensures real unload
 ```
@@ -372,12 +378,16 @@ device_worker_main(device_id)
                 new (buf) NativeRunState()     owns Runtime + executor state
                 bind_callable_to_runtime()     replay + rtMalloc, rtMemcpy to device
               simpler_launch_run(...)
-                executor thread: DeviceRunner::run()
+                executor thread: DeviceRunner::enqueue_run()
                   ensure_binaries_loaded()     already done by init
                   launch_aicore_kernel()       cached rtRegisterAllKernel handle
                                                  + rtKernelLaunchWithHandleV2
                   launch_aicpu_kernel(Run)     rtsLaunchCpuKernel, cached rtFuncHandle
+                  publish launch fence         simpler_launch_run may return
+                executor thread: DeviceRunner::drain_run()
                   aclrtSynchronizeStreamWithTimeout() wait on both streams
+              simpler_poll_run(...)            caller thread, concurrent with drain
+                DeviceRunner::poll_run()       nonblocking stream query
               simpler_wait_run(...)
               simpler_finalize_run(...)        rtMemcpy results back; destroy state
 

--- a/src/a2a3/platform/docs/tpush-tpop-sim.md
+++ b/src/a2a3/platform/docs/tpush-tpop-sim.md
@@ -130,7 +130,7 @@ physical_core_id [block_dim..3*block_dim-1] = AIV pairs
 
 ### Lifecycle
 
-- `DeviceRunner::run()` start: `clear_cpu_sim_shared_storage()` frees all
+- Device-runner enqueue start: `clear_cpu_sim_shared_storage()` frees all
   `SharedState` entries for the current device.
 - `DeviceRunner::finalize()`: same cleanup.
 - `pto_cpu_sim_release_device()`: destroys the entire device context including

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -238,19 +238,20 @@ int DeviceRunner::provision_native_run_resources(uint32_t pipeline_slot) {
 }
 
 int DeviceRunner::abandon_native_run_resources(uint32_t pipeline_slot) {
-    return retire_run_aicore_stream(pipeline_slot);
+    return retire_run_aicore_stream(pipeline_slot, RunStreamSlots::CompletionStatus::Unproven);
 }
 
-int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
     const unsigned selected_pipeline_slot = pipeline_slot();
-    // The AICore stream is created during native prepare so its provisioning
-    // can overlap the predecessor's execution. Once run() is entered, every
-    // exit owns retirement; the success path reports destroy failure, while
-    // early-error paths keep the original error and leave a failed-destroy
-    // handle in the slot so it cannot be reused.
-    bool aicore_stream_retired = false;
-    auto aicore_stream_retire = RAIIScopeGuard([this, selected_pipeline_slot, &aicore_stream_retired]() {
-        if (!aicore_stream_retired) (void)retire_run_aicore_stream(selected_pipeline_slot);
+    if (active_run_.owns_resources) {
+        LOG_ERROR("enqueue_run entered while slot %u still owns resources", active_run_.slot);
+        return -1;
+    }
+    active_run_ = ActiveRunState{selected_pipeline_slot, true, false};
+    // Before the real AICPU launch marker, enqueue owns rollback. A successful
+    // enqueue dismisses this guard and transfers every resource to drain_run().
+    auto enqueue_rollback = RAIIScopeGuard([this]() {
+        cleanup_active_run(/*retire_aicore=*/true);
     });
     if (!run_stream_slots_.ready(selected_pipeline_slot)) {
         LOG_ERROR("run stream set %u was not provisioned during native prepare", selected_pipeline_slot);
@@ -260,7 +261,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // paths below read them; block_dim/aicpu_thread_num are consumed locally.
     apply_call_config(config);
     // activate_launch_shape() latches this run's geometry onto the runner on the
-    // executor thread immediately before run(), so block_dim_ is this run's.
+    // executor thread immediately before enqueue, so block_dim_ is this run's.
     const int block_dim = block_dim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
@@ -272,9 +273,9 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // worker session's tests from a slow, confusing failure cascade into a
     // single fast, self-explanatory error; the runner is then recovered at
     // finalize.
-    if (device_unusable_) {
+    if (device_unusable_.load(std::memory_order_acquire)) {
         LOG_ERROR(
-            "DeviceRunner marked unusable by a prior AICore failure; refusing to run. "
+            "DeviceRunner marked unusable by a prior AICore failure; refusing to enqueue. "
             "A soft reset does not clear the poison; finalize() will force-reset "
             "the card so the next Worker on it inits clean."
         );
@@ -291,27 +292,10 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     ensure_device_wall_buffer();
 
     if (block_dim < 1) {
-        LOG_ERROR("run() reached with unresolved block_dim; activate_launch_shape must run first");
+        LOG_ERROR("enqueue_run reached with unresolved block_dim; activate_launch_shape must run first");
         return -1;
     }
     int num_aicore = block_dim * cores_per_blockdim_;
-
-    // Scope guards for register-address cleanup on all exit paths. Declared
-    // before the allocs so that an alloc-failure early-return still triggers
-    // cleanup of previously-allocated buffers (the predicates no-op on 0).
-    auto regs_cleanup = RAIIScopeGuard([this]() {
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-    });
-
-    auto pmu_regs_cleanup = RAIIScopeGuard([this]() {
-        if (kernel_args_.args.pmu_reg_addrs != 0) {
-            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.pmu_reg_addrs));
-            kernel_args_.args.pmu_reg_addrs = 0;
-        }
-    });
 
     // Get AICore register addresses for register-based task dispatch
     rc = init_aicore_register_addresses(
@@ -400,11 +384,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         );
     }
 
-    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
-        kernel_args_.finalize_device_kernel_args();
-        kernel_args_.finalize_runtime_args();
-    });
-
     // Initialize per-subsystem shared memory.
     if (enable_chip_swimlane_) {
         rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
@@ -449,14 +428,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
             return rc;
         }
     }
-
-    // On any exit from run() — success or early error — release the diagnostics
-    // collectors' shared memory. They are only re-initialized per run(), so a
-    // Worker reused across runs (e.g. a pytest session-scoped worker pool) would
-    // otherwise re-enter init_chip_swimlane() with stale state still allocated.
-    auto perf_cleanup = RAIIScopeGuard([this]() {
-        finalize_collectors();
-    });
 
     // Resolve the orchestration SO into a device-resident buffer and refresh
     // runtime metadata before the Runtime struct is uploaded to device.
@@ -510,20 +481,68 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     rc = launch_run(runtime, num_aicore, launch_aicpu_num, selected_pipeline_slot);
     if (rc != 0) return rc;
 
-    rc = reap_run(selected_pipeline_slot);
-    if (rc != 0) return rc;
-
-    // The run owns its AICore stream, so a destroy this run cannot complete is
-    // this run's failure: reporting success would leave the caller believing a
-    // slot is reusable that the next prepare will now refuse.
-    aicore_stream_retired = true;
-    rc = retire_run_aicore_stream(selected_pipeline_slot);
-    if (rc != 0) return rc;
-
-    // Print handshake results (reads from device memory, must be before free)
-    print_handshake_results();
-
+    enqueue_rollback.dismiss();
     return 0;
+}
+
+int DeviceRunner::poll_run(uint32_t pipeline_slot) {
+    return run_stream_slots_.poll(pipeline_slot, [](void *aicpu, void *aicore) {
+        return query_stream_pair_nonblocking(static_cast<rtStream_t>(aicpu), static_cast<rtStream_t>(aicore));
+    });
+}
+
+int DeviceRunner::drain_run(uint32_t pipeline_slot) {
+    if (!active_run_.owns_resources || active_run_.slot != pipeline_slot) {
+        LOG_ERROR(
+            "drain_run slot mismatch: requested=%u active=%u owns=%d", pipeline_slot, active_run_.slot,
+            static_cast<int>(active_run_.owns_resources)
+        );
+        return -1;
+    }
+    auto drain_cleanup = RAIIScopeGuard([this]() {
+        cleanup_active_run(/*retire_aicore=*/true);
+    });
+
+    int rc = reap_run(pipeline_slot);
+    if (rc != 0) {
+        // The device/sync error remains authoritative over teardown errors.
+        return rc;
+    }
+
+    // On a successful device drain, failure to retire this run's AICore stream
+    // is the run's error. Mark the attempt first so cleanup does not immediately
+    // retry a failed destroy; the retained handle keeps the slot unusable and
+    // lets finalize retry it later.
+    active_run_.aicore_retirement_attempted = true;
+    rc = retire_run_aicore_stream(pipeline_slot, RunStreamSlots::CompletionStatus::Complete);
+    if (rc != 0) return rc;
+
+    // Reads device memory, so it must precede KernelArgs/runtime cleanup.
+    print_handshake_results();
+    return 0;
+}
+
+void DeviceRunner::cleanup_active_run(bool retire_aicore) noexcept {
+    if (!active_run_.owns_resources) return;
+
+    // Collectors must stop before their backing arguments are released; the
+    // per-run stream retires last. Each cleanup operation is idempotent.
+    finalize_collectors();
+    (void)kernel_args_.finalize_device_kernel_args();
+    (void)kernel_args_.finalize_runtime_args();
+    if (kernel_args_.args.pmu_reg_addrs != 0) {
+        (void)mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.pmu_reg_addrs));
+        kernel_args_.args.pmu_reg_addrs = 0;
+    }
+    if (kernel_args_.args.regs != 0) {
+        (void)mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
+        kernel_args_.args.regs = 0;
+    }
+    if (retire_aicore && !active_run_.aicore_retirement_attempted) {
+        active_run_.aicore_retirement_attempted = true;
+        (void)retire_run_aicore_stream(active_run_.slot, RunStreamSlots::CompletionStatus::Unproven);
+    }
+    active_run_.owns_resources = false;
 }
 
 int DeviceRunner::ensure_run_stream_set(unsigned slot) {
@@ -535,8 +554,8 @@ int DeviceRunner::ensure_run_stream_set(unsigned slot) {
     return rc;
 }
 
-int DeviceRunner::retire_run_aicore_stream(unsigned slot) {
-    int rc = run_stream_slots_.retire_aicore(slot);
+int DeviceRunner::retire_run_aicore_stream(unsigned slot, RunStreamSlots::CompletionStatus completion_status) {
+    int rc = run_stream_slots_.retire_aicore(slot, completion_status);
     if (rc != 0) {
         LOG_ERROR("rtStreamDestroy (run AICore slot %u) failed: %d, slot is now unusable", slot, rc);
     }
@@ -564,6 +583,15 @@ int DeviceRunner::launch_run(Runtime &runtime, int num_aicore, int launch_aicpu_
     }
     RunStreamSet streams{run_stream_slots_.aicpu(slot), run_stream_slots_.aicore(slot)};
     int rc = 0;
+
+    // Publish query/drain ownership before either kernel launch. The real
+    // launch marker is notified inside launch_aicpu_kernel(), so no state that
+    // poll or drain needs may be committed after that call succeeds.
+    rc = run_stream_slots_.mark_submitted(slot);
+    if (rc != 0) {
+        LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
+        return rc;
+    }
 
     // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
     // so the two arches stay symmetric. First-launch latency optimization +
@@ -679,7 +707,7 @@ void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
     // An AICore launch failure (207001) or an op-timeout reaped by STARS
     // (surfaced as 507000/507018/507046 at stream sync) leaves the device
     // context in a sticky-error state: the streams stay poisoned and the
-    // SAME DeviceRunner's next run() fails early — observed on a2a3 as
+    // SAME DeviceRunner's next enqueue fails early — observed on a2a3 as
     // `rtMalloc failed: 507899`, and on a5 as `halResMap failed (rc=62)` in
     // init_aicore_register_addresses. Reused across a session (the L2
     // st_worker pool hands one ChipWorker to every test class on a device),
@@ -693,8 +721,8 @@ void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
     // untriggered and cascaded into 16 skipped L2 cases on CI run 27742754024
     // (st-onboard-a2a3 gw3). The op-timeout sticky-error is only cleared by a
     // force reset (a soft reset/drain does not), so always mark the runner
-    // unusable here: run() fails fast and finalize() force-resets the card, so
-    // the next Worker.init lands clean regardless of what the drain reported.
+    // unusable here: admission fails fast and finalize() force-resets the card,
+    // so the next Worker.init lands clean regardless of what the drain reported.
     int sync_rc = aclrtSynchronizeDeviceWithTimeout(timeout_config_.stream_sync_timeout_ms);
     if (sync_rc != ACL_SUCCESS) {
         LOG_ERROR(
@@ -707,7 +735,7 @@ void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
             aicore_rc
         );
     }
-    device_unusable_ = true;
+    device_unusable_.store(true, std::memory_order_release);
 }
 
 namespace {
@@ -927,7 +955,7 @@ int DeviceRunner::finalize() {
     }
 
     // Cleanup performance profiling (including a2a3's dep_gen). Normally
-    // already done by run()'s perf_cleanup guard; this is the backstop
+    // already done by drain or enqueue rollback; this is the backstop
     // for the no-run-since-init case.
     finalize_collectors();
 
@@ -988,7 +1016,7 @@ int DeviceRunner::finalize() {
     // .claude/rules/running-onboard.md), and the reset scopes to this card alone,
     // so it cannot disturb other devices/users.
     int reset_rc = 0;
-    if (device_unusable_) {
+    if (device_unusable_.load(std::memory_order_acquire)) {
         // Bounded retry: a single force reset normally clears the op-timeout
         // sticky-error (verified 5/5 on a2a3), but the poison occasionally needs
         // a drain-then-reset cycle, so retry up to kMaxResetAttempts.
@@ -1024,10 +1052,10 @@ int DeviceRunner::finalize() {
     device_id_ = -1;
     // Clear the poison flag only if the force reset actually recovered the card,
     // so a still-poisoned card stays flagged: a reused DeviceRunner then fails
-    // run() fast instead of being treated as clean. On the normal (not unusable)
-    // path reset_rc stays 0 and the flag is already false.
+    // admission instead of being treated as clean. On the normal (not
+    // unusable) path reset_rc stays 0 and the flag is already false.
     if (reset_rc == 0) {
-        device_unusable_ = false;
+        device_unusable_.store(false, std::memory_order_release);
     }
     return rc != 0 ? rc : reset_rc;
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -19,8 +19,7 @@
  * - DeviceRunner: kernel launching and execution
  */
 
-#ifndef RUNTIME_DEVICERUNNER_H
-#define RUNTIME_DEVICERUNNER_H
+#pragma once
 
 #include <runtime/rt.h>
 
@@ -93,29 +92,11 @@ public:
     // `device_id`, `last_device_wall_ns`, `launch_aicpu_kernel`, and
     // `launch_aicore_kernel` are inherited from `DeviceRunnerBase`.
 
-    /**
-     * Execute a runtime
-     *
-     * This method:
-     * 1. Initializes device if not already done (lazy initialization)
-     * 2. Initializes worker handshake buffers in the runtime based on block_dim
-     * 3. Transfers runtime to device memory
-     * 4. Launches AICore kernel
-     * 5. Launches AICPU main kernel
-     * 6. Synchronizes streams
-     * 7. Cleans up runtime memory
-     *
-     * @param runtime             Runtime to execute (will be modified to
-     * initialize workers)
-     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param launch_aicpu_num     Number of AICPU instances (default: 1)
-     * @return 0 on success, error code on failure
-     *
-     * The bound device id, AICPU/AICore executor binaries, and log filter
-     * are captured once by simpler_init (binaries) / libsimpler_log.so (log)
-     * and read off DeviceRunner state / HostLogger here — no per-run args.
-     */
-    int run(Runtime &runtime, const CallConfig &config) override;
+    // The blocking entry point composes these operations. enqueue owns rollback
+    // until the AICPU launch marker; drain takes that ownership on success.
+    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int poll_run(uint32_t pipeline_slot) override;
+    int drain_run(uint32_t pipeline_slot) override;
     bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }
     int provision_native_run_resources(uint32_t pipeline_slot) override;
     int abandon_native_run_resources(uint32_t pipeline_slot) override;
@@ -221,15 +202,15 @@ private:
     // Set true when an AICore launch/sync error (e.g. an op-timeout reaped by
     // STARS, surfaced as 507000/507018 at stream sync, or a 207001 launch
     // failure) left the device context in a sticky-error state that an
-    // in-place drain could not clear. Once set, run() fails fast instead of
-    // cascading into the confusing downstream failures (rtMalloc 507899, or
+    // in-place drain could not clear. Once set, admission/enqueue fail fast
+    // instead of cascading into the confusing downstream failures (rtMalloc 507899, or
     // halResMap rc=62 at init_aicore_register_addresses) that a poisoned
     // context produces. The poison survives a close()+soft-reset for the life
     // of the process (an in-process re-init fails with rtStreamCreate 507899),
     // but a *force* reset clears it: finalize() calls force_reset_device() on
     // this path so the next Worker re-inits clean in the same process (see
-    // force_reset_device()). This flag fails run() fast and drives that
-    // recovery. See run() and recover_device_or_mark_unusable().
+    // force_reset_device()). This flag drives admission and recovery. See
+    // enqueue_run() and recover_device_or_mark_unusable().
     // The prepared-run admission thread reads this while the sole device
     // executor may poison the runner after a failed launch.
     std::atomic<bool> device_unusable_{false};
@@ -263,18 +244,30 @@ private:
     // the handle when the destroy fails: the stream may still hold the previous
     // image's instructions, so the slot must refuse the next run until finalize
     // reclaims it.
-    int retire_run_aicore_stream(unsigned slot);
+    int retire_run_aicore_stream(unsigned slot, RunStreamSlots::CompletionStatus completion_status);
     int destroy_run_stream_sets();
 
-    // The kernel submission boundary is separate from the stream wait and the
-    // post-run teardown; run() invokes the two back-to-back.
+    struct ActiveRunState {
+        unsigned slot{PTO_PIPELINE_MAX_DEPTH};
+        bool owns_resources{false};
+        bool aicore_retirement_attempted{false};
+    };
+    ActiveRunState active_run_{};
+
+    // Release executor-owned resources in collector, runtime-argument,
+    // register-buffer, then stream order. Stream retirement is optional because
+    // the success path must report its error without retrying it immediately.
+    void cleanup_active_run(bool retire_aicore) noexcept;
+
+    // The kernel submission boundary is separate from the stream wait and
+    // post-run teardown: enqueue_run() launches and drain_run() reaps.
     int launch_run(Runtime &runtime, int num_aicore, int launch_aicpu_num, unsigned slot);
     int reap_run(unsigned slot);
 
     // On an AICore launch/sync error, best-effort drain the device so a later
-    // run() on the same DeviceRunner can recover in place; if the drain itself
+    // enqueue on the same DeviceRunner can recover in place; if the drain itself
     // errors the context is unrecoverable without a full reset, so flip
-    // device_unusable_ and let run() fail fast.
+    // device_unusable_ and let admission/enqueue fail fast.
     void recover_device_or_mark_unusable(int aicore_rc);
 
     // Force-reset the card via aclrtResetDeviceForce to clear an op-timeout
@@ -362,7 +355,7 @@ private:
      *
      * Idempotent and safe to call multiple times: each collector's finalize()
      * early-outs once its shm has been released. Invoked both at the end of
-     * every run() (so a Worker reused across runs starts each run with the
+     * every drain or enqueue rollback (so a reused Worker starts each run with
      * collectors in a pristine, re-initializable state) and from finalize()
      * as a backstop before mem_alloc_.finalize().
      */
@@ -374,5 +367,3 @@ private:
     // dep_gen enablement is a2a3-only.
     bool enable_dep_gen_{false};
 };
-
-#endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -21,7 +21,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
@@ -79,7 +78,52 @@ extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_host_graph_em
     return -1;
 }
 
+struct DeviceRunner::ActiveRun {
+    Runtime *runtime{nullptr};
+    void *reg_blocks{nullptr};
+    void *pmu_reg_blocks{nullptr};
+    std::vector<std::thread> aicpu_threads;
+    std::vector<std::thread> aicore_threads;
+    std::vector<AicpuPhaseRecord> phase_buf;
+
+    void join() noexcept {
+        for (auto &thread : aicpu_threads) {
+            if (thread.joinable()) thread.join();
+        }
+        for (auto &thread : aicore_threads) {
+            if (thread.joinable()) thread.join();
+        }
+    }
+
+    ~ActiveRun() { join(); }
+};
+
+DeviceRunner::DeviceRunner() = default;
 DeviceRunner::~DeviceRunner() { finalize(); }
+
+void DeviceRunner::cleanup_active_run() noexcept {
+    if (active_run_ == nullptr) return;
+    active_run_->join();
+
+    if (kernel_args_.pmu_reg_addrs != 0) {
+        mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.pmu_reg_addrs));
+        kernel_args_.pmu_reg_addrs = 0;
+    }
+    if (active_run_->pmu_reg_blocks != nullptr) {
+        mem_alloc_.free(active_run_->pmu_reg_blocks);
+        active_run_->pmu_reg_blocks = nullptr;
+    }
+    if (kernel_args_.regs != 0) {
+        mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.regs));
+        kernel_args_.regs = 0;
+    }
+    if (active_run_->reg_blocks != nullptr) {
+        mem_alloc_.free(active_run_->reg_blocks);
+        active_run_->reg_blocks = nullptr;
+    }
+    finalize_collectors();
+    active_run_.reset();
+}
 
 int DeviceRunner::ensure_binaries_loaded() {
     // AICPU .so: load-once, matching onboard's binaries_loaded_ pattern.
@@ -252,7 +296,19 @@ void DeviceRunner::destroy_native_run_thread_state(void *snapshot) noexcept {
     dep_gen_host_graph_destroy_capture(snapshot);
 }
 
-int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
+    if (active_run_ != nullptr) {
+        LOG_ERROR("enqueue_run called while another simulated run still owns execution state");
+        return -1;
+    }
+    active_run_ = std::make_unique<ActiveRun>();
+    active_run_->runtime = &runtime;
+    run_completion_.reset(1);
+    auto enqueue_cleanup = RAIIScopeGuard([this]() {
+        run_completion_.abandon();
+        cleanup_active_run();
+    });
+
     apply_call_config(config);
     // prepare_launch_shape() resolved block_dim before the graph was built, so
     // the geometry this run launches with is already on the runner.
@@ -265,7 +321,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
     runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
-        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
+        LOG_ERROR("enqueue_run reached with unresolved block_dim; prepare_launch_shape must run first");
         return -1;
     }
 
@@ -376,23 +432,13 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         }
     }
 
-    // On any exit from run() — success or early error — release the diagnostics
-    // collectors' shared memory.
-    auto perf_cleanup = RAIIScopeGuard([this]() {
-        finalize_collectors();
-    });
-
     size_t total_reg_size = num_aicore * SIM_REG_BLOCK_SIZE;
-    void *reg_blocks = mem_alloc_.alloc(total_reg_size);
-    if (reg_blocks == nullptr) {
+    active_run_->reg_blocks = mem_alloc_.alloc(total_reg_size);
+    if (active_run_->reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated register memory (%zu bytes)", total_reg_size);
         return -1;
     }
-    std::memset(reg_blocks, 0, total_reg_size);
-
-    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() {
-        mem_alloc_.free(reg_blocks);
-    });
+    std::memset(active_run_->reg_blocks, 0, total_reg_size);
 
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
@@ -401,32 +447,22 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t *>(reg_blocks) + i * SIM_REG_BLOCK_SIZE);
+        regs_array[i] =
+            reinterpret_cast<uint64_t>(static_cast<uint8_t *>(active_run_->reg_blocks) + i * SIM_REG_BLOCK_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
-
-    auto regs_array_cleanup = RAIIScopeGuard([this]() {
-        if (kernel_args_.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.regs));
-            kernel_args_.regs = 0;
-        }
-    });
 
     // Allocate simulated PMU register blocks. PMU MMIO is a separate address
     // region from the general AICore regs on hardware, so sim mirrors that with
     // its own backing memory; otherwise the AICPU PMU collector would early-out
     // on every core.
     size_t total_pmu_reg_size = num_aicore * SIM_REG_BLOCK_SIZE;
-    void *pmu_reg_blocks = mem_alloc_.alloc(total_pmu_reg_size);
-    if (pmu_reg_blocks == nullptr) {
+    active_run_->pmu_reg_blocks = mem_alloc_.alloc(total_pmu_reg_size);
+    if (active_run_->pmu_reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated PMU register memory (%zu bytes)", total_pmu_reg_size);
         return -1;
     }
-    std::memset(pmu_reg_blocks, 0, total_pmu_reg_size);
-
-    auto pmu_reg_blocks_cleanup = RAIIScopeGuard([this, pmu_reg_blocks]() {
-        mem_alloc_.free(pmu_reg_blocks);
-    });
+    std::memset(active_run_->pmu_reg_blocks, 0, total_pmu_reg_size);
 
     size_t pmu_regs_array_size = num_aicore * sizeof(uint64_t);
     uint64_t *pmu_regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(pmu_regs_array_size));
@@ -435,16 +471,10 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        pmu_regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t *>(pmu_reg_blocks) + i * SIM_REG_BLOCK_SIZE);
+        pmu_regs_array[i] =
+            reinterpret_cast<uint64_t>(static_cast<uint8_t *>(active_run_->pmu_reg_blocks) + i * SIM_REG_BLOCK_SIZE);
     }
     kernel_args_.pmu_reg_addrs = reinterpret_cast<uint64_t>(pmu_regs_array);
-
-    auto pmu_regs_array_cleanup = RAIIScopeGuard([this]() {
-        if (kernel_args_.pmu_reg_addrs != 0) {
-            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.pmu_reg_addrs));
-            kernel_args_.pmu_reg_addrs = 0;
-        }
-    });
 
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
         set_platform_dump_base_func_ == nullptr || set_platform_phase_base_func_ == nullptr ||
@@ -498,9 +528,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
 
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
-    std::vector<std::thread> aicpu_threads;
-    aicpu_threads.reserve(over_launch);
-    std::atomic<int> aicpu_rc{0};
+    active_run_->aicpu_threads.reserve(over_launch);
+    active_run_->aicore_threads.reserve(num_aicore);
 
     // Sim "device wall" capture: RunWall via host steady_clock through the
     // single-uint64 device_wall_data_base buffer (sim has no kernel.cpp wrapper
@@ -508,8 +537,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // phases are stamped by the AICPU `.so` (real sim get_sys_cnt_aicpu clock)
     // into a separate AicpuPhaseRecord buffer whose base is published into the SO
     // via the dlsym'd set_platform_phase_base — crossing the dlopen boundary the
-    // same way set_platform_dump_base etc. do. Local buffer: sim runs in-process,
-    // its lifetime spans the join below; reduced into device_phase_ns_ after.
+    // same way set_platform_dump_base etc. do. The active run owns the buffer
+    // until drain reduces it into device_phase_ns_.
     if (kernel_args_.device_wall_data_base != 0) {
         *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
     }
@@ -522,51 +551,59 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // resolves the tail at base + task_timing_tail_offset(), so it must be part of
     // the same published buffer.
     static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
-    std::vector<AicpuPhaseRecord> phase_buf(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
-    set_platform_phase_base_func_(reinterpret_cast<uint64_t>(phase_buf.data()));
+    active_run_->phase_buf.assign(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
+    set_platform_phase_base_func_(reinterpret_cast<uint64_t>(active_run_->phase_buf.data()));
     const auto sim_t0 = std::chrono::steady_clock::now();
+    run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
+    ActiveRun *run = active_run_.get();
 
     for (int i = 0; i < over_launch; i++) {
-        aicpu_threads.push_back(create_thread([this, &runtime, launch_aicpu_num, over_launch, &aicpu_rc, sim_t0]() {
+        run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
             if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
+                run_completion_.task_finished();
                 return;
             }
-            int rc = aicpu_execute_func_(&runtime);
-            if (rc != 0) {
-                int expected = 0;
-                aicpu_rc.compare_exchange_strong(expected, rc, std::memory_order_acq_rel);
-            }
+            int rc = aicpu_execute_func_(run->runtime);
             if (kernel_args_.device_wall_data_base != 0) {
                 const auto t1 = std::chrono::steady_clock::now();
                 *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) =
                     static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - sim_t0).count());
             }
+            run_completion_.task_finished(rc);
         }));
     }
 
     LOG_INFO("Launching %d AICore thread(s)", num_aicore);
-    std::vector<std::thread> aicore_threads;
     for (int i = 0; i < num_aicore; i++) {
         CoreType core_type = runtime.get_workers()[i].core_type;
         uint32_t physical_core_id = static_cast<uint32_t>(i);
-        aicore_threads.push_back(create_thread([this, &runtime, i, core_type, physical_core_id]() {
+        run->aicore_threads.push_back(create_thread([this, run, i, core_type, physical_core_id]() {
             aicore_execute_func_(
-                &runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
+                run->runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
                 kernel_args_.chip_swimlane_aicore_rotation_table
             );
+            run_completion_.task_finished();
         }));
     }
 
     // Both simulated kernel thread groups now exist. This is the sim's real
-    // launch boundary: publish before joining either group.
+    // launch boundary. Their state remains owned until drain_run().
     publish_task_accepted();
+    enqueue_cleanup.dismiss();
+    return 0;
+}
 
-    for (auto &t : aicpu_threads) {
-        t.join();
+int DeviceRunner::poll_run() { return run_completion_.poll(); }
+
+int DeviceRunner::drain_run() {
+    if (active_run_ == nullptr) {
+        LOG_ERROR("drain_run called without an enqueued simulated run");
+        return -1;
     }
-    for (auto &t : aicore_threads) {
-        t.join();
-    }
+    auto run_cleanup = RAIIScopeGuard([this]() {
+        cleanup_active_run();
+    });
+    active_run_->join();
     LOG_INFO("All threads completed");
 
     // Snapshot the device_wall buffer into device_wall_ns_.
@@ -582,7 +619,9 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // is computable and the sub-phases nest correctly.
     uint64_t phase_start[NUM_AICPU_PHASES];
     uint64_t phase_cycles[NUM_AICPU_PHASES];
-    reduce_aicpu_phase_windows(phase_buf.data(), kPhaseThreads, phase_start, phase_cycles);
+    constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
+    reduce_aicpu_phase_windows(active_run_->phase_buf.data(), kPhaseThreads, phase_start, phase_cycles);
     auto cyc_to_ns = [](uint64_t c) {
         return static_cast<uint64_t>(c * 1'000'000'000.0 / static_cast<double>(PLATFORM_PROF_SYS_CNT_FREQ));
     };
@@ -603,10 +642,11 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // Resolve the task-timing tail on the phase `origin` timeline (shared logic
     // in device_phase.h). Sim-specific here: the tail lives inline in phase_buf
     // (in-process, no D2H) and `cyc_to_ns` uses the sim sys-counter frequency.
-    const TaskTimingRecord *tail = reinterpret_cast<const TaskTimingRecord *>(phase_buf.data() + kPhaseRecs);
+    const TaskTimingRecord *tail =
+        reinterpret_cast<const TaskTimingRecord *>(active_run_->phase_buf.data() + kPhaseRecs);
     resolve_task_timing_slots_ns(tail, kPhaseThreads, origin, cyc_to_ns, task_slot_dispatch_ns_, task_slot_finish_ns_);
 
-    int runtime_rc = aicpu_rc.load(std::memory_order_acquire);
+    int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
         return runtime_rc;
@@ -716,12 +756,13 @@ void DeviceRunner::unload_executor_binaries() {
 }
 
 int DeviceRunner::finalize() {
+    cleanup_active_run();
     if (device_id_ == -1 && aicpu_so_handle_ == nullptr && aicore_so_handle_ == nullptr) {
         return 0;
     }
 
-    // Cleanup performance profiling. Normally already done by run()'s
-    // perf_cleanup guard; this is the backstop for the no-run-since-init case.
+    // cleanup_active_run() normally stops active collectors; this is the
+    // backstop for the initialized-but-never-enqueued case.
     finalize_collectors();
 
     release_callable_state();
@@ -750,7 +791,7 @@ int DeviceRunner::finalize() {
     prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
     prebuilt_runtime_arena_cache_image_.clear();
 
-    // Free the 8-byte device_wall buffer (allocated lazily in run()) before
+    // Free the 8-byte device_wall buffer (allocated lazily in enqueue_run()) before
     // mem_alloc_.finalize().
     if (device_wall_dev_ptr_ != nullptr) {
         free_tensor(device_wall_dev_ptr_);

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -13,27 +13,30 @@
  * execution model. The shared base (`SimDeviceRunnerBase`) hosts the arena /
  * tensor-copy / callable-registry / chip-callable-buffer pool. This subclass
  * adds the a2a3-specific dlsym'd function-pointer table, dep_gen collector +
- * gating, and the run() / init_* / ensure_binaries_loaded sequence wired to
- * a2a3's aicore_execute signature.
+ * gating, and the enqueue/poll/drain sequence wired to a2a3's aicore_execute
+ * signature.
  */
 
-#ifndef SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_
-#define SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_
+#pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "common/core_type.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"
+#include "sim_run_completion.h"
 
 class DeviceRunner : public SimDeviceRunnerBase {
 public:
-    DeviceRunner() = default;
+    DeviceRunner();
     ~DeviceRunner() override;
 
-    int run(Runtime &runtime, const CallConfig &config) override;
+    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int poll_run() override;
+    int drain_run() override;
     int finalize() override;
     // Also arms the loaded runtime's host-side graph capture, which a host-orch
     // runtime uses instead of the device collector. Defined in the .cpp so this
@@ -44,9 +47,12 @@ public:
     void destroy_native_run_thread_state(void *snapshot) noexcept override;
 
 private:
+    struct ActiveRun;
+
     int ensure_binaries_loaded() override;
     int invoke_device_register(const RegisterCallableArgs &reg_args) override;
     void unload_executor_binaries();
+    void cleanup_active_run() noexcept;
 
     int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
     int init_args_dump(Runtime &runtime, int device_id);
@@ -86,6 +92,6 @@ private:
     // a2a3-only; a5 has no dep_gen.
     DepGenCollector dep_gen_collector_;
     bool enable_dep_gen_{false};
+    std::unique_ptr<ActiveRun> active_run_;
+    simpler::common::sim_host::SimRunCompletion run_completion_;
 };
-
-#endif  // SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -909,7 +909,8 @@ extern "C" int bind_callable_to_runtime_impl(
  * 3. Clears tensor pair state
  *
  * @param runtime       Pointer to Runtime
- * @param execution_rc  Status returned by DeviceRunner::run
+ * @param execution_rc  Device-runner drain status after successful enqueue,
+ *                      or enqueue status on failure
  * @return 0 on success, -1 on failure
  */
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {

--- a/src/a2a3/runtime/host_build_graph/runtime/dep_gen_host_graph.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/dep_gen_host_graph.h
@@ -38,7 +38,7 @@
  *
  * The graph is per-thread state while it is being built. After bind, prepare
  * moves the completed graph into run-owned storage; launch adopts that snapshot
- * into the executor's thread-local state before DeviceRunner::run emits it.
+ * into the executor's thread-local state before enqueue, and drain emits it.
  * This keeps capture lock-free while allowing serialized lifecycle calls to
  * use different host threads and preventing two prepared contexts on one
  * thread from overwriting one another.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -966,7 +966,8 @@ extern "C" int prewarm_config_impl(
  * 3. Clears tensor lease state
  *
  * @param runtime       Pointer to Runtime
- * @param execution_rc  Status returned by DeviceRunner::run
+ * @param execution_rc  Device-runner drain status after successful enqueue,
+ *                      or enqueue status on failure
  * @return 0 on success, -1 on failure
  */
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {

--- a/src/a5/platform/docs/tpush-tpop-sim.md
+++ b/src/a5/platform/docs/tpush-tpop-sim.md
@@ -130,7 +130,7 @@ physical_core_id [block_dim..3*block_dim-1] = AIV pairs
 
 ### Lifecycle
 
-- `DeviceRunner::run()` start: `clear_cpu_sim_shared_storage()` frees all
+- Device-runner enqueue start: `clear_cpu_sim_shared_storage()` frees all
   `SharedState` entries for the current device.
 - `DeviceRunner::finalize()`: same cleanup.
 - `pto_cpu_sim_release_device()`: destroys the entire device context including

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -137,12 +137,27 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
     return 0;
 }
 
-int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
+    if (run_resources_owned_) {
+        LOG_ERROR(
+            "enqueue_run entered while slot %u still owns resources", run_poll_slot_.load(std::memory_order_relaxed)
+        );
+        return -1;
+    }
+    const uint32_t selected_pipeline_slot = pipeline_slot();
+    run_poll_slot_.store(selected_pipeline_slot, std::memory_order_relaxed);
+    run_poll_state_.store(RunPollState::Enqueuing, std::memory_order_release);
+    run_resources_owned_ = true;
+    // Before the real AICPU launch marker, enqueue owns rollback. A successful
+    // enqueue dismisses this guard and transfers every resource to drain_run().
+    auto enqueue_rollback = RAIIScopeGuard([this]() {
+        cleanup_active_run();
+    });
     // Latch this run's diagnostic enables onto the runner before the collector
     // paths below read them; block_dim/aicpu_thread_num are consumed locally.
     apply_call_config(config);
     // activate_launch_shape() latches this run's geometry onto the runner on the
-    // executor thread immediately before run(), so block_dim_ is this run's.
+    // executor thread immediately before enqueue, so block_dim_ is this run's.
     const int block_dim = block_dim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
@@ -154,9 +169,9 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // turns the rest of an xdist worker session's tests from a slow, confusing
     // failure cascade into a single fast, self-explanatory error; the runner is
     // then recovered at finalize.
-    if (device_unusable_) {
+    if (device_unusable_.load(std::memory_order_acquire)) {
         LOG_ERROR(
-            "DeviceRunner marked unusable by a prior AICore failure; refusing to run. "
+            "DeviceRunner marked unusable by a prior AICore failure; refusing to enqueue. "
             "A soft reset does not clear the poison on a5; finalize() will force-reset "
             "the card so the next Worker on it inits clean."
         );
@@ -175,7 +190,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     ensure_device_wall_buffer();
 
     if (block_dim < 1) {
-        LOG_ERROR("run() reached with unresolved block_dim; activate_launch_shape must run first");
+        LOG_ERROR("enqueue_run reached with unresolved block_dim; activate_launch_shape must run first");
         return -1;
     }
     int num_aicore = block_dim * cores_per_blockdim_;
@@ -251,19 +266,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         }
     }
 
-    // Scope guards for cleanup on all exit paths
-    auto regs_cleanup = RAIIScopeGuard([this]() {
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-    });
-
-    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
-        kernel_args_.finalize_device_kernel_args();
-        kernel_args_.finalize_runtime_args();
-    });
-
     // Initialize per-subsystem shared memory.
     if (enable_chip_swimlane_) {
         rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
@@ -305,13 +307,6 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
             return rc;
         }
     }
-
-    // Cleanup guard for early returns: stops all started collectors so
-    // their mgmt + poll threads exit cleanly. stop() is idempotent and a
-    // no-op on collectors that never started.
-    auto perf_cleanup = RAIIScopeGuard([this]() {
-        finalize_collectors();
-    });
 
     rc = prepare_orch_so(runtime);
     if (rc != 0) {
@@ -379,6 +374,10 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         LOG_ERROR("init_device_kernel_args failed: %d", rc);
         return rc;
     }
+    // Publish query/drain ownership before either kernel launch. The real
+    // launch marker is notified inside launch_aicpu_kernel(), so no state that
+    // poll or drain needs may be committed after that call succeeds.
+    run_poll_state_.store(RunPollState::Submitted, std::memory_order_release);
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
@@ -405,28 +404,56 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         return rc;
     }
 
-    rc = sync_run_streams();
+    enqueue_rollback.dismiss();
+    return 0;
+}
+
+int DeviceRunner::poll_run(uint32_t pipeline_slot) {
+    const RunPollState state = run_poll_state_.load(std::memory_order_acquire);
+    if (run_poll_slot_.load(std::memory_order_relaxed) != pipeline_slot) {
+        return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    }
+    if (state == RunPollState::DeviceComplete || state == RunPollState::Drained) {
+        return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    }
+    if (state != RunPollState::Submitted) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+
+    const int rc = query_stream_pair_nonblocking(stream_aicpu_, stream_aicore_);
+    if (rc == SIMPLER_NATIVE_RUN_POLL_COMPLETE) {
+        RunPollState expected = RunPollState::Submitted;
+        (void)run_poll_state_.compare_exchange_strong(
+            expected, RunPollState::DeviceComplete, std::memory_order_acq_rel, std::memory_order_acquire
+        );
+    }
+    return rc;
+}
+
+int DeviceRunner::drain_run(uint32_t pipeline_slot) {
+    if (!run_resources_owned_ || run_poll_slot_.load(std::memory_order_relaxed) != pipeline_slot) {
+        LOG_ERROR(
+            "drain_run slot mismatch: requested=%u active=%u owns=%d", pipeline_slot,
+            run_poll_slot_.load(std::memory_order_relaxed), static_cast<int>(run_resources_owned_)
+        );
+        return -1;
+    }
+    auto drain_cleanup = RAIIScopeGuard([this]() {
+        cleanup_active_run();
+    });
+
+    int rc = sync_run_streams();
     if (rc != 0) {
         // sync_run_streams surfaces the AICore op-timeout (STARS-reaped op ->
         // 507000/507018/507046 at AICPU/AICore stream sync). The op-timeout
-        // leaves the device context poisoned for the SAME DeviceRunner's next
-        // run, so attempt recovery / mark-unusable here too, not only on the
-        // launch-error path above.
+        // leaves the context poisoned, so recovery remains the drain owner's
+        // responsibility and its error remains authoritative over cleanup.
         recover_device_or_mark_unusable(rc);
-        // On an AICPU-detected scheduler hang the device flushed its diagnostic
-        // buffers during emergency_shutdown before returning the timeout rc.
-        // Export them here too — otherwise the success-only teardown below is
-        // skipped and the dumped tensors (the stuck task's inputs plus every
-        // completed task's in/out) are streamed to .bin but left without the
-        // JSON manifest, i.e. unusable for triage. reconcile/export are not
-        // idempotent, so this runs only on the error return; the success path
-        // still exports exactly once below.
+        // Emergency shutdown may already have flushed diagnostics. Export the
+        // manifest on the error path exactly once.
         teardown_shared_collectors_after_run();
         return rc;
     }
 
     read_device_wall_ns();
-
     teardown_shared_collectors_after_run();
 
     // a5-specific dep_gen teardown: stop + reconcile + replay emit.
@@ -442,17 +469,31 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         }
     }
 
-    // Print handshake results (reads from device memory, must be before free)
+    // Reads device memory, so it must precede KernelArgs/runtime cleanup.
     print_handshake_results();
-
     return 0;
+}
+
+void DeviceRunner::cleanup_active_run() noexcept {
+    if (!run_resources_owned_) return;
+
+    // Collectors stop before device/runtime arguments and register buffers.
+    finalize_collectors();
+    (void)kernel_args_.finalize_device_kernel_args();
+    (void)kernel_args_.finalize_runtime_args();
+    if (kernel_args_.args.regs != 0) {
+        (void)mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
+        kernel_args_.args.regs = 0;
+    }
+    run_resources_owned_ = false;
+    run_poll_state_.store(RunPollState::Drained, std::memory_order_release);
 }
 
 void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
     // An AICore launch failure (207001) or an op-timeout reaped by STARS
     // (surfaced as 507000/507018/507046 at stream sync) leaves the device
     // context in a sticky-error state: the streams stay poisoned and the
-    // SAME DeviceRunner's next run() fails early — observed on a5 as
+    // SAME DeviceRunner's next enqueue fails early — observed on a5 as
     // `halResMap failed (rc=62)` in init_aicore_register_addresses, and on
     // a2a3 as `rtMalloc failed: 507899`. Reused across a session (the L2
     // st_worker pool hands one ChipWorker to every test class on a device),
@@ -466,8 +507,8 @@ void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
     // untriggered (observed cascading into skipped L2 cases on a2a3 CI run
     // 27742754024; the same gate exists here). The op-timeout sticky-error is
     // only cleared by a force reset (a soft reset/drain does not), so always mark
-    // the runner unusable here: run() fails fast and finalize() force-resets the
-    // card, so the next Worker.init lands clean regardless of the drain result.
+    // the runner unusable here: admission fails fast and finalize() force-resets
+    // the card, so the next Worker.init lands clean regardless of the drain result.
     int sync_rc = aclrtSynchronizeDeviceWithTimeout(timeout_config_.stream_sync_timeout_ms);
     if (sync_rc != ACL_SUCCESS) {
         LOG_ERROR(
@@ -480,7 +521,7 @@ void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
             aicore_rc
         );
     }
-    device_unusable_ = true;
+    device_unusable_.store(true, std::memory_order_release);
 }
 
 namespace {
@@ -649,7 +690,7 @@ int DeviceRunner::finalize() {
     }
 
     // Cleanup all profiling subsystems (free shm + per-buffer dev/host
-    // shadows). Normally already done by run()'s exit path; this is the
+    // shadows). Normally already done by drain or enqueue rollback; this is the
     // backstop for the no-run-since-init case.
     finalize_collectors();
 
@@ -693,7 +734,7 @@ int DeviceRunner::finalize() {
     // .claude/rules/running-onboard.md), and the reset is verified to scope to
     // this card alone, so it cannot disturb other devices/users.
     int reset_rc = 0;
-    if (device_unusable_) {
+    if (device_unusable_.load(std::memory_order_acquire)) {
         // Bounded retry: a single force reset normally clears the op-timeout
         // sticky-error, but the poison occasionally needs a drain-then-reset
         // cycle, so retry up to kMaxResetAttempts. force_reset_device() drains
@@ -728,10 +769,10 @@ int DeviceRunner::finalize() {
     device_id_ = -1;
     // Clear the poison flag only if the force reset actually recovered the card,
     // so a still-poisoned card stays flagged: a reused DeviceRunner then fails
-    // run() fast instead of being treated as clean. On the normal (not unusable)
-    // path reset_rc stays 0 and the flag is already false.
+    // admission instead of being treated as clean. On the normal (not
+    // unusable) path reset_rc stays 0 and the flag is already false.
     if (reset_rc == 0) {
-        device_unusable_ = false;
+        device_unusable_.store(false, std::memory_order_release);
     }
     return rc != 0 ? rc : reset_rc;
 }
@@ -739,8 +780,8 @@ int DeviceRunner::finalize() {
 // `launch_aicpu_kernel` and `launch_aicore_kernel` live on `DeviceRunnerBase`.
 
 void DeviceRunner::finalize_collectors() {
-    // On any exit from run() — success or early error — release the diagnostics
-    // collectors' shared memory. They are only re-initialized per run(), so a
+    // On drain or enqueue rollback, release the diagnostics collectors' shared
+    // memory. They are only re-initialized per run, so a
     // Worker reused across runs (e.g. a pytest session-scoped worker pool) would
     // otherwise re-enter init_chip_swimlane() with stale state still allocated.
     // Matches a2a3's finalize_collectors().

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -19,11 +19,11 @@
  * - DeviceRunner: kernel launching and execution
  */
 
-#ifndef RUNTIME_DEVICERUNNER_H
-#define RUNTIME_DEVICERUNNER_H
+#pragma once
 
 #include <runtime/rt.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -37,6 +37,7 @@
 
 #include "callable.h"
 #include "prepare_callable_common.h"
+#include "pto_runtime_c_api.h"
 #include "utils/device_arena.h"
 #include "device_runner_base.h"     // common DeviceRunnerBase
 #include "device_runner_helpers.h"  // common KernelArgsHelper
@@ -83,30 +84,12 @@ public:
     // `device_id`, `last_device_wall_ns`, `launch_aicpu_kernel`, and
     // `launch_aicore_kernel` are inherited from `DeviceRunnerBase`.
 
-    /**
-     * Execute a runtime
-     *
-     * This method:
-     * 1. Initializes device if not already done (lazy initialization)
-     * 2. Initializes worker handshake buffers in the runtime based on block_dim
-     * 3. Transfers runtime to device memory
-     * 4. Launches AICPU main kernel
-     * 5. Launches AICore kernel
-     * 6. Synchronizes streams
-     * 7. Cleans up runtime memory
-     *
-     * @param runtime             Runtime to execute (will be modified to
-     * initialize workers)
-     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param launch_aicpu_num     Number of AICPU instances (default: 1)
-     * @return 0 on success, error code on failure
-     *
-     * The bound device id, AICPU/AICore executor binaries, and log filter
-     * are captured once by simpler_init (binaries) / libsimpler_log.so (log)
-     * and read off DeviceRunner state / HostLogger here — no per-run args.
-     */
-    int run(Runtime &runtime, const CallConfig &config) override;
-    bool can_accept_run() const override { return !device_unusable_; }
+    // The blocking entry point composes these operations. enqueue owns rollback
+    // until the AICPU launch marker; drain takes that ownership on success.
+    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int poll_run(uint32_t pipeline_slot) override;
+    int drain_run(uint32_t pipeline_slot) override;
+    bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }
 
     // `set_chip_swimlane_enabled`, `set_dump_args_enabled`,
     // `set_pmu_enabled`, `set_scope_stats_enabled`, `set_output_prefix`,
@@ -202,21 +185,37 @@ private:
     // Set true when an AICore launch/sync error (e.g. an op-timeout reaped by
     // STARS, surfaced as 507000/507018 at stream sync, or a 207001 launch
     // failure) left the device context in a sticky-error state that an
-    // in-place drain could not clear. Once set, run() fails fast instead of
-    // cascading into the confusing downstream failures (halResMap rc=62 at
+    // in-place drain could not clear. Once set, admission/enqueue fail fast
+    // instead of cascading into the confusing downstream failures (halResMap rc=62 at
     // init_aicore_register_addresses, or rtMalloc 507899) that a poisoned
     // context produces. On a5 the poison survives a close()+soft-reset for the
     // life of the process (an in-process re-init fails with rtStreamCreate
     // 507899), but a *force* reset clears it: finalize() calls
     // force_reset_device() on this path so the next Worker re-inits clean in the
-    // same process (see force_reset_device()). This flag fails run() fast and
-    // drives that recovery. See run() and recover_device_or_mark_unusable().
-    bool device_unusable_{false};
+    // same process (see force_reset_device()). This flag drives admission and
+    // recovery. See enqueue_run() and recover_device_or_mark_unusable().
+    // Admission and recovery execute on different host threads.
+    std::atomic<bool> device_unusable_{false};
+
+    enum class RunPollState : uint8_t {
+        Idle,
+        Enqueuing,
+        Submitted,
+        DeviceComplete,
+        Drained,
+    };
+    std::atomic<RunPollState> run_poll_state_{RunPollState::Idle};
+    std::atomic<uint32_t> run_poll_slot_{PTO_PIPELINE_MAX_DEPTH};
+    bool run_resources_owned_{false};
+
+    // Release executor-owned per-run resources and publish a sticky terminal
+    // state. Idempotent so enqueue rollback and drain share one path.
+    void cleanup_active_run() noexcept;
 
     // On an AICore launch/sync error, best-effort drain the device so a later
-    // run() on the same DeviceRunner can recover in place; if the drain itself
+    // enqueue on the same DeviceRunner can recover in place; if the drain itself
     // errors the context is unrecoverable without a full reset, so flip
-    // device_unusable_ and let run() fail fast.
+    // device_unusable_ and let admission/enqueue fail fast.
     void recover_device_or_mark_unusable(int aicore_rc);
 
     // Force-reset the card via aclrtResetDeviceForce to clear an op-timeout
@@ -288,5 +287,3 @@ private:
     // Does not release device memory; full release happens in finalize().
     void finalize_collectors();
 };
-
-#endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -22,7 +22,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
@@ -71,7 +70,43 @@ static int prof_free_cb(void *dev_ptr) {
     return 0;
 }
 
+struct DeviceRunner::ActiveRun {
+    Runtime *runtime{nullptr};
+    void *reg_blocks{nullptr};
+    std::vector<std::thread> aicpu_threads;
+    std::vector<std::thread> aicore_threads;
+    std::vector<AicpuPhaseRecord> phase_buf;
+
+    void join() noexcept {
+        for (auto &thread : aicpu_threads) {
+            if (thread.joinable()) thread.join();
+        }
+        for (auto &thread : aicore_threads) {
+            if (thread.joinable()) thread.join();
+        }
+    }
+
+    ~ActiveRun() { join(); }
+};
+
+DeviceRunner::DeviceRunner() = default;
 DeviceRunner::~DeviceRunner() { finalize(); }
+
+void DeviceRunner::cleanup_active_run() noexcept {
+    if (active_run_ == nullptr) return;
+    active_run_->join();
+
+    if (kernel_args_.regs != 0) {
+        mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.regs));
+        kernel_args_.regs = 0;
+    }
+    if (active_run_->reg_blocks != nullptr) {
+        mem_alloc_.free(active_run_->reg_blocks);
+        active_run_->reg_blocks = nullptr;
+    }
+    finalize_collectors();
+    active_run_.reset();
+}
 
 int DeviceRunner::ensure_binaries_loaded() {
     // AICPU .so: load-once, matching onboard's binaries_loaded_ pattern.
@@ -216,7 +251,19 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
+    if (active_run_ != nullptr) {
+        LOG_ERROR("enqueue_run called while another simulated run still owns execution state");
+        return -1;
+    }
+    active_run_ = std::make_unique<ActiveRun>();
+    active_run_->runtime = &runtime;
+    run_completion_.reset(1);
+    auto enqueue_cleanup = RAIIScopeGuard([this]() {
+        run_completion_.abandon();
+        cleanup_active_run();
+    });
+
     apply_call_config(config);
     // prepare_launch_shape() resolved block_dim before the graph was built, so
     // the geometry this run launches with is already on the runner.
@@ -229,7 +276,7 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
     runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
-        LOG_ERROR("run() reached with unresolved block_dim; prepare_launch_shape must run first");
+        LOG_ERROR("enqueue_run reached with unresolved block_dim; prepare_launch_shape must run first");
         return -1;
     }
 
@@ -333,27 +380,16 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         }
     }
 
-    // Cleanup guard for early returns: stops all started collectors so their
-    // mgmt + poll threads exit cleanly. stop() is idempotent and a no-op on
-    // collectors that never started.
-    auto perf_cleanup = RAIIScopeGuard([this]() {
-        finalize_collectors();
-    });
-
     // Allocate simulated register blocks for all AICore cores. Uses sparse
     // mapping: 3 x 4KB pages per core (SIM_REG_TOTAL_SIZE) instead of a
     // contiguous block.
     size_t total_reg_size = num_aicore * SIM_REG_TOTAL_SIZE;
-    void *reg_blocks = mem_alloc_.alloc(total_reg_size);
-    if (reg_blocks == nullptr) {
+    active_run_->reg_blocks = mem_alloc_.alloc(total_reg_size);
+    if (active_run_->reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated register memory (%zu bytes)", total_reg_size);
         return -1;
     }
-    std::memset(reg_blocks, 0, total_reg_size);
-
-    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() {
-        mem_alloc_.free(reg_blocks);
-    });
+    std::memset(active_run_->reg_blocks, 0, total_reg_size);
 
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
@@ -362,16 +398,10 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t *>(reg_blocks) + i * SIM_REG_TOTAL_SIZE);
+        regs_array[i] =
+            reinterpret_cast<uint64_t>(static_cast<uint8_t *>(active_run_->reg_blocks) + i * SIM_REG_TOTAL_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
-
-    auto regs_array_cleanup = RAIIScopeGuard([this]() {
-        if (kernel_args_.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.regs));
-            kernel_args_.regs = 0;
-        }
-    });
 
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
         set_platform_dump_base_func_ == nullptr || set_platform_phase_base_func_ == nullptr ||
@@ -423,9 +453,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
 
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
-    std::vector<std::thread> aicpu_threads;
-    aicpu_threads.reserve(over_launch);
-    std::atomic<int> aicpu_rc{0};
+    active_run_->aicpu_threads.reserve(over_launch);
+    active_run_->aicore_threads.reserve(num_aicore);
 
     if (kernel_args_.device_wall_data_base != 0) {
         *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
@@ -437,8 +466,8 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // buffer base is published into the dlopen'd runtime SO via the dlsym'd
     // set_platform_phase_base (crossing the host↔SO boundary like the dump base),
     // and each thread resolves its slot from platform_aicpu_affinity_thread_idx()
-    // — no C++ thread_local. Local buffer: sim runs in-process so its lifetime
-    // spans the join below; reduced into device_phase_ns_ after.
+    // — no C++ thread_local. The active run owns the buffer until drain reduces
+    // it into device_phase_ns_.
     constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
     constexpr size_t kTailRecs = static_cast<size_t>(task_timing_buffer_slots(kPhaseThreads));
@@ -448,50 +477,58 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // resolves the tail at base + task_timing_tail_offset(), so it must be part of
     // the same published buffer.
     static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
-    std::vector<AicpuPhaseRecord> phase_buf(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
-    set_platform_phase_base_func_(reinterpret_cast<uint64_t>(phase_buf.data()));
+    active_run_->phase_buf.assign(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
+    set_platform_phase_base_func_(reinterpret_cast<uint64_t>(active_run_->phase_buf.data()));
+    run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
+    ActiveRun *run = active_run_.get();
 
     for (int i = 0; i < over_launch; i++) {
-        aicpu_threads.push_back(create_thread([this, &runtime, launch_aicpu_num, over_launch, &aicpu_rc, sim_t0]() {
+        run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
             if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
+                run_completion_.task_finished();
                 return;
             }
-            int rc = aicpu_execute_func_(&runtime);
-            if (rc != 0) {
-                int expected = 0;
-                aicpu_rc.compare_exchange_strong(expected, rc, std::memory_order_acq_rel);
-            }
+            int rc = aicpu_execute_func_(run->runtime);
             if (kernel_args_.device_wall_data_base != 0) {
                 const auto t1 = std::chrono::steady_clock::now();
                 *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) =
                     static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - sim_t0).count());
             }
+            run_completion_.task_finished(rc);
         }));
     }
 
     LOG_INFO("Launching %d AICore thread(s)", num_aicore);
-    std::vector<std::thread> aicore_threads;
     for (int i = 0; i < num_aicore; i++) {
         CoreType core_type = runtime.get_workers()[i].core_type;
         uint32_t physical_core_id = static_cast<uint32_t>(i);
-        aicore_threads.push_back(create_thread([this, &runtime, i, core_type, physical_core_id]() {
+        run->aicore_threads.push_back(create_thread([this, run, i, core_type, physical_core_id]() {
             aicore_execute_func_(
-                &runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
+                run->runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
                 kernel_args_.chip_swimlane_aicore_rotation_table, kernel_args_.aicore_pmu_ring_addrs
             );
+            run_completion_.task_finished();
         }));
     }
 
     // Both simulated kernel thread groups now exist. This is the sim's real
-    // launch boundary: publish before joining either group.
+    // launch boundary. Their state remains owned until drain_run().
     publish_task_accepted();
+    enqueue_cleanup.dismiss();
+    return 0;
+}
 
-    for (auto &t : aicpu_threads) {
-        t.join();
+int DeviceRunner::poll_run() { return run_completion_.poll(); }
+
+int DeviceRunner::drain_run() {
+    if (active_run_ == nullptr) {
+        LOG_ERROR("drain_run called without an enqueued simulated run");
+        return -1;
     }
-    for (auto &t : aicore_threads) {
-        t.join();
-    }
+    auto run_cleanup = RAIIScopeGuard([this]() {
+        cleanup_active_run();
+    });
+    active_run_->join();
 
     LOG_INFO("All threads completed");
 
@@ -507,7 +544,9 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // is computable and the sub-phases nest correctly.
     uint64_t phase_start[NUM_AICPU_PHASES];
     uint64_t phase_cycles[NUM_AICPU_PHASES];
-    reduce_aicpu_phase_windows(phase_buf.data(), kPhaseThreads, phase_start, phase_cycles);
+    constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
+    reduce_aicpu_phase_windows(active_run_->phase_buf.data(), kPhaseThreads, phase_start, phase_cycles);
     auto cyc_to_ns = [](uint64_t c) {
         return static_cast<uint64_t>(c * 1'000'000'000.0 / static_cast<double>(PLATFORM_PROF_SYS_CNT_FREQ));
     };
@@ -528,10 +567,11 @@ int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
     // Resolve the task-timing tail on the phase `origin` timeline (shared logic
     // in device_phase.h). Sim-specific here: the tail lives inline in phase_buf
     // (in-process, no D2H) and `cyc_to_ns` uses the sim sys-counter frequency.
-    const TaskTimingRecord *tail = reinterpret_cast<const TaskTimingRecord *>(phase_buf.data() + kPhaseRecs);
+    const TaskTimingRecord *tail =
+        reinterpret_cast<const TaskTimingRecord *>(active_run_->phase_buf.data() + kPhaseRecs);
     resolve_task_timing_slots_ns(tail, kPhaseThreads, origin, cyc_to_ns, task_slot_dispatch_ns_, task_slot_finish_ns_);
 
-    int runtime_rc = aicpu_rc.load(std::memory_order_acquire);
+    int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
         return runtime_rc;
@@ -628,12 +668,13 @@ void DeviceRunner::unload_executor_binaries() {
 }
 
 int DeviceRunner::finalize() {
+    cleanup_active_run();
     if (device_id_ == -1 && aicpu_so_handle_ == nullptr && aicore_so_handle_ == nullptr) {
         return 0;
     }
 
-    // Cleanup performance profiling. Normally already done by run()'s
-    // perf_cleanup guard; this is the backstop for the no-run-since-init case.
+    // cleanup_active_run() normally stops active collectors; this is the
+    // backstop for the initialized-but-never-enqueued case.
     finalize_collectors();
 
     release_callable_state();

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -13,35 +13,41 @@
  * execution model. The shared base (`SimDeviceRunnerBase`) hosts the arena /
  * tensor-copy / callable-registry / chip-callable-buffer pool. This subclass
  * adds the a5-specific dlsym'd function-pointer table (different aicore_execute
- * signature than a2a3 — extra aicore_pmu_ring_addrs arg) and the run() /
- * init_* / ensure_binaries_loaded sequence wired to a5's contract.
+ * signature than a2a3 — extra aicore_pmu_ring_addrs arg) and the
+ * enqueue/poll/drain sequence wired to a5's contract.
  */
 
-#ifndef SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_
-#define SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_
+#pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "common/core_type.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"
+#include "sim_run_completion.h"
 
 class DeviceRunner : public SimDeviceRunnerBase {
 public:
-    DeviceRunner() = default;
+    DeviceRunner();
     ~DeviceRunner() override;
 
-    int run(Runtime &runtime, const CallConfig &config) override;
+    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int poll_run() override;
+    int drain_run() override;
     int finalize() override;
     // a5 dep_gen enablement setter, overriding the base no-op (the c_api
     // unconditionally calls it).
     void set_dep_gen_enabled(bool enable) override { enable_dep_gen_ = enable; }
 
 private:
+    struct ActiveRun;
+
     int ensure_binaries_loaded() override;
     int invoke_device_register(const RegisterCallableArgs &reg_args) override;
     void unload_executor_binaries();
+    void cleanup_active_run() noexcept;
 
     int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
     int init_args_dump(Runtime &runtime, int device_id);
@@ -50,7 +56,7 @@ private:
     int init_dep_gen(int num_threads, int device_id);
 
     // Per-run collector teardown: stop + release shm so a session-scoped Worker
-    // can re-init collectors on the next run(). Matches a2a3 sim.
+    // can re-init collectors on the next enqueue. Matches a2a3 sim.
     void finalize_collectors();
 
     // a5 sim's dlsym'd function-pointer table. Loaded once via
@@ -79,6 +85,6 @@ private:
     // dep_gen collector — captures orchestrator submit_task inputs for offline replay.
     DepGenCollector dep_gen_collector_;
     bool enable_dep_gen_{false};
+    std::unique_ptr<ActiveRun> active_run_;
+    simpler::common::sim_host::SimRunCompletion run_completion_;
 };
-
-#endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -909,7 +909,8 @@ extern "C" int bind_callable_to_runtime_impl(
  * 3. Clears tensor pair state
  *
  * @param runtime       Pointer to Runtime
- * @param execution_rc  Status returned by DeviceRunner::run
+ * @param execution_rc  Device-runner drain status after successful enqueue,
+ *                      or enqueue status on failure
  * @return 0 on success, -1 on failure
  */
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {

--- a/src/a5/runtime/host_build_graph/runtime/dep_gen_host_graph.h
+++ b/src/a5/runtime/host_build_graph/runtime/dep_gen_host_graph.h
@@ -38,7 +38,7 @@
  *
  * The graph is per-thread state while it is being built. After bind, prepare
  * moves the completed graph into run-owned storage; launch adopts that snapshot
- * into the executor's thread-local state before DeviceRunner::run emits it.
+ * into the executor's thread-local state before enqueue, and drain emits it.
  * This keeps capture lock-free while allowing serialized lifecycle calls to
  * use different host threads and preventing two prepared contexts on one
  * thread from overwriting one another.

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -949,7 +949,8 @@ extern "C" int prewarm_config_impl(
  * 3. Clears tensor lease state
  *
  * @param runtime       Pointer to Runtime
- * @param execution_rc  Status returned by DeviceRunner::run
+ * @param execution_rc  Device-runner drain status after successful enqueue,
+ *                      or enqueue status on failure
  * @return 0 on success, -1 on failure
  */
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {

--- a/src/common/platform/include/host/run_stream_slots.h
+++ b/src/common/platform/include/host/run_stream_slots.h
@@ -9,13 +9,14 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_RUN_STREAM_SLOTS_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_HOST_RUN_STREAM_SLOTS_H_
+#pragma once
 
 #include <array>
 #include <atomic>
 #include <cstddef>
 #include <functional>
+#include <mutex>
+#include <utility>
 
 #include "pto_runtime_c_api.h"
 
@@ -35,19 +36,19 @@
  * to retry. Stream creation and destruction are injected so this state machine
  * is exercisable without a device.
  *
- * Threading: a `Slot` is touched only by the thread that owns that slot's run,
- * and admission gives at most one owner per slot, so the per-slot handles need
- * no synchronization. Two slots are therefore serviced concurrently — a native
- * prepare acquires the successor's slot while the executor retires the
- * predecessor's. `created_count_` is the one field shared across those owners
- * and is additionally readable from an unrelated thread through
- * `get_run_stream_set_create_count`, so it is atomic. `destroy_all()` walks
- * every slot and requires all runs to be quiesced.
+ * Threading: prepare and drain remain the owning operations, but poll may query
+ * the active slot from a progress thread while the executor retires its AICore
+ * stream. Each slot therefore serializes query with handle mutation. Poll uses
+ * try-lock and reports NOT_READY rather than waiting behind retirement. Two
+ * different slots remain independent, so native prepare can acquire a
+ * successor while the executor drains its predecessor. `created_count_` is
+ * additionally readable from unrelated threads and remains atomic.
  */
 class RunStreamSlots {
 public:
     using CreateFn = std::function<int(void **out_stream)>;
     using DestroyFn = std::function<int(void *stream)>;
+    enum class CompletionStatus { Unproven, Complete };
 
     RunStreamSlots(CreateFn create, DestroyFn destroy) :
         create_(std::move(create)),
@@ -61,6 +62,7 @@ public:
     int acquire(unsigned slot) {
         if (slot >= slots_.size()) return -1;
         Slot &s = slots_[slot];
+        std::lock_guard<std::mutex> lock(s.mutex);
         if (s.aicpu == nullptr) {
             int rc = create_(&s.aicpu);
             if (rc != 0) {
@@ -75,13 +77,59 @@ public:
             return rc;
         }
         created_count_.fetch_add(1, std::memory_order_relaxed);
+        s.submitted = false;
+        s.complete = false;
         return 0;
     }
 
-    /** Retire `slot`'s AICore stream. The handle survives a failed destroy. */
-    int retire_aicore(unsigned slot) {
+    /** Make the prepared stream pair visible to non-blocking poll. */
+    int mark_submitted(unsigned slot) {
         if (slot >= slots_.size()) return -1;
         Slot &s = slots_[slot];
+        std::lock_guard<std::mutex> lock(s.mutex);
+        if (s.aicpu == nullptr || s.aicore == nullptr) return -1;
+        s.submitted = true;
+        s.complete = false;
+        return 0;
+    }
+
+    /**
+     * Query both streams without waiting behind retirement.
+     *
+     * A completed result is sticky until the slot is acquired for its next
+     * generation, so a poll racing with successful stream destruction never
+     * observes a missing handle as an error.
+     */
+    template <typename QueryPairFn>
+    int poll(unsigned slot, QueryPairFn &&query) {
+        if (slot >= slots_.size()) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+        Slot &s = slots_[slot];
+        std::unique_lock<std::mutex> lock(s.mutex, std::try_to_lock);
+        if (!lock.owns_lock()) return SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+        if (s.complete) return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+        if (!s.submitted || s.aicpu == nullptr || s.aicore == nullptr) {
+            return SIMPLER_NATIVE_RUN_POLL_ERROR;
+        }
+        const int rc = std::forward<QueryPairFn>(query)(s.aicpu, s.aicore);
+        if (rc == SIMPLER_NATIVE_RUN_POLL_COMPLETE) s.complete = true;
+        return rc;
+    }
+
+    /**
+     * Retire `slot`'s AICore stream. The handle survives a failed destroy.
+     * Only a successful device query or stream synchronization may pass
+     * Complete; launch rollback and abandoned preparation pass Unproven.
+     */
+    int retire_aicore(unsigned slot, CompletionStatus completion_status) {
+        if (slot >= slots_.size()) return -1;
+        Slot &s = slots_[slot];
+        std::lock_guard<std::mutex> lock(s.mutex);
+        // Publish the proven terminal state before destroying the handle. Poll
+        // either finishes its in-flight query first or observes this result.
+        // An error-path retirement clears a completion that raced ahead of a
+        // later failing sync, so the sync error remains authoritative.
+        s.submitted = false;
+        s.complete = completion_status == CompletionStatus::Complete;
         if (s.aicore == nullptr) return 0;
         int rc = destroy_(s.aicore);
         if (rc != 0) return rc;
@@ -93,6 +141,9 @@ public:
     int destroy_all() {
         int first_error = 0;
         for (Slot &s : slots_) {
+            std::lock_guard<std::mutex> lock(s.mutex);
+            s.submitted = false;
+            s.complete = false;
             for (void **stream : {&s.aicpu, &s.aicore}) {
                 if (*stream == nullptr) continue;
                 int rc = destroy_(*stream);
@@ -114,8 +165,11 @@ public:
 
 private:
     struct Slot {
+        mutable std::mutex mutex;
         void *aicpu{nullptr};
         void *aicore{nullptr};
+        bool submitted{false};
+        bool complete{false};
     };
 
     CreateFn create_;
@@ -123,5 +177,3 @@ private:
     std::array<Slot, PTO_PIPELINE_MAX_DEPTH> slots_{};
     std::atomic<size_t> created_count_{0};
 };
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_RUN_STREAM_SLOTS_H_

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -836,7 +836,20 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
     }
-    return SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+    int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
+    if (attach_rc != 0) {
+        if (!state->execution_done.load(std::memory_order_acquire)) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+        state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
+        return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    }
+    const int poll_rc = state->runner->poll_run(state->pipeline_slot);
+    if (state->execution_done.load(std::memory_order_acquire)) {
+        state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
+        return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    }
+    // The stream fence may precede host-side DFX and resource cleanup, so
+    // terminal publication remains at executor completion.
+    return poll_rc == SIMPLER_NATIVE_RUN_POLL_COMPLETE ? SIMPLER_NATIVE_RUN_POLL_NOT_READY : poll_rc;
 }
 
 int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -28,13 +28,13 @@
  *
  * Subclasses (`{a2a3,a5}::DeviceRunner`) add arch-specific state
  * (callable registry, profiling collectors, ACL/HCCL plumbing on a2a3,
- * `enable_*` flags) and the divergent methods (`run`, `finalize`,
- * `setup_static_arena`, the kernel launch / chip-callable upload, the
- * per-callable registration helpers, and the per-diagnostic `init_*`).
+ * `enable_*` flags) and the divergent methods (`enqueue_run`, `poll_run`,
+ * `drain_run`, `finalize`, `setup_static_arena`, the kernel launch /
+ * chip-callable upload, the per-callable registration helpers, and the
+ * per-diagnostic `init_*`).
  */
 
-#ifndef SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_BASE_H
-#define SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_BASE_H
+#pragma once
 
 #include <runtime/rt.h>
 
@@ -70,7 +70,7 @@
 #include "pto_runtime_c_api.h"
 
 struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
-struct CallConfig;  // task_interface/call_config.h — per-run config threaded into run()
+struct CallConfig;  // task_interface/call_config.h — per-run execution config
 class NativeRunLaunchSignal;
 
 /**
@@ -267,14 +267,14 @@ public:
     /**
      * Print handshake results from device. Reads the per-core
      * `Handshake` array out of device memory and logs it at DEBUG. Must
-     * be called after `run()` and before `finalize()`.
+     * be called after `drain_run()` and before `finalize()`.
      */
     void print_handshake_results();
 
     /**
      * Take ownership of the AICPU + AICore executor binaries. Called
      * once by simpler_init at ChipWorker::init time; subsequent
-     * `run()` invocations read from `aicpu_so_binary_` /
+     * enqueue invocations read from `aicpu_so_binary_` /
      * `aicore_kernel_binary_`.
      */
     void set_executors(std::vector<uint8_t> aicpu_so_binary, std::vector<uint8_t> aicore_kernel_binary) {
@@ -527,15 +527,16 @@ public:
     //
     // The shared `pto_runtime_c_api` glue (`src/common/platform/onboard/host/
     // c_api_shared.cpp`) works through `DeviceRunnerBase *` and dispatches
-    // through these virtuals. Each arch's `DeviceRunner` overrides
-    // `run` and `finalize`; a2a3 and a5 both override `set_dep_gen_enabled`
-    // (an arch without dep_gen keeps the base no-op default).
+    // through these virtuals. Each arch's `DeviceRunner` overrides the
+    // enqueue/poll/drain lifecycle and `finalize`; a2a3 and a5 both override
+    // `set_dep_gen_enabled` (an arch without dep_gen keeps the base no-op
+    // default).
 
     /**
      * Whether this runner may start another run without first being finalized.
      * The shared c_api checks this before attaching the thread or provisioning
      * optional resources, so a poisoned runner cannot create SDMA streams on
-     * its way to the arch-specific run() fail-fast guard.
+     * its way to the arch-specific enqueue fail-fast guard.
      */
     virtual bool can_accept_run() const = 0;
 
@@ -543,15 +544,33 @@ public:
     virtual int provision_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }
     virtual int abandon_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }
 
+    /** Compatibility composition retained while the C API owns an executor. */
+    int run(Runtime &runtime, const CallConfig &config) {
+        const uint32_t slot = pipeline_slot();
+        const int rc = enqueue_run(runtime, config);
+        return rc == 0 ? drain_run(slot) : rc;
+    }
+
     /**
-     * Execute a Runtime. Each arch implements its own `run()` — the bodies
-     * are too divergent for a shared implementation (FFTS / dep_gen / ACL
-     * register init on a2a3; MIX core handling on a5). See the subclass
-     * docs for the per-arch contract. `config` carries block_dim (0 = auto),
-     * aicpu_thread_num, and the diagnostic enables; each arch calls
-     * `apply_call_config(config)` at entry to latch the `enable_*_` members.
+     * Prepare host-owned execution state and submit the Runtime to the device.
+     * Success means the platform's real kernel-launch boundary was crossed;
+     * all state needed by poll_run() and drain_run() remains owned by the
+     * runner until drain completes.
      */
-    virtual int run(Runtime &runtime, const CallConfig &config) = 0;
+    virtual int enqueue_run(Runtime &runtime, const CallConfig &config) = 0;
+
+    /**
+     * Query the active run without waiting. Returns one of the
+     * SIMPLER_NATIVE_RUN_POLL_* values. This may run concurrently with
+     * drain_run() on the compatibility executor.
+     */
+    virtual int poll_run(uint32_t pipeline_slot) = 0;
+
+    /**
+     * Wait for the enqueued run, publish DFX, and release its execution
+     * resources. Called on the same executor thread as enqueue_run().
+     */
+    virtual int drain_run(uint32_t pipeline_slot) = 0;
 
     /**
      * Cleanup all resources. Each arch's `finalize()` wraps
@@ -621,8 +640,8 @@ public:
 
     /**
      * Enablement setters for the four shared diagnostics sub-features.
-     * Applied from the per-run CallConfig by `apply_call_config()` at `run()`
-     * entry; downstream `run()` paths read the corresponding `enable_*_`
+     * Applied from the per-run CallConfig by `apply_call_config()` at enqueue;
+     * downstream execution paths read the corresponding `enable_*_`
      * members directly.
      *
      * `set_dep_gen_enabled` is a2a3-only and lives on the subclass.
@@ -643,8 +662,8 @@ public:
 
     /**
      * Latch this run's per-run diagnostic config onto the runner's `enable_*_`
-     * members before `run()` uses them. Each arch's `run()` calls this once at
-     * entry — the c_api no longer reaches in with individual set_*_enabled
+     * members before enqueue uses them. Each arch calls this once at enqueue —
+     * the c_api no longer reaches in with individual set_*_enabled
      * calls; it just threads the CallConfig through. Defined in the .cpp so this
      * header does not need the full CallConfig definition.
      */
@@ -724,9 +743,9 @@ protected:
      */
     int query_max_block_dim(rtStream_t stream, uint32_t *out_cube = nullptr, uint32_t *out_vector = nullptr);
 
-    // ---- run() sub-sequence helpers --------------------------------------
+    // ---- execution sub-sequence helpers ---------------------------------
     //
-    // Each arch's `run()` keeps the heavily-divergent middle (register
+    // Each arch keeps the heavily-divergent middle (register
     // address setup, profiling flag building, init_*, collector start /
     // teardown, dep_gen, ffts setup, kernel launches). These helpers
     // cover the byte-identical sub-sequences at the head and tail.
@@ -777,7 +796,7 @@ protected:
     /**
      * Rewrites each task's `function_bin_addr` from
      * `runtime.get_function_bin_addr(func_id) +
-     * CoreCallable::binary_data_offset()`. Runs inside `run()`, after the
+     * CoreCallable::binary_data_offset()`. Runs during enqueue, after the
      * bind that populates the task table.
      */
     void resolve_task_binary_addrs(Runtime &runtime);
@@ -1058,7 +1077,7 @@ protected:
     // AicpuPhaseRecord[NUM_AICPU_PHASES] per launched AICPU thread (thread-
     // major), whose address rides on `KernelArgs.device_wall_data_base`. AICPU
     // stamps raw sys-counter cycles per phase through that pointer; subclass
-    // `run()` pulls it back via `read_device_wall_ns()` after stream sync and
+    // drain pulls it back via `read_device_wall_ns()` after stream sync and
     // caches the per-phase ns spans for `last_device_phase_ns()` (and RunWall
     // for `last_device_wall_ns()`). Allocated once at simpler_init, freed in the
     // subclass `finalize()`.
@@ -1088,8 +1107,7 @@ protected:
     ScopeStatsCollector scope_stats_collector_;
 
     // Enablement for the four shared diagnostics sub-features.
-    // Written by the c_api entry point via `set_*_enabled()` before
-    // `run()`, read inside `run()` and its helpers.
+    // Written from CallConfig before enqueue and read by execution helpers.
     bool enable_chip_swimlane_{false};
     bool enable_dump_args_{false};
     DumpArgsLevel dump_args_level_{DumpArgsLevel::OFF};  // resolved from set_dump_args_enabled()
@@ -1099,5 +1117,3 @@ protected:
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};         // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                         // diagnostic artifact root directory
 };
-
-#endif  // SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_BASE_H

--- a/src/common/platform/onboard/host/device_runner_helpers.cpp
+++ b/src/common/platform/onboard/host/device_runner_helpers.cpp
@@ -20,7 +20,42 @@
 
 #include <runtime/rt.h>
 
+#include "acl/error_codes/rt_error_codes.h"
 #include "common/unified_log.h"
+#include "host/acl_error_log.h"
+
+namespace {
+
+int query_stream_nonblocking(rtStream_t stream, const char *name) {
+    if (stream == nullptr) {
+        LOG_ERROR("rtStreamQuery (%s) received a null stream", name);
+        return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    }
+
+    const rtError_t rc = rtStreamQuery(stream);
+    if (rc == RT_ERROR_NONE) return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    if (rc == ACL_ERROR_RT_STREAM_NOT_COMPLETE) return SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+
+    LOG_ERROR("rtStreamQuery (%s) failed: %d", name, static_cast<int>(rc));
+    ACL_LOG_ERROR_DETAIL(rc);
+    return SIMPLER_NATIVE_RUN_POLL_ERROR;
+}
+
+}  // namespace
+
+int query_stream_pair_nonblocking(rtStream_t aicpu_stream, rtStream_t aicore_stream) {
+    // Query both even when the first is pending. Besides making completion a
+    // true pair fence, this preserves an error from either device queue.
+    const int aicpu_rc = query_stream_nonblocking(aicpu_stream, "AICPU");
+    const int aicore_rc = query_stream_nonblocking(aicore_stream, "AICore");
+    if (aicpu_rc == SIMPLER_NATIVE_RUN_POLL_ERROR || aicore_rc == SIMPLER_NATIVE_RUN_POLL_ERROR) {
+        return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    }
+    if (aicpu_rc == SIMPLER_NATIVE_RUN_POLL_COMPLETE && aicore_rc == SIMPLER_NATIVE_RUN_POLL_COMPLETE) {
+        return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    }
+    return SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+}
 
 int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator) {
     allocator_ = &allocator;

--- a/src/common/platform/onboard/host/device_runner_helpers.h
+++ b/src/common/platform/onboard/host/device_runner_helpers.h
@@ -25,14 +25,25 @@
  *   - C-API common shims.
  */
 
-#ifndef SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_HELPERS_H
-#define SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_HELPERS_H
+#pragma once
+
+#include <runtime/rt.h>
 
 #include <cstdint>
 
 #include "common/kernel_args.h"  // arch-specific KernelArgs layout
 #include "host/memory_allocator.h"
+#include "pto_runtime_c_api.h"
 #include "runtime.h"
+
+/**
+ * Query both streams that form one onboard run without waiting.
+ *
+ * Completion is reported only after rtStreamQuery reports both the AICPU and
+ * AICore streams complete. The return value is one of the
+ * SIMPLER_NATIVE_RUN_POLL_* constants.
+ */
+int query_stream_pair_nonblocking(rtStream_t aicpu_stream, rtStream_t aicore_stream);
 
 /**
  * Helper class for managing `KernelArgs` with device memory.
@@ -86,5 +97,3 @@ struct KernelArgsHelper {
     operator KernelArgs *() { return &args; }
     KernelArgs *operator&() { return &args; }
 };
-
-#endif  // SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_HELPERS_H

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -790,12 +790,12 @@ int ArgsDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const Dump
 
     // ProfilerBase::stop() only joins the mgmt + poll threads. The writer
     // thread is otherwise torn down solely by export_dump_files(), so any path
-    // that skips export — e.g. run() bailing on a device error before its
+    // that skips export — e.g. drain bailing on a device error before its
     // collector-teardown block — would leak it: left blocked on write_cv_ with
     // writer_done_ == false while writer_thread_ stays joinable, which trips
     // std::terminate when the collector is destroyed or re-run. finalize() is
-    // reached via run()'s perf_cleanup guard on every exit path, so join the
-    // writer here too. Idempotent: export_dump_files() clears writer_started_
+    // reached via device-runner active-run cleanup on every exit path, so join
+    // the writer here too. Idempotent: export_dump_files() clears writer_started_
     // on the success path, making this a no-op.
     if (writer_started_ && writer_thread_.joinable()) {
         writer_done_.store(true);

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -856,9 +856,10 @@ void ChipSwimlaneCollector::read_phase_header_metadata() {
     // orchestrator runs on the last AICPU thread (aicpu_thread_num_ - 1). The
     // orch-phase pool is a single instance, so its pool index does not encode
     // the AICPU thread — derive the thread number from aicpu_thread_num_.
-    // aicpu_thread_num_ is >= 1 (DeviceRunner::run validates launch_aicpu_num in
-    // [1, PLATFORM_MAX_AICPU_THREADS] before initialize()), so the subtraction
-    // can't go negative. This is a log-only display value, never an index.
+    // aicpu_thread_num_ is >= 1 (device-runner enqueue validates
+    // launch_aicpu_num in [1, PLATFORM_MAX_AICPU_THREADS] before initialize()),
+    // so the subtraction can't go negative. This is a log-only display value,
+    // never an index.
     const int orch_thread = aicpu_thread_num_ - 1;
     LOG_INFO("Collecting phase metadata: scheduler threads 0-%d, orchestrator thread %d", num_sched - 1, orch_thread);
 

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -700,7 +700,14 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
     }
-    return SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+    const int poll_rc = state->runner->poll_run();
+    if (state->execution_done.load(std::memory_order_acquire)) {
+        state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
+        return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    }
+    // The simulated kernel fence may precede host-side DFX and resource
+    // cleanup, so terminal publication remains at executor completion.
+    return poll_rc == SIMPLER_NATIVE_RUN_POLL_COMPLETE ? SIMPLER_NATIVE_RUN_POLL_NOT_READY : poll_rc;
 }
 
 int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -14,16 +14,15 @@
  * Mirrors the onboard DeviceRunnerBase pattern: shared lifecycle / callable
  * registry / arena / tensor-copy methods live here once; per-arch DeviceRunner
  * subclasses (in src/{a2a3,a5}/platform/sim/host/) implement the arch-specific
- * run() / finalize() / init_* / ensure_binaries_loaded path with their own
- * dlsym'd function-pointer table.
+ * enqueue/poll/drain / finalize / init_* / ensure_binaries_loaded path with
+ * their own dlsym'd function-pointer table.
  *
  * Polymorphism keeps the c_api shared glue (c_api_shared.cpp) arch-agnostic —
- * it works through SimDeviceRunnerBase* and dispatches run() / finalize() /
- * set_dep_gen_enabled() through virtuals.
+ * it works through SimDeviceRunnerBase* and dispatches the execution lifecycle,
+ * finalize(), and set_dep_gen_enabled() through virtuals.
  */
 
-#ifndef SRC_COMMON_PLATFORM_SIM_HOST_DEVICE_RUNNER_BASE_H_
-#define SRC_COMMON_PLATFORM_SIM_HOST_DEVICE_RUNNER_BASE_H_
+#pragma once
 
 #include <dlfcn.h>
 #include <unistd.h>
@@ -58,7 +57,7 @@
 #include "runtime.h"
 
 struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
-struct CallConfig;  // task_interface/call_config.h — per-run config threaded into run()
+struct CallConfig;  // task_interface/call_config.h — per-run execution config
 class NativeRunLaunchSignal;
 
 // Width sim resolves the CallConfig "auto" sentinel to, deliberately below
@@ -96,7 +95,18 @@ public:
     virtual ~SimDeviceRunnerBase() = default;
 
     // --- Pure / no-op virtuals dispatched from the shared c_api glue ----
-    virtual int run(Runtime &runtime, const CallConfig &config) = 0;
+    /** Compatibility composition retained while the C API owns an executor. */
+    int run(Runtime &runtime, const CallConfig &config) {
+        const int rc = enqueue_run(runtime, config);
+        return rc == 0 ? drain_run() : rc;
+    }
+
+    /** Submit a Runtime and retain all state needed to query and drain it. */
+    virtual int enqueue_run(Runtime &runtime, const CallConfig &config) = 0;
+    /** Return one of the SIMPLER_NATIVE_RUN_POLL_* values without waiting. */
+    virtual int poll_run() = 0;
+    /** Wait for completion, publish DFX, and release per-run resources. */
+    virtual int drain_run() = 0;
     virtual int finalize() = 0;
     // a2a3 and a5 both override; an arch without dep_gen leaves the no-op.
     virtual void set_dep_gen_enabled(bool /*enable*/) {}
@@ -231,8 +241,8 @@ public:
     const std::string &output_prefix() const { return output_prefix_; }
 
     // Latch this run's per-run diagnostic config onto the runner's enable_*_
-    // members before run() uses them. Each arch's run() calls this at entry; the
-    // c_api threads the CallConfig through instead of calling set_*_enabled.
+    // members before enqueue_run() uses them. Each arch calls this at enqueue;
+    // the c_api threads the CallConfig through instead of calling setters.
     // Defined in the .cpp so this header does not need the full CallConfig.
     void apply_call_config(const CallConfig &config);
 
@@ -240,7 +250,7 @@ public:
     size_t host_dlopen_count() const { return host_dlopen_total_; }
 
 protected:
-    // --- Helpers usable by subclass run() / finalize() -------------------
+    // --- Helpers usable by subclass execution / finalize -----------------
     /** Publish after both simulated kernel thread groups have been created. */
     void publish_task_accepted() const;
     int ensure_device_initialized();
@@ -256,7 +266,7 @@ protected:
     // finalize() calls this before mem_alloc_.finalize(). Idempotent.
     void release_callable_state();
 
-    // --- Shared state (protected so subclass run() / init_* / finalize()
+    // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
 
     // Configuration. device_id_ is set once in attach_current_thread() during
@@ -321,7 +331,7 @@ protected:
     size_t prebuilt_runtime_arena_cache_runtime_off_{0};
     std::vector<uint8_t> prebuilt_runtime_arena_cache_image_;
 
-    // Simulation state — written by run() / init_* and read by the AICPU /
+    // Simulation state — written by enqueue/init and read by the AICPU /
     // AICore execute functions via the platform-regs setter functions.
     KernelArgs kernel_args_;
 
@@ -329,7 +339,7 @@ protected:
     // address rides on KernelArgs.device_wall_data_base. AICPU writes the
     // run wall (ns) through that pointer; this DeviceRunner pulls it back
     // via copy_from_device after stream sync and caches it for
-    // last_device_wall_ns(). Allocated lazily in run(), freed in finalize().
+    // last_device_wall_ns(). Allocated lazily at enqueue, freed in finalize().
     void *device_wall_dev_ptr_{nullptr};
     uint64_t device_wall_ns_{0};
     uint64_t device_phase_ns_[NUM_AICPU_PHASES] = {0};
@@ -401,7 +411,7 @@ protected:
     PmuCollector pmu_collector_;
     ScopeStatsCollector scope_stats_collector_;
 
-    // Enablement flags. Written via setters before run(); read inside run().
+    // Enablement flags. Written before enqueue and read by execution helpers.
     bool enable_chip_swimlane_{false};
     bool enable_dump_args_{false};
     DumpArgsLevel dump_args_level_{DumpArgsLevel::OFF};  // resolved from set_dump_args_enabled()
@@ -420,5 +430,3 @@ namespace simpler::common::sim_host {
 bool create_temp_so_file(const std::string &path_template, const uint8_t *data, size_t size, std::string *out_path);
 
 }  // namespace simpler::common::sim_host
-
-#endif  // SRC_COMMON_PLATFORM_SIM_HOST_DEVICE_RUNNER_BASE_H_

--- a/src/common/platform/sim/host/sim_run_completion.h
+++ b/src/common/platform/sim/host/sim_run_completion.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+
+#include "pto_runtime_c_api.h"
+
+namespace simpler::common::sim_host {
+
+/**
+ * Sticky completion state shared by a simulated run's kernel threads and its
+ * nonblocking poller.
+ *
+ * reset() is called before any kernel thread starts. Each submitted thread
+ * calls task_finished() exactly once. The final task publishes COMPLETE only
+ * after every earlier task's writes and any recorded error are visible to a
+ * poller that observes completion. abandon() publishes sticky ERROR when
+ * enqueue rollback wins; a late task completion cannot overwrite it.
+ */
+class SimRunCompletion {
+public:
+    void reset(size_t submitted_tasks) noexcept {
+        assert(submitted_tasks > 0);
+        first_error_.store(0, std::memory_order_relaxed);
+        remaining_.store(submitted_tasks, std::memory_order_relaxed);
+        state_.store(SIMPLER_NATIVE_RUN_POLL_NOT_READY, std::memory_order_release);
+    }
+
+    void abandon() noexcept { state_.store(SIMPLER_NATIVE_RUN_POLL_ERROR, std::memory_order_release); }
+
+    void task_finished(int rc = 0) noexcept {
+        if (rc != 0) {
+            int expected = 0;
+            first_error_.compare_exchange_strong(expected, rc, std::memory_order_relaxed);
+        }
+        const size_t previous = remaining_.fetch_sub(1, std::memory_order_acq_rel);
+        assert(previous > 0);
+        if (previous == 1) {
+            int expected = SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+            (void)state_.compare_exchange_strong(
+                expected, SIMPLER_NATIVE_RUN_POLL_COMPLETE, std::memory_order_release, std::memory_order_relaxed
+            );
+        }
+    }
+
+    int poll() const noexcept { return state_.load(std::memory_order_acquire); }
+    int first_error() const noexcept { return first_error_.load(std::memory_order_acquire); }
+
+private:
+    std::atomic<size_t> remaining_{0};
+    std::atomic<int> first_error_{0};
+    std::atomic<int> state_{SIMPLER_NATIVE_RUN_POLL_ERROR};
+};
+
+}  // namespace simpler::common::sim_host

--- a/src/common/worker/native_run_state.h
+++ b/src/common/worker/native_run_state.h
@@ -9,8 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_COMMON_WORKER_NATIVE_RUN_STATE_H_
-#define SRC_COMMON_WORKER_NATIVE_RUN_STATE_H_
+#pragma once
 
 #include <atomic>
 #include <cstdint>
@@ -50,7 +49,7 @@ struct NativeRunState {
         }
     }
 
-    /** Move prepare-thread state into the executor before runner->run(). */
+    /** Move prepare-thread state into the executor before enqueue and drain. */
     void adopt_host_thread_state() noexcept {
         void *snapshot = host_thread_state;
         host_thread_state = nullptr;
@@ -90,5 +89,3 @@ void destroy_native_run_state(NativeRunState<Runner> *state) {
     constexpr uint64_t kEmpty = 0;
     std::memcpy(storage, &kEmpty, sizeof(kEmpty));
 }
-
-#endif  // SRC_COMMON_WORKER_NATIVE_RUN_STATE_H_

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -350,9 +350,12 @@ int supports_concurrent_native_prepare_ctx(DeviceContextHandle ctx);
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime);
 
 /**
- * Non-blocking completion query. Returns SIMPLER_NATIVE_RUN_POLL_NOT_READY,
- * SIMPLER_NATIVE_RUN_POLL_COMPLETE, or a negative validation/phase error. Call
- * only after simpler_launch_run() returns.
+ * Non-blocking device-completion query. Returns
+ * SIMPLER_NATIVE_RUN_POLL_NOT_READY, SIMPLER_NATIVE_RUN_POLL_COMPLETE, or a
+ * negative validation, phase, or device-query error. COMPLETE is published
+ * only after the executor has also finished host-side drain work. Polling
+ * never releases the prepared run's resources; call only after
+ * simpler_launch_run() returns.
  */
 int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime);
 

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -419,6 +419,19 @@ target_link_libraries(test_native_run_launch_signal PRIVATE ${GTEST_MAIN_LIB} ${
 add_test(NAME test_native_run_launch_signal COMMAND test_native_run_launch_signal)
 set_tests_properties(test_native_run_launch_signal PROPERTIES LABELS "no_hardware")
 
+# Sim kernel threads publish one sticky completion state. A gated unit test
+# proves submission and completion are separate without relying on kernel
+# duration or host scheduling.
+add_executable(test_sim_run_completion common/test_sim_run_completion.cpp)
+target_include_directories(test_sim_run_completion PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/host
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+)
+target_link_libraries(test_sim_run_completion PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_sim_run_completion COMMAND test_sim_run_completion)
+set_tests_properties(test_sim_run_completion PROPERTIES LABELS "no_hardware")
+
 # ---------------------------------------------------------------------------
 # Types / task_interface tests (src/common/task_interface/)
 # ---------------------------------------------------------------------------

--- a/tests/ut/cpp/common/test_sim_run_completion.cpp
+++ b/tests/ut/cpp/common/test_sim_run_completion.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <future>
+#include <thread>
+
+#include "sim_run_completion.h"
+
+using simpler::common::sim_host::SimRunCompletion;
+
+TEST(SimRunCompletionTest, SubmissionRemainsPendingUntilTheFinalTaskCompletes) {
+    SimRunCompletion completion;
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_ERROR);
+    std::promise<void> task_started;
+    std::promise<void> release_task;
+    std::shared_future<void> release = release_task.get_future().share();
+
+    completion.reset(1);
+    std::thread task([&]() {
+        task_started.set_value();
+        release.wait();
+        completion.task_finished();
+    });
+
+    task_started.get_future().wait();
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+
+    release_task.set_value();
+    task.join();
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+    EXPECT_EQ(completion.first_error(), 0);
+}
+
+TEST(SimRunCompletionTest, CompletionWaitsForEveryTaskAndKeepsTheFirstError) {
+    SimRunCompletion completion;
+    completion.reset(2);
+
+    completion.task_finished(-7);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+    EXPECT_EQ(completion.first_error(), -7);
+
+    completion.task_finished(-9);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+    EXPECT_EQ(completion.first_error(), -7);
+
+    completion.reset(1);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+    EXPECT_EQ(completion.first_error(), 0);
+}
+
+TEST(SimRunCompletionTest, AbandonPublishesStickyErrorAndLateCompletionCannotOverwriteIt) {
+    SimRunCompletion completion;
+    completion.reset(1);
+
+    completion.abandon();
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_ERROR);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_ERROR);
+
+    completion.task_finished();
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_ERROR);
+
+    completion.reset(1);
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+    completion.task_finished();
+    EXPECT_EQ(completion.poll(), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+}

--- a/tests/ut/cpp/hierarchical/test_run_stream_slots.cpp
+++ b/tests/ut/cpp/hierarchical/test_run_stream_slots.cpp
@@ -11,12 +11,17 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
+#include <future>
+#include <thread>
 #include <vector>
 
 #include "host/run_stream_slots.h"
 
 namespace {
+
+using CompletionStatus = RunStreamSlots::CompletionStatus;
 
 // Hands out distinct fake handles and can be told to fail the next N destroys,
 // which is what makes the destroy-failure path reachable without a device.
@@ -82,7 +87,7 @@ TEST(RunStreamSlots, EveryAcquireCreatesAnAicoreStreamAndKeepsTheAicpuOne) {
     ASSERT_NE(first_aicore, nullptr);
     EXPECT_EQ(slots.created_count(), 1u);
 
-    ASSERT_EQ(slots.retire_aicore(0), 0);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Unproven), 0);
     EXPECT_EQ(slots.aicore(0), nullptr);
 
     ASSERT_EQ(slots.acquire(0), 0);
@@ -97,14 +102,27 @@ TEST(RunStreamSlots, AFailedDestroyReportsKeepsTheHandleAndLocksTheSlot) {
     RunStreamSlots slots = make_slots(fake);
 
     ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
     void *stranded = slots.aicore(0);
 
     // 1. the error reaches the caller
     fake.fail_next_destroys(1);
-    EXPECT_EQ(slots.retire_aicore(0), -13);
+    EXPECT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), -13);
 
     // 2. the handle survives, so teardown still has something to reclaim
     EXPECT_EQ(slots.aicore(0), stranded);
+
+    // Device execution was already drained before retirement. The retained
+    // handle is teardown ownership, not permission to query that stream again.
+    EXPECT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_ERROR;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_COMPLETE
+    );
 
     // 3. the next run is refused rather than handed a second live stream
     EXPECT_NE(slots.acquire(0), 0);
@@ -124,11 +142,11 @@ TEST(RunStreamSlots, AStrandedSlotDoesNotBlockItsPeer) {
 
     ASSERT_EQ(slots.acquire(0), 0);
     fake.fail_next_destroys(1);
-    ASSERT_NE(slots.retire_aicore(0), 0);
+    ASSERT_NE(slots.retire_aicore(0, CompletionStatus::Unproven), 0);
 
     ASSERT_EQ(slots.acquire(1), 0);
     EXPECT_NE(slots.aicore(1), nullptr);
-    EXPECT_EQ(slots.retire_aicore(1), 0);
+    EXPECT_EQ(slots.retire_aicore(1, CompletionStatus::Unproven), 0);
 }
 
 TEST(RunStreamSlots, SuccessorProvisionAndAbandonDoNotTouchTheActiveSlot) {
@@ -147,14 +165,187 @@ TEST(RunStreamSlots, SuccessorProvisionAndAbandonDoNotTouchTheActiveSlot) {
 
     // Abandoning the unpublished successor retires only its fresh AICore
     // stream. Its slot-persistent AICPU stream remains reusable.
-    ASSERT_EQ(slots.retire_aicore(1), 0);
+    ASSERT_EQ(slots.retire_aicore(1, CompletionStatus::Unproven), 0);
     EXPECT_TRUE(slots.ready(0));
     EXPECT_EQ(slots.aicore(0), active_aicore);
     EXPECT_EQ(slots.aicore(1), nullptr);
     EXPECT_NE(slots.aicpu(1), nullptr);
 
-    EXPECT_EQ(slots.retire_aicore(0), 0);
+    EXPECT_EQ(slots.retire_aicore(0, CompletionStatus::Unproven), 0);
     EXPECT_EQ(slots.destroy_all(), 0);
+}
+
+TEST(RunStreamSlots, PollReportsPendingThenStickyCompleteWithoutRetiringStreams) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+
+    void *expected_aicpu = slots.aicpu(0);
+    void *expected_aicore = slots.aicore(0);
+    int query_count = 0;
+    auto query = [&](void *aicpu, void *aicore) {
+        EXPECT_EQ(aicpu, expected_aicpu);
+        EXPECT_EQ(aicore, expected_aicore);
+        ++query_count;
+        return query_count == 1 ? SIMPLER_NATIVE_RUN_POLL_NOT_READY : SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+    };
+
+    EXPECT_EQ(slots.poll(0, query), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+    EXPECT_EQ(fake.live_count(), 2u);
+    EXPECT_EQ(slots.poll(0, query), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+    EXPECT_EQ(slots.poll(0, query), SIMPLER_NATIVE_RUN_POLL_COMPLETE);
+    EXPECT_EQ(query_count, 2) << "a completed stream pair must not be queried again";
+    EXPECT_EQ(fake.live_count(), 2u) << "poll observes ownership but never retires it";
+}
+
+TEST(RunStreamSlots, UnprovenRetirementClearsAnEarlyCompletion) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+
+    EXPECT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_COMPLETE
+    );
+
+    // A later stream-sync error is authoritative even if a concurrent query
+    // reached COMPLETE first. Error-path cleanup must not preserve that fence.
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Unproven), 0);
+    EXPECT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                ADD_FAILURE() << "an unproven retired stream must not be queried";
+                return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_ERROR
+    );
+}
+
+TEST(RunStreamSlots, PollRequiresSubmissionAndPropagatesQueryErrors) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+    ASSERT_EQ(slots.acquire(0), 0);
+
+    EXPECT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_ERROR
+    );
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+    EXPECT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_ERROR;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_ERROR
+    );
+    EXPECT_EQ(
+        slots.poll(
+            static_cast<unsigned>(RunStreamSlots::capacity()),
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_ERROR
+    );
+}
+
+TEST(RunStreamSlots, RetireWaitsForAnInFlightPoll) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+
+    std::promise<void> query_entered;
+    std::promise<void> release_query;
+    std::shared_future<void> release = release_query.get_future().share();
+    auto poll = std::async(std::launch::async, [&]() {
+        return slots.poll(0, [&](void *, void *) {
+            query_entered.set_value();
+            release.wait();
+            return SIMPLER_NATIVE_RUN_POLL_NOT_READY;
+        });
+    });
+    query_entered.get_future().wait();
+
+    std::promise<void> retire_started;
+    auto retire = std::async(std::launch::async, [&]() {
+        retire_started.set_value();
+        return slots.retire_aicore(0, CompletionStatus::Unproven);
+    });
+    retire_started.get_future().wait();
+    EXPECT_EQ(retire.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+
+    release_query.set_value();
+    EXPECT_EQ(poll.get(), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+    EXPECT_EQ(retire.get(), 0);
+    EXPECT_EQ(fake.live_count(), 1u);
+    EXPECT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_ERROR;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_ERROR
+    );
+}
+
+TEST(RunStreamSlots, PollDoesNotWaitBehindRetirement) {
+    FakeStreams fake;
+    std::promise<void> destroy_entered;
+    std::promise<void> release_destroy;
+    std::shared_future<void> release = release_destroy.get_future().share();
+    RunStreamSlots slots(
+        [&fake](void **out) {
+            return fake.create(out);
+        },
+        [&](void *stream) {
+            destroy_entered.set_value();
+            release.wait();
+            return fake.destroy(stream);
+        }
+    );
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+
+    auto retire = std::async(std::launch::async, [&]() {
+        return slots.retire_aicore(0, CompletionStatus::Complete);
+    });
+    destroy_entered.get_future().wait();
+
+    std::promise<void> poll_started;
+    bool query_called = false;
+    auto poll = std::async(std::launch::async, [&]() {
+        poll_started.set_value();
+        return slots.poll(0, [&](void *, void *) {
+            query_called = true;
+            return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+        });
+    });
+    poll_started.get_future().wait();
+    const std::future_status poll_status = poll.wait_for(std::chrono::seconds(1));
+
+    release_destroy.set_value();
+    EXPECT_EQ(poll_status, std::future_status::ready);
+    EXPECT_EQ(poll.get(), SIMPLER_NATIVE_RUN_POLL_NOT_READY);
+    EXPECT_FALSE(query_called);
+    EXPECT_EQ(retire.get(), 0);
 }
 
 // destroy_all reports the first failure and keeps only what it could not free,
@@ -188,7 +379,7 @@ TEST(RunStreamSlots, AFailedCreateLeavesTheSlotEmpty) {
     // rather than half-ready.
     fake.fail_next_creates(0);
     ASSERT_EQ(slots.acquire(0), 0);
-    ASSERT_EQ(slots.retire_aicore(0), 0);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Unproven), 0);
     fake.fail_next_creates(1);
     EXPECT_NE(slots.acquire(0), 0);
     EXPECT_FALSE(slots.ready(0));
@@ -199,7 +390,7 @@ TEST(RunStreamSlots, RejectsASlotOutsideTheContractDepth) {
     RunStreamSlots slots = make_slots(fake);
     const unsigned past_end = static_cast<unsigned>(RunStreamSlots::capacity());
     EXPECT_NE(slots.acquire(past_end), 0);
-    EXPECT_NE(slots.retire_aicore(past_end), 0);
+    EXPECT_NE(slots.retire_aicore(past_end, CompletionStatus::Unproven), 0);
     EXPECT_EQ(slots.aicore(past_end), nullptr);
 }
 


### PR DESCRIPTION
## Summary

- Split `DeviceRunner` execution into enqueue, nonblocking poll, and drain across a2a3/a5 onboard and simulation backends.
- Retain the compatibility executor and current public completion semantics while establishing the completion-query seam needed by the next change.
- Keep run-owned streams, simulated threads, DFX state, and cleanup alive through drain; serialize a2a3 query/retirement and publish completion only after a proven device fence.
- Update lifecycle documentation and add deterministic state-machine coverage.

## Testing

- [x] Build all 8 runtime variants: a2a3sim/a5sim/a2a3/a5, HBG/TMR
- [x] Focused C++ tests: run-stream slots, sim completion, launch signal
- [x] a2a3sim native-run lifecycle
- [x] a5sim vector smoke
- [x] a2a3 onboard native-run lifecycle
- [x] a2a3 onboard async endpoint (concurrent `rtStreamQuery`/drain path)
- [x] Pre-commit hooks, including clang-tidy, cpplint, and markdownlint
- [ ] a5 onboard hardware (local host is a2a3; defer to CI)