### PR TITLE
Refactor: make stream launch exact

### DIFF
--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -63,10 +63,10 @@ jobs:
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest examples tests/st -m "not sdma" --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
+            python -m pytest examples tests/st -m "not sdma" --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
+              --run "python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"
           fi
 
       - name: Run pytest scene tests (a2a3 legacy SDMA paths)

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -249,8 +249,8 @@ Applies to all 4 runtime executors: a2a3 (hbg, tmr), a5 (hbg, tmr).
 | SO | Caching | Lifecycle |
 | -- | ------- | --------- |
 | Host runtime | `ChipWorker::lib_handle_` | Per-init: dlopen in `init()`, dlclose in `finalize()` |
-| AICPU | `DeviceRunner::aicpu_so_handle_` | Per-init: loaded lazily by the first `enqueue_run()`, retained across runs, closed by `finalize()` |
-| AICore | `DeviceRunner::aicore_so_handle_` | Per-run: reloaded for the run's kernel binary, closed after a successful `drain_run()` (or by final cleanup) |
+| AICPU | `DeviceRunner::aicpu_so_handle_` | Per-init: loaded lazily by the first `prepare_execution()`, retained across runs, closed by `finalize()` |
+| AICore | `DeviceRunner::aicore_so_handle_` | Per-run: reloaded for the run's kernel binary, closed after a successful `drain_execution()` (or by final cleanup) |
 | Kernel | `DeviceRunner::func_id_to_addr_` (map by func_id) | Per-task: uploaded in `init_runtime_impl()`, removed in `validate_runtime_impl()` |
 | Orchestration | `AicpuExecutor::orch_so_handle_` | Per-run: loaded by orchestrator thread, closed by last thread in `deinit()` |
 
@@ -315,16 +315,16 @@ ChipWorker.run(handle, args, config)                   # public wrapper path
       new (buf) NativeRunContext(..., descriptor, host_api)   owns Runtime + executor state
       DeviceRunner::bind_callable_to_runtime(r, cid, &host_api, args, rings)
     simpler_launch_run(...)                         # acceptance was captured by prepare
-      executor thread: DeviceRunner::enqueue_run(r, config, slot)
+      executor thread: DeviceRunner::launch_execution(prepared, permit)
         clear_cpu_sim_shared_storage()
         ensure_binaries_loaded()             lazily dlopen AICPU; reload AICore for this run
         launch AICPU + AICore threads
         publish launch fence                 simpler_launch_run may return
-      executor thread: DeviceRunner::drain_run()
+      executor thread: DeviceRunner::drain_execution(active)
         join all threads
         dlclose AICore SO                     AICPU stays loaded across runs
     simpler_poll_run(...)                    caller thread, concurrent with drain
-      DeviceRunner::poll_run()                nonblocking completion query
+      DeviceRunner::poll_execution(active)    nonblocking completion query
     simpler_wait_run(...)
     simpler_finalize_run(...)
       validate_runtime_impl(r)               copy results, remove kernels
@@ -377,16 +377,16 @@ device_worker_main(device_id)
                 new (buf) NativeRunContext(..., descriptor, host_api)   owns Runtime + executor state
                 bind_callable_to_runtime()     replay + rtMalloc, rtMemcpy to device
               simpler_launch_run(...)               # publishes descriptor acceptance
-                executor thread: DeviceRunner::enqueue_run(..., slot)
+                executor thread: DeviceRunner::launch_execution(prepared, permit)
                   ensure_binaries_loaded()     already done by init
                   launch_aicore_kernel()       cached rtRegisterAllKernel handle
                                                  + rtKernelLaunchWithHandleV2
                   launch_aicpu_kernel(Run)     rtsLaunchCpuKernel, cached rtFuncHandle
                   publish launch fence         simpler_launch_run may return
-                executor thread: DeviceRunner::drain_run()
+                executor thread: DeviceRunner::drain_execution(active)
                   aclrtSynchronizeStreamWithTimeout() wait on both streams
               simpler_poll_run(...)            caller thread, concurrent with drain
