### PR TITLE
CI: split per-arch NPU/sim workflows and merge OS setup steps

### DIFF
--- a/.github/workflows/_packaging.yml
+++ b/.github/workflows/_packaging.yml
@@ -37,17 +37,16 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
-      - name: Set up C++ compiler (Linux)
-        if: inputs.setup_variant == 'github' && runner.os == 'Linux'
+      - name: Set up C++ compiler
+        if: inputs.setup_variant == 'github'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build g++
-
-      - name: Set up C++ compiler (macOS)
-        if: inputs.setup_variant == 'github' && runner.os == 'macOS'
-        run: |
-          brew install ninja cmake
-          brew install gcc@15 || brew install gcc
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y cmake ninja-build g++
+          else
+            brew install ninja cmake
+            brew install gcc@15 || brew install gcc
+          fi
 
       - name: Set up Python ${{ inputs.python_version }}
         if: inputs.setup_variant == 'github'

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -1,4 +1,4 @@
-name: NPU Scene Tests
+name: NPU Scene Tests (a2a3)
 
 permissions:
   contents: read
@@ -11,10 +11,6 @@ on:
         type: string
       ref:
         required: false
-        type: string
-      platform:
-        description: a2a3 or a5.
-        required: true
         type: string
       runs_on:
         required: true
@@ -31,7 +27,7 @@ on:
 
 jobs:
   run:
-    name: st-onboard-${{ inputs.platform }}
+    name: st-onboard-a2a3
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 60
     env:
@@ -52,17 +48,17 @@ jobs:
           packages: ".[test]"
           install-torch: "false"
           system-site-packages: "true"
-          source-cann: ${{ inputs.platform == 'a2a3' && 'true' || 'false' }}
+          source-cann: "true"
 
       - name: Warn when graphviz is missing
-        if: inputs.platform == 'a2a3' && inputs.include_dfx_smokes
+        if: inputs.include_dfx_smokes
         run: |
           if ! command -v dot >/dev/null 2>&1; then
             echo "::warning::graphviz 'dot' not found on PATH; deps_viewer tool smoke will skip. Install graphviz on this self-hosted runner to restore coverage."
           fi
 
       - name: Run pytest scene tests (a2a3)
-        if: inputs.platform == 'a2a3' && inputs.a2a3_sdma_mode == 'marker'
+        if: inputs.a2a3_sdma_mode == 'marker'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -74,7 +70,7 @@ jobs:
           fi
 
       - name: Run pytest scene tests (a2a3 legacy SDMA paths)
-        if: inputs.platform == 'a2a3' && inputs.a2a3_sdma_mode == 'legacy-paths'
+        if: inputs.a2a3_sdma_mode == 'legacy-paths'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -87,7 +83,7 @@ jobs:
           fi
 
       - name: SDMA pytest (a2a3)
-        if: inputs.platform == 'a2a3' && inputs.a2a3_sdma_mode == 'marker'
+        if: inputs.a2a3_sdma_mode == 'marker'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -100,7 +96,7 @@ jobs:
           fi
 
       - name: SDMA pytest (a2a3 legacy paths)
-        if: inputs.platform == 'a2a3' && inputs.a2a3_sdma_mode == 'legacy-paths'
+        if: inputs.a2a3_sdma_mode == 'legacy-paths'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -112,16 +108,8 @@ jobs:
               --run "python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
           fi
 
-      - name: Run pytest scene tests (a5)
-        if: inputs.platform == 'a5'
-        run: |
-          source .venv/bin/activate
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 1200"
-
       - name: dep_gen smoke (a2a3)
-        if: inputs.platform == 'a2a3' && inputs.include_dfx_smokes
+        if: inputs.include_dfx_smokes
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -137,7 +125,7 @@ jobs:
           fi
 
       - name: dep_gen smoke (a2a3 host_build_graph)
-        if: inputs.platform == 'a2a3' && inputs.include_dfx_smokes
+        if: inputs.include_dfx_smokes
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -153,7 +141,7 @@ jobs:
           fi
 
       - name: chip_swimlane smoke (a2a3)
-        if: inputs.platform == 'a2a3' && inputs.include_dfx_smokes
+        if: inputs.include_dfx_smokes
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -169,7 +157,7 @@ jobs:
           fi
 
       - name: PMU smoke (a2a3)
