### PR TITLE
Fix: keep forked host log records intact

### DIFF
--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -48,16 +48,26 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 
+# The host-log record prefix `HostLogger::emit` writes ahead of every message.
+# Its func segment excludes ':' because `LOG_TIMING` passes `__FUNCTION__`, an
+# unqualified name; a qualified name containing '::' would stop this alternative
+# from matching, leaving the `[STRACE]` alternative to bound the record instead.
 _HOST_LOG_PREFIX = (
     r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\]"
     r"\[T0x[0-9a-fA-F]+\]\[[A-Z]+\]\s+[^:\r\n]+:\s+"
 )
+# MULTILINE anchors the `$` alternative at every line end, so a caller passing a
+# multi-line blob rather than one line per item keeps every record but the last.
 _STRACE_RE = re.compile(
     r"\[STRACE\]\s+v=(?P<v>\d+)\s+pid=(?P<pid>\d+)\s+tid=(?P<tid>\d+)\s+"
     r"inv=(?P<inv>\d+)\s+hid=(?P<hid>[0-9a-fA-F]+)\s+depth=(?P<depth>\d+)\s+"
     r"name=(?P<name>\S+)\s+ts=(?P<ts>\d+)\s+dur=(?P<dur>\d+)(?P<attrs>.*?)"
-    rf"(?={_HOST_LOG_PREFIX}|\[STRACE\]|\r?$)"
+    rf"(?={_HOST_LOG_PREFIX}|\[STRACE\]|\r?$)",
+    re.MULTILINE,
 )
+# A record start, matched independently of whether the rest of that record
+# survived the write that emitted it.
+_STRACE_HEAD_RE = re.compile(r"\[STRACE\]\s+v=\d+")
 
 
 @dataclass
@@ -98,6 +108,16 @@ class Invocation:
         for s in self.spans:
             m.setdefault(s.name, s)
         return m
+
+
+def count_record_heads(lines):
+    """Count ``[STRACE]`` record starts, torn ones included.
+
+    Pairs with :func:`parse_spans`, which yields only records that survived
+    intact. A shortfall between the two counts is instrumentation loss, and
+    without it a torn record is indistinguishable from a real measurement.
+    """
+    return sum(len(_STRACE_HEAD_RE.findall(line)) for line in lines)
 
 
 def parse_spans(lines):
@@ -496,6 +516,13 @@ def main(argv=None):
             lines = f.readlines()
 
     spans = list(parse_spans(lines))
+    heads = count_record_heads(lines)
+    if heads > len(spans):
+        print(
+            f"warning: {heads - len(spans)} of {heads} [STRACE] records are incomplete and are "
+            "excluded from the timing below",
+            file=sys.stderr,
+        )
     invocations = group_invocations(spans)
     buckets = bucket_by_hid(invocations)
 

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -48,10 +48,15 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 
+_HOST_LOG_PREFIX = (
+    r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\]"
+    r"\[T0x[0-9a-fA-F]+\]\[[A-Z]+\]\s+[^:\r\n]+:\s+"
+)
 _STRACE_RE = re.compile(
     r"\[STRACE\]\s+v=(?P<v>\d+)\s+pid=(?P<pid>\d+)\s+tid=(?P<tid>\d+)\s+"
     r"inv=(?P<inv>\d+)\s+hid=(?P<hid>[0-9a-fA-F]+)\s+depth=(?P<depth>\d+)\s+"
-    r"name=(?P<name>\S+)\s+ts=(?P<ts>\d+)\s+dur=(?P<dur>\d+)(?P<attrs>.*)"
+    r"name=(?P<name>\S+)\s+ts=(?P<ts>\d+)\s+dur=(?P<dur>\d+)(?P<attrs>.*?)"
+    rf"(?={_HOST_LOG_PREFIX}|\[STRACE\]|\r?$)"
 )
 
 
@@ -96,22 +101,20 @@ class Invocation:
 
 
 def parse_spans(lines):
-    """Yield Span for every matching [STRACE] line."""
+    """Yield every complete span, including adjacent records on one line."""
     for line in lines:
