### PR TITLE
Refactor: give each run its own host tensor accessor

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -45,7 +45,7 @@ addresses populate the per-run dispatch table.
 
 For each run, the host:
 
-1. validates and stages external tensors, registering their host views;
+1. validates and stages external tensors into a run-owned host accessor;
 2. reserves one backing arena for runtime/shared-memory subregions;
 3. binds the runtime to the orchestration DSO;
 4. calls the orchestration entry synchronously;
@@ -65,7 +65,7 @@ eligibility. Exactly one returning AICPU thread claims that eligibility and
 resets executor/scheduler state for the next run.
 
 Publishing cleanup only after destruction prevents `deinit()` from racing the
-runtime arena or its file-scope binding.
+runtime arena or this run's host accessor.
 
 ## 3. Prebuilt Graph Image
 

--- a/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -22,8 +22,6 @@
 
 #include "common/host_api.h"
 
-namespace {
-
 struct HostTensorRegion {
     uint64_t dev_base;
     uint64_t size;
@@ -36,14 +34,17 @@ struct HostTensorRegion {
 // One entry per tensor staged for the run being orchestrated. A run stages a
 // handful of tensors and orchestration reads are cold-path, so a linear scan
 // costs less than the map that would replace it.
-std::vector<HostTensorRegion> g_regions;
-
-const HostApi *g_host_api = nullptr;
+struct HostTensorAccessor::Impl {
+    const HostApi *api;
+    std::vector<HostTensorRegion> regions;
+    std::vector<void *> mappings;
+};
 
 // The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
 // `*offset` is the span's distance from that region's base.
-const HostTensorRegion *find_region(uint64_t dev_addr, uint64_t bytes, uint64_t *offset) {
-    for (const HostTensorRegion &region : g_regions) {
+const HostTensorRegion *
+find_region(const std::vector<HostTensorRegion> &regions, uint64_t dev_addr, uint64_t bytes, uint64_t *offset) {
+    for (const HostTensorRegion &region : regions) {
         if (dev_addr < region.dev_base) {
             continue;
         }
@@ -57,11 +58,40 @@ const HostTensorRegion *find_region(uint64_t dev_addr, uint64_t bytes, uint64_t 
     return nullptr;
 }
 
-}  // namespace
+HostTensorAccessor::HostTensorAccessor(const HostApi *api) :
+    impl_(new Impl{api, {}, {}}) {}
 
-bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
+HostTensorAccessor::~HostTensorAccessor() {
+    close();
+    delete impl_;
+}
+
+bool HostTensorAccessor::add(uint64_t dev_base, uint64_t size, void *fallback_host_view) {
+    if (impl_->api == nullptr || dev_base == 0 || size == 0) {
+        return false;
+    }
+    // Both push_backs below run after the registration succeeds, so reserve
+    // first: a reallocation that threw there would leak the mapping.
+    impl_->regions.reserve(impl_->regions.size() + 1);
+    impl_->mappings.reserve(impl_->mappings.size() + 1);
+    void *host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
+    if (host_view != nullptr) {
+        impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
+    } else {
+        host_view = fallback_host_view;
+    }
+    if (host_view == nullptr) {
+        return false;
+    }
+    impl_->regions.push_back(
+        {dev_base, size, static_cast<unsigned char *>(host_view), reinterpret_cast<uintptr_t>(host_view) != dev_base}
+    );
+    return true;
+}
+
+bool HostTensorAccessor::read(uint64_t dev_addr, void *dst, uint64_t bytes) const {
     uint64_t offset = 0;
-    const HostTensorRegion *region = find_region(dev_addr, bytes, &offset);
+    const HostTensorRegion *region = find_region(impl_->regions, dev_addr, bytes, &offset);
     if (region == nullptr) {
         return false;
     }
@@ -69,9 +99,9 @@ bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
     return true;
 }
 
-bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
+bool HostTensorAccessor::write(uint64_t dev_addr, const void *src, uint64_t bytes) const {
     uint64_t offset = 0;
-    const HostTensorRegion *region = find_region(dev_addr, bytes, &offset);
+    const HostTensorRegion *region = find_region(impl_->regions, dev_addr, bytes, &offset);
     if (region == nullptr) {
         return false;
     }
@@ -80,26 +110,21 @@ bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
     if (!region->mirrored) {
         return true;
     }
-    if (g_host_api == nullptr) {
-        return false;
-    }
-    return g_host_api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
+    return impl_->api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
 }
 
-void host_tensor_access_reset(const HostApi *api) {
-    g_regions.clear();
-    g_host_api = api;
+void HostTensorAccessor::close() noexcept {
+    for (void *dev_ptr : impl_->mappings) {
+        impl_->api->unregister_device_memory_from_host(dev_ptr);
+    }
+    impl_->mappings.clear();
+    impl_->regions.clear();
 }
 
-bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view) {
-    if (host_view == nullptr || size == 0) {
-        return false;
-    }
-    HostTensorRegion region;
-    region.dev_base = dev_base;
-    region.size = size;
-    region.host_view = static_cast<unsigned char *>(host_view);
-    region.mirrored = reinterpret_cast<uintptr_t>(host_view) != static_cast<uintptr_t>(dev_base);
-    g_regions.push_back(region);
-    return true;
+bool host_tensor_read(HostTensorAccessor *accessor, uint64_t dev_addr, void *dst, uint64_t bytes) {
+    return accessor != nullptr && accessor->read(dev_addr, dst, bytes);
+}
+
+bool host_tensor_write(HostTensorAccessor *accessor, uint64_t dev_addr, const void *src, uint64_t bytes) {
+    return accessor != nullptr && accessor->write(dev_addr, src, bytes);
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -67,7 +67,6 @@
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
-#include "host/raii_scope_guard.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -348,11 +347,10 @@ typedef void (*OrchestrationEntryFunc)(const ChipTaskArgs &);
 typedef void (*OrchestrationBindFunc)(PTO2Runtime *);
 
 // Resolved orchestration .so entry points. register_callable_impl allocates one
-// of these (so both the entry and the .so's own framework_bind_runtime — which
-// sets the .so-private g_current_runtime its inline rt_submit_* reads — are
-// available per run) and stores its pointer in CallableArtifacts::
-// host_orch_func_ptr. Owned for the callable's lifetime alongside
-// host_dlopen_handle.
+// of these (the entry, plus the .so's own framework_bind_runtime, which sets
+// the .so-private g_current_runtime its inline rt_submit_* read) and stores its
+// pointer in CallableArtifacts::host_orch_func_ptr. Owned for the callable's
+// lifetime alongside host_dlopen_handle.
 struct HostOrchEntryPoints {
     OrchestrationEntryFunc entry{nullptr};
     OrchestrationBindFunc bind{nullptr};
@@ -467,7 +465,7 @@ struct GraphHostStateBinding {
 };
 
 int32_t run_host_orchestration(
-    Runtime *runtime, const HostApi *api, PTO2Runtime *rt, DeviceArena &host_arena,
+    Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
     const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
     const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
     void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
@@ -508,12 +506,17 @@ int32_t run_host_orchestration(
     rt->mode = PTO2_MODE_EXECUTE;
 
     const auto *entry_points = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
-    framework_bind_runtime(rt);
     if (entry_points->bind == nullptr) {
         LOG_ERROR("host-orch: orch .so framework_bind_runtime was not resolved");
         return -1;
     }
     rt->active_callable_hash = reinterpret_cast<uint64_t>(entry_points->entry);
+    rt->tensor_access = &tensor_access;
+    // Binds the orchestration .so's own framework_current_runtime, which its
+    // inline rt_submit_* read. The host library links a same-named copy from
+    // orchestration/common.cpp, but nothing outside the .so includes
+    // pto_orchestration_api.h, so nothing reads that one — rt_scope_* and
+    // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
     rt_scope_begin(rt);
@@ -697,13 +700,10 @@ extern "C" int bind_callable_to_runtime_impl(
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
 
-    // Open this run's host-view window. It closes once the orchestrator has
-    // finished, so no host view outlives the point at which a task could make
-    // it stale.
-    host_tensor_access_reset(api);
-    auto host_tensor_access_guard = RAIIScopeGuard([]() {
-        host_tensor_access_reset(nullptr);
-    });
+    // This run's host-view window. The accessor owns every mapping it
+    // registers and releases them on every exit path, so no host view outlives
+    // the point at which a task could make it stale.
+    HostTensorAccessor tensor_access(api);
 
     int64_t t_args_start = _now_ms();
     for (int i = 0; i < tensor_count; i++) {
@@ -757,11 +757,7 @@ extern "C" int bind_callable_to_runtime_impl(
         // to the device. A tensor with neither is not host-accessible, so the
         // prepare fails here rather than the orchestrator dereferencing a
         // device address.
-        void *host_view = api->register_device_memory_to_host(dev_ptr, size);
-        if (host_view == nullptr) {
-            host_view = host_ptr;
-        }
-        if (!host_tensor_access_add(reinterpret_cast<uint64_t>(dev_ptr), size, host_view)) {
+        if (!tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
             LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
             return -1;
         }
@@ -858,13 +854,12 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
-            eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap,
+            eff_heap_sizes, eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
-        host_tensor_access_reset(nullptr);
-        host_tensor_access_guard.dismiss();
+        tensor_access.close();
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;
@@ -988,12 +983,6 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     LOG_INFO("=== Cleaning Up ===");
     for (int i = 0; i < tensor_pair_count; i++) {
         if (tensor_pairs[i].dev_ptr != nullptr) {
-            // Release the SVM host mapping installed at staging time before
-            // freeing the device buffer (unregister-before-free, as the HAL
-            // requires). No-op on sim. Keyed by dev_ptr.
-            if (tensor_pairs[i].host_ptr != nullptr) {
-                api->unregister_device_memory_from_host(tensor_pairs[i].dev_ptr);
-            }
             api->device_free(tensor_pairs[i].dev_ptr);
         }
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -34,11 +34,11 @@
  * dereference: only tensors the runtime staged have a host view at all, so a
  * GM-heap tensor or a pass-through child-memory buffer resolves to nothing.
  *
- * Registrations are valid only for one orchestration run — the window between
+ * Registrations are owned by one orchestration run — the window between
  * staging and the first dispatched task. A mirror is a copy, and nothing has
  * executed yet to make it stale; once tasks run, a stale mirror would be
- * indistinguishable from live device memory. `host_tensor_access_reset` bounds
- * that window at both ends.
+ * indistinguishable from live device memory. `HostTensorAccessor` bounds that
+ * window and releases its mappings on every exit path.
  *
  * The read/write pair carries weak fallbacks in the runtime translation unit
  * (`orchestrator_core/pto_runtime2.cpp`) that dereference `dev_addr` directly,
@@ -55,12 +55,64 @@
 struct HostApi;  // common/host_api.h — fwd-declared so this header stays out of platform includes
 
 /**
+ * The registered regions of one orchestration run, and the mappings that run
+ * installed to serve them.
+ *
+ * One accessor per run, mutated only by the thread running that run's
+ * orchestration. The region and mapping tables are plain vectors with no lock,
+ * so concurrent `add` / `close` on one accessor is a data race; concurrent runs
+ * are isolated by each owning a separate accessor, which is what makes two runs
+ * unable to see or drop each other's regions.
+ *
+ * `add` is the only producer of mappings and the only caller of
+ * `register_device_memory_to_host`; `close` unregisters exactly the mappings
+ * this accessor installed and nothing else. Both are reached on every return
+ * path — `close` is idempotent and the destructor calls it — so a mapping
+ * cannot outlive the run that made it.
+ *
+ * A null `api` makes every `add` fail, so a registered region always implies a
+ * usable `api`; `write`'s mirror push-back relies on that and does not re-check.
+ *
+ * The state lives behind `Impl` because this header is also compiled by the
+ * AICPU build (through `orchestrator_core/pto_runtime2.cpp`, which resolves the
+ * weak read/write fallbacks below), and that build has no `<vector>`. Keep the
+ * standard containers in `host/host_tensor_access.cpp`.
+ */
+class HostTensorAccessor {
+public:
+    explicit HostTensorAccessor(const HostApi *api);
+    ~HostTensorAccessor();
+
+    HostTensorAccessor(const HostTensorAccessor &) = delete;
+    HostTensorAccessor &operator=(const HostTensorAccessor &) = delete;
+
+    /**
+     * Register `[dev_base, dev_base + size)`, preferring a host mapping of the
+     * device buffer and falling back to `fallback_host_view` (the staging copy)
+     * when the platform cannot map it.
+     *
+     * @return false for an empty region, a null `api`, or when neither a
+     *         mapping nor a fallback view is available.
+     */
+    bool add(uint64_t dev_base, uint64_t size, void *fallback_host_view);
+    bool read(uint64_t dev_addr, void *dst, uint64_t bytes) const;
+    bool write(uint64_t dev_addr, const void *src, uint64_t bytes) const;
+
+    /** Drop every region and unregister every mapping this accessor installed. */
+    void close() noexcept;
+
+private:
+    struct Impl;
+    Impl *impl_;
+};
+
+/**
  * Read `bytes` at device address `dev_addr` into `dst`.
  *
  * @return false when no registered region covers the whole span; `dst` is
  *         untouched.
  */
-bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
+bool host_tensor_read(HostTensorAccessor *accessor, uint64_t dev_addr, void *dst, uint64_t bytes);
 
 /**
  * Write `bytes` from `src` to device address `dev_addr`, leaving the bytes
@@ -69,23 +121,4 @@ bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
  * @return false when no registered region covers the whole span, or when the
  *         push-back to the device fails.
  */
-bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes);
-
-/**
- * Drop every registration and latch the host interface used to push
- * mirror-mode writes to the device (its `copy_to_device`; null when no write
- * can need one).
- *
- * Called around one orchestration run: before the first
- * `host_tensor_access_add`, and again once the run has finished, after which
- * every access fails until the next run registers its own tensors.
- */
-void host_tensor_access_reset(const HostApi *api);
-
-/**
- * Register `[dev_base, dev_base + size)` as reachable from the host at
- * `host_view`.
- *
- * @return false for an empty region or a null `host_view`.
- */
-bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view);
+bool host_tensor_write(HostTensorAccessor *accessor, uint64_t dev_addr, const void *src, uint64_t bytes);

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -41,12 +41,14 @@
 // address is not loadable in general. Visibility is hidden so the host .so
 // does not export them into the global dynamic symbol table (same pattern as
 // get_sys_cnt_aicpu above and the dep_gen stubs in pto_orchestrator.cpp).
-__attribute__((weak, visibility("hidden"))) bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
+__attribute__((weak, visibility("hidden"))) bool
+host_tensor_read(HostTensorAccessor *, uint64_t dev_addr, void *dst, uint64_t bytes) {
     memcpy(dst, reinterpret_cast<const void *>(dev_addr), bytes);
     return true;
 }
 
-__attribute__((weak, visibility("hidden"))) bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
+__attribute__((weak, visibility("hidden"))) bool
+host_tensor_write(HostTensorAccessor *, uint64_t dev_addr, const void *src, uint64_t bytes) {
     memcpy(reinterpret_cast<void *>(dev_addr), src, bytes);
     return true;
 }
@@ -310,7 +312,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
     uint64_t elem_size = get_element_size(tensor.dtype);
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     uint64_t result = 0;
-    if (!host_tensor_read(elem_addr, &result, elem_size)) {
+    if (!host_tensor_read(rt->tensor_access, elem_addr, &result, elem_size)) {
         rt->orchestrator.report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no host view for device address %#llx (%llu bytes): during host orchestration only tensors the "
@@ -341,7 +343,7 @@ void set_tensor_data(
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
-    if (!host_tensor_write(elem_addr, &value, elem_size)) {
+    if (!host_tensor_write(rt->tensor_access, elem_addr, &value, elem_size)) {
         rt->orchestrator.report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no writable host view for device address %#llx (%llu bytes): during host orchestration only tensors "

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -66,6 +66,7 @@ enum PTO2RuntimeMode {
  * dependencies on runtime .cpp files.
  */
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+class HostTensorAccessor;
 
 struct PTO2RuntimeOps {
     TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
@@ -156,6 +157,13 @@ struct PTO2Runtime {
     // Graph definitions are process-local host cache entries. The callable
     // identity prevents two orchestration DSOs from sharing the same key.
     uint64_t active_callable_hash;
+
+    // Host views of the tensors this run staged, owned by the run that
+    // registered them. Null on the AICPU path, which loads device addresses
+    // directly; get_tensor_data / set_tensor_data then fail closed rather than
+    // dereferencing one. Lives past the first two fields, so the orchestration
+    // .so's partial PTO2Runtime definition neither sees nor needs it.
+    HostTensorAccessor *tensor_access;
 
     // Prebuilt-arena fast path metadata. Carries every offset
     // wire_arena_pointers needs at AICPU boot so the AICPU can reconstruct

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -45,7 +45,7 @@ addresses populate the per-run dispatch table.
 
 For each run, the host:
 
-1. validates and stages external tensors, registering their host views;
+1. validates and stages external tensors into a run-owned host accessor;
 2. reserves one backing arena for runtime/shared-memory subregions;
 3. binds the runtime to the orchestration DSO;
 4. calls the orchestration entry synchronously;
@@ -65,7 +65,7 @@ eligibility. Exactly one returning AICPU thread claims that eligibility and
 resets executor/scheduler state for the next run.
 
 Publishing cleanup only after destruction prevents `deinit()` from racing the
-runtime arena or its file-scope binding.
+runtime arena or this run's host accessor.
 
 ## 3. Prebuilt Graph Image
 

--- a/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -22,8 +22,6 @@
 
 #include "common/host_api.h"
 
-namespace {
-
 struct HostTensorRegion {
     uint64_t dev_base;
     uint64_t size;
@@ -36,14 +34,17 @@ struct HostTensorRegion {
 // One entry per tensor staged for the run being orchestrated. A run stages a
 // handful of tensors and orchestration reads are cold-path, so a linear scan
 // costs less than the map that would replace it.
-std::vector<HostTensorRegion> g_regions;
-
-const HostApi *g_host_api = nullptr;
+struct HostTensorAccessor::Impl {
+    const HostApi *api;
+    std::vector<HostTensorRegion> regions;
+    std::vector<void *> mappings;
+};
 
 // The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
 // `*offset` is the span's distance from that region's base.
-const HostTensorRegion *find_region(uint64_t dev_addr, uint64_t bytes, uint64_t *offset) {
-    for (const HostTensorRegion &region : g_regions) {
+const HostTensorRegion *
+find_region(const std::vector<HostTensorRegion> &regions, uint64_t dev_addr, uint64_t bytes, uint64_t *offset) {
+    for (const HostTensorRegion &region : regions) {
         if (dev_addr < region.dev_base) {
             continue;
         }
@@ -57,11 +58,40 @@ const HostTensorRegion *find_region(uint64_t dev_addr, uint64_t bytes, uint64_t 
     return nullptr;
 }
 
-}  // namespace
+HostTensorAccessor::HostTensorAccessor(const HostApi *api) :
+    impl_(new Impl{api, {}, {}}) {}
 
-bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
+HostTensorAccessor::~HostTensorAccessor() {
+    close();
+    delete impl_;
+}
+
+bool HostTensorAccessor::add(uint64_t dev_base, uint64_t size, void *fallback_host_view) {
+    if (impl_->api == nullptr || dev_base == 0 || size == 0) {
+        return false;
+    }
+    // Both push_backs below run after the registration succeeds, so reserve
+    // first: a reallocation that threw there would leak the mapping.
+    impl_->regions.reserve(impl_->regions.size() + 1);
+    impl_->mappings.reserve(impl_->mappings.size() + 1);
+    void *host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
+    if (host_view != nullptr) {
+        impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
+    } else {
+        host_view = fallback_host_view;
+    }
+    if (host_view == nullptr) {
+        return false;
+    }
+    impl_->regions.push_back(
+        {dev_base, size, static_cast<unsigned char *>(host_view), reinterpret_cast<uintptr_t>(host_view) != dev_base}
+    );
+    return true;
+}
+
+bool HostTensorAccessor::read(uint64_t dev_addr, void *dst, uint64_t bytes) const {
     uint64_t offset = 0;
-    const HostTensorRegion *region = find_region(dev_addr, bytes, &offset);
+    const HostTensorRegion *region = find_region(impl_->regions, dev_addr, bytes, &offset);
     if (region == nullptr) {
         return false;
     }
@@ -69,9 +99,9 @@ bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
     return true;
 }
 
-bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
+bool HostTensorAccessor::write(uint64_t dev_addr, const void *src, uint64_t bytes) const {
     uint64_t offset = 0;
-    const HostTensorRegion *region = find_region(dev_addr, bytes, &offset);
+    const HostTensorRegion *region = find_region(impl_->regions, dev_addr, bytes, &offset);
     if (region == nullptr) {
         return false;
     }
@@ -80,26 +110,21 @@ bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
     if (!region->mirrored) {
         return true;
     }
-    if (g_host_api == nullptr) {
-        return false;
-    }
-    return g_host_api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
+    return impl_->api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
 }
 
-void host_tensor_access_reset(const HostApi *api) {
-    g_regions.clear();
-    g_host_api = api;
+void HostTensorAccessor::close() noexcept {
+    for (void *dev_ptr : impl_->mappings) {
+        impl_->api->unregister_device_memory_from_host(dev_ptr);
+    }
+    impl_->mappings.clear();
+    impl_->regions.clear();
 }
 
-bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view) {
-    if (host_view == nullptr || size == 0) {
-        return false;
-    }
-    HostTensorRegion region;
-    region.dev_base = dev_base;
-    region.size = size;
-    region.host_view = static_cast<unsigned char *>(host_view);
-    region.mirrored = reinterpret_cast<uintptr_t>(host_view) != static_cast<uintptr_t>(dev_base);
-    g_regions.push_back(region);
-    return true;
+bool host_tensor_read(HostTensorAccessor *accessor, uint64_t dev_addr, void *dst, uint64_t bytes) {
+    return accessor != nullptr && accessor->read(dev_addr, dst, bytes);
+}
+
+bool host_tensor_write(HostTensorAccessor *accessor, uint64_t dev_addr, const void *src, uint64_t bytes) {
+    return accessor != nullptr && accessor->write(dev_addr, src, bytes);
 }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -62,7 +62,6 @@
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
-#include "host/raii_scope_guard.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -346,11 +345,10 @@ typedef void (*OrchestrationEntryFunc)(const ChipTaskArgs &);
 typedef void (*OrchestrationBindFunc)(PTO2Runtime *);
 
 // Resolved orchestration .so entry points. register_callable_impl allocates one
-// of these (so both the entry and the .so's own framework_bind_runtime — which
-// sets the .so-private g_current_runtime its inline rt_submit_* reads — are
-// available per run) and stores its pointer in CallableArtifacts::
-// host_orch_func_ptr. Owned for the callable's lifetime alongside
-// host_dlopen_handle.
+// of these (the entry, plus the .so's own framework_bind_runtime, which sets
+// the .so-private g_current_runtime its inline rt_submit_* read) and stores its
+// pointer in CallableArtifacts::host_orch_func_ptr. Owned for the callable's
+// lifetime alongside host_dlopen_handle.
 struct HostOrchEntryPoints {
     OrchestrationEntryFunc entry{nullptr};
     OrchestrationBindFunc bind{nullptr};
@@ -449,7 +447,7 @@ static bool relocate_host_orch_image(
 }
 
 int32_t run_host_orchestration(
-    Runtime *runtime, const HostApi *api, PTO2Runtime *rt, DeviceArena &host_arena,
+    Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
     const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
     const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
     void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
@@ -496,12 +494,14 @@ int32_t run_host_orchestration(
     // context_lens/block_table) whether or not the platform maps device memory
     // into the host address space.
 
-    // Bind both framework_current_runtime instances: the host library's (used by
-    // rt_scope_* / rt_orchestration_done) and the orch .so's own copy (used by
-    // its inline rt_submit_* -> current_runtime()).
     const HostOrchEntryPoints *eps = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
-    framework_bind_runtime(rt);
     if (eps->bind != nullptr) {
+        rt->tensor_access = &tensor_access;
+        // Binds the orchestration .so's own framework_current_runtime, which its
+        // inline rt_submit_* read. The host library links a same-named copy from
+        // orchestration/common.cpp, but nothing outside the .so includes
+        // pto_orchestration_api.h, so nothing reads that one — rt_scope_* and
+        // rt_orchestration_done take the runtime as an argument.
         eps->bind(rt);
     } else {
         LOG_ERROR("host-orch: orch .so framework_bind_runtime was not resolved");
@@ -693,13 +693,10 @@ extern "C" int bind_callable_to_runtime_impl(
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
 
-    // Open this run's host-view window. It closes once the orchestrator has
-    // finished, so no host view outlives the point at which a task could make
-    // it stale.
-    host_tensor_access_reset(api);
-    auto host_tensor_access_guard = RAIIScopeGuard([]() {
-        host_tensor_access_reset(nullptr);
-    });
+    // This run's host-view window. The accessor owns every mapping it
+    // registers and releases them on every exit path, so no host view outlives
+    // the point at which a task could make it stale.
+    HostTensorAccessor tensor_access(api);
 
     int64_t t_args_start = _now_ms();
     for (int i = 0; i < tensor_count; i++) {
@@ -753,11 +750,7 @@ extern "C" int bind_callable_to_runtime_impl(
         // to the device. A tensor with neither is not host-accessible, so the
         // prepare fails here rather than the orchestrator dereferencing a
         // device address.
-        void *host_view = api->register_device_memory_to_host(dev_ptr, size);
-        if (host_view == nullptr) {
-            host_view = host_ptr;
-        }
-        if (!host_tensor_access_add(reinterpret_cast<uint64_t>(dev_ptr), size, host_view)) {
+        if (!tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
             LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
             return -1;
         }
@@ -860,13 +853,12 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
-            eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap,
+            eff_heap_sizes, eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
-        host_tensor_access_reset(nullptr);
-        host_tensor_access_guard.dismiss();
+        tensor_access.close();
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;
@@ -990,10 +982,6 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     LOG_INFO("=== Cleaning Up ===");
     for (int i = 0; i < tensor_pair_count; i++) {
         if (tensor_pairs[i].dev_ptr != nullptr) {
-            // Release the SVM host mapping installed at staging time before
-            // freeing the device buffer (unregister-before-free, as the HAL
-            // requires). No-op on sim. Keyed by dev_ptr.
-            api->unregister_device_memory_from_host(tensor_pairs[i].dev_ptr);
             api->device_free(tensor_pairs[i].dev_ptr);
         }
     }

--- a/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -34,11 +34,11 @@
  * dereference: only tensors the runtime staged have a host view at all, so a
  * GM-heap tensor or a pass-through child-memory buffer resolves to nothing.
  *
- * Registrations are valid only for one orchestration run — the window between
+ * Registrations are owned by one orchestration run — the window between
  * staging and the first dispatched task. A mirror is a copy, and nothing has
  * executed yet to make it stale; once tasks run, a stale mirror would be
- * indistinguishable from live device memory. `host_tensor_access_reset` bounds
- * that window at both ends.
+ * indistinguishable from live device memory. `HostTensorAccessor` bounds that
+ * window and releases its mappings on every exit path.
  *
  * The read/write pair carries weak fallbacks in the runtime translation unit
  * (`orchestrator_core/pto_runtime2.cpp`) that dereference `dev_addr` directly,
@@ -55,12 +55,64 @@
 struct HostApi;  // common/host_api.h — fwd-declared so this header stays out of platform includes
 
 /**
+ * The registered regions of one orchestration run, and the mappings that run
+ * installed to serve them.
+ *
+ * One accessor per run, mutated only by the thread running that run's
+ * orchestration. The region and mapping tables are plain vectors with no lock,
+ * so concurrent `add` / `close` on one accessor is a data race; concurrent runs
+ * are isolated by each owning a separate accessor, which is what makes two runs
+ * unable to see or drop each other's regions.
+ *
+ * `add` is the only producer of mappings and the only caller of
+ * `register_device_memory_to_host`; `close` unregisters exactly the mappings
+ * this accessor installed and nothing else. Both are reached on every return
+ * path — `close` is idempotent and the destructor calls it — so a mapping
+ * cannot outlive the run that made it.
+ *
+ * A null `api` makes every `add` fail, so a registered region always implies a
+ * usable `api`; `write`'s mirror push-back relies on that and does not re-check.
+ *
+ * The state lives behind `Impl` because this header is also compiled by the
+ * AICPU build (through `orchestrator_core/pto_runtime2.cpp`, which resolves the
+ * weak read/write fallbacks below), and that build has no `<vector>`. Keep the
+ * standard containers in `host/host_tensor_access.cpp`.
+ */
+class HostTensorAccessor {
+public:
+    explicit HostTensorAccessor(const HostApi *api);
+    ~HostTensorAccessor();
+
+    HostTensorAccessor(const HostTensorAccessor &) = delete;
+    HostTensorAccessor &operator=(const HostTensorAccessor &) = delete;
+
+    /**
+     * Register `[dev_base, dev_base + size)`, preferring a host mapping of the
+     * device buffer and falling back to `fallback_host_view` (the staging copy)
+     * when the platform cannot map it.
+     *
+     * @return false for an empty region, a null `api`, or when neither a
+     *         mapping nor a fallback view is available.
+     */
+    bool add(uint64_t dev_base, uint64_t size, void *fallback_host_view);
+    bool read(uint64_t dev_addr, void *dst, uint64_t bytes) const;
+    bool write(uint64_t dev_addr, const void *src, uint64_t bytes) const;
+
+    /** Drop every region and unregister every mapping this accessor installed. */
+    void close() noexcept;
+
+private:
+    struct Impl;
+    Impl *impl_;
+};
+
+/**
  * Read `bytes` at device address `dev_addr` into `dst`.
  *
  * @return false when no registered region covers the whole span; `dst` is
  *         untouched.
  */
-bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
+bool host_tensor_read(HostTensorAccessor *accessor, uint64_t dev_addr, void *dst, uint64_t bytes);
 
 /**
  * Write `bytes` from `src` to device address `dev_addr`, leaving the bytes
@@ -69,23 +121,4 @@ bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes);
  * @return false when no registered region covers the whole span, or when the
  *         push-back to the device fails.
  */
-bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes);
-
-/**
- * Drop every registration and latch the host interface used to push
- * mirror-mode writes to the device (its `copy_to_device`; null when no write
- * can need one).
- *
- * Called around one orchestration run: before the first
- * `host_tensor_access_add`, and again once the run has finished, after which
- * every access fails until the next run registers its own tensors.
- */
-void host_tensor_access_reset(const HostApi *api);
-
-/**
- * Register `[dev_base, dev_base + size)` as reachable from the host at
- * `host_view`.
- *
- * @return false for an empty region or a null `host_view`.
- */
-bool host_tensor_access_add(uint64_t dev_base, uint64_t size, void *host_view);
+bool host_tensor_write(HostTensorAccessor *accessor, uint64_t dev_addr, const void *src, uint64_t bytes);

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -41,12 +41,14 @@
 // address is not loadable in general. Visibility is hidden so the host .so
 // does not export them into the global dynamic symbol table (same pattern as
 // get_sys_cnt_aicpu above and the dep_gen stubs in pto_orchestrator.cpp).
-__attribute__((weak, visibility("hidden"))) bool host_tensor_read(uint64_t dev_addr, void *dst, uint64_t bytes) {
+__attribute__((weak, visibility("hidden"))) bool
+host_tensor_read(HostTensorAccessor *, uint64_t dev_addr, void *dst, uint64_t bytes) {
     memcpy(dst, reinterpret_cast<const void *>(dev_addr), bytes);
     return true;
 }
 
-__attribute__((weak, visibility("hidden"))) bool host_tensor_write(uint64_t dev_addr, const void *src, uint64_t bytes) {
+__attribute__((weak, visibility("hidden"))) bool
+host_tensor_write(HostTensorAccessor *, uint64_t dev_addr, const void *src, uint64_t bytes) {
     memcpy(reinterpret_cast<void *>(dev_addr), src, bytes);
     return true;
 }
@@ -297,7 +299,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
     uint64_t elem_size = get_element_size(tensor.dtype);
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     uint64_t result = 0;
-    if (!host_tensor_read(elem_addr, &result, elem_size)) {
+    if (!host_tensor_read(rt->tensor_access, elem_addr, &result, elem_size)) {
         rt->orchestrator.report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no host view for device address %#llx (%llu bytes): during host orchestration only tensors the "
@@ -328,7 +330,7 @@ void set_tensor_data(
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
-    if (!host_tensor_write(elem_addr, &value, elem_size)) {
+    if (!host_tensor_write(rt->tensor_access, elem_addr, &value, elem_size)) {
         rt->orchestrator.report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no writable host view for device address %#llx (%llu bytes): during host orchestration only tensors "

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -65,6 +65,7 @@ enum PTO2RuntimeMode {
  * dependencies on runtime .cpp files.
  */
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+class HostTensorAccessor;
 
 struct PTO2RuntimeOps {
     TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
@@ -150,6 +151,13 @@ struct PTO2Runtime {
 
     // Statistics
     int64_t total_cycles;
+
+    // Host views of the tensors this run staged, owned by the run that
+    // registered them. Null on the AICPU path, which loads device addresses
+    // directly; get_tensor_data / set_tensor_data then fail closed rather than
+    // dereferencing one. Lives past the first two fields, so the orchestration
+    // .so's partial PTO2Runtime definition neither sees nor needs it.
+    HostTensorAccessor *tensor_access;
 
     // Prebuilt-arena fast path metadata. Carries every offset
     // wire_arena_pointers needs at AICPU boot so the AICPU can reconstruct

--- a/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
@@ -10,17 +10,22 @@
  */
 
 /**
- * Host-view resolution for the host orchestrator's tensor reads and writes.
+ * Host-view resolution for the host orchestrator's tensor reads and writes,
+ * and the per-run ownership of the mappings that serve them.
  *
  * The mirror path (a platform that cannot map device memory into the host
  * address space) has no reachable call site on a2a3, whose SVM map always
- * succeeds, so these tests are the only place it executes.
+ * succeeds, so these tests are the only place it executes. `g_registered_view`
+ * is what the fake `register_device_memory_to_host` hands back: null models a
+ * platform with no mapping, so `add` falls back to the staging view.
  */
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <atomic>
 #include <cstdint>
-#include <cstring>
+#include <thread>
 #include <vector>
 
 #include "common/host_api.h"
@@ -39,67 +44,65 @@ struct CopyCall {
 };
 
 std::vector<CopyCall> g_copies;
+std::vector<void *> g_unregistered;
+void *g_registered_view = nullptr;
 int g_copy_result = 0;
 
-int record_copy(void *dev_ptr, const void *host_ptr, size_t size) {
+int record_copy(void *, void *dev_ptr, const void *host_ptr, size_t size) {
     g_copies.push_back({dev_ptr, host_ptr, size});
     return g_copy_result;
 }
 
-// host_tensor_access_reset retains the HostApi pointer for the run, so this
-// static test object outlives every binding. The adapter ignores runner_ctx.
-int record_copy_for_api(void * /*runner_ctx*/, void *dev_ptr, const void *host_ptr, size_t size) {
-    return record_copy(dev_ptr, host_ptr, size);
-}
-const HostApiOps kRecordCopyOps{.copy_to_device = record_copy_for_api};
-HostApi record_copy_api(nullptr, 0, 0, &kRecordCopyOps);
+void *record_register(void *, void *, size_t) { return g_registered_view; }
+
+void record_unregister(void *, void *dev_ptr) { g_unregistered.push_back(dev_ptr); }
+
+const HostApiOps kHostApiOps{
+    .copy_to_device = record_copy,
+    .register_device_memory_to_host = record_register,
+    .unregister_device_memory_from_host = record_unregister,
+};
+const HostApi kHostApi(nullptr, 0, 0, &kHostApiOps);
 
 class HostTensorAccessTest : public ::testing::Test {
 protected:
     void SetUp() override {
         g_copies.clear();
+        g_unregistered.clear();
+        g_registered_view = nullptr;
         g_copy_result = 0;
-        host_tensor_access_reset(&record_copy_api);
     }
-    void TearDown() override { host_tensor_access_reset(nullptr); }
 };
 
-// A buffer the host can load directly: the device address IS a host address,
-// as on a2a3 after halHostRegister and on sim.
 TEST_F(HostTensorAccessTest, DirectRegionReadsAndWritesInPlace) {
     int32_t buffer[4] = {10, 20, 30, 40};
     const uint64_t base = reinterpret_cast<uint64_t>(buffer);
-    ASSERT_TRUE(host_tensor_access_add(base, sizeof(buffer), buffer));
+    g_registered_view = buffer;
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(base, sizeof(buffer), nullptr));
 
     int32_t value = 0;
-    ASSERT_TRUE(host_tensor_read(base + 2 * sizeof(int32_t), &value, sizeof(value)));
+    ASSERT_TRUE(host_tensor_read(&accessor, base + 2 * sizeof(int32_t), &value, sizeof(value)));
     EXPECT_EQ(value, 30);
 
     const int32_t written = 99;
-    ASSERT_TRUE(host_tensor_write(base + sizeof(int32_t), &written, sizeof(written)));
+    ASSERT_TRUE(host_tensor_write(&accessor, base + sizeof(int32_t), &written, sizeof(written)));
     EXPECT_EQ(buffer[1], 99);
-    // The bytes are already the device's, so no push-back is issued.
     EXPECT_TRUE(g_copies.empty());
 }
 
-// A buffer the host reaches only through the staging copy.
-TEST_F(HostTensorAccessTest, MirroredRegionReadsFromTheHostView) {
+TEST_F(HostTensorAccessTest, MirroredRegionReadsAndPushesWrites) {
     int32_t mirror[4] = {1, 2, 3, 4};
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
 
     int32_t value = 0;
-    ASSERT_TRUE(host_tensor_read(kFakeDeviceBase + 3 * sizeof(int32_t), &value, sizeof(value)));
+    ASSERT_TRUE(host_tensor_read(&accessor, kFakeDeviceBase + 3 * sizeof(int32_t), &value, sizeof(value)));
     EXPECT_EQ(value, 4);
-}
-
-TEST_F(HostTensorAccessTest, MirroredWritePushesTheTouchedBytesToTheDevice) {
-    int32_t mirror[4] = {1, 2, 3, 4};
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
 
     const int32_t written = 77;
     const uint64_t dev_addr = kFakeDeviceBase + 2 * sizeof(int32_t);
-    ASSERT_TRUE(host_tensor_write(dev_addr, &written, sizeof(written)));
-
+    ASSERT_TRUE(host_tensor_write(&accessor, dev_addr, &written, sizeof(written)));
     EXPECT_EQ(mirror[2], 77);
     ASSERT_EQ(g_copies.size(), 1u);
     EXPECT_EQ(g_copies[0].dev_ptr, reinterpret_cast<void *>(dev_addr));
@@ -107,81 +110,183 @@ TEST_F(HostTensorAccessTest, MirroredWritePushesTheTouchedBytesToTheDevice) {
     EXPECT_EQ(g_copies[0].size, sizeof(int32_t));
 }
 
-TEST_F(HostTensorAccessTest, MirroredWriteFailsWhenThePushBackFails) {
+TEST_F(HostTensorAccessTest, MirroredWriteReportsCopyFailure) {
     int32_t mirror[2] = {1, 2};
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
 
     g_copy_result = -1;
     const int32_t written = 5;
-    EXPECT_FALSE(host_tensor_write(kFakeDeviceBase, &written, sizeof(written)));
-}
-
-TEST_F(HostTensorAccessTest, MirroredWriteFailsWithNoCopyHook) {
-    int32_t mirror[2] = {1, 2};
-    host_tensor_access_reset(nullptr);
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
-
-    const int32_t written = 5;
-    EXPECT_FALSE(host_tensor_write(kFakeDeviceBase, &written, sizeof(written)));
+    EXPECT_FALSE(host_tensor_write(&accessor, kFakeDeviceBase, &written, sizeof(written)));
 }
 
 // The fail-closed contract: an address outside every registered region — a
 // GM-heap tensor the orchestrator created, or a pass-through child-memory
 // buffer — resolves to nothing instead of being dereferenced.
-TEST_F(HostTensorAccessTest, UnregisteredAddressFailsAndLeavesTheDestination) {
+TEST_F(HostTensorAccessTest, UnregisteredSpanFailsClosed) {
     int32_t mirror[2] = {1, 2};
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
 
     int32_t value = 0xABCD;
-    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase + 0x100000, &value, sizeof(value)));
+    EXPECT_FALSE(host_tensor_read(&accessor, kFakeDeviceBase + 0x100000, &value, sizeof(value)));
     EXPECT_EQ(value, 0xABCD);
 
     const int32_t written = 5;
-    EXPECT_FALSE(host_tensor_write(kFakeDeviceBase + 0x100000, &written, sizeof(written)));
+    EXPECT_FALSE(host_tensor_write(&accessor, kFakeDeviceBase + 0x100000, &written, sizeof(written)));
     EXPECT_TRUE(g_copies.empty());
 }
 
-TEST_F(HostTensorAccessTest, SpanRunningPastTheRegionEndFails) {
+TEST_F(HostTensorAccessTest, SpanOverrunningTheRegionFails) {
     int32_t mirror[2] = {1, 2};
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
 
     int64_t value = 0;
     // Starts inside the region, ends past it.
-    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase + sizeof(int32_t), &value, sizeof(value)));
+    EXPECT_FALSE(host_tensor_read(&accessor, kFakeDeviceBase + sizeof(int32_t), &value, sizeof(value)));
     // Starts before it.
-    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase - sizeof(int32_t), &value, sizeof(int32_t)));
+    EXPECT_FALSE(host_tensor_read(&accessor, kFakeDeviceBase - sizeof(int32_t), &value, sizeof(int32_t)));
 }
 
-TEST_F(HostTensorAccessTest, ResetDropsEveryRegistration) {
-    int32_t mirror[2] = {1, 2};
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), mirror));
-
-    int32_t value = 0;
-    ASSERT_TRUE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
-
-    host_tensor_access_reset(&record_copy_api);
-    EXPECT_FALSE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
-}
-
-TEST_F(HostTensorAccessTest, EmptyOrNullRegionIsRejected) {
-    int32_t mirror[2] = {1, 2};
-    EXPECT_FALSE(host_tensor_access_add(kFakeDeviceBase, 0, mirror));
-    EXPECT_FALSE(host_tensor_access_add(kFakeDeviceBase, sizeof(mirror), nullptr));
-}
-
-// Several tensors are staged per run and each resolves against its own region.
-TEST_F(HostTensorAccessTest, RegionsAreResolvedIndependently) {
+// Several tensors are staged per run into one accessor, and each resolves
+// against its own region.
+TEST_F(HostTensorAccessTest, RegionsWithinOneAccessorResolveIndependently) {
     int32_t first[2] = {1, 2};
     int32_t second[2] = {3, 4};
     const uint64_t second_base = kFakeDeviceBase + 0x10000;
-    ASSERT_TRUE(host_tensor_access_add(kFakeDeviceBase, sizeof(first), first));
-    ASSERT_TRUE(host_tensor_access_add(second_base, sizeof(second), second));
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(first), first));
+    ASSERT_TRUE(accessor.add(second_base, sizeof(second), second));
 
     int32_t value = 0;
-    ASSERT_TRUE(host_tensor_read(kFakeDeviceBase, &value, sizeof(value)));
+    ASSERT_TRUE(host_tensor_read(&accessor, kFakeDeviceBase, &value, sizeof(value)));
     EXPECT_EQ(value, 1);
-    ASSERT_TRUE(host_tensor_read(second_base + sizeof(int32_t), &value, sizeof(value)));
+    ASSERT_TRUE(host_tensor_read(&accessor, second_base + sizeof(int32_t), &value, sizeof(value)));
     EXPECT_EQ(value, 4);
+}
+
+// `write` pushes mirror bytes back through `api->copy_to_device` without
+// re-checking the hook, which is only sound because a null api cannot produce a
+// region in the first place.
+TEST_F(HostTensorAccessTest, NullApiRegistersNothing) {
+    int32_t mirror[2] = {1, 2};
+    HostTensorAccessor accessor(nullptr);
+    EXPECT_FALSE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
+
+    int32_t value = 0;
+    EXPECT_FALSE(host_tensor_read(&accessor, kFakeDeviceBase, &value, sizeof(value)));
+    const int32_t written = 5;
+    EXPECT_FALSE(host_tensor_write(&accessor, kFakeDeviceBase, &written, sizeof(written)));
+}
+
+TEST_F(HostTensorAccessTest, ContextsKeepRegionsIndependent) {
+    int32_t first[2] = {1, 2};
+    int32_t second[2] = {3, 4};
+    HostTensorAccessor first_access(&kHostApi);
+    HostTensorAccessor second_access(&kHostApi);
+    ASSERT_TRUE(first_access.add(kFakeDeviceBase, sizeof(first), first));
+    ASSERT_TRUE(second_access.add(kFakeDeviceBase, sizeof(second), second));
+
+    int32_t value = 0;
+    ASSERT_TRUE(host_tensor_read(&first_access, kFakeDeviceBase, &value, sizeof(value)));
+    EXPECT_EQ(value, 1);
+    ASSERT_TRUE(host_tensor_read(&second_access, kFakeDeviceBase, &value, sizeof(value)));
+    EXPECT_EQ(value, 3);
+
+    first_access.close();
+    EXPECT_FALSE(host_tensor_read(&first_access, kFakeDeviceBase, &value, sizeof(value)));
+    EXPECT_TRUE(host_tensor_read(&second_access, kFakeDeviceBase, &value, sizeof(value)));
+}
+
+// Two concurrent runs each stage, read and close their own accessor. Both use
+// overlapping device addresses and the fallback view, so the only thing keeping
+// their regions apart is that each accessor owns its own tables — the property
+// a shared file-scope region list cannot have. Each thread mutates its tables
+// while the other is mutating its own, so a reintroduced global shows up as a
+// wrong value or a failed lookup rather than as a passing no-op.
+TEST_F(HostTensorAccessTest, ConcurrentRunsKeepRegionsIndependent) {
+    constexpr int kRegions = 8;
+    constexpr int kRounds = 64;
+
+    std::atomic<int> ready{0};
+    std::atomic<bool> start{false};
+
+    auto run = [&](int32_t seed, bool *ok) {
+        std::vector<std::array<int32_t, 2>> buffers(kRegions);
+        ready.fetch_add(1, std::memory_order_release);
+        while (!start.load(std::memory_order_acquire)) {}
+        for (int round = 0; round < kRounds; ++round) {
+            HostTensorAccessor accessor(&kHostApi);
+            for (int i = 0; i < kRegions; ++i) {
+                buffers[i] = {seed + i, seed + i + 100};
+                const uint64_t base = kFakeDeviceBase + static_cast<uint64_t>(i) * 0x10000;
+                if (!accessor.add(base, sizeof(buffers[i]), buffers[i].data())) {
+                    *ok = false;
+                    return;
+                }
+            }
+            for (int i = 0; i < kRegions; ++i) {
+                const uint64_t base = kFakeDeviceBase + static_cast<uint64_t>(i) * 0x10000;
+                int32_t value = 0;
+                if (!host_tensor_read(&accessor, base, &value, sizeof(value)) || value != seed + i) {
+                    *ok = false;
+                    return;
+                }
+            }
+            accessor.close();
+        }
+    };
+
+    bool first_ok = true;
+    bool second_ok = true;
+    std::thread first_thread(run, 1, &first_ok);
+    std::thread second_thread(run, 1000, &second_ok);
+    while (ready.load(std::memory_order_acquire) != 2) {}
+    start.store(true, std::memory_order_release);
+    first_thread.join();
+    second_thread.join();
+
+    EXPECT_TRUE(first_ok);
+    EXPECT_TRUE(second_ok);
+}
+
+TEST_F(HostTensorAccessTest, CloseReleasesOnlyOwnedMappings) {
+    int32_t first[2] = {1, 2};
+    int32_t second[2] = {3, 4};
+    HostTensorAccessor first_access(&kHostApi);
+    HostTensorAccessor second_access(&kHostApi);
+
+    g_registered_view = first;
+    ASSERT_TRUE(first_access.add(kFakeDeviceBase, sizeof(first), nullptr));
+    g_registered_view = second;
+    const uint64_t second_base = kFakeDeviceBase + 0x10000;
+    ASSERT_TRUE(second_access.add(second_base, sizeof(second), nullptr));
+
+    first_access.close();
+    ASSERT_EQ(g_unregistered.size(), 1u);
+    EXPECT_EQ(g_unregistered[0], reinterpret_cast<void *>(kFakeDeviceBase));
+    second_access.close();
+    ASSERT_EQ(g_unregistered.size(), 2u);
+    EXPECT_EQ(g_unregistered[1], reinterpret_cast<void *>(second_base));
+}
+
+TEST_F(HostTensorAccessTest, DestructorReleasesOwnedMapping) {
+    int32_t buffer[2] = {1, 2};
+    g_registered_view = buffer;
+    {
+        HostTensorAccessor accessor(&kHostApi);
+        ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(buffer), nullptr));
+    }
+    ASSERT_EQ(g_unregistered.size(), 1u);
+    EXPECT_EQ(g_unregistered[0], reinterpret_cast<void *>(kFakeDeviceBase));
+}
+
+TEST_F(HostTensorAccessTest, EmptyOrNullFallbackRegionIsRejected) {
+    int32_t mirror[2] = {1, 2};
+    HostTensorAccessor accessor(&kHostApi);
+    EXPECT_FALSE(accessor.add(kFakeDeviceBase, 0, mirror));
+    EXPECT_FALSE(accessor.add(kFakeDeviceBase, sizeof(mirror), nullptr));
 }
 
 }  // namespace

--- a/tests/ut/py/test_worker/test_remote_zero_residual.py
+++ b/tests/ut/py/test_worker/test_remote_zero_residual.py
@@ -157,7 +157,7 @@ def _remote_spec(port: int, *, num_sub_workers: int = 0) -> RemoteWorkerSpec:
     return RemoteWorkerSpec(
         endpoint=f"127.0.0.1:{port}",
         platform="a2a3sim",
-        transport="sim",
+        transport="host_tcp",
         num_sub_workers=num_sub_workers,
     )
 


### PR DESCRIPTION
## Summary

The host views a run stages lived in two file-scope globals in `libhost_runtime.so` — a region list and the `HostApi` pointer serving mirror-mode writes. **One instance per process, shared by every worker**, so two runs staging tensors overwrite each other's regions. The window was bounded by a hand-paired `host_tensor_access_reset(api)` / `reset(nullptr)` plus an `RAIIScopeGuard`, and the mapping each region needed was registered by the caller but released far away in cleanup.

`HostTensorAccessor` replaces both globals with one object per run:

- It **owns every mapping it registers** and releases them in `close()`, which the destructor also calls, so no exit path can leak one. Registration reserves both tables *before* it registers, so a throwing `push_back` cannot strand a mapping it has no record of.
- `register_device_memory_to_host` moves inside `add()`, which takes the staging buffer as the fallback view. **Register and unregister are now balanced per run** — previously a run that bound more than once per validate leaked the extra mappings.
- A null `HostApi` admits no region, so a mirrored write can no longer reach a null `copy_to_device` and `write()` needs no second check.

The runtime carries the accessor in a field past its first two — the only ones the orchestration `.so`'s partial `PTO2Runtime` definition can see. `get_tensor_data` / `set_tensor_data` read it from there, **so the ops table and every author-facing signature are unchanged and no kernel needs editing.**

`run_host_orchestration` no longer binds the host library's own copy of `framework_current_runtime`. Nothing outside the orchestration `.so` includes `pto_orchestration_api.h`, so nothing read it; `rt_scope_*` and `rt_orchestration_done` take the runtime as an argument. The `.so`'s own copy is still resolved and bound — its inline `rt_submit_*` read that one.

## Scope change from the previous revision

This PR previously also threaded an explicit `OrchestrationContext` parameter through every orchestration API (194 files, +2676 −2217). That half is **not** in this revision. Three findings, each checked against the code rather than reasoned about:

1. **The host-side bind was dead.** Every reader of `current_runtime()` is in `pto_orchestration_api.h`, and no source under `host/`, `aicpu/`, `runtime/`, `runtime/orchestrator_core/` or `runtime/shared/` `#include`s it — the only two greps that hit are comments:

   ```
   $ git grep -ln "pto_orchestration_api.h" main -- 'src/**'
     .../orchestration/{common.cpp,pto_arg_with_deps.h,pto_orchestration_api.h}
     .../runtime/{common.h,pto_runtime2.h}      # comments, not #include
   ```

2. **The `.so`-side global is per-callable, not per-process.** `register_callable_impl` creates a unique temp file per callable and `dlopen`s it `RTLD_LOCAL`; TMR keys `orch_so_table_[callable_id]`. Two workers get two `.so` mappings and two independent globals.

3. **Pipelining does not produce concurrent orchestration.** In `[orch N] → [device N]` overlapped with `[orch N+1]`, `orch N` has already returned before `orch N+1` starts — orch being shorter than the device phase is exactly what keeps the write/read serialized. TMR runs several orchestrator threads, but the comment on that code records that *"All orchestrator threads bind the same rt value"*.

So the global region table was the only state a concurrent run could actually corrupt, and it is what this PR fixes. Separately, `pto_orchestration_api.h` is a **Tier C external contract** under [`codestyle.md` rule 10](.claude/rules/codestyle.md) — `pypto`'s orchestration codegen (`src/codegen/orchestration/orchestration_codegen.cpp`) emits `rt_submit_aic_task` / `PTO2_SCOPE()` / `alloc_tensors(` against it, and five collectives templates `#include` it directly — so changing it needs a coordinated cross-repo change, not a unilateral sweep. If explicit context is wanted later (the concrete trigger would be W1c "direct depth two" genuinely putting two runs in `prepare` at once), rule 10's incremental doctrine applies: additive overloads plus the pypto change, not one sweep.

## Deliberately left out

- **The AICPU executors' `framework_bind_runtime` calls** (HBG teardown, TMR bind + teardown) are dead by the same argument, but they live in a different binary and a different file from this change. Separate cleanup.
- **Pre-existing doc drift** found while checking: `SUBMIT_BY_CLUSTER.md` documents `rt_submit_task(PTO2Runtime*, Arg*, int32_t)`, and the TMR `RUNTIME_LOGIC.md` export section documents `aicpu_orchestration_entry(uint64_t*, int)`. Both are wrong on `main` today and unrelated to this change, so they are not fixed here.

## Testing

- C++ no-hardware UT: **86 passed** on a clean rebuild. The host-tensor-access suite is 12 tests, up from 9.
- **All 105 orchestration sources parse unmodified** (`g++ -fsyntax-only` against each runtime's `build_config.py` include set) — direct evidence the author-facing API is untouched.
- `clang-format` clean; `examples/` and `tests/st/` have **zero** changed files.
- Not run here: scene tests, simulation, hardware.

## New coverage

`test_hbg_tensor_access.cpp` gains the cases the old global-based tests could not express:

- a null `api` admits no region — the invariant that lets `write()` skip re-checking the copy hook;
- two regions **in one accessor** each resolve independently, which is the production shape (a run stages several tensors) and the only case that walks past the first table entry;
- a span starting *before* a region base, alongside the existing overrun case;
- an unregistered write fails and issues no device copy;
- two concurrent runs each stage, read and close their own accessor over overlapping device addresses, so a reintroduced shared region table surfaces as a wrong value rather than passing silently.