-        if: inputs.platform == 'a2a3' && inputs.include_dfx_smokes
+        if: inputs.include_dfx_smokes
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -185,7 +173,7 @@ jobs:
           fi
 
       - name: args_dump smoke (a2a3)
-        if: inputs.platform == 'a2a3' && inputs.include_dfx_smokes
+        if: inputs.include_dfx_smokes
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
@@ -199,43 +187,3 @@ jobs:
               --platform a2a3 --device \$TASK_DEVICE -p no:xdist --pto-session-timeout 600 \
               --require-pto-isa --dump-args"
           fi
-
-      - name: dep_gen smoke (a5)
-        if: inputs.platform == 'a5' && inputs.include_dfx_smokes
-        run: |
-          source .venv/bin/activate
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
-            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-dep-gen"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
-
-      - name: chip_swimlane smoke (a5)
-        if: inputs.platform == 'a5' && inputs.include_dfx_smokes
-        run: |
-          source .venv/bin/activate
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
-            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-chip-swimlane --enable-dep-gen"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
-
-      - name: PMU smoke (a5)
-        if: inputs.platform == 'a5' && inputs.include_dfx_smokes
-        run: |
-          source .venv/bin/activate
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
-            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-pmu 2"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
-
-      - name: args_dump smoke (a5)
-        if: inputs.platform == 'a5' && inputs.include_dfx_smokes
-        run: |
-          source .venv/bin/activate
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
-            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --dump-args"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -1,0 +1,93 @@
+name: NPU Scene Tests (a5)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: false
+        type: string
+      ref:
+        required: false
+        type: string
+      runs_on:
+        required: true
+        type: string
+      include_dfx_smokes:
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    name: st-onboard-a5
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: 60
+    env:
+      SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
+      SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
+      SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-venv
+        with:
+          packages: ".[test]"
+          install-torch: "false"
+          system-site-packages: "true"
+          source-cann: "false"
+
+      - name: Run pytest scene tests (a5)
+        run: |
+          source .venv/bin/activate
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 1200"
+
+      - name: dep_gen smoke (a5)
+        if: inputs.include_dfx_smokes
+        run: |
+          source .venv/bin/activate
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
+            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-dep-gen"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+
+      - name: chip_swimlane smoke (a5)
+        if: inputs.include_dfx_smokes
+        run: |
+          source .venv/bin/activate
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
+            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-chip-swimlane --enable-dep-gen"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+
+      - name: PMU smoke (a5)
+        if: inputs.include_dfx_smokes
+        run: |
+          source .venv/bin/activate
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
+            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-pmu 2"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"
+
+      - name: args_dump smoke (a5)
+        if: inputs.include_dfx_smokes
+        run: |
+          source .venv/bin/activate
+          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          PYTEST="python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
+            --platform a5 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --dump-args"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST"

--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -1,0 +1,136 @@
+name: Simulation Scene Tests (a2a3sim)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: false
+        type: string
+      ref:
+        required: false
+        type: string
+      runs_on:
+        required: true
+        type: string
+      setup_variant:
+        description: github or self-cpu.
+        required: true
+        type: string
+      include_dfx_smokes:
+        required: false
+        default: false
+        type: boolean
+      python_version:
+        required: false
+        default: "3.10"
+        type: string
+
+jobs:
+  run:
+    name: st-sim-a2a3sim
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: 30
+    env:
+      SIMPLER_SCHEDULER_TIMEOUT_MS: "5000"
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+
+      - name: Set up C++ compiler
+        if: inputs.setup_variant == 'github'
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+            sudo apt-get install -y ninja-build
+            sudo apt-get install -y g++-15 || sudo apt-get install -y g++
+            if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
+            sudo apt-get install -y graphviz
+          else
+            brew install ninja
+            brew install gcc@15 || brew install gcc
+            brew install graphviz
+          fi
+
+      - name: Verify provisioned toolchain
+        if: inputs.setup_variant == 'self-cpu'
+        run: |
+          command -v ninja
+          command -v g++
+          command -v dot
+          if ! command -v g++-15 >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/bin"
+            ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
+            echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Set up Python ${{ inputs.python_version }}
+        if: inputs.setup_variant == 'github'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Cache pip packages
+        uses: ./.github/actions/cache-pip
+
+      - name: Install dependencies
+        if: inputs.setup_variant == 'github'
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install '.[test]'
+
+      - name: venv + deps
+        if: inputs.setup_variant == 'self-cpu'
+        uses: ./.github/actions/setup-venv
+        with:
+          packages: ".[test]"
+
+      - name: Run pytest scene tests
+        run: |
+          if [ "${{ inputs.setup_variant }}" = "self-cpu" ]; then
+            source .venv/bin/activate
+          fi
+          python -m pytest examples tests/st --platform a2a3sim --device 0-15 -v \
+            --pto-session-timeout 600 --require-pto-isa
+
+      - name: dep_gen smoke (a2a3)
+        if: inputs.include_dfx_smokes
+        run: |
+          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-dep-gen
+
+      - name: dep_gen smoke (a2a3 host_build_graph)
+        if: inputs.include_dfx_smokes
+        run: |
+          pytest tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-dep-gen
+
+      - name: chip_swimlane smoke (a2a3)
+        if: inputs.include_dfx_smokes
+        run: |
+          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-chip-swimlane --enable-dep-gen
+
+      - name: PMU smoke (a2a3)
+        if: inputs.include_dfx_smokes
+        run: |
+          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-pmu 2
+
+      - name: args_dump smoke (a2a3)
+        if: inputs.include_dfx_smokes
+        run: |
+          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --dump-args

