### PR TITLE
Refactor: carry host callbacks and launch identity per native run

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -106,7 +106,7 @@ DeviceRunner runner;
 void *ptr = runner.allocate_tensor(bytes);
 runner.copy_to_device(dev_ptr, host_ptr, bytes);
 runner.set_executors(aicpu_binary, aicore_binary);   // once, at init time
-runner.run(runtime, config);                         // compatibility composition: enqueue + drain
+runner.run(runtime, config, pipeline_slot);          // compatibility composition: enqueue + drain
 runner.finalize();
 ```
 
@@ -127,10 +127,12 @@ void *runtime = allocate_zeroed_aligned(size, alignment); // stable until finali
 simpler_register_callable(ctx, cid, callable);        // one-time per callable
 
 // Progressable form; simpler_run(...) composes these phases synchronously.
-simpler_prepare_run(ctx, runtime, cid, args, config); // bind, no device launch
-simpler_launch_run(ctx, runtime);                     // returns after launch fence
-simpler_wait_run(ctx, runtime);                       // or poll until complete
-simpler_finalize_run(ctx, runtime);                   // validate, copy back, destroy
+// `descriptor` carries this run's slot/bank/identity and the optional
+// launch-acceptance target published at the kernel-launch marker.
+simpler_prepare_run(ctx, runtime, cid, args, config, &descriptor); // bind, no device launch
+simpler_launch_run(ctx, runtime);  // publishes descriptor acceptance and returns after launch fence
+simpler_wait_run(ctx, runtime);                                    // or poll until complete
+simpler_finalize_run(ctx, runtime);                                // validate, copy back, destroy
 
 simpler_unregister_callable(ctx, cid);
 finalize_device(ctx);

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -299,7 +299,6 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
            simpler_wait_run, simpler_finalize_run, simpler_run,
            simpler_unregister_callable, get_pipeline_contract,
            supports_concurrent_native_prepare_ctx,
-           set_native_run_identity_ctx, set_task_accepted_state_ctx,
            get_arena_bank_gm_heap_base_ctx, get_retained_temp_addr_ctx,
            finalize_device
     create_device_context() → DeviceContextHandle
@@ -311,12 +310,12 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
       DeviceRunner::set_executors(aicpu, aicore)       binaries owned by runner
 
 ChipWorker.run(handle, args, config)                   # public wrapper path
-  simpler_run(ctx, buf, internal callable entry, args, config)
-    simpler_prepare_run(...)
-      new (buf) NativeRunState()             owns Runtime + executor state
-      DeviceRunner::bind_callable_to_runtime(r, cid, api, args, rings)
-    simpler_launch_run(...)
-      executor thread: DeviceRunner::enqueue_run(r, config)
+  simpler_run(ctx, buf, cid, args, config, &descriptor)
+    simpler_prepare_run(..., &descriptor)
+      new (buf) NativeRunContext(..., descriptor, host_api)   owns Runtime + executor state
+      DeviceRunner::bind_callable_to_runtime(r, cid, &host_api, args, rings)
+    simpler_launch_run(...)                         # acceptance was captured by prepare
+      executor thread: DeviceRunner::enqueue_run(r, config, slot)
         clear_cpu_sim_shared_storage()
         ensure_binaries_loaded()             lazily dlopen AICPU; reload AICore for this run
         launch AICPU + AICore threads
@@ -329,7 +328,7 @@ ChipWorker.run(handle, args, config)                   # public wrapper path
     simpler_wait_run(...)
     simpler_finalize_run(...)
       validate_runtime_impl(r)               copy results, remove kernels
-      state->~NativeRunState()               destroys Runtime
+      state->~NativeRunContext()               destroys Runtime
 
 ChipWorker.finalize()
   finalize_device(ctx)
@@ -373,12 +372,12 @@ device_worker_main(device_id)
             upload child kernels, copy orch SO to device buffer
         for each launch with that handle:
           ChipWorker.run(handle, args, config)
-            simpler_run(ctx, buf, internal callable entry, args, config)
-              simpler_prepare_run(...)
-                new (buf) NativeRunState()     owns Runtime + executor state
+            simpler_run(ctx, buf, cid, args, config, &descriptor)
+              simpler_prepare_run(..., &descriptor)
+                new (buf) NativeRunContext(..., descriptor, host_api)   owns Runtime + executor state
                 bind_callable_to_runtime()     replay + rtMalloc, rtMemcpy to device
-              simpler_launch_run(...)
-                executor thread: DeviceRunner::enqueue_run()
+              simpler_launch_run(...)               # publishes descriptor acceptance
+                executor thread: DeviceRunner::enqueue_run(..., slot)
                   ensure_binaries_loaded()     already done by init
                   launch_aicore_kernel()       cached rtRegisterAllKernel handle
                                                  + rtKernelLaunchWithHandleV2

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1798,7 +1798,7 @@ NB_MODULE(_task_interface, m) {
             },
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::arg("slot_id"), nb::arg("generation"),
             nb::call_guard<nb::gil_scoped_release>(),
-            "Prepare a generation-bound native run without crossing its device launch fence."
+            "Prepare a native run after lease admission without crossing its device launch fence."
         )
         .def(
             "_prepare_native_run_with_pipeline_lease",
@@ -1808,28 +1808,26 @@ NB_MODULE(_task_interface, m) {
             },
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::arg("slot_id"), nb::arg("generation"),
             nb::call_guard<nb::gil_scoped_release>(),
-            "Prepare a generation-bound native run from pre-encoded task args."
+            "Prepare a native run from pre-encoded task args after lease admission."
         )
         .def(
             "_prepare_native_run_from_blob",
             [](ChipWorker &self, int32_t callable_id, uint64_t args_blob_ptr, size_t blob_capacity,
-               const CallConfig &config, uint32_t slot_id, uint64_t generation, uint64_t run_id, uint64_t dispatch_id) {
+               const CallConfig &config, uint32_t slot_id, uint64_t generation, uint64_t run_id, uint64_t dispatch_id,
+               uint64_t accepted_state_addr, int32_t accepted_value) {
                 TaskArgsView view = read_blob(reinterpret_cast<const uint8_t *>(args_blob_ptr), blob_capacity);
                 return self.prepare_native_run(
-                    callable_id, view, config, PipelineSlotLease{slot_id, 0, generation}, run_id, dispatch_id
+                    callable_id, view, config, PipelineSlotLease{slot_id, 0, generation}, run_id, dispatch_id,
+                    reinterpret_cast<volatile int32_t *>(accepted_state_addr), accepted_value
                 );
             },
             nb::arg("callable_id"), nb::arg("args_blob_ptr"), nb::arg("blob_capacity"), nb::arg("config"),
             nb::arg("slot_id"), nb::arg("generation"), nb::arg("run_id") = 0, nb::arg("dispatch_id") = 0,
-            nb::call_guard<nb::gil_scoped_release>(),
-            "Prepare a generation-bound native run from a raw mailbox TaskArgs blob."
+            nb::arg("accepted_state_addr") = 0, nb::arg("accepted_value") = 0, nb::call_guard<nb::gil_scoped_release>(),
+            "Prepare a native run from a raw mailbox TaskArgs blob after lease admission."
         )
         .def(
-            "_launch_native_run",
-            [](ChipWorker &self, const ChipWorkerNativeRun &run, uint64_t accepted_state_addr, int32_t accepted_value) {
-                self.launch_native_run(run, reinterpret_cast<volatile int32_t *>(accepted_state_addr), accepted_value);
-            },
-            nb::arg("run"), nb::arg("accepted_state_addr") = 0, nb::arg("accepted_value") = 0,
+            "_launch_native_run", &ChipWorker::launch_native_run, nb::arg("run"),
             nb::call_guard<nb::gil_scoped_release>(),
             "Launch a prepared native run and return after its real device launch fence."
         )

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1386,9 +1386,9 @@ class ChipWorker:
     def _prepare_native_run_with_pipeline_lease(self, callable_id, args, slot_id, generation, config=None, **kwargs):
         """Prepare one native run without crossing its device launch fence.
 
-        Private B3a seam for the hierarchical endpoint. The returned token is
-        bound to both the pipeline lease generation and a unique prepare epoch;
-        it must be passed back to launch/poll/wait/finalize on this ChipWorker.
+        The lease generation is validated during admission. The returned
+        token's unique prepare epoch is authoritative for subsequent
+        launch/poll/wait/finalize calls on this ChipWorker.
         Keep every tensor backing buffer referenced by ``args`` alive until
         finalize returns.
         """

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -2504,6 +2504,8 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 generation,
                 run_id,
                 dispatch_id,
+                frame.frame_addr + _OFF_ACCEPTED,
+                _TASK_ACCEPTED,
             )
             return frame.native_run
 
@@ -2764,11 +2766,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                             native_run = None
                             try:
                                 native_run = prepare_frame_native_run(next_frame)
-                                cw._impl._launch_native_run(
-                                    native_run,
-                                    next_frame.frame_addr + _OFF_ACCEPTED,
-                                    _TASK_ACCEPTED,
-                                )
+                                cw._impl._launch_native_run(native_run)
                             except Exception as e:  # noqa: BLE001
                                 launch_message = _format_exc(f"chip_process dev={device_id}: native launch", e)
                                 finalize_failed = False

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -241,8 +241,8 @@ int DeviceRunner::abandon_native_run_resources(uint32_t pipeline_slot) {
     return retire_run_aicore_stream(pipeline_slot, RunStreamSlots::CompletionStatus::Unproven);
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
-    const unsigned selected_pipeline_slot = pipeline_slot();
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
+    const unsigned selected_pipeline_slot = pipeline_slot;
     if (active_run_.owns_resources) {
         LOG_ERROR("enqueue_run entered while slot %u still owns resources", active_run_.slot);
         return -1;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -94,7 +94,7 @@ public:
 
     // The blocking entry point composes these operations. enqueue owns rollback
     // until the AICPU launch marker; drain takes that ownership on success.
-    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
     int poll_run(uint32_t pipeline_slot) override;
     int drain_run(uint32_t pipeline_slot) override;
     bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -296,7 +296,7 @@ void DeviceRunner::destroy_native_run_thread_state(void *snapshot) noexcept {
     dep_gen_host_graph_destroy_capture(snapshot);
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t /*pipeline_slot*/) {
     if (active_run_ != nullptr) {
         LOG_ERROR("enqueue_run called while another simulated run still owns execution state");
         return -1;
@@ -782,8 +782,6 @@ int DeviceRunner::finalize() {
         bank->cached_gm_sm_size = 0;
         bank->cached_runtime_arena_size = 0;
     }
-    pipeline_slot_ = 0;
-    arena_bank_ = 0;
     prebuilt_runtime_arena_cache_valid_ = false;
     prebuilt_runtime_arena_cache_key_.clear();
     prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -34,7 +34,7 @@ public:
     DeviceRunner();
     ~DeviceRunner() override;
 
-    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
     int poll_run() override;
     int drain_run() override;
     int finalize() override;

--- a/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -20,6 +20,8 @@
 
 #include <vector>
 
+#include "common/host_api.h"
+
 namespace {
 
 struct HostTensorRegion {
@@ -36,7 +38,7 @@ struct HostTensorRegion {
 // costs less than the map that would replace it.
 std::vector<HostTensorRegion> g_regions;
 
-int (*g_copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size) = nullptr;
+const HostApi *g_host_api = nullptr;
 
 // The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
 // `*offset` is the span's distance from that region's base.
@@ -78,15 +80,15 @@ bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
     if (!region->mirrored) {
         return true;
     }
-    if (g_copy_to_device == nullptr) {
+    if (g_host_api == nullptr) {
         return false;
     }
-    return g_copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
+    return g_host_api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
 }
 
-void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size)) {
+void host_tensor_access_reset(const HostApi *api) {
     g_regions.clear();
-    g_copy_to_device = copy_to_device;
+    g_host_api = api;
 }
 
 bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view) {

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -62,6 +62,7 @@
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "host/raii_scope_guard.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -542,23 +543,21 @@ int32_t run_host_orchestration(
 
 /**
  * Stage the per-callable resources (kernel binaries + orchestration SO) into
- * the supplied runtime so a subsequent bind_callable_to_runtime_impl can use
- * them. This is the cacheable half of init_runtime_impl: nothing here depends
- * on per-run argument values, so the prepare_callable / run_prepared split
- * lets us run this once per callable_id and amortize across runs.
+ * CallableArtifacts for subsequent per-run binding. Nothing here depends on
+ * per-run argument values, so registration runs once per callable_id.
  *
- * @param runtime   Pointer to pre-constructed Runtime (host_api populated)
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
+ * @param api       Context-bound platform operations used during registration
+ * @param out       Callable-owned artifacts retained across runs
  * @return 0 on success, -1 on failure
  */
-extern "C" int
-register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out) {
+extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
-    if (upload_fn == nullptr || out == nullptr) {
-        LOG_ERROR("upload_fn or out is null");
+    if (api == nullptr || out == nullptr) {
+        LOG_ERROR("HostApi or out is null");
         return -1;
     }
     *out = CallableArtifacts{};
@@ -566,8 +565,7 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
 
     LOG_INFO("Registering %d kernel(s) in register_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(
-            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash,
-            &out->aicore_image_hash
+            callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
@@ -652,7 +650,8 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
  * design: register/run_prepared invokes this every call, while the prep
  * half runs only once per callable_id.
  *
- * @param runtime    Pointer to pre-constructed Runtime (host_api populated)
+ * @param runtime    Pointer to the per-run Runtime
+ * @param api        Context-bound platform operations for this run
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
@@ -697,7 +696,10 @@ extern "C" int bind_callable_to_runtime_impl(
     // Open this run's host-view window. It closes once the orchestrator has
     // finished, so no host view outlives the point at which a task could make
     // it stale.
-    host_tensor_access_reset(api->copy_to_device);
+    host_tensor_access_reset(api);
+    auto host_tensor_access_guard = RAIIScopeGuard([]() {
+        host_tensor_access_reset(nullptr);
+    });
 
     int64_t t_args_start = _now_ms();
     for (int i = 0; i < tensor_count; i++) {
@@ -769,8 +771,8 @@ extern "C" int bind_callable_to_runtime_impl(
     int64_t t_args_end = _now_ms();
 
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
-    // and the prebuilt runtime arena all live in a single backing allocation;
-    // setup_static_arena reserves the three regions and commits in one shot.
+    // and the prebuilt runtime arena use three independent pooled device
+    // allocations committed together by setup_static_arena.
     // Owned by DeviceRunner across runs — do NOT record in tensor_pairs_; the
     // free is deferred to DeviceRunner::finalize(). The runtime-arena size is
     // determined by replaying the reserve sequence on a host-side arena.
@@ -864,6 +866,7 @@ extern "C" int bind_callable_to_runtime_impl(
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
         host_tensor_access_reset(nullptr);
+        host_tensor_access_guard.dismiss();
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;

--- a/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -47,11 +47,12 @@
  * strong definitions from `host/host_tensor_access.cpp`.
  */
 
-#ifndef SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_HOST_TENSOR_ACCESS_H_
-#define SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_HOST_TENSOR_ACCESS_H_
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
+
+struct HostApi;  // common/host_api.h — fwd-declared so this header stays out of platform includes
 
 /**
  * Read `bytes` at device address `dev_addr` into `dst`.
@@ -71,14 +72,15 @@ bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
 bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes);
 
 /**
- * Drop every registration and latch the hook used to push mirror-mode writes
- * to the device (`HostApi::copy_to_device`; null when no write can need one).
+ * Drop every registration and latch the host interface used to push
+ * mirror-mode writes to the device (its `copy_to_device`; null when no write
+ * can need one).
  *
  * Called around one orchestration run: before the first
  * `host_tensor_access_add`, and again once the run has finished, after which
  * every access fails until the next run registers its own tensors.
  */
-void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size));
+void host_tensor_access_reset(const HostApi *api);
 
 /**
  * Register `[dev_base, dev_base + size)` as reachable from the host at
@@ -87,5 +89,3 @@ void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *h
  * @return false for an empty region or a null `host_view`.
  */
 bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view);
-
-#endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_HOST_TENSOR_ACCESS_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include "common/core_type.h"
-#include "common/host_api.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
@@ -115,15 +114,6 @@ struct TensorPair {
     // keep the safe default of copying back.
     bool needs_copy_back = true;
 };
-
-/**
- * Host API function pointers for device memory operations live in the shared
- * common/host_api.h (included at the top of this header) so the field set
- * stays identical across runtime variants (tensormap_and_ringbuffer /
- * host_build_graph) and arches; the platform layer builds one const table and
- * passes it by address. hbg leaves the trb-only fields (prebuilt-arena cache)
- * unset — see host_api.h.
- */
 
 /**
  * Task structure - Compatibility stub for platform layer
@@ -304,9 +294,9 @@ public:
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in
     // validate_runtime_impl. Not read by AICPU/AICore — the device-side
-    // Runtime image carries the std::vector control block as harmless
-    // garbage, identical to host_api above. No fixed cap — grows with the
-    // chip-level entry-tensor count.
+    // Runtime image also carries the host-only std::vector control block, which
+    // device code must not inspect. No fixed cap — grows with the chip-level
+    // entry-tensor count.
     std::vector<TensorPair> tensor_pairs_;
 };
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -26,9 +26,6 @@
 // =============================================================================
 
 Runtime::Runtime() {
-    // NOTE: host_api is initialized in InitRuntime() (host-only code)
-    // because the CApi functions don't exist when compiled for device.
-
     // Initialize handshake buffers
     memset(workers, 0, sizeof(workers));
     worker_count = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -128,10 +128,9 @@ On each trb bind, `RetainedTempBump`:
 
 Slices are recorded as `BufferNoop` leases: per-tensor release is a no-op, and
 the retained buffer is neither freed at end of run nor per run — it lives on
-the runner and is freed once in `finalize`. If the platform leaves the slot
-callbacks null (e.g. a backend without a retained buffer), bind transparently
-falls back to per-tensor `device_malloc` (recorded as `Free` leases, freed in
-validate).
+the runner and is freed once in `finalize`. The uniform host-runtime contract
+requires the retained-buffer callbacks on every backend; bind has no
+per-tensor allocation fallback.
 
 Public device-memory APIs keep their original semantics. `device_malloc_ctx`,
 `device_free_ctx`, `Worker.malloc()`, and `Worker.free()` still allocate and

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -392,23 +392,21 @@ private:
 
 /**
  * Stage the per-callable resources (kernel binaries + orchestration SO) into
- * the supplied runtime so a subsequent bind_callable_to_runtime_impl can use
- * them. This is the cacheable half of init_runtime_impl: nothing here depends
- * on per-run argument values, so the simpler_register_callable / simpler_run split
- * lets us run this once per callable_id and amortize across runs.
+ * CallableArtifacts for subsequent per-run binding. Nothing here depends on
+ * per-run argument values, so registration runs once per callable_id.
  *
- * @param runtime   Pointer to pre-constructed Runtime
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
+ * @param api       Context-bound platform operations used during registration
+ * @param out       Callable-owned artifacts retained across runs
  * @return 0 on success, -1 on failure
  */
-extern "C" int
-register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out) {
+extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
-    if (upload_fn == nullptr || out == nullptr) {
-        LOG_ERROR("upload_fn or out is null");
+    if (api == nullptr || out == nullptr) {
+        LOG_ERROR("HostApi or out is null");
         return -1;
     }
     *out = CallableArtifacts{};
@@ -416,8 +414,7 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
 
     LOG_INFO("Registering %d kernel(s) in register_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(
-            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash,
-            &out->aicore_image_hash
+            callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
@@ -729,10 +726,6 @@ static int bind_cached_runtime_image(
     Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe,
     const ChipStorageTaskArgs &device_args
 ) {
-    if (api->lookup_prebuilt_runtime_arena_cache == nullptr) {
-        return 1;
-    }
-
     void *gm_heap = nullptr;
     void *sm_ptr = nullptr;
     void *runtime_arena_dev = nullptr;
@@ -759,9 +752,6 @@ static void store_prebuilt_runtime_image(
     const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
     const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
-    if (api->mark_prebuilt_runtime_arena_cached == nullptr) {
-        return;
-    }
     api->mark_prebuilt_runtime_arena_cached(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
         ptrs.runtime_arena_dev, layout.offsets.off_runtime, host_arena.base(), layout.offsets.arena_size
@@ -870,14 +860,12 @@ extern "C" int bind_callable_to_runtime_impl(
     }
 
     // The retained temporary buffer is always used on the trb path — it is an
-    // internal allocation optimization, not user-facing config. Gate only on
-    // whether the platform wired the slot accessors (trb always does; a backend
-    // that leaves them null transparently falls back to per-tensor
-    // device_malloc). The buffer itself lives on the runner across runs; here we
-    // just grow it to this run's packed size and bump-slice from it.
+    // internal allocation optimization, not user-facing config. Every host
+    // runtime provides the uniform HostApiOps table. The buffer itself lives on
+    // the runner across runs; here we grow it to this run's packed size and
+    // bump-slice from it.
     RetainedTempBump bump;
-    bool use_temporary_buffer = api->get_retained_temp_buffer != nullptr && api->set_retained_temp_buffer != nullptr;
-    if (use_temporary_buffer && !bump.begin(api, orch_args)) {
+    if (!bump.begin(api, orch_args)) {
         return -1;
     }
 
@@ -886,9 +874,7 @@ extern "C" int bind_callable_to_runtime_impl(
     });
 
     ChipStorageTaskArgs device_args;
-    if (!stage_device_args(
-            runtime, api, orch_args, signature, sig_count, use_temporary_buffer ? &bump : nullptr, &device_args
-        )) {
+    if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &bump, &device_args)) {
         return -1;
     }
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -137,14 +137,14 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
     return 0;
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
     if (run_resources_owned_) {
         LOG_ERROR(
             "enqueue_run entered while slot %u still owns resources", run_poll_slot_.load(std::memory_order_relaxed)
         );
         return -1;
     }
-    const uint32_t selected_pipeline_slot = pipeline_slot();
+    const uint32_t selected_pipeline_slot = pipeline_slot;
     run_poll_slot_.store(selected_pipeline_slot, std::memory_order_relaxed);
     run_poll_state_.store(RunPollState::Enqueuing, std::memory_order_release);
     run_resources_owned_ = true;

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -86,7 +86,7 @@ public:
 
     // The blocking entry point composes these operations. enqueue owns rollback
     // until the AICPU launch marker; drain takes that ownership on success.
-    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
     int poll_run(uint32_t pipeline_slot) override;
     int drain_run(uint32_t pipeline_slot) override;
     bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -251,7 +251,7 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config) {
+int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t /*pipeline_slot*/) {
     if (active_run_ != nullptr) {
         LOG_ERROR("enqueue_run called while another simulated run still owns execution state");
         return -1;
@@ -692,8 +692,6 @@ int DeviceRunner::finalize() {
         bank->cached_gm_sm_size = 0;
         bank->cached_runtime_arena_size = 0;
     }
-    pipeline_slot_ = 0;
-    arena_bank_ = 0;
     prebuilt_runtime_arena_cache_valid_ = false;
     prebuilt_runtime_arena_cache_key_.clear();
     prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -33,7 +33,7 @@ public:
     DeviceRunner();
     ~DeviceRunner() override;
 
-    int enqueue_run(Runtime &runtime, const CallConfig &config) override;
+    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
     int poll_run() override;
     int drain_run() override;
     int finalize() override;

--- a/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -20,6 +20,8 @@
 
 #include <vector>
 
+#include "common/host_api.h"
+
 namespace {
 
 struct HostTensorRegion {
@@ -36,7 +38,7 @@ struct HostTensorRegion {
 // costs less than the map that would replace it.
 std::vector<HostTensorRegion> g_regions;
 
-int (*g_copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size) = nullptr;
+const HostApi *g_host_api = nullptr;
 
 // The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
 // `*offset` is the span's distance from that region's base.
@@ -78,15 +80,15 @@ bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
     if (!region->mirrored) {
         return true;
     }
-    if (g_copy_to_device == nullptr) {
+    if (g_host_api == nullptr) {
         return false;
     }
-    return g_copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
+    return g_host_api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
 }
 
-void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size)) {
+void host_tensor_access_reset(const HostApi *api) {
     g_regions.clear();
-    g_copy_to_device = copy_to_device;
+    g_host_api = api;
 }
 
 bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view) {

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -62,6 +62,7 @@
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "host/raii_scope_guard.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -542,23 +543,21 @@ int32_t run_host_orchestration(
 
 /**
  * Stage the per-callable resources (kernel binaries + orchestration SO) into
- * the supplied runtime so a subsequent bind_callable_to_runtime_impl can use
- * them. This is the cacheable half of init_runtime_impl: nothing here depends
- * on per-run argument values, so the prepare_callable / run_prepared split
- * lets us run this once per callable_id and amortize across runs.
+ * CallableArtifacts for subsequent per-run binding. Nothing here depends on
+ * per-run argument values, so registration runs once per callable_id.
  *
- * @param runtime   Pointer to pre-constructed Runtime (host_api populated)
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
+ * @param api       Context-bound platform operations used during registration
+ * @param out       Callable-owned artifacts retained across runs
  * @return 0 on success, -1 on failure
  */
-extern "C" int
-register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out) {
+extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
-    if (upload_fn == nullptr || out == nullptr) {
-        LOG_ERROR("upload_fn or out is null");
+    if (api == nullptr || out == nullptr) {
+        LOG_ERROR("HostApi or out is null");
         return -1;
     }
     *out = CallableArtifacts{};
@@ -566,8 +565,7 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
 
     LOG_INFO("Registering %d kernel(s) in register_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(
-            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash,
-            &out->aicore_image_hash
+            callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
@@ -652,7 +650,8 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
  * design: register/run_prepared invokes this every call, while the prep
  * half runs only once per callable_id.
  *
- * @param runtime    Pointer to pre-constructed Runtime (host_api populated)
+ * @param runtime    Pointer to the per-run Runtime
+ * @param api        Context-bound platform operations for this run
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
@@ -697,7 +696,10 @@ extern "C" int bind_callable_to_runtime_impl(
     // Open this run's host-view window. It closes once the orchestrator has
     // finished, so no host view outlives the point at which a task could make
     // it stale.
-    host_tensor_access_reset(api->copy_to_device);
+    host_tensor_access_reset(api);
+    auto host_tensor_access_guard = RAIIScopeGuard([]() {
+        host_tensor_access_reset(nullptr);
+    });
 
     int64_t t_args_start = _now_ms();
     for (int i = 0; i < tensor_count; i++) {
@@ -769,8 +771,8 @@ extern "C" int bind_callable_to_runtime_impl(
     int64_t t_args_end = _now_ms();
 
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
-    // and the prebuilt runtime arena all live in a single backing allocation;
-    // setup_static_arena reserves the three regions and commits in one shot.
+    // and the prebuilt runtime arena use three independent pooled device
+    // allocations committed together by setup_static_arena.
     // Owned by DeviceRunner across runs — do NOT record in tensor_pairs_; the
     // free is deferred to DeviceRunner::finalize(). The runtime-arena size is
     // determined by replaying the reserve sequence on a host-side arena.
@@ -864,6 +866,7 @@ extern "C" int bind_callable_to_runtime_impl(
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
         host_tensor_access_reset(nullptr);
+        host_tensor_access_guard.dismiss();
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;

--- a/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -52,6 +52,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct HostApi;  // common/host_api.h — fwd-declared so this header stays out of platform includes
+
 /**
  * Read `bytes` at device address `dev_addr` into `dst`.
  *
@@ -70,14 +72,15 @@ bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
 bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes);
 
 /**
- * Drop every registration and latch the hook used to push mirror-mode writes
- * to the device (`HostApi::copy_to_device`; null when no write can need one).
+ * Drop every registration and latch the host interface used to push
+ * mirror-mode writes to the device (its `copy_to_device`; null when no write
+ * can need one).
  *
  * Called around one orchestration run: before the first
  * `host_tensor_access_add`, and again once the run has finished, after which
  * every access fails until the next run registers its own tensors.
  */
-void host_tensor_access_reset(int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size));
+void host_tensor_access_reset(const HostApi *api);
 
 /**
  * Register `[dev_base, dev_base + size)` as reachable from the host at

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -36,7 +36,6 @@
 #include <vector>
 
 #include "common/core_type.h"
-#include "common/host_api.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
@@ -114,15 +113,6 @@ struct TensorPair {
     // keep the safe default of copying back.
     bool needs_copy_back = true;
 };
-
-/**
- * Host API function pointers for device memory operations live in the shared
- * common/host_api.h (included at the top of this header) so the field set
- * stays identical across runtime variants (tensormap_and_ringbuffer /
- * host_build_graph) and arches; the platform layer builds one const table and
- * passes it by address. hbg leaves the trb-only fields (prebuilt-arena cache)
- * unset — see host_api.h.
- */
 
 /**
  * Task structure - Compatibility stub for platform layer
@@ -303,9 +293,9 @@ public:
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in
     // validate_runtime_impl. Not read by AICPU/AICore — the device-side
-    // Runtime image carries the std::vector control block as harmless
-    // garbage, identical to host_api above. No fixed cap — grows with the
-    // chip-level entry-tensor count.
+    // Runtime image also carries the host-only std::vector control block, which
+    // device code must not inspect. No fixed cap — grows with the chip-level
+    // entry-tensor count.
     std::vector<TensorPair> tensor_pairs_;
 };
 

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -26,9 +26,6 @@
 // =============================================================================
 
 Runtime::Runtime() {
-    // NOTE: host_api is initialized in InitRuntime() (host-only code)
-    // because the CApi functions don't exist when compiled for device.
-
     // Initialize handshake buffers
     memset(workers, 0, sizeof(workers));
     worker_count = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -125,10 +125,9 @@ On each trb bind, `RetainedTempBump`:
 
 Slices are recorded as `BufferNoop` leases: per-tensor release is a no-op, and
 the retained buffer is neither freed at end of run nor per run — it lives on
-the runner and is freed once in `finalize`. If the platform leaves the slot
-callbacks null (e.g. a backend without a retained buffer), bind transparently
-falls back to per-tensor `device_malloc` (recorded as `Free` leases, freed in
-validate).
+the runner and is freed once in `finalize`. The uniform host-runtime contract
+requires the retained-buffer callbacks on every backend; bind has no
+per-tensor allocation fallback.
 
 Public device-memory APIs keep their original semantics. `device_malloc_ctx`,
 `device_free_ctx`, `Worker.malloc()`, and `Worker.free()` still allocate and

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -375,23 +375,21 @@ private:
 
 /**
  * Stage the per-callable resources (kernel binaries + orchestration SO) into
- * the supplied runtime so a subsequent bind_callable_to_runtime_impl can use
- * them. This is the cacheable half of init_runtime_impl: nothing here depends
- * on per-run argument values, so the simpler_register_callable / simpler_run split
- * lets us run this once per callable_id and amortize across runs.
+ * CallableArtifacts for subsequent per-run binding. Nothing here depends on
+ * per-run argument values, so registration runs once per callable_id.
  *
- * @param runtime   Pointer to pre-constructed Runtime
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
+ * @param api       Context-bound platform operations used during registration
+ * @param out       Callable-owned artifacts retained across runs
  * @return 0 on success, -1 on failure
  */
-extern "C" int
-register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out) {
+extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
-    if (upload_fn == nullptr || out == nullptr) {
-        LOG_ERROR("upload_fn or out is null");
+    if (api == nullptr || out == nullptr) {
+        LOG_ERROR("HostApi or out is null");
         return -1;
     }
     *out = CallableArtifacts{};
@@ -399,8 +397,7 @@ register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const
 
     LOG_INFO("Registering %d kernel(s) in register_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(
-            callable, upload_fn, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash,
-            &out->aicore_image_hash
+            callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
@@ -712,10 +709,6 @@ static int bind_cached_runtime_image(
     Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe,
     const ChipStorageTaskArgs &device_args
 ) {
-    if (api->lookup_prebuilt_runtime_arena_cache == nullptr) {
-        return 1;
-    }
-
     void *gm_heap = nullptr;
     void *sm_ptr = nullptr;
     void *runtime_arena_dev = nullptr;
@@ -742,9 +735,6 @@ static void store_prebuilt_runtime_image(
     const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
     const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
-    if (api->mark_prebuilt_runtime_arena_cached == nullptr) {
-        return;
-    }
     api->mark_prebuilt_runtime_arena_cached(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
         ptrs.runtime_arena_dev, layout.offsets.off_runtime, host_arena.base(), layout.offsets.arena_size
@@ -853,14 +843,12 @@ extern "C" int bind_callable_to_runtime_impl(
     }
 
     // The retained temporary buffer is always used on the trb path — it is an
-    // internal allocation optimization, not user-facing config. Gate only on
-    // whether the platform wired the slot accessors (trb always does; a backend
-    // that leaves them null transparently falls back to per-tensor
-    // device_malloc). The buffer itself lives on the runner across runs; here we
-    // just grow it to this run's packed size and bump-slice from it.
+    // internal allocation optimization, not user-facing config. Every host
+    // runtime provides the uniform HostApiOps table. The buffer itself lives on
+    // the runner across runs; here we grow it to this run's packed size and
+    // bump-slice from it.
     RetainedTempBump bump;
-    bool use_temporary_buffer = api->get_retained_temp_buffer != nullptr && api->set_retained_temp_buffer != nullptr;
-    if (use_temporary_buffer && !bump.begin(api, orch_args)) {
+    if (!bump.begin(api, orch_args)) {
         return -1;
     }
 
@@ -869,9 +857,7 @@ extern "C" int bind_callable_to_runtime_impl(
     });
 
     ChipStorageTaskArgs device_args;
-    if (!stage_device_args(
-            runtime, api, orch_args, signature, sig_count, use_temporary_buffer ? &bump : nullptr, &device_args
-        )) {
+    if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &bump, &device_args)) {
         return -1;
     }
 

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -8,8 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#ifndef COMMON_HOST_API_H_
-#define COMMON_HOST_API_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -18,20 +17,15 @@
  * Host API function pointers for device memory operations.
  * Allows a runtime to use pluggable device-memory backends.
  *
- * This is a platform capability, not runtime state: the platform layer
- * (onboard / sim c_api_shared.cpp) builds one shared, const table of
- * context-free function pointers at load time and passes it by address into
- * bind_callable_to_runtime_impl / validate_runtime_impl. Each pointer recovers
- * its runner from a thread-local, so the single table is valid for every runner
- * and every run — it is not rebuilt per simpler_run. Shared by every runtime
- * variant (tensormap_and_ringbuffer / host_build_graph) and arch (a2a3 / a5) so
- * the field set stays defined in exactly one place.
+ * The platform layer owns one immutable function table per backend. A HostApi
+ * value binds that table to one runner and one run's slot/bank selection, so
+ * callbacks never recover mutable context from process or thread globals.
  */
-struct HostApi {
-    void *(*device_malloc)(size_t size);
-    void (*device_free)(void *dev_ptr);
-    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
-    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+struct HostApiOps {
+    void *(*device_malloc)(void *runner_ctx, size_t size);
+    void (*device_free)(void *runner_ctx, void *dev_ptr);
+    int (*copy_to_device)(void *runner_ctx, void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *runner_ctx, void *host_ptr, const void *dev_ptr, size_t size);
     // Map a device buffer into host address space and return a host-readable VA
     // (nullptr on failure); the paired unregister releases it. The returned VA
     // may differ from dev_ptr, so callers must use it, not dev_ptr, for host
@@ -40,13 +34,11 @@ struct HostApi {
     // buffer.addr is a device address. a2a3 onboard wraps
     // halHostRegister(DEV_SVM_MAP_HOST); sim is identity; a5 onboard and any
     // backend without a host-map path return nullptr / no-op.
-    void *(*register_device_memory_to_host)(void *dev_ptr, size_t bytes);
-    void (*unregister_device_memory_from_host)(void *dev_ptr);
+    void *(*register_device_memory_to_host)(void *runner_ctx, void *dev_ptr, size_t bytes);
+    void (*unregister_device_memory_from_host)(void *runner_ctx, void *dev_ptr);
     // Set a device buffer to a byte value (device-side, no PCIe). Used to
-    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
-    // null on backends that don't wire it; callers must fall back to
-    // copy_to_device.
-    int (*device_memset)(void *dev_ptr, int value, size_t size);
+    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in.
+    int (*device_memset)(void *runner_ctx, void *dev_ptr, int value, size_t size);
     // Runner-scoped retained temporary buffer for TRB device-arg staging.
     // This is NOT an allocator — it is a single {addr, size} slot that lives
     // across runs on the DeviceRunner. trb bind reads the slot, and if the
@@ -55,42 +47,42 @@ struct HostApi {
     // new {addr, size} back. The grow/pack/slice logic lives in trb bind
     // (runtime_maker); the platform only remembers the slot so it can be reused
     // by later runs and freed at finalize. The slot is per pipeline slot, so
-    // the pair reads and writes whichever one the current run's lease selected
-    // — two runs in different slots never share a staging buffer. hbg leaves
-    // these null and stages tensors through per-tensor device_malloc. `get`
-    // returns {nullptr, 0} when nothing is retained yet.
-    void (*get_retained_temp_buffer)(void **addr, size_t *size);
-    void (*set_retained_temp_buffer)(void *addr, size_t size);
-    // Commit the three pooled regions (PTO2 GM heap, PTO2 shared memory, trb
-    // prebuilt runtime arena) of the arena bank the current run's lease
-    // selected, as three independent device allocations. `runtime_arena_size == 0` skips the third region (hbg
-    // path: hbg has no prebuilt runtime arena). Idempotent on identical
-    // sizes; returns 0 on success, -1 on allocation failure.
-    int (*setup_static_arena)(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
-    // Return the per-Worker pooled pointer for the PTO2 GM heap / shared
+    // two runs in different slots never share a staging buffer. `get` returns
+    // {nullptr, 0} when nothing is retained yet.
+    void (*get_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void **addr, size_t *size);
+    void (*set_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void *addr, size_t size);
+    // Commit the three pooled regions (GM heap, runtime shared memory, and
+    // prebuilt runtime arena) of the arena bank selected by this run, as three
+    // independent device allocations. `runtime_arena_size == 0` skips the
+    // third region. Idempotent on identical sizes; returns 0 on success, -1 on
+    // allocation failure.
+    int (*setup_static_arena)(
+        void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
+    );
+    // Return the per-Worker pooled pointer for the GM heap / runtime shared
     // memory / prebuilt runtime arena. setup_static_arena must have already
     // committed the relevant region; the returned pointer is owned by the
     // DeviceRunner and freed in `DeviceRunner::finalize()` — do NOT pass it
     // to device_free or record it as an owned tensor lease.
     //
-    // acquire_pooled_runtime_arena is trb-only — the runtime-arena region is
-    // only committed when setup_static_arena was invoked with
-    // runtime_arena_size > 0. Calling it on the hbg path
-    // (setup_static_arena(...,0)) returns nullptr (not undefined).
-    void *(*acquire_pooled_gm_heap)();
-    void *(*acquire_pooled_gm_sm)();
-    void *(*acquire_pooled_runtime_arena)();
+    // The runtime-arena region exists only when setup_static_arena was invoked
+    // with runtime_arena_size > 0; otherwise acquire_pooled_runtime_arena
+    // returns nullptr.
+    void *(*acquire_pooled_gm_heap)(void *runner_ctx, uint32_t arena_bank);
+    void *(*acquire_pooled_gm_sm)(void *runner_ctx, uint32_t arena_bank);
+    void *(*acquire_pooled_runtime_arena)(void *runner_ctx, uint32_t arena_bank);
     // Prebuilt runtime-arena image cache (trb): look up a previously built
     // image by content hash, returning its pooled device bases + image bytes on
     // a hit; and record a freshly built image so a later run with the same key
     // can skip the rebuild. Populated on the trb path; unused by hbg.
     bool (*lookup_prebuilt_runtime_arena_cache)(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
+        void *runner_ctx, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size,
+        void **gm_heap_base, void **sm_base, void **runtime_arena_base, size_t *runtime_off, const void **image_data,
+        size_t *image_size
     );
     void (*mark_prebuilt_runtime_arena_cached)(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
-        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
+        void *runner_ctx, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base,
+        void *sm_base, void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
     );
     // Single-shot upload of the entire ChipCallable buffer. `callable` is a
     // `const ChipCallable *` (declared void* to avoid pulling task_interface
@@ -106,7 +98,77 @@ struct HostApi {
     // and records them in the CallableArtifacts kernel_addrs table, which
     // DeviceRunner::bind_callable_to_runtime replays onto the runtime's
     // func_id_to_addr_ before each run.
-    uint64_t (*upload_chip_callable_buffer)(const void *callable);
+    uint64_t (*upload_chip_callable_buffer)(void *runner_ctx, const void *callable);
 };
 
-#endif  // COMMON_HOST_API_H_
+/**
+ * One run's binding of the immutable function table to a runner and that run's
+ * slot/bank selection. Constructed per run and passed by const pointer into the
+ * runtime impls; a callback reaches its runner and resources through the bound
+ * members instead of a thread-local.
+ */
+struct HostApi {
+public:
+    HostApi(void *runner_ctx, uint32_t pipeline_slot, uint32_t arena_bank, const HostApiOps *ops) noexcept :
+        runner_ctx_(runner_ctx),
+        pipeline_slot_(pipeline_slot),
+        arena_bank_(arena_bank),
+        ops_(ops) {}
+
+    void *device_malloc(size_t size) const { return ops_->device_malloc(runner_ctx_, size); }
+    void device_free(void *dev_ptr) const { ops_->device_free(runner_ctx_, dev_ptr); }
+    int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) const {
+        return ops_->copy_to_device(runner_ctx_, dev_ptr, host_ptr, size);
+    }
+    int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) const {
+        return ops_->copy_from_device(runner_ctx_, host_ptr, dev_ptr, size);
+    }
+    void *register_device_memory_to_host(void *dev_ptr, size_t bytes) const {
+        return ops_->register_device_memory_to_host(runner_ctx_, dev_ptr, bytes);
+    }
+    void unregister_device_memory_from_host(void *dev_ptr) const {
+        ops_->unregister_device_memory_from_host(runner_ctx_, dev_ptr);
+    }
+    int device_memset(void *dev_ptr, int value, size_t size) const {
+        return ops_->device_memset(runner_ctx_, dev_ptr, value, size);
+    }
+    void get_retained_temp_buffer(void **addr, size_t *size) const {
+        ops_->get_retained_temp_buffer(runner_ctx_, pipeline_slot_, addr, size);
+    }
+    void set_retained_temp_buffer(void *addr, size_t size) const {
+        ops_->set_retained_temp_buffer(runner_ctx_, pipeline_slot_, addr, size);
+    }
+    int setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) const {
+        return ops_->setup_static_arena(runner_ctx_, arena_bank_, gm_heap_size, gm_sm_size, runtime_arena_size);
+    }
+    void *acquire_pooled_gm_heap() const { return ops_->acquire_pooled_gm_heap(runner_ctx_, arena_bank_); }
+    void *acquire_pooled_gm_sm() const { return ops_->acquire_pooled_gm_sm(runner_ctx_, arena_bank_); }
+    void *acquire_pooled_runtime_arena() const { return ops_->acquire_pooled_runtime_arena(runner_ctx_, arena_bank_); }
+    bool lookup_prebuilt_runtime_arena_cache(
+        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
+        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
+    ) const {
+        return ops_->lookup_prebuilt_runtime_arena_cache(
+            runner_ctx_, arena_bank_, hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off,
+            image_data, image_size
+        );
+    }
+    void mark_prebuilt_runtime_arena_cached(
+        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
+        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
+    ) const {
+        ops_->mark_prebuilt_runtime_arena_cached(
+            runner_ctx_, arena_bank_, hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off,
+            image_data, image_size
+        );
+    }
+    uint64_t upload_chip_callable_buffer(const void *callable) const {
+        return ops_->upload_chip_callable_buffer(runner_ctx_, callable);
+    }
+
+private:
+    void *runner_ctx_{nullptr};
+    uint32_t pipeline_slot_{0};
+    uint32_t arena_bank_{0};
+    const HostApiOps *ops_{nullptr};
+};

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -30,11 +30,9 @@
 #include "prepare_callable_common.h"
 #include "pto_runtime_c_api.h"
 #include "task_args.h"
-#include "native_run_state.h"
+#include "native_run_context.h"
 
 #include <dlfcn.h>
-#include <pthread.h>
-
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -55,167 +53,180 @@
 // time against `libunified_dlog.so` / `libascendalog.so`.
 extern "C" int dlog_setlevel(int moduleId, int level, int enableEvent);
 
-using OnboardNativeRunState = NativeRunState<DeviceRunnerBase>;
+using OnboardNativeRunContext = NativeRunContext<DeviceRunnerBase>;
 // Phase entry points validate raw caller storage before beginning object
 // lifetime, so the on-storage magic must remain the leading bytes.
-static_assert(__builtin_offsetof(OnboardNativeRunState, magic) == 0, "native-run magic must lead runtime storage");
+static_assert(__builtin_offsetof(OnboardNativeRunContext, magic) == 0, "native-run magic must lead runtime storage");
 
 extern "C" {
 
 /* ===========================================================================
  * Runtime Implementation Functions (defined in each runtime's runtime_maker.cpp)
  * =========================================================================== */
-int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
+int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out);
 int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
 __attribute__((weak)) int concurrent_native_prepare_supported_impl(void) { return 0; }
 
 /* ===========================================================================
- * Per-thread DeviceRunnerBase binding (set by simpler_register_callable / simpler_run)
+ * Context-bound HostApi functions passed to runtime implementations.
  * =========================================================================== */
 
-static pthread_key_t g_runner_key;
-static pthread_once_t g_runner_key_once = PTHREAD_ONCE_INIT;
-static void create_runner_key() { pthread_key_create(&g_runner_key, nullptr); }
-
-static DeviceRunnerBase *current_runner() { return static_cast<DeviceRunnerBase *>(pthread_getspecific(g_runner_key)); }
-
-/* ===========================================================================
- * Internal device-memory functions (wired into a HostApi and passed to the
- * runtime impls, NOT dlsym'd)
- * =========================================================================== */
-
-static void *device_malloc(size_t size) {
+static void *device_malloc(void *runner_ctx, size_t size) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->allocate_tensor(size);
-    } catch (...) {
-        return NULL;
-    }
-}
-
-static void device_free(void *dev_ptr) {
-    if (dev_ptr == NULL) return;
-    try {
-        current_runner()->free_tensor(dev_ptr);
-    } catch (...) {}
-}
-
-static int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
-    if (dev_ptr == NULL || host_ptr == NULL) return -1;
-    try {
-        return current_runner()->copy_to_device(dev_ptr, host_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
-    if (host_ptr == NULL || dev_ptr == NULL) return -1;
-    try {
-        return current_runner()->copy_from_device(host_ptr, dev_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-static void *register_device_memory_to_host(void *dev_ptr, size_t bytes) {
-    try {
-        return current_runner()->register_device_memory_to_host(dev_ptr, bytes);
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->allocate_tensor(size);
     } catch (...) {
         return nullptr;
     }
 }
 
-static void unregister_device_memory_from_host(void *dev_ptr) {
+static void device_free(void *runner_ctx, void *dev_ptr) {
+    if (runner_ctx == nullptr || dev_ptr == nullptr) return;
     try {
-        current_runner()->unregister_device_memory_from_host(dev_ptr);
+        static_cast<DeviceRunnerBase *>(runner_ctx)->free_tensor(dev_ptr);
     } catch (...) {}
 }
 
-static int device_memset(void *dev_ptr, int value, size_t size) {
-    if (dev_ptr == NULL) return -1;
+static int copy_to_device(void *runner_ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    if (runner_ctx == nullptr || dev_ptr == nullptr || host_ptr == nullptr) return -1;
     try {
-        return current_runner()->device_memset(dev_ptr, value, size);
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-static void get_retained_temp_buffer(void **addr, size_t *size) {
+static int copy_from_device(void *runner_ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    if (runner_ctx == nullptr || host_ptr == nullptr || dev_ptr == nullptr) return -1;
     try {
-        current_runner()->get_retained_temp_buffer(addr, size);
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+static void *register_device_memory_to_host(void *runner_ctx, void *dev_ptr, size_t bytes) {
+    if (runner_ctx == nullptr) return nullptr;
+    try {
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->register_device_memory_to_host(dev_ptr, bytes);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void unregister_device_memory_from_host(void *runner_ctx, void *dev_ptr) {
+    if (runner_ctx == nullptr) return;
+    try {
+        static_cast<DeviceRunnerBase *>(runner_ctx)->unregister_device_memory_from_host(dev_ptr);
+    } catch (...) {}
+}
+
+static int device_memset(void *runner_ctx, void *dev_ptr, int value, size_t size) {
+    if (runner_ctx == nullptr || dev_ptr == nullptr) return -1;
+    try {
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->device_memset(dev_ptr, value, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+static void get_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, void **addr, size_t *size) {
+    if (runner_ctx == nullptr) {
+        if (addr != nullptr) *addr = nullptr;
+        if (size != nullptr) *size = 0;
+        return;
+    }
+    try {
+        static_cast<DeviceRunnerBase *>(runner_ctx)->get_retained_temp_buffer(pipeline_slot, addr, size);
     } catch (...) {
         if (addr != nullptr) *addr = nullptr;
         if (size != nullptr) *size = 0;
     }
 }
 
-static void set_retained_temp_buffer(void *addr, size_t size) {
+static void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, void *addr, size_t size) {
+    if (runner_ctx == nullptr) return;
     try {
-        current_runner()->set_retained_temp_buffer(addr, size);
+        static_cast<DeviceRunnerBase *>(runner_ctx)->set_retained_temp_buffer(pipeline_slot, addr, size);
     } catch (...) {}
 }
 
-static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
+static uint64_t upload_chip_callable_buffer_wrapper(void *runner_ctx, const void *callable) {
+    if (runner_ctx == nullptr) return 0;
     try {
-        return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
+        return static_cast<DeviceRunnerBase *>(runner_ctx)
+            ->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
     } catch (...) {
         return 0;
     }
 }
 
-static int setup_static_arena_wrapper(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) {
+static int setup_static_arena_wrapper(
+    void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
+) {
+    if (runner_ctx == nullptr) return -1;
     try {
-        return current_runner()->setup_static_arena(gm_heap_size, gm_sm_size, runtime_arena_size);
+        return static_cast<DeviceRunnerBase *>(runner_ctx)
+            ->setup_static_arena(arena_bank, gm_heap_size, gm_sm_size, runtime_arena_size);
     } catch (...) {
         return -1;
     }
 }
 
-static void *acquire_pooled_gm_heap_wrapper() {
+static void *acquire_pooled_gm_heap_wrapper(void *runner_ctx, uint32_t arena_bank) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->acquire_pooled_gm_heap();
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->acquire_pooled_gm_heap(arena_bank);
     } catch (...) {
         return nullptr;
     }
 }
 
-static void *acquire_pooled_gm_sm_wrapper() {
+static void *acquire_pooled_gm_sm_wrapper(void *runner_ctx, uint32_t arena_bank) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->acquire_pooled_gm_sm();
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->acquire_pooled_gm_sm(arena_bank);
     } catch (...) {
         return nullptr;
     }
 }
 
-static void *acquire_pooled_runtime_arena_wrapper() {
+static void *acquire_pooled_runtime_arena_wrapper(void *runner_ctx, uint32_t arena_bank) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->acquire_pooled_runtime_arena();
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->acquire_pooled_runtime_arena(arena_bank);
     } catch (...) {
         return nullptr;
     }
 }
 
 static bool lookup_prebuilt_runtime_arena_cache_wrapper(
-    uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-    void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
+    void *runner_ctx, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base,
+    void **sm_base, void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
 ) {
+    if (runner_ctx == nullptr) return false;
     try {
-        return current_runner()->lookup_prebuilt_runtime_arena_cache(
-            hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off, image_data, image_size
-        );
+        return static_cast<DeviceRunnerBase *>(runner_ctx)
+            ->lookup_prebuilt_runtime_arena_cache(
+                arena_bank, hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off,
+                image_data, image_size
+            );
     } catch (...) {
         return false;
     }
 }
 
 static void mark_prebuilt_runtime_arena_cached_wrapper(
-    uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base, void *runtime_arena_base,
-    size_t runtime_off, const void *image_data, size_t image_size
+    void *runner_ctx, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base,
+    void *sm_base, void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
 ) {
+    if (runner_ctx == nullptr) return;
     try {
-        current_runner()->mark_prebuilt_runtime_arena_cached(
-            hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off, image_data, image_size
-        );
+        static_cast<DeviceRunnerBase *>(runner_ctx)
+            ->mark_prebuilt_runtime_arena_cached(
+                arena_bank, hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off,
+                image_data, image_size
+            );
     } catch (...) {}
 }
 
@@ -226,12 +237,9 @@ extern "C" int prewarm_config_impl(
     const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 );
 
-// The HostApi is a set of context-free function pointers: each wrapper above
-// recovers its runner from the thread-local current_runner(), so a single
-// filled table is valid for every runner and every run. Build it once at load
-// time rather than reassembling the pointer table on each simpler_run. Passed by
-// address into bind_callable_to_runtime_impl / validate_runtime_impl.
-static const HostApi g_host_api = {
+// One immutable function table is shared by all runners. Each HostApi value
+// binds it to a specific runner and immutable per-run slot/bank selection.
+static const HostApiOps g_host_api_ops = {
     .device_malloc = device_malloc,
     .device_free = device_free,
     .copy_to_device = copy_to_device,
@@ -267,9 +275,9 @@ void destroy_device_context(DeviceContextHandle ctx) {
     delete runner;
 }
 
-size_t get_runtime_size(void) { return sizeof(OnboardNativeRunState); }
+size_t get_runtime_size(void) { return sizeof(OnboardNativeRunContext); }
 
-size_t get_runtime_alignment(void) { return alignof(OnboardNativeRunState); }
+size_t get_runtime_alignment(void) { return alignof(OnboardNativeRunContext); }
 
 void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) {
     if (ctx == NULL) return NULL;
@@ -327,16 +335,6 @@ int simpler_init(
     if (ctx == NULL) return -1;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
-    // HostApi callbacks, including the prewarm path below, recover their
-    // DeviceRunner from this thread-local binding.
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
-    (void)runner->select_pipeline_slot(0);
-    (void)runner->select_arena_bank(0);
-    (void)runner->set_native_run_identity(0, 0, 0, 0);
 
     // CANN dlog must be levelled BEFORE the device context is opened
     // (rtSetDevice inside attach_current_thread): CANN snapshots the
@@ -395,8 +393,9 @@ int simpler_init(
     // sizing is read.
     if (prewarm_config != NULL) {
         try {
+            const HostApi prewarm_api(runner, 0, 0, &g_host_api_ops);
             rc = prewarm_config_impl(
-                &g_host_api, prewarm_config->runtime_env.ring_task_window, prewarm_config->runtime_env.ring_heap,
+                &prewarm_api, prewarm_config->runtime_env.ring_task_window, prewarm_config->runtime_env.ring_heap,
                 prewarm_config->runtime_env.ring_dep_pool
             );
         } catch (...) {
@@ -419,12 +418,6 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         return -1;
     }
 
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
-
     try {
         int rc = runner->attach_current_thread(runner->device_id());
         if (rc != 0) return rc;
@@ -435,9 +428,8 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
                 runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
             }
         });
-        rc = register_callable_impl(
-            reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
-        );
+        const HostApi host_api(runner, 0, 0, &g_host_api_ops);
+        rc = register_callable_impl(reinterpret_cast<const ChipCallable *>(callable), &host_api, &artifacts);
         if (rc != 0) {
             return rc;
         }
@@ -573,15 +565,16 @@ static void emit_device_phase_markers(DeviceRunnerBase *runner) {
     }
 }
 
-static OnboardNativeRunState *native_run_state(DeviceContextHandle ctx, RuntimeHandle runtime, const char *operation) {
+static OnboardNativeRunContext *
+native_run_context(DeviceContextHandle ctx, RuntimeHandle runtime, const char *operation) {
     if (ctx == nullptr || runtime == nullptr) return nullptr;
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
-    if (magic != OnboardNativeRunState::kMagic) {
+    if (magic != OnboardNativeRunContext::kMagic) {
         LOG_ERROR("%s: runtime does not contain a prepared native run", operation);
         return nullptr;
     }
-    auto *state = static_cast<OnboardNativeRunState *>(runtime);
+    auto *state = static_cast<OnboardNativeRunContext *>(runtime);
     if (state->runner != static_cast<DeviceRunnerBase *>(ctx)) {
         LOG_ERROR("%s: prepared run belongs to a different device context", operation);
         return nullptr;
@@ -600,7 +593,7 @@ int supports_concurrent_native_prepare_ctx(DeviceContextHandle ctx) {
     return ctx != nullptr && concurrent_native_prepare_supported_impl() != 0 ? 1 : 0;
 }
 
-static int cleanup_failed_prepare(OnboardNativeRunState *state, int execution_rc, bool clear_gm_sm) {
+static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_rc, bool clear_gm_sm) {
     const unsigned trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
@@ -609,14 +602,14 @@ static int cleanup_failed_prepare(OnboardNativeRunState *state, int execution_rc
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
     int validation_rc = -1;
     try {
-        validation_rc = validate_runtime_impl(&state->runtime, &g_host_api, execution_rc);
+        validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
     } catch (...) {
         validation_rc = -1;
     }
     int resources_rc = 0;
     if (state->runner_resources_owned) {
         try {
-            resources_rc = state->runner->abandon_native_run_resources(state->pipeline_slot);
+            resources_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
         } catch (...) {
             resources_rc = -1;
         }
@@ -630,7 +623,7 @@ static int cleanup_failed_prepare(OnboardNativeRunState *state, int execution_rc
         state->runner->release_native_run_reservation(state);
         state->runner_reserved = false;
     }
-    destroy_native_run_state(state);
+    destroy_native_run_context(state);
     emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, trace_attrs);
     if (validation_rc != 0) return validation_rc;
     if (resources_rc != 0) return resources_rc;
@@ -638,10 +631,18 @@ static int cleanup_failed_prepare(OnboardNativeRunState *state, int execution_rc
 }
 
 int simpler_prepare_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
 ) {
-    if (ctx == nullptr || runtime == nullptr || config == nullptr) return -1;
-    if (reinterpret_cast<uintptr_t>(runtime) % alignof(OnboardNativeRunState) != 0) {
+    if (ctx == nullptr || runtime == nullptr || config == nullptr || descriptor == nullptr) return -1;
+    if (descriptor->pipeline_slot >= PTO_PIPELINE_MAX_DEPTH || descriptor->arena_bank >= PTO_PIPELINE_MAX_DEPTH) {
+        LOG_ERROR(
+            "simpler_prepare_run: descriptor selects slot=%u bank=%u outside [0, %u)", descriptor->pipeline_slot,
+            descriptor->arena_bank, PTO_PIPELINE_MAX_DEPTH
+        );
+        return -1;
+    }
+    if (reinterpret_cast<uintptr_t>(runtime) % alignof(OnboardNativeRunContext) != 0) {
         LOG_ERROR("simpler_prepare_run: runtime storage does not satisfy get_runtime_alignment()");
         return -1;
     }
@@ -656,7 +657,7 @@ int simpler_prepare_run(
     }
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
-    if (magic == OnboardNativeRunState::kMagic) {
+    if (magic == OnboardNativeRunContext::kMagic) {
         LOG_ERROR("simpler_prepare_run: runtime already contains a prepared run; finalize it before reuse");
         return -1;
     }
@@ -665,38 +666,27 @@ int simpler_prepare_run(
         return -1;
     }
 
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
-
-    OnboardNativeRunState *state = nullptr;
+    OnboardNativeRunContext *state = nullptr;
     const uint64_t trace_hid = runner->callable_hash(callable_id);
     const unsigned trace_inv = STRACE_ALLOC_INV();
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
-        state = new (runtime) OnboardNativeRunState(runner, *config, trace_hid);
-        const DeviceRunnerBase::NativeRunThreadSelection selection = runner->capture_native_run_thread_selection();
-        (void)runner->set_native_run_identity(0, 0, 0, 0);
-        state->run_id = selection.run_id;
-        state->generation = selection.generation;
-        state->dispatch_id = selection.dispatch_id;
-        state->run_epoch = selection.run_epoch;
-        state->pipeline_slot = selection.pipeline_slot;
-        state->arena_bank = selection.arena_bank;
+        state = new (runtime) OnboardNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
         std::snprintf(
             state->trace_attrs, sizeof(state->trace_attrs),
             "run_id=%llu slot=%u generation=%llu dispatch_id=%llu run_epoch=%llu",
-            static_cast<unsigned long long>(state->run_id), state->pipeline_slot,
-            static_cast<unsigned long long>(state->generation), static_cast<unsigned long long>(state->dispatch_id),
-            static_cast<unsigned long long>(state->run_epoch)
+            static_cast<unsigned long long>(state->descriptor.run_id), state->descriptor.pipeline_slot,
+            static_cast<unsigned long long>(state->descriptor.generation),
+            static_cast<unsigned long long>(state->descriptor.dispatch_id),
+            static_cast<unsigned long long>(state->descriptor.run_epoch)
         );
         const bool allow_prepared_successor =
             concurrent_native_prepare_supported_impl() != 0 && !config->diagnostics_any();
-        if (!runner->try_reserve_native_run(state, state->pipeline_slot, state->arena_bank, allow_prepared_successor)) {
+        if (!runner->try_reserve_native_run(
+                state, state->descriptor.pipeline_slot, state->descriptor.arena_bank, allow_prepared_successor
+            )) {
             LOG_ERROR("simpler_prepare_run: native-run admission is occupied (%s)", state->trace_attrs);
-            destroy_native_run_state(state);
+            destroy_native_run_context(state);
             return -1;
         }
         state->runner_reserved = true;
@@ -709,7 +699,7 @@ int simpler_prepare_run(
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
 
         state->runner_resources_owned = true;
-        rc = runner->provision_native_run_resources(state->pipeline_slot);
+        rc = runner->provision_native_run_resources(state->descriptor.pipeline_slot);
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
 
         rc = runner->prepare_launch_shape(state->runtime, state->config);
@@ -723,7 +713,7 @@ int simpler_prepare_run(
         {
             STRACE("simpler_run.bind");
             rc = runner->bind_callable_to_runtime(
-                state->runtime, callable_id, &g_host_api, args, state->config.runtime_env.ring_task_window,
+                state->runtime, callable_id, &state->host_api, args, state->config.runtime_env.ring_task_window,
                 state->config.runtime_env.ring_heap, state->config.runtime_env.ring_dep_pool
             );
         }
@@ -737,7 +727,7 @@ int simpler_prepare_run(
 }
 
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    OnboardNativeRunState *state = native_run_state(ctx, runtime, "simpler_launch_run");
+    OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_launch_run");
     if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared) return -1;
     if (!state->runner->can_accept_run() || !state->runner_reserved) return -1;
     if (!state->runner->try_acquire_native_run(state, &state->launch_signal)) {
@@ -753,29 +743,12 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         return -1;
     }
 
-    // Phase entry points temporarily install the run's resource selection.
-    // Preserve the caller's selection so interleaving finalize(A) and
-    // launch(B) on one progress thread cannot leave that thread bound to A.
-    const DeviceRunnerBase::NativeRunThreadSelection caller_selection =
-        state->runner->capture_native_run_thread_selection();
-    auto selection_guard = RAIIScopeGuard([runner = state->runner, caller_selection]() {
-        runner->restore_native_run_thread_selection(caller_selection);
-    });
-    if (state->runner->select_pipeline_slot(state->pipeline_slot) != 0 ||
-        state->runner->select_arena_bank(state->arena_bank) != 0) {
-        state->runner->release_native_run(state);
-        state->runner_claimed = false;
-        return -1;
-    }
-
     state->phase.store(NativeRunPhase::Launching, std::memory_order_release);
 
     try {
         // The compatibility backend uses one blocking executor per run. The
         // prepare-through-finalize runner claim limits it to one per context.
-        state->executor = state->runner->create_thread([state, ctx]() {
-            pthread_once(&g_runner_key_once, create_runner_key);
-            pthread_setspecific(g_runner_key, ctx);
+        state->executor = state->runner->create_thread([state]() {
             STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
             int rc = -1;
             bool entered_run = false;
@@ -787,7 +760,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
                     {
                         STRACE("simpler_run.runner_run");
                         entered_run = true;
-                        rc = state->runner->run(state->runtime, state->config);
+                        rc = state->runner->run(state->runtime, state->config, state->descriptor.pipeline_slot);
                     }
                 } else {
                     rc = attach_rc;
@@ -801,12 +774,11 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
             } else if (state->runner_resources_owned) {
                 int resources_rc = -1;
                 try {
-                    resources_rc = state->runner->abandon_native_run_resources(state->pipeline_slot);
+                    resources_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
                 } catch (...) {}
                 state->runner_resources_owned = false;
                 if (rc == 0) rc = resources_rc;
             }
-            pthread_setspecific(g_runner_key, nullptr);
             state->execution_rc.store(rc, std::memory_order_relaxed);
             state->execution_done.store(true, std::memory_order_release);
             state->launch_signal.notify();
@@ -828,7 +800,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    OnboardNativeRunState *state = native_run_state(ctx, runtime, "simpler_poll_run");
+    OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_poll_run");
     if (state == nullptr) return SIMPLER_NATIVE_RUN_POLL_ERROR;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Prepared) return SIMPLER_NATIVE_RUN_POLL_ERROR;
@@ -842,7 +814,7 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
     }
-    const int poll_rc = state->runner->poll_run(state->pipeline_slot);
+    const int poll_rc = state->runner->poll_run(state->descriptor.pipeline_slot);
     if (state->execution_done.load(std::memory_order_acquire)) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
@@ -853,7 +825,7 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    OnboardNativeRunState *state = native_run_state(ctx, runtime, "simpler_wait_run");
+    OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_wait_run");
     if (state == nullptr) return -1;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Prepared || phase == NativeRunPhase::Launching) return -1;
@@ -863,7 +835,7 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    OnboardNativeRunState *state = native_run_state(ctx, runtime, "simpler_finalize_run");
+    OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_finalize_run");
     if (state == nullptr) return -1;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Launching) return -1;
@@ -873,25 +845,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     char trace_attrs[sizeof(state->trace_attrs)];
     std::memcpy(trace_attrs, state->trace_attrs, sizeof(trace_attrs));
 
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
-
-    // Finalization can target A after the same caller has already prepared B.
-    // Resource selection is phase-local; restore B's caller selection on every
-    // return path, including validation and resource-retirement failures.
-    const DeviceRunnerBase::NativeRunThreadSelection caller_selection =
-        state->runner->capture_native_run_thread_selection();
-    auto selection_guard = RAIIScopeGuard([runner = state->runner, caller_selection]() {
-        runner->restore_native_run_thread_selection(caller_selection);
-    });
-    if (state->runner->select_pipeline_slot(state->pipeline_slot) != 0 ||
-        state->runner->select_arena_bank(state->arena_bank) != 0) {
-        return -1;
-    }
 
     int execution_rc = -1;
     const bool launched = phase != NativeRunPhase::Prepared;
@@ -907,7 +861,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         if (attach_rc == 0) {
             {
                 STRACE("simpler_run.validate");
-                validation_rc = validate_runtime_impl(&state->runtime, &g_host_api, launched ? execution_rc : -1);
+                validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, launched ? execution_rc : -1);
             }
             if (launched && execution_rc == 0) emit_device_phase_markers(state->runner);
         } else {
@@ -920,7 +874,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     int resources_rc = 0;
     if (!launched && state->runner_resources_owned) {
         try {
-            resources_rc = state->runner->abandon_native_run_resources(state->pipeline_slot);
+            resources_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
         } catch (...) {
             resources_rc = -1;
         }
@@ -935,7 +889,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner->release_native_run_reservation(state);
         state->runner_reserved = false;
     }
-    destroy_native_run_state(state);
+    destroy_native_run_context(state);
     emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, trace_attrs);
     if (validation_rc != 0) return validation_rc;
     if (resources_rc != 0) return resources_rc;
@@ -943,54 +897,15 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
 ) {
-    int rc = simpler_prepare_run(ctx, runtime, callable_id, args, config);
+    int rc = simpler_prepare_run(ctx, runtime, callable_id, args, config, descriptor);
     if (rc != 0) return rc;
     rc = simpler_launch_run(ctx, runtime);
     if (rc == 0) rc = simpler_wait_run(ctx, runtime);
     int finalize_rc = simpler_finalize_run(ctx, runtime);
     return finalize_rc != 0 ? finalize_rc : rc;
-}
-
-int set_task_accepted_state_ctx(DeviceContextHandle ctx, volatile int32_t *state, int32_t accepted_value) {
-    if (ctx == NULL) return -1;
-    try {
-        return static_cast<DeviceRunnerBase *>(ctx)->set_task_accepted_state(state, accepted_value);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int select_pipeline_slot_ctx(DeviceContextHandle ctx, uint32_t slot_id) {
-    if (ctx == NULL) return -1;
-    try {
-        return static_cast<DeviceRunnerBase *>(ctx)->select_pipeline_slot(slot_id);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int select_arena_bank_ctx(DeviceContextHandle ctx, uint32_t bank_id) {
-    if (ctx == NULL) return -1;
-    try {
-        return static_cast<DeviceRunnerBase *>(ctx)->select_arena_bank(bank_id);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int set_native_run_identity_ctx(
-    DeviceContextHandle ctx, uint64_t run_id, uint64_t generation, uint64_t dispatch_id, uint64_t run_epoch
-) {
-    if (ctx == NULL) return -1;
-    try {
-        return static_cast<DeviceRunnerBase *>(ctx)->set_native_run_identity(
-            run_id, generation, dispatch_id, run_epoch
-        );
-    } catch (...) {
-        return -1;
-    }
 }
 
 uint64_t get_arena_bank_gm_heap_base_ctx(DeviceContextHandle ctx, uint32_t bank_id) {

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -15,11 +15,8 @@
  * the static trampolines declared in the header. Per-region commit is
  * still driven by the subclass's `setup_static_arena`.
  *
- * Each lifecycle method is a verbatim move of code that was identical
- * between `src/{a2a3,a5}/platform/onboard/host/device_runner.cpp` —
- * the implementations have already been validated by the production CI
- * for both arches. No behavioral changes here; this is a pure
- * deduplication pass.
+ * Shared lifecycle methods own runner-level resources; architecture-specific
+ * launch, completion, and reset behavior remains in each DeviceRunner.
  */
 
 #include "device_runner_base.h"
@@ -27,7 +24,6 @@
 #include <runtime/rt.h>
 #include <acl/acl.h>
 #include <dlfcn.h>
-#include <pthread.h>
 
 #include <algorithm>
 #include <cassert>
@@ -35,10 +31,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <limits>
-#include <new>
-#include <stdexcept>
-#include <type_traits>
 
 #include "callable.h"
 #include "callable_protocol.h"
@@ -68,50 +60,6 @@
 extern "C" const char *const *runtime_extra_aicpu_symbols(size_t *count);
 
 namespace {
-
-pthread_key_t g_run_selection_key;
-pthread_once_t g_run_selection_once = PTHREAD_ONCE_INIT;
-int g_run_selection_key_error = 0;
-
-using NativeRunThreadSelection = DeviceRunnerBase::NativeRunThreadSelection;
-static_assert(
-    std::is_trivially_destructible_v<NativeRunThreadSelection>,
-    "pthread TLS releases native-run selection storage without a DSO-local destructor"
-);
-
-void create_run_selection_key() {
-    // The pthread key can outlive this dlclosed host-runtime DSO. Point its
-    // destructor directly at process-lifetime libc instead of a DSO-local
-    // lambda, which would become an invalid callback when the thread exits.
-    g_run_selection_key_error = pthread_key_create(&g_run_selection_key, std::free);
-}
-
-/** This thread's selection storage, or nullptr when it cannot be installed. */
-NativeRunThreadSelection *try_run_selection() noexcept {
-    int once_rc = pthread_once(&g_run_selection_once, create_run_selection_key);
-    if (once_rc != 0 || g_run_selection_key_error != 0) return nullptr;
-    auto *selection = static_cast<NativeRunThreadSelection *>(pthread_getspecific(g_run_selection_key));
-    if (selection == nullptr) {
-        void *storage = std::malloc(sizeof(NativeRunThreadSelection));
-        if (storage == nullptr) return nullptr;
-        selection = new (storage) NativeRunThreadSelection{};
-        int set_rc = pthread_setspecific(g_run_selection_key, selection);
-        if (set_rc != 0) {
-            selection->~NativeRunThreadSelection();
-            std::free(storage);
-            return nullptr;
-        }
-    }
-    return selection;
-}
-
-DeviceRunnerBase::NativeRunThreadSelection &run_selection() {
-    NativeRunThreadSelection *selection = try_run_selection();
-    if (selection == nullptr) {
-        throw std::runtime_error("failed to install native-run pthread TLS state");
-    }
-    return *selection;
-}
 
 HostRuntimeTimeoutConfig resolve_onboard_timeout_config() {
     RuntimeTimeoutConfig order_defaults{
@@ -176,44 +124,6 @@ DeviceRunnerBase::DeviceRunnerBase() {
     }
 }
 
-int DeviceRunnerBase::select_pipeline_slot(uint32_t slot_id) {
-    if (slot_id >= PTO_PIPELINE_MAX_DEPTH) {
-        LOG_ERROR("pipeline slot %u is outside [0, %u)", slot_id, PTO_PIPELINE_MAX_DEPTH);
-        return -1;
-    }
-    run_selection().pipeline_slot = slot_id;
-    return 0;
-}
-
-int DeviceRunnerBase::select_arena_bank(uint32_t bank_id) {
-    if (bank_id >= PTO_PIPELINE_MAX_DEPTH) {
-        LOG_ERROR("arena bank %u is outside [0, %u)", bank_id, PTO_PIPELINE_MAX_DEPTH);
-        return -1;
-    }
-    run_selection().arena_bank = bank_id;
-    return 0;
-}
-
-uint32_t DeviceRunnerBase::pipeline_slot() const { return run_selection().pipeline_slot; }
-
-uint32_t DeviceRunnerBase::selected_arena_bank() const { return run_selection().arena_bank; }
-
-DeviceRunnerBase::NativeRunThreadSelection DeviceRunnerBase::capture_native_run_thread_selection() const {
-    return run_selection();
-}
-
-void DeviceRunnerBase::restore_native_run_thread_selection(const NativeRunThreadSelection &selection) noexcept {
-    NativeRunThreadSelection *target = try_run_selection();
-    if (target == nullptr) {
-        // Returning would leave this thread on the default slot and bank, so a
-        // run would address storage another run's lease owns. There is no
-        // caller-visible channel for the failure on a freshly started thread.
-        LOG_ERROR("native-run thread selection storage could not be installed");
-        std::abort();
-    }
-    *target = selection;
-}
-
 uint64_t DeviceRunnerBase::arena_bank_gm_heap_base(uint32_t bank_id) const {
     if (bank_id >= arena_banks_.size()) return 0;
     const ArenaBank &bank = *arena_banks_[bank_id];
@@ -245,14 +155,20 @@ int DeviceRunnerBase::device_memset(void *dev_ptr, int value, std::size_t bytes)
     return aclrtMemset(dev_ptr, bytes, value, bytes);
 }
 
-void DeviceRunnerBase::get_retained_temp_buffer(void **addr, size_t *size) {
-    if (addr != nullptr) *addr = retained_temp_addrs_[pipeline_slot()];
-    if (size != nullptr) *size = retained_temp_sizes_[pipeline_slot()];
+void DeviceRunnerBase::get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, size_t *size) {
+    if (pipeline_slot >= retained_temp_addrs_.size()) {
+        if (addr != nullptr) *addr = nullptr;
+        if (size != nullptr) *size = 0;
+        return;
+    }
+    if (addr != nullptr) *addr = retained_temp_addrs_[pipeline_slot];
+    if (size != nullptr) *size = retained_temp_sizes_[pipeline_slot];
 }
 
-void DeviceRunnerBase::set_retained_temp_buffer(void *addr, size_t size) {
-    retained_temp_addrs_[pipeline_slot()] = addr;
-    retained_temp_sizes_[pipeline_slot()] = size;
+void DeviceRunnerBase::set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, size_t size) {
+    if (pipeline_slot >= retained_temp_addrs_.size()) return;
+    retained_temp_addrs_[pipeline_slot] = addr;
+    retained_temp_sizes_[pipeline_slot] = size;
 }
 
 void DeviceRunnerBase::clear_temporary_buffer() {
@@ -264,33 +180,36 @@ void DeviceRunnerBase::clear_temporary_buffer() {
     }
 }
 
-void *DeviceRunnerBase::acquire_pooled_gm_heap() {
-    DeviceArena &arena = arena_bank().gm_heap;
+void *DeviceRunnerBase::acquire_pooled_gm_heap(uint32_t arena_bank) {
+    if (arena_bank >= arena_banks_.size()) return nullptr;
+    DeviceArena &arena = this->arena_bank(arena_bank).gm_heap;
     if (!arena.is_committed()) return nullptr;
     return arena.base();
 }
 
-void *DeviceRunnerBase::acquire_pooled_gm_sm() {
-    DeviceArena &arena = arena_bank().gm_sm;
+void *DeviceRunnerBase::acquire_pooled_gm_sm(uint32_t arena_bank) {
+    if (arena_bank >= arena_banks_.size()) return nullptr;
+    DeviceArena &arena = this->arena_bank(arena_bank).gm_sm;
     if (!arena.is_committed()) return nullptr;
     return arena.base();
 }
 
-void *DeviceRunnerBase::acquire_pooled_runtime_arena() {
+void *DeviceRunnerBase::acquire_pooled_runtime_arena(uint32_t arena_bank) {
+    if (arena_bank >= arena_banks_.size()) return nullptr;
     // hbg calls setup_static_arena(...,0) and leaves the runtime pool
     // uncommitted — fail loudly if a caller asks for it anyway.
-    DeviceArena &arena = arena_bank().runtime_pool;
+    DeviceArena &arena = this->arena_bank(arena_bank).runtime_pool;
     if (!arena.is_committed()) return nullptr;
     return arena.base();
 }
 
 bool DeviceRunnerBase::lookup_prebuilt_runtime_arena_cache(
-    uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
+    uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
     void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
 ) const {
     // The cache holds one entry and its bases point into bank 0, so any other
     // bank must rebuild rather than be handed a region it does not own.
-    if (selected_arena_bank() != 0) return false;
+    if (arena_bank != 0) return false;
     if (!prebuilt_runtime_arena_cache_valid_ || prebuilt_runtime_arena_cache_hash_ != hash ||
         prebuilt_runtime_arena_cache_key_.size() != key_size || key_data == nullptr || gm_heap_base == nullptr ||
         sm_base == nullptr || runtime_arena_base == nullptr || runtime_off == nullptr || image_data == nullptr ||
@@ -310,11 +229,11 @@ bool DeviceRunnerBase::lookup_prebuilt_runtime_arena_cache(
 }
 
 void DeviceRunnerBase::mark_prebuilt_runtime_arena_cached(
-    uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base, void *runtime_arena_base,
-    size_t runtime_off, const void *image_data, size_t image_size
+    uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
+    void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
 ) {
     // Single-entry cache owned by bank 0; see lookup_prebuilt_runtime_arena_cache.
-    if (selected_arena_bank() != 0) return;
+    if (arena_bank != 0) return;
     prebuilt_runtime_arena_cache_valid_ = false;
     prebuilt_runtime_arena_cache_hash_ = hash;
     prebuilt_runtime_arena_cache_key_.assign(
@@ -330,7 +249,13 @@ void DeviceRunnerBase::mark_prebuilt_runtime_arena_cached(
     prebuilt_runtime_arena_cache_valid_ = true;
 }
 
-int DeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) {
+int DeviceRunnerBase::setup_static_arena(
+    uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
+) {
+    if (arena_bank >= arena_banks_.size()) {
+        LOG_ERROR("arena bank %u is outside [0, %zu)", arena_bank, arena_banks_.size());
+        return -1;
+    }
     // Three independent device_malloc'd buffers: GM heap, PTO2 SM, prebuilt
     // runtime arena. Split out from a single large allocation because the
     // combined size can exceed the device allocator's largest contiguous
@@ -341,7 +266,7 @@ int DeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_size,
     // worker's lifetime). If a caller asks for a larger layout on any
     // region, redo just that region — already-committed peers stay alive
     // so their callers don't have to re-acquire.
-    ArenaBank &bank = arena_bank();
+    ArenaBank &bank = this->arena_bank(arena_bank);
 
     bool arena_changed = false;
     auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
@@ -390,7 +315,7 @@ int DeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_size,
         bank.cached_gm_heap_size = 0;
         bank.cached_gm_sm_size = 0;
         bank.cached_runtime_arena_size = 0;
-        if (selected_arena_bank() == 0) {
+        if (arena_bank == 0) {
             prebuilt_runtime_arena_cache_valid_ = false;
             prebuilt_runtime_arena_cache_key_.clear();
             prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;
@@ -400,7 +325,7 @@ int DeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_size,
         }
         return -1;
     }
-    if (arena_changed && selected_arena_bank() == 0) {
+    if (arena_changed && arena_bank == 0) {
         prebuilt_runtime_arena_cache_valid_ = false;
         prebuilt_runtime_arena_cache_key_.clear();
         prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;
@@ -413,10 +338,8 @@ int DeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_size,
 
 std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
     int dev_id = device_id_;
-    NativeRunThreadSelection selection = capture_native_run_thread_selection();
-    return std::thread([this, dev_id, selection, fn = std::move(fn)]() {
+    return std::thread([dev_id, fn = std::move(fn)]() {
         rtSetDevice(dev_id);
-        restore_native_run_thread_selection(selection);
         fn();
     });
 }
@@ -1578,23 +1501,6 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run() {
     }
 }
 
-int DeviceRunnerBase::set_task_accepted_state(volatile int32_t *state, int32_t accepted_value) {
-    run_selection().accepted_state = state;
-    run_selection().accepted_value = accepted_value;
-    return 0;
-}
-
-int DeviceRunnerBase::set_native_run_identity(
-    uint64_t run_id, uint64_t generation, uint64_t dispatch_id, uint64_t run_epoch
-) {
-    NativeRunThreadSelection &selection = run_selection();
-    selection.run_id = run_id;
-    selection.generation = generation;
-    selection.dispatch_id = dispatch_id;
-    selection.run_epoch = run_epoch;
-    return 0;
-}
-
 bool DeviceRunnerBase::try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal) {
     if (owner == nullptr || launch_signal == nullptr) return false;
     std::lock_guard<std::mutex> lk(native_run_mu_);
@@ -1690,9 +1596,6 @@ bool DeviceRunnerBase::native_runs_outstanding() const {
 }
 
 void DeviceRunnerBase::publish_task_accepted() const {
-    NativeRunThreadSelection &selection = run_selection();
-    if (selection.accepted_state != nullptr) {
-        __atomic_store_n(selection.accepted_state, selection.accepted_value, __ATOMIC_RELEASE);
-    }
-    if (native_launch_signal_ != nullptr) native_launch_signal_->notify();
+    std::lock_guard<std::mutex> lk(native_run_mu_);
+    if (native_launch_signal_ != nullptr) native_launch_signal_->publish_acceptance();
 }

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -84,17 +84,6 @@ class NativeRunLaunchSignal;
  */
 class DeviceRunnerBase {
 public:
-    struct NativeRunThreadSelection {
-        uint32_t pipeline_slot{0};
-        uint32_t arena_bank{0};
-        volatile int32_t *accepted_state{nullptr};
-        int32_t accepted_value{0};
-        uint64_t run_id{0};
-        uint64_t generation{0};
-        uint64_t dispatch_id{0};
-        uint64_t run_epoch{0};
-    };
-
     // Public virtual dtor so the shared c_api can `delete` a polymorphic
     // `DeviceRunnerBase *` (the `destroy_device_context` entrypoint). Each
     // arch's `DeviceRunner` defaults this through the compiler-generated dtor.
@@ -103,10 +92,6 @@ public:
     DeviceRunnerBase &operator=(const DeviceRunnerBase &) = delete;
     DeviceRunnerBase(DeviceRunnerBase &&) = delete;
     DeviceRunnerBase &operator=(DeviceRunnerBase &&) = delete;
-
-    /** Bind this runner's launch-acceptance publication target. */
-    int set_task_accepted_state(volatile int32_t *state, int32_t accepted_value);
-    int set_native_run_identity(uint64_t run_id, uint64_t generation, uint64_t dispatch_id, uint64_t run_epoch);
 
     /**
      * Claim the runner for one native execution. The opaque owner and
@@ -128,22 +113,6 @@ public:
     );
     void release_native_run_reservation(const void *owner);
     bool native_runs_outstanding() const;
-
-    /** Carry an already-validated run lease into resource selection. */
-    int select_pipeline_slot(uint32_t slot_id);
-    int select_arena_bank(uint32_t bank_id);
-
-    /** Slot selected by the current run lease. */
-    uint32_t pipeline_slot() const;
-    uint32_t selected_arena_bank() const;
-    NativeRunThreadSelection capture_native_run_thread_selection() const;
-    /**
-     * Install `selection` on the calling thread. Aborts if the per-thread
-     * storage cannot be created: every caller either runs inside a scope guard
-     * or on a thread that has not started its run yet, so proceeding on the
-     * default slot and bank would silently address another lease's storage.
-     */
-    void restore_native_run_thread_selection(const NativeRunThreadSelection &selection) noexcept;
 
     /**
      * Committed GM heap base of one arena bank, or 0 while that bank has never
@@ -168,8 +137,8 @@ public:
     int copy_to_device(void *dev_ptr, const void *host_ptr, std::size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, std::size_t bytes);
     int device_memset(void *dev_ptr, int value, std::size_t bytes);
-    void get_retained_temp_buffer(void **addr, std::size_t *size);
-    void set_retained_temp_buffer(void *addr, std::size_t size);
+    void get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, std::size_t *size);
+    void set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, std::size_t size);
     void clear_temporary_buffer();
     /**
      * Map a device buffer into the host address space and return a
@@ -207,7 +176,7 @@ public:
      *
      * @return 0 on success, -1 on failure.
      */
-    int setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
+    int setup_static_arena(uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
 
     /**
      * Return the pooled GM heap / PTO2 SM / runtime arena base pointer of the
@@ -217,15 +186,15 @@ public:
      * `setup_static_arena(...,0)` leaves the runtime pool uncommitted and this
      * returns nullptr.
      */
-    void *acquire_pooled_gm_heap();
-    void *acquire_pooled_gm_sm();
-    void *acquire_pooled_runtime_arena();
+    void *acquire_pooled_gm_heap(uint32_t arena_bank);
+    void *acquire_pooled_gm_sm(uint32_t arena_bank);
+    void *acquire_pooled_runtime_arena(uint32_t arena_bank);
     bool lookup_prebuilt_runtime_arena_cache(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
+        uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
         void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
     ) const;
     void mark_prebuilt_runtime_arena_cached(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
+        uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
         void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
     );
 
@@ -469,7 +438,7 @@ public:
      * with the CallableState-derived host_orch_func_ptr + signature (kept
      * internal to the runner rather than returned across the c_api boundary).
      *
-     * @param api               Platform device-memory hooks (g_host_api).
+     * @param api               Context-bound platform device-memory hooks.
      * @param orch_args         const ChipStorageTaskArgs* for this run (void* to
      *                          keep task_interface headers out of this header).
      * @param ring_task_window  Per-ring overrides (trb); ignored by hbg.
@@ -545,10 +514,9 @@ public:
     virtual int abandon_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }
 
     /** Compatibility composition retained while the C API owns an executor. */
-    int run(Runtime &runtime, const CallConfig &config) {
-        const uint32_t slot = pipeline_slot();
-        const int rc = enqueue_run(runtime, config);
-        return rc == 0 ? drain_run(slot) : rc;
+    int run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
+        const int rc = enqueue_run(runtime, config, pipeline_slot);
+        return rc == 0 ? drain_run(pipeline_slot) : rc;
     }
 
     /**
@@ -557,7 +525,7 @@ public:
      * all state needed by poll_run() and drain_run() remains owned by the
      * runner until drain completes.
      */
-    virtual int enqueue_run(Runtime &runtime, const CallConfig &config) = 0;
+    virtual int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) = 0;
 
     /**
      * Query the active run without waiting. Returns one of the
@@ -596,7 +564,7 @@ public:
 
     /**
      * Launch an AICPU kernel. Internal helper used by the subclass's
-     * `run()`; thin wrapper that dispatches through `load_aicpu_op_`'s
+     * `enqueue_run()`; thin wrapper that dispatches through `load_aicpu_op_`'s
      * cached `rtFuncHandle` (resolved by `LoadAicpuOp::Init` at first
      * bootstrap).
      *
@@ -679,7 +647,7 @@ public:
     const std::string &output_prefix() const { return output_prefix_; }
 
 protected:
-    /** Publish launch acceptance for the currently bound target, if any. */
+    /** Publish acceptance through the active run's launch signal, if any. */
     void publish_task_accepted() const;
     // Ctor is protected: this class is for inheritance only — direct
     // instantiation (`new DeviceRunnerBase()`) is a compile error. The
@@ -1053,7 +1021,7 @@ protected:
     // Held by pointer because DeviceArena is non-copyable and non-movable, so
     // the array cannot be brace-initialised without naming every bank.
     std::array<std::unique_ptr<ArenaBank>, PTO_PIPELINE_MAX_DEPTH> arena_banks_;
-    ArenaBank &arena_bank() { return *arena_banks_[selected_arena_bank()]; }
+    ArenaBank &arena_bank(uint32_t bank_id) { return *arena_banks_[bank_id]; }
 
     bool prebuilt_runtime_arena_cache_valid_{false};
     uint64_t prebuilt_runtime_arena_cache_hash_{0};

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -28,10 +28,9 @@
 #include "device_runner_base.h"
 #include "prepare_callable_common.h"
 #include "task_args.h"
-#include "native_run_state.h"
+#include "native_run_context.h"
 
 #include <dlfcn.h>
-#include <pthread.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -47,176 +46,184 @@
 #include "host/raii_scope_guard.h"
 #include "runtime.h"
 
-using SimNativeRunState = NativeRunState<SimDeviceRunnerBase>;
+using SimNativeRunContext = NativeRunContext<SimDeviceRunnerBase>;
 // Phase entry points validate raw caller storage before beginning object
 // lifetime, so the on-storage magic must remain the leading bytes.
-static_assert(__builtin_offsetof(SimNativeRunState, magic) == 0, "native-run magic must lead runtime storage");
+static_assert(__builtin_offsetof(SimNativeRunContext, magic) == 0, "native-run magic must lead runtime storage");
 
 extern "C" {
 
 /* ===========================================================================
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
-int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
+int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out);
 int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc);
 
 /* ===========================================================================
- * Per-thread DeviceRunner binding
+ * Context-bound HostApi functions passed to runtime implementations.
  * =========================================================================== */
 
-static pthread_key_t g_runner_key;
-static pthread_once_t g_runner_key_once = PTHREAD_ONCE_INIT;
-static void create_runner_key() { pthread_key_create(&g_runner_key, nullptr); }
-
-static SimDeviceRunnerBase *current_runner() {
-    return static_cast<SimDeviceRunnerBase *>(pthread_getspecific(g_runner_key));
-}
-
-/* ===========================================================================
- * Internal device-memory functions (wired into a HostApi and passed to the
- * runtime impls, NOT dlsym'd)
- * =========================================================================== */
-
-static void *device_malloc(size_t size) {
+static void *device_malloc(void *runner_ctx, size_t size) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->allocate_tensor(size);
-    } catch (...) {
-        return NULL;
-    }
-}
-
-static void device_free(void *dev_ptr) {
-    if (dev_ptr == NULL) return;
-    try {
-        current_runner()->free_tensor(dev_ptr);
-    } catch (...) {}
-}
-
-static int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
-    if (dev_ptr == NULL || host_ptr == NULL) return -1;
-    try {
-        return current_runner()->copy_to_device(dev_ptr, host_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
-    if (host_ptr == NULL || dev_ptr == NULL) return -1;
-    try {
-        return current_runner()->copy_from_device(host_ptr, dev_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-static void *register_device_memory_to_host(void *dev_ptr, size_t bytes) {
-    try {
-        return current_runner()->register_device_memory_to_host(dev_ptr, bytes);
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->allocate_tensor(size);
     } catch (...) {
         return nullptr;
     }
 }
 
-static void unregister_device_memory_from_host(void *dev_ptr) {
+static void device_free(void *runner_ctx, void *dev_ptr) {
+    if (runner_ctx == nullptr || dev_ptr == nullptr) return;
     try {
-        current_runner()->unregister_device_memory_from_host(dev_ptr);
+        static_cast<SimDeviceRunnerBase *>(runner_ctx)->free_tensor(dev_ptr);
     } catch (...) {}
 }
 
-static int device_memset(void *dev_ptr, int value, size_t size) {
-    if (dev_ptr == NULL) return -1;
+static int copy_to_device(void *runner_ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    if (runner_ctx == nullptr || dev_ptr == nullptr || host_ptr == nullptr) return -1;
     try {
-        return current_runner()->device_memset(dev_ptr, value, size);
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-static void get_retained_temp_buffer(void **addr, size_t *size) {
+static int copy_from_device(void *runner_ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    if (runner_ctx == nullptr || host_ptr == nullptr || dev_ptr == nullptr) return -1;
     try {
-        current_runner()->get_retained_temp_buffer(addr, size);
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+static void *register_device_memory_to_host(void *runner_ctx, void *dev_ptr, size_t bytes) {
+    if (runner_ctx == nullptr) return nullptr;
+    try {
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->register_device_memory_to_host(dev_ptr, bytes);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void unregister_device_memory_from_host(void *runner_ctx, void *dev_ptr) {
+    if (runner_ctx == nullptr) return;
+    try {
+        static_cast<SimDeviceRunnerBase *>(runner_ctx)->unregister_device_memory_from_host(dev_ptr);
+    } catch (...) {}
+}
+
+static int device_memset(void *runner_ctx, void *dev_ptr, int value, size_t size) {
+    if (runner_ctx == nullptr || dev_ptr == nullptr) return -1;
+    try {
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->device_memset(dev_ptr, value, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+static void get_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, void **addr, size_t *size) {
+    if (runner_ctx == nullptr) {
+        if (addr != nullptr) *addr = nullptr;
+        if (size != nullptr) *size = 0;
+        return;
+    }
+    try {
+        static_cast<SimDeviceRunnerBase *>(runner_ctx)->get_retained_temp_buffer(pipeline_slot, addr, size);
     } catch (...) {
         if (addr != nullptr) *addr = nullptr;
         if (size != nullptr) *size = 0;
     }
 }
 
-static void set_retained_temp_buffer(void *addr, size_t size) {
+static void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, void *addr, size_t size) {
+    if (runner_ctx == nullptr) return;
     try {
-        current_runner()->set_retained_temp_buffer(addr, size);
+        static_cast<SimDeviceRunnerBase *>(runner_ctx)->set_retained_temp_buffer(pipeline_slot, addr, size);
     } catch (...) {}
 }
 
-static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
+static uint64_t upload_chip_callable_buffer_wrapper(void *runner_ctx, const void *callable) {
+    if (runner_ctx == nullptr) return 0;
     try {
-        return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)
+            ->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
     } catch (...) {
         return 0;
     }
 }
 
-static int setup_static_arena_wrapper(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) {
+static int setup_static_arena_wrapper(
+    void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
+) {
+    if (runner_ctx == nullptr) return -1;
     try {
-        return current_runner()->setup_static_arena(gm_heap_size, gm_sm_size, runtime_arena_size);
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)
+            ->setup_static_arena(arena_bank, gm_heap_size, gm_sm_size, runtime_arena_size);
     } catch (...) {
         return -1;
     }
 }
 
-static void *acquire_pooled_gm_heap_wrapper() {
+static void *acquire_pooled_gm_heap_wrapper(void *runner_ctx, uint32_t arena_bank) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->acquire_pooled_gm_heap();
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->acquire_pooled_gm_heap(arena_bank);
     } catch (...) {
         return nullptr;
     }
 }
 
-static void *acquire_pooled_gm_sm_wrapper() {
+static void *acquire_pooled_gm_sm_wrapper(void *runner_ctx, uint32_t arena_bank) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->acquire_pooled_gm_sm();
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->acquire_pooled_gm_sm(arena_bank);
     } catch (...) {
         return nullptr;
     }
 }
 
-static void *acquire_pooled_runtime_arena_wrapper() {
+static void *acquire_pooled_runtime_arena_wrapper(void *runner_ctx, uint32_t arena_bank) {
+    if (runner_ctx == nullptr) return nullptr;
     try {
-        return current_runner()->acquire_pooled_runtime_arena();
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->acquire_pooled_runtime_arena(arena_bank);
     } catch (...) {
         return nullptr;
     }
 }
 
 static bool lookup_prebuilt_runtime_arena_cache_wrapper(
-    uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-    void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
+    void *runner_ctx, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base,
+    void **sm_base, void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
 ) {
+    if (runner_ctx == nullptr) return false;
     try {
-        return current_runner()->lookup_prebuilt_runtime_arena_cache(
-            hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off, image_data, image_size
-        );
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)
+            ->lookup_prebuilt_runtime_arena_cache(
+                arena_bank, hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off,
+                image_data, image_size
+            );
     } catch (...) {
         return false;
     }
 }
 
 static void mark_prebuilt_runtime_arena_cached_wrapper(
-    uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base, void *runtime_arena_base,
-    size_t runtime_off, const void *image_data, size_t image_size
+    void *runner_ctx, uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base,
+    void *sm_base, void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
 ) {
+    if (runner_ctx == nullptr) return;
     try {
-        current_runner()->mark_prebuilt_runtime_arena_cached(
-            hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off, image_data, image_size
-        );
+        static_cast<SimDeviceRunnerBase *>(runner_ctx)
+            ->mark_prebuilt_runtime_arena_cached(
+                arena_bank, hash, key_data, key_size, gm_heap_base, sm_base, runtime_arena_base, runtime_off,
+                image_data, image_size
+            );
     } catch (...) {}
 }
 
-// The HostApi is a set of context-free function pointers: each wrapper above
-// recovers its runner from the thread-local current_runner(), so a single
-// filled table is valid for every runner and every run. Build it once at load
-// time rather than reassembling the pointer table on each simpler_run. Passed by
-// address into bind_callable_to_runtime_impl / validate_runtime_impl.
+// One immutable function table is shared by all runners. Each HostApi value
+// binds it to a specific runner and immutable per-run slot/bank selection.
 
 // Weak no-op default lives in device_runner_base.cpp; tensormap_and_ringbuffer
 // links a strong override that builds + caches the prebuilt runtime-arena.
@@ -225,7 +232,7 @@ extern "C" int prewarm_config_impl(
     const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 );
 
-static const HostApi g_host_api = {
+static const HostApiOps g_host_api_ops = {
     .device_malloc = device_malloc,
     .device_free = device_free,
     .copy_to_device = copy_to_device,
@@ -257,9 +264,9 @@ void destroy_device_context(DeviceContextHandle ctx) {
     delete runner;
 }
 
-size_t get_runtime_size(void) { return sizeof(SimNativeRunState); }
+size_t get_runtime_size(void) { return sizeof(SimNativeRunContext); }
 
-size_t get_runtime_alignment(void) { return alignof(SimNativeRunState); }
+size_t get_runtime_alignment(void) { return alignof(SimNativeRunContext); }
 
 void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) {
     if (ctx == NULL) return NULL;
@@ -329,13 +336,6 @@ int simpler_init(
     if (ctx == NULL) return -1;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
-    // HostApi callbacks, including the prewarm path below, recover their
-    // DeviceRunner from this thread-local binding.
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
 
     int rc;
     try {
@@ -365,8 +365,9 @@ int simpler_init(
     // runtimes link the weak no-op. Only the ring sizing is read.
     if (prewarm_config != NULL) {
         try {
+            const HostApi prewarm_api(runner, 0, 0, &g_host_api_ops);
             rc = prewarm_config_impl(
-                &g_host_api, prewarm_config->runtime_env.ring_task_window, prewarm_config->runtime_env.ring_heap,
+                &prewarm_api, prewarm_config->runtime_env.ring_task_window, prewarm_config->runtime_env.ring_heap,
                 prewarm_config->runtime_env.ring_dep_pool
             );
         } catch (...) {
@@ -389,9 +390,6 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         return -1;
     }
 
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-
     try {
         CallableArtifacts artifacts;
         auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
@@ -399,11 +397,9 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
                 runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
             }
         });
-        int rc = register_callable_impl(
-            reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
-        );
+        const HostApi host_api(runner, 0, 0, &g_host_api_ops);
+        int rc = register_callable_impl(reinterpret_cast<const ChipCallable *>(callable), &host_api, &artifacts);
         if (rc != 0) {
-            pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
         auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
@@ -445,10 +441,8 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
                 runner->unregister_callable(callable_id);
             }
         }
-        pthread_setspecific(g_runner_key, nullptr);
         return rc;
     } catch (...) {
-        pthread_setspecific(g_runner_key, nullptr);
         return -1;
     }
 }
@@ -531,15 +525,15 @@ static void emit_device_phase_markers(SimDeviceRunnerBase *runner) {
     }
 }
 
-static SimNativeRunState *native_run_state(DeviceContextHandle ctx, RuntimeHandle runtime, const char *operation) {
+static SimNativeRunContext *native_run_context(DeviceContextHandle ctx, RuntimeHandle runtime, const char *operation) {
     if (ctx == nullptr || runtime == nullptr) return nullptr;
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
-    if (magic != SimNativeRunState::kMagic) {
+    if (magic != SimNativeRunContext::kMagic) {
         LOG_ERROR("%s: runtime does not contain a prepared native run", operation);
         return nullptr;
     }
-    auto *state = static_cast<SimNativeRunState *>(runtime);
+    auto *state = static_cast<SimNativeRunContext *>(runtime);
     if (state->runner != static_cast<SimDeviceRunnerBase *>(ctx)) {
         LOG_ERROR("%s: prepared run belongs to a different device context", operation);
         return nullptr;
@@ -553,14 +547,14 @@ static void emit_native_run_host_wall(unsigned trace_inv, uint64_t trace_hid, lo
     STRACE_HOST_SPAN_AT("simpler_run", trace_start_ns, end_ns - trace_start_ns, 0);
 }
 
-static int cleanup_failed_prepare(SimNativeRunState *state, int execution_rc, bool clear_gm_sm) {
+static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, bool clear_gm_sm) {
     const unsigned trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
     int validation_rc = -1;
     try {
-        validation_rc = validate_runtime_impl(&state->runtime, &g_host_api, execution_rc);
+        validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
     } catch (...) {
         validation_rc = -1;
     }
@@ -568,16 +562,24 @@ static int cleanup_failed_prepare(SimNativeRunState *state, int execution_rc, bo
         state->runner->release_native_run(state);
         state->runner_claimed = false;
     }
-    destroy_native_run_state(state);
+    destroy_native_run_context(state);
     emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns);
     return validation_rc != 0 ? validation_rc : execution_rc;
 }
 
 int simpler_prepare_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
 ) {
-    if (ctx == nullptr || runtime == nullptr || config == nullptr) return -1;
-    if (reinterpret_cast<uintptr_t>(runtime) % alignof(SimNativeRunState) != 0) {
+    if (ctx == nullptr || runtime == nullptr || config == nullptr || descriptor == nullptr) return -1;
+    if (descriptor->pipeline_slot >= PTO_PIPELINE_MAX_DEPTH || descriptor->arena_bank >= PTO_PIPELINE_MAX_DEPTH) {
+        LOG_ERROR(
+            "simpler_prepare_run: descriptor selects slot=%u bank=%u outside [0, %u)", descriptor->pipeline_slot,
+            descriptor->arena_bank, PTO_PIPELINE_MAX_DEPTH
+        );
+        return -1;
+    }
+    if (reinterpret_cast<uintptr_t>(runtime) % alignof(SimNativeRunContext) != 0) {
         LOG_ERROR("simpler_prepare_run: runtime storage does not satisfy get_runtime_alignment()");
         return -1;
     }
@@ -588,7 +590,7 @@ int simpler_prepare_run(
     }
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
-    if (magic == SimNativeRunState::kMagic) {
+    if (magic == SimNativeRunContext::kMagic) {
         LOG_ERROR("simpler_prepare_run: runtime already contains a prepared run; finalize it before reuse");
         return -1;
     }
@@ -597,21 +599,15 @@ int simpler_prepare_run(
         return -1;
     }
 
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
-
-    SimNativeRunState *state = nullptr;
+    SimNativeRunContext *state = nullptr;
     const uint64_t trace_hid = static_cast<uint64_t>(callable_id);
     const unsigned trace_inv = STRACE_ALLOC_INV();
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
-        state = new (runtime) SimNativeRunState(runner, *config, trace_hid);
+        state = new (runtime) SimNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
         if (!runner->try_acquire_native_run(state, &state->launch_signal)) {
             LOG_ERROR("simpler_prepare_run: another native run is active on this device context");
-            destroy_native_run_state(state);
+            destroy_native_run_context(state);
             return -1;
         }
         state->runner_claimed = true;
@@ -630,7 +626,7 @@ int simpler_prepare_run(
         {
             STRACE("simpler_run.bind");
             rc = runner->bind_callable_to_runtime(
-                state->runtime, callable_id, &g_host_api, args, state->config.runtime_env.ring_task_window,
+                state->runtime, callable_id, &state->host_api, args, state->config.runtime_env.ring_task_window,
                 state->config.runtime_env.ring_heap, state->config.runtime_env.ring_dep_pool
             );
         }
@@ -644,7 +640,7 @@ int simpler_prepare_run(
 }
 
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    SimNativeRunState *state = native_run_state(ctx, runtime, "simpler_launch_run");
+    SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_launch_run");
     if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared) return -1;
     if (!state->runner_claimed || !state->runner->native_run_owned_by(state)) return -1;
 
@@ -653,9 +649,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     try {
         // The compatibility backend uses one blocking executor per run. The
         // prepare-through-finalize runner claim limits it to one per context.
-        state->executor = state->runner->create_thread([state, ctx]() {
-            pthread_once(&g_runner_key_once, create_runner_key);
-            pthread_setspecific(g_runner_key, ctx);
+        state->executor = state->runner->create_thread([state]() {
             STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
             int rc = -1;
             try {
@@ -664,7 +658,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
                     state->adopt_host_thread_state();
                     {
                         STRACE("simpler_run.runner_run");
-                        rc = state->runner->run(state->runtime, state->config);
+                        rc = state->runner->run(state->runtime, state->config, state->descriptor.pipeline_slot);
                     }
                 } else {
                     rc = attach_rc;
@@ -672,7 +666,6 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
             } catch (...) {
                 rc = -1;
             }
-            pthread_setspecific(g_runner_key, nullptr);
             state->execution_rc.store(rc, std::memory_order_relaxed);
             state->execution_done.store(true, std::memory_order_release);
             state->launch_signal.notify();
@@ -692,7 +685,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    SimNativeRunState *state = native_run_state(ctx, runtime, "simpler_poll_run");
+    SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_poll_run");
     if (state == nullptr) return SIMPLER_NATIVE_RUN_POLL_ERROR;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Prepared) return SIMPLER_NATIVE_RUN_POLL_ERROR;
@@ -711,7 +704,7 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    SimNativeRunState *state = native_run_state(ctx, runtime, "simpler_wait_run");
+    SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_wait_run");
     if (state == nullptr) return -1;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Prepared || phase == NativeRunPhase::Launching) return -1;
@@ -721,7 +714,7 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 }
 
 int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
-    SimNativeRunState *state = native_run_state(ctx, runtime, "simpler_finalize_run");
+    SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_finalize_run");
     if (state == nullptr) return -1;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Launching) return -1;
@@ -729,11 +722,6 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
 
-    pthread_once(&g_runner_key_once, create_runner_key);
-    pthread_setspecific(g_runner_key, ctx);
-    auto tsd_guard = RAIIScopeGuard([]() {
-        pthread_setspecific(g_runner_key, nullptr);
-    });
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
 
     int execution_rc = -1;
@@ -750,7 +738,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         if (attach_rc == 0) {
             {
                 STRACE("simpler_run.validate");
-                validation_rc = validate_runtime_impl(&state->runtime, &g_host_api, launched ? execution_rc : -1);
+                validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, launched ? execution_rc : -1);
             }
             if (launched && execution_rc == 0) emit_device_phase_markers(state->runner);
         } else {
@@ -764,16 +752,17 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;
     }
-    destroy_native_run_state(state);
+    destroy_native_run_context(state);
     emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns);
     if (validation_rc != 0) return validation_rc;
     return launched ? execution_rc : 0;
 }
 
 int simpler_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
 ) {
-    int rc = simpler_prepare_run(ctx, runtime, callable_id, args, config);
+    int rc = simpler_prepare_run(ctx, runtime, callable_id, args, config, descriptor);
     if (rc != 0) return rc;
     rc = simpler_launch_run(ctx, runtime);
     if (rc == 0) rc = simpler_wait_run(ctx, runtime);
@@ -782,38 +771,6 @@ int simpler_run(
 }
 
 int supports_concurrent_native_prepare_ctx(DeviceContextHandle) { return 0; }
-
-int set_task_accepted_state_ctx(DeviceContextHandle ctx, volatile int32_t *state, int32_t accepted_value) {
-    if (ctx == NULL) return -1;
-    try {
-        return static_cast<SimDeviceRunnerBase *>(ctx)->set_task_accepted_state(state, accepted_value);
-    } catch (...) {
-        return -1;
-    }
-}
-
-/**
- * Simulation keeps no per-thread run selection, so the identity is carried only
- * by the onboard runner's trace attributes and is discarded here. Accepting it
- * keeps the pipeline symbol set uniform across every host runtime.
- */
-int set_native_run_identity_ctx(DeviceContextHandle ctx, uint64_t, uint64_t, uint64_t, uint64_t) {
-    return ctx == NULL ? -1 : 0;
-}
-
-int select_pipeline_slot_ctx(DeviceContextHandle ctx, uint32_t slot_id) {
-    if (ctx == NULL) return -1;
-    SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
-    if (runner->native_run_active()) return -1;
-    return runner->select_pipeline_slot(slot_id);
-}
-
-int select_arena_bank_ctx(DeviceContextHandle ctx, uint32_t bank_id) {
-    if (ctx == NULL) return -1;
-    SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
-    if (runner->native_run_active()) return -1;
-    return runner->select_arena_bank(bank_id);
-}
 
 uint64_t get_arena_bank_gm_heap_base_ctx(DeviceContextHandle ctx, uint32_t bank_id) {
     if (ctx == NULL) return 0;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -83,12 +83,6 @@ bool create_temp_so_file(const std::string &path_template, const uint8_t *data, 
 // SimDeviceRunnerBase Implementation
 // =============================================================================
 
-int SimDeviceRunnerBase::set_task_accepted_state(volatile int32_t *state, int32_t accepted_value) {
-    task_accepted_state_ = state;
-    task_accepted_value_ = accepted_value;
-    return 0;
-}
-
 bool SimDeviceRunnerBase::try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal) {
     if (owner == nullptr || launch_signal == nullptr) return false;
     const void *expected = nullptr;
@@ -119,22 +113,7 @@ bool SimDeviceRunnerBase::native_run_owned_by(const void *owner) const {
 }
 
 void SimDeviceRunnerBase::publish_task_accepted() const {
-    if (task_accepted_state_ != nullptr) {
-        __atomic_store_n(task_accepted_state_, task_accepted_value_, __ATOMIC_RELEASE);
-    }
-    if (native_launch_signal_ != nullptr) native_launch_signal_->notify();
-}
-
-int SimDeviceRunnerBase::select_pipeline_slot(uint32_t slot_id) {
-    if (slot_id >= PTO_PIPELINE_MAX_DEPTH) return -1;
-    pipeline_slot_ = slot_id;
-    return 0;
-}
-
-int SimDeviceRunnerBase::select_arena_bank(uint32_t bank_id) {
-    if (bank_id >= PTO_PIPELINE_MAX_DEPTH) return -1;
-    arena_bank_ = bank_id;
-    return 0;
+    if (native_launch_signal_ != nullptr) native_launch_signal_->publish_acceptance();
 }
 
 uint64_t SimDeviceRunnerBase::arena_bank_gm_heap_base(uint32_t bank_id) const {
@@ -148,8 +127,11 @@ uint64_t SimDeviceRunnerBase::retained_temp_addr(uint32_t slot_id) const {
     return reinterpret_cast<uint64_t>(retained_temp_addrs_[slot_id]);
 }
 
-int SimDeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) {
-    ArenaBank &bank = arena_bank();
+int SimDeviceRunnerBase::setup_static_arena(
+    uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
+) {
+    if (arena_bank >= arena_banks_.size()) return -1;
+    ArenaBank &bank = this->arena_bank(arena_bank);
     // Three independent device_malloc'd buffers: GM heap, PTO2 SM, prebuilt
     // runtime arena. Split out from a single large allocation because the
     // combined size can exceed the device allocator's largest contiguous
@@ -217,12 +199,12 @@ int SimDeviceRunnerBase::setup_static_arena(size_t gm_heap_size, size_t gm_sm_si
 }
 
 bool SimDeviceRunnerBase::lookup_prebuilt_runtime_arena_cache(
-    uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
+    uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
     void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
 ) const {
     // The cache holds one entry and its bases point into bank 0, so any other
     // bank must rebuild rather than be handed a region it does not own.
-    if (arena_bank_ != 0) return false;
+    if (arena_bank != 0) return false;
     if (!prebuilt_runtime_arena_cache_valid_ || prebuilt_runtime_arena_cache_hash_ != hash ||
         prebuilt_runtime_arena_cache_key_.size() != key_size || key_data == nullptr || gm_heap_base == nullptr ||
         sm_base == nullptr || runtime_arena_base == nullptr || runtime_off == nullptr || image_data == nullptr ||
@@ -242,11 +224,11 @@ bool SimDeviceRunnerBase::lookup_prebuilt_runtime_arena_cache(
 }
 
 void SimDeviceRunnerBase::mark_prebuilt_runtime_arena_cached(
-    uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base, void *runtime_arena_base,
-    size_t runtime_off, const void *image_data, size_t image_size
+    uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
+    void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
 ) {
     // Single-entry cache owned by bank 0; see lookup_prebuilt_runtime_arena_cache.
-    if (arena_bank_ != 0) return;
+    if (arena_bank != 0) return;
     prebuilt_runtime_arena_cache_valid_ = false;
     prebuilt_runtime_arena_cache_hash_ = hash;
     prebuilt_runtime_arena_cache_key_.assign(
@@ -262,20 +244,23 @@ void SimDeviceRunnerBase::mark_prebuilt_runtime_arena_cached(
     prebuilt_runtime_arena_cache_valid_ = true;
 }
 
-void *SimDeviceRunnerBase::acquire_pooled_gm_heap() {
-    DeviceArena &arena = arena_bank().gm_heap;
+void *SimDeviceRunnerBase::acquire_pooled_gm_heap(uint32_t arena_bank) {
+    if (arena_bank >= arena_banks_.size()) return nullptr;
+    DeviceArena &arena = this->arena_bank(arena_bank).gm_heap;
     if (!arena.is_committed()) return nullptr;
     return arena.base();
 }
 
-void *SimDeviceRunnerBase::acquire_pooled_gm_sm() {
-    DeviceArena &arena = arena_bank().gm_sm;
+void *SimDeviceRunnerBase::acquire_pooled_gm_sm(uint32_t arena_bank) {
+    if (arena_bank >= arena_banks_.size()) return nullptr;
+    DeviceArena &arena = this->arena_bank(arena_bank).gm_sm;
     if (!arena.is_committed()) return nullptr;
     return arena.base();
 }
 
-void *SimDeviceRunnerBase::acquire_pooled_runtime_arena() {
-    DeviceArena &arena = arena_bank().runtime_pool;
+void *SimDeviceRunnerBase::acquire_pooled_runtime_arena(uint32_t arena_bank) {
+    if (arena_bank >= arena_banks_.size()) return nullptr;
+    DeviceArena &arena = this->arena_bank(arena_bank).runtime_pool;
     if (!arena.is_committed()) return nullptr;
     return arena.base();
 }
@@ -377,14 +362,20 @@ int SimDeviceRunnerBase::device_memset(void *dev_ptr, int value, size_t bytes) {
     return 0;
 }
 
-void SimDeviceRunnerBase::get_retained_temp_buffer(void **addr, size_t *size) {
-    if (addr != nullptr) *addr = retained_temp_addrs_[pipeline_slot_];
-    if (size != nullptr) *size = retained_temp_sizes_[pipeline_slot_];
+void SimDeviceRunnerBase::get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, size_t *size) {
+    if (pipeline_slot >= retained_temp_addrs_.size()) {
+        if (addr != nullptr) *addr = nullptr;
+        if (size != nullptr) *size = 0;
+        return;
+    }
+    if (addr != nullptr) *addr = retained_temp_addrs_[pipeline_slot];
+    if (size != nullptr) *size = retained_temp_sizes_[pipeline_slot];
 }
 
-void SimDeviceRunnerBase::set_retained_temp_buffer(void *addr, size_t size) {
-    retained_temp_addrs_[pipeline_slot_] = addr;
-    retained_temp_sizes_[pipeline_slot_] = size;
+void SimDeviceRunnerBase::set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, size_t size) {
+    if (pipeline_slot >= retained_temp_addrs_.size()) return;
+    retained_temp_addrs_[pipeline_slot] = addr;
+    retained_temp_sizes_[pipeline_slot] = size;
 }
 
 void SimDeviceRunnerBase::clear_temporary_buffer() {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -77,10 +77,6 @@ public:
         }
     }
 
-    /** Carry an already-validated run lease into resource selection. */
-    int select_pipeline_slot(uint32_t slot_id);
-    int select_arena_bank(uint32_t bank_id);
-    uint32_t pipeline_slot() const { return pipeline_slot_; }
     uint64_t arena_bank_gm_heap_base(uint32_t bank_id) const;
 
     /**
@@ -96,13 +92,13 @@ public:
 
     // --- Pure / no-op virtuals dispatched from the shared c_api glue ----
     /** Compatibility composition retained while the C API owns an executor. */
-    int run(Runtime &runtime, const CallConfig &config) {
-        const int rc = enqueue_run(runtime, config);
+    int run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
+        const int rc = enqueue_run(runtime, config, pipeline_slot);
         return rc == 0 ? drain_run() : rc;
     }
 
     /** Submit a Runtime and retain all state needed to query and drain it. */
-    virtual int enqueue_run(Runtime &runtime, const CallConfig &config) = 0;
+    virtual int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) = 0;
     /** Return one of the SIMPLER_NATIVE_RUN_POLL_* values without waiting. */
     virtual int poll_run() = 0;
     /** Wait for completion, publish DFX, and release per-run resources. */
@@ -117,9 +113,6 @@ public:
     virtual void adopt_native_run_thread_state(void * /*snapshot*/) noexcept {}
     virtual void destroy_native_run_thread_state(void * /*snapshot*/) noexcept {}
 
-    /** Bind an optional external launch-acceptance target. */
-    int set_task_accepted_state(volatile int32_t *state, int32_t accepted_value);
-
     /** Reserve the runner's single active native execution through finalize. */
     bool try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal);
     void release_native_run(const void *owner);
@@ -128,17 +121,17 @@ public:
 
     // --- Shared methods --------------------------------------------------
 
-    int setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
+    int setup_static_arena(uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
 
-    void *acquire_pooled_gm_heap();
-    void *acquire_pooled_gm_sm();
-    void *acquire_pooled_runtime_arena();
+    void *acquire_pooled_gm_heap(uint32_t arena_bank);
+    void *acquire_pooled_gm_sm(uint32_t arena_bank);
+    void *acquire_pooled_runtime_arena(uint32_t arena_bank);
     bool lookup_prebuilt_runtime_arena_cache(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
+        uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
         void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
     ) const;
     void mark_prebuilt_runtime_arena_cached(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
+        uint32_t arena_bank, uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
         void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
     );
 
@@ -152,8 +145,8 @@ public:
     int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
     int device_memset(void *dev_ptr, int value, size_t bytes);
-    void get_retained_temp_buffer(void **addr, size_t *size);
-    void set_retained_temp_buffer(void *addr, size_t size);
+    void get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, size_t *size);
+    void set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, size_t size);
     void clear_temporary_buffer();
 
     // On sim, allocate_tensor returns a plain host pointer, so the "device"
@@ -178,7 +171,7 @@ public:
     bool has_callable(int32_t callable_id) const;
     // One-step bind: replay CallableState (kernel addrs + active_callable_id)
     // then run the per-run bind_callable_to_runtime_impl with the state's
-    // host_orch_func_ptr + signature. `api` is g_host_api; `orch_args` is a
+    // host_orch_func_ptr + signature. `api` is bound to this run; `orch_args` is a
     // const ChipStorageTaskArgs* (void* keeps task_interface headers out of this
     // header). Returns 0 on success, non-zero on failure.
     int bind_callable_to_runtime(
@@ -319,9 +312,7 @@ protected:
         size_t cached_runtime_arena_size{0};
     };
     std::array<std::unique_ptr<ArenaBank>, PTO_PIPELINE_MAX_DEPTH> arena_banks_;
-    ArenaBank &arena_bank() { return *arena_banks_[arena_bank_]; }
-    uint32_t pipeline_slot_{0};
-    uint32_t arena_bank_{0};
+    ArenaBank &arena_bank(uint32_t bank_id) { return *arena_banks_[bank_id]; }
     bool prebuilt_runtime_arena_cache_valid_{false};
     uint64_t prebuilt_runtime_arena_cache_hash_{0};
     std::vector<uint8_t> prebuilt_runtime_arena_cache_key_;
@@ -392,8 +383,6 @@ protected:
 
     Runtime *last_runtime_{nullptr};
 
-    volatile int32_t *task_accepted_state_{nullptr};
-    int32_t task_accepted_value_{0};
     std::atomic<const void *> active_native_run_{nullptr};
     NativeRunLaunchSignal *native_launch_signal_{nullptr};
 

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -30,6 +30,7 @@
 #include "arg_direction.h"
 #include "callable.h"
 #include "chip_callable_layout.h"
+#include "common/host_api.h"
 
 struct ChildKernelAddr {
     int func_id;
@@ -74,15 +75,13 @@ struct CallableArtifacts {
 };
 
 /**
- * Upload the ChipCallable buffer via `upload_fn` and compute the device-side
+ * Upload the ChipCallable buffer through `api` and compute the device-side
  * address of every child kernel.
  *
  * @param callable   ChipCallable to upload. May have child_count() == 0; the
  *                   chip buffer is still uploaded and retained, while `out`
  *                   remains empty on success.
- * @param upload_fn  HostApi::upload_chip_callable_buffer — declared as
- *                   `uint64_t (*)(const void *)` to avoid pulling runtime
- *                   headers into task_interface. Must not be null.
+ * @param api        Context-bound platform host interface. Must not be null.
  * @param out        Cleared on entry; on success, populated with one
  *                   {func_id, device_addr} entry per child kernel. Caller is
  *                   responsible for validating func_id against its runtime's
@@ -90,14 +89,14 @@ struct CallableArtifacts {
  * @return 0 on success, -1 on argument error or upload failure.
  */
 inline int upload_and_collect_child_addrs(
-    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), std::vector<ChildKernelAddr> *out,
+    const ChipCallable *callable, const HostApi *api, std::vector<ChildKernelAddr> *out,
     uint64_t *out_chip_dev = nullptr, uint64_t *out_chip_hash = nullptr, uint64_t *out_aicore_image_hash = nullptr
 ) {
-    if (callable == nullptr || upload_fn == nullptr || out == nullptr) return -1;
+    if (callable == nullptr || api == nullptr || out == nullptr) return -1;
     out->clear();
 
     const ChipCallableLayout layout = compute_chip_callable_layout(callable);
-    uint64_t chip_dev = upload_fn(callable);
+    uint64_t chip_dev = api->upload_chip_callable_buffer(callable);
     if (chip_dev == 0) return -1;
     if (out_chip_dev != nullptr) *out_chip_dev = chip_dev;
     if (out_chip_hash != nullptr) *out_chip_hash = layout.content_hash;

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -164,13 +164,9 @@ void ChipWorker::init(
         finalize_run_fn_ = load_symbol<SimplerNativeRunFn>(handle, "simpler_finalize_run");
         supports_concurrent_native_prepare_fn_ =
             load_symbol<SupportsConcurrentNativePrepareFn>(handle, "supports_concurrent_native_prepare_ctx");
-        select_pipeline_slot_fn_ = load_symbol<SelectPipelineSlotFn>(handle, "select_pipeline_slot_ctx");
-        select_arena_bank_fn_ = load_symbol<SelectArenaBankFn>(handle, "select_arena_bank_ctx");
-        set_native_run_identity_fn_ = load_symbol<SetNativeRunIdentityFn>(handle, "set_native_run_identity_ctx");
         get_arena_bank_gm_heap_base_fn_ =
             load_symbol<GetArenaBankGmHeapBaseFn>(handle, "get_arena_bank_gm_heap_base_ctx");
         get_retained_temp_addr_fn_ = load_symbol<GetRetainedTempAddrFn>(handle, "get_retained_temp_addr_ctx");
-        set_task_accepted_state_fn_ = load_symbol<SetTaskAcceptedStateFn>(handle, "set_task_accepted_state_ctx");
         get_pipeline_contract_fn = load_symbol<GetPipelineContractFn>(handle, "get_pipeline_contract");
         unregister_callable_fn_ = load_symbol<SimplerUnregisterCallableFn>(handle, "simpler_unregister_callable");
         get_aicpu_dlopen_count_fn_ = load_symbol<GetAicpuDlopenCountFn>(handle, "get_aicpu_dlopen_count");
@@ -300,12 +296,8 @@ void ChipWorker::init(
         wait_run_fn_ = nullptr;
         finalize_run_fn_ = nullptr;
         supports_concurrent_native_prepare_fn_ = nullptr;
-        select_pipeline_slot_fn_ = nullptr;
-        select_arena_bank_fn_ = nullptr;
-        set_native_run_identity_fn_ = nullptr;
         get_arena_bank_gm_heap_base_fn_ = nullptr;
         get_retained_temp_addr_fn_ = nullptr;
-        set_task_accepted_state_fn_ = nullptr;
         unregister_callable_fn_ = nullptr;
         get_aicpu_dlopen_count_fn_ = nullptr;
         get_host_dlopen_count_fn_ = nullptr;
@@ -354,12 +346,8 @@ void ChipWorker::init(
         wait_run_fn_ = nullptr;
         finalize_run_fn_ = nullptr;
         supports_concurrent_native_prepare_fn_ = nullptr;
-        select_pipeline_slot_fn_ = nullptr;
-        select_arena_bank_fn_ = nullptr;
-        set_native_run_identity_fn_ = nullptr;
         get_arena_bank_gm_heap_base_fn_ = nullptr;
         get_retained_temp_addr_fn_ = nullptr;
-        set_task_accepted_state_fn_ = nullptr;
         unregister_callable_fn_ = nullptr;
         get_aicpu_dlopen_count_fn_ = nullptr;
         get_host_dlopen_count_fn_ = nullptr;
@@ -439,12 +427,8 @@ void ChipWorker::finalize() {
     wait_run_fn_ = nullptr;
     finalize_run_fn_ = nullptr;
     supports_concurrent_native_prepare_fn_ = nullptr;
-    select_pipeline_slot_fn_ = nullptr;
-    select_arena_bank_fn_ = nullptr;
-    set_native_run_identity_fn_ = nullptr;
     get_arena_bank_gm_heap_base_fn_ = nullptr;
     get_retained_temp_addr_fn_ = nullptr;
-    set_task_accepted_state_fn_ = nullptr;
     unregister_callable_fn_ = nullptr;
     get_aicpu_dlopen_count_fn_ = nullptr;
     get_host_dlopen_count_fn_ = nullptr;
@@ -507,7 +491,7 @@ void ChipWorker::run(
     run_on_slot(callable_id, args, config, UNLEASED_SLOT, accepted_state, accepted_value);
 }
 
-uint32_t ChipWorker::select_slot_resources(uint32_t slot_id) {
+uint32_t ChipWorker::arena_bank_for_slot(uint32_t slot_id) const {
     // init() rejected any contract whose three arena kinds disagree, so
     // whichever of them the runtime declares yields the same bank.
     const PipelineSlotLease selector{slot_id, 0, 0};
@@ -517,12 +501,6 @@ uint32_t ChipWorker::select_slot_resources(uint32_t slot_id) {
         if (resource == nullptr) continue;
         arena_bank = pipeline_resource_slot(pipeline_contract_, *resource, selector);
         break;
-    }
-    if (select_pipeline_slot_fn_(device_ctx_, slot_id) != 0) {
-        throw std::runtime_error("select_pipeline_slot_ctx failed");
-    }
-    if (select_arena_bank_fn_(device_ctx_, arena_bank) != 0) {
-        throw std::runtime_error("select_arena_bank_ctx failed");
     }
     return arena_bank;
 }
@@ -576,33 +554,13 @@ void ChipWorker::run_on_slot(
         throw std::runtime_error("ChipWorker not initialized; call init() first");
     }
 
-    (void)select_slot_resources(slot_id);
-    if (set_native_run_identity_fn_(device_ctx_, 0, 0, 0, 0) != 0) {
-        throw std::runtime_error("set_native_run_identity_ctx failed");
-    }
+    const NativeRunDescriptor descriptor{slot_id,       arena_bank_for_slot(slot_id), 0, 0, 0, 0, accepted_state,
+                                         accepted_value};
     void *rt = runtime_bufs_[slot_id].data();
-    if (accepted_state != nullptr) {
-        int bind_rc = set_task_accepted_state_fn_(device_ctx_, accepted_state, accepted_value);
-        if (bind_rc != 0) {
-            throw std::runtime_error("set_task_accepted_state_ctx failed with code " + std::to_string(bind_rc));
-        }
-    }
-    auto clear_accepted_state = [&]() {
-        if (accepted_state != nullptr) {
-            (void)set_task_accepted_state_fn_(device_ctx_, nullptr, 0);
-        }
-    };
     // Per-stage timing is emitted by the platform as `[STRACE]` log markers, not
     // returned (see chip_worker.h::run). CallConfig is threaded through to the C
     // ABI as a single pointer rather than unpacked into per-field args.
-    int rc = -1;
-    try {
-        rc = run_fn_(device_ctx_, rt, callable_id, args, &config);
-    } catch (...) {
-        clear_accepted_state();
-        throw;
-    }
-    clear_accepted_state();
+    int rc = run_fn_(device_ctx_, rt, callable_id, args, &config, &descriptor);
     if (rc != 0) {
         throw std::runtime_error("run failed with code " + std::to_string(rc));
     }
@@ -610,20 +568,24 @@ void ChipWorker::run_on_slot(
 
 ChipWorkerNativeRun ChipWorker::prepare_native_run(
     int32_t callable_id, TaskArgsView args, const CallConfig &config, const PipelineSlotLease &lease, uint64_t run_id,
-    uint64_t dispatch_id
+    uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value
 ) {
     ChipStorageTaskArgs chip_storage = view_to_chip_storage(args);
-    return prepare_native_run(callable_id, &chip_storage, config, lease, run_id, dispatch_id);
+    return prepare_native_run(
+        callable_id, &chip_storage, config, lease, run_id, dispatch_id, accepted_state, accepted_value
+    );
 }
 
 ChipWorkerNativeRun ChipWorker::prepare_native_run(
     int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, const PipelineSlotLease &lease,
-    uint64_t run_id, uint64_t dispatch_id
+    uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value
 ) {
     if (lease.reserved != 0 || lease.generation == 0 || lease.slot_id >= pipeline_contract_.pipeline_depth) {
         throw std::runtime_error("native-run pipeline lease is outside the runtime PipelineContract");
     }
-    return prepare_native_run_on_slot(callable_id, args, config, lease.slot_id, lease.generation, run_id, dispatch_id);
+    return prepare_native_run_on_slot(
+        callable_id, args, config, lease.slot_id, lease.generation, run_id, dispatch_id, accepted_state, accepted_value
+    );
 }
 
 bool ChipWorker::supports_concurrent_native_prepare() const {
@@ -633,7 +595,7 @@ bool ChipWorker::supports_concurrent_native_prepare() const {
 
 ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
-    uint64_t generation, uint64_t run_id, uint64_t dispatch_id
+    uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value
 ) {
     config.validate();
     if (!initialized_) {
@@ -690,12 +652,11 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
 
     int rc = -1;
     try {
-        (void)select_slot_resources(slot_id);
-        int identity_rc = set_native_run_identity_fn_(device_ctx_, run_id, generation, dispatch_id, run_epoch);
-        if (identity_rc != 0) {
-            throw std::runtime_error("set_native_run_identity_ctx failed with code " + std::to_string(identity_rc));
-        }
-        rc = prepare_run_fn_(device_ctx_, runtime_bufs_[slot_id].data(), callable_id, args, &config);
+        const NativeRunDescriptor descriptor{slot_id,        arena_bank_for_slot(slot_id),
+                                             run_id,         generation,
+                                             dispatch_id,    run_epoch,
+                                             accepted_state, accepted_value};
+        rc = prepare_run_fn_(device_ctx_, runtime_bufs_[slot_id].data(), callable_id, args, &config, &descriptor);
     } catch (...) {
         std::lock_guard<std::mutex> lk(native_run_mu_);
         NativeRunSlotState &state = native_run_states_[slot_id];
@@ -718,8 +679,7 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     {
         std::lock_guard<std::mutex> lk(native_run_mu_);
         NativeRunSlotState &state = native_run_states_[slot_id];
-        if (state.lease_generation != generation || state.run_epoch != run_epoch ||
-            state.phase != NativeRunPhase::PREPARING) {
+        if (state.run_epoch != run_epoch || state.phase != NativeRunPhase::PREPARING) {
             (void)finalize_run_fn_(device_ctx_, runtime_bufs_[slot_id].data());
             state = NativeRunSlotState{};
             throw std::runtime_error("native-run identity changed while prepare was in progress");
@@ -729,48 +689,30 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     return run_identity;
 }
 
-void ChipWorker::launch_native_run(
-    const ChipWorkerNativeRun &run, volatile int32_t *accepted_state, int32_t accepted_value
-) {
+void ChipWorker::launch_native_run(const ChipWorkerNativeRun &run) {
     {
         std::lock_guard<std::mutex> lk(native_run_mu_);
         if (run.slot_id >= runtime_bufs_.size()) {
             throw std::runtime_error("native-run token slot is outside the runtime PipelineContract");
         }
         NativeRunSlotState &state = native_run_states_[run.slot_id];
-        if (state.lease_generation != run.generation || state.run_epoch != run.run_epoch ||
-            state.phase != NativeRunPhase::PREPARED) {
+        if (state.run_epoch != run.run_epoch || state.phase != NativeRunPhase::PREPARED) {
             throw std::runtime_error("native-run token is stale or used in the wrong phase");
         }
         state.phase = NativeRunPhase::LAUNCHING;
     }
 
-    auto clear_accepted_state = [&]() {
-        if (accepted_state != nullptr) {
-            (void)set_task_accepted_state_fn_(device_ctx_, nullptr, 0);
-        }
-    };
-
     int rc = -1;
     try {
-        if (accepted_state != nullptr) {
-            int bind_rc = set_task_accepted_state_fn_(device_ctx_, accepted_state, accepted_value);
-            if (bind_rc != 0) {
-                throw std::runtime_error("set_task_accepted_state_ctx failed with code " + std::to_string(bind_rc));
-            }
-        }
         rc = launch_run_fn_(device_ctx_, runtime_bufs_[run.slot_id].data());
     } catch (...) {
-        clear_accepted_state();
         std::lock_guard<std::mutex> lk(native_run_mu_);
         NativeRunSlotState &state = native_run_states_[run.slot_id];
-        if (state.lease_generation == run.generation && state.run_epoch == run.run_epoch &&
-            state.phase == NativeRunPhase::LAUNCHING) {
+        if (state.run_epoch == run.run_epoch && state.phase == NativeRunPhase::LAUNCHING) {
             state.phase = NativeRunPhase::PREPARED;
         }
         throw;
     }
-    clear_accepted_state();
     if (rc != 0) {
         int poll_rc = poll_run_fn_(device_ctx_, runtime_bufs_[run.slot_id].data());
         std::lock_guard<std::mutex> lk(native_run_mu_);
@@ -793,7 +735,7 @@ bool ChipWorker::poll_native_run(const ChipWorkerNativeRun &run) {
             throw std::runtime_error("native-run token slot is outside the runtime PipelineContract");
         }
         const NativeRunSlotState &state = native_run_states_[run.slot_id];
-        if (state.lease_generation != run.generation || state.run_epoch != run.run_epoch ||
+        if (state.run_epoch != run.run_epoch ||
             (state.phase != NativeRunPhase::LAUNCHED && state.phase != NativeRunPhase::REAPED)) {
             throw std::runtime_error("native-run token is stale or used in the wrong phase");
         }
@@ -821,7 +763,7 @@ void ChipWorker::wait_native_run(const ChipWorkerNativeRun &run) {
             throw std::runtime_error("native-run token slot is outside the runtime PipelineContract");
         }
         const NativeRunSlotState &state = native_run_states_[run.slot_id];
-        if (state.lease_generation != run.generation || state.run_epoch != run.run_epoch ||
+        if (state.run_epoch != run.run_epoch ||
             (state.phase != NativeRunPhase::LAUNCHED && state.phase != NativeRunPhase::REAPED)) {
             throw std::runtime_error("native-run token is stale or used in the wrong phase");
         }
@@ -843,7 +785,7 @@ void ChipWorker::finalize_native_run(const ChipWorkerNativeRun &run) {
             throw std::runtime_error("native-run token slot is outside the runtime PipelineContract");
         }
         NativeRunSlotState &state = native_run_states_[run.slot_id];
-        if (state.lease_generation != run.generation || state.run_epoch != run.run_epoch ||
+        if (state.run_epoch != run.run_epoch ||
             (state.phase != NativeRunPhase::PREPARED && state.phase != NativeRunPhase::LAUNCHED &&
              state.phase != NativeRunPhase::REAPED)) {
             throw std::runtime_error("native-run token is stale or already finalized");

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -9,8 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_COMMON_WORKER_CHIP_WORKER_H_
-#define SRC_COMMON_WORKER_CHIP_WORKER_H_
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -120,22 +119,22 @@ public:
      *
      * Onboard HBG may prepare one distinct-slot successor while another run
      * owns the execution claim. Diagnostics and backends without the explicit
-     * capability remain depth-one. The slot/lease-generation/process-unique-
-     * run-epoch token prevents a delayed phase call from touching reused
-     * storage, including another run under the same pipeline lease or on
-     * another ChipWorker.
+     * capability remain depth-one. Lease generation gates admission; after a
+     * successful prepare, the slot plus process-unique run epoch prevents a
+     * delayed phase call from touching reused storage, including another run
+     * under the same pipeline lease or on another ChipWorker.
      */
     ChipWorkerNativeRun prepare_native_run(
         int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, const PipelineSlotLease &lease,
-        uint64_t run_id = 0, uint64_t dispatch_id = 0
+        uint64_t run_id = 0, uint64_t dispatch_id = 0, volatile int32_t *accepted_state = nullptr,
+        int32_t accepted_value = 0
     );
     ChipWorkerNativeRun prepare_native_run(
         int32_t callable_id, TaskArgsView args, const CallConfig &config, const PipelineSlotLease &lease,
-        uint64_t run_id = 0, uint64_t dispatch_id = 0
+        uint64_t run_id = 0, uint64_t dispatch_id = 0, volatile int32_t *accepted_state = nullptr,
+        int32_t accepted_value = 0
     );
-    void launch_native_run(
-        const ChipWorkerNativeRun &run, volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0
-    );
+    void launch_native_run(const ChipWorkerNativeRun &run);
     bool poll_native_run(const ChipWorkerNativeRun &run);
     void wait_native_run(const ChipWorkerNativeRun &run);
     void finalize_native_run(const ChipWorkerNativeRun &run);
@@ -247,14 +246,10 @@ private:
         void *, int, const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *, size_t, const CallConfig *
     );
     using SimplerRegisterCallableFn = int (*)(void *, int32_t, const void *);
-    using SimplerRunFn = int (*)(void *, void *, int32_t, const void *, const CallConfig *);
-    using SimplerPrepareRunFn = int (*)(void *, void *, int32_t, const void *, const CallConfig *);
-    using SimplerNativeRunFn = int (*)(void *, void *);
+    using SimplerRunFn = decltype(&simpler_run);
+    using SimplerPrepareRunFn = decltype(&simpler_prepare_run);
+    using SimplerNativeRunFn = decltype(&simpler_launch_run);
     using SupportsConcurrentNativePrepareFn = int (*)(void *);
-    using SetTaskAcceptedStateFn = int (*)(void *, volatile int32_t *, int32_t);
-    using SelectPipelineSlotFn = int (*)(void *, uint32_t);
-    using SelectArenaBankFn = int (*)(void *, uint32_t);
-    using SetNativeRunIdentityFn = int (*)(void *, uint64_t, uint64_t, uint64_t, uint64_t);
     using GetArenaBankGmHeapBaseFn = uint64_t (*)(void *, uint32_t);
     using GetRetainedTempAddrFn = uint64_t (*)(void *, uint32_t);
     using GetPipelineContractFn = const PipelineContract *(*)();
@@ -312,10 +307,6 @@ private:
     SimplerNativeRunFn wait_run_fn_ = nullptr;
     SimplerNativeRunFn finalize_run_fn_ = nullptr;
     SupportsConcurrentNativePrepareFn supports_concurrent_native_prepare_fn_ = nullptr;
-    SetTaskAcceptedStateFn set_task_accepted_state_fn_ = nullptr;
-    SelectPipelineSlotFn select_pipeline_slot_fn_ = nullptr;
-    SelectArenaBankFn select_arena_bank_fn_ = nullptr;
-    SetNativeRunIdentityFn set_native_run_identity_fn_ = nullptr;
     GetArenaBankGmHeapBaseFn get_arena_bank_gm_heap_base_fn_ = nullptr;
     GetRetainedTempAddrFn get_retained_temp_addr_fn_ = nullptr;
     SimplerUnregisterCallableFn unregister_callable_fn_ = nullptr;
@@ -349,7 +340,7 @@ private:
         int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
         volatile int32_t *accepted_state, int32_t accepted_value
     );
-    uint32_t select_slot_resources(uint32_t slot_id);
+    uint32_t arena_bank_for_slot(uint32_t slot_id) const;
 
     enum class NativeRunPhase : uint8_t { EMPTY, PREPARING, PREPARED, LAUNCHING, LAUNCHED, REAPED, FINALIZING };
     struct NativeRunSlotState {
@@ -361,7 +352,8 @@ private:
     };
     ChipWorkerNativeRun prepare_native_run_on_slot(
         int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
-        uint64_t generation, uint64_t run_id, uint64_t dispatch_id
+        uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state,
+        int32_t accepted_value
     );
     void cleanup_native_runs_noexcept() noexcept;
 
@@ -399,5 +391,3 @@ private:
     bool initialized_ = false;
     bool finalized_ = false;
 };
-
-#endif  // SRC_COMMON_WORKER_CHIP_WORKER_H_

--- a/src/common/worker/native_run_context.h
+++ b/src/common/worker/native_run_context.h
@@ -17,7 +17,9 @@
 #include <thread>
 
 #include "call_config.h"
+#include "common/host_api.h"
 #include "native_run_launch_signal.h"
+#include "pto_runtime_c_api.h"
 #include "runtime.h"
 
 /** Internal phase of the caller-owned opaque native-run storage. */
@@ -29,20 +31,37 @@ enum class NativeRunPhase : uint8_t {
 };
 
 /**
- * Caller-owned state for one progressable native lifecycle. Runtime,
- * CallConfig, and resource selection are per-run. Runner-owned execution,
- * diagnostics, and timing remain exclusive from launch through finalize.
+ * The single placement-owned carrier for one progressable native lifecycle.
+ * It captures immutable selection, identity, acceptance, configuration, and
+ * HostApi binding during prepare; later phases never recover them from a
+ * runner field or thread-local. The object is address-stable through finalize.
  */
 template <typename Runner>
-struct NativeRunState {
+struct NativeRunContext {
     static constexpr uint64_t kMagic = UINT64_C(0x534d504c52554e31);  // "SMPLRUN1"
 
-    NativeRunState(Runner *runner_in, const CallConfig &config_in, uint64_t trace_hid_in) :
+    NativeRunContext(
+        Runner *runner_in, const CallConfig &config_in, uint64_t trace_hid_in, const NativeRunDescriptor &descriptor_in,
+        const HostApiOps *host_api_ops
+    ) :
         runner(runner_in),
         config(config_in),
-        trace_hid(trace_hid_in) {}
+        descriptor(descriptor_in),
+        host_api(runner_in, descriptor_in.pipeline_slot, descriptor_in.arena_bank, host_api_ops),
+        trace_hid(trace_hid_in),
+        launch_signal(descriptor_in.accepted_state, descriptor_in.accepted_value) {
+        // Publish the storage tag only after every potentially-throwing member
+        // has been constructed. A failed placement construction must leave the
+        // caller-owned slot reusable rather than looking like a prepared run.
+        magic = kMagic;
+    }
 
-    ~NativeRunState() {
+    NativeRunContext(const NativeRunContext &) = delete;
+    NativeRunContext &operator=(const NativeRunContext &) = delete;
+    NativeRunContext(NativeRunContext &&) = delete;
+    NativeRunContext &operator=(NativeRunContext &&) = delete;
+
+    ~NativeRunContext() {
         if (executor.joinable()) executor.join();
         if (host_thread_state != nullptr) {
             runner->destroy_native_run_thread_state(host_thread_state);
@@ -56,9 +75,11 @@ struct NativeRunState {
         if (snapshot != nullptr) runner->adopt_native_run_thread_state(snapshot);
     }
 
-    uint64_t magic{kMagic};
+    uint64_t magic{0};
     Runner *runner{nullptr};
     CallConfig config{};
+    NativeRunDescriptor descriptor{};
+    HostApi host_api;
     Runtime runtime{};
     uint64_t trace_hid{0};
     unsigned trace_inv{0};
@@ -67,14 +88,8 @@ struct NativeRunState {
     std::atomic<int> execution_rc{-1};
     std::atomic<bool> execution_done{false};
     std::atomic<NativeRunPhase> phase{NativeRunPhase::Prepared};
-    NativeRunLaunchSignal launch_signal{};
+    NativeRunLaunchSignal launch_signal;
     void *host_thread_state{nullptr};
-    uint64_t run_id{0};
-    uint64_t generation{0};
-    uint64_t dispatch_id{0};
-    uint64_t run_epoch{0};
-    uint32_t pipeline_slot{0};
-    uint32_t arena_bank{0};
     char trace_attrs[192]{};
     bool runner_resources_owned{false};
     bool runner_reserved{false};
@@ -83,9 +98,9 @@ struct NativeRunState {
 
 /** End object lifetime, then mark the caller-owned storage reusable. */
 template <typename Runner>
-void destroy_native_run_state(NativeRunState<Runner> *state) {
-    void *storage = state;
-    state->~NativeRunState<Runner>();
+void destroy_native_run_context(NativeRunContext<Runner> *context) {
+    void *storage = context;
+    context->~NativeRunContext<Runner>();
     constexpr uint64_t kEmpty = 0;
     std::memcpy(storage, &kEmpty, sizeof(kEmpty));
 }

--- a/src/common/worker/native_run_launch_signal.h
+++ b/src/common/worker/native_run_launch_signal.h
@@ -9,16 +9,20 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_COMMON_WORKER_NATIVE_RUN_LAUNCH_SIGNAL_H_
-#define SRC_COMMON_WORKER_NATIVE_RUN_LAUNCH_SIGNAL_H_
+#pragma once
 
+#include <cstdint>
 #include <condition_variable>
 #include <mutex>
 
-/** Sticky one-shot wakeup for the host thread waiting on launch readiness. */
+/** Sticky one-shot wakeup for the host thread waiting on launch readiness, and
+ * the per-run home of the launch-acceptance target the host binds before launch
+ * and the device publishes at its real kernel-launch marker. */
 class NativeRunLaunchSignal {
 public:
-    NativeRunLaunchSignal() = default;
+    explicit NativeRunLaunchSignal(volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0) :
+        accepted_state_(accepted_state),
+        accepted_value_(accepted_value) {}
     NativeRunLaunchSignal(const NativeRunLaunchSignal &) = delete;
     NativeRunLaunchSignal &operator=(const NativeRunLaunchSignal &) = delete;
 
@@ -29,9 +33,26 @@ public:
         });
     }
 
+    /** Publish the acceptance value (if bound) at the launch marker and wake the
+     * launch waiter. */
+    void publish_acceptance() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (notified_) return;
+            if (accepted_state_ != nullptr) {
+                __atomic_store_n(accepted_state_, accepted_value_, __ATOMIC_RELEASE);
+            }
+            accepted_state_ = nullptr;
+            notified_ = true;
+        }
+        cv_.notify_one();
+    }
+
     void notify() {
         {
             std::lock_guard<std::mutex> lock(mutex_);
+            if (notified_) return;
+            accepted_state_ = nullptr;
             notified_ = true;
         }
         cv_.notify_one();
@@ -40,7 +61,7 @@ public:
 private:
     std::mutex mutex_;
     std::condition_variable cv_;
+    volatile int32_t *accepted_state_{nullptr};
+    int32_t accepted_value_{0};
     bool notified_{false};
 };
-
-#endif  // SRC_COMMON_WORKER_NATIVE_RUN_LAUNCH_SIGNAL_H_

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -31,13 +31,10 @@
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
  *                   get_run_stream_set_create_count,
  *                   simpler_provision_dma_workspace
- *   - pipeline:     get_pipeline_contract, select_pipeline_slot_ctx,
- *                   select_arena_bank_ctx,
+ *   - pipeline:     get_pipeline_contract,
  *                   supports_concurrent_native_prepare_ctx,
- *                   set_native_run_identity_ctx,
  *                   get_arena_bank_gm_heap_base_ctx,
- *                   get_retained_temp_addr_ctx,
- *                   set_task_accepted_state_ctx
+ *                   get_retained_temp_addr_ctx
  *   - ACL/stream:   ensure_acl_ready_ctx, create_comm_stream_ctx,
  *                   destroy_comm_stream_ctx
  *   - comm:         comm_init, comm_alloc_windows, comm_get_local_window_base,
@@ -53,8 +50,7 @@
  * Error codes: 0 = success, negative = error.
  */
 
-#ifndef SRC_COMMON_WORKER_PTO_RUNTIME_C_API_H_
-#define SRC_COMMON_WORKER_PTO_RUNTIME_C_API_H_
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -157,6 +153,26 @@ typedef struct PipelineSlotLease {
     uint32_t reserved;
     uint64_t generation;
 } PipelineSlotLease;
+
+/**
+ * Immutable resource and trace identity copied into one prepared run.
+ * `pipeline_slot` and `arena_bank` must be smaller than
+ * PTO_PIPELINE_MAX_DEPTH; they remain explicit because some runtimes map a
+ * leased slot to a different arena bank. `run_epoch` is the process-unique
+ * identity used by later phase calls; lease generation, run id, and dispatch
+ * id remain diagnostic after admission. A non-null acceptance sink is written
+ * only at the real kernel-launch marker.
+ */
+typedef struct NativeRunDescriptor {
+    uint32_t pipeline_slot;
+    uint32_t arena_bank;
+    uint64_t run_id;
+    uint64_t generation;
+    uint64_t dispatch_id;
+    uint64_t run_epoch;
+    volatile int32_t *accepted_state;
+    int32_t accepted_value;
+} NativeRunDescriptor;
 
 /* Per-stage run timing is no longer returned. The platform emits it as
  * `[STRACE]` log markers (host stages + the AICPU device-phase breakdown,
@@ -316,12 +332,18 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
  * precedence per ring: per-ring entry > PTO2_RING_* env var > compile-time
  * default). Ring overrides are consumed by tensormap_and_ringbuffer only; other
  * runtime variants accept and ignore them. Wire-compatible POD; prepare copies
- * it into the native-run state before returning.
+ * it into the native-run context before returning.
+ *
+ * `descriptor` carries this run's immutable resource selection, trace identity,
+ * and optional launch-acceptance sink. It is copied before prepare returns. The
+ * platform release-stores the acceptance value only after the real
+ * kernel-launch marker; the sink is not retained after this blocking call.
  *
  * @return 0 on success, negative on error (no prep state, NULL ctx/config, etc.).
  */
 int simpler_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
 );
 
 /**
@@ -331,10 +353,13 @@ int simpler_run(
  * prepare and need not remain alive afterward, but every tensor backing buffer
  * referenced by it must remain valid through finalize (which may copy results
  * back to those addresses). See the storage size/alignment/lifetime contract at
- * the top of this header.
+ * the top of this header. `descriptor` is required and copied before this
+ * function returns. A non-null acceptance sink in the descriptor must remain
+ * valid until launch returns or the prepared run is finalized without launch.
  */
 int simpler_prepare_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
 );
 
 /**
@@ -346,6 +371,8 @@ int supports_concurrent_native_prepare_ctx(DeviceContextHandle ctx);
 /**
  * Launch a prepared run. Returns only after the platform has published its
  * real kernel-launch marker, or after execution terminates before that marker.
+ * The acceptance sink captured by prepare is published at that marker; an
+ * execution failure before the marker leaves it unchanged.
  */
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime);
 
@@ -368,17 +395,6 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime);
  */
 int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime);
 
-/** Select the per-run/exec-handle slot used by the next synchronous run. */
-int select_pipeline_slot_ctx(DeviceContextHandle ctx, uint32_t slot_id);
-
-/** Select the HOST_PER_RUN arena bank used by the next synchronous run. */
-int select_arena_bank_ctx(DeviceContextHandle ctx, uint32_t bank_id);
-
-/** Attach optional L3 identity metadata to the current thread's next native prepare. */
-int set_native_run_identity_ctx(
-    DeviceContextHandle ctx, uint64_t run_id, uint64_t generation, uint64_t dispatch_id, uint64_t run_epoch
-);
-
 /**
  * Committed GM heap base of one arena bank, or 0 when that bank has never been
  * committed or the platform keeps a single shared arena set. Reports which
@@ -392,12 +408,6 @@ uint64_t get_arena_bank_gm_heap_base_ctx(DeviceContextHandle ctx, uint32_t bank_
  * nothing.
  */
 uint64_t get_retained_temp_addr_ctx(DeviceContextHandle ctx, uint32_t slot_id);
-
-/**
- * Bind an optional host state word that the runner publishes after both device
- * kernels have been enqueued. Passing NULL clears the binding.
- */
-int set_task_accepted_state_ctx(DeviceContextHandle ctx, volatile int32_t *state, int32_t accepted_value);
 
 /**
  * Drop the prepared state for `callable_id` and release the per-id share of
@@ -456,5 +466,3 @@ int simpler_provision_dma_workspace(DeviceContextHandle ctx, uint32_t required_m
 #ifdef __cplusplus
 }
 #endif
-
-#endif  // SRC_COMMON_WORKER_PTO_RUNTIME_C_API_H_

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""End-to-end validation of the B3a prepare/launch/poll/wait/finalize seam."""
+"""End-to-end validation of the native prepare/launch/poll/wait/finalize seam."""
 
 import tempfile
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_launch_acceptance.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_launch_acceptance.py
@@ -10,10 +10,9 @@
 """L3 launch acceptance is published on every platform.
 
 A ChipTask's sticky acceptance word is written by the platform runner once the
-run crosses its launch boundary, through the `set_task_accepted_state_ctx`
-binding ChipWorker resolves at init. Both the onboard and the simulation
-host_runtime.so export that symbol, so a completed dispatch must leave the word
-set in whichever mailbox frame carried it.
+run crosses its launch boundary, through the launch-acceptance target bound per
+run and published at the real kernel-launch marker. A completed dispatch must
+leave the word set in whichever mailbox frame carried it.
 """
 
 import ctypes

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -419,6 +419,10 @@ target_link_libraries(test_native_run_launch_signal PRIVATE ${GTEST_MAIN_LIB} ${
 add_test(NAME test_native_run_launch_signal COMMAND test_native_run_launch_signal)
 set_tests_properties(test_native_run_launch_signal PROPERTIES LABELS "no_hardware")
 
+# A HostApi value keeps one runner and one run's resource selection even when
+# callers invoke it from different host threads.
+add_common_utils_test(test_host_api common/test_host_api.cpp)
+
 # Sim kernel threads publish one sticky completion state. A gated unit test
 # proves submission and completion are separate without relying on kernel
 # duration or host scheduling.

--- a/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <vector>
 
+#include "common/host_api.h"
 #include "host_tensor_access.h"
 
 namespace {
@@ -45,12 +46,20 @@ int record_copy(void *dev_ptr, const void *host_ptr, size_t size) {
     return g_copy_result;
 }
 
+// host_tensor_access_reset retains the HostApi pointer for the run, so this
+// static test object outlives every binding. The adapter ignores runner_ctx.
+int record_copy_for_api(void * /*runner_ctx*/, void *dev_ptr, const void *host_ptr, size_t size) {
+    return record_copy(dev_ptr, host_ptr, size);
+}
+const HostApiOps kRecordCopyOps{.copy_to_device = record_copy_for_api};
+HostApi record_copy_api(nullptr, 0, 0, &kRecordCopyOps);
+
 class HostTensorAccessTest : public ::testing::Test {
 protected:
     void SetUp() override {
         g_copies.clear();
         g_copy_result = 0;
-        host_tensor_access_reset(&record_copy);
+        host_tensor_access_reset(&record_copy_api);
     }
     void TearDown() override { host_tensor_access_reset(nullptr); }
 };
@@ -150,7 +159,7 @@ TEST_F(HostTensorAccessTest, ResetDropsEveryRegistration) {
     int32_t value = 0;
     ASSERT_TRUE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
 
-    host_tensor_access_reset(&record_copy);
+    host_tensor_access_reset(&record_copy_api);
     EXPECT_FALSE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
 }
 

--- a/tests/ut/cpp/common/test_host_api.cpp
+++ b/tests/ut/cpp/common/test_host_api.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "common/host_api.h"
+
+namespace {
+
+struct FakeRunner {
+    void record_pipeline_slot(uint32_t slot) {
+        std::lock_guard<std::mutex> lock(mutex);
+        pipeline_slots.push_back(slot);
+    }
+
+    void record_arena_bank(uint32_t bank) {
+        std::lock_guard<std::mutex> lock(mutex);
+        arena_banks.push_back(bank);
+    }
+
+    std::mutex mutex;
+    std::vector<uint32_t> pipeline_slots;
+    std::vector<uint32_t> arena_banks;
+};
+
+void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, void *, size_t) {
+    static_cast<FakeRunner *>(runner_ctx)->record_pipeline_slot(pipeline_slot);
+}
+
+int setup_static_arena(void *runner_ctx, uint32_t arena_bank, size_t, size_t, size_t) {
+    static_cast<FakeRunner *>(runner_ctx)->record_arena_bank(arena_bank);
+    return 0;
+}
+
+const HostApiOps &fake_ops() {
+    static const HostApiOps ops = []() {
+        HostApiOps result{};
+        result.set_retained_temp_buffer = set_retained_temp_buffer;
+        result.setup_static_arena = setup_static_arena;
+        return result;
+    }();
+    return ops;
+}
+
+class StartGate {
+public:
+    void arrive_and_wait() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        ++arrivals_;
+        if (arrivals_ == 2) {
+            cv_.notify_all();
+            return;
+        }
+        cv_.wait(lock, [this]() {
+            return arrivals_ == 2;
+        });
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    int arrivals_{0};
+};
+
+bool all_equal(const std::vector<uint32_t> &values, uint32_t expected) {
+    return std::all_of(values.begin(), values.end(), [expected](uint32_t value) {
+        return value == expected;
+    });
+}
+
+}  // namespace
+
+TEST(HostApiTest, BoundRunnerSlotAndBankSurviveConcurrentCrossThreadCalls) {
+    constexpr uint32_t kRunnerASlot = 1;
+    constexpr uint32_t kRunnerABank = 3;
+    constexpr uint32_t kRunnerBSlot = 7;
+    constexpr uint32_t kRunnerBBank = 5;
+    constexpr int kCallsPerThread = 128;
+
+    FakeRunner runner_a;
+    FakeRunner runner_b;
+    const HostApi api_a(&runner_a, kRunnerASlot, kRunnerABank, &fake_ops());
+    const HostApi api_b(&runner_b, kRunnerBSlot, kRunnerBBank, &fake_ops());
+    StartGate start_gate;
+
+    std::thread first([&]() {
+        start_gate.arrive_and_wait();
+        for (int i = 0; i < kCallsPerThread; ++i) {
+            api_a.set_retained_temp_buffer(nullptr, 0);
+            api_b.setup_static_arena(0, 0, 0);
+        }
+    });
+    std::thread second([&]() {
+        start_gate.arrive_and_wait();
+        for (int i = 0; i < kCallsPerThread; ++i) {
+            api_b.set_retained_temp_buffer(nullptr, 0);
+            api_a.setup_static_arena(0, 0, 0);
+        }
+    });
+
+    first.join();
+    second.join();
+
+    EXPECT_EQ(runner_a.pipeline_slots.size(), kCallsPerThread);
+    EXPECT_EQ(runner_a.arena_banks.size(), kCallsPerThread);
+    EXPECT_EQ(runner_b.pipeline_slots.size(), kCallsPerThread);
+    EXPECT_EQ(runner_b.arena_banks.size(), kCallsPerThread);
+    EXPECT_TRUE(all_equal(runner_a.pipeline_slots, kRunnerASlot));
+    EXPECT_TRUE(all_equal(runner_a.arena_banks, kRunnerABank));
+    EXPECT_TRUE(all_equal(runner_b.pipeline_slots, kRunnerBSlot));
+    EXPECT_TRUE(all_equal(runner_b.arena_banks, kRunnerBBank));
+}

--- a/tests/ut/cpp/common/test_native_run_launch_signal.cpp
+++ b/tests/ut/cpp/common/test_native_run_launch_signal.cpp
@@ -53,3 +53,30 @@ TEST(NativeRunLaunchSignalTest, NotificationBeforeWaitIsRemembered) {
     });
     EXPECT_EQ(waiter.wait_for(std::chrono::seconds(1)), std::future_status::ready);
 }
+
+TEST(NativeRunLaunchSignalTest, PublishAcceptanceStoresOnceAndKeepsNotificationSticky) {
+    volatile int32_t accepted_state = 0;
+    NativeRunLaunchSignal signal(&accepted_state, 17);
+
+    signal.publish_acceptance();
+    EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 17);
+
+    __atomic_store_n(&accepted_state, 23, __ATOMIC_RELEASE);
+    signal.publish_acceptance();
+    EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 23);
+
+    auto waiter = std::async(std::launch::async, [&]() {
+        signal.wait();
+    });
+    EXPECT_EQ(waiter.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+}
+
+TEST(NativeRunLaunchSignalTest, NotificationBeforeLaunchMarkerSuppressesAcceptance) {
+    volatile int32_t accepted_state = 5;
+    NativeRunLaunchSignal signal(&accepted_state, 17);
+
+    signal.notify();
+    signal.publish_acceptance();
+
+    EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 5);
+}

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -86,7 +86,7 @@ struct FakeHostApi {
 
 FakeHostApi *g_fake = nullptr;
 
-void *fake_device_malloc(size_t size) {
+void *fake_device_malloc(void * /*runner_ctx*/, size_t size) {
     if (g_fake->fail_device_malloc_on_call != 0 &&
         g_fake->device_malloc_count + 1 == g_fake->fail_device_malloc_on_call) {
         ++g_fake->device_malloc_count;
@@ -103,7 +103,7 @@ void *fake_device_malloc(size_t size) {
     return ptr;
 }
 
-void fake_device_free(void *ptr) {
+void fake_device_free(void * /*runner_ctx*/, void *ptr) {
     if (ptr == nullptr) {
         return;
     }
@@ -113,7 +113,7 @@ void fake_device_free(void *ptr) {
     std::free(ptr);
 }
 
-int fake_copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
+int fake_copy_to_device(void * /*runner_ctx*/, void *dev_ptr, const void *host_ptr, size_t size) {
     ++g_fake->copy_to_count;
     if (g_fake->fail_copy_to_on_call != 0 && g_fake->copy_to_count == g_fake->fail_copy_to_on_call) {
         return -7;
@@ -122,33 +122,35 @@ int fake_copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
     return 0;
 }
 
-int fake_copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
+int fake_copy_from_device(void * /*runner_ctx*/, void *host_ptr, const void *dev_ptr, size_t size) {
     ++g_fake->copy_from_count;
     std::memcpy(host_ptr, dev_ptr, size);
     return 0;
 }
 
-void *fake_register_device_memory_to_host(void *dev_ptr, size_t /* bytes */) { return dev_ptr; }
+void *fake_register_device_memory_to_host(void * /*runner_ctx*/, void *dev_ptr, size_t /* bytes */) { return dev_ptr; }
 
-void fake_unregister_device_memory_from_host(void * /* dev_ptr */) {}
+void fake_unregister_device_memory_from_host(void * /*runner_ctx*/, void * /* dev_ptr */) {}
 
-int fake_device_memset(void *dev_ptr, int value, size_t size) {
+int fake_device_memset(void * /*runner_ctx*/, void *dev_ptr, int value, size_t size) {
     ++g_fake->device_memset_count;
     std::memset(dev_ptr, value, size);
     return 0;
 }
 
-void fake_get_retained_temp_buffer(void **addr, size_t *size) {
+void fake_get_retained_temp_buffer(void * /*runner_ctx*/, uint32_t /*pipeline_slot*/, void **addr, size_t *size) {
     if (addr != nullptr) *addr = g_fake->retained_addr;
     if (size != nullptr) *size = g_fake->retained_size;
 }
 
-void fake_set_retained_temp_buffer(void *addr, size_t size) {
+void fake_set_retained_temp_buffer(void * /*runner_ctx*/, uint32_t /*pipeline_slot*/, void *addr, size_t size) {
     g_fake->retained_addr = addr;
     g_fake->retained_size = size;
 }
 
-int fake_setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) {
+int fake_setup_static_arena(
+    void * /*runner_ctx*/, uint32_t /*arena_bank*/, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
+) {
     ++g_fake->setup_static_arena_count;
     g_fake->gm_heap.assign(gm_heap_size, 0);
     g_fake->gm_sm.assign(gm_sm_size, 0);
@@ -156,46 +158,49 @@ int fake_setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runti
     return 0;
 }
 
-void *fake_acquire_pooled_gm_heap() { return g_fake->gm_heap.empty() ? nullptr : g_fake->gm_heap.data(); }
-void *fake_acquire_pooled_gm_sm() { return g_fake->gm_sm.empty() ? nullptr : g_fake->gm_sm.data(); }
-void *fake_acquire_pooled_runtime_arena() {
+void *fake_acquire_pooled_gm_heap(void * /*runner_ctx*/, uint32_t /*arena_bank*/) {
+    return g_fake->gm_heap.empty() ? nullptr : g_fake->gm_heap.data();
+}
+void *fake_acquire_pooled_gm_sm(void * /*runner_ctx*/, uint32_t /*arena_bank*/) {
+    return g_fake->gm_sm.empty() ? nullptr : g_fake->gm_sm.data();
+}
+void *fake_acquire_pooled_runtime_arena(void * /*runner_ctx*/, uint32_t /*arena_bank*/) {
     return g_fake->runtime_arena.empty() ? nullptr : g_fake->runtime_arena.data();
 }
 bool fake_lookup_prebuilt_runtime_arena_cache(
-    uint64_t /* hash */, const void * /* key_data */, size_t /* key_size */, void ** /* gm_heap_base */,
-    void ** /* sm_base */, void ** /* runtime_arena_base */, size_t * /* runtime_off */, const void ** /* image_data */,
-    size_t * /* image_size */
+    void * /*runner_ctx*/, uint32_t /*arena_bank*/, uint64_t /* hash */, const void * /* key_data */,
+    size_t /* key_size */, void ** /* gm_heap_base */, void ** /* sm_base */, void ** /* runtime_arena_base */,
+    size_t * /* runtime_off */, const void ** /* image_data */, size_t * /* image_size */
 ) {
     return false;
 }
 void fake_mark_prebuilt_runtime_arena_cached(
-    uint64_t /* hash */, const void * /* key_data */, size_t /* key_size */, void * /* gm_heap_base */,
-    void * /* sm_base */, void * /* runtime_arena_base */, size_t /* runtime_off */, const void * /* image_data */,
-    size_t /* image_size */
+    void * /*runner_ctx*/, uint32_t /*arena_bank*/, uint64_t /* hash */, const void * /* key_data */,
+    size_t /* key_size */, void * /* gm_heap_base */, void * /* sm_base */, void * /* runtime_arena_base */,
+    size_t /* runtime_off */, const void * /* image_data */, size_t /* image_size */
 ) {}
-uint64_t fake_upload_chip_callable_buffer(const void * /* callable */) { return 0; }
+uint64_t fake_upload_chip_callable_buffer(void * /*runner_ctx*/, const void * /* callable */) { return 0; }
 
-// with_temporary_buffer=false leaves the retained-slot callbacks null, which
-// makes trb bind fall back to a per-tensor device_malloc for each tensor.
-HostApi make_host_api(bool with_temporary_buffer = true) {
-    return HostApi{
-        fake_device_malloc,
-        fake_device_free,
-        fake_copy_to_device,
-        fake_copy_from_device,
-        fake_register_device_memory_to_host,
-        fake_unregister_device_memory_from_host,
-        fake_device_memset,
-        with_temporary_buffer ? fake_get_retained_temp_buffer : nullptr,
-        with_temporary_buffer ? fake_set_retained_temp_buffer : nullptr,
-        fake_setup_static_arena,
-        fake_acquire_pooled_gm_heap,
-        fake_acquire_pooled_gm_sm,
-        fake_acquire_pooled_runtime_arena,
-        fake_lookup_prebuilt_runtime_arena_cache,
-        fake_mark_prebuilt_runtime_arena_cached,
-        fake_upload_chip_callable_buffer,
+HostApi make_host_api() {
+    static const HostApiOps ops = {
+        .device_malloc = fake_device_malloc,
+        .device_free = fake_device_free,
+        .copy_to_device = fake_copy_to_device,
+        .copy_from_device = fake_copy_from_device,
+        .register_device_memory_to_host = fake_register_device_memory_to_host,
+        .unregister_device_memory_from_host = fake_unregister_device_memory_from_host,
+        .device_memset = fake_device_memset,
+        .get_retained_temp_buffer = fake_get_retained_temp_buffer,
+        .set_retained_temp_buffer = fake_set_retained_temp_buffer,
+        .setup_static_arena = fake_setup_static_arena,
+        .acquire_pooled_gm_heap = fake_acquire_pooled_gm_heap,
+        .acquire_pooled_gm_sm = fake_acquire_pooled_gm_sm,
+        .acquire_pooled_runtime_arena = fake_acquire_pooled_runtime_arena,
+        .lookup_prebuilt_runtime_arena_cache = fake_lookup_prebuilt_runtime_arena_cache,
+        .mark_prebuilt_runtime_arena_cached = fake_mark_prebuilt_runtime_arena_cached,
+        .upload_chip_callable_buffer = fake_upload_chip_callable_buffer,
     };
+    return HostApi(nullptr, 0, 0, &ops);
 }
 
 ChipTensor make_tensor(std::vector<uint8_t> &storage, bool child_memory = false) {
@@ -235,8 +240,6 @@ protected:
 
     FakeHostApi fake_;
     HostApi api_ = make_host_api();
-    // Temp-buffer slot callbacks left null: trb bind falls back to device_malloc.
-    HostApi malloc_api_ = make_host_api(false);
 };
 
 }  // namespace
@@ -298,26 +301,14 @@ TEST_F(TrbRuntimeTempBufferTest, FailedExecutionWithoutDeviceStatusSkipsTensorCo
     }));
 }
 
-// The retained buffer is malloc'd once for the run and sliced (not per-tensor
-// malloc'd); copies/memsets are unchanged from the fallback path.
+// The retained buffer is malloc'd once for the run and sliced, not per tensor.
 TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
     std::vector<uint8_t> input(64, 7);
     std::vector<uint8_t> output(64, 0);
     ChipStorageTaskArgs args = make_args(input, output);
     ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
 
-    // Fallback path (null slot callbacks): one device_malloc per tensor.
-    fake_.reset();
-    Runtime malloc_runtime = make_runtime();
-    ASSERT_EQ(bind_runtime(malloc_runtime, malloc_api_, args, signature, 2), 0);
-    EXPECT_EQ(fake_.device_malloc_count, 2);
-    EXPECT_EQ(fake_.copy_to_count, 2);
-    EXPECT_EQ(fake_.device_memset_count, 0);
-    ASSERT_EQ(validate_runtime_impl(&malloc_runtime, &malloc_api_, 0), 0);
-    EXPECT_EQ(fake_.device_free_count, 2);
-    EXPECT_EQ(fake_.copy_from_count, 1);
-
-    // Retained-buffer path: single device_malloc for the whole run (two
+    // A single device_malloc backs the whole run (two
     // 64-byte tensors pack to 2 * 1024-aligned = 2048 bytes), sliced in place.
     fake_.reset();
     Runtime buffer_runtime = make_runtime();
@@ -427,23 +418,6 @@ TEST_F(TrbRuntimeTempBufferTest, GrowAllocationFailureFailsBindWithoutLeak) {
     EXPECT_EQ(fake_.retained_addr, nullptr);
     EXPECT_EQ(fake_.retained_size, 0u);
     EXPECT_TRUE(fake_.live_mallocs.empty());
-    EXPECT_TRUE(runtime.tensor_leases_.empty());
-}
-
-TEST_F(TrbRuntimeTempBufferTest, FailedCopyReleasesRecordedFreeLease) {
-    fake_.reset();
-    fake_.fail_copy_to_on_call = 1;
-    Runtime runtime = make_runtime();
-    std::vector<uint8_t> input(64, 9);
-    ChipStorageTaskArgs args;
-    args.add_tensor(make_tensor(input));
-    ArgDirection signature[1] = {ArgDirection::IN};
-
-    // Fallback path: the per-tensor device_malloc is freed on the copy-failure
-    // error path, leaving no lease and no leak.
-    EXPECT_EQ(bind_runtime(runtime, malloc_api_, args, signature, 1), -1);
-    EXPECT_EQ(fake_.device_malloc_count, 1);
-    EXPECT_EQ(fake_.device_free_count, 1);
     EXPECT_TRUE(runtime.tensor_leases_.empty());
 }
 

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -21,9 +21,13 @@ _NEWLY_REQUIRED_PIPELINE_SYMBOLS = {
     "get_arena_bank_gm_heap_base_ctx",
     "get_pipeline_contract",
     "get_retained_temp_addr_ctx",
+    "supports_concurrent_native_prepare_ctx",
+}
+_REMOVED_AMBIENT_SELECTION_SYMBOLS = {
+    "select_arena_bank_ctx",
+    "select_pipeline_slot_ctx",
     "set_native_run_identity_ctx",
     "set_task_accepted_state_ctx",
-    "supports_concurrent_native_prepare_ctx",
 }
 
 _SIM_CASES = [
@@ -69,3 +73,4 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     symbols = _defined_external_symbols(runtime_path)
 
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
+    assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -285,19 +285,29 @@ class _FakeNativeRunImpl:
         generation,
         _run_id=0,
         _dispatch_id=0,
+        accepted_addr=0,
+        accepted_value=0,
     ):
         slot = int(slot_id)
         prepare_error = self.prepare_errors.get((slot, int(generation)))
         if prepare_error is not None:
             raise prepare_error
         self.prepare_identities.append((slot, int(generation), int(_run_id), int(_dispatch_id)))
-        token = SimpleNamespace(slot_id=slot, generation=int(generation), run_epoch=slot + 1)
+        token = SimpleNamespace(
+            slot_id=slot,
+            generation=int(generation),
+            run_epoch=slot + 1,
+            accepted_addr=int(accepted_addr),
+            accepted_value=int(accepted_value),
+        )
         self.events.append(("prepare", slot))
         self.prepared[slot].set()
         return token
 
-    def _launch_native_run(self, token, accepted_addr, accepted_value) -> None:
+    def _launch_native_run(self, token) -> None:
         slot = int(token.slot_id)
+        accepted_addr = int(token.accepted_addr)
+        accepted_value = int(token.accepted_value)
         state_addr = int(accepted_addr) - worker_mod._OFF_ACCEPTED
         self.events.append(
             (


### PR DESCRIPTION
## Summary

Make each prepared native run self-contained instead of recovering mutable runner selection from thread-local state.

- Replace ambient runner, slot, bank, identity, and acceptance setters with a per-run `HostApi` value backed by one complete `HostApiOps` table.
- Placement-construct one `NativeRunContext` in caller-owned storage. It owns the copied descriptor, bound `HostApi`, runtime implementation, launch signal, and compatibility executor through finalize.
- Capture the launch-acceptance sink during prepare and publish it only at the real kernel-launch marker.
- Validate lease generation during admission, then use process-unique `run_epoch` as the authoritative phase-token identity.
- Preserve the enqueue, poll, and drain lifecycle introduced by #1683.
- Clear the existing HBG host-access bridge on every exit path so it cannot retain a completed run HostApi pointer.

This removes thread identity from native-run resource selection while preserving Worker-visible execution behavior.

## Contract decisions

- `simpler_init` is unchanged.
- All eight host-runtime DSOs (a2a3/a5 × onboard/sim × HBG/TRB) are rebuilt together and implement the same complete callback contract.
- There is no optional-symbol loading, feature-bit negotiation, descriptor versioning, or runtime ABI negotiation.
- `PTO_PIPELINE_CONTRACT_ABI_VERSION` remains `1`.

## Scope

This PR does not add the direct-L2 asynchronous lane or remove the compatibility executor. It also does not perform the later HBG process-global ownership redesign; the HBG change here is limited to making the existing temporary binding lifetime-safe.

## Validation

- `.venv/bin/pre-commit run --files ...`: all hooks passed.
- `.venv/bin/python -m pip install --no-build-isolation -e .`: rebuilt successfully.
- Focused C++ tests: 4/4 passed (`HostApi`, launch signal, TRB retained buffer, HBG tensor access).
- Focused Python tests: 31 passed, 4 onboard-marker skips, 189 deselected.
- Direct symbol inspection verified all eight DSOs export the required pipeline symbols and none export the four removed ambient-selection setters.