-                DeviceRunner::poll_run()       nonblocking stream query
+                DeviceRunner::poll_execution(active) nonblocking stream query
               simpler_wait_run(...)
               simpler_finalize_run(...)        rtMemcpy results back; destroy state
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -241,28 +241,22 @@ int DeviceRunner::abandon_native_run_resources(uint32_t pipeline_slot) {
     return retire_run_aicore_stream(pipeline_slot, RunStreamSlots::CompletionStatus::Unproven);
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
+int DeviceRunner::prepare_execution(
+    Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+    std::unique_ptr<PreparedExecution> *prepared
+) {
+    if (prepared == nullptr || *prepared != nullptr) return -1;
     const unsigned selected_pipeline_slot = pipeline_slot;
-    if (active_run_.owns_resources) {
-        LOG_ERROR("enqueue_run entered while slot %u still owns resources", active_run_.slot);
-        return -1;
-    }
-    active_run_ = ActiveRunState{selected_pipeline_slot, true, false};
-    // Before the real AICPU launch marker, enqueue owns rollback. A successful
-    // enqueue dismisses this guard and transfers every resource to drain_run().
-    auto enqueue_rollback = RAIIScopeGuard([this]() {
-        cleanup_active_run(/*retire_aicore=*/true);
+    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
+    execution->resources_owned = true;
+    auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
+        cleanup_execution(*execution, /*launched=*/false, /*retire_aicore=*/false);
     });
     if (!run_stream_slots_.ready(selected_pipeline_slot)) {
         LOG_ERROR("run stream set %u was not provisioned during native prepare", selected_pipeline_slot);
         return -1;
     }
-    // Latch this run's diagnostic enables onto the runner before the collector
-    // paths below read them; block_dim/aicpu_thread_num are consumed locally.
-    apply_call_config(config);
-    // activate_launch_shape() latches this run's geometry onto the runner on the
-    // executor thread immediately before enqueue, so block_dim_ is this run's.
-    const int block_dim = block_dim_;
+    const int block_dim = runtime.get_worker_count() / cores_per_blockdim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade into
@@ -289,17 +283,17 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         return rc;
     }
 
-    ensure_device_wall_buffer();
+    ensure_device_wall_buffer(execution->kernel_args);
 
     if (block_dim < 1) {
-        LOG_ERROR("enqueue_run reached with unresolved block_dim; activate_launch_shape must run first");
+        LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
         return -1;
     }
     int num_aicore = block_dim * cores_per_blockdim_;
 
     // Get AICore register addresses for register-based task dispatch
     rc = init_aicore_register_addresses(
-        &kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_, AicoreRegKind::Ctrl
+        &execution->kernel_args.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_, AicoreRegKind::Ctrl
     );
     if (rc != 0) {
         LOG_ERROR("init_aicore_register_addresses(Ctrl) failed: %d", rc);
@@ -309,7 +303,8 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     // Get AICore PMU register addresses (distinct MMIO page from AIC_CTRL).
     if (enable_pmu_) {
         rc = init_aicore_register_addresses(
-            &kernel_args_.args.pmu_reg_addrs, static_cast<uint64_t>(device_id_), mem_alloc_, AicoreRegKind::Pmu
+            &execution->kernel_args.args.pmu_reg_addrs, static_cast<uint64_t>(device_id_), mem_alloc_,
+            AicoreRegKind::Pmu
         );
         if (rc != 0) {
             LOG_ERROR("init_aicore_register_addresses(Pmu) failed: %d", rc);
@@ -328,7 +323,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DEP_GEN);
     }
     if (enable_scope_stats_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
-    kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
+    execution->kernel_args.args.enable_profiling_flag = enable_profiling_flag;
 
     resolve_task_binary_addrs(runtime);
 
@@ -386,7 +381,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
 
     // Initialize per-subsystem shared memory.
     if (enable_chip_swimlane_) {
-        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
+        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
@@ -395,7 +390,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
 
     if (enable_dump_args_) {
         // Initialize args dump (independent from profiling)
-        rc = init_args_dump(runtime, device_id_);
+        rc = init_args_dump(runtime, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
@@ -403,7 +398,10 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     }
 
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
+        rc = init_pmu(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_,
+            execution->kernel_args
+        );
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -414,7 +412,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     // the device ring and its collector would allocate shared memory and a
     // drain thread for a stream that never produces a record.
     if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
-        rc = init_dep_gen(launch_aicpu_num, device_id_);
+        rc = init_dep_gen(launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
             return rc;
@@ -422,7 +420,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     }
 
     if (enable_scope_stats_) {
-        rc = init_scope_stats(launch_aicpu_num, device_id_);
+        rc = init_scope_stats(launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_scope_stats failed: %d", rc);
             return rc;
@@ -437,70 +435,43 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         return rc;
     }
 
-    rc = init_runtime_args_with_metadata(runtime);
+    rc = init_runtime_args_with_metadata(runtime, execution->kernel_args);
     if (rc != 0) return rc;
 
-    rc = kernel_args_init_ffts_base_addr(kernel_args_);
+    rc = kernel_args_init_ffts_base_addr(execution->kernel_args);
     if (rc != 0) {
         LOG_ERROR("init_ffts_base_addr failed: %d", rc);
         return rc;
     }
 
     // Copy KernelArgs to device memory for AICore
-    rc = kernel_args_.init_device_kernel_args(mem_alloc_);
+    rc = execution->kernel_args.init_device_kernel_args(mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("init_device_kernel_args failed: %d", rc);
         return rc;
     }
 
-    start_shared_collectors_for_run();
-    // a2a3-only dep_gen collector — share the same thread_factory shape as base.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
-        auto thread_factory = [this](std::function<void()> fn) {
-            return create_thread(std::move(fn));
-        };
-        dep_gen_collector_.start(thread_factory);
-    }
-
-    // workers[i].core_type is written by the AICore kernel during its
-    // AICPU<->AICore handshake (aicore_executor.cpp). That kernel is launched
-    // further below, so the values read here reflect the most recent prior
-    // run's handshake still resident in device memory (unset on the first run
-    // of a freshly-loaded runtime). We publish them to the chip swimlane
-    // collector so the AICORE_TIMING (level=1) host emit path can label lanes
-    // ("aic" / "aiv"). Sim sets workers[].core_type via the rule-based path in
-    // its own device_runner before init_chip_swimlane.
-    if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
-        std::vector<CoreType> core_types(num_aicore);
-        for (int i = 0; i < num_aicore; i++) {
-            core_types[i] = runtime.get_workers()[i].core_type;
-        }
-        chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
-    }
-
-    rc = launch_run(runtime, num_aicore, launch_aicpu_num, selected_pipeline_slot);
-    if (rc != 0) return rc;
-
-    enqueue_rollback.dismiss();
+    execution->num_aicore = num_aicore;
+    execution->launch_aicpu_num = launch_aicpu_num;
+    prepare_rollback.dismiss();
+    *prepared = std::move(execution);
     return 0;
 }
 
-int DeviceRunner::poll_run(uint32_t pipeline_slot) {
+int DeviceRunner::poll_execution(const ActiveExecution &active) {
+    if (active.prepared == nullptr) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    const uint32_t pipeline_slot = active.prepared->pipeline_slot;
     return run_stream_slots_.poll(pipeline_slot, [](void *aicpu, void *aicore) {
         return query_stream_pair_nonblocking(static_cast<rtStream_t>(aicpu), static_cast<rtStream_t>(aicore));
     });
 }
 
-int DeviceRunner::drain_run(uint32_t pipeline_slot) {
-    if (!active_run_.owns_resources || active_run_.slot != pipeline_slot) {
-        LOG_ERROR(
-            "drain_run slot mismatch: requested=%u active=%u owns=%d", pipeline_slot, active_run_.slot,
-            static_cast<int>(active_run_.owns_resources)
-        );
-        return -1;
-    }
-    auto drain_cleanup = RAIIScopeGuard([this]() {
-        cleanup_active_run(/*retire_aicore=*/true);
+int DeviceRunner::drain_execution(ActiveExecution &active) {
+    if (active.prepared == nullptr || !active.prepared->resources_owned) return -1;
+    PreparedExecution &prepared = *active.prepared;
+    const uint32_t pipeline_slot = prepared.pipeline_slot;
+    auto drain_cleanup = RAIIScopeGuard([this, &prepared]() {
+        cleanup_execution(prepared, /*launched=*/true, /*retire_aicore=*/true);
     });
 
     int rc = reap_run(pipeline_slot);
@@ -513,36 +484,40 @@ int DeviceRunner::drain_run(uint32_t pipeline_slot) {
     // is the run's error. Mark the attempt first so cleanup does not immediately
     // retry a failed destroy; the retained handle keeps the slot unusable and
     // lets finalize retry it later.
-    active_run_.aicore_retirement_attempted = true;
+    prepared.aicore_retirement_attempted = true;
     rc = retire_run_aicore_stream(pipeline_slot, RunStreamSlots::CompletionStatus::Complete);
     if (rc != 0) return rc;
 
     // Reads device memory, so it must precede KernelArgs/runtime cleanup.
-    print_handshake_results();
+    print_handshake_results(prepared.kernel_args);
     return 0;
 }
 
-void DeviceRunner::cleanup_active_run(bool retire_aicore) noexcept {
-    if (!active_run_.owns_resources) return;
+void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched, bool retire_aicore) noexcept {
+    if (!prepared.resources_owned) return;
 
     // Collectors must stop before their backing arguments are released; the
     // per-run stream retires last. Each cleanup operation is idempotent.
-    finalize_collectors();
-    (void)kernel_args_.finalize_device_kernel_args();
-    (void)kernel_args_.finalize_runtime_args();
-    if (kernel_args_.args.pmu_reg_addrs != 0) {
-        (void)mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.pmu_reg_addrs));
-        kernel_args_.args.pmu_reg_addrs = 0;
+    if (launched) finalize_collectors();
+    (void)prepared.kernel_args.finalize_device_kernel_args();
+    (void)prepared.kernel_args.finalize_runtime_args();
+    if (prepared.kernel_args.args.pmu_reg_addrs != 0) {
+        (void)mem_alloc_.free(reinterpret_cast<void *>(prepared.kernel_args.args.pmu_reg_addrs));
+        prepared.kernel_args.args.pmu_reg_addrs = 0;
     }
-    if (kernel_args_.args.regs != 0) {
-        (void)mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
-        kernel_args_.args.regs = 0;
+    if (prepared.kernel_args.args.regs != 0) {
+        (void)mem_alloc_.free(reinterpret_cast<void *>(prepared.kernel_args.args.regs));
+        prepared.kernel_args.args.regs = 0;
     }
-    if (retire_aicore && !active_run_.aicore_retirement_attempted) {
-        active_run_.aicore_retirement_attempted = true;
-        (void)retire_run_aicore_stream(active_run_.slot, RunStreamSlots::CompletionStatus::Unproven);
+    if (retire_aicore && !prepared.aicore_retirement_attempted) {
+        prepared.aicore_retirement_attempted = true;
+        (void)retire_run_aicore_stream(prepared.pipeline_slot, RunStreamSlots::CompletionStatus::Unproven);
     }
-    active_run_.owns_resources = false;
+    prepared.resources_owned = false;
+}
+
+void DeviceRunner::abandon_prepared_execution(PreparedExecution &prepared) noexcept {
+    cleanup_execution(prepared, /*launched=*/false, /*retire_aicore=*/true);
 }
 
 int DeviceRunner::ensure_run_stream_set(unsigned slot) {
@@ -573,73 +548,103 @@ int DeviceRunner::destroy_run_stream_sets() {
     return rc;
 }
 
-int DeviceRunner::launch_run(Runtime &runtime, int num_aicore, int launch_aicpu_num, unsigned slot) {
+DeviceRunnerBase::LaunchOutcome
+DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) {
+    LaunchOutcome outcome;
+    if (prepared == nullptr) return outcome;
+
+    LaunchTransactionResult transaction = launch_run(*prepared, std::move(permit));
+    if (transaction.poisoned()) recover_device_or_mark_unusable(transaction.rc);
+    outcome.rc = transaction.rc;
+    outcome.progress = transaction.progress;
+    outcome.receipt = std::move(transaction.receipt);
+    if (transaction.progress == LaunchProgress::NotStarted) {
+        outcome.prepared = std::move(prepared);
+    } else {
+        outcome.active = std::make_unique<ActiveExecution>(std::move(prepared), transaction.progress);
+    }
+    return outcome;
+}
+
+LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, LaunchPermit permit) {
+    Runtime &runtime = *prepared.runtime;
+    const int num_aicore = prepared.num_aicore;
+    const int launch_aicpu_num = prepared.launch_aicpu_num;
+    const unsigned slot = prepared.pipeline_slot;
     // KernelLaunch is the pipeline boundary: this method clears the handshake
     // consumed by the launch and submits exactly the AICore and AICPU kernels.
     // It intentionally performs no stream synchronization or per-run cleanup.
     if (!run_stream_slots_.ready(slot)) {
         LOG_ERROR("launch_run: stream set %u is not ready", slot);
-        return -1;
+        return LaunchTransactionResult{};
     }
     RunStreamSet streams{run_stream_slots_.aicpu(slot), run_stream_slots_.aicore(slot)};
-    int rc = 0;
+    LaunchTransactionResult result = exact_launch_transaction(
+        prepared.identity, std::move(permit),
+        [&]() {
+            activate_launch_shape(runtime);
+            (void)arm_device_wall_buffer(prepared.kernel_args);
+            start_shared_collectors_for_run();
+            if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                auto thread_factory = [this](std::function<void()> fn) {
+                    return create_thread(std::move(fn));
+                };
+                dep_gen_collector_.start(thread_factory);
+            }
+            if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
+                std::vector<CoreType> core_types(num_aicore);
+                for (int i = 0; i < num_aicore; i++)
+                    core_types[i] = runtime.get_workers()[i].core_type;
+                chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
+            }
+            int rc = run_stream_slots_.mark_submitted(slot);
+            if (rc != 0) {
+                LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
+                return rc;
+            }
 
-    // Publish query/drain ownership before either kernel launch. The real
-    // launch marker is notified inside launch_aicpu_kernel(), so no state that
-    // poll or drain needs may be committed after that call succeeds.
-    rc = run_stream_slots_.mark_submitted(slot);
-    if (rc != 0) {
-        LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
-        return rc;
-    }
+            // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
+            // so the two arches stay symmetric. First-launch latency optimization +
+            // op-timeout-family defense-in-depth: with the AICPU Run task launched first
+            // it occupies the device (spinning in the handshake), and the first AICore
+            // launch — which lazily loads the kernel binary onto the device inside
+            // rtKernelLaunchWithHandleV2 — is slow; launching AICore first does that load
+            // on an idle device. The handshake is launch-order-independent. The ~1.4 s
+            // slow-launch / 207001 wedge was measured on a5; this mirror is UNVERIFIED on
+            // a2a3 silicon (the dev box is a5-only), relying on CI. See
+            // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
+            // The AICore publishes aicore_done on launch (gated by nothing), and the
+            // workers region persists across runs in the pooled arena. Clearing each
+            // worker's aicore_done before the AICore kernel launches keeps the AICPU's
+            // handshake sweep from reading a prior run's report — which would open a
+            // window on that run's physical_core_id. Only aicore_done needs clearing; the
+            // AICore overwrites physical_core_id/core_type in the same report.
+            Handshake *workers = runtime.get_workers();
+            for (int i = 0; i < num_aicore; i++)
+                workers[i].aicore_done = 0;
 
-    // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
-    // so the two arches stay symmetric. First-launch latency optimization +
-    // op-timeout-family defense-in-depth: with the AICPU Run task launched first
-    // it occupies the device (spinning in the handshake), and the first AICore
-    // launch — which lazily loads the kernel binary onto the device inside
-    // rtKernelLaunchWithHandleV2 — is slow; launching AICore first does that load
-    // on an idle device. The handshake is launch-order-independent. The ~1.4 s
-    // slow-launch / 207001 wedge was measured on a5; this mirror is UNVERIFIED on
-    // a2a3 silicon (the dev box is a5-only), relying on CI. See
-    // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
-    // The AICore publishes aicore_done on launch (gated by nothing), and the
-    // workers region persists across runs in the pooled arena. Clearing each
-    // worker's aicore_done before the AICore kernel launches keeps the AICPU's
-    // handshake sweep from reading a prior run's report — which would open a
-    // window on that run's physical_core_id. Only aicore_done needs clearing; the
-    // AICore overwrites physical_core_id/core_type in the same report.
-    {
-        Handshake *workers = runtime.get_workers();
-        for (int i = 0; i < num_aicore; i++) {
-            workers[i].aicore_done = 0;
+            LOG_INFO("=== launch_aicore_kernel ===");
+            int launch_rc = launch_aicore_kernel(streams.aicore, prepared.kernel_args.device_k_args_);
+            if (launch_rc != 0) {
+                LOG_ERROR("launch_aicore_kernel failed: %d", launch_rc);
+                recover_device_or_mark_unusable(launch_rc);
+            }
+            return launch_rc;
+        },
+        [&]() {
+            LOG_INFO("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
+            int aicpu_launch_n =
+                (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
+            int launch_rc = launch_aicpu_kernel(
+                streams.aicpu, &prepared.kernel_args.args, host::KernelNames::RunName, aicpu_launch_n
+            );
+            if (launch_rc != 0) {
+                LOG_ERROR("launch_aicpu_kernel (main) failed: %d", launch_rc);
+            }
+            return launch_rc;
         }
-    }
-
-    LOG_INFO("=== launch_aicore_kernel ===");
-    // Launch AICore kernel (pass device copy of KernelArgs)
-    rc = launch_aicore_kernel(streams.aicore, kernel_args_.device_k_args_);
-    if (rc != 0) {
-        LOG_ERROR("launch_aicore_kernel failed: %d", rc);
-        recover_device_or_mark_unusable(rc);
-        return rc;
-    }
-
-    LOG_INFO("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
-    int aicpu_launch_n = (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
-    rc = launch_aicpu_kernel(streams.aicpu, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
-    if (rc != 0) {
-        LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
-        // The AICore worker was already launched above and is now spinning in
-        // the handshake waiting for this AICPU Run task. If the Run launch
-        // fails, that AICore is orphaned and will spin to the op-timeout,
-        // poisoning the device — so recover/mark-unusable here (matches the
-        // launch_aicore failure path).
-        recover_device_or_mark_unusable(rc);
-        return rc;
-    }
-
-    return 0;
+    );
+    return result;
 }
 
 int DeviceRunner::reap_run(unsigned slot) {
@@ -1062,7 +1067,9 @@ int DeviceRunner::finalize() {
 
 // `launch_aicpu_kernel` and `launch_aicore_kernel` live on `DeviceRunnerBase`.
 
-int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id) {
+int DeviceRunner::init_chip_swimlane(
+    int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args
+) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1091,14 +1098,14 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
         return rc;
     }
 
-    kernel_args_.args.chip_swimlane_data_base =
+    kernel_args.args.chip_swimlane_data_base =
         reinterpret_cast<uint64_t>(chip_swimlane_collector_.get_chip_swimlane_setup_device_ptr());
-    kernel_args_.args.chip_swimlane_aicore_rotation_table =
+    kernel_args.args.chip_swimlane_aicore_rotation_table =
         reinterpret_cast<uint64_t>(chip_swimlane_collector_.get_aicore_ring_addr_table_device_ptr());
     return 0;
 }
 
-int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
+int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
@@ -1129,12 +1136,13 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
         return rc;
     }
 
-    kernel_args_.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
+    kernel_args.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
     return 0;
 }
 
 int DeviceRunner::init_pmu(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
+    KernelArgsHelper &kernel_args
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -1163,11 +1171,11 @@ int DeviceRunner::init_pmu(
         return rc;
     }
 
-    kernel_args_.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
+    kernel_args.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
     return 0;
 }
 
-int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
+int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1194,11 +1202,11 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
         return rc;
     }
 
-    kernel_args_.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
+    kernel_args.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
 }
 
-int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
+int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1225,7 +1233,7 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
         return rc;
     }
 
-    kernel_args_.args.scope_stats_data_base =
+    kernel_args.args.scope_stats_data_base =
         reinterpret_cast<uint64_t>(scope_stats_collector_.get_scope_stats_shm_device_ptr());
     return 0;
 }
@@ -1256,6 +1264,5 @@ void DeviceRunner::finalize_collectors() {
     }
     if (scope_stats_collector_.is_initialized()) {
         scope_stats_collector_.finalize(unregister_cb, free_cb);
-        kernel_args_.args.scope_stats_data_base = 0;
     }
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -94,9 +94,14 @@ public:
 
     // The blocking entry point composes these operations. enqueue owns rollback
     // until the AICPU launch marker; drain takes that ownership on success.
-    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
-    int poll_run(uint32_t pipeline_slot) override;
-    int drain_run(uint32_t pipeline_slot) override;
+    int prepare_execution(
+        Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+        std::unique_ptr<PreparedExecution> *prepared
+    ) override;
+    LaunchOutcome launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) override;
+    void abandon_prepared_execution(PreparedExecution &prepared) noexcept override;
+    int poll_execution(const ActiveExecution &active) override;
+    int drain_execution(ActiveExecution &active) override;
     bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }
     int provision_native_run_resources(uint32_t pipeline_slot) override;
     int abandon_native_run_resources(uint32_t pipeline_slot) override;
@@ -185,7 +190,7 @@ private:
     // Most lifecycle state (device_id_, block_dim_, cores_per_blockdim_,
     // worker_count_, executor + dispatcher bytes, aicore_bin_handle_,
     // load_aicpu_op_, mem_alloc_, the three DeviceArenas + their cached
-    // sizes, persistent AICPU/AICore streams, kernel_args_, device_wall_*,
+    // sizes, persistent AICPU/AICore streams, device_wall_*,
     // binaries_loaded_) is inherited from `DeviceRunnerBase`.
 
     // Group D state (`chip_callable_buffers_`, `callables_`,
@@ -210,7 +215,7 @@ private:
     // but a *force* reset clears it: finalize() calls force_reset_device() on
     // this path so the next Worker re-inits clean in the same process (see
     // force_reset_device()). This flag drives admission and recovery. See
-    // enqueue_run() and recover_device_or_mark_unusable().
+    // launch_execution() and recover_device_or_mark_unusable().
     // The prepared-run admission thread reads this while the sole device
     // executor may poison the runner after a failed launch.
     std::atomic<bool> device_unusable_{false};
@@ -247,21 +252,14 @@ private:
     int retire_run_aicore_stream(unsigned slot, RunStreamSlots::CompletionStatus completion_status);
     int destroy_run_stream_sets();
 
-    struct ActiveRunState {
-        unsigned slot{PTO_PIPELINE_MAX_DEPTH};
-        bool owns_resources{false};
-        bool aicore_retirement_attempted{false};
-    };
-    ActiveRunState active_run_{};
-
-    // Release executor-owned resources in collector, runtime-argument,
-    // register-buffer, then stream order. Stream retirement is optional because
-    // the success path must report its error without retrying it immediately.
-    void cleanup_active_run(bool retire_aicore) noexcept;
+    // Release execution-owned resources in collector, runtime-argument,
+    // register-buffer, then stream order. Prepared-only cleanup must not touch
+    // collector state owned by an active predecessor.
+    void cleanup_execution(PreparedExecution &prepared, bool launched, bool retire_aicore) noexcept;
 
     // The kernel submission boundary is separate from the stream wait and
-    // post-run teardown: enqueue_run() launches and drain_run() reaps.
-    int launch_run(Runtime &runtime, int num_aicore, int launch_aicpu_num, unsigned slot);
+    // post-run teardown: launch_run() submits and drain_execution() reaps.
+    LaunchTransactionResult launch_run(PreparedExecution &prepared, LaunchPermit permit);
     int reap_run(unsigned slot);
 
     // On an AICore launch/sync error, best-effort drain the device so a later
@@ -304,7 +302,7 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
+    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Initialize args dump shared memory and collector.
@@ -316,7 +314,7 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_args_dump(Runtime &runtime, int device_id);
+    int init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Initialize PMU streaming shared memory.
@@ -332,7 +330,10 @@ private:
      * @param device_id  Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+    int init_pmu(
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
+        KernelArgsHelper &kernel_args
+    );
 
     /**
      * Initialize dep_gen capture shared memory.
@@ -346,8 +347,8 @@ private:
      * @param device_id          Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_dep_gen(int num_threads, int device_id);
-    int init_scope_stats(int num_threads, int device_id);
+    int init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args);
+    int init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Finalize whichever diagnostics collectors are currently initialized,

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -296,23 +296,26 @@ void DeviceRunner::destroy_native_run_thread_state(void *snapshot) noexcept {
     dep_gen_host_graph_destroy_capture(snapshot);
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t /*pipeline_slot*/) {
+int DeviceRunner::prepare_execution(
+    Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+    std::unique_ptr<PreparedExecution> *prepared
+) {
+    if (prepared == nullptr || *prepared != nullptr) return -1;
     if (active_run_ != nullptr) {
-        LOG_ERROR("enqueue_run called while another simulated run still owns execution state");
+        LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
         return -1;
     }
+    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     active_run_ = std::make_unique<ActiveRun>();
     active_run_->runtime = &runtime;
     run_completion_.reset(1);
-    auto enqueue_cleanup = RAIIScopeGuard([this]() {
+    auto prepare_cleanup = RAIIScopeGuard([this]() {
         run_completion_.abandon();
         cleanup_active_run();
     });
 
     apply_call_config(config);
-    // prepare_launch_shape() resolved block_dim before the graph was built, so
-    // the geometry this run launches with is already on the runner.
-    const int block_dim = block_dim_;
+    const int block_dim = runtime.get_worker_count() / cores_per_blockdim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
     // Sim has no hardware topology to probe, so auto uses the architecture
@@ -321,7 +324,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
     runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
-        LOG_ERROR("enqueue_run reached with unresolved block_dim; prepare_launch_shape must run first");
+        LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
         return -1;
     }
 
@@ -489,115 +492,123 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         return -1;
     }
 
-    set_platform_regs_func_(kernel_args_.regs);
-    if (set_orch_device_id_func_ != nullptr) {
-        set_orch_device_id_func_(device_id_);
-    }
-    set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_dump_args_enabled_func_(enable_dump_args_);
-    set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
-    set_platform_chip_swimlane_aicore_rotation_table_func_(kernel_args_.chip_swimlane_aicore_rotation_table);
-    set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
-    set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
-    set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);
-    set_pmu_enabled_func_(enable_pmu_);
-    set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
-    set_dep_gen_enabled_func_(enable_dep_gen_ && !dep_gen_host_graph_active());
-    set_scope_stats_enabled_func_(enable_scope_stats_);
-    set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
-
-    // Start collector mgmt + poll threads now, just before kernels launch.
-    auto thread_factory = [this](std::function<void()> fn) {
-        return create_thread(std::move(fn));
-    };
-    if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.start(thread_factory);
-    }
-    if (enable_dump_args_) {
-        dump_collector_.start(thread_factory);
-    }
-    if (enable_pmu_) {
-        pmu_collector_.start(thread_factory);
-    }
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
-        dep_gen_collector_.start(thread_factory);
-    }
-    if (enable_scope_stats_) {
-        scope_stats_collector_.start(thread_factory);
-    }
-
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
-    active_run_->aicpu_threads.reserve(over_launch);
-    active_run_->aicore_threads.reserve(num_aicore);
-
-    // Sim "device wall" capture: RunWall via host steady_clock through the
-    // single-uint64 device_wall_data_base buffer (sim has no kernel.cpp wrapper
-    // to stamp it). The finer preamble/so_load/graph_build/post_orch + orch/sched
-    // phases are stamped by the AICPU `.so` (real sim get_sys_cnt_aicpu clock)
-    // into a separate AicpuPhaseRecord buffer whose base is published into the SO
-    // via the dlsym'd set_platform_phase_base — crossing the dlopen boundary the
-    // same way set_platform_dump_base etc. do. The active run owns the buffer
-    // until drain reduces it into device_phase_ns_.
-    if (kernel_args_.device_wall_data_base != 0) {
-        *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
-    }
     constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
     constexpr size_t kTailRecs = static_cast<size_t>(task_timing_buffer_slots(kPhaseThreads));
-    // One 16-byte-record vector backs the phase region plus the task-timing tail
-    // (both records are 16 bytes; {kPhaseUnset, 0} initializes an AicpuPhaseRecord
-    // start/end and a TaskTimingRecord dispatch/finish identically). The AICPU SO
-    // resolves the tail at base + task_timing_tail_offset(), so it must be part of
-    // the same published buffer.
     static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
     active_run_->phase_buf.assign(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
-    set_platform_phase_base_func_(reinterpret_cast<uint64_t>(active_run_->phase_buf.data()));
-    const auto sim_t0 = std::chrono::steady_clock::now();
-    run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
-    ActiveRun *run = active_run_.get();
-
-    for (int i = 0; i < over_launch; i++) {
-        run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
-            if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
-                run_completion_.task_finished();
-                return;
-            }
-            int rc = aicpu_execute_func_(run->runtime);
-            if (kernel_args_.device_wall_data_base != 0) {
-                const auto t1 = std::chrono::steady_clock::now();
-                *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) =
-                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - sim_t0).count());
-            }
-            run_completion_.task_finished(rc);
-        }));
-    }
-
-    LOG_INFO("Launching %d AICore thread(s)", num_aicore);
-    for (int i = 0; i < num_aicore; i++) {
-        CoreType core_type = runtime.get_workers()[i].core_type;
-        uint32_t physical_core_id = static_cast<uint32_t>(i);
-        run->aicore_threads.push_back(create_thread([this, run, i, core_type, physical_core_id]() {
-            aicore_execute_func_(
-                run->runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
-                kernel_args_.chip_swimlane_aicore_rotation_table
-            );
-            run_completion_.task_finished();
-        }));
-    }
-
-    // Both simulated kernel thread groups now exist. This is the sim's real
-    // launch boundary. Their state remains owned until drain_run().
-    publish_task_accepted();
-    enqueue_cleanup.dismiss();
+    active_run_->aicpu_threads.reserve(over_launch);
+    active_run_->aicore_threads.reserve(num_aicore);
+    execution->num_aicore = num_aicore;
+    execution->launch_aicpu_num = launch_aicpu_num;
+    prepare_cleanup.dismiss();
+    *prepared = std::move(execution);
     return 0;
 }
 