--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -1,4 +1,4 @@
-name: Simulation Scene Tests
+name: Simulation Scene Tests (a5sim)
 
 permissions:
   contents: read
@@ -19,10 +19,6 @@ on:
         description: github or self-cpu.
         required: true
         type: string
-      platform:
-        description: a2a3sim or a5sim.
-        required: true
-        type: string
       include_dfx_smokes:
         required: false
         default: false
@@ -34,7 +30,7 @@ on:
 
 jobs:
   run:
-    name: st-sim-${{ inputs.platform }}
+    name: st-sim-a5sim
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 30
     env:
@@ -101,67 +97,32 @@ jobs:
           if [ "${{ inputs.setup_variant }}" = "self-cpu" ]; then
             source .venv/bin/activate
           fi
-          python -m pytest examples tests/st --platform "${{ inputs.platform }}" --device 0-15 -v \
+          python -m pytest examples tests/st --platform a5sim --device 0-15 -v \
             --pto-session-timeout 600 --require-pto-isa
 
-      - name: dep_gen smoke (a2a3)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a2a3sim'
-        run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
-            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-dep-gen
-
-      - name: dep_gen smoke (a2a3 host_build_graph)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a2a3sim'
-        run: |
-          pytest tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py \
-            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-dep-gen
-
-      - name: chip_swimlane smoke (a2a3)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a2a3sim'
-        run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
-            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-chip-swimlane --enable-dep-gen
-
-      - name: PMU smoke (a2a3)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a2a3sim'
-        run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
-            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --enable-pmu 2
-
-      - name: args_dump smoke (a2a3)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a2a3sim'
-        run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
-            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --require-pto-isa --dump-args
-
       - name: dep_gen smoke (a5)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a5sim'
+        if: inputs.include_dfx_smokes
         run: |
           pytest tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-dep-gen
 
       - name: chip_swimlane smoke (a5)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a5sim'
+        if: inputs.include_dfx_smokes
         run: |
           pytest tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-chip-swimlane --enable-dep-gen
 
       - name: PMU smoke (a5)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a5sim'
+        if: inputs.include_dfx_smokes
         run: |
           pytest tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-pmu 2
 
       - name: args_dump smoke (a5)
-        if: inputs.include_dfx_smokes && inputs.platform == 'a5sim'
+        if: inputs.include_dfx_smokes
         run: |
           pytest tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \

--- a/.github/workflows/_ut-no-hardware.yml
+++ b/.github/workflows/_ut-no-hardware.yml
@@ -44,19 +44,19 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: Install GoogleTest (Linux)
-        if: inputs.setup_variant == 'github' && runner.os == 'Linux'
+      - name: Install GoogleTest
+        if: inputs.setup_variant == 'github'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake libgtest-dev
-          cd /usr/src/googletest
-          sudo cmake -B build
-          sudo cmake --build build
-          sudo cmake --install build
-
-      - name: Install GoogleTest (macOS)
-        if: inputs.setup_variant == 'github' && runner.os == 'macOS'
-        run: brew install googletest
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y cmake libgtest-dev
+            cd /usr/src/googletest
+            sudo cmake -B build
+            sudo cmake --build build
+            sudo cmake --install build
+          else
+            brew install googletest
+          fi
 
       - name: Cache pip packages
         uses: ./.github/actions/cache-pip

