### PR TITLE
Fix: release A5 swimlane buffers on completion

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -375,16 +375,6 @@ void SchedulerContext::check_running_cores_for_completion(
         );
         if (!t.matched) continue;
 
-#if SIMPLER_DFX
-        // Release an ACK-gated AICore swimlane buffer if this matched ACK/FIN is
-        // the one a rotation is waiting on: it proves the core advanced past the
-        // just-rotated buffer's tail record (FIN precedes the record write on
-        // this runtime, so rotation could not release the buffer itself).
-        if (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED) {
-            chip_swimlane_aicpu_on_aicore_ack(core_id, thread_idx, static_cast<uint32_t>(reg_task_id));
-        }
-#endif
-
 #if SIMPLER_SCHED_PROFILING
         if (chip_swimlane.chip_swimlane_enabled && (t.running_done || t.pending_done)) {
             chip_swimlane.complete_hit_count++;
@@ -401,6 +391,15 @@ void SchedulerContext::check_running_cores_for_completion(
         uint64_t finish_ts = 0;
         if (chip_swimlane_level_ >= ChipSwimlaneLevel::AICPU_TIMING && (t.pending_done || t.running_done)) {
             finish_ts = get_sys_cnt_aicpu();
+        }
+#endif
+
+#if SIMPLER_DFX
+        // Release an ACK-gated AICore swimlane buffer only after capturing the
+        // FIN observation timestamp. Publishing the retained buffer can do
+        // deferred-release work, which must not be charged to (end -> finish).
+        if (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED) {
+            chip_swimlane_aicpu_on_aicore_ack(core_id, thread_idx, static_cast<uint32_t>(reg_task_id));
         }
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -335,6 +335,15 @@ void SchedulerContext::check_running_cores_for_completion(
         }
 #endif
 
+#if SIMPLER_DFX
+        // Release an ACK-gated AICore swimlane buffer only after capturing the
+        // FIN observation timestamp. Publishing the retained buffer can do
+        // deferred-release work, which must not be charged to (end -> finish).
+        if (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED) {
+            chip_swimlane_aicpu_on_aicore_ack(core_id, thread_idx, static_cast<uint32_t>(reg_task_id));
+        }
+#endif
+
         // --- Apply phase: execute actions based on transition ---
 
         // 1. Complete finished tasks (capture pointers before modifying core state)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -184,9 +184,8 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 
     // AICore buffer rotation lives on the dispatch path: count this dispatch
     // and rotate before write_reg when we're about to cross a BUFFER_SIZE
-    // boundary. The just-filled buffer is stashed for ACK-gated release; a5 does
-    // not wire the ACK hook, so it drains via the next-rotation / run-end
-    // backstop. `reg_task_id` is passed as the gate token.
+    // boundary. The just-filled buffer is stashed until the completion path
+    // observes the matching ACK/FIN. `reg_task_id` is passed as the gate token.
 #if SIMPLER_DFX
     if (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED) {
         chip_swimlane_aicpu_on_aicore_dispatch(core_id, thread_idx, reg_task_id);


### PR DESCRIPTION
## Summary
- wire the A5 tensormap-and-ringbuffer completion path to the existing ACK-gated AICore buffer release hook
- release only after the completion state machine matches the ACK/FIN token, mirroring A2/A3
- update the dispatch-path comment to describe the active completion handshake

## Performance
A5 `vector_example`, same device, five independent one-round runs per variant. Each reported value drops one maximum and one minimum, then averages the remaining three.

| Chip swimlane | Metric | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| disabled | Device | 520.9 us | 498.2 us | -4.36% |
| disabled | Scheduler | 71.9 us | 69.5 us | -3.34% |
| level 1 | Device | 783.2 us | 754.6 us | -3.66% |
| level 1 | Scheduler | 77.0 us | 76.2 us | -1.08% |

No performance regression was observed; the small improvements are within run-to-run variation.

## Testing
- `pip install --no-build-isolation -e .`
- `python simpler_setup/build_runtimes.py --platforms a5 a5sim`
- C++ UT: `test_a5_wiring`, `test_chip_swimlane_aicore`
- A5 sim chip-swimlane smoke: 3 passed
- A5 onboard chip-swimlane smoke: 3 passed
- targeted `clang-format`, `clang-tidy`, and `cpplint`

Addresses #1582 (B1)