-int DeviceRunner::poll_run() { return run_completion_.poll(); }
+SimDeviceRunnerBase::LaunchOutcome
+DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) {
+    LaunchOutcome outcome;
+    if (prepared == nullptr) return outcome;
+    Runtime &runtime = *prepared->runtime;
+    const int num_aicore = prepared->num_aicore;
+    const int launch_aicpu_num = prepared->launch_aicpu_num;
+    constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    ActiveRun *run = active_run_.get();
+    if (run == nullptr) {
+        outcome.prepared = std::move(prepared);
+        return outcome;
+    }
 
-int DeviceRunner::drain_run() {
+    std::chrono::steady_clock::time_point sim_t0;
+
+    LaunchTransactionResult result = exact_launch_transaction(
+        prepared->identity, std::move(permit),
+        [&]() {
+            set_platform_regs_func_(kernel_args_.regs);
+            if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
+            set_platform_dump_base_func_(kernel_args_.dump_data_base);
+            set_dump_args_enabled_func_(enable_dump_args_);
+            set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
+            set_platform_chip_swimlane_aicore_rotation_table_func_(kernel_args_.chip_swimlane_aicore_rotation_table);
+            set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
+            set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+            set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);
+            set_pmu_enabled_func_(enable_pmu_);
+            set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
+            set_dep_gen_enabled_func_(enable_dep_gen_ && !dep_gen_host_graph_active());
+            set_scope_stats_enabled_func_(enable_scope_stats_);
+            set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
+
+            auto thread_factory = [this](std::function<void()> fn) {
+                return create_thread(std::move(fn));
+            };
+            if (enable_chip_swimlane_) chip_swimlane_collector_.start(thread_factory);
+            if (enable_dump_args_) dump_collector_.start(thread_factory);
+            if (enable_pmu_) pmu_collector_.start(thread_factory);
+            if (enable_dep_gen_ && !dep_gen_host_graph_active()) dep_gen_collector_.start(thread_factory);
+            if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
+
+            if (kernel_args_.device_wall_data_base != 0) {
+                *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
+            }
+            set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
+            sim_t0 = std::chrono::steady_clock::now();
+            run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
+
+            LOG_INFO("Launching %d AICore thread(s)", num_aicore);
+            for (int i = 0; i < num_aicore; i++) {
+                CoreType core_type = runtime.get_workers()[i].core_type;
+                uint32_t physical_core_id = static_cast<uint32_t>(i);
+                run->aicore_threads.push_back(create_thread([this, run, i, core_type, physical_core_id]() {
+                    aicore_execute_func_(
+                        run->runtime, i, core_type, physical_core_id, kernel_args_.regs,
+                        kernel_args_.enable_profiling_flag, kernel_args_.chip_swimlane_aicore_rotation_table
+                    );
+                    run_completion_.task_finished();
+                }));
+            }
+            return 0;
+        },
+        [&]() {
+            LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
+            for (int i = 0; i < over_launch; i++) {
+                run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
+                    if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
+                        run_completion_.task_finished();
+                        return;
+                    }
+                    int rc = aicpu_execute_func_(run->runtime);
+                    if (kernel_args_.device_wall_data_base != 0) {
+                        const auto t1 = std::chrono::steady_clock::now();
+                        *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = static_cast<uint64_t>(
+                            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - sim_t0).count()
+                        );
+                    }
+                    run_completion_.task_finished(rc);
+                }));
+            }
+            return 0;
+        }
+    );
+    if (result.poisoned()) poison_launch();
+    outcome.rc = result.rc;
+    outcome.progress = result.progress;
+    outcome.receipt = std::move(result.receipt);
+    if (result.progress == LaunchProgress::NotStarted) {
+        outcome.prepared = std::move(prepared);
+    } else {
+        outcome.active = std::make_unique<ActiveExecution>(std::move(prepared), result.progress);
+    }
+    return outcome;
+}
+
+int DeviceRunner::poll_execution(const ActiveExecution &) { return run_completion_.poll(); }
+
+int DeviceRunner::drain_execution(ActiveExecution &) {
     if (active_run_ == nullptr) {
-        LOG_ERROR("drain_run called without an enqueued simulated run");
+        LOG_ERROR("drain_execution called without a launched simulated run");
         return -1;
     }
     auto run_cleanup = RAIIScopeGuard([this]() {
@@ -717,6 +728,11 @@ int DeviceRunner::drain_run() {
     return 0;
 }
 
+void DeviceRunner::abandon_prepared_execution(PreparedExecution &) noexcept {
+    run_completion_.abandon();
+    cleanup_active_run();
+}
+
 void DeviceRunner::unload_executor_binaries() {
     if (aicpu_so_handle_ != nullptr) {
         dlclose(aicpu_so_handle_);
@@ -790,7 +806,7 @@ int DeviceRunner::finalize() {
     prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
     prebuilt_runtime_arena_cache_image_.clear();
 
-    // Free the 8-byte device_wall buffer (allocated lazily in enqueue_run()) before
+    // Free the 8-byte device_wall buffer (allocated lazily in prepare_execution()) before
     // mem_alloc_.finalize().
     if (device_wall_dev_ptr_ != nullptr) {
         free_tensor(device_wall_dev_ptr_);

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -34,9 +34,14 @@ public:
     DeviceRunner();
     ~DeviceRunner() override;
 
-    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
-    int poll_run() override;
-    int drain_run() override;
+    int prepare_execution(
+        Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+        std::unique_ptr<PreparedExecution> *prepared
+    ) override;
+    LaunchOutcome launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) override;
+    void abandon_prepared_execution(PreparedExecution &prepared) noexcept override;
+    int poll_execution(const ActiveExecution &active) override;
+    int drain_execution(ActiveExecution &active) override;
     int finalize() override;
     // Also arms the loaded runtime's host-side graph capture, which a host-orch
     // runtime uses instead of the device collector. Defined in the .cpp so this

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -137,28 +137,18 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
     return 0;
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
-    if (run_resources_owned_) {
-        LOG_ERROR(
-            "enqueue_run entered while slot %u still owns resources", run_poll_slot_.load(std::memory_order_relaxed)
-        );
-        return -1;
-    }
+int DeviceRunner::prepare_execution(
+    Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+    std::unique_ptr<PreparedExecution> *prepared
+) {
+    if (prepared == nullptr || *prepared != nullptr) return -1;
+    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
+    execution->resources_owned = true;
     const uint32_t selected_pipeline_slot = pipeline_slot;
-    run_poll_slot_.store(selected_pipeline_slot, std::memory_order_relaxed);
-    run_poll_state_.store(RunPollState::Enqueuing, std::memory_order_release);
-    run_resources_owned_ = true;
-    // Before the real AICPU launch marker, enqueue owns rollback. A successful
-    // enqueue dismisses this guard and transfers every resource to drain_run().
-    auto enqueue_rollback = RAIIScopeGuard([this]() {
-        cleanup_active_run();
+    auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
+        cleanup_execution(*execution, /*launched=*/false);
     });
-    // Latch this run's diagnostic enables onto the runner before the collector
-    // paths below read them; block_dim/aicpu_thread_num are consumed locally.
-    apply_call_config(config);
-    // activate_launch_shape() latches this run's geometry onto the runner on the
-    // executor thread immediately before enqueue, so block_dim_ is this run's.
-    const int block_dim = block_dim_;
+    const int block_dim = runtime.get_worker_count() / cores_per_blockdim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade
@@ -187,15 +177,17 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         return rc;
     }
 
-    ensure_device_wall_buffer();
+    ensure_device_wall_buffer(execution->kernel_args);
 
     if (block_dim < 1) {
-        LOG_ERROR("enqueue_run reached with unresolved block_dim; activate_launch_shape must run first");
+        LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
         return -1;
     }
     int num_aicore = block_dim * cores_per_blockdim_;
 
-    rc = init_aicore_register_addresses(&kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_);
+    rc = init_aicore_register_addresses(
+        &execution->kernel_args.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_
+    );
     if (rc != 0) {
         LOG_ERROR("init_aicore_register_addresses failed: %d", rc);
         return rc;
@@ -208,7 +200,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     if (enable_pmu_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
     if (enable_dep_gen_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DEP_GEN);
     if (enable_scope_stats_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
-    kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
+    execution->kernel_args.args.enable_profiling_flag = enable_profiling_flag;
 
     resolve_task_binary_addrs(runtime);
 
@@ -268,7 +260,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
 
     // Initialize per-subsystem shared memory.
     if (enable_chip_swimlane_) {
-        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
+        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
@@ -276,7 +268,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     }
 
     if (enable_dump_args_) {
-        rc = init_args_dump(runtime, device_id_);
+        rc = init_args_dump(runtime, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
@@ -284,16 +276,19 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     }
 
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
+        rc = init_pmu(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_,
+            execution->kernel_args
+        );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
-            kernel_args_.args.pmu_data_base = 0;
+            execution->kernel_args.args.pmu_data_base = 0;
             enable_pmu_ = false;
         }
     }
 
     if (enable_dep_gen_) {
-        rc = init_dep_gen(launch_aicpu_num, device_id_);
+        rc = init_dep_gen(launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
             return rc;
@@ -301,7 +296,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     }
 
     if (enable_scope_stats_) {
-        rc = init_scope_stats(launch_aicpu_num, device_id_);
+        rc = init_scope_stats(launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_scope_stats failed: %d", rc);
             return rc;
@@ -313,102 +308,120 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         LOG_ERROR("prepare_orch_so failed: %d", rc);
         return rc;
     }
-    rc = init_runtime_args_with_metadata(runtime);
+    rc = init_runtime_args_with_metadata(runtime, execution->kernel_args);
     if (rc != 0) return rc;
 
-    start_shared_collectors_for_run();
-    // a5-specific dep_gen collector — share the same thread_factory shape as base.
-    if (enable_dep_gen_) {
-        auto thread_factory = [this](std::function<void()> fn) {
-            return create_thread(std::move(fn));
-        };
-        dep_gen_collector_.start(thread_factory);
-    }
-
-    // workers[i].core_type is written by the AICore kernel during its
-    // AICPU<->AICore handshake (aicore_executor.cpp), launched further below,
-    // so the values read here reflect the most recent prior run's handshake
-    // still resident in device memory (unset on the first run of a freshly-
-    // loaded runtime). Publish the table to the chip swimlane collector so the
-    // AICORE_TIMING (level=1) host emit path can label lanes ("aic"/"aiv").
-    if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
-        std::vector<CoreType> core_types(num_aicore);
-        for (int i = 0; i < num_aicore; i++) {
-            core_types[i] = runtime.get_workers()[i].core_type;
-        }
-        chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
-    }
-
-    // Launch the AICore worker BEFORE the AICPU Run task. This is a first-launch
-    // latency optimization, not a correctness requirement (the handshake is
-    // launch-order-independent). When the AICPU Run task is launched first it
-    // immediately occupies the device (spinning in handshake_all_cores), and the
-    // first AICore launch — which lazily loads the kernel binary onto the device
-    // inside rtKernelLaunchWithHandleV2 — then takes ~1.4 s instead of ~0.4 ms
-    // (measured a5; the exact device-side contention is not pinned, see the
-    // investigation doc). Submitting the AICore first does that load on an idle
-    // device, then the AICPU spins and finds the AICore already up.
-    //
-    // Defense-in-depth for the op-timeout family (#1019): that ~1.4 s slow launch
-    // is what trips the op-execute timeout when it is tight. #1035 widened the
-    // timeout 1 s -> 3 s so the slow launch no longer wedges, but this ordering
-    // removes the slow launch itself, so the wedge cannot return if the timeout
-    // is ever tightened or a slower device pushes the launch past it. See
-    // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
-    // The AICore publishes aicore_done on launch (gated by nothing), and the
-    // workers region persists across runs in the pooled arena. Clearing each
-    // worker's aicore_done before the AICore kernel launches keeps the AICPU's
-    // handshake sweep from reading a prior run's report — which would open a
-    // window on that run's physical_core_id. Only aicore_done needs clearing; the
-    // AICore overwrites physical_core_id/core_type in the same report.
-    {
-        Handshake *workers = runtime.get_workers();
-        for (int i = 0; i < num_aicore; i++) {
-            workers[i].aicore_done = 0;
-        }
-    }
-
-    LOG_INFO("=== launch_aicore_kernel ===");
-    rc = kernel_args_.init_device_kernel_args(mem_alloc_);
+    rc = execution->kernel_args.init_device_kernel_args(mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("init_device_kernel_args failed: %d", rc);
         return rc;
     }
-    // Publish query/drain ownership before either kernel launch. The real
-    // launch marker is notified inside launch_aicpu_kernel(), so no state that
-    // poll or drain needs may be committed after that call succeeds.
-    run_poll_state_.store(RunPollState::Submitted, std::memory_order_release);
-    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
-    if (rc != 0) {
-        LOG_ERROR("launch_aicore_kernel failed: %d", rc);
-        recover_device_or_mark_unusable(rc);
-        return rc;
-    }
-
-    LOG_INFO("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
-    // launch_count = popcount(OCCUPY) from the topology probe — one thread
-    // per user-schedulable cpu_id. The filter gate barriers exactly this
-    // many threads (runtime.aicpu_launch_count is read on the device side
-    // by kernel.cpp). The fallback is defensive; normal runs always publish
-    // the topology-derived launch count above.
-    int aicpu_launch_n = (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
-    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
-    if (rc != 0) {
-        LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
-        // The AICore worker was already launched above and is now spinning in
-        // the handshake waiting for this AICPU Run task. If the Run launch
-        // fails, that AICore is orphaned and will spin to the op-timeout,
-        // poisoning the device — so recover/mark-unusable here (matches the
-        // launch_aicore failure path).
-        recover_device_or_mark_unusable(rc);
-        return rc;
-    }
-
-    enqueue_rollback.dismiss();
+    execution->num_aicore = num_aicore;
+    execution->launch_aicpu_num = launch_aicpu_num;
+    prepare_rollback.dismiss();
+    *prepared = std::move(execution);
     return 0;
 }
 
-int DeviceRunner::poll_run(uint32_t pipeline_slot) {
+DeviceRunnerBase::LaunchOutcome
+DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) {
+    LaunchOutcome outcome;
+    if (prepared == nullptr) return outcome;
+
+    Runtime &runtime = *prepared->runtime;
+    const int num_aicore = prepared->num_aicore;
+    const int launch_aicpu_num = prepared->launch_aicpu_num;
+
+    LaunchTransactionResult transaction = exact_launch_transaction(
+        prepared->identity, std::move(permit),
+        [&]() {
+            activate_launch_shape(runtime);
+            (void)arm_device_wall_buffer(prepared->kernel_args);
+            run_poll_slot_.store(prepared->pipeline_slot, std::memory_order_relaxed);
+            run_poll_state_.store(RunPollState::Enqueuing, std::memory_order_release);
+            start_shared_collectors_for_run();
+            if (enable_dep_gen_) {
+                auto thread_factory = [this](std::function<void()> fn) {
+                    return create_thread(std::move(fn));
+                };
+                dep_gen_collector_.start(thread_factory);
+            }
+            if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
+                std::vector<CoreType> core_types(num_aicore);
+                for (int i = 0; i < num_aicore; i++)
+                    core_types[i] = runtime.get_workers()[i].core_type;
+                chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
+            }
+
+            // Launch the AICore worker BEFORE the AICPU Run task. This is a first-launch
+            // latency optimization, not a correctness requirement (the handshake is
+            // launch-order-independent). When the AICPU Run task is launched first it
+            // immediately occupies the device (spinning in handshake_all_cores), and the
+            // first AICore launch — which lazily loads the kernel binary onto the device
+            // inside rtKernelLaunchWithHandleV2 — then takes ~1.4 s instead of ~0.4 ms
+            // (measured a5; the exact device-side contention is not pinned, see the
+            // investigation doc). Submitting the AICore first does that load on an idle
+            // device, then the AICPU spins and finds the AICore already up.
+            //
+            // Defense-in-depth for the op-timeout family (#1019): that ~1.4 s slow launch
+            // is what trips the op-execute timeout when it is tight. #1035 widened the
+            // timeout 1 s -> 3 s so the slow launch no longer wedges, but this ordering
+            // removes the slow launch itself, so the wedge cannot return if the timeout
+            // is ever tightened or a slower device pushes the launch past it. See
+            // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
+            // The AICore publishes aicore_done on launch (gated by nothing), and the
+            // workers region persists across runs in the pooled arena. Clearing each
+            // worker's aicore_done before the AICore kernel launches keeps the AICPU's
+            // handshake sweep from reading a prior run's report — which would open a
+            // window on that run's physical_core_id. Only aicore_done needs clearing; the
+            // AICore overwrites physical_core_id/core_type in the same report.
+            Handshake *workers = runtime.get_workers();
+            for (int i = 0; i < num_aicore; i++)
+                workers[i].aicore_done = 0;
+
+            LOG_INFO("=== launch_aicore_kernel ===");
+            run_poll_state_.store(RunPollState::Submitted, std::memory_order_release);
+            int launch_rc = launch_aicore_kernel(stream_aicore_, prepared->kernel_args.device_k_args_);
+            if (launch_rc != 0) {
+                LOG_ERROR("launch_aicore_kernel failed: %d", launch_rc);
+                recover_device_or_mark_unusable(launch_rc);
+            }
+            return launch_rc;
+        },
+        [&]() {
+            LOG_INFO("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
+            // launch_count = popcount(OCCUPY) from the topology probe — one thread
+            // per user-schedulable cpu_id. The filter gate barriers exactly this
+            // many threads (runtime.aicpu_launch_count is read on the device side
+            // by kernel.cpp). The fallback is defensive; normal runs always publish
+            // the topology-derived launch count above.
+            int aicpu_launch_n =
+                (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
+            int launch_rc = launch_aicpu_kernel(
+                stream_aicpu_, &prepared->kernel_args.args, host::KernelNames::RunName, aicpu_launch_n
+            );
+            if (launch_rc != 0) {
+                LOG_ERROR("launch_aicpu_kernel (main) failed: %d", launch_rc);
+            }
+            return launch_rc;
+        }
+    );
+
+    if (transaction.poisoned()) recover_device_or_mark_unusable(transaction.rc);
+    outcome.rc = transaction.rc;
+    outcome.progress = transaction.progress;
+    outcome.receipt = std::move(transaction.receipt);
+    if (transaction.progress == LaunchProgress::NotStarted) {
+        outcome.prepared = std::move(prepared);
+    } else {
+        outcome.active = std::make_unique<ActiveExecution>(std::move(prepared), transaction.progress);
+    }
+    return outcome;
+}
+
+int DeviceRunner::poll_execution(const ActiveExecution &active) {
+    if (active.prepared == nullptr) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    const uint32_t pipeline_slot = active.prepared->pipeline_slot;
     const RunPollState state = run_poll_state_.load(std::memory_order_acquire);
     if (run_poll_slot_.load(std::memory_order_relaxed) != pipeline_slot) {
         return SIMPLER_NATIVE_RUN_POLL_ERROR;
@@ -428,16 +441,19 @@ int DeviceRunner::poll_run(uint32_t pipeline_slot) {
     return rc;
 }
 
-int DeviceRunner::drain_run(uint32_t pipeline_slot) {
-    if (!run_resources_owned_ || run_poll_slot_.load(std::memory_order_relaxed) != pipeline_slot) {
+int DeviceRunner::drain_execution(ActiveExecution &active) {
+    if (active.prepared == nullptr) return -1;
+    PreparedExecution &prepared = *active.prepared;
+    const uint32_t pipeline_slot = prepared.pipeline_slot;
+    if (!prepared.resources_owned || run_poll_slot_.load(std::memory_order_relaxed) != pipeline_slot) {
         LOG_ERROR(
-            "drain_run slot mismatch: requested=%u active=%u owns=%d", pipeline_slot,
-            run_poll_slot_.load(std::memory_order_relaxed), static_cast<int>(run_resources_owned_)
+            "drain_execution slot mismatch: requested=%u active=%u owns=%d", pipeline_slot,
+            run_poll_slot_.load(std::memory_order_relaxed), static_cast<int>(prepared.resources_owned)
         );
         return -1;
     }
-    auto drain_cleanup = RAIIScopeGuard([this]() {
-        cleanup_active_run();
+    auto drain_cleanup = RAIIScopeGuard([this, &prepared]() {
+        cleanup_execution(prepared, /*launched=*/true);
     });
 
     int rc = sync_run_streams();
@@ -470,23 +486,27 @@ int DeviceRunner::drain_run(uint32_t pipeline_slot) {
     }
 
     // Reads device memory, so it must precede KernelArgs/runtime cleanup.
-    print_handshake_results();
+    print_handshake_results(prepared.kernel_args);
     return 0;
 }
 
-void DeviceRunner::cleanup_active_run() noexcept {
-    if (!run_resources_owned_) return;
+void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched) noexcept {
+    if (!prepared.resources_owned) return;
 
     // Collectors stop before device/runtime arguments and register buffers.
-    finalize_collectors();
-    (void)kernel_args_.finalize_device_kernel_args();
-    (void)kernel_args_.finalize_runtime_args();
-    if (kernel_args_.args.regs != 0) {
-        (void)mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
-        kernel_args_.args.regs = 0;
+    if (launched) finalize_collectors();
+    (void)prepared.kernel_args.finalize_device_kernel_args();
+    (void)prepared.kernel_args.finalize_runtime_args();
+    if (prepared.kernel_args.args.regs != 0) {
+        (void)mem_alloc_.free(reinterpret_cast<void *>(prepared.kernel_args.args.regs));
+        prepared.kernel_args.args.regs = 0;
     }
-    run_resources_owned_ = false;
-    run_poll_state_.store(RunPollState::Drained, std::memory_order_release);
+    prepared.resources_owned = false;
+    if (launched) run_poll_state_.store(RunPollState::Drained, std::memory_order_release);
+}
+
+void DeviceRunner::abandon_prepared_execution(PreparedExecution &prepared) noexcept {
+    cleanup_execution(prepared, /*launched=*/false);
 }
 
 void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
@@ -802,11 +822,12 @@ void DeviceRunner::finalize_collectors() {
     }
     if (scope_stats_collector_.is_initialized()) {
         scope_stats_collector_.finalize(/*unregister_cb=*/nullptr, free_cb);
-        kernel_args_.args.scope_stats_data_base = 0;
     }
 }
 
-int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id) {
+int DeviceRunner::init_chip_swimlane(
+    int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args
+) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -818,15 +839,15 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
         /*register_cb=*/nullptr, free_cb, output_prefix_
     );
     if (rc == 0) {
-        kernel_args_.args.chip_swimlane_data_base =
+        kernel_args.args.chip_swimlane_data_base =
             reinterpret_cast<uint64_t>(chip_swimlane_collector_.get_chip_swimlane_setup_device_ptr());
-        kernel_args_.args.chip_swimlane_aicore_rotation_table =
+        kernel_args.args.chip_swimlane_aicore_rotation_table =
             reinterpret_cast<uint64_t>(chip_swimlane_collector_.get_aicore_ring_addr_table_device_ptr());
     }
     return rc;
 }
 
-int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
+int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
@@ -842,12 +863,13 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
         return rc;
     }
 
-    kernel_args_.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
+    kernel_args.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
     return 0;
 }
 
 int DeviceRunner::init_pmu(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
+    KernelArgsHelper &kernel_args
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -859,14 +881,14 @@ int DeviceRunner::init_pmu(
         num_cores, num_threads, csv_path, event_type, alloc_cb, /*register_cb=*/nullptr, free_cb, device_id
     );
     if (rc == 0) {
-        kernel_args_.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
-        kernel_args_.args.aicore_pmu_ring_addrs =
+        kernel_args.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
+        kernel_args.args.aicore_pmu_ring_addrs =
             reinterpret_cast<uint64_t>(pmu_collector_.get_aicore_ring_addrs_device_ptr());
     }
     return rc;
 }
 
-int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
+int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device (see
     // ProfilerBase::alloc_paired_buffer). No halHostRegister on a5.
@@ -880,12 +902,12 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
     if (rc != 0) {
         return rc;
     }
-    kernel_args_.args.scope_stats_data_base =
+    kernel_args.args.scope_stats_data_base =
         reinterpret_cast<uint64_t>(scope_stats_collector_.get_scope_stats_shm_device_ptr());
     return 0;
 }
 
-int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
+int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device. No
     // halHostRegister on a5 (matches PMU / chip swimlane / dump collectors).
@@ -899,6 +921,6 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
     if (rc != 0) {
         return rc;
     }
-    kernel_args_.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
+    kernel_args.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -86,9 +86,14 @@ public:
 
     // The blocking entry point composes these operations. enqueue owns rollback
     // until the AICPU launch marker; drain takes that ownership on success.
-    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
-    int poll_run(uint32_t pipeline_slot) override;
-    int drain_run(uint32_t pipeline_slot) override;
+    int prepare_execution(
+        Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+        std::unique_ptr<PreparedExecution> *prepared
+    ) override;
+    LaunchOutcome launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) override;
+    void abandon_prepared_execution(PreparedExecution &prepared) noexcept override;
+    int poll_execution(const ActiveExecution &active) override;
+    int drain_execution(ActiveExecution &active) override;
     bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }
 
     // `set_chip_swimlane_enabled`, `set_dump_args_enabled`,
@@ -157,7 +162,7 @@ private:
     // Most lifecycle state (device_id_, block_dim_, cores_per_blockdim_,
     // worker_count_, executor + dispatcher bytes, aicore_bin_handle_,
     // load_aicpu_op_, mem_alloc_, the three DeviceArenas + their cached
-    // sizes, persistent AICPU/AICore streams, kernel_args_, device_wall_*,
+    // sizes, persistent AICPU/AICore streams, device_wall_*,
     // binaries_loaded_) is inherited from `DeviceRunnerBase`.
 
     // Group D state (`chip_callable_buffers_`, `callables_`,
@@ -193,7 +198,7 @@ private:
     // 507899), but a *force* reset clears it: finalize() calls
     // force_reset_device() on this path so the next Worker re-inits clean in the
     // same process (see force_reset_device()). This flag drives admission and
-    // recovery. See enqueue_run() and recover_device_or_mark_unusable().
+    // recovery. See launch_execution() and recover_device_or_mark_unusable().
     // Admission and recovery execute on different host threads.
     std::atomic<bool> device_unusable_{false};
 
@@ -206,11 +211,10 @@ private:
     };
     std::atomic<RunPollState> run_poll_state_{RunPollState::Idle};
     std::atomic<uint32_t> run_poll_slot_{PTO_PIPELINE_MAX_DEPTH};
-    bool run_resources_owned_{false};
 
-    // Release executor-owned per-run resources and publish a sticky terminal
+    // Release execution-owned per-run resources and publish a sticky terminal
     // state. Idempotent so enqueue rollback and drain share one path.
-    void cleanup_active_run() noexcept;
+    void cleanup_execution(PreparedExecution &prepared, bool launched) noexcept;
 
     // On an AICore launch/sync error, best-effort drain the device so a later
     // enqueue on the same DeviceRunner can recover in place; if the drain itself
@@ -243,7 +247,7 @@ private:
      * @param device_id Device ID
      * @return 0 on success, error code on failure
      */
-    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
+    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Initialize args dump device buffers.
@@ -253,7 +257,7 @@ private:
      * @param device_id Device ID for allocations
      * @return 0 on success, error code on failure
      */
-    int init_args_dump(Runtime &runtime, int device_id);
+    int init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Initialize PMU profiling device buffers.
@@ -269,8 +273,11 @@ private:
     // dep_gen enablement is a5-specific (a2a3 carries its own copy).
     bool enable_dep_gen_{false};
 
-    int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
-    int init_scope_stats(int num_threads, int device_id);
+    int init_pmu(
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
+        KernelArgsHelper &kernel_args
+    );
+    int init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Initialize dep_gen capture shared memory.
@@ -279,7 +286,7 @@ private:
      * stores the device pointer to the data header into
      * kernel_args.dep_gen_data_base.
      */
-    int init_dep_gen(int num_threads, int device_id);
+    int init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args);
 
     // Per-run collector teardown: stops mgmt + poll threads on every collector
     // whose init succeeded, in the only safe order (stop() joins mgmt before

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -251,23 +251,26 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t /*pipeline_slot*/) {
+int DeviceRunner::prepare_execution(
+    Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+    std::unique_ptr<PreparedExecution> *prepared
+) {
+    if (prepared == nullptr || *prepared != nullptr) return -1;
     if (active_run_ != nullptr) {
-        LOG_ERROR("enqueue_run called while another simulated run still owns execution state");
+        LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
         return -1;
     }
+    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     active_run_ = std::make_unique<ActiveRun>();
     active_run_->runtime = &runtime;
     run_completion_.reset(1);
-    auto enqueue_cleanup = RAIIScopeGuard([this]() {
+    auto prepare_cleanup = RAIIScopeGuard([this]() {
         run_completion_.abandon();
         cleanup_active_run();
     });
 
     apply_call_config(config);
-    // prepare_launch_shape() resolved block_dim before the graph was built, so
-    // the geometry this run launches with is already on the runner.
-    const int block_dim = block_dim_;
+    const int block_dim = runtime.get_worker_count() / cores_per_blockdim_;
     int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
     // Sim has no hardware topology to probe, so auto uses the architecture
@@ -276,7 +279,7 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
     if (launch_aicpu_num == 0) launch_aicpu_num = PLATFORM_DEFAULT_AICPU_THREAD_NUM;
     runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
-        LOG_ERROR("enqueue_run reached with unresolved block_dim; prepare_launch_shape must run first");
+        LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
         return -1;
     }
 
@@ -415,114 +418,123 @@ int DeviceRunner::enqueue_run(Runtime &runtime, const CallConfig &config, uint32
         return -1;
     }
 
-    set_platform_regs_func_(kernel_args_.regs);
-    if (set_orch_device_id_func_ != nullptr) {
-        set_orch_device_id_func_(device_id_);
-    }
-    set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_dump_args_enabled_func_(enable_dump_args_);
-    set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
-    set_platform_chip_swimlane_aicore_rotation_table_func_(kernel_args_.chip_swimlane_aicore_rotation_table);
-    set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
-    set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
-    set_pmu_enabled_func_(enable_pmu_);
-    set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
-    set_dep_gen_enabled_func_(enable_dep_gen_);
-    set_scope_stats_enabled_func_(enable_scope_stats_);
-    set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
-
-    // Start collector mgmt + poll threads now, just before kernels launch.
-    auto thread_factory = [this](std::function<void()> fn) {
-        return create_thread(std::move(fn));
-    };
-    if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.start(thread_factory);
-    }
-    if (enable_dump_args_) {
-        dump_collector_.start(thread_factory);
-    }
-    if (enable_pmu_) {
-        pmu_collector_.start(thread_factory);
-    }
-    if (enable_dep_gen_) {
-        dep_gen_collector_.start(thread_factory);
-    }
-    if (enable_scope_stats_) {
-        scope_stats_collector_.start(thread_factory);
-    }
-
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
-    active_run_->aicpu_threads.reserve(over_launch);
-    active_run_->aicore_threads.reserve(num_aicore);
-
-    if (kernel_args_.device_wall_data_base != 0) {
-        *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
-    }
-    const auto sim_t0 = std::chrono::steady_clock::now();
-
-    // AICPU phase capture (preamble/so_load/graph_build/post_orch + orch/sched).
-    // The sim AICPU threads run the same aicpu_execute as onboard; the phase
-    // buffer base is published into the dlopen'd runtime SO via the dlsym'd
-    // set_platform_phase_base (crossing the host↔SO boundary like the dump base),
-    // and each thread resolves its slot from platform_aicpu_affinity_thread_idx()
-    // — no C++ thread_local. The active run owns the buffer until drain reduces
-    // it into device_phase_ns_.
     constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
     constexpr size_t kTailRecs = static_cast<size_t>(task_timing_buffer_slots(kPhaseThreads));
-    // One 16-byte-record vector backs the phase region plus the task-timing tail
-    // (both records are 16 bytes; {kPhaseUnset, 0} initializes an AicpuPhaseRecord
-    // start/end and a TaskTimingRecord dispatch/finish identically). The AICPU SO
-    // resolves the tail at base + task_timing_tail_offset(), so it must be part of
-    // the same published buffer.
     static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
     active_run_->phase_buf.assign(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
-    set_platform_phase_base_func_(reinterpret_cast<uint64_t>(active_run_->phase_buf.data()));
-    run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
-    ActiveRun *run = active_run_.get();
-
-    for (int i = 0; i < over_launch; i++) {
-        run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
-            if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
-                run_completion_.task_finished();
-                return;
-            }
-            int rc = aicpu_execute_func_(run->runtime);
-            if (kernel_args_.device_wall_data_base != 0) {
-                const auto t1 = std::chrono::steady_clock::now();
-                *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) =
-                    static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - sim_t0).count());
-            }
-            run_completion_.task_finished(rc);
-        }));
-    }
-
-    LOG_INFO("Launching %d AICore thread(s)", num_aicore);
-    for (int i = 0; i < num_aicore; i++) {
-        CoreType core_type = runtime.get_workers()[i].core_type;
-        uint32_t physical_core_id = static_cast<uint32_t>(i);
-        run->aicore_threads.push_back(create_thread([this, run, i, core_type, physical_core_id]() {
-            aicore_execute_func_(
-                run->runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
-                kernel_args_.chip_swimlane_aicore_rotation_table, kernel_args_.aicore_pmu_ring_addrs
-            );
-            run_completion_.task_finished();
-        }));
-    }
-
-    // Both simulated kernel thread groups now exist. This is the sim's real
-    // launch boundary. Their state remains owned until drain_run().
-    publish_task_accepted();
-    enqueue_cleanup.dismiss();
+    active_run_->aicpu_threads.reserve(over_launch);
+    active_run_->aicore_threads.reserve(num_aicore);
+    execution->num_aicore = num_aicore;
+    execution->launch_aicpu_num = launch_aicpu_num;
+    prepare_cleanup.dismiss();
+    *prepared = std::move(execution);
     return 0;
 }
 
-int DeviceRunner::poll_run() { return run_completion_.poll(); }
+SimDeviceRunnerBase::LaunchOutcome
+DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) {
+    LaunchOutcome outcome;
+    if (prepared == nullptr) return outcome;
+    Runtime &runtime = *prepared->runtime;
+    const int num_aicore = prepared->num_aicore;
+    const int launch_aicpu_num = prepared->launch_aicpu_num;
+    constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    ActiveRun *run = active_run_.get();
+    if (run == nullptr) {
+        outcome.prepared = std::move(prepared);
+        return outcome;
+    }
 
-int DeviceRunner::drain_run() {
+    std::chrono::steady_clock::time_point sim_t0;
+
+    LaunchTransactionResult result = exact_launch_transaction(
+        prepared->identity, std::move(permit),
+        [&]() {
+            set_platform_regs_func_(kernel_args_.regs);
+            if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
+            set_platform_dump_base_func_(kernel_args_.dump_data_base);
+            set_dump_args_enabled_func_(enable_dump_args_);
+            set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
+            set_platform_chip_swimlane_aicore_rotation_table_func_(kernel_args_.chip_swimlane_aicore_rotation_table);
+            set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
+            set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+            set_pmu_enabled_func_(enable_pmu_);
+            set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
+            set_dep_gen_enabled_func_(enable_dep_gen_);
+            set_scope_stats_enabled_func_(enable_scope_stats_);
+            set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
+
+            auto thread_factory = [this](std::function<void()> fn) {
+                return create_thread(std::move(fn));
+            };
+            if (enable_chip_swimlane_) chip_swimlane_collector_.start(thread_factory);
+            if (enable_dump_args_) dump_collector_.start(thread_factory);
+            if (enable_pmu_) pmu_collector_.start(thread_factory);
+            if (enable_dep_gen_) dep_gen_collector_.start(thread_factory);
+            if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
+
+            if (kernel_args_.device_wall_data_base != 0) {
+                *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
+            }
+            set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
+            sim_t0 = std::chrono::steady_clock::now();
+            run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
+
+            LOG_INFO("Launching %d AICore thread(s)", num_aicore);
+            for (int i = 0; i < num_aicore; i++) {
+                CoreType core_type = runtime.get_workers()[i].core_type;
+                uint32_t physical_core_id = static_cast<uint32_t>(i);
+                run->aicore_threads.push_back(create_thread([this, run, i, core_type, physical_core_id]() {
+                    aicore_execute_func_(
+                        run->runtime, i, core_type, physical_core_id, kernel_args_.regs,
+                        kernel_args_.enable_profiling_flag, kernel_args_.chip_swimlane_aicore_rotation_table,
+                        kernel_args_.aicore_pmu_ring_addrs
+                    );
+                    run_completion_.task_finished();
+                }));
+            }
+            return 0;
+        },
+        [&]() {
+            LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
+            for (int i = 0; i < over_launch; i++) {
+                run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
+                    if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
+                        run_completion_.task_finished();
+                        return;
+                    }
+                    int rc = aicpu_execute_func_(run->runtime);
+                    if (kernel_args_.device_wall_data_base != 0) {
+                        const auto t1 = std::chrono::steady_clock::now();
+                        *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = static_cast<uint64_t>(
+                            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - sim_t0).count()
+                        );
+                    }
+                    run_completion_.task_finished(rc);
+                }));
+            }
+            return 0;
+        }
+    );
+    if (result.poisoned()) poison_launch();
+    outcome.rc = result.rc;
+    outcome.progress = result.progress;
+    outcome.receipt = std::move(result.receipt);
+    if (result.progress == LaunchProgress::NotStarted) {
+        outcome.prepared = std::move(prepared);
+    } else {
+        outcome.active = std::make_unique<ActiveExecution>(std::move(prepared), result.progress);
+    }
+    return outcome;
+}
+
+int DeviceRunner::poll_execution(const ActiveExecution &) { return run_completion_.poll(); }
+
+int DeviceRunner::drain_execution(ActiveExecution &) {
     if (active_run_ == nullptr) {
-        LOG_ERROR("drain_run called without an enqueued simulated run");
+        LOG_ERROR("drain_execution called without a launched simulated run");
         return -1;
     }
     auto run_cleanup = RAIIScopeGuard([this]() {
@@ -628,6 +640,11 @@ int DeviceRunner::drain_run() {
     }
 
     return 0;
+}
+
+void DeviceRunner::abandon_prepared_execution(PreparedExecution &) noexcept {
+    run_completion_.abandon();
+    cleanup_active_run();
 }
 
 void DeviceRunner::unload_executor_binaries() {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -33,9 +33,14 @@ public:
     DeviceRunner();
     ~DeviceRunner() override;
 
-    int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) override;
-    int poll_run() override;
-    int drain_run() override;
+    int prepare_execution(
+        Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+        std::unique_ptr<PreparedExecution> *prepared
+    ) override;
+    LaunchOutcome launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) override;
+    void abandon_prepared_execution(PreparedExecution &prepared) noexcept override;
+    int poll_execution(const ActiveExecution &active) override;
+    int drain_execution(ActiveExecution &active) override;
     int finalize() override;
     // a5 dep_gen enablement setter, overriding the base no-op (the c_api
     // unconditionally calls it).

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -606,9 +606,17 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
         validation_rc = -1;
     }
     int resources_rc = 0;