--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -1,0 +1,111 @@
+name: NPU Unit Tests (a2a3)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: false
+        type: string
+      ref:
+        required: false
+        type: string
+      runs_on:
+        required: true
+        type: string
+      include_cann_examples:
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    name: ut-a2a3
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: 30
+    env:
+      SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
+      SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
+      SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-venv
+        with:
+          packages: ".[test]"
+          install-torch: "false"
+          system-site-packages: "true"
+          source-cann: "true"
+
+      - name: Run Python hardware unit tests (a2a3)
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          source .venv/bin/activate
+          if [ "$(uname -m)" = "x86_64" ]; then
+            python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
+          else
+            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+              --run "python -m pytest tests -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v"
+          fi
+
+      - name: Build and run C++ hardware unit tests (a2a3)
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          source .venv/bin/activate
+          python -c "from simpler_setup.runtime_builder import RuntimeBuilder; RuntimeBuilder('a2a3').get_binaries('tensormap_and_ringbuffer', build=True)"
+          cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
+          cmake --build tests/ut/cpp/build
+          if [ "$(uname -m)" = "x86_64" ]; then
+            python3 -c "
+          import json, os
+          p = os.environ['DEVICE_RANGE'].split('-'); s, e = p[0], p[-1]
+          npus = [{'id': str(i), 'slots': 1} for i in range(int(s), int(e)+1)]
+          json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
+                    open('tests/ut/cpp/build/resources.json', 'w'))
+          "
+            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure
+          else
+            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+              --run "python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
+          fi
+
+      - name: Build cann-examples/query
+        if: inputs.include_cann_examples
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          cd tools/cann-examples/query
+          cmake -B build .
+          cmake --build build
+          ./build/query version
+
+      - name: Build cann-examples/aicpu-device-query
+        if: inputs.include_cann_examples
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          export CROSS=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu
+          cd tools/cann-examples/aicpu-device-query/device
+          cmake -B build . -DCMAKE_C_COMPILER=${CROSS}-gcc -DCMAKE_CXX_COMPILER=${CROSS}-g++
+          cmake --build build
+          cd ../host
+          cmake -B build .
+          cmake --build build
+
+      - name: Build cann-examples/aicpu-kernel-launch
+        if: inputs.include_cann_examples
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          export CROSS=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu
+          cd tools/cann-examples/aicpu-kernel-launch/device
+          cmake -B build . -DCMAKE_C_COMPILER=${CROSS}-gcc -DCMAKE_CXX_COMPILER=${CROSS}-g++
+          cmake --build build
+          cd ../host
+          cmake -B build .
+          cmake --build build

--- a/.github/workflows/_ut-npu-a5.yml
+++ b/.github/workflows/_ut-npu-a5.yml
@@ -1,4 +1,4 @@
-name: NPU Unit Tests
+name: NPU Unit Tests (a5)
 
 permissions:
   contents: read
@@ -12,10 +12,6 @@ on:
       ref:
         required: false
         type: string
-      platform:
-        description: a2a3 or a5.
-        required: true
-        type: string
       runs_on:
         required: true
         type: string
@@ -26,7 +22,7 @@ on:
 
 jobs:
   run:
-    name: ut-${{ inputs.platform }}
+    name: ut-a5
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 30
     env:
@@ -47,51 +43,15 @@ jobs:
           packages: ".[test]"
           install-torch: "false"
           system-site-packages: "true"
-          source-cann: ${{ inputs.platform == 'a2a3' && 'true' || 'false' }}
-
-      - name: Run Python hardware unit tests (a2a3)
-        if: inputs.platform == 'a2a3'
-        run: |
-          source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
-          if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest tests -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v"
-          fi
-
-      - name: Build and run C++ hardware unit tests (a2a3)
-        if: inputs.platform == 'a2a3'
-        run: |
-          source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
-          python -c "from simpler_setup.runtime_builder import RuntimeBuilder; RuntimeBuilder('a2a3').get_binaries('tensormap_and_ringbuffer', build=True)"
-          cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
-          cmake --build tests/ut/cpp/build
-          if [ "$(uname -m)" = "x86_64" ]; then
-            python3 -c "
-          import json, os
-          p = os.environ['DEVICE_RANGE'].split('-'); s, e = p[0], p[-1]
-          npus = [{'id': str(i), 'slots': 1} for i in range(int(s), int(e)+1)]
-          json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
-                    open('tests/ut/cpp/build/resources.json', 'w'))
-          "
-            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
-          fi
+          source-cann: "false"
 
       - name: Run Python hardware unit tests (a5)