-        m = _STRACE_RE.search(line)
-        if not m:
-            continue
-        yield Span(
-            pid=int(m["pid"]),
-            tid=int(m["tid"]),
-            inv=int(m["inv"]),
-            hid=m["hid"].lower(),
-            depth=int(m["depth"]),
-            name=m["name"],
-            ts=int(m["ts"]),
-            dur=int(m["dur"]),
-            attrs=m["attrs"].strip(),
-        )
+        for m in _STRACE_RE.finditer(line):
+            yield Span(
+                pid=int(m["pid"]),
+                tid=int(m["tid"]),
+                inv=int(m["inv"]),
+                hid=m["hid"].lower(),
+                depth=int(m["depth"]),
+                name=m["name"],
+                ts=int(m["ts"]),
+                dur=int(m["dur"]),
+                attrs=m["attrs"].strip(),
+            )
 
 
 def group_invocations(spans):

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -15,14 +15,58 @@
 
 #include "host_log.h"
 
+#include <cerrno>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <pthread.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
 
 using simpler::log::LogLevel;
+
+namespace {
+
+std::string format_message(const char *fmt, va_list args) {
+    va_list sizing_args;
+    va_copy(sizing_args, args);
+    const int required = vsnprintf(nullptr, 0, fmt, sizing_args);
+    va_end(sizing_args);
+    if (required < 0) {
+        return {};
+    }
+
+    std::vector<char> buffer(static_cast<size_t>(required) + 1);
+    va_list formatting_args;
+    va_copy(formatting_args, args);
+    const int written = vsnprintf(buffer.data(), buffer.size(), fmt, formatting_args);
+    va_end(formatting_args);
+    if (written < 0) {
+        return {};
+    }
+    return std::string(buffer.data(), static_cast<size_t>(written));
+}
+
+void write_stderr(const std::string &record) {
+    size_t offset = 0;
+    while (offset < record.size()) {
+        const ssize_t written = ::write(STDERR_FILENO, record.data() + offset, record.size() - offset);
+        if (written > 0) {
+            offset += static_cast<size_t>(written);
+        } else if (written < 0 && errno == EINTR) {
+            continue;
+        } else {
+            break;
+        }
+    }
+}
+
+}  // namespace
 
 HostLogger &HostLogger::get_instance() {
     static HostLogger instance;
@@ -83,13 +127,18 @@ void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, 
 
     auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
 
-    std::scoped_lock lock(mutex_);
-    fprintf(stderr, "[%s][T0x%lx][%s] %s: ", ts, tid, level_tag, func);
-    vfprintf(stderr, fmt, args);
+    std::ostringstream stream;
+    stream << '[' << ts << "][T0x" << std::hex << tid << "][" << level_tag << "] " << func << ": "
+           << format_message(fmt, args);
+    std::string record = stream.str();
     if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n') {
-        fputc('\n', stderr);
+        record.push_back('\n');
     }