+    if (state->prepared_execution != nullptr) {
+        try {
+            state->runner->abandon_prepared_execution(*state->prepared_execution);
+        } catch (...) {
+            resources_rc = -1;
+        }
+    }
     if (state->runner_resources_owned) {
         try {
-            resources_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
+            int abandon_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
+            if (resources_rc == 0) resources_rc = abandon_rc;
         } catch (...) {
             resources_rc = -1;
         }
@@ -717,6 +725,12 @@ int simpler_prepare_run(
             );
         }
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
+        rc = runner->prepare_execution(
+            state->runtime, state->config, state->descriptor.pipeline_slot, state->identity(),
+            &state->prepared_execution
+        );
+        if (rc != 0) return cleanup_failed_prepare(state, rc, true);
+        state->runner_resources_owned = false;
         state->host_thread_state = runner->take_native_run_thread_state();
         return 0;
     } catch (...) {
@@ -729,7 +743,8 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_launch_run");
     if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared) return -1;
     if (!state->runner->can_accept_run() || !state->runner_reserved) return -1;
-    if (!state->runner->try_acquire_native_run(state, &state->launch_signal)) {
+    if (state->prepared_execution == nullptr ||
+        !state->runner->try_acquire_native_run(state, state->identity(), &state->launch_permit)) {
         LOG_ERROR("simpler_launch_run: execution claim is occupied (%s)", state->trace_attrs);
         return -1;
     }
@@ -755,11 +770,29 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
                 int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
                 if (attach_rc == 0) {
                     state->adopt_host_thread_state();
-                    state->runner->activate_launch_shape(state->runtime);
                     {
                         STRACE("simpler_run.runner_run");
                         entered_run = true;
-                        rc = state->runner->run(state->runtime, state->config, state->descriptor.pipeline_slot);
+                        DeviceRunnerBase::LaunchOutcome launch = state->runner->launch_execution(
+                            std::move(state->prepared_execution), std::move(state->launch_permit)
+                        );
+                        rc = launch.rc;
+                        state->prepared_execution = std::move(launch.prepared);
+                        state->active_execution = std::move(launch.active);
+                        if (launch.progress == LaunchProgress::Complete) {
+                            if (!state->launch_signal.publish_receipt(launch.receipt, state->identity())) {
+                                LOG_ERROR(
+                                    "simpler_launch_run: launch receipt identity mismatch (%s)", state->trace_attrs
+                                );
+                                rc = -1;
+                            }
+                        }
+                        if (state->active_execution != nullptr) {
+                            int drain_rc = state->runner->drain_execution(*state->active_execution);
+                            if (rc == 0) rc = drain_rc;
+                        } else if (state->prepared_execution != nullptr) {
+                            state->runner->abandon_prepared_execution(*state->prepared_execution);
+                        }
                     }
                 } else {
                     rc = attach_rc;
@@ -767,10 +800,14 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
             } catch (...) {
                 rc = -1;
             }
-            if (entered_run) {
-                // run() owns stream retirement on every exit once entered.
-                state->runner_resources_owned = false;
-            } else if (state->runner_resources_owned) {
+            if (!entered_run && state->prepared_execution != nullptr) {
+                try {
+                    state->runner->abandon_prepared_execution(*state->prepared_execution);
+                } catch (...) {
+                    rc = -1;
+                }
+            }
+            if (!entered_run && state->runner_resources_owned) {
                 int resources_rc = -1;
                 try {
                     resources_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
@@ -813,7 +850,8 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
     }
-    const int poll_rc = state->runner->poll_run(state->descriptor.pipeline_slot);
+    if (state->active_execution == nullptr) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    const int poll_rc = state->runner->poll_execution(*state->active_execution);
     if (state->execution_done.load(std::memory_order_acquire)) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
@@ -871,9 +909,17 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     }
 
     int resources_rc = 0;
-    if (!launched && state->runner_resources_owned) {
+    if (state->prepared_execution != nullptr) {
         try {
-            resources_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
+            state->runner->abandon_prepared_execution(*state->prepared_execution);
+        } catch (...) {
+            resources_rc = -1;
+        }
+    }
+    if (state->runner_resources_owned) {
+        try {
+            int abandon_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
+            if (resources_rc == 0) resources_rc = abandon_rc;
         } catch (...) {
             resources_rc = -1;
         }

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -43,7 +43,6 @@
 #include "host/acl_error_log.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
-#include "native_run_launch_signal.h"
 #include "platform_comm/comm.h"
 #include "pto_runtime_c_api.h"
 #include "task_args.h"
@@ -621,8 +620,8 @@ int DeviceRunnerBase::query_max_block_dim(rtStream_t stream, uint32_t *out_cube,
     return PLATFORM_MAX_BLOCKDIM;
 }
 
-void DeviceRunnerBase::print_handshake_results() {
-    if (stream_aicpu_ == nullptr || worker_count_ == 0 || kernel_args_.args.runtime_args == nullptr) {
+void DeviceRunnerBase::print_handshake_results(const KernelArgsHelper &kernel_args) {
+    if (stream_aicpu_ == nullptr || worker_count_ == 0 || kernel_args.args.runtime_args == nullptr) {
         return;
     }
 
@@ -630,7 +629,7 @@ void DeviceRunnerBase::print_handshake_results() {
     std::vector<Handshake> workers(worker_count_);
     size_t total_size = sizeof(Handshake) * worker_count_;
     rtMemcpy(
-        workers.data(), total_size, kernel_args_.args.runtime_args->get_workers(), total_size, RT_MEMCPY_DEVICE_TO_HOST
+        workers.data(), total_size, kernel_args.args.runtime_args->get_workers(), total_size, RT_MEMCPY_DEVICE_TO_HOST
     );
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
@@ -1054,13 +1053,7 @@ int DeviceRunnerBase::launch_aicpu_kernel(
     // exported symbol (simpler_aicpu_exec). LaunchBuiltInOp dispatches via
     // rtsLaunchCpuKernel on the cached rtFuncHandle resolved by
     // LoadAicpuOp::Init at first-time bootstrap.
-    int rc = load_aicpu_op_.LaunchBuiltInOp(stream, k_args, sizeof(KernelArgs), aicpu_num, kernel_name);
-    if (rc == 0) {
-        // Both onboard arches enqueue AICore before this Run launch. A
-        // successful return is therefore the common post-enqueue boundary.
-        publish_task_accepted();
-    }
-    return rc;
+    return load_aicpu_op_.LaunchBuiltInOp(stream, k_args, sizeof(KernelArgs), aicpu_num, kernel_name);
 }
 
 int DeviceRunnerBase::launch_aicpu_payload(
@@ -1275,13 +1268,12 @@ int DeviceRunnerBase::resolve_aicpu_thread_num(int requested, int usable, int ar
     return total;
 }
 
-void DeviceRunnerBase::ensure_device_wall_buffer() {
+void DeviceRunnerBase::ensure_device_wall_buffer(KernelArgsHelper &kernel_args) {
     if (!device_phase_capture_enabled()) {
         // A null base makes the AICPU stamping helpers no-op.
-        kernel_args_.args.device_wall_data_base = 0;
+        kernel_args.args.device_wall_data_base = 0;
         return;
     }
-
     // Per-thread fixed AICPU phase records (thread-major:
     // AicpuPhaseRecord[NUM_AICPU_PHASES] per launched AICPU thread). Slot
     // AicpuPhase::RunWall keeps the original whole-run wall; the rest subdivide
@@ -1290,33 +1282,34 @@ void DeviceRunnerBase::ensure_device_wall_buffer() {
     // max(end) - min(start) and surfaces the other phases as trace markers. The
     // buffer is allocated once (lazy) but RESET every run so a stale prior run
     // cannot leak into the reduction.
-    constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    // Phase region followed by the task-timing tail. Both records are 16 bytes and
-    // share the {kPhaseUnset, 0} reset, so one AicpuPhaseRecord init array covers
-    // both; the AICPU SO resolves the tail at base + task_timing_tail_offset().
-    static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
-    constexpr int kRecords = kThreads * NUM_AICPU_PHASES + task_timing_buffer_slots(kThreads);
-    constexpr size_t kBytes = device_phase_buffer_bytes(kThreads);
+    constexpr size_t kBytes = device_phase_buffer_bytes(PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
     if (device_wall_dev_ptr_ == nullptr) {
         device_wall_dev_ptr_ = allocate_tensor(kBytes);
     }
     if (device_wall_dev_ptr_ != nullptr) {
-        kernel_args_.args.device_wall_data_base = reinterpret_cast<uint64_t>(device_wall_dev_ptr_);
-        AicpuPhaseRecord init[kRecords];
-        for (int i = 0; i < kRecords; ++i) {
-            init[i].start_cycle = kPhaseUnset;  // start/dispatch: sentinel so min()/unset-check ignore unused slots
-            init[i].end_cycle = 0;              // end/finish: 0 so max() ignores unused slots
-        }
-        if (copy_to_device(device_wall_dev_ptr_, init, sizeof(init)) != 0) {
-            // Reset failed — disable capture for this run so stale slot data
-            // can't leak into the reduction. Cleared pointer means the buffer
-            // is re-allocated (and re-reset) on the next run.
-            LOG_WARN("device_phase reset H2D failed; disabling phase capture this run");
-            free_tensor(device_wall_dev_ptr_);
-            device_wall_dev_ptr_ = nullptr;
-            kernel_args_.args.device_wall_data_base = 0;
-        }
+        kernel_args.args.device_wall_data_base = reinterpret_cast<uint64_t>(device_wall_dev_ptr_);
     }
+}
+
+int DeviceRunnerBase::arm_device_wall_buffer(KernelArgsHelper &kernel_args) {
+    if (device_wall_dev_ptr_ == nullptr) return 0;
+    constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
+    constexpr int kRecords = kThreads * NUM_AICPU_PHASES + task_timing_buffer_slots(kThreads);
+    AicpuPhaseRecord init[kRecords];
+    for (int i = 0; i < kRecords; ++i) {
+        init[i].start_cycle = kPhaseUnset;  // start/dispatch: sentinel so min()/unset-check ignore unused slots
+        init[i].end_cycle = 0;              // end/finish: 0 so max() ignores unused slots
+    }
+    if (copy_to_device(device_wall_dev_ptr_, init, sizeof(init)) != 0) {
+        // Reset failed — disable capture for this run so stale slot data
+        // can't leak into the reduction. Keep the shared allocation alive:
+        // an earlier run may still reference it, and the next run retries reset.
+        LOG_WARN("device_phase reset H2D failed; disabling phase capture this run");
+        kernel_args.args.device_wall_data_base = 0;
+        return 0;
+    }
+    return 0;
 }
 
 int DeviceRunnerBase::resolve_block_dim() {
@@ -1491,8 +1484,8 @@ void DeviceRunnerBase::read_device_wall_ns() {
     );
 }
 
-int DeviceRunnerBase::init_runtime_args_with_metadata(Runtime &runtime) {
-    int rc = kernel_args_.init_runtime_args(runtime, mem_alloc_);
+int DeviceRunnerBase::init_runtime_args_with_metadata(Runtime &runtime, KernelArgsHelper &kernel_args) {
+    int rc = kernel_args.init_runtime_args(runtime, mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("init_runtime_args failed: %d", rc);
         return rc;
@@ -1554,8 +1547,10 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run() {
     }
 }
 
-bool DeviceRunnerBase::try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal) {
-    if (owner == nullptr || launch_signal == nullptr) return false;
+bool DeviceRunnerBase::try_acquire_native_run(
+    const void *owner, const NativeRunIdentity &identity, LaunchPermit *permit
+) {
+    if (owner == nullptr || permit == nullptr) return false;
     std::lock_guard<std::mutex> lk(native_run_mu_);
     bool reserved = false;
     for (const NativeRunReservation &reservation : native_run_reservations_) {
@@ -1571,14 +1566,13 @@ bool DeviceRunnerBase::try_acquire_native_run(const void *owner, NativeRunLaunch
         )) {
         return false;
     }
-    native_launch_signal_ = launch_signal;
+    *permit = LaunchPermit(identity);
     return true;
 }
 
 void DeviceRunnerBase::release_native_run(const void *owner) {
     std::lock_guard<std::mutex> lk(native_run_mu_);
     if (active_native_run_.load(std::memory_order_acquire) != owner) return;
-    native_launch_signal_ = nullptr;
     const void *expected = owner;
     (void)active_native_run_.compare_exchange_strong(
         expected, nullptr, std::memory_order_release, std::memory_order_relaxed
@@ -1646,9 +1640,4 @@ bool DeviceRunnerBase::native_runs_outstanding() const {
         if (reservation.owner != nullptr) return true;
     }
     return false;
-}
-
-void DeviceRunnerBase::publish_task_accepted() const {
-    std::lock_guard<std::mutex> lk(native_run_mu_);
-    if (native_launch_signal_ != nullptr) native_launch_signal_->publish_acceptance();
 }

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -28,8 +28,9 @@
  *
  * Subclasses (`{a2a3,a5}::DeviceRunner`) add arch-specific state
  * (callable registry, profiling collectors, ACL/HCCL plumbing on a2a3,
- * `enable_*` flags) and the divergent methods (`enqueue_run`, `poll_run`,
- * `drain_run`, `finalize`, `setup_static_arena`, the kernel launch /
+ * `enable_*` flags) and the divergent methods (`prepare_execution`,
+ * `launch_execution`, `poll_execution`, `drain_execution`, `finalize`,
+ * `setup_static_arena`, the kernel launch /
  * chip-callable upload, the per-callable registration helpers, and the
  * per-diagnostic `init_*`).
  */
@@ -53,6 +54,7 @@
 #include <vector>
 
 #include "arg_direction.h"
+#include "call_config.h"
 #include "callable.h"
 #include "common/device_phase.h"
 #include "common/dma_workspace.h"
@@ -69,9 +71,9 @@
 #include "host/args_dump_collector.h"
 #include "prepare_callable_common.h"
 #include "pto_runtime_c_api.h"
+#include "native_run_execution.h"
 
-struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
-struct CallConfig;  // task_interface/call_config.h — per-run execution config
+struct HostApi;  // common/host_api.h — fwd-declared to keep task_interface headers out
 class NativeRunLaunchSignal;
 
 /**
@@ -99,7 +101,7 @@ public:
      * runner-owned timing and diagnostic state remain exclusive through
      * validation/finalize.
      */
-    bool try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal);
+    bool try_acquire_native_run(const void *owner, const NativeRunIdentity &identity, LaunchPermit *permit);
     void release_native_run(const void *owner);
     bool native_run_active() const;
     bool native_run_owned_by(const void *owner) const;
@@ -240,9 +242,9 @@ public:
     /**
      * Print handshake results from device. Reads the per-core
      * `Handshake` array out of device memory and logs it at DEBUG. Must
-     * be called after `drain_run()` and before `finalize()`.
+     * be called after `drain_execution()` and before `finalize()`.
      */
-    void print_handshake_results();
+    void print_handshake_results(const KernelArgsHelper &kernel_args);
 
     /**
      * Take ownership of the AICPU + AICore executor binaries. Called
@@ -517,32 +519,88 @@ public:
     virtual int provision_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }
     virtual int abandon_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }
 
-    /** Compatibility composition retained while the C API owns an executor. */
-    int run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
-        const int rc = enqueue_run(runtime, config, pipeline_slot);
-        return rc == 0 ? drain_run(pipeline_slot) : rc;
-    }
+    struct PreparedExecution {
+        PreparedExecution(
+            const NativeRunIdentity &identity_in, Runtime &runtime_in, const CallConfig &config_in,
+            uint32_t pipeline_slot_in
+        ) :
+            identity(identity_in),
+            runtime(&runtime_in),
+            config(config_in),
+            pipeline_slot(pipeline_slot_in) {}
+        PreparedExecution(const PreparedExecution &) = delete;
+        PreparedExecution &operator=(const PreparedExecution &) = delete;
+        PreparedExecution(PreparedExecution &&other) noexcept :
+            identity(other.identity),
+            runtime(std::exchange(other.runtime, nullptr)),
+            config(other.config),
+            pipeline_slot(other.pipeline_slot),
+            num_aicore(other.num_aicore),
+            launch_aicpu_num(other.launch_aicpu_num),
+            kernel_args(std::move(other.kernel_args)),
+            resources_owned(std::exchange(other.resources_owned, false)),
+            aicore_retirement_attempted(std::exchange(other.aicore_retirement_attempted, false)) {}
+        PreparedExecution &operator=(PreparedExecution &&) = delete;
+
+        NativeRunIdentity identity{};
+        Runtime *runtime{nullptr};
+        CallConfig config{};
+        uint32_t pipeline_slot{PTO_PIPELINE_MAX_DEPTH};
+        int num_aicore{0};
+        int launch_aicpu_num{0};
+        KernelArgsHelper kernel_args{};
+        bool resources_owned{false};
+        bool aicore_retirement_attempted{false};
+    };
+
+    struct ActiveExecution {
+        explicit ActiveExecution(std::unique_ptr<PreparedExecution> prepared_in, LaunchProgress progress_in) :
+            prepared(std::move(prepared_in)),
+            progress(progress_in) {}
+        ActiveExecution(const ActiveExecution &) = delete;
+        ActiveExecution &operator=(const ActiveExecution &) = delete;
+        ActiveExecution(ActiveExecution &&) noexcept = default;
+        ActiveExecution &operator=(ActiveExecution &&) noexcept = default;
+
+        std::unique_ptr<PreparedExecution> prepared;
+        LaunchProgress progress{LaunchProgress::NotStarted};
+    };
+
+    struct LaunchOutcome {
+        int rc{-1};
+        LaunchProgress progress{LaunchProgress::NotStarted};
+        std::unique_ptr<PreparedExecution> prepared{};
+        std::unique_ptr<ActiveExecution> active{};
+        LaunchReceipt receipt{};
+
+        bool poisoned() const { return progress == LaunchProgress::Partial; }
+    };
 
     /**
      * Prepare host-owned execution state and submit the Runtime to the device.
      * Success means the platform's real kernel-launch boundary was crossed;
-     * all state needed by poll_run() and drain_run() remains owned by the
+     * all state needed by poll_execution() and drain_execution() remains owned by the
      * runner until drain completes.
      */
-    virtual int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) = 0;
+    virtual int prepare_execution(
+        Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+        std::unique_ptr<PreparedExecution> *prepared
+    ) = 0;
+    virtual LaunchOutcome launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) = 0;
+    virtual void abandon_prepared_execution(PreparedExecution &prepared) noexcept = 0;
 
     /**
      * Query the active run without waiting. Returns one of the
      * SIMPLER_NATIVE_RUN_POLL_* values. This may run concurrently with
-     * drain_run() on the compatibility executor.
+     * drain_execution() on the compatibility executor.
      */
-    virtual int poll_run(uint32_t pipeline_slot) = 0;
+    virtual int poll_execution(const ActiveExecution &active) = 0;
 
     /**
-     * Wait for the enqueued run, publish DFX, and release its execution
-     * resources. Called on the same executor thread as enqueue_run().
+     * Wait for the launched run, publish DFX, and release its execution
+     * resources. Called on the same executor thread as launch_execution().
      */
-    virtual int drain_run(uint32_t pipeline_slot) = 0;
+    virtual int drain_execution(ActiveExecution &active) = 0;
 
     /**
      * Cleanup all resources. Each arch's `finalize()` wraps
@@ -568,7 +626,7 @@ public:
 
     /**
      * Launch an AICPU kernel. Internal helper used by the subclass's
-     * `enqueue_run()`; thin wrapper that dispatches through `load_aicpu_op_`'s
+     * `launch_execution()`; thin wrapper that dispatches through `load_aicpu_op_`'s
      * cached `rtFuncHandle` (resolved by `LoadAicpuOp::Init` at first
      * bootstrap).
      *
@@ -612,7 +670,7 @@ public:
 
     /**
      * Enablement setters for the four shared diagnostics sub-features.
-     * Applied from the per-run CallConfig by `apply_call_config()` at enqueue;
+     * Applied from the per-run CallConfig by `apply_call_config()` before prepare;
      * downstream execution paths read the corresponding `enable_*_`
      * members directly.
      *
@@ -634,10 +692,9 @@ public:
 
     /**
      * Latch this run's per-run diagnostic config onto the runner's `enable_*_`
-     * members before enqueue uses them. Each arch calls this once at enqueue —
-     * the c_api no longer reaches in with individual set_*_enabled
-     * calls; it just threads the CallConfig through. Defined in the .cpp so this
-     * header does not need the full CallConfig definition.
+     * members before prepare uses them. The c_api applies it only when no active
+     * run can observe the runner-global collector configuration. Defined in the
+     * .cpp so this header does not need the full CallConfig definition.
      */
     void apply_call_config(const CallConfig &config);
 
@@ -651,8 +708,6 @@ public:
     const std::string &output_prefix() const { return output_prefix_; }
 
 protected:
-    /** Publish acceptance through the active run's launch signal, if any. */
-    void publish_task_accepted() const;
     // Ctor is protected: this class is for inheritance only — direct
     // instantiation (`new DeviceRunnerBase()`) is a compile error. The
     // public virtual dtor above lets the shared c_api delete through a
@@ -745,7 +800,8 @@ protected:
      * reset every record, and publish the base for AICPU stamping. Allocation or
      * reset failure is non-fatal; the base stays null and timing reads as 0.
      */
-    void ensure_device_wall_buffer();
+    void ensure_device_wall_buffer(KernelArgsHelper &kernel_args);
+    int arm_device_wall_buffer(KernelArgsHelper &kernel_args);
 
     /**
      * Resolve this run's block_dim: every cluster the device has, i.e.
@@ -790,7 +846,7 @@ protected:
     void read_device_wall_ns();
 
     /**
-     * H2D the Runtime struct via `kernel_args_.init_runtime_args`. Log config
+     * H2D the Runtime struct via the supplied per-execution kernel arguments. Log config
      * and device ordinal are NOT published here: they are per-device invariants
      * latched once into the AICPU SO globals by `simpler_aicpu_init`
      * (`ensure_aicpu_init_launched`) at device init, not carried per-run on
@@ -798,7 +854,7 @@ protected:
      *
      * @return 0 on success, the underlying init_runtime_args rc on failure.
      */
-    int init_runtime_args_with_metadata(Runtime &runtime);
+    int init_runtime_args_with_metadata(Runtime &runtime, KernelArgsHelper &kernel_args);
 
     /**
      * Start collector mgmt + poll threads for the four shared
@@ -938,7 +994,6 @@ protected:
     mutable std::mutex native_run_mu_;
     std::array<NativeRunReservation, PTO_PIPELINE_MAX_DEPTH> native_run_reservations_{};
     std::atomic<const void *> active_native_run_{nullptr};
-    NativeRunLaunchSignal *native_launch_signal_{nullptr};
 
     // ---- State shared by both a2a3 and a5 ---------------------------------
     //
@@ -1046,8 +1101,6 @@ protected:
     // `nullptr` before init.
     rtStream_t stream_aicpu_{nullptr};
     rtStream_t stream_aicore_{nullptr};
-    KernelArgsHelper kernel_args_;
-
     // Platform-level device phase buffer: device-resident
     // AicpuPhaseRecord[NUM_AICPU_PHASES] per launched AICPU thread (thread-
     // major), whose address rides on `KernelArgs.device_wall_data_base`. AICPU

--- a/src/common/platform/onboard/host/device_runner_helpers.h
+++ b/src/common/platform/onboard/host/device_runner_helpers.h
@@ -30,6 +30,7 @@
 #include <runtime/rt.h>
 
 #include <cstdint>
+#include <utility>
 
 #include "common/kernel_args.h"  // arch-specific KernelArgs layout
 #include "host/memory_allocator.h"
@@ -60,6 +61,17 @@ int query_stream_pair_nonblocking(rtStream_t aicpu_stream, rtStream_t aicore_str
  * free functions in the arch's own `device_runner.h`.
  */
 struct KernelArgsHelper {
+    KernelArgsHelper() = default;
+    KernelArgsHelper(const KernelArgsHelper &) = delete;
+    KernelArgsHelper &operator=(const KernelArgsHelper &) = delete;
+    KernelArgsHelper(KernelArgsHelper &&other) noexcept :
+        args(other.args),
+        allocator_(std::exchange(other.allocator_, nullptr)),
+        device_k_args_(std::exchange(other.device_k_args_, nullptr)) {
+        other.args = KernelArgs{};
+    }
+    KernelArgsHelper &operator=(KernelArgsHelper &&) = delete;
+
     KernelArgs args;
     MemoryAllocator *allocator_{nullptr};
     KernelArgs *device_k_args_{nullptr};  // Device copy of KernelArgs for AICore

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -571,6 +571,9 @@ static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, 
     } catch (...) {
         validation_rc = -1;
     }
+    if (state->prepared_execution != nullptr) {
+        state->runner->abandon_prepared_execution(*state->prepared_execution);
+    }
     if (state->runner_claimed) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;
@@ -601,6 +604,10 @@ int simpler_prepare_run(
         LOG_ERROR("simpler_prepare_run: callable_id=%d not registered", callable_id);
         return -1;
     }
+    if (!runner->can_accept_run()) {
+        LOG_ERROR("simpler_prepare_run: runner is poisoned by an uncertain partial launch");
+        return -1;
+    }
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
     if (magic == SimNativeRunContext::kMagic) {
@@ -618,7 +625,7 @@ int simpler_prepare_run(
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
         state = new (runtime) SimNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
-        if (!runner->try_acquire_native_run(state, &state->launch_signal)) {
+        if (!runner->try_acquire_native_run(state, state->identity(), &state->launch_permit)) {
             LOG_ERROR("simpler_prepare_run: another native run is active on this device context");
             destroy_native_run_context(state);
             return -1;
@@ -644,6 +651,11 @@ int simpler_prepare_run(
             );
         }
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
+        rc = runner->prepare_execution(
+            state->runtime, state->config, state->descriptor.pipeline_slot, state->identity(),
+            &state->prepared_execution
+        );
+        if (rc != 0) return cleanup_failed_prepare(state, rc, true);
         state->host_thread_state = runner->take_native_run_thread_state();
         return 0;
     } catch (...) {
@@ -665,19 +677,42 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->executor = state->runner->create_thread([state]() {
             STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
             int rc = -1;
+            bool entered_run = false;
             try {
                 int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
                 if (attach_rc == 0) {
                     state->adopt_host_thread_state();
                     {
                         STRACE("simpler_run.runner_run");
-                        rc = state->runner->run(state->runtime, state->config, state->descriptor.pipeline_slot);
+                        entered_run = true;
+                        SimDeviceRunnerBase::LaunchOutcome launch = state->runner->launch_execution(
+                            std::move(state->prepared_execution), std::move(state->launch_permit)
+                        );
+                        rc = launch.rc;
+                        state->prepared_execution = std::move(launch.prepared);
+                        state->active_execution = std::move(launch.active);
+                        if (launch.progress == LaunchProgress::Complete) {
+                            if (!state->launch_signal.publish_receipt(launch.receipt, state->identity())) rc = -1;
+                        }
+                        if (state->active_execution != nullptr) {
+                            int drain_rc = state->runner->drain_execution(*state->active_execution);
+                            if (rc == 0) rc = drain_rc;
+                        } else if (state->prepared_execution != nullptr) {
+                            state->runner->abandon_prepared_execution(*state->prepared_execution);
+                        }
                     }
                 } else {
                     rc = attach_rc;
                 }
             } catch (...) {
                 rc = -1;
+            }
+            if (!entered_run && state->prepared_execution != nullptr) {
+                try {
+                    state->runner->abandon_prepared_execution(*state->prepared_execution);
+                } catch (...) {
+                    rc = -1;
+                }
             }
             state->execution_rc.store(rc, std::memory_order_relaxed);
             state->execution_done.store(true, std::memory_order_release);
@@ -706,7 +741,8 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
     }
-    const int poll_rc = state->runner->poll_run();
+    if (state->active_execution == nullptr) return SIMPLER_NATIVE_RUN_POLL_ERROR;
+    const int poll_rc = state->runner->poll_execution(*state->active_execution);
     if (state->execution_done.load(std::memory_order_acquire)) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
@@ -759,6 +795,10 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         }
     } catch (...) {
         validation_rc = -1;
+    }
+
+    if (state->prepared_execution != nullptr) {
+        state->runner->abandon_prepared_execution(*state->prepared_execution);
     }
 
     if (state->runner_claimed) {

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -28,7 +28,6 @@
 #include "common/host_api.h"
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
-#include "native_run_launch_signal.h"
 #include "task_args.h"
 #include "utils/elf_build_id.h"
 
@@ -83,21 +82,22 @@ bool create_temp_so_file(const std::string &path_template, const uint8_t *data, 
 // SimDeviceRunnerBase Implementation
 // =============================================================================
 
-bool SimDeviceRunnerBase::try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal) {
-    if (owner == nullptr || launch_signal == nullptr) return false;
+bool SimDeviceRunnerBase::try_acquire_native_run(
+    const void *owner, const NativeRunIdentity &identity, LaunchPermit *permit
+) {
+    if (owner == nullptr || permit == nullptr) return false;
     const void *expected = nullptr;
     if (!active_native_run_.compare_exchange_strong(
             expected, owner, std::memory_order_acq_rel, std::memory_order_acquire
         )) {
         return false;
     }
-    native_launch_signal_ = launch_signal;
+    *permit = LaunchPermit(identity);
     return true;
 }
 
 void SimDeviceRunnerBase::release_native_run(const void *owner) {
     if (active_native_run_.load(std::memory_order_acquire) != owner) return;
-    native_launch_signal_ = nullptr;
     const void *expected = owner;
     (void)active_native_run_.compare_exchange_strong(
         expected, nullptr, std::memory_order_release, std::memory_order_relaxed
@@ -110,10 +110,6 @@ bool SimDeviceRunnerBase::native_run_active() const {
 
 bool SimDeviceRunnerBase::native_run_owned_by(const void *owner) const {
     return owner != nullptr && active_native_run_.load(std::memory_order_acquire) == owner;
-}
-
-void SimDeviceRunnerBase::publish_task_accepted() const {
-    if (native_launch_signal_ != nullptr) native_launch_signal_->publish_acceptance();
 }
 
 uint64_t SimDeviceRunnerBase::arena_bank_gm_heap_base(uint32_t bank_id) const {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -37,11 +37,14 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "pto_runtime_c_api.h"
+#include "native_run_execution.h"
 
 #include "callable.h"
+#include "call_config.h"
 #include "prepare_callable_common.h"
 #include "utils/device_arena.h"
 #include "common/kernel_args.h"
@@ -56,8 +59,7 @@
 #include "host/scope_stats_collector.h"
 #include "runtime.h"
 
-struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
-struct CallConfig;  // task_interface/call_config.h — per-run execution config
+struct HostApi;  // common/host_api.h — fwd-declared to keep task_interface headers out
 class NativeRunLaunchSignal;
 
 // Width sim resolves the CallConfig "auto" sentinel to, deliberately below
@@ -91,18 +93,68 @@ public:
     virtual ~SimDeviceRunnerBase() = default;
 
     // --- Pure / no-op virtuals dispatched from the shared c_api glue ----
-    /** Compatibility composition retained while the C API owns an executor. */
-    int run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) {
-        const int rc = enqueue_run(runtime, config, pipeline_slot);
-        return rc == 0 ? drain_run() : rc;
-    }
+    struct PreparedExecution {
+        PreparedExecution(
+            const NativeRunIdentity &identity_in, Runtime &runtime_in, const CallConfig &config_in,
+            uint32_t pipeline_slot_in
+        ) :
+            identity(identity_in),
+            runtime(&runtime_in),
+            config(config_in),
+            pipeline_slot(pipeline_slot_in) {}
+        virtual ~PreparedExecution() = default;
+        PreparedExecution(const PreparedExecution &) = delete;
+        PreparedExecution &operator=(const PreparedExecution &) = delete;
+        PreparedExecution(PreparedExecution &&other) noexcept :
+            identity(other.identity),
+            runtime(std::exchange(other.runtime, nullptr)),
+            config(other.config),
+            pipeline_slot(other.pipeline_slot),
+            num_aicore(other.num_aicore),
+            launch_aicpu_num(other.launch_aicpu_num) {}
+        PreparedExecution &operator=(PreparedExecution &&) = delete;
+
+        NativeRunIdentity identity{};
+        Runtime *runtime{nullptr};
+        CallConfig config{};
+        uint32_t pipeline_slot{PTO_PIPELINE_MAX_DEPTH};
+        int num_aicore{0};
+        int launch_aicpu_num{0};
+    };
+
+    struct ActiveExecution {
+        explicit ActiveExecution(std::unique_ptr<PreparedExecution> prepared_in, LaunchProgress progress_in) :
+            prepared(std::move(prepared_in)),
+            progress(progress_in) {}
+        ActiveExecution(const ActiveExecution &) = delete;
+        ActiveExecution &operator=(const ActiveExecution &) = delete;
+        ActiveExecution(ActiveExecution &&) noexcept = default;
+        ActiveExecution &operator=(ActiveExecution &&) noexcept = default;
+        std::unique_ptr<PreparedExecution> prepared;
+        LaunchProgress progress{LaunchProgress::NotStarted};
+    };
+
+    struct LaunchOutcome {
+        int rc{-1};
+        LaunchProgress progress{LaunchProgress::NotStarted};
+        std::unique_ptr<PreparedExecution> prepared{};
+        std::unique_ptr<ActiveExecution> active{};
+        LaunchReceipt receipt{};
+
+        bool poisoned() const { return progress == LaunchProgress::Partial; }
+    };
 
     /** Submit a Runtime and retain all state needed to query and drain it. */
-    virtual int enqueue_run(Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot) = 0;
+    virtual int prepare_execution(
+        Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
+        std::unique_ptr<PreparedExecution> *prepared
+    ) = 0;
+    virtual LaunchOutcome launch_execution(std::unique_ptr<PreparedExecution> prepared, LaunchPermit permit) = 0;
+    virtual void abandon_prepared_execution(PreparedExecution &prepared) noexcept = 0;
     /** Return one of the SIMPLER_NATIVE_RUN_POLL_* values without waiting. */
-    virtual int poll_run() = 0;
+    virtual int poll_execution(const ActiveExecution &active) = 0;
     /** Wait for completion, publish DFX, and release per-run resources. */
-    virtual int drain_run() = 0;
+    virtual int drain_execution(ActiveExecution &active) = 0;
     virtual int finalize() = 0;
     // a2a3 and a5 both override; an arch without dep_gen leaves the no-op.
     virtual void set_dep_gen_enabled(bool /*enable*/) {}
@@ -114,10 +166,12 @@ public:
     virtual void destroy_native_run_thread_state(void * /*snapshot*/) noexcept {}
 
     /** Reserve the runner's single active native execution through finalize. */
-    bool try_acquire_native_run(const void *owner, NativeRunLaunchSignal *launch_signal);
+    bool try_acquire_native_run(const void *owner, const NativeRunIdentity &identity, LaunchPermit *permit);
     void release_native_run(const void *owner);
     bool native_run_active() const;
     bool native_run_owned_by(const void *owner) const;
+    bool can_accept_run() const { return !launch_poisoned_.load(std::memory_order_acquire); }
+    void poison_launch() { launch_poisoned_.store(true, std::memory_order_release); }
 
     // --- Shared methods --------------------------------------------------
 
@@ -237,7 +291,7 @@ public:
     const std::string &output_prefix() const { return output_prefix_; }
 
     // Latch this run's per-run diagnostic config onto the runner's enable_*_
-    // members before enqueue_run() uses them. Each arch calls this at enqueue;
+    // members before prepare_execution() uses them. Each arch calls this at prepare;
     // the c_api threads the CallConfig through instead of calling setters.
     // Defined in the .cpp so this header does not need the full CallConfig.
     void apply_call_config(const CallConfig &config);
@@ -247,8 +301,6 @@ public:
 
 protected:
     // --- Helpers usable by subclass execution / finalize -----------------
-    /** Publish after both simulated kernel thread groups have been created. */
-    void publish_task_accepted() const;
     int ensure_device_initialized();
     virtual int ensure_binaries_loaded() = 0;
     // Hand the orch-SO descriptor to the sim AICPU register entry. Built
@@ -395,7 +447,7 @@ protected:
     Runtime *last_runtime_{nullptr};
 
     std::atomic<const void *> active_native_run_{nullptr};
-    NativeRunLaunchSignal *native_launch_signal_{nullptr};
+    std::atomic<bool> launch_poisoned_{false};
 
     // Dynamically loaded executor libraries (shared infra; the dlsym'd function-
     // pointer table itself lives on the subclass since signatures diverge

--- a/src/common/worker/native_run_context.h
+++ b/src/common/worker/native_run_context.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <thread>
 
 #include "call_config.h"
@@ -89,11 +90,20 @@ struct NativeRunContext {
     std::atomic<bool> execution_done{false};
     std::atomic<NativeRunPhase> phase{NativeRunPhase::Prepared};
     NativeRunLaunchSignal launch_signal;
+    std::unique_ptr<typename Runner::PreparedExecution> prepared_execution{};
+    std::unique_ptr<typename Runner::ActiveExecution> active_execution{};
+    LaunchPermit launch_permit{};
     void *host_thread_state{nullptr};
     char trace_attrs[192]{};
     bool runner_resources_owned{false};
     bool runner_reserved{false};
     bool runner_claimed{false};
+
+    NativeRunIdentity identity() const {
+        return NativeRunIdentity{
+            descriptor.run_epoch, descriptor.generation, descriptor.dispatch_id, descriptor.pipeline_slot
+        };
+    }
 };
 
 /** End object lifetime, then mark the caller-owned storage reusable. */

--- a/src/common/worker/native_run_execution.h
+++ b/src/common/worker/native_run_execution.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+class DeviceRunnerBase;
+class NativeRunExecutionTestPeer;
+class SimDeviceRunnerBase;
+
+struct NativeRunIdentity {
+    uint64_t run_epoch{0};
+    uint64_t generation{0};
+    uint64_t dispatch_id{0};
+    uint32_t pipeline_slot{0};
+
+    bool operator==(const NativeRunIdentity &other) const {
+        return run_epoch == other.run_epoch && generation == other.generation && dispatch_id == other.dispatch_id &&
+               pipeline_slot == other.pipeline_slot;
+    }
+    bool operator!=(const NativeRunIdentity &other) const { return !(*this == other); }
+};
+
+class LaunchPermit {
+public:
+    LaunchPermit() = default;
+    LaunchPermit(const LaunchPermit &) = delete;
+    LaunchPermit &operator=(const LaunchPermit &) = delete;
+
+    LaunchPermit(LaunchPermit &&other) noexcept :
+        identity_(other.identity_),
+        valid_(other.valid_) {
+        other.valid_ = false;
+    }
+
+    LaunchPermit &operator=(LaunchPermit &&other) noexcept {
+        if (this == &other) return *this;
+        identity_ = other.identity_;
+        valid_ = other.valid_;
+        other.valid_ = false;
+        return *this;
+    }
+
+    bool valid() const { return valid_; }
+
+private:
+    friend class DeviceRunnerBase;
+    friend class NativeRunExecutionTestPeer;
+    friend class SimDeviceRunnerBase;
+    template <typename AicoreSubmit, typename AicpuSubmit>
+    friend struct ExactLaunchTransaction;
+
+    explicit LaunchPermit(const NativeRunIdentity &identity) :
+        identity_(identity),
+        valid_(true) {}
+
+    bool consume(const NativeRunIdentity &identity) {
+        if (!valid_ || identity_ != identity) return false;
+        valid_ = false;
+        return true;
+    }
+
+    NativeRunIdentity identity_{};
+    bool valid_{false};
+};
+
+class LaunchReceipt {
+public:
+    LaunchReceipt() = default;
+    LaunchReceipt(const LaunchReceipt &) = delete;
+    LaunchReceipt &operator=(const LaunchReceipt &) = delete;
+
+    LaunchReceipt(LaunchReceipt &&other) noexcept :
+        identity_(other.identity_),
+        valid_(other.valid_) {
+        other.valid_ = false;
+    }
+
+    LaunchReceipt &operator=(LaunchReceipt &&other) noexcept {
+        if (this == &other) return *this;
+        identity_ = other.identity_;
+        valid_ = other.valid_;
+        other.valid_ = false;
+        return *this;
+    }
+
+    bool valid() const { return valid_; }
+    bool matches(const NativeRunIdentity &identity) const { return valid_ && identity_ == identity; }
+
+private:
+    template <typename AicoreSubmit, typename AicpuSubmit>
+    friend struct ExactLaunchTransaction;
+
+    explicit LaunchReceipt(const NativeRunIdentity &identity) :
+        identity_(identity),
+        valid_(true) {}
+
+    NativeRunIdentity identity_{};
+    bool valid_{false};
+};
+
+enum class LaunchProgress : uint8_t {
+    NotStarted,
+    Partial,
+    Complete,
+};
+
+struct LaunchTransactionResult {
+    int rc{-1};
+    LaunchProgress progress{LaunchProgress::NotStarted};
+    LaunchReceipt receipt{};
+
+    bool poisoned() const { return progress == LaunchProgress::Partial; }
+};
+
+template <typename AicoreSubmit, typename AicpuSubmit>
+struct ExactLaunchTransaction {
+    static LaunchTransactionResult
+    run(const NativeRunIdentity &identity, LaunchPermit permit, AicoreSubmit &&submit_aicore,
+        AicpuSubmit &&submit_aicpu) {
+        LaunchTransactionResult result;
+        if (!permit.consume(identity)) return result;
+
+        try {
+            result.rc = std::forward<AicoreSubmit>(submit_aicore)();
+        } catch (...) {
+            result.rc = -1;
+            // Submission callbacks may throw after starting work. Without a
+            // receipt, the caller must retain resources and poison admission.
+            result.progress = LaunchProgress::Partial;
+            return result;
+        }
+        if (result.rc != 0) return result;
+
+        result.progress = LaunchProgress::Partial;
+        try {
+            result.rc = std::forward<AicpuSubmit>(submit_aicpu)();
+        } catch (...) {
+            result.rc = -1;
+        }
+        if (result.rc != 0) return result;
+
+        result.progress = LaunchProgress::Complete;
+        result.receipt = LaunchReceipt(identity);
+        return result;
+    }
+};
+
+template <typename AicoreSubmit, typename AicpuSubmit>
+LaunchTransactionResult exact_launch_transaction(
+    const NativeRunIdentity &identity, LaunchPermit permit, AicoreSubmit &&submit_aicore, AicpuSubmit &&submit_aicpu
+) {
+    return ExactLaunchTransaction<AicoreSubmit, AicpuSubmit>::run(
+        identity, std::move(permit), std::forward<AicoreSubmit>(submit_aicore), std::forward<AicpuSubmit>(submit_aicpu)
+    );
+}

--- a/src/common/worker/native_run_launch_signal.h
+++ b/src/common/worker/native_run_launch_signal.h
@@ -15,6 +15,8 @@
 #include <condition_variable>
 #include <mutex>
 
+#include "native_run_execution.h"
+
 /** Sticky one-shot wakeup for the host thread waiting on launch readiness, and
  * the per-run home of the launch-acceptance target the host binds before launch
  * and the device publishes at its real kernel-launch marker. */
@@ -33,12 +35,12 @@ public:
         });
     }
 
-    /** Publish the acceptance value (if bound) at the launch marker and wake the
-     * launch waiter. */
-    void publish_acceptance() {
+    /** Publish only from the receipt for this run's completed launch transaction. */
+    bool publish_receipt(const LaunchReceipt &receipt, const NativeRunIdentity &identity) {
+        if (!receipt.matches(identity)) return false;
         {
-            std::lock_guard<std::mutex> lock(mutex_);
-            if (notified_) return;
+            std::scoped_lock lock(mutex_);
+            if (notified_) return true;
             if (accepted_state_ != nullptr) {
                 __atomic_store_n(accepted_state_, accepted_value_, __ATOMIC_RELEASE);
             }
@@ -46,11 +48,12 @@ public:
             notified_ = true;
         }
         cv_.notify_one();
+        return true;
     }
 
     void notify() {
         {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::scoped_lock lock(mutex_);
             if (notified_) return;
             accepted_state_ = nullptr;
             notified_ = true;

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -419,6 +419,15 @@ target_link_libraries(test_native_run_launch_signal PRIVATE ${GTEST_MAIN_LIB} ${
 add_test(NAME test_native_run_launch_signal COMMAND test_native_run_launch_signal)
 set_tests_properties(test_native_run_launch_signal PROPERTIES LABELS "no_hardware")
 
+add_executable(test_native_run_execution common/test_native_run_execution.cpp)
+target_include_directories(test_native_run_execution PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+)
+target_link_libraries(test_native_run_execution PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_native_run_execution COMMAND test_native_run_execution)
+set_tests_properties(test_native_run_execution PROPERTIES LABELS "no_hardware")
+
 # A HostApi value keeps one runner and one run's resource selection even when
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)

--- a/tests/ut/cpp/common/native_run_execution_test_peer.h
+++ b/tests/ut/cpp/common/native_run_execution_test_peer.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "native_run_execution.h"
+
+class NativeRunExecutionTestPeer {
+public:
+    static LaunchPermit mint(const NativeRunIdentity &identity) { return LaunchPermit(identity); }
+};

--- a/tests/ut/cpp/common/test_native_run_execution.cpp
+++ b/tests/ut/cpp/common/test_native_run_execution.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+#include <utility>
+
+#include "native_run_execution_test_peer.h"
+
+namespace {
+
+constexpr NativeRunIdentity kIdentity{17, 23, 29, 1};
+
+static_assert(!std::is_copy_constructible_v<LaunchPermit>);
+static_assert(!std::is_copy_assignable_v<LaunchPermit>);
+static_assert(std::is_nothrow_move_constructible_v<LaunchPermit>);
+static_assert(!std::is_copy_constructible_v<LaunchReceipt>);
+static_assert(std::is_nothrow_move_constructible_v<LaunchReceipt>);
+
+TEST(NativeRunExecutionTest, IdentityMismatchDoesNotSubmit) {
+    NativeRunIdentity other = kIdentity;
+    other.run_epoch++;
+    int submissions = 0;
+
+    LaunchTransactionResult result = exact_launch_transaction(
+        other, NativeRunExecutionTestPeer::mint(kIdentity),
+        [&]() {
+            ++submissions;
+            return 0;
+        },
+        [&]() {
+            ++submissions;
+            return 0;
+        }
+    );
+
+    EXPECT_EQ(result.rc, -1);
+    EXPECT_EQ(result.progress, LaunchProgress::NotStarted);
+    EXPECT_EQ(submissions, 0);
+    EXPECT_FALSE(result.receipt.valid());
+}
+
+TEST(NativeRunExecutionTest, AicoreFailureIsSafePrelaunchFailure) {
+    int aicpu_submissions = 0;
+    LaunchTransactionResult result = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        []() {
+            return 41;
+        },
+        [&]() {
+            ++aicpu_submissions;
+            return 0;
+        }
+    );
+
+    EXPECT_EQ(result.rc, 41);
+    EXPECT_EQ(result.progress, LaunchProgress::NotStarted);
+    EXPECT_EQ(aicpu_submissions, 0);
+    EXPECT_FALSE(result.poisoned());
+}
+
+TEST(NativeRunExecutionTest, AicoreExceptionPoisonsWithoutTryingAicpu) {
+    int aicpu_submissions = 0;
+    LaunchTransactionResult result = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        []() -> int {
+            throw 41;
+        },
+        [&]() {
+            ++aicpu_submissions;
+            return 0;
+        }
+    );
+
+    EXPECT_EQ(result.rc, -1);
+    EXPECT_EQ(result.progress, LaunchProgress::Partial);
+    EXPECT_EQ(aicpu_submissions, 0);
+    EXPECT_TRUE(result.poisoned());
+    EXPECT_FALSE(result.receipt.valid());
+}
+
+TEST(NativeRunExecutionTest, AicpuFailureAfterAicorePoisonsWithoutReceipt) {
+    LaunchTransactionResult result = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        []() {
+            return 0;
+        },
+        []() {
+            return 43;
+        }
+    );
+
+    EXPECT_EQ(result.rc, 43);
+    EXPECT_EQ(result.progress, LaunchProgress::Partial);
+    EXPECT_TRUE(result.poisoned());
+    EXPECT_FALSE(result.receipt.valid());
+}
+
+TEST(NativeRunExecutionTest, AicpuExceptionAfterAicorePoisonsWithoutReceipt) {
+    int aicore_submissions = 0;
+    LaunchTransactionResult result = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        [&]() {
+            ++aicore_submissions;
+            return 0;
+        },
+        []() -> int {
+            throw 43;
+        }
+    );
+
+    EXPECT_EQ(result.rc, -1);
+    EXPECT_EQ(result.progress, LaunchProgress::Partial);
+    EXPECT_EQ(aicore_submissions, 1);
+    EXPECT_TRUE(result.poisoned());
+    EXPECT_FALSE(result.receipt.valid());
+}
+
+TEST(NativeRunExecutionTest, BothSubmissionsProduceIdentityBoundReceipt) {
+    int order = 0;
+    LaunchTransactionResult result = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        [&]() {
+            EXPECT_EQ(order++, 0);
+            return 0;
+        },
+        [&]() {
+            EXPECT_EQ(order++, 1);
+            return 0;
+        }
+    );
+
+    EXPECT_EQ(result.rc, 0);
+    EXPECT_EQ(result.progress, LaunchProgress::Complete);
+    EXPECT_EQ(order, 2);
+    EXPECT_TRUE(result.receipt.matches(kIdentity));
+
+    NativeRunIdentity stale = kIdentity;
+    stale.generation++;
+    EXPECT_FALSE(result.receipt.matches(stale));
+}
+
+TEST(NativeRunExecutionTest, PermitIsOneShot) {
+    LaunchPermit permit = NativeRunExecutionTestPeer::mint(kIdentity);
+    LaunchPermit first = std::move(permit);
+    ASSERT_TRUE(first.valid());
+    EXPECT_FALSE(permit.valid());
+
+    LaunchTransactionResult success = exact_launch_transaction(
+        kIdentity, std::move(first),
+        []() {
+            return 0;
+        },
+        []() {
+            return 0;
+        }
+    );
+    EXPECT_EQ(success.progress, LaunchProgress::Complete);
+    EXPECT_FALSE(first.valid());
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_native_run_launch_signal.cpp
+++ b/tests/ut/cpp/common/test_native_run_launch_signal.cpp
@@ -16,6 +16,7 @@
 #include <future>
 #include <thread>
 
+#include "native_run_execution_test_peer.h"
 #include "native_run_launch_signal.h"
 
 TEST(NativeRunLaunchSignalTest, WaitBlocksWithoutConsumingCpu) {
@@ -57,12 +58,22 @@ TEST(NativeRunLaunchSignalTest, NotificationBeforeWaitIsRemembered) {
 TEST(NativeRunLaunchSignalTest, PublishAcceptanceStoresOnceAndKeepsNotificationSticky) {
     volatile int32_t accepted_state = 0;
     NativeRunLaunchSignal signal(&accepted_state, 17);
+    NativeRunIdentity identity{11, 13, 17, 1};
+    LaunchTransactionResult launched = exact_launch_transaction(
+        identity, NativeRunExecutionTestPeer::mint(identity),
+        []() {
+            return 0;
+        },
+        []() {
+            return 0;
+        }
+    );
 
-    signal.publish_acceptance();
+    ASSERT_TRUE(signal.publish_receipt(launched.receipt, identity));
     EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 17);
 
     __atomic_store_n(&accepted_state, 23, __ATOMIC_RELEASE);
-    signal.publish_acceptance();
+    EXPECT_TRUE(signal.publish_receipt(launched.receipt, identity));
     EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 23);
 
     auto waiter = std::async(std::launch::async, [&]() {
@@ -74,9 +85,40 @@ TEST(NativeRunLaunchSignalTest, PublishAcceptanceStoresOnceAndKeepsNotificationS
 TEST(NativeRunLaunchSignalTest, NotificationBeforeLaunchMarkerSuppressesAcceptance) {
     volatile int32_t accepted_state = 5;
     NativeRunLaunchSignal signal(&accepted_state, 17);
+    NativeRunIdentity identity{11, 13, 17, 1};
+    LaunchTransactionResult launched = exact_launch_transaction(
+        identity, NativeRunExecutionTestPeer::mint(identity),
+        []() {
+            return 0;
+        },
+        []() {
+            return 0;
+        }
+    );
 
     signal.notify();
-    signal.publish_acceptance();
+    EXPECT_TRUE(signal.publish_receipt(launched.receipt, identity));
 
     EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 5);
+}
+
+TEST(NativeRunLaunchSignalTest, StaleReceiptCannotPublishAcceptance) {
+    volatile int32_t accepted_state = 5;
+    NativeRunLaunchSignal signal(&accepted_state, 17);
+    NativeRunIdentity identity{11, 13, 17, 1};
+    NativeRunIdentity stale = identity;
+    stale.generation++;
+    LaunchTransactionResult launched = exact_launch_transaction(
+        stale, NativeRunExecutionTestPeer::mint(stale),
+        []() {
+            return 0;
+        },
+        []() {
+            return 0;
+        }
+    );
+
+    EXPECT_FALSE(signal.publish_receipt(launched.receipt, identity));
+    EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 5);
+    signal.notify();
 }


### PR DESCRIPTION
## Summary

- add move-only launch permits and identity-bound receipts
- move launch-safe materialization into prepared execution ownership
- consume prepared state and produce active state at the exact AICore/AICPU submission boundary
- retain and poison uncertain partial launches while keeping pre-launch failures rollback-safe
- keep prepared-successor rollback isolated from active-run collectors and terminal state
- keep device-wall capture failure non-fatal without freeing a shared in-flight buffer
- place simulation launch side effects after permit consumption
- update stale lifecycle documentation and remove dead runner-global kernel arguments

## CI budget

The a2a3 full-scene lane had reached 587 seconds on #1695 with a 600-second session limit. The earlier #1700 run reported every case passed at 100% and then exited 124 at the same session wall. The main a2a3 sweep now uses 1200 seconds, matching the a5 sweep; isolated smoke and SDMA limits remain unchanged.

## Validation

- current base: 29b119d1
- LCW arm64 CANN editable build: passed
- C++ no-hardware targeted tests: test_native_run_launch_signal and test_native_run_execution passed
- pre-commit: headers, English-only, platform literals, large-file, YAML, EOF, whitespace, clang-format, Markdown, Ruff, and pyright hooks passed
- standalone clang-tidy was blocked by a shared compile-database cache rebuild race; it reported no finding attributable to this diff before the cache failure
- earlier a2a3 hardware lifecycle/stream/FIFO coverage on the exact-launch implementation: 10/10 scenes and 6/6 hardware unit tests

Simulation scene execution was intentionally omitted; simulation targets were compile-validated.