-        if: inputs.platform == 'a5'
         run: |
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v"
 
       - name: Build and run C++ hardware unit tests (a5)
-        if: inputs.platform == 'a5'
         run: |
           source .venv/bin/activate
           cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
@@ -109,9 +69,6 @@ jobs:
       - name: Build cann-examples/query
         if: inputs.include_cann_examples
         run: |
-          if [ "${{ inputs.platform }}" = "a2a3" ]; then
-            source /usr/local/Ascend/cann/set_env.sh
-          fi
           cd tools/cann-examples/query
           cmake -B build .
           cmake --build build
@@ -120,9 +77,6 @@ jobs:
       - name: Build cann-examples/aicpu-device-query
         if: inputs.include_cann_examples
         run: |
-          if [ "${{ inputs.platform }}" = "a2a3" ]; then
-            source /usr/local/Ascend/cann/set_env.sh
-          fi
           export CROSS=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu
           cd tools/cann-examples/aicpu-device-query/device
           cmake -B build . -DCMAKE_C_COMPILER=${CROSS}-gcc -DCMAKE_CXX_COMPILER=${CROSS}-g++
@@ -134,9 +88,6 @@ jobs:
       - name: Build cann-examples/aicpu-kernel-launch
         if: inputs.include_cann_examples
         run: |
-          if [ "${{ inputs.platform }}" = "a2a3" ]; then
-            source /usr/local/Ascend/cann/set_env.sh
-          fi
           export CROSS=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu
           cd tools/cann-examples/aicpu-kernel-launch/device
           cmake -B build . -DCMAKE_C_COMPILER=${CROSS}-gcc -DCMAKE_CXX_COMPILER=${CROSS}-g++

--- a/.github/workflows/ci-self-cpu.yml
+++ b/.github/workflows/ci-self-cpu.yml
@@ -111,46 +111,42 @@ jobs:
   st-sim-a2a3:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-sim.yml
+    uses: ./.github/workflows/_st-sim-a2a3.yml
     with:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
       runs_on: '["self-hosted","cpu"]'
       setup_variant: self-cpu
-      platform: a2a3sim
       include_dfx_smokes: false
 
   st-sim-a5:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.a5_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-sim.yml
+    uses: ./.github/workflows/_st-sim-a5.yml
     with:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
       runs_on: '["self-hosted","cpu"]'
       setup_variant: self-cpu
-      platform: a5sim
       include_dfx_smokes: false
 
   ut-a2a3:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
-    uses: ./.github/workflows/_ut-npu.yml
+    uses: ./.github/workflows/_ut-npu-a2a3.yml
     with:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
-      platform: a2a3
       runs_on: '["self-hosted","a2a3"]'
       include_cann_examples: false
 
   st-onboard-a2a3:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-npu.yml
+    uses: ./.github/workflows/_st-npu-a2a3.yml
     with:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
-      platform: a2a3
       runs_on: '["self-hosted","a2a3"]'
       include_dfx_smokes: false
       a2a3_sdma_mode: legacy-paths
@@ -158,21 +154,19 @@ jobs:
   ut-a5:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
-    uses: ./.github/workflows/_ut-npu.yml
+    uses: ./.github/workflows/_ut-npu-a5.yml
     with:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
-      platform: a5
       runs_on: '["self-hosted","a5"]'
       include_cann_examples: false
 
   st-onboard-a5:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.a5_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-npu.yml
+    uses: ./.github/workflows/_st-npu-a5.yml
     with:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || github.sha }}
-      platform: a5
       runs_on: '["self-hosted","a5"]'
       include_dfx_smokes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10"]
-    uses: ./.github/workflows/_st-sim.yml
+    uses: ./.github/workflows/_st-sim-a2a3.yml
     with:
       runs_on: ${{ toJSON(matrix.os) }}
       setup_variant: github
-      platform: a2a3sim
       include_dfx_smokes: true
       python_version: ${{ matrix.python-version }}
 