-    fflush(stderr);
+
+    std::scoped_lock lock(mutex_);
+    // STRACE records fit within PIPE_BUF, so one write keeps each record
+    // indivisible when forked workers share a captured stderr pipe.
+    write_stderr(record);
 }
 
 void HostLogger::vlog(LogLevel level, const char *func, const char *fmt, va_list args) {

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -22,8 +22,6 @@
 #include <cstring>
 #include <ctime>
 #include <pthread.h>
-#include <sstream>
-#include <string>
 #include <vector>
 
 #include <unistd.h>
@@ -32,30 +30,54 @@ using simpler::log::LogLevel;
 
 namespace {
 
-std::string format_message(const char *fmt, va_list args) {
-    va_list sizing_args;
-    va_copy(sizing_args, args);
-    const int required = vsnprintf(nullptr, 0, fmt, sizing_args);
-    va_end(sizing_args);
-    if (required < 0) {
-        return {};
-    }
+// Every STRACE marker renders well inside this, so the heap fallback below
+// stays off the path a traced run pays per span.
+constexpr size_t kRecordStackCapacity = 2048;
 
-    std::vector<char> buffer(static_cast<size_t>(required) + 1);
+// Renders the timestamp/thread/level prefix, the caller's message, and an
+// optional trailing newline into `buffer`, and returns the length of the whole
+// record. A return value of `capacity` or more means `buffer` holds only a
+// truncated prefix and the caller must re-render into that many bytes.
+size_t format_record(
+    char *buffer, size_t capacity, const char *ts, unsigned long tid, const char *level_tag, const char *func,
+    const char *fmt, va_list args, bool append_newline
+) {
+    size_t length = 0;
+    auto tail = [&]() -> char * {
+        return length < capacity ? buffer + length : nullptr;
+    };
+    auto remaining = [&]() -> size_t {
+        return length < capacity ? capacity - length : 0;
+    };
+
+    const int prefix = snprintf(tail(), remaining(), "[%s][T0x%lx][%s] %s: ", ts, tid, level_tag, func);
+    if (prefix < 0) {
+        return 0;
+    }
+    length += static_cast<size_t>(prefix);
+
     va_list formatting_args;
     va_copy(formatting_args, args);
-    const int written = vsnprintf(buffer.data(), buffer.size(), fmt, formatting_args);
+    const int body = vsnprintf(tail(), remaining(), fmt, formatting_args);
     va_end(formatting_args);
-    if (written < 0) {
-        return {};
+    if (body > 0) {
+        length += static_cast<size_t>(body);
     }
-    return std::string(buffer.data(), static_cast<size_t>(written));
+
+    if (append_newline) {
+        if (length + 1 < capacity) {
+            buffer[length] = '\n';
+            buffer[length + 1] = '\0';
+        }
+        length += 1;
+    }
+    return length;
 }
 
-void write_stderr(const std::string &record) {
+void write_stderr(const char *record, size_t size) {
     size_t offset = 0;
-    while (offset < record.size()) {
-        const ssize_t written = ::write(STDERR_FILENO, record.data() + offset, record.size() - offset);
+    while (offset < size) {
+        const ssize_t written = ::write(STDERR_FILENO, record + offset, size - offset);
         if (written > 0) {
             offset += static_cast<size_t>(written);
         } else if (written < 0 && errno == EINTR) {
@@ -127,18 +149,26 @@ void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, 
 
     auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
 
-    std::ostringstream stream;
-    stream << '[' << ts << "][T0x" << std::hex << tid << "][" << level_tag << "] " << func << ": "
-           << format_message(fmt, args);
-    std::string record = stream.str();
-    if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n') {
-        record.push_back('\n');
+    const bool append_newline = fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n';
+
+    // One write per record: a record of at most PIPE_BUF bytes reaches a shared
+    // pipe indivisibly, so forked workers writing a captured stderr cannot
+    // interleave inside it. A longer record — a large LOG_ERROR dump, say — has
+    // no such guarantee; STRACE markers stay well below the limit.
+    char stack_buffer[kRecordStackCapacity];
+    const size_t length =
+        format_record(stack_buffer, sizeof(stack_buffer), ts, tid, level_tag, func, fmt, args, append_newline);
+    if (length < sizeof(stack_buffer)) {
+        std::scoped_lock lock(mutex_);
+        write_stderr(stack_buffer, length);
+        return;
     }
 
+    std::vector<char> heap_buffer(length + 1);
+    const size_t heap_length =
+        format_record(heap_buffer.data(), heap_buffer.size(), ts, tid, level_tag, func, fmt, args, append_newline);
     std::scoped_lock lock(mutex_);
-    // STRACE records fit within PIPE_BUF, so one write keeps each record
-    // indivisible when forked workers share a captured stderr pipe.
-    write_stderr(record);
+    write_stderr(heap_buffer.data(), heap_length < heap_buffer.size() ? heap_length : length);
 }
 
 void HostLogger::vlog(LogLevel level, const char *func, const char *fmt, va_list args) {

--- a/src/common/log/include/host_log.h
+++ b/src/common/log/include/host_log.h
@@ -17,8 +17,7 @@
  * both TIMING and WARN thresholds to CANN WARN.
  */
 
-#ifndef PLATFORM_HOST_LOG_H_
-#define PLATFORM_HOST_LOG_H_
+#pragma once
 
 #include <cstdarg>
 #include <cstdio>
@@ -32,9 +31,8 @@ public:
 
     void log(simpler::log::LogLevel level, const char *func, const char *fmt, ...);
 
-    // va_list-taking primitives — used by unified_log_* adapters to forward
-    // a caller's variadic args without an intermediate vsnprintf-to-buffer
-    // round-trip. Caller is responsible for `va_start` / `va_end`.
+    // va_list-taking primitive used by unified_log_* adapters. Caller is
+    // responsible for `va_start` / `va_end`.
     void vlog(simpler::log::LogLevel level, const char *func, const char *fmt, va_list args);
 
     void set_level(simpler::log::LogLevel level);
@@ -66,5 +64,3 @@ private:
     simpler::log::LogLevel current_level_;
     std::mutex mutex_;
 };
-
-#endif  // PLATFORM_HOST_LOG_H_

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -15,7 +15,13 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <algorithm>
+#include <cerrno>
+#include <sstream>
 #include <string>
+#include <thread>
+#include <vector>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <gtest/gtest.h>
@@ -197,4 +203,109 @@ TEST(HostLogTest, AllOutputGoesToStderr) {
     EXPECT_NE(captured.err.find("timing-output-marker"), std::string::npos);
     EXPECT_NE(captured.err.find("info-output-marker"), std::string::npos);
     EXPECT_NE(captured.err.find("debug-output-marker"), std::string::npos);
+}
+
+TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
+    int log_pipe[2];
+    int start_pipe[2];
+    ASSERT_EQ(pipe(log_pipe), 0);
+    ASSERT_EQ(pipe(start_pipe), 0);
+
+    const long pipe_buf = fpathconf(log_pipe[1], _PC_PIPE_BUF);
+    ASSERT_GT(pipe_buf, 256);
+    const size_t payload_size = static_cast<size_t>(std::min<long>(pipe_buf - 256, 2048));
+    constexpr int child_count = 16;
+    constexpr int records_per_child = 128;
+
+    std::vector<pid_t> children;
+    for (int child = 0; child < child_count; ++child) {
+        const pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+        if (pid == 0) {
+            close(log_pipe[0]);
+            close(start_pipe[1]);
+            char start;
+            if (read(start_pipe[0], &start, 1) != 1 || dup2(log_pipe[1], STDERR_FILENO) < 0) {
+                _exit(2);
+            }
+            close(start_pipe[0]);
+            close(log_pipe[1]);
+
+            HostLogger::get_instance().set_level(LogLevel::DEBUG);
+            const std::string payload(payload_size, static_cast<char>('a' + child));
+            for (int seq = 0; seq < records_per_child; ++seq) {
+                HostLogger::get_instance().log(
+                    LogLevel::ERROR, "fork_writer", "child=%d seq=%d payload=%s", child, seq, payload.c_str()
+                );
+            }
+            _exit(0);
+        }
+        children.push_back(pid);
+    }
+
+    close(log_pipe[1]);
+    close(start_pipe[0]);
+    std::string captured;
+    std::thread reader([&] {
+        char buffer[8192];
+        while (true) {
+            const ssize_t count = read(log_pipe[0], buffer, sizeof(buffer));
+            if (count > 0) {
+                captured.append(buffer, static_cast<size_t>(count));
+            } else if (count < 0 && errno == EINTR) {
+                continue;
+            } else {
+                break;
+            }
+        }
+        close(log_pipe[0]);
+    });
+
+    const std::string starts(child_count, 'x');
+    EXPECT_EQ(write(start_pipe[1], starts.data(), starts.size()), static_cast<ssize_t>(starts.size()));
+    close(start_pipe[1]);
+
+    for (pid_t child : children) {
+        int status = 0;
+        const pid_t waited = waitpid(child, &status, 0);
+        EXPECT_EQ(waited, child);
+        if (waited == child) {
+            EXPECT_TRUE(WIFEXITED(status));
+            if (WIFEXITED(status)) {
+                EXPECT_EQ(WEXITSTATUS(status), 0);
+            }
+        }
+    }
+    reader.join();
+
+    std::vector<std::vector<bool>> seen(child_count, std::vector<bool>(records_per_child, false));
+    std::istringstream lines(captured);
+    std::string line;
+    int line_count = 0;
+    constexpr char payload_marker[] = " payload=";
+    while (std::getline(lines, line)) {
+        const size_t record_pos = line.find("child=");
+        const size_t payload_pos = line.find(payload_marker);
+        ASSERT_NE(record_pos, std::string::npos);
+        ASSERT_NE(payload_pos, std::string::npos);
+        ASSERT_EQ(line.find("child=", record_pos + 1), std::string::npos);
+
+        int child = -1;
+        int seq = -1;
+        ASSERT_EQ(sscanf(line.c_str() + record_pos, "child=%d seq=%d", &child, &seq), 2);
+        ASSERT_GE(child, 0);
+        ASSERT_LT(child, child_count);
+        ASSERT_GE(seq, 0);
+        ASSERT_LT(seq, records_per_child);
+        ASSERT_FALSE(seen[child][seq]);
+        seen[child][seq] = true;
+
+        const std::string payload = line.substr(payload_pos + sizeof(payload_marker) - 1);
+        ASSERT_EQ(payload.size(), payload_size);
+        EXPECT_TRUE(std::all_of(payload.begin(), payload.end(), [child](char value) {
+            return value == static_cast<char>('a' + child);
+        }));
+        ++line_count;
+    }
+    EXPECT_EQ(line_count, child_count * records_per_child);
 }

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from simpler_setup.tools.strace_timing import parse_spans
+
+
+def _marker(pid, inv, name, attrs=""):
+    return f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
+
+
+def test_parse_spans_finds_adjacent_records_on_one_physical_line():
+    line = (
+        "[2026-08-04 10:00:00.000001][T0x1][TIMING] emit: "
+        + _marker(11, 1, "simpler_run", "rank=0")
+        + "[2026-08-04 10:00:00.000002][T0x2][TIMING] emit: "
+        + _marker(22, 2, "simpler_run.runner_run.device_wall", "clk=dev rank=1")
+        + "\n"
+    )
+
+    spans = list(parse_spans([line]))
+
+    assert [(span.pid, span.inv, span.name) for span in spans] == [
+        (11, 1, "simpler_run"),
+        (22, 2, "simpler_run.runner_run.device_wall"),
+    ]
+    assert spans[0].attrs == "rank=0"
+    assert spans[1].attrs == "clk=dev rank=1"

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -8,27 +8,55 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-from simpler_setup.tools.strace_timing import parse_spans
+from simpler_setup.tools.strace_timing import count_record_heads, parse_spans
 
 
-def _marker(pid, inv, name, attrs=""):
-    return f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
+def _record(pid, inv, name, attrs=""):
+    """One host-log record in the shape `HostLogger::emit` writes it.
+
+    `LOG_TIMING` prepends `[<file>:<line>] ` to the caller's format string, so
+    the marker never sits flush against the `<func>: ` separator on stderr.
+    """
+    return (
+        f"[2026-08-04 10:00:00.00000{pid}][T0x{pid}][TIMING] emit_span: [strace.h:132] "
+        f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
+    )
 
 
 def test_parse_spans_finds_adjacent_records_on_one_physical_line():
     line = (
-        "[2026-08-04 10:00:00.000001][T0x1][TIMING] emit: "
-        + _marker(11, 1, "simpler_run", "rank=0")
-        + "[2026-08-04 10:00:00.000002][T0x2][TIMING] emit: "
-        + _marker(22, 2, "simpler_run.runner_run.device_wall", "clk=dev rank=1")
+        _record(1, 1, "simpler_run", "rank=0")
+        + _record(2, 2, "simpler_run.runner_run.device_wall", "clk=dev rank=1")
         + "\n"
     )
 
     spans = list(parse_spans([line]))
 
     assert [(span.pid, span.inv, span.name) for span in spans] == [
-        (11, 1, "simpler_run"),
-        (22, 2, "simpler_run.runner_run.device_wall"),
+        (1, 1, "simpler_run"),
+        (2, 2, "simpler_run.runner_run.device_wall"),
     ]
     assert spans[0].attrs == "rank=0"
     assert spans[1].attrs == "clk=dev rank=1"
+
+
+def test_parse_spans_keeps_every_record_of_a_multi_line_blob():
+    blob = _record(1, 1, "simpler_run", "rank=0") + "\n" + _record(2, 2, "simpler_run.bind", "rank=1") + "\n"
+
+    spans = list(parse_spans([blob]))
+
+    assert [(span.pid, span.inv, span.name) for span in spans] == [
+        (1, 1, "simpler_run"),
+        (2, 2, "simpler_run.bind"),
+    ]
+    assert spans[0].attrs == "rank=0"
+    assert spans[1].attrs == "rank=1"
+
+
+def test_count_record_heads_sees_a_torn_record_that_parse_spans_drops():
+    intact = _record(1, 1, "simpler_run", "rank=0")
+    torn = intact[: intact.index(" ts=")]
+    lines = [intact + "\n", torn + "\n"]
+
+    assert count_record_heads(lines) == 2
+    assert len(list(parse_spans(lines))) == 1


### PR DESCRIPTION
## Summary

- format each host log record dynamically and emit it with one `write`, preventing forked chip workers from interleaving STRACE records on shared stderr
- parse every STRACE marker on a physical line instead of letting greedy `attrs` consume later records
- add deterministic forked-process logger and adjacent-record parser regressions

## Testing

- baseline regression: `test_host_log_off` fails on `main` with two child records merged onto one physical line
- `ctest -R '^test_host_log_off$'`: 8/8 passed
- `pytest tests/ut/py/test_strace_timing.py -q`: 1 passed
- `ctest -LE requires_hardware`: 79/79 passed
- pre-commit checks passed, including formatting, Ruff, cpplint, pyright, headers, and clang-tidy
- full Python UT collection was blocked by the remote environment's stale editable install/Torch visibility; the targeted Python regression passed in an isolated checkout

Fixes #1690