### PR TITLE
Fix: guard tensor producer resolution on the returned slot pointer

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -899,7 +899,13 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     always_assert(orch->scheduler != nullptr);
     // === Validate submit inputs ===
     ActiveMask active_mask = mixed_kernels.to_active_mask();
-    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
+    if (!static_cast<bool>(active_mask)) {
+        report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
+            "MixedKernels names no active slot; set at least one of aic/aiv0/aiv1 kernel_id"
+        );
+        return TaskOutputTensors{};
+    }
 
     int16_t block_num = args.launch_spec.block_num();
 

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -142,6 +142,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     int seg_count = 0;
     bool failed = false;
 
+    // Returns nullptr for every rejected producer, having latched the fatal.
+    // Callers branch on the returned pointer, not on `failed`: the slot is
+    // dereferenced immediately and a null return is the only safe signal.
     auto resolve_producer = [&](PTO2TaskId producer) -> const PTO2TaskSlotState * {
         if (!producer.is_valid() || producer.ring() != 0) {
             orch.report_fatal(
@@ -254,7 +257,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         // Step A: creator retention — read owner directly from tensor metadata
         if (owner.is_valid()) {
             const auto *slot = resolve_producer(owner);
-            if (failed) return;
+            if (slot == nullptr) return;
             try_push(*slot);
         }
 
@@ -262,7 +265,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
             PTO2TaskId pid = entry.producer_task_id;
             const auto *slot = resolve_producer(pid);
-            if (failed) return false;
+            if (slot == nullptr) return false;
             try_push(*slot);
             return !failed;
         });

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -899,7 +899,13 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     always_assert(orch->scheduler != nullptr);
     // === Validate submit inputs ===
     ActiveMask active_mask = mixed_kernels.to_active_mask();
-    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
+    if (!static_cast<bool>(active_mask)) {
+        report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
+            "MixedKernels names no active slot; set at least one of aic/aiv0/aiv1 kernel_id"
+        );
+        return TaskOutputTensors{};
+    }
 
     int16_t block_num = args.launch_spec.block_num();
 

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -142,6 +142,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     int seg_count = 0;
     bool failed = false;
 