@@ -81,11 +80,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10"]
-    uses: ./.github/workflows/_st-sim.yml
+    uses: ./.github/workflows/_st-sim-a5.yml
     with:
       runs_on: ${{ toJSON(matrix.os) }}
       setup_variant: github
-      platform: a5sim
       include_dfx_smokes: true
       python_version: ${{ matrix.python-version }}
 
@@ -100,18 +98,16 @@ jobs:
   ut-a2a3:
     needs: [detect-changes, pre-commit]
     if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
-    uses: ./.github/workflows/_ut-npu.yml
+    uses: ./.github/workflows/_ut-npu-a2a3.yml
     with:
-      platform: a2a3
       runs_on: '["self-hosted","a2a3"]'
       include_cann_examples: true
 
   st-onboard-a2a3:
     needs: [detect-changes, pre-commit]
     if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-npu.yml
+    uses: ./.github/workflows/_st-npu-a2a3.yml
     with:
-      platform: a2a3
       runs_on: '["self-hosted","a2a3"]'
       include_dfx_smokes: true
       a2a3_sdma_mode: marker
@@ -119,17 +115,15 @@ jobs:
   ut-a5:
     needs: [detect-changes, pre-commit]
     if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
-    uses: ./.github/workflows/_ut-npu.yml
+    uses: ./.github/workflows/_ut-npu-a5.yml
     with:
-      platform: a5
       runs_on: '["self-hosted","a5"]'
       include_cann_examples: true
 
   st-onboard-a5:
     needs: [detect-changes, pre-commit]
     if: needs.detect-changes.outputs.a5_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-npu.yml
+    uses: ./.github/workflows/_st-npu-a5.yml
     with:
-      platform: a5
       runs_on: '["self-hosted","a5"]'
       include_dfx_smokes: true

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -28,8 +28,11 @@ The complete test-type × hardware-tier matrix. Empty cells have no tests yet; o
 triggers, `needs:`, gate `if:` expressions, runner/setup inputs, and matrix
 shape. The executable job bodies live in reusable workflows:
 `_detect-changes.yml`, `_pre-commit.yml`, `_ut-no-hardware.yml`,
-`_packaging.yml`, `_profiling-flags-smoke.yml`, `_st-sim.yml`,
-`_ut-npu.yml`, and `_st-npu.yml`. Shared step scaffolding that is safe to run
+`_packaging.yml`, `_profiling-flags-smoke.yml`, `_st-sim-a2a3.yml`,
+`_st-sim-a5.yml`, `_ut-npu-a2a3.yml`, `_ut-npu-a5.yml`,
+`_st-npu-a2a3.yml`, and `_st-npu-a5.yml`. The scene-test and NPU unit-test
+bodies are split one workflow per architecture so each job renders only its own
+steps. Shared step scaffolding that is safe to run
 after checkout lives in composite actions under `.github/actions/`
 (`cache-pip`, `setup-venv`).
 
@@ -311,5 +314,5 @@ No `--platform` means "run all sims" — tests with no sim in their `platforms` 
 
 - **macOS libomp collision**: on macOS, the root `conftest.py` sets `KMP_DUPLICATE_LIB_OK=TRUE` before `import pytest` to work around a duplicate-libomp abort triggered by homebrew numpy and pip torch coexisting in one Python process (see [troubleshooting/macos-libomp-collision.md](troubleshooting/macos-libomp-collision.md)). Standalone `python test_*.py` bypasses conftest — rely on the env var being exported by the shell or `tools/verify_packaging.sh`.
 - **sim hangs / `rc=-1` under CPU oversubscription**: on a few-vCPU runner, high `--max-parallel` (or many concurrent sim cases) oversubscribes the host CPUs, where sim's busy-spin handshake can livelock (hang → `rc=124`) or the deinit timeout can false-trip (`simpler_run failed with code -1`). Mitigate with `--max-parallel 2`; onboard is unaffected (see [troubleshooting/sim-oversubscription-hang.md](troubleshooting/sim-oversubscription-hang.md)).
-- **local runs time out more slowly than CI**: compiled defaults are lenient for serving workloads, while CI sets tighter `PTO2_*_TIMEOUT_*` env values to fail fast. Use the same env values locally when debugging suspected hangs (see [troubleshooting/local-timeout-defaults.md](troubleshooting/local-timeout-defaults.md)).
+- **local runs time out more slowly than CI**: compiled defaults are lenient for serving workloads, while CI sets tighter `SIMPLER_*_TIMEOUT_*` env values to fail fast. Use the same env values locally when debugging suspected hangs (see [troubleshooting/local-timeout-defaults.md](troubleshooting/local-timeout-defaults.md)).
 - **`st-onboard-a2a3` mass 507899 is not OOM**: a whole-suite collapse of `507899`/`507018`/`register_callable -1` is an AICPU device-fault cascade (`simpler_aicpu_exec` exception), not memory exhaustion. Diagnosis recipe and the per-device preinstall-name fix are in [troubleshooting/a2a3-507899-aicpu-shared-so-fault.md](troubleshooting/a2a3-507899-aicpu-shared-so-fault.md).

--- a/docs/troubleshooting/device-error-codes/stall.md
+++ b/docs/troubleshooting/device-error-codes/stall.md
@@ -7,9 +7,9 @@
 Three watchdogs compete, and whichever fires first determines whether you get a
 clean `-100` with a `sub_class`, or a masked `507018`:
 
-- the scheduler no-progress timeout (`PTO2_SCHEDULER_TIMEOUT_MS`),
-- the STARS op-execute timeout (`PTO2_OP_EXECUTE_TIMEOUT_US`, ~45 s, kills `aicpu-sd`),
-- the host stream-sync timeout (`PTO2_STREAM_SYNC_TIMEOUT_MS`).
+- the scheduler no-progress timeout (`SIMPLER_SCHEDULER_TIMEOUT_MS`),
+- the STARS op-execute timeout (`SIMPLER_OP_EXECUTE_TIMEOUT_US`, ~45 s, kills `aicpu-sd`),
+- the host stream-sync timeout (`SIMPLER_STREAM_SYNC_TIMEOUT_MS`).
 
 **A 45 s op-execute kill is not proof of a deadlock** — the kernel may simply be
 slow. To find out which, order the race deliberately. The STs do exactly this, and


### PR DESCRIPTION
## Summary

Follow-up to #1640, which consolidated the a2a3/a5 NPU and sim jobs into shared reusable workflows branching on `platform` / `runner.os` via `if:`. Behavior was preserved, but each job rendered the **other** variant's steps as *skipped* rows in the Actions UI — `st-onboard-a2a3` showed 7 skipped a5/legacy rows, and `packaging`/`ut` showed skipped Linux/macOS compiler sibling rows.

- **Split the arch-specific workflows one file per platform** so each job lists only its own steps:
  - `_st-npu.yml` → `_st-npu-a2a3.yml` + `_st-npu-a5.yml`
  - `_st-sim.yml` → `_st-sim-a2a3.yml` + `_st-sim-a5.yml`
  - `_ut-npu.yml` → `_ut-npu-a2a3.yml` + `_ut-npu-a5.yml`
  - The `platform` input is dropped (now implied by the file) and the platform value hardcoded. Lane-correlated gates (`a2a3_sdma_mode`, `include_dfx_smokes`, `include_cann_examples`) remain as the accepted residual skip.
- **Merge the OS-conditional setup pairs** into single `uname`-branching steps: `_packaging.yml` (C++ compiler) and `_ut-no-hardware.yml` (GoogleTest).
- **Doc fix**: `PTO2_*_TIMEOUT_*` → `SIMPLER_*_TIMEOUT_*` in `docs/ci.md` and `docs/troubleshooting/device-error-codes/stall.md` — the `PTO2_*` timeout env vars do not exist; the runtime `getenv`-reads `SIMPLER_*`.

## Effect (github lane — what every PR sees)

- `st-onboard-a2a3`: 7 → 2 skipped (legacy SDMA mode only)
- `st-onboard-a5` / `st-sim-*` / `ut-*`: → **0 skipped**
- `packaging` / `ut`: no more Linux/macOS sibling skip

## Testing

- [x] `yaml.safe_load` over all workflows + composite actions; `actionlint` clean (only pre-existing shellcheck style notes + the known self-hosted `cpu` label)
- [x] `task-submit` invocation counts unchanged (`_st-npu` 14→14, `_ut-npu` 4→4); no test steps lost
- [x] Zero residual `inputs.platform` in split files; zero `runner.os == Linux/macOS` step pairs; callers pass no dangling `platform:`
- [ ] Observe on a PR that touches a2a3 code: `st-onboard-a2a3` shows ~12 steps with only 2 skipped (legacy), and `st-onboard-a5` shows 0 skipped