+    // Returns nullptr for every rejected producer, having latched the fatal.
+    // Callers branch on the returned pointer, not on `failed`: the slot is
+    // dereferenced immediately and a null return is the only safe signal.
     auto resolve_producer = [&](PTO2TaskId producer) -> const PTO2TaskSlotState * {
         if (!producer.is_valid() || producer.ring() != 0) {
             orch.report_fatal(
@@ -254,7 +257,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         // Step A: creator retention — read owner directly from tensor metadata
         if (owner.is_valid()) {
             const auto *slot = resolve_producer(owner);
-            if (failed) return;
+            if (slot == nullptr) return;
             try_push(*slot);
         }
 
@@ -262,7 +265,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
             PTO2TaskId pid = entry.producer_task_id;
             const auto *slot = resolve_producer(pid);
-            if (failed) return false;
+            if (slot == nullptr) return false;
             try_push(*slot);
             return !failed;
         });

--- a/src/common/utils/thread_completion_gate.h
+++ b/src/common/utils/thread_completion_gate.h
@@ -16,6 +16,22 @@
 
 namespace simpler {
 
+// Rendezvous for N threads that must run a one-shot finalizer after the last
+// arrival, then hand exactly one thread the right to tear down what the
+// finalizer released.
+//
+// The release store on cleanup_ready_ happens after finalize() returns and
+// pairs with the acquire on a successful claim_cleanup() CAS: a thread that
+// wins the claim is guaranteed to observe every write the finalizer made.
+// Publishing eligibility before running the finalizer would let a peer tear
+// down state the last thread is still using.
+//
+// thread_count must be the same on every arrival of a given round; it is the
+// round's participant count, not a property of one arrival.
+//
+// reset() is NOT synchronized against the other two operations. It may only be
+// called when no thread is between its arrive and the end of its finalizer —
+// i.e. from a single thread outside the round (a run's setup or teardown).
 class ThreadCompletionGate {
 public:
     template <typename Finalize>

--- a/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
+++ b/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
@@ -7,7 +7,18 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Wide host-build-graph dispatch across the high half of the 128-bit core mask."""
+"""Wide host-build-graph dispatch: AIV cohort plus sync-start and normal MIX placement.
+
+Sizes every cohort from ``rt_available_cluster_count`` / ``rt_available_aiv_count``, so
+coverage follows the device the case runs on. On the sim platforms this file is marked
+for, that is ``SIM_AUTO_BLOCKDIM`` (8) clusters — 24 core-state bits, entirely within the
+low 64 of ``CoreTracker::BitStates``. **This case therefore does not reach a cluster
+offset above bit 63**; the >63-bit MIX selection path is covered by the arch-parity unit
+test ``tests/ut/cpp/common/test_hbg_core_tracker.cpp``, which drives ``CoreTracker``
+directly at ``MAX_CLUSTERS``. What this case does cover is that MIX placement, sync-start
+drain, and the AIV cohort agree on block-to-core mapping when a single scheduler thread
+(``aicpu_thread_num=2`` leaves one scheduler plus one resolution thread) owns every cluster.
+"""
 
 import torch
 from simpler.task_interface import ArgDirection as D
@@ -16,6 +27,9 @@ from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_MIX_BLOCK = 3
+# Buffer capacity ceiling, not an expected count: the orchestration sizes cohorts from the
+# runtime and writes back the actual geometry, which compare_outputs reads. a5 has the
+# larger PLATFORM_MAX_BLOCKDIM of the two arches, so it bounds both.
 MAX_CLUSTERS = 36
 MAX_AIV = MAX_CLUSTERS * 2
 MAX_TOTAL_CL = MAX_AIV + 2 * MAX_CLUSTERS * SLOTS_PER_MIX_BLOCK


### PR DESCRIPTION
## Summary

Follow-ups from the review of #1674, which merged as e0410833. No behavior change
on any path that was already correct; each item removes a latent hazard or a
claim the code does not support.

- `wait_for_tensor_ready`'s `resolve_producer` returns `nullptr` for a rejected
  producer and both call sites dereference the result immediately, but they
  branched on the `failed` flag rather than the pointer. That is safe only
  because every rejection path happens to latch `failed` first — a coupling
  invisible at the call site, and one early-return without the flag turns it
  into a null deref inside the fatal-error path. Branch on the pointer.
- `submit_task` aborted via `always_assert` on an empty `MixedKernels` active
  mask while the adjacent `block_num` check reports `INVALID_ARGS`. Both are
  caller input errors; report them the same way. `submit_dummy_task` is
  deliberately untouched — it calls `submit_task_common` directly and an empty
  mask is exactly what routes it to the DUMMY bucket.
- Document `ThreadCompletionGate`'s contract: the release/acquire pair that
  makes the finalizer's writes visible to the cleanup claimant, that
  `thread_count` is a per-round constant rather than a property of one arrival,
  and that `reset()` is unsynchronized and may only run outside a round.
- Correct the wide-dispatch scene test's docstring, which claimed coverage
  "across the high half of the 128-bit core mask". It sizes cohorts from
  `rt_available_cluster_count()`, which is `SIM_AUTO_BLOCKDIM` (8) on the sim
  platforms it is marked for — 24 core-state bits, so it cannot reach a cluster
  offset above bit 63. `test_hbg_core_tracker.cpp` carries that coverage by
  driving `CoreTracker` directly at `MAX_CLUSTERS`.

Both arch trees stay byte-identical for the two `.cpp` files touched.

## Testing

- `thread_completion_gate.h` compiled standalone with `-Wall -Wextra` and
  exercised with the blocked-finalizer and reset-reuse cases from the existing
  UT: passes, and passes again under `-fsanitize=thread`.
- Both edited `.cpp` files: `clang++ -std=c++17 -fsyntax-only` clean with the
  UT target's include paths.
- pre-commit on the changed files: clang-format, cpplint, ruff check, ruff
  format, pyright, and the repo header/English/platform-literal hooks all pass.

Not run, and why: this host has neither the scikit-build-core/nanobind build
environment nor an NPU (`npu-smi` absent), so I could not do an editable rebuild
or run the C++ UTs, the sim sweeps, or any onboard test. The three C++ edits are
a branch-condition swap, an assert-to-error-return conversion, and comments; the
Python edit is docstring and comment only. CI is the first real build of this
branch.

One unrelated environment defect found: the `clang-tidy` pre-commit hook aborts
with `FileNotFoundError` on a stale worktree path in `PYTHONPATH`
(`tests/lint/clang_tidy.py:33`). It reproduces on a clean tree with all local
changes stashed, so it is not caused by this branch, and CI is unaffected since
it builds a fresh environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)