### PR TITLE
Add: restore marked tensors for Core swimlane replay

### DIFF
--- a/.claude/skills/core-swimlane/SKILL.md
+++ b/.claude/skills/core-swimlane/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: core-swimlane
-description: Produce an L0 (intra-core AICore pipeline) swimlane for one task — a single kernel or a mix — via the dump-driven `simpler_setup.tools.core_swimlane` tool. Use when the user asks to "run/produce a core swimlane", "trace a task's intra-core pipeline", profile why one AICore task is slow inside the core(s), or needs help choosing the tool's manual flags (`--func-id`, `--set-arg`, `--spmd-block-num`, `--case`). The tool captures real per-task args from an args dump and auto-generates the `msprof op simulator` replay — no hand-authored workspace. For a hand-authored single-`kernel_entry` replay use [insight-trace](../insight-trace/SKILL.md); for cross-task / scheduler / dependency timing use the chip swimlane.
+description: Produce a Core swimlane (the L0/intra-core AICore pipeline) for one task — a single kernel or a mix — via the dump-driven `simpler_setup.tools.core_swimlane` tool. Use when the user asks to "run/produce a core swimlane", "trace a task's intra-core pipeline", profile why one AICore task is slow inside the core(s), or needs help choosing the tool's manual flags (`--func-id`, `--restore-arg`, `--set-arg`, `--spmd-block-num`, `--case`). The tool captures real per-task args from an args dump and auto-generates the `msprof op simulator` replay — no hand-authored workspace. For a hand-authored single-`kernel_entry` replay use [insight-trace](../insight-trace/SKILL.md); for cross-task / scheduler / dependency timing use the chip swimlane.
 ---
 
 # Core Swimlane — Intra-core Pipeline Trace for a Task
@@ -10,8 +10,9 @@ reconstructs them, generates a combined `msprof op simulator` replay of the
 **whole task** (a mix runs AIC + AIV0 + AIV1 in one op), and exports an
 Insight `trace.json` whose lanes are the cluster's pipes. Full reference:
 [docs/dfx/core-swimlane-profiling.md](../../../docs/dfx/core-swimlane-profiling.md).
-This skill is the **operating procedure** — above all the one genuinely
-manual decision: the slot/value for `--set-arg`.
+This skill is the **operating procedure** — above all the manual decisions:
+whether a structured control tensor needs `--restore-arg`, and the
+slot/value for any `--set-arg`.
 
 ## When to use
 
@@ -19,7 +20,7 @@ manual decision: the slot/value for `--set-arg`.
   per-pipe (`MTE2` / `MTE1` / `CUBE` / `FIXP` / `SCALAR` / `VECTOR`)
   intra-core picture, or to confirm AIC↔AIV overlap inside a mix.
 - **Not** for cross-task dependencies / scheduler / dispatch / finish
-  timing — that is the **chip swimlane**. L0 traces ONE task in isolation
+  timing — that is the **chip swimlane**. Core swimlane traces ONE task in isolation
   with no AICPU, so inter-task ordering is out of scope (doc §9, tier C).
 - **vs `insight-trace`**: that skill hand-authors a wrapper around one
   `kernel_entry`; `core_swimlane` automates the whole thing from a real dump
@@ -42,6 +43,16 @@ Onboard `a2a3` instead of `a2a3sim`: run
 runs on the locked device). The five internal steps and all flags are in
 doc §3.2 / §3.3.
 
+**Payload-restoration scope:** `--restore-arg` is supported only with
+`--platform a2a3sim` or `a2a3`. On `a5sim` / `a5`, tensor payload bytes from
+args dump are not trustworthy because of
+[#1560](https://github.com/hw-native-sys/simpler/issues/1560), so do not use
+them as tensor truth or pass `--restore-arg`. Metadata-only and zero-filled
+A5 Core swimlane replays remain usable. A5 still writes level-3 `args.bin` for tensors
+marked with `CoreTaskArgs::dump(...)`,
+but a Core swimlane trace restored from it is untrustworthy until #1560 is fixed;
+this limitation does not make the whole Core swimlane tool a2a3-only.
+
 ## Choosing the manual flags (the hard part)
 
 ### `--func-id` — the task's member set
@@ -53,6 +64,24 @@ lanes SPMD mix the dump records a duplicate (`[0,1,1]`), so pass
 `--func-id 0,1` (`set([0,1,1]) == {0,1}`). Wrong set → the tool lists the
 func_id shapes present in the dump; pick one of those.
 
+### `--restore-arg SLOT` — real structured control data
+
+This is currently an **a2a3/a2a3sim-only** capability. Do not use A5 payload
+for restoration while
+[#1560](https://github.com/hw-native-sys/simpler/issues/1560) is open.
+
+Use this repeatable flag when a tensor contains non-uniform runtime-built
+state that changes control flow or addresses, such as a tiling struct.
+Mark that tensor in orchestration with `CoreTaskArgs::dump(...)` before running
+the tool. The fresh capture stays at `--dump-args 3` (hybrid): every argument appears
+in JSON, while the existing Level-1 task mask writes only marked tensor bytes
+to `args.bin`. `--restore-arg` consumes the requested `before_dispatch` bytes
+and leaves all other replay tensors zero. A reused `--dump-json` must have its
+sibling `args.bin` and the requested record payload.
+
+Do not mark weights, activations, or KV pools merely for replay. A restored
+slot cannot also use `--set-arg`.
+
 ### `--set-arg SLOT=VALUE` — only when a loop count must shrink
 
 First classify where the kernel's loop trip count comes from:
@@ -62,6 +91,7 @@ First classify where the kernel's loop trip count comes from:
 | **Tensor shape** (e.g. `shapes[0] / TILE_ELEMS`) | **No** | shape is the real dump value; changing it distorts. (mixed_example / single-kernel rows need no `--set-arg`.) |
 | **A scalar arg** (e.g. `n_blocks`) | **Yes** — set the count directly | camodel would run the full loop; shrink to ≥ 3–4 (doc §7.2: floor 3, prefer 4). |
 | **A control-tensor's content** (e.g. `context_lens`) | **Yes** — fill the buffer | the kernel *derives* the count from the data; fill so the derived count ≈ 4 (need `block_size` to back out the value). Integer dtypes only. |
+| **A structured control tensor** (e.g. `FAInferTilingData`) | **No** — use `--restore-arg` on a2a3/a2a3sim | One uniform integer cannot reproduce a struct; restore its captured bytes on the supported platform family. |
 | **The SPMD `block_num`** | **No** — use `--spmd-block-num` | block_num lives in the synthesised slot-48 context, which `--set-arg` cannot reach. |
 
 Then find the slot — it is **per-kernel, never fixed**. Discover it:
@@ -86,10 +116,18 @@ Verified examples (slots read from source):
 ### `--spmd-block-num N` — SPMD grid width
 
 `block_num` is written into the synthesised slot-48 `LocalContext`. Default
-is 1; pass it to replay an SPMD cohort, or for a kernel that branches or
-grid-strides on `block_num` (e.g. set the real hw width `24`). `block_idx`
-is always synthesised to `0` (a representative block) and is **not** a flag —
-it has no instruction-stream branches (doc §8).
+is 1, which models a single-block replay and does not take multi-block
+branches such as `block_idx + 1 < block_num`. Keep that default only when the
+kernel ignores `block_num`. For a kernel that branches or grid-strides on it,
+read the selected task's real logical width from its orchestration and pass it
+explicitly. That value may come from `rt_available_cluster_count()`, or it may
+be task-specific. For example, the default lowest task-id in
+`spmd_multiblock_aiv` uses `--spmd-block-num 4`, while the default lowest task
+in `spmd_multiblock_mix` uses `--spmd-block-num 2`. When the real value is
+unavailable, a value of at least 2 is only a bounded approximation for
+exercising the next-block branch; record that limitation in the analysis.
+`block_idx` is always synthesised to `0` (a representative block) and is
+**not** a flag — it has no instruction-stream branches (doc §8).
 
 ### `--case NAME` — pin a small case on a multi-case test
 
@@ -111,6 +149,36 @@ per-block pipeline stays identical to production (you lose only iteration
 *count*, which does not change the pipeline shape). A case with different
 tile shapes traces only itself, not production.
 
+### Oversized CAModel checklist
+
+On the supported a2a3/a2a3sim path, marking only the required tensors with
+`CoreTaskArgs::dump(...)` limits the level-3 `args.bin`; the replay still
+allocates and zero-initializes every tensor at its dumped shape. For a large
+weight or KV tensor:
+
+1. Run with `--dump-json <manifest> --no-collect` first and inspect the printed
+   slot shapes.
+2. Use `--case <bounded-case>` to reduce the actual shape-driving extents
+   (layers, pages, cache rows, or sequence blocks). Lowering runtime `seq_len`
+   alone does not help when shapes use fixed `MAX_SEQ` or layer constants.
+3. Use `--set-arg` only when the remaining cost is a loop count; it does not
+   resize tensors. On a2a3/a2a3sim, use `--restore-arg` only to preserve
+   structured control state; it does not make the replay smaller. Do not use
+   A5 payload restoration while #1560 is open.
+4. Keep the default `--msprof-timeout 120` for ordinary cases. For a large,
+   repetitive workload where a partial pipeline is sufficient, set a shorter
+   timeout such as `--msprof-timeout 4`. This is the behavior recommended by
+   the [Ascend CANN official QA/parameter guidance for msProf `--timeout`](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/82RC1alpha001/devaids/optool/atlasopdev_16_0082.html):
+   msProf terminates simulation at the limit and parses the data produced so
+   far. A partial trace can show the observed pipeline segment, but cannot
+   establish whole-kernel duration or tail completeness. If the target kernel
+   produced no profiler data before timeout, there may be no `trace.json`.
+
+If no bounded case exists, make a focused workload-local case with the same
+target task, func-id set, argument order, tiling path, and tile geometry but
+smaller shape-driving extents. Keep a diagnostic-only case out of the PR unless
+it is intended as permanent regression coverage. Full details are in doc §3.6.
+
 ## Self-check after every run
 
 A known msprof/camodel export bug can truncate the last loop iteration(s).
@@ -123,4 +191,4 @@ raw Insight `trace.json`, for sub-laned per-instruction overlap (doc §3.4).
 
 Representative command per task shape (single AIC / single AIV / 1+1 mix /
 2-AIV mix / 3-way mix / SPMD single-source / SPMD coop mix / same-AIV-both-
-lanes / paged-attn scalar & control-tensor loops / qwen3) is in doc §3.7.
+lanes / paged-attn scalar & control-tensor loops) is in doc §3.8.

--- a/conftest.py
+++ b/conftest.py
@@ -155,8 +155,9 @@ def pytest_addoption(parser):
         type=int,
         default=0,
         help="Dump per-task args at runtime. Level: 0=off, 1=partial (only "
-        "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks), "
-        "3=full_json_only (all tasks, JSON metadata only, no .bin payload).",
+        "args selected via Arg::dump(...), default when given without a value), 2=full (all args), "
+        "3=hybrid (all tasks' JSON metadata; args marked via Arg::dump(...) also write payload; "
+        "used by simpler_setup.tools.core_swimlane for Core swimlane simulator replay).",
     )
     parser.addoption(
         "--enable-dep-gen",

--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -11,7 +11,8 @@ the bug in the first place.
 Args Dump captures per-task tensor inputs/outputs plus scalar inputs during kernel
 execution and writes them to disk for offline inspection. The host
 pre-allocates the recording buffers, AICPU writes records during
-execution, and the host exports a JSON manifest plus a binary payload.
+execution, and the host exports a JSON manifest plus any level-selected binary
+payload.
 The result is a stable, replayable record of every dumped argument a kernel
 saw, without the timing distortion of inline printing.
 
@@ -23,21 +24,25 @@ saw, without the timing distortion of inline printing.
 - **Logical shape preserved.** Records carry dtype, shape,
   `strides`, `start_offset`, and `is_contiguous` so logical views are
   reconstructable.
-- **Manifest + binary payload.** `--dump-args` writes a JSON
-  manifest plus one `.bin` payload per run; tensor entries carry
-  `bin_offset` / `bin_size`, while scalar entries stay manifest-only.
+- **Manifest + level-dependent binary payload.** Once at least one record is
+  collected, every enabled level writes `args_dump.json`. Levels 1 and 2 then
+  create `args.bin` eagerly; hybrid Level 3 creates it lazily only when an
+  `Arg::dump(...)`-selected tensor contributes payload. Tensor payload records
+  carry `bin_offset` / `bin_size`, while scalar values remain manifest-only.
 - **Unified scalar args.** Scalar values are emitted as
   `kind: scalar`, `stage: before_dispatch`, zero-dim records in
   `args_dump.json`; there is no separate args-only manifest. Their
   final `dtype` is registered at submit time in a dump-only per-task side table
   and resolved by AICPU when writing each scalar dump record.
-- **Cross-architecture.** Same flags and on-disk layout family on
-  `a2a3` and `a5`. Both runtimes are wired through.
+- **Cross-architecture metadata.** The flags, manifest schema, and scalar
+  metadata are wired through both runtime variants on `a2a3` and `a5`.
+  Real tensor-payload consumption is currently supported only on the
+  `a2a3` platform family; see the platform scope below.
 
 Enable in one line (`2` = full dump, every task):
 
 ```bash
-python tests/st/<case>/test_<name>.py -p a5sim --dump-args 2
+python tests/st/<case>/test_<name>.py -p a2a3sim --dump-args 2
 ```
 
 ## 3. How to Use
@@ -51,38 +56,61 @@ python tests/st/<case>/test_<name>.py -p a5sim --dump-args 2
 | `0` (or flag absent) | off — zero overhead |
 | `1` (bare `--dump-args`) | **partial** — only args marked with `CoreTaskArgs::dump(...)` (see §3.2) |
 | `2` (`--dump-args 2`) | **full** — every task's tensor inputs/outputs and scalar args |
-| `3` (`--dump-args 3`) | **full, JSON only** — every task's tensor/scalar metadata (shape, dtype, strides, scalar values) to `args_dump.json`; no payload captured, no `.bin` file |
+| `3` (`--dump-args 3`) | **hybrid** — every task's tensor/scalar metadata goes to `args_dump.json`; tensors marked with `CoreTaskArgs::dump(...)` also contribute payload to `args.bin` |
 
-Level 3 exists for consumers that need only the per-task argument metadata,
-not the tensor element data — e.g. feeding the manifest into tooling. The AICPU
-skips the arena payload copy entirely (treating every tensor like a scalar
-for payload purposes), so it incurs none of full mode's device→host
-bandwidth or arena pressure, and the manifest's `bin_file` is `null` with
-every `bin_size` at `0`.
+> **Tensor-payload platform scope:** levels 1/2 and marked level 3 are
+> currently supported for payload consumers only on `a2a3` / `a2a3sim`.
+> On `a5` / `a5sim`, payload truth remains outside the supported consumer
+> contract while [#1560](https://github.com/hw-native-sys/simpler/issues/1560)
+> is open. Do not use an a5 dump as a source of tensor truth. A marked
+> level-3 payload still produces `args.bin` on that platform family, but it is
+> not trustworthy for a Core swimlane replay that restores it.
+> Plain level-3 metadata, including inline scalar values, does not consume
+> tensor payload and remains available.
+
+The hybrid Level 3 is the capture mode used by
+`python -m simpler_setup.tools.core_swimlane` to build a Core swimlane simulator replay:
+it provides complete per-task argument metadata without dumping every tensor's
+element data. It reuses the exact task/argument mask produced by
+`CoreTaskArgs::dump(...)` for Level 1: every argument still gets a JSON record,
+while only marked tensors contribute bytes to `args.bin`.
+Scalar values already live inline in the manifest and never need payload copy.
+With no `dump(...)` markers, the AICPU skips all arena payload copies, the
+manifest's `bin_file` is `null`, and every `bin_size` is `0`.
+
+Level 3 deliberately inherits Level 1's existing mask-propagation scope; it
+does not add a second selector path. Both runtime variants on `a2a3` and `a5`
+already propagate the `CoreTaskArgs::dump(...)` mask. Level 3 consumes that same
+mask without changing Level 1 behavior. On `a5`, however, the resulting tensor
+bytes remain untrusted under #1560, so payload restoration stays outside this
+change until that issue is fixed.
 
 ```bash
 # Standalone runner
-python tests/st/<case>/test_<name>.py -p a5sim --dump-args 2     # full
+python tests/st/<case>/test_<name>.py -p a2a3sim --dump-args 2  # full
 python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --dump-args   # partial (level 1)
 
 # pytest
 pytest tests/st/<case> --platform a5sim --dump-args 2
 # a5 host_build_graph has no examples — use the scene test
 pytest tests/st/a5/host_build_graph/dump_args --platform a5sim --dump-args 2
+pytest tests/st/<case> --platform a2a3sim --dump-args 2
+pytest examples/a2a3/host_build_graph/vector_example --platform a2a3sim --dump-args 2
 ```
 
 The level sets `CallConfig::enable_dump_args` (0/1/2/3). The host then
 allocates dump storage, publishes its base address through
 `kernel_args.dump_data_base`, and sets `SIMPLER_DFX_FLAG_DUMP_ARGS`
 (levels 1, 2, and 3) in each worker handshake's `enable_profiling_flag` for
-the enable/disable decision. The **partial / full / full-json-only**
+the enable/disable decision. The **partial / full / hybrid**
 distinction is carried as a `DumpArgsLevel` in the dump shared-memory header
 (`DumpDataHeader::dump_args_level`, host-written before launch) rather
 than in the profiling-flag bitmask. The on-device AICPU reads the storage base
 via `set_platform_dump_base()`, the enable bit via
 `set_dump_args_enabled(SIMPLER_GET_DFX_FLAG(...))`, and latches the mode
-in `dump_args_init()` from the header level (`PARTIAL` → selective,
-`FULL_JSON_ONLY` → metadata-only, payload copy suppressed). Because the
+from the header level before task dispatch (`PARTIAL` → selective,
+`HYBRID` → all metadata, payload copy controlled by the
+same per-task mask as `PARTIAL`). Because the
 level is decided host-side **before any task is
 dispatched**, it is latched up front — there is no dependence on task
 submission order. AICore executors read the same `SIMPLER_DFX_FLAG_DUMP_ARGS`
@@ -150,13 +178,14 @@ before any dispatch — not inferred from the markers, so it never depends
 on task submission order. At level 1, tasks without a marker are skipped
 and marked tasks dump only their selected arguments. At level 2, the
 markers are ignored and every task's tensors/scalars are dumped. At level
-3, every task's tensors/scalars are dumped as metadata only (no payload,
-no `.bin`). With no
-`--dump-args` (level 0) dump is off entirely.
+3, every task's tensors/scalars are dumped as metadata and the same markers
+control which tensor records carry payload. A5 tensor payload remains
+unsupported under [#1560](https://github.com/hw-native-sys/simpler/issues/1560).
+With no `--dump-args` (level 0) dump is off entirely.
 
 If you run at level 1 but place no `dump(...)` markers anywhere, the
-manifest is empty — that is the deliberate "only what I marked" contract.
-Use `--dump-args 2` when you want everything.
+collector receives no records and exports no manifest — that is the deliberate
+"only what I marked" contract. Use `--dump-args 2` when you want everything.
 
 ### 3.3 Output
 
@@ -169,19 +198,25 @@ The dump artifacts land under the per-task output prefix
 <output_prefix>/
 └── args_dump/
     ├── args_dump.json  # unified argument manifest (`--dump-args`)
-    └── args.bin   # raw tensor payload (`--dump-args`)
+    └── [args.bin]      # eager at levels 1/2; present at level 3 only with selected tensor payload
 ```
 
 Filenames are fixed (no per-file timestamp) — the directory is the
-per-task uniqueness boundary. `--dump-args` emits both files in the
-same `args_dump/` directory.
+per-task uniqueness boundary. Once at least one record reaches the collector,
+levels 1/2 create `args.bin`, which may be empty when no tensor payload was
+selected or recorded. Hybrid Level 3 with records but no selected tensor
+payload emits only `args_dump.json`; otherwise it also emits `args.bin`.
+On a5, a present and correctly sized `args.bin` does not establish payload
+truth while [#1560](https://github.com/hw-native-sys/simpler/issues/1560) is
+open.
 
 #### `args_dump.json` — Unified manifest
 
 `args_dump.json` is the manifest; its `bin_file` field points at
-the sibling binary payload. At level 3 (full, JSON only) no payload is
-captured: `bin_file` is `null`, no `.bin` is written, and every entry's
-`bin_size` is `0`.
+the sibling binary payload. A plain level-3 capture has `bin_file: null`, no
+`.bin`, and `bin_size: 0` for every entry. A level-3 capture with marked tensors
+has `bin_file: "args.bin"`; only the `CoreTaskArgs::dump(...)`-marked tensor
+records have a non-zero `bin_size`.
 
 Example manifest (one input tensor captured before dispatch):
 
@@ -192,6 +227,7 @@ Example manifest (one input tensor captured before dispatch):
     "type": "logical_contiguous",
     "byte_order": "little_endian"
   },
+  "dump_args_level": 2,
   "total_args": 1,
   "before_dispatch": 1,
   "after_completion": 0,
@@ -226,6 +262,7 @@ Example manifest (one input tensor captured before dispatch):
 
 Key fields:
 
+- `dump_args_level` — the capture mode (`0` / `1` / `2` / `3`).
 - `task_id` — runtime task identity. Use to correlate with swimlane / PMU
   output.
 - `func_id` — **array** of the task's active-subtask kernel ids (its mix
@@ -322,7 +359,7 @@ Full template:
 
 ## 4. Capabilities
 
-What you can read out of `args_dump.json` + `args.bin`:
+What you can read out of `args_dump.json` and, when present, `args.bin`:
 
 - **Per-task input snapshots** (`role: input`, `stage:
   before_dispatch`) — what each kernel was given.
@@ -363,7 +400,7 @@ DumpDataHeader                                  (host init, AICPU reads)
 ├── num_dump_threads
 ├── records_per_buffer
 ├── magic = 0x44554D50 ("DUMP")
-└── dump_args_level  (DumpArgsLevel: 0=off, 1=partial, 2=full, 3=full_json_only; AICPU latches in dump_args_init)
+└── dump_args_level  (DumpArgsLevel: 0=off, 1=partial, 2=full, 3=hybrid; AICPU latches before dispatch)
 
 DumpBufferState[num_dump_threads]               (per-thread)
 ├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
@@ -483,7 +520,7 @@ remaining watermark deficit is batch-allocated without writing device free
 queues.
 
 Each collector appends metadata to its own vector, so collectors do not
-serialize on the manifest accumulator. Payloads still share one `args.bin`:
+serialize on the manifest accumulator. Captured payloads share one `args.bin`:
 the narrow writer lock assigns the next binary offset and enqueues the payload
 in the same order, while metadata insertion stays outside that lock. Export
 joins the writer, folds the shard-local vectors together, and sorts the merged
@@ -561,10 +598,10 @@ framework reference.
 
 a5's `ArgsDumpCollector` derives from
 `ProfilerBase<ArgsDumpCollector, DumpModule>` and shares the
-split mgmt + collector shard structure with a2a3. The single behavioral
+split mgmt + collector shard structure with a2a3. The architectural
 deviation from §5.4 is the **transport channel**: a5 has no
 `halHostRegister`, so each device buffer is paired with a
-host-shadow `malloc()` and the mgmt loop synchronizes the two via
+host-shadow `malloc()` and the framework synchronizes selected fields via
 `profiling_copy.h` (`rtMemcpy` onboard, `memcpy` in sim).
 `MemoryOps` therefore carries five callbacks (`alloc` / `reg` /
 `free_` / `copy_to_device` / `copy_from_device`). The mgmt threads
@@ -652,7 +689,7 @@ on a5 inherits the same CRTP base
 as a2a3 and parameterizes
 [`BufferPoolManager`](../../src/common/platform/include/host/buffer_pool_manager.h)
 with `DumpModule`. The only a5-specific glue is the 5-callback
-`MemoryOps`, the per-tick shm mirror, and the on-demand arena copy
+`MemoryOps`, targeted shared-field refreshes, and the on-demand arena copy
 inside `on_buffer_collected`.
 
 a5 normally relies on per-thread AICPU flush (`dump_args_flush`) to move
@@ -670,9 +707,10 @@ before that flush runs, `reconcile_counters` recovers a non-empty
 | Buffer model | rotating pool (free + ready queues per thread) | identical |
 | Host threads | split mgmt + collector shards, streams during execution | identical |
 | Host-class shape | `ProfilerBase<ArgsDumpCollector, DumpModule>` | identical |
-| Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
+| Host transport | `halHostRegister` shared memory | host-shadow `malloc` + targeted `rtMemcpy`/`memcpy` |
 | `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
-| Arena access | direct via SVM | `copy_from_device` inside `on_buffer_collected` |
+| Arena access | direct via SVM | targeted `copy_from_device` inside `on_buffer_collected` |
+| Tensor-payload support | Supported | payload consumers remain unsupported while #1560 is open |
 | `reconcile_counters` | recover leftover current buffers + dropped accounting | identical |
 | Lifecycle | `initialize` → `start` → `stop` → `reconcile_counters` → `export_dump_files` → `finalize` | identical |
 
@@ -683,9 +721,10 @@ Args Dump is opt-in and zero-overhead when disabled — without
 AICore skip the dump-specific code paths. The `pipe_barrier(PIPE_ALL)`
 before FIN is also gated on the same handshake bit.
 
-With `--dump-args`, AICPU records full `BEFORE_DISPATCH` /
-`AFTER_COMPLETION` tensor payloads plus manifest-only
-`BEFORE_DISPATCH` scalar args. The per-task overhead is dominated by:
+With `--dump-args`, AICPU records level-selected tensor/scalar metadata and
+copies tensor payload according to the level table in §3.1. Scalar values stay
+manifest-only. When tensor payload is selected, the per-task overhead is
+dominated by:
 
 - The `BEFORE_DISPATCH` / `AFTER_COMPLETION` payload memcpy into
   the per-thread arena (contiguous fast-path; logical traversal for
@@ -821,25 +860,28 @@ Per-thread arena =
 
 ## 8. FAQ and Debug Guide
 
-**No `args_dump/` directory in the output.** Check that
-`--dump-args` was passed; without it (level 0) the host does not
-allocate dump storage. Verify the run wrote to the expected
-`<output_prefix>` and that the kernel actually executed (a kernel
-that exits early before any task dispatch produces an empty
-manifest).
+**No `args_dump/` directory or `args_dump.json` in the output.** Check that
+`--dump-args` was passed; without it (level 0) the host does not allocate dump
+storage. The collector exports files only after receiving at least one record,
+so the same result is expected when the kernel dispatches no arguments or when
+Level 1 has no `CoreTaskArgs::dump(...)` markers. Add markers (§3.2), or pass
+`--dump-args 2` for a full dump.
 
-**`args_dump/` exists but the manifest captured nothing.** You are
-most likely at the default partial level (`--dump-args` = level 1)
-with no `CoreTaskArgs::dump(...)` markers in the orchestration, so every task is
-skipped. Add markers (§3.2), or pass `--dump-args 2` for a full dump.
+**a5 `args.bin` fails known-value validation.** Treat this as the payload-truth
+problem tracked by [#1560](https://github.com/hw-native-sys/simpler/issues/1560)
+while that issue remains open; it is not evidence that the recorded tensors
+were actually zero. Use `a2a3` / `a2a3sim` for any payload consumer. Plain
+level-3 metadata remains usable on a5 because it does not read tensor bytes.
 
-**Manifest has tasks but expected tensor records are missing.** A
-AICPU received a payload whose tensor count or metadata did not
-match what the orchestrator registered. A scalar-only task will
-have zero tensors and is intentionally empty. Look for a
-`LOG_WARN` from `try_log_dump_args_layout_mismatch` — it
+**Manifest has tasks but expected tensor records are missing.** AICPU received
+a payload whose tensor count or metadata did not match what the orchestrator
+registered. Look for a `LOG_WARN` from `try_log_dump_args_layout_mismatch` — it
 identifies the first mismatched task, then is suppressed to avoid
-log flooding. Ensure every task that expects a tensor output calls
+log flooding. A scalar-only task has no tensor records but still carries its
+scalar records in the manifest. For `host_build_graph`, ensure
+`set_tensor_info_to_task` (or
+`add_task_with_tensor_info`) was called for every task. For
+`tensormap_and_ringbuffer`, ensure every task that expects a tensor output calls
 `alloc_tensors` with a `TensorCreateInfo`, and every input tensor
 is added via `add_input` / `add_output` / `add_inout`.
 
@@ -872,12 +914,11 @@ explicit dump-dir path to the viewer:
 `python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/args_dump`.
 
 **The run hung (AICore op-timeout / scheduler timeout) — is there
-still a dump?** Yes, and it includes the hung kernel's own partial
-output. The host exports the manifest even though `run()` returns the
-timeout error, and you get the inputs of every dispatched task
-(captured at `BEFORE_DISPATCH`) plus the `AFTER_COMPLETION` output of
-every task that completed before the hang. This rests on the timeout
-ordering — the three budgets are tuned so the **AICPU detects the
+still a dump?** Yes. The host exports the manifest even though `run()` returns
+the timeout error. Within the selected level's record scope, it contains task
+inputs captured at `BEFORE_DISPATCH`, outputs from tasks that completed before
+the hang, and any recoverable partial output from an in-flight task. This rests
+on the timeout ordering — the three budgets are tuned so the **AICPU detects the
 hang first**, dumps, and only then the hardware/host timeouts fire:
 
 ```text

--- a/docs/dfx/core-swimlane-profiling.md
+++ b/docs/dfx/core-swimlane-profiling.md
@@ -15,12 +15,12 @@ task. It runs the task in isolation under `msprof op simulator` (the
 AICore camodel) and exports a MindStudio Insight `trace.json` whose lanes
 are the cluster's pipes, not the chip's cores. It deliberately
 **bypasses AICPU orchestration**: scheduler / tensormap / ringbuffer
-state is out of scope (that is L2's job, and needs real silicon). L0 is
+state is out of scope (that is L2's job, and needs real silicon). Core swimlane is
 the per-pipe, per-instruction zoom that sits one level below an L2 task
 block.
 
 A task may be a single kernel or a **mix** — multiple sub-task kernels
-sharing one `args[]` on the 1C2V cluster (1 AIC + up to 2 AIV). L0
+sharing one `args[]` on the 1C2V cluster (1 AIC + up to 2 AIV). Core swimlane
 replays the **whole task together**: a mix runs its AIC + AIV0 + AIV1
 kernels in one combined op, so the trace shows all the cluster's
 sub-cores side by side, not one kernel in isolation.
@@ -44,15 +44,17 @@ captured args — zero hand-written shapes or scalars.
   `msprof op simulator` op. The cube sub-core runs the AIC member, the
   vec sub-cores run the AIV member(s) → a combined AIC+AIV swimlane.
 - **Zero-guess args** — the task's real Tensor descriptors and scalars
-  come from a JSON-only `--dump-args 3` capture (metadata + scalar
-  values, no `.bin` payload — all reconstruction needs). The dump's
+  come from a `--dump-args 3` (hybrid) capture. When a structured
+  control tensor also needs its real contents, repeatable
+  `--restore-arg SLOT` restores payload already selected in orchestration by
+  `CoreTaskArgs::dump(...)` into the replay on `a2a3` / `a2a3sim`. The dump's
   `func_id` array gives the task's mix membership directly.
 - **Loop-count control (`--set-arg SLOT=VALUE`)** — when a kernel's loop
   trip count comes from a scalar or a control tensor, override it to
   shrink a runaway loop (so the camodel doesn't hang) or to fix a
   "fake-fast" zero-filled control tensor — without distorting the
-  per-iteration pipeline structure. Repeatable; default uses the real
-  dump values. See
+  per-iteration pipeline structure. Repeatable; scalars keep their real
+  dump values, while unselected tensor payloads default to zero. See
   [§7.2](#72-arg-floor-for-a-loop-count-without-distortion).
 - **Source-line attribution (`--debug-line` / `-g`)** — compile the
   kernel with `-g` (skipping the link strip) so the trace carries
@@ -65,6 +67,8 @@ captured args — zero hand-written shapes or scalars.
   replay is camodel either way — so `a2a3sim` is the default and needs
   no NPU and no arch-precheck. Use onboard only for a kernel whose sync
   idiom (e.g. a manual `prod.record()`) compiles only for the device.
+  Tensor restoration is currently an a2a3-only capability; a5 metadata-only
+  and zero-filled replays remain available.
 - **Two trace outputs** — a native Insight `trace.json` and an
   auto-generated Perfetto-friendly variant (sub-laned + atomic flags;
   see [§3.4](#34-viewing-insight-vs-perfetto)).
@@ -125,7 +129,7 @@ onboard `--platform`; a sim `--platform` uses no NPU until step 5):
 | Step | Action | Uses NPU |
 | ---- | ------ | -------- |
 | 1 | Read the test's `CALLABLE`; build a `func_id → (source, core_type)` table | No |
-| 2 | Run `--dump-args 3` (JSON-only) → `args_dump.json` (or reuse via `--dump-json`) | Onboard only |
+| 2 | Run `--dump-args 3` (hybrid) → full `args_dump.json` plus `args.bin` for tensors marked with `CoreTaskArgs::dump(...)` (or reuse via `--dump-json`) | Onboard only |
 | 3 | Select the task whose member set == `--func-id`, reconstruct its full positional args, **print the arg-slot table** (slot / kind / shape / value) | No |
 | 4 | Emit the replay workspace and smoke-build it locally | No |
 | 5 | `msprof op simulator` collect + export → `trace.json`, then auto-converts a Perfetto variant | **Yes** |
@@ -137,7 +141,7 @@ reading the kernel source — names are not in the dump (only kind / shape
 ```text
 [core_swimlane] func_id=0 task=0x... mix=[0, 1, 2] mode=mix block_num=3
               members=[MATMUL(aic,func 0), ADD(aiv,func 1), MUL(aiv,func 2)]
-[core_swimlane] arg slots (override with --set-arg SLOT=VALUE):
+[core_swimlane] arg slots (override with --set-arg SLOT=VALUE or --restore-arg SLOT):
     slot 0  tensor  FLOAT32  [16384]
     ...
 ```
@@ -145,6 +149,8 @@ reading the kernel source — names are not in the dump (only kind / shape
 A scalar slot holds the value directly (`--set-arg 4=4`); a tensor slot
 holds a pointer, so `--set-arg` fills its buffer (`--set-arg 4=512`). See
 [§7.2](#72-arg-floor-for-a-loop-count-without-distortion).
+Use `--restore-arg 6` instead when a tensor contains a non-uniform
+structure or lookup table that a single fill value cannot represent.
 
 ### 3.3 Key flags
 
@@ -153,15 +159,26 @@ holds a pointer, so `--set-arg` fills its buffer (`--set-arg 4=512`). See
 | `--test <file.py>` | SceneTest test file (required) |
 | `--func-id A[,B,C]` | The task's **member set** (comma-separated func_ids), required. `--func-id 0` traces the single-kernel task `{0}`; `--func-id 0,1,2` traces that 3-way mix. The set must exactly match a dispatched task's `func_id` array (you wrote the orchestration, so you know the members) |
 | `--task-id <hex>` | Which task instance to replay (default: lowest). Instances of the same mix shape are structurally identical |
-| `--platform <p>` | Dump platform → arch / compile / SoC params (default `a2a3sim`). Sim (`a2a3sim` / `a5sim`) dumps with no NPU; onboard (`a2a3` / `a5`) dumps on `$TASK_DEVICE` (wrap the tool in `task-submit`). The replay is camodel regardless; geometry is identical, so prefer sim |
+| `--platform <p>` | Dump platform → arch / compile / SoC params (default `a2a3sim`). Sim (`a2a3sim` / `a5sim`) dumps with no NPU; onboard (`a2a3` / `a5`) dumps on `$TASK_DEVICE` (wrap the tool in `task-submit`). The replay is camodel regardless; geometry is identical, so prefer sim. Tensor restoration is supported only on `a2a3` / `a2a3sim` |
 | `--device <ID>` | NPU device for an onboard dump + collect. **Auto-supplied** — `task-submit` appends `--device <id>` (also `$TASK_DEVICE`). Sim platforms ignore it |
 | `--case <NAME>` | Pin the dump to one `CASES[*].name`. Omitting it auto-pins the first case that lists `--platform`; pass it to target a smaller case when that first one overflows the camodel. Accepts `ClassName::Case` |
-| `--dump-json <path>` | Reuse an existing `args_dump.json`, skipping the dump re-run |
-| `--set-arg SLOT=VALUE` | Override an arg by `args[]` slot. Scalar slot → rewrite value; tensor slot → fill its buffer (integer dtypes). Shrinks a loop count without distortion. Repeatable. Default: real dump values |
-| `--spmd-block-num N` | `block_num` written into the synthesized SPMD context (slot 48). Default: the **selected** case's `block_dim` |
+| `--dump-json <path>` | Reuse an existing `args_dump.json`, skipping the dump re-run. `--restore-arg` requires its selected record payload and sibling `args.bin` |
+| `--restore-arg SLOT` | Restore one tensor's captured `before_dispatch` payload on `a2a3` / `a2a3sim`. Repeatable. The tensor must already be marked with `CoreTaskArgs::dump(...)` in orchestration; scalar/output-only/unmarked/truncated/overwritten slots are rejected. Cannot target the same slot as `--set-arg`. Do not use with a5 payloads while #1560 is open |
+| `--set-arg SLOT=VALUE` | Override an arg by `args[]` slot. Scalar slot → rewrite value; tensor slot → fill its buffer (integer dtypes). Shrinks a loop count without distortion. Repeatable. By default scalars retain dump values and tensor payloads are zero-filled |
+| `--spmd-block-num N` | `block_num` written into the synthesized SPMD context (slot 48). Default: 1 |
 | `--debug-line` / `-g` | Compile with `-g` (skip strip) so the trace carries `debug_line` → Insight maps instructions to source lines |
-| `--no-collect` | Generate + smoke-build only; do not take an NPU |
+| `--no-collect` | Stop after workspace generation and smoke build; an onboard dump still uses its locked NPU |
 | `--max-time <sec>` | `task-submit` budget (default 1800) |
+| `--msprof-timeout <minutes>` | `msprof op simulator --timeout` application-run limit in **minutes**. The Core swimlane tool always passes it; default 120, valid range 1–2880. Use a shorter value deliberately for large, repetitive workloads that only need a partial pipeline |
+
+Payload restoration currently targets the a2a3 platform family. The target
+tensor must be marked in the task's orchestration before capture. a5/a5sim
+tensor payload is not trustworthy because of
+[#1560](https://github.com/hw-native-sys/simpler/issues/1560), so it is outside
+the current restore contract. An a5/a5sim Level-3 run with marked tensors may
+produce `args.bin`, but a Core swimlane that restores its tensor payload is
+untrustworthy; this does not prevent a5 metadata-only or zero-filled Core
+replays.
 
 Per-arch build parameters are fixed in the tool's `ARCH_CONFIG`:
 
@@ -200,7 +217,7 @@ The raw export is under `<ws>/insight_export/OPPROF_*/simulator/`.
   [`.claude/skills/insight-trace/SKILL.md`](../../.claude/skills/insight-trace/SKILL.md);
   here it is built into the tool.
 
-### 3.5 Selecting a task / mix, and what to `--set-arg`
+### 3.5 Selecting a task / mix, and what to initialize
 
 `--func-id` **is** the task's member set — you name the exact func_ids the
 task is made of, and the tool picks the task whose `func_id` array matches.
@@ -226,14 +243,92 @@ the tensor **shape** (`shapes[0]`), which the dump captures truthfully,
 so **no `--set-arg` is needed** — the real count (one 128×128 tile) is
 already small.
 
+Use `--restore-arg` only when the kernel reads non-uniform tensor contents
+that affect control flow or addressing — for example a runtime-built tiling
+structure. Mark the tensor in the task's `CoreTaskArgs::dump(...)`; a fresh run
+then uses hybrid dump level 3 for full metadata and reuses that Level-1 mask for
+payload. Restoration is currently supported only with `--platform a2a3` or
+`a2a3sim`; do not consume a5 tensor payload while #1560 is open. Do not mark
+weight, activation, or KV-pool tensors merely for replay.
+Slots restored from their `before_dispatch` snapshot cannot also use
+`--set-arg`.
+
 Omitting `--case` auto-pins the **first** `CASES[*]` that lists your
 `--platform`, so the dump always targets exactly one case (deterministic —
 no "run every case, reconstruct from the newest dump dir" ambiguity). Pass
 `--case` explicitly when that first case is not the smallest — a full-size
-production case's shapes overflow the camodel replay (§3.4). The synthesized
-slot-48 `block_num` comes from `--spmd-block-num` (default 1); an SPMD cohort sizes itself on device, so it is not readable from the test file.
+production case's shapes can make the camodel impractical (§3.6). The
+synthesized slot-48 `block_num` comes from `--spmd-block-num` (default 1);
+the args dump does not carry that context, so consult the selected task's
+orchestration for its real logical width.
 
-### 3.6 Reusing a dump across kernels
+### 3.6 Oversized CAModel cases
+
+CAModel is a cycle-accurate, whole-chip simulator. The replay allocates every
+tensor at the shape recorded in `args_dump.json`, including tensors whose
+payload is left zero. Marking only the required tensors with
+`CoreTaskArgs::dump(...)` reduces the level-3 `args.bin` size and onboard dump
+pressure; it does **not** reduce replay allocation, zero-initialization, or
+kernel loop work. A large KV pool or weight tensor can therefore remain
+expensive even when only a small metadata slot is restored.
+
+Use this order:
+
+1. **Smoke-build before collecting.** Reuse the dump when available and pass
+   `--no-collect`. Step 3 prints every slot and shape, and the generated
+   workspace proves the sources and argument layout compile without spending
+   time in CAModel.
+2. **Shrink shapes with `--case`.** Choose a bounded case that preserves the
+   target kernel's compile-time batch/head/tile geometry and mix membership,
+   while reducing shape-driving quantities such as layer count, page count,
+   cache rows, or sequence blocks. Changing only a runtime `seq_len` does not
+   help when allocation still uses a fixed `MAX_SEQ`, layer count, or cache
+   extent.
+3. **Shrink only the loop when shapes are already acceptable.** Use
+   `--set-arg SLOT=VALUE` for scalar or uniform integer control inputs. It does
+   not resize tensor descriptors. Keep at least 3–4 iterations when the goal
+   is steady-state pipeline analysis.
+4. **Restore only structured control inputs on a2a3/a2a3sim.** Use
+   `--restore-arg` for tiling structs or lookup tables; do not restore weights,
+   activations, or KV pools. Restoration preserves control truth but is not a
+   scaling mechanism. Do not consume A5 tensor payload while
+   [#1560](https://github.com/hw-native-sys/simpler/issues/1560) is open.
+5. **Use a shorter timeout only when partial simulation is useful.** The
+   default is 120 minutes, so ordinary cases normally finish in full without
+   changing this option. For a large, repetitive case,
+   `--msprof-timeout 4` asks msProf to stop after four minutes and parse the
+   simulation data produced so far. This follows the
+   [Ascend CANN official QA/parameter guidance for msProf `--timeout`](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/82RC1alpha001/devaids/optool/atlasopdev_16_0082.html):
+   the option is intended for data-heavy, repeatedly computed operators whose
+   full simulation takes a long time, when a partial pipeline is enough to
+   obtain the necessary information. The official range is 1–2880 minutes.
+
+A timeout-generated trace is intentionally partial. It can answer questions
+about an observed steady-state pipeline segment, but it cannot establish total
+kernel duration or complete tail behavior, and the normal MMAD/FIX tail-count
+self-check does not apply to a deliberately truncated run. If the timeout
+fires before the target kernel produces any profiler data, msProf may have
+nothing to parse and no `trace.json` will be available.
+
+Typical two-stage invocation:
+
+```bash
+# Validate task selection, restored slots, shapes, and compilation.
+python -m simpler_setup.tools.core_swimlane ... \
+    --case <bounded-case> --dump-json <args_dump.json> --no-collect
+
+# Request a four-minute partial simulation for a large, repetitive case.
+python -m simpler_setup.tools.core_swimlane ... \
+    --case <bounded-case> --dump-json <args_dump.json> --msprof-timeout 4
+```
+
+If the workload has no bounded case, create a focused workload-local case that
+submits the same target task with the same func-id set, argument order, tiling
+path, and tile geometry, but smaller shape-driving extents. A one-off
+diagnostic case should not be committed unless it provides durable regression
+coverage.
+
+### 3.7 Reusing a dump across kernels
 
 The dump in step 2 is the slow part. When tracing several tasks from the
 same case, capture once and reuse:
@@ -247,12 +342,16 @@ python -m simpler_setup.tools.core_swimlane --test <file> --func-id 3,4 --platfo
     --dump-json outputs/<ClassName>_<Case>_<ts>/args_dump/args_dump.json
 ```
 
-The manifest holds every task's args for the whole case.
+The manifest holds every task's args for the whole case. The default level-3
+manifest is sufficient for descriptor/scalar reconstruction. Reusing it with
+`--restore-arg` is rejected if the requested tensor was not marked with
+`CoreTaskArgs::dump(...)`. Add the marker and capture a fresh Level-3 run, or
+reuse a payload-carrying manifest together with its sibling `args.bin`.
 
-### 3.7 Coverage across the #1181 test suite
+### 3.8 Coverage across the #1181 test suite
 
 Commit `b1e4bd23` (#1181) touched ~70 test files. The
-`tensormap_and_ringbuffer` kernels among them fall into these l0
+`tensormap_and_ringbuffer` kernels among them fall into these Core swimlane
 categories — one representative each, with its verified `--func-id`. The
 runnable commands follow the table, wrapped in `task-submit` (the step-5
 `msprof` collect takes a device on the shared box). Most use
@@ -267,8 +366,8 @@ arch-precheck (the case must declare the `--platform` you pass — §3.1).
 | Single AIV | `vector_example` | `--func-id 0` | `kernel_add`, dispatched `rt_submit_aiv_task(0)` (vec only) |
 | Mix 2 AIV (per-lane) | `mixed_example` | `--func-id 3,4` | ADD_STD@AIV0 + MUL_STD@AIV1 (`get_subblockid` routing) |
 | Mix 3-way 1C2V | `mixed_example` | `--func-id 0,1,2` | MATMUL@AIC + ADD@AIV0 + MUL@AIV1 |
-| SPMD single-source | `spmd_multiblock_aiv` | `--func-id 0` | single AIV reading `get_block_idx` (pass `--spmd-block-num`; replay traces block 0) |
-| SPMD mix, 2 AIV share a source | `spmd_multiblock_mix` | `--func-id 0,1,2` | func 1 & 2 are distinct ids but **both `kernel_spmd_mix.cpp`** → the 2 AIV collapse to one (both lanes run it). Routes by `get_sub_block_id` (slot 49) → in replay both lanes read `sub_block_id=0`; AIV0/AIV1 differ only by write offset, so the pipeline stays representative. (The same-source collapse also covers the duplicate-func_id `[0,1,1]` shape an SPMD mix produces when `aiv0 = aiv1`.) |
+| SPMD single-source | `spmd_multiblock_aiv` | `--func-id 0 --spmd-block-num 4` | single AIV reading `get_block_idx`; the default lowest task-id is orchestration task T0 with logical `block_num=4` |
+| SPMD mix, 2 AIV share a source | `spmd_multiblock_mix` | `--func-id 0,1,2 --spmd-block-num 2` | the default lowest task-id is orchestration task T0 with logical `block_num=2`. Func 1 & 2 are distinct ids but **both `kernel_spmd_mix.cpp`** → the 2 AIV collapse to one (both lanes run it). Routes by `get_sub_block_id` (slot 49) → in replay both lanes read `sub_block_id=0`; AIV0/AIV1 differ only by write offset, so the pipeline stays representative. (The same-source collapse also covers the duplicate-func_id `[0,1,1]` shape an SPMD mix produces when `aiv0 = aiv1`.) |
 | Paged-attn, loop = scalar | `paged_attention_unroll` | `--func-id 0 --set-arg 4=4` | QK stage; `n_blocks` scalar (slot 4) → shrink to 4 ([§7.2](#72-arg-floor-for-a-loop-count-without-distortion)) |
 | Paged-attn, loop = control tensor | `batch_paged_attention` | `--func-id 1 --set-arg 1=512 --case CaseSmall1` | SF reads `context_lens` (**slot 1**) content (`aiv_softmax_prepare.cpp`); `--set-arg 1=512` fills it uniformly → shrinks the derived per-batch block count |
 
@@ -276,56 +375,46 @@ Runnable commands (one per category):
 
 ```bash
 T=tests/st/a2a3/tensormap_and_ringbuffer        # most representatives
-E=examples/a2a3/tensormap_and_ringbuffer        # vector_example / qwen3
+E=examples/a2a3/tensormap_and_ringbuffer        # vector_example
 
 # --- a2a3sim cases (case declares a2a3sim; dump takes no NPU) ---
-L0="python -m simpler_setup.tools.core_swimlane --platform a2a3sim -g"  # -g: source-line attribution
+CORE="python -m simpler_setup.tools.core_swimlane --platform a2a3sim -g"  # -g: source-line attribution
 # Single AIV — vector_example kernel_add
-task-submit --device auto --max-time 1800 --run "$L0 --func-id 0     --test $E/vector_example/test_vector_example.py"
+task-submit --device auto --max-time 1800 --run "$CORE --func-id 0     --test $E/vector_example/test_vector_example.py"
 # Mix 2 AIV (per-lane) — ADD_STD + MUL_STD
-task-submit --device auto --max-time 1800 --run "$L0 --func-id 3,4   --test $T/mixed_example/test_mixed_example.py"
+task-submit --device auto --max-time 1800 --run "$CORE --func-id 3,4   --test $T/mixed_example/test_mixed_example.py"
 # Mix 3-way 1C2V — MATMUL + ADD + MUL
-task-submit --device auto --max-time 1800 --run "$L0 --func-id 0,1,2 --test $T/mixed_example/test_mixed_example.py"
+task-submit --device auto --max-time 1800 --run "$CORE --func-id 0,1,2 --test $T/mixed_example/test_mixed_example.py"
 # SPMD single-source
-task-submit --device auto --max-time 1800 --run "$L0 --func-id 0     --test $T/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py"
+task-submit --device auto --max-time 1800 --run "$CORE --func-id 0 --spmd-block-num 4 --test $T/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py"
 # SPMD mix, 2 AIV share a source
-task-submit --device auto --max-time 1800 --run "$L0 --func-id 0,1,2 --test $T/spmd_multiblock_mix/test_spmd_multiblock_mix.py"
+task-submit --device auto --max-time 1800 --run "$CORE --func-id 0,1,2 --spmd-block-num 2 --test $T/spmd_multiblock_mix/test_spmd_multiblock_mix.py"
 # Paged-attn, loop = control tensor (context_lens = slot 1; fill it to shrink the per-batch block count)
-task-submit --device auto --max-time 1800 --run "$L0 --func-id 1 --set-arg 1=512 --case CaseSmall1 --test $T/batch_paged_attention/test_batch_paged_attention.py"
+task-submit --device auto --max-time 1800 --run "$CORE --func-id 1 --set-arg 1=512 --case CaseSmall1 --test $T/batch_paged_attention/test_batch_paged_attention.py"
 
 # --- a2a3-ONLY cases (CASES declare no a2a3sim) ---
 # Onboard: run arch-precheck once, then --platform a2a3 (the dump runs on the locked device).
 .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
-L0a="python -m simpler_setup.tools.core_swimlane --platform a2a3 -g"
+CORE_HW="python -m simpler_setup.tools.core_swimlane --platform a2a3 -g"
 # Single AIC — standalone matmul (genuine single-AIC task)
-task-submit --device auto --max-time 1800 --run "$L0a --func-id 0 --test $T/alternating_matmul_add/test_alternating_matmul_add.py"
+task-submit --device auto --max-time 1800 --run "$CORE_HW --func-id 0 --test $T/alternating_matmul_add/test_alternating_matmul_add.py"
 # Paged-attn, loop = scalar (shrink n_blocks to 4)
-task-submit --device auto --max-time 1800 --run "$L0a --func-id 0 --set-arg 4=4 --test $T/paged_attention_unroll/test_paged_attention_unroll.py"
+task-submit --device auto --max-time 1800 --run "$CORE_HW --func-id 0 --set-arg 4=4 --test $T/paged_attention_unroll/test_paged_attention_unroll.py"
 ```
 
 `qwen3_14b_decode` used to serve as the "real SPMD workload" row here, driving
 its generated `fa_fused` mix with `--set-arg 0=96` on the `fa_total` work-item
 count. That kernel is gone: its attention is now a CANN
-`FusedInferAttentionScore` extern, so the row was dropped.
+`FusedInferAttentionScore` extern. Being an extern is not a blocker — the replay
+still feeds `kernel_entry`. Its work distribution now comes from a
+`FAInferTilingData` struct in the slot-6 `UINT8 metadata` buffer that
+`paged_attention_tiling_cce` fills at runtime. After that slot is marked with
+`CoreTaskArgs::dump(...)` in orchestration, `--restore-arg 6` can restore its real
+bytes without trying to synthesize a struct through uniform `--set-arg` filling.
+The committed production case is too large for a practical
+cycle-accurate replay, so it is not listed as a runnable coverage case here.
 
-Being an extern is not what blocks it — the replay feeds `kernel_entry` and does
-not care whether the source was generated or hand-written. The blocker is that
-this one takes its work distribution from a `FAInferTilingData` **struct**, in a
-`UINT8 metadata` buffer that `paged_attention_tiling_cce` fills at runtime.
-`--set-arg` writes one integer into *every* element, so it cannot synthesize a
-coherent struct (it is not even refused — `UINT8` passes the integer-dtype
-check), and this tool dumps at level 3, which captures metadata but no payload
-([args-dump](args-dump.md) §levels). With a zeroed `metadata`,
-`fai_body.hpp` reads `tiling->needCoreNum == 0` and takes the degenerate branch,
-so the trace would be unrepresentative rather than absent.
-
-That gap is in the tooling, not the kernel: `--dump-args 2` does capture the
-buffer's real bytes. Restoring payloads for control tensors — rather than only
-uniform-filling them — would make this and any other metadata-driven extern
-replayable. Until then the "real SPMD workload" category has no representative
-here.
-
-**Not l0 targets (excluded).** Runtime-mechanics tests (`orch_so_cache`,
+**Not Core swimlane targets (excluded).** Runtime-mechanics tests (`orch_so_cache`,
 `prepared_callable`, `dynamic_register`, `l3_group`, `l3_dependency`,
 `worker_chip_orch_comm`, `aicore_op_timeout`, `scope_stats`); comm / notify
 demos (`async_notify_demo`, `deferred_notify_demo`,
@@ -355,7 +444,7 @@ What it does **not** show (use [chip swimlane](chip-swimlane-profiling.md)):
 - **Cross-core synchronization timing.** The isolated replay has no
   AICPU, so orchestration-driven inter-core waits are absent — sub-cores
   appear freely parallel (see [§9](#9-limitations), tier C).
-- Multi-task placement across clusters. L0 is one task, one cluster.
+- Multi-task placement across clusters. Core swimlane is one task, one cluster.
 
 ## 5. How It Works
 
@@ -399,9 +488,11 @@ correctness-critical details:
 - **Buffer size uses the extent formula**
   `(start_offset + 1 + Σ(shape[i]-1)*stride[i]) * elem_size`, not
   `numel` — strided / offset views read past `numel`.
-- Replay data is **memset to 0**; only the descriptor metadata is real.
-  Data-dependent branches / addresses can distort while pure pipeline
-  structure stays faithful (see [§8](#8-fidelity-rules)).
+- Tensor payloads default to **memset 0**. `--restore-arg` reads the selected
+  logical-contiguous payload from `args.bin`, scatters it through the original
+  shape/strides/start-offset view, embeds the physical bytes in
+  `replay_host.cpp`, and initializes that device buffer with `aclrtMemcpy`.
+  `--set-arg` remains the uniform-fill alternative.
 
 ### 5.3 Build & collect
 
@@ -462,12 +553,17 @@ orchestration, so `replay_host.cpp` **synthesizes** it: one
 pointed at slots 48/49. This is harmless for positional kernels (they
 ignore 48/49) and required for SPMD kernels that read `get_block_idx` /
 `get_block_num` (which would otherwise dereference null). `block_idx=0`
-traces a representative block; `block_num` (from `--spmd-block-num`, default
-
-1) keeps steady-state branches (`block_idx+1 < block_num`) on their normal
-path — see [§8](#8-fidelity-rules). An SPMD cohort sizes itself from
-`rt_available_cluster_count()` on device, so the width is not readable from
-the test file and must be passed.
+traces a representative block. The default `block_num=1` models a single-block
+replay and does **not** take multi-block branches such as
+`block_idx+1 < block_num`. That default is sufficient only when the kernel
+ignores `block_num`. The args dump does not record the synthesized slot-48
+context, so read the selected task's logical grid width from its orchestration
+and supply it with `--spmd-block-num`. Some workloads derive that value from
+`rt_available_cluster_count()`; others set an explicit task-specific value.
+Pass the selected task's real value for faithful branch and grid-stride
+behavior. A value of at least 2 can exercise the next-block branch as a bounded
+approximation when the real value is unavailable, but it is not a substitute
+for that value.
 Note the per-AIV-lane routing for a mix uses the hardware
 `get_subblockid()` (§5.4), not the synthesized slot-49 value.
 
@@ -558,16 +654,16 @@ do not draw timing conclusions; retry with a different `n_blocks`.
 | Case selection (`--case`) | Pick a *scaled-down* case | Faithful if it keeps the tile geometry (just fewer blocks / shorter sequence); a case that changes tile M/K/N / head_dim traces only itself, not production |
 | Scalar values (`scale` / offsets …) | Use real dump values | Wrong value → wrong branch → distorted |
 | Loop count (`n_blocks`, via `--set-arg`) | Shrinkable to ≥ 3–4 | Faithful at ≥ 3–4; `= 1` distorts (§7.2) |
-| Data filled to 0 | Default (memset 0) | Data-dependent branches / addresses distort; pure pipeline structure is fine |
+| Tensor contents | Zero by default; on a2a3/a2a3sim, `--restore-arg` selected control tensors | Unrestored data-dependent branches/addresses can distort; supported restored slots use their real `before_dispatch` bytes. A5 restoration is excluded by #1560 |
 | SPMD `block_idx` (slot 48) | Fixed 0 | Traces a real block 0 — representative for uniform SPMD |
-| SPMD `block_num` (slot 48) | Default `block_dim`; `--spmd-block-num` | Any value ≥ 2 keeps steady-state branches |
+| SPMD `block_num` (slot 48) | Default 1; pass the selected task's real logical width with `--spmd-block-num` when the kernel reads it | `1` is a single-block path; ≥ 2 only approximates a multi-block branch, while the selected task's real value preserves branch and grid-stride behavior |
 | Per-AIV-lane routing (`get_subblockid`) | Automatic | Faithful — lanes run their real kernels (§6) |
 | Cross-core sync timing | Not modeled | **Optimistic** — sub-cores appear freely parallel (§9 tier C) |
 | Cross-platform (a2a3 vs a5) | Set by target | Instructions / timing genuinely differ (real silicon — §7.3) |
 
 ## 9. Limitations
 
-- **AICPU orchestration is out of scope.** L0 sees only the AICore
+- **AICPU orchestration is out of scope.** Core swimlane sees only the AICore
   pipeline of one task. For dispatch / finish / scheduler / dependency
   data use [chip swimlane](chip-swimlane-profiling.md).
 - **Orchestration-driven sync is not modeled (tier C).** Two kinds of
@@ -578,15 +674,22 @@ do not draw timing conclusions; retry with a different `n_blocks`.
   dependencies / barriers / scheduling the AICPU enforces — these are
   **absent**, the isolated replay has no AICPU. So a mix's own in-kernel
   AIC↔AIV coordination is faithful; what's lost is mainly **inter-task**
-  ordering (task A → task B), which is out of L0's single-task scope
+  ordering (task A → task B), which is out of Core swimlane's single-task scope
   anyway — that is [chip swimlane](chip-swimlane-profiling.md)'s view. Edge
   case: if a mix's sub-core ordering relied on the AICPU rather than
   in-kernel flags, the replay shows those cores more parallel than
   reality.
 - **Simulation clock, not silicon.** Use it for *relative* per-pipe /
   per-arch structure, not absolute-latency claims.
-- **Replay data is zero.** Only descriptor metadata is real; data-driven
-  control flow can diverge (§8).
+- **Unselected tensor payloads are zero.** On a2a3/a2a3sim, restore structured
+  control inputs with `--restore-arg`; other data-driven control flow can
+  still diverge (§8).
+- **A5 restored-payload Core swimlane traces are untrustworthy.** While
+  [#1560](https://github.com/hw-native-sys/simpler/issues/1560) is open, do
+  not treat A5 args-dump payload as tensor truth or use it with
+  `--restore-arg`. A5 may still write level-3 `args.bin` for marked tensors, but
+  a Core swimlane restored from it is untrustworthy; metadata-only and
+  zero-filled Core swimlane replays remain usable.
 - **Tail-truncation collection bug.** Validate `MMAD`/`FIX` counts every
   run (§7.4).
 - **1C2V only.** The mix path assumes 1 AIC + up to 2 AIV (the only
@@ -607,6 +710,17 @@ one of those (a shape it printed, not an arbitrary combination of func_ids).
 disagrees with the dispatched payload, so the dump skipped it — see
 [§3.1](#31-prerequisites-one-time-per-test-case) and
 [args-dump.md](args-dump.md).
+
+**`--restore-arg` says the manifest has no `bin_file`.** The reused dump
+was captured without a matching `CoreTaskArgs::dump(...)` marker. Mark the target
+tensor in orchestration and capture a fresh Level-3 run, or reuse a
+payload-carrying manifest together with its sibling `args.bin`.
+
+**A5 `--restore-arg` is rejected.** A5 tensor payload restoration is outside
+the supported contract while
+[#1560](https://github.com/hw-native-sys/simpler/issues/1560) is open. Use
+`a2a3` / `a2a3sim` for tensor truth; A5 metadata-only or zero-filled replay
+remains available.
 
 **Smoke build fails on a missing symbol.** `replay_entry` /
 `launch_replay` must appear in `libreplay_kernel.so`. A wrong
@@ -630,11 +744,11 @@ Trace each AIV kernel as its own single-kernel task instead (e.g.
 
 - [`.claude/skills/core-swimlane/SKILL.md`](../../.claude/skills/core-swimlane/SKILL.md)
   — the operating procedure for this tool (picking `--func-id` /
-  `--set-arg` / `--spmd-block-num`).
+  `--restore-arg` / `--set-arg` / `--spmd-block-num`).
 - [chip-swimlane-profiling.md](chip-swimlane-profiling.md) — the
   per-task / scheduler swimlane one level up.
 - [args-dump.md](args-dump.md) — the `func_id`-array-tagged per-task arg
-  capture L0 reconstructs from.
+  capture Core swimlane reconstructs from.
 - [`.claude/skills/insight-trace/SKILL.md`](../../.claude/skills/insight-trace/SKILL.md)
   — the manual `msprof op simulator` replay recipe + Perfetto notes.
 - [chip-level-arch.md](../chip-level-arch.md) — the AICore pipe model the

--- a/docs/user/how-to/profile-a-kernel.md
+++ b/docs/user/how-to/profile-a-kernel.md
@@ -11,7 +11,7 @@ Start by asking which question you have:
 | Where did wall-clock go, host vs device? | nothing — `[STRACE]` markers are always emitted | [L2 Timing](../../dfx/l2-timing.md), [host trace](../../dfx/host-trace.md) |
 | Which task ran when, on which core? | `--enable-chip-swimlane` | [Chip Swimlane Profiling](../../dfx/chip-swimlane-profiling.md) |
 | Is the scheduler the bottleneck, or starved? | `--enable-chip-swimlane --enable-dep-gen --enable-swimlane-overhead` | [Scheduler-Overhead Model](../../dfx/sched-overhead-model.md) |
-| Why is *one* task slow inside the core? | `--dump-args`, then the L0 tool | [Core Swimlane Profiling](../../dfx/core-swimlane-profiling.md) |
+| Why is *one* task slow inside the core? | `--dump-args`, then Core Swimlane | [Core Swimlane Profiling](../../dfx/core-swimlane-profiling.md) |
 | What do the AICore hardware counters say? | `--enable-pmu` | [PMU Profiling](../../dfx/pmu-profiling.md) |
 | What does the dependency graph actually look like? | `--enable-dep-gen` | [dep_gen](../../dfx/dep-gen.md) |
 | Am I near a ring / dep-pool capacity limit? | `--enable-scope-stats` | [Scope Stats](../../dfx/scope-stats.md) |

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -35,7 +35,7 @@ programs — see the [Python API reference](python-api.md).
 | `--enable-chip-swimlane` | Per-task timing. Bare flag = level 4 (full); `1` AICore timing, `2` + dispatch/fanout, `3` + scheduler phases, `4` + orchestration. **L2 only** |
 | `--enable-swimlane-overhead` | Adds the 8 Overhead Analysis counter tracks. Requires `--enable-chip-swimlane` **and** a `deps.json` — add `--enable-dep-gen` if absent |
 | `--enable-pmu` | AICore hardware counters. Bare flag = `PIPE_UTILIZATION` (2); pass an event type to override, e.g. `--enable-pmu 4` |
-| `--dump-args` | Capture per-task arguments. `0` off, `1` partial (only args marked via `Arg::dump(...)`) |
+| `--dump-args` | Capture per-task arguments. `0` off; `1` partial; `2` full; `3` hybrid (all metadata plus payload selected via `Arg::dump(...)`) |
 | `--enable-dep-gen` | Capture the dependency graph (first round only) |
 | `--enable-scope-stats` | Per-scope peaks to `<output_prefix>/scope_stats.jsonl` |
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1883,7 +1883,7 @@ NB_MODULE(_task_interface, m) {
             }
         )
         // Accept either an int dump level (0=off, 1=partial, 2=full,
-        // 3=full_json_only) or a Python bool. `True` maps to level 1
+        // 3=hybrid) or a Python bool. `True` maps to level 1
         // (partial) — the default when --dump-args is passed without a
         // value; `False` maps to 0.
         .def_prop_rw(

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1593,8 +1593,10 @@ class SceneTestCase:
             type=int,
             default=0,
             help="Dump per-task args at runtime. Level: 0=off, 1=partial (only "
-            "tasks marked via Arg::dump(...), default when given without a value), "
-            "2=full (all tasks), 3=full_json_only (all tasks, JSON metadata only, no .bin payload).",
+            "args selected via Arg::dump(...), default when given without a value), "
+            "2=full (all args), 3=hybrid (all tasks' JSON metadata; args marked "
+            "via Arg::dump(...) also write payload; used by "
+            "simpler_setup.tools.core_swimlane for Core swimlane simulator replay).",
         )
         parser.add_argument(
             "--enable-dep-gen",
@@ -1693,6 +1695,9 @@ class SceneTestCase:
         if args.rounds > 1 and args.enable_dep_gen:
             logger.warning("dep_gen disabled: --rounds > 1")
             args.enable_dep_gen = False
+        if args.rounds > 1 and args.dump_args:
+            logger.warning("Dump args disabled: --rounds > 1")
+            args.dump_args = 0
         if args.rounds > 1 and args.enable_scope_stats:
             logger.warning("scope_stats disabled: --rounds > 1")
             args.enable_scope_stats = False

--- a/simpler_setup/tools/core_swimlane.py
+++ b/simpler_setup/tools/core_swimlane.py
@@ -11,8 +11,9 @@
 
 Given a SceneTest test file + platform + a comma-list of func_ids (the mix
 member set), this tool:
-  1. runs (or reuses) a JSON-only args dump (`--dump-args 3`) to capture the
-     task's real per-arg metadata,
+  1. runs (or reuses) an args dump to capture the task's real per-arg
+     metadata with `--dump-args 3` (hybrid); tensors marked by orchestration's
+     `CoreTaskArgs::dump(...)` also contribute payload bytes,
   2. picks the task whose active-subtask set == `--func-id` and reconstructs its
      FULL positional args[] (shapes / dtypes / strides / start_offset / scalar
      values) from the #1181 dump; the task's func_id ARRAY is its mix membership,
@@ -152,10 +153,11 @@ ARCH_CONFIG = {
 #                   one source. Detected by load_kernel_meta; everything else
 #                   (incl. independent kernels packed into a mix dispatch, like
 #                   mixed_example) goes through the AIC/AIV-only path.
-#   * hw_block_dim / block_num — the SPMD grid width, from `--spmd-block-num`
-#                   (defaults to 1). Cohorts size themselves from
-#                   rt_available_cluster_count() at run time, so the width is
-#                   not statically known from the test file.
+#   * block_num   — the selected SPMD task's logical grid width, from
+#                   `--spmd-block-num` (defaults to 1). The args dump does not
+#                   carry slot-48 context; read the real value from the
+#                   orchestration, where it may be task-specific or derived
+#                   from rt_available_cluster_count().
 #   * aiv_lanes_per_block      — the arch's hardware subblockdim (ARCH_CONFIG).
 # The mix path additionally needs ONE incore to declare the full tensor
 # `signature` (so the dump captures the shared args) — a standard CALLABLE
@@ -189,6 +191,7 @@ def load_kernel_meta(test_path: Path, func_id: int, platform: str):
     spec.loader.exec_module(module)
 
     from simpler_setup import SceneTestCase  # noqa: PLC0415
+    from simpler_setup.scene_test import _resolve_incore_include_dirs  # noqa: PLC0415
 
     classes = [
         v
@@ -213,11 +216,15 @@ def load_kernel_meta(test_path: Path, func_id: int, platform: str):
     for cls in classes:
         for inc in cls.CALLABLE.get("incores", []):
             fid = inc["func_id"]
+            extra_include_dirs = inc.get("extra_include_dirs", [])
             by_func[fid] = {
                 "func_id": fid,
                 "source": (test_path.parent / inc["source"]).resolve(),
                 "core_type": inc["core_type"],
                 "name": inc.get("name") or Path(inc["source"]).stem,
+                "extra_include_dirs": (
+                    _resolve_incore_include_dirs(extra_include_dirs, inc) if extra_include_dirs else []
+                ),
             }
             owner_cls[fid] = cls
     if func_id not in by_func:
@@ -247,7 +254,14 @@ def _case_from_manifest(manifest: Path, class_name: str) -> str:
 # ---------------------------------------------------------------------------
 # Step 2: obtain an args_dump.json (run the test in sim, or reuse one)
 # ---------------------------------------------------------------------------
-def get_or_run_dump(test_path: Path, platform: str, variant: str, dump_json, case=None, device=None):
+def get_or_run_dump(
+    test_path: Path,
+    platform: str,
+    variant: str,
+    dump_json,
+    case=None,
+    device=None,
+):
     if dump_json:
         p = Path(dump_json)
         if not p.is_file():
@@ -256,11 +270,8 @@ def get_or_run_dump(test_path: Path, platform: str, variant: str, dump_json, cas
 
     outputs = PROJECT_ROOT / "outputs"
     before = set(outputs.glob("*/args_dump")) if outputs.is_dir() else set()
-    # Level 3 (full, JSON-only): every task's tensor *metadata* (shape/dtype/
-    # strides) + scalar values, no .bin payload copy. That is exactly what arg
-    # reconstruction consumes (it never reads the payload), and it skips the
-    # device->host arena copy entirely — cheaper, and avoids the large-shape
-    # copy failing onboard.
+    # Hybrid Level 3 captures the complete metadata needed by this Core swimlane replay
+    # and reuses the existing Arg::dump() mask for requested tensor payload.
     cmd = [sys.executable, str(test_path), "-p", platform, "--dump-args", "3"]
     # Pin the dump to exactly one case, allowing it to be `manual` (core_swimlane
     # tracing targets are often manual to stay out of CI). `case` is main's
@@ -391,6 +402,12 @@ def reconstruct_task_args(manifest: Path, func_id_list, task_id=None):
                 "shape": shape,
                 "strides": strides,
                 "start_offset": int(t.get("start_offset", 0)),
+                "role": t.get("role"),
+                "stage": t.get("stage"),
+                "bin_offset": int(t.get("bin_offset", 0)),
+                "bin_size": int(t.get("bin_size", 0)),
+                "truncated": bool(t.get("truncated", False)),
+                "overwritten": bool(t.get("overwritten", False)),
             }
         )
     for s in scalars:
@@ -422,6 +439,124 @@ def _is_contiguous(shape, strides, start_offset):
             return False
         exp *= s
     return start_offset == 0
+
+
+def _logical_numel(shape):
+    numel = 1
+    for dim in shape:
+        if dim < 0:
+            raise ValueError(f"negative tensor dimension {dim}")
+        numel *= dim
+    return numel
+
+
+def _materialize_physical_payload(logical_data, shape, strides, start_offset, elem_size):
+    """Scatter row-major logical dump bytes into the tensor's physical view."""
+    if len(shape) != len(strides):
+        raise ValueError(f"shape/strides rank mismatch: {shape} vs {strides}")
+    if start_offset < 0 or any(stride < 0 for stride in strides):
+        raise ValueError(f"negative start_offset/stride is unsupported: start={start_offset}, strides={strides}")
+
+    numel = _logical_numel(shape)
+    expected = numel * elem_size
+    if len(logical_data) != expected:
+        raise ValueError(f"logical payload size {len(logical_data)} does not match expected {expected}")
+    if expected == 0:
+        raise ValueError("zero-sized tensor payload cannot be restored")
+
+    physical = bytearray((start_offset + _extent_elem(shape, strides)) * elem_size)
+    for linear_idx in range(numel):
+        rem = linear_idx
+        physical_elem = start_offset
+        for dim, stride in zip(reversed(shape), reversed(strides)):
+            coord = rem % dim
+            rem //= dim
+            physical_elem += coord * stride
+        src = linear_idx * elem_size
+        dst = physical_elem * elem_size
+        physical[dst : dst + elem_size] = logical_data[src : src + elem_size]
+    return bytes(physical)
+
+
+def restore_arg_payloads(manifest: Path, kargs: list[dict], restore_slots):
+    """Load and materialize payloads for explicitly selected tensor slots."""
+    if not restore_slots:
+        return
+
+    data = json.loads(manifest.read_text())
+    bin_format = data.get("bin_format") or {}
+    if bin_format.get("type") != "logical_contiguous" or bin_format.get("byte_order") != "little_endian":
+        raise ValueError("--restore-arg requires bin_format type=logical_contiguous and byte_order=little_endian")
+
+    bin_name = data.get("bin_file")
+    if not bin_name:
+        raise ValueError(
+            "--restore-arg requires a payload-carrying dump; this manifest has no bin_file "
+            "(mark the tensor with CoreTaskArgs::dump(...) in orchestration and recapture with "
+            "--dump-args 3 (hybrid))"
+        )
+    bin_path = manifest.parent / bin_name
+    if not bin_path.is_file():
+        raise ValueError(f"--restore-arg payload file not found: {bin_path}")
+
+    by_slot = {a["slot"]: a for a in kargs}
+    file_size = bin_path.stat().st_size
+    with open(bin_path, "rb") as payload_file:
+        for slot in restore_slots:
+            arg = by_slot.get(slot)
+            if arg is None:
+                raise ValueError(f"--restore-arg slot {slot} is not an arg of this task")
+            if arg["kind"] != "tensor":
+                raise ValueError(f"--restore-arg slot {slot} is a scalar; only tensor payloads can be restored")
+            if arg.get("stage") != "before_dispatch":
+                raise ValueError(
+                    f"--restore-arg slot {slot} has no before_dispatch payload; output-only tensors "
+                    "cannot initialize a replay"
+                )
+            if arg.get("truncated"):
+                raise ValueError(f"--restore-arg slot {slot} payload is truncated")
+            if arg.get("overwritten"):
+                raise ValueError(f"--restore-arg slot {slot} payload was overwritten before export")
+
+            dtype = arg["dtype"]
+            if dtype not in DTYPE_SIZE:
+                raise ValueError(f"--restore-arg slot {slot} has unsupported dtype {dtype}")
+            expected_size = _logical_numel(arg["shape"]) * DTYPE_SIZE[dtype]
+            bin_offset = arg["bin_offset"]
+            bin_size = arg["bin_size"]
+            if bin_size == 0:
+                raise ValueError(
+                    f"--restore-arg slot {slot} has no captured payload; mark that tensor with "
+                    "CoreTaskArgs::dump(...) in orchestration and capture a fresh hybrid level-3 dump"
+                )
+            if bin_size != expected_size:
+                raise ValueError(
+                    f"--restore-arg slot {slot} bin_size {bin_size} does not match logical tensor size {expected_size}"
+                )
+            if bin_offset < 0 or bin_offset + bin_size > file_size:
+                raise ValueError(
+                    f"--restore-arg slot {slot} payload range [{bin_offset}, {bin_offset + bin_size}) "
+                    f"exceeds {bin_path} size {file_size}"
+                )
+
+            payload_file.seek(bin_offset)
+            logical_data = payload_file.read(bin_size)
+            if len(logical_data) != bin_size:
+                raise ValueError(
+                    f"--restore-arg slot {slot} short read: expected {bin_size} bytes, got {len(logical_data)}"
+                )
+            arg["restore_data"] = _materialize_physical_payload(
+                logical_data,
+                arg["shape"],
+                arg["strides"],
+                arg["start_offset"],
+                DTYPE_SIZE[dtype],
+            )
+            print(
+                f"[core_swimlane] restoring tensor slot {slot} "
+                f"({dtype} {arg['shape']}): {bin_size} logical bytes -> "
+                f"{len(arg['restore_data'])} physical bytes"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -639,14 +774,27 @@ def _emit_tensor_alloc_descs(args):
         ndims = len(shape)
         shp = ", ".join(str(x) for x in shape)
         strd = ", ".join(str(x) for x in strides)
-        # Default: data memset to 0 (only descriptor metadata is real). When
-        # --set-arg fills this tensor, write VALUE into every element instead —
-        # for control tensors whose CONTENT drives the kernel (e.g. paged
-        # attention reads n_blocks from the context_lens tensor). The low `esz`
-        # bytes of the int64 VALUE are copied per element (correct for any
-        # integer width, little-endian).
+        # Tensor initialization has three exclusive modes: restored dump bytes,
+        # a --set-arg uniform integer fill, or zero.
         fill = a.get("fill")
-        if fill is None:
+        restore_data = a.get("restore_data")
+        if fill is not None and restore_data is not None:
+            raise ValueError(f"tensor slot {slot} cannot be both restored and uniformly filled")
+        if restore_data is not None:
+            byte_rows = []
+            for off in range(0, len(restore_data), 16):
+                byte_rows.append("            " + ", ".join(f"0x{b:02x}" for b in restore_data[off : off + 16]))
+            byte_literal = ",\n".join(byte_rows)
+            init = (
+                f"    {{\n"
+                f"        static const unsigned char hbuf{ti}[] = {{\n"
+                f"{byte_literal}\n"
+                f"        }};\n"
+                f"        ACL_CHECK(aclrtMemcpy(d_t{ti}, t{ti}Bytes, hbuf{ti}, sizeof(hbuf{ti}),\n"
+                f"                              ACL_MEMCPY_HOST_TO_DEVICE));\n"
+                f"    }}"
+            )
+        elif fill is None:
             init = f"    ACL_CHECK(aclrtMemset(d_t{ti}, t{ti}Bytes, 0, t{ti}Bytes));"
         else:
             init = (
@@ -758,8 +906,9 @@ int main() {{
     // positional kernels (they ignore 48/49); required for SPMD kernels that
     // read get_block_idx / get_block_num / get_sub_block_id, which would
     // otherwise dereference a null context. block_idx=0 traces a representative
-    // block; block_num={block_num} (from --spmd-block-num) keeps steady-state
-    // branches (e.g. `block_idx+1 < block_num`) on their normal path.
+    // block. block_num={block_num} comes from --spmd-block-num; 1 models a
+    // single-block path, while SPMD branch/grid-stride fidelity requires the
+    // real grid width.
     uint8_t h_local[64] = {{0}};   // LocalContext: block_idx@0, block_num@4
     *reinterpret_cast<int32_t *>(h_local + 0) = 0;
     *reinterpret_cast<int32_t *>(h_local + 4) = {block_num};
@@ -794,11 +943,12 @@ int main() {{
 """
 
 
-def emit_cmakelists(arch: str, name: str, cfg, debug: bool = False) -> str:
+def emit_cmakelists(arch: str, name: str, cfg, debug: bool = False, extra_include_dirs=None) -> str:
     # With -g, also drop the linker `-s` (strip) so the device kernel's
     # debug_line survives -> Insight can map instructions to source lines.
     link_opts = "-Wl,-z,relro -Wl,-z,now" if debug else "-s -Wl,-z,relro -Wl,-z,now"
     dbg_flag = "\n    -g" if debug else ""
+    extra_includes = "\n".join(f'    "{include_dir}"' for include_dir in (extra_include_dirs or []))
     return f"""\
 cmake_minimum_required(VERSION 3.16)
 
@@ -850,6 +1000,7 @@ set(COMMON_INCLUDES
     ${{PTO_ISA_ROOT}}/include/pto
     ${{REPO_ROOT}}/src/{arch}/runtime/tensormap_and_ringbuffer/runtime
     ${{REPO_ROOT}}/src/{arch}/runtime/tensormap_and_ringbuffer/common
+    ${{REPO_ROOT}}/src/common/platform/include
     ${{REPO_ROOT}}/src/common/task_interface
     ${{REPO_ROOT}}/src/{arch}/platform/include
     ${{REPO_ROOT}}/simpler_setup/incore
@@ -857,6 +1008,7 @@ set(COMMON_INCLUDES
     ${{ASCEND_HOME_PATH}}/pkg_inc/profiling
     ${{ASCEND_HOME_PATH}}/pkg_inc/runtime/runtime
     ${{ASCEND_HOME_PATH}}/include
+{extra_includes}
 )
 
 add_library(replay_kernel SHARED replay_kernel.cpp replay_launch.cpp)
@@ -882,10 +1034,14 @@ target_link_libraries(replay_host PRIVATE
 """
 
 
-def emit_run_collect(cfg, pto_isa_root: str) -> str:
+def emit_run_collect(cfg, pto_isa_root: str, msprof_timeout: int = 120) -> str:
     # Plain string (bash uses ${} braces) — bake SoC default and the
     # pin-resolved pto-isa path via tokens (no ambient PTO_ISA_ROOT env #1403).
-    return _RUN_COLLECT_TEMPLATE.replace("__SOC_DEFAULT__", cfg["soc"]).replace("__PTO_ISA_ROOT__", pto_isa_root)
+    return (
+        _RUN_COLLECT_TEMPLATE.replace("__SOC_DEFAULT__", cfg["soc"])
+        .replace("__PTO_ISA_ROOT__", pto_isa_root)
+        .replace("__MSPROF_TIMEOUT__", str(msprof_timeout))
+    )
 
 
 _RUN_COLLECT_TEMPLATE = """\
@@ -917,7 +1073,7 @@ cmake --build "$BUILD_DIR" --target replay_host
 
 msprof op simulator \\
     --application="$BUILD_DIR/replay_host" --kernel-name="replay_entry" \\
-    --launch-count=1 --soc-version="$SOC_VERSION" --timeout=120 \\
+    --launch-count=1 --soc-version="$SOC_VERSION" --timeout=__MSPROF_TIMEOUT__ \\
     --output="$COLLECT_DIR/out" 2>&1 | tee "$COLLECT_DIR/msprof_collect.log"
 
 OPPROF_DIR="$(find "$COLLECT_DIR/out" -maxdepth 1 -mindepth 1 -type d -name 'OPPROF_*' | sort | tail -n 1)"
@@ -944,6 +1100,7 @@ def generate_workspace(  # noqa: PLR0913
     pto_isa_root: str,
     debug: bool = False,
     block_num: int = 1,
+    msprof_timeout: int = 120,
 ):
     ws.mkdir(parents=True, exist_ok=True)
     # One combined replay_entry for the whole mix task (cube=AIC member, vec=AIV
@@ -953,9 +1110,12 @@ def generate_workspace(  # noqa: PLR0913
     (ws / "replay_kernel.cpp").write_text(emit_replay_kernel_combined(members, cfg))
     (ws / "replay_launch.cpp").write_text(emit_replay_launch())
     (ws / "replay_host.cpp").write_text(emit_replay_host(tensor_count, args, block_num))
-    (ws / "CMakeLists.txt").write_text(emit_cmakelists(arch, name, cfg, debug))
+    extra_include_dirs = list(
+        dict.fromkeys(include_dir for member in members for include_dir in member.get("extra_include_dirs", []))
+    )
+    (ws / "CMakeLists.txt").write_text(emit_cmakelists(arch, name, cfg, debug, extra_include_dirs=extra_include_dirs))
     rc = ws / "run_collect.sh"
-    rc.write_text(emit_run_collect(cfg, pto_isa_root))
+    rc.write_text(emit_run_collect(cfg, pto_isa_root, msprof_timeout))
     rc.chmod(0o755)
 
 
@@ -1197,6 +1357,20 @@ def collect(ws: Path, env, max_time: int, device=None, dest_name: str = "trace.j
 
 
 # ---------------------------------------------------------------------------
+def parse_arg_overrides(set_arg, ap: argparse.ArgumentParser):
+    parsed = []
+    for spec in set_arg:
+        if "=" not in spec:
+            ap.error(f"--set-arg must be SLOT=VALUE (got {spec!r})")
+        slot_s, val_s = spec.split("=", 1)
+        try:
+            slot, value = int(slot_s), int(val_s)
+        except ValueError:
+            ap.error(f"--set-arg SLOT and VALUE must be integers (got {spec!r})")
+        parsed.append((slot, value))
+    return parsed
+
+
 def apply_arg_overrides(kargs: list[dict], set_arg, ap: argparse.ArgumentParser):
     """Apply --set-arg SLOT=VALUE overrides to reconstructed args.
 
@@ -1210,15 +1384,10 @@ def apply_arg_overrides(kargs: list[dict], set_arg, ap: argparse.ArgumentParser)
     """
     if not set_arg:
         return
+    if isinstance(set_arg[0], str):
+        set_arg = parse_arg_overrides(set_arg, ap)
     by_slot = {a["slot"]: a for a in kargs}
-    for spec in set_arg:
-        if "=" not in spec:
-            ap.error(f"--set-arg must be SLOT=VALUE (got {spec!r})")
-        slot_s, val_s = spec.split("=", 1)
-        try:
-            slot, value = int(slot_s), int(val_s)
-        except ValueError:
-            ap.error(f"--set-arg SLOT and VALUE must be integers (got {spec!r})")
+    for slot, value in set_arg:
         a = by_slot.get(slot)
         if a is None:
             ap.error(f"--set-arg slot {slot} is not an arg of this task")
@@ -1290,8 +1459,24 @@ def main():
         "the camodel replay — name the small one instead. Accepts "
         "ClassName::Case too.",
     )
-    ap.add_argument("--dump-json", default=None, help="reuse an existing args_dump.json")
+    ap.add_argument(
+        "--dump-json",
+        default=None,
+        help="reuse an existing args_dump.json. --restore-arg additionally "
+        "requires the selected payload in the manifest's args.bin.",
+    )
     # ----- replay tuning -----
+    ap.add_argument(
+        "--restore-arg",
+        action="append",
+        default=[],
+        type=int,
+        metavar="SLOT",
+        help="initialize a tensor slot from its captured before_dispatch payload. "
+        "Repeatable. The tensor must already be marked with CoreTaskArgs::dump(...) "
+        "in orchestration; a reused --dump-json must reference args.bin. Intended "
+        "for structured control tensors that --set-arg cannot represent.",
+    )
     ap.add_argument(
         "--set-arg",
         action="append",
@@ -1305,7 +1490,8 @@ def main():
         "(--set-arg 4=4); mix paged-attention derives n_blocks "
         "from the context_lens tensor (--set-arg 4=512 -> "
         "n_blocks=ceil(512/block_size)). Only real arg slots are "
-        "settable. Repeatable. Default: real dump values.",
+        "settable. Repeatable. By default scalars retain dump values and "
+        "tensor payloads are zero-filled.",
     )
     ap.add_argument(
         "--spmd-block-num",
@@ -1313,10 +1499,9 @@ def main():
         default=None,
         metavar="N",
         help="block_num written into the synthesized SPMD LocalContext "
-        "(slot 48). Default: 1. Required to replay an SPMD cohort, whose "
-        "width is resolved on device. Only matters for "
-        "kernels that branch/stride on block_num; set the real grid "
-        "width for those.",
+        "(slot 48). Default: 1. The args dump does not carry this context. "
+        "For kernels that branch/stride on block_num, pass the selected "
+        "task's real logical grid width from its orchestration.",
     )
     ap.add_argument(
         "--debug-line",
@@ -1329,13 +1514,33 @@ def main():
     # ----- run control -----
     ap.add_argument("--no-collect", action="store_true", help="smoke build only")
     ap.add_argument("--max-time", type=int, default=1800, help="task-submit budget (sec)")
+    ap.add_argument(
+        "--msprof-timeout",
+        type=int,
+        default=120,
+        metavar="MINUTES",
+        help="msprof op simulator application timeout in minutes (default: 120; valid range: 1-2880)",
+    )
     args = ap.parse_args()
+
+    if not 1 <= args.msprof_timeout <= 2880:
+        ap.error("--msprof-timeout MINUTES must be in [1, 2880]")
+    set_arg = parse_arg_overrides(args.set_arg, ap)
+    restore_slots = list(dict.fromkeys(args.restore_arg))
+    invalid_restore_slots = [slot for slot in restore_slots if slot < 0 or slot >= KARGS_SLOTS]
+    if invalid_restore_slots:
+        ap.error(f"--restore-arg SLOT must be in [0, {KARGS_SLOTS - 1}] (got {invalid_restore_slots})")
+    conflicts = sorted(set(restore_slots) & {slot for slot, _ in set_arg})
+    if conflicts:
+        ap.error(f"arg slot(s) {conflicts} cannot use both --restore-arg and --set-arg")
 
     test_path = Path(args.test).resolve()
     arch, variant = parse_platform(args.platform)
     cfg = ARCH_CONFIG.get(arch)
     if cfg is None:
         ap.error(f"unsupported arch {arch} (from {args.platform}); supported: {', '.join(ARCH_CONFIG)}")
+    if restore_slots and arch == "a5":
+        ap.error("--restore-arg does not support a5/a5sim tensor payload while #1560 is open")
 
     func_id_list = [int(x) for x in args.func_id.split(",")]
     meta = load_kernel_meta(test_path, func_id_list[0], args.platform)
@@ -1367,6 +1572,10 @@ def main():
     # positional payload. mix_func_ids is the dump's array (slot order
     # AIC,AIV0,AIV1), NOT the typed order, so lane assignment stays correct.
     chosen, tensor_count, kargs, mix_func_ids = reconstruct_task_args(manifest, func_id_list, args.task_id)
+    try:
+        restore_arg_payloads(manifest, kargs, restore_slots)
+    except ValueError as exc:
+        ap.error(str(exc))
 
     # Resolve the mix members (slot order) to their sources/core_types.
     missing = [f for f in mix_func_ids if f not in by_func]
@@ -1388,13 +1597,14 @@ def main():
     # Full arg-slot map so the caller can pick a slot for --set-arg without
     # cross-referencing the kernel source. Names are not in the dump (only
     # kind/shape/value) — read the kernel's `args:` header for those.
-    print("[core_swimlane] arg slots (override with --set-arg SLOT=VALUE):")
+    print("[core_swimlane] arg slots (override with --set-arg SLOT=VALUE or --restore-arg SLOT):")
     for a in sorted(kargs, key=lambda x: x["slot"]):
         if a["kind"] == "tensor":
-            print(f"    slot {a['slot']:<2} tensor  {a['dtype']:<8} {a['shape']}")
+            restored = " [restored payload]" if "restore_data" in a else ""
+            print(f"    slot {a['slot']:<2} tensor  {a['dtype']:<8} {a['shape']}{restored}")
         else:
             print(f"    slot {a['slot']:<2} scalar  = {a['value']}")
-    apply_arg_overrides(kargs, args.set_arg, ap)
+    apply_arg_overrides(kargs, set_arg, ap)
 
     # Self-describing label: <TestClass>_<Case>_<platform>_<kernel>_<mix>, so the
     # workspace dir and the trace.json filename say which case/kernel/mix they are.
@@ -1418,6 +1628,7 @@ def main():
         pto_isa_root,
         debug=args.debug_line,
         block_num=block_num,
+        msprof_timeout=args.msprof_timeout,
     )
     print(f"[core_swimlane] workspace: {ws}")
 

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -280,8 +280,9 @@ def main():
     with open(manifest_path) as f:
         manifest = json.load(f)
 
-    # full_json_only dumps (level 3) carry no payload: bin_file is null and
-    # there is no .bin to export from — listing metadata still works.
+    # Level 3 names args.bin only when orchestration marked at least one tensor
+    # with Arg::dump(). Follow the manifest rather than inferring payload
+    # availability from the level.
     bin_name = manifest.get("bin_file", "args.bin")
     bin_path = (dump_dir / bin_name) if bin_name else None
     args_data = manifest.get("args", manifest.get("tensors", []))

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1296,10 +1296,9 @@ static TaskOutputTensors submit_task_common(
                 task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
             );
         }
-        // Selective vs full dump is latched at dump_args_init from DumpDataHeader
-        // (host-decided before any dispatch), so it is race-free regardless of
-        // submission order. Here we only record each marked task's arg mask and
-        // metadata flags, which selective collection consults.
+        // Preserve the existing Level-1 task/arg mask whenever dump is enabled.
+        // Level 1 uses it to select records; hybrid Level 3 reuses the same mask only
+        // to decide which tensors contribute payload alongside full metadata.
         if (args.dump_arg_mask() != 0) {
             set_dump_args_task_mask(task_id.raw, args.dump_arg_mask(), args.dump_arg_index_ambiguous_mask());
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -998,10 +998,9 @@ static TaskOutputTensors submit_task_common(
                 task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
             );
         }
-        // Selective vs full dump is latched at dump_args_init from DumpDataHeader
-        // (host-decided before any dispatch), so it is race-free regardless of
-        // submission order. Here we only record each marked task's arg mask and
-        // metadata flags, which selective collection consults.
+        // Preserve the existing Level-1 task/arg mask whenever dump is enabled.
+        // Level 1 uses it to select records; hybrid Level 3 reuses the same mask only
+        // to decide which tensors contribute payload alongside full metadata.
         if (args.dump_arg_mask() != 0) {
             set_dump_args_task_mask(task_id.raw, args.dump_arg_mask(), args.dump_arg_index_ambiguous_mask());
         }

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -839,10 +839,9 @@ static TaskOutputTensors submit_task_common(
                 task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
             );
         }
-        // Selective vs full dump is latched at dump_args_init from DumpDataHeader
-        // (host-decided before any dispatch), so it is race-free regardless of
-        // submission order. Here we only record each marked task's arg mask and
-        // metadata flags, which selective collection consults.
+        // Preserve the existing Level-1 task/arg mask whenever dump is enabled.
+        // Level 1 uses it to select records; hybrid Level 3 reuses the same mask only
+        // to decide which tensors contribute payload alongside full metadata.
         if (args.dump_arg_mask() != 0) {
             set_dump_args_task_mask(task_id.raw, args.dump_arg_mask(), args.dump_arg_index_ambiguous_mask());
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -1000,10 +1000,9 @@ static TaskOutputTensors submit_task_common(
                 task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
             );
         }
-        // Selective vs full dump is latched at dump_args_init from DumpDataHeader
-        // (host-decided before any dispatch), so it is race-free regardless of
-        // submission order. Here we only record each marked task's arg mask and
-        // metadata flags, which selective collection consults.
+        // Preserve the existing Level-1 task/arg mask whenever dump is enabled.
+        // Level 1 uses it to select records; hybrid Level 3 reuses the same mask only
+        // to decide which tensors contribute payload alongside full metadata.
         if (args.dump_arg_mask() != 0) {
             set_dump_args_task_mask(task_id.raw, args.dump_arg_mask(), args.dump_arg_index_ambiguous_mask());
         }

--- a/src/common/platform/include/aicpu/args_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/args_dump_aicpu.h
@@ -73,6 +73,7 @@ void set_dump_args_enabled(bool enable);
  */
 bool is_dump_args_enabled();
 bool is_dump_args_selective_mode();
+bool should_load_dump_args_task_masks();
 void set_dump_args_task_mask(uint64_t task_id, ArgsDumpArgMask mask, ArgsDumpArgMask flags);
 void get_dump_args_task_masks(uint64_t task_id, ArgsDumpArgMask *mask, ArgsDumpArgMask *flags);
 void set_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes);
@@ -104,7 +105,7 @@ inline void dump_args_for_task(
     const auto &pl = *slot_state.payload;
     ArgsDumpArgMask dump_arg_mask = ARGS_DUMP_ARG_MASK_NONE;
     ArgsDumpArgMask dump_arg_flags = ARGS_DUMP_ARG_MASK_NONE;
-    if (is_dump_args_selective_mode()) {
+    if (should_load_dump_args_task_masks()) {
         get_dump_args_task_masks(slot_state.task->task_id.raw, &dump_arg_mask, &dump_arg_flags);
     }
     if (!should_dump_task(dump_arg_mask)) {

--- a/src/common/platform/include/common/args_dump.h
+++ b/src/common/platform/include/common/args_dump.h
@@ -242,13 +242,13 @@ static_assert(sizeof(DumpReadyQueueEntry) == 32, "DumpReadyQueueEntry must be 32
  * - Queue full: (tail + 1) % capacity == head
  */
 
-// Args-dump level. Carried in DumpDataHeader so the
-// AICPU latches the mode in dump_args_init() before any task is dispatched.
+// Args-dump level. Carried in DumpDataHeader so the AICPU can latch the mode
+// before any task is dispatched.
 enum class DumpArgsLevel : uint32_t {
-    OFF = 0,             // no dump
-    PARTIAL = 1,         // only args marked with Arg::dump(...)
-    FULL = 2,            // every task's tensor/scalar I/O (JSON manifest + BIN payload)
-    FULL_JSON_ONLY = 3,  // every task's tensor/scalar metadata to JSON; no BIN
+    OFF = 0,      // no dump
+    PARTIAL = 1,  // only args marked with Arg::dump(...)
+    FULL = 2,     // every task's tensor/scalar I/O (JSON manifest + BIN payload)
+    HYBRID = 3,   // every task's metadata; payload only for Arg::dump()-marked tensors
 };
 
 struct DumpDataHeader {
@@ -262,7 +262,7 @@ struct DumpDataHeader {
     uint32_t records_per_buffer;
     uint64_t arena_size_per_thread;
     uint32_t magic;
-    uint32_t dump_args_level;  // DumpArgsLevel: 0=off, 1=partial, 2=full, 3=full_json_only
+    uint32_t dump_args_level;  // DumpArgsLevel: 0=off, 1=partial, 2=full, 3=hybrid
     // DFX backpressure coordination (unified across all DFX subsystems).
     DfxBackpressureHeader backpressure;
 } __attribute__((aligned(64)));

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -219,9 +219,9 @@ public:
      * @param user_data         Opaque pointer forwarded to callbacks
      * @param output_prefix     Per-task directory; args_dump/ subdir lands here
      * @param dump_args_level OFF / PARTIAL (only Arg::dump()-marked args) /
-     *                          FULL / FULL_JSON_ONLY (every task's metadata to
-     *                          JSON, no payload or .bin). Written to
-     *                          DumpDataHeader so the AICPU latches the mode
+     *                          FULL / HYBRID (every task's metadata,
+     *                          with Arg::dump()-marked tensor payload). Written
+     *                          to DumpDataHeader so the AICPU latches the mode
      *                          before any dispatch.
      * @return 0 on success, error code on failure
      */
@@ -343,7 +343,8 @@ private:
     std::queue<PayloadWriteRequest> write_queue_;
     std::atomic<bool> writer_done_{false};
 
-    // Resolved dump level; FULL_JSON_ONLY suppresses the .bin file entirely.
+    // Resolved dump level; HYBRID creates .bin lazily when an
+    // Arg::dump()-selected tensor contributes payload.
     DumpArgsLevel dump_args_level_{DumpArgsLevel::OFF};
 
     // Output directory and single binary file

--- a/src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/args_dump_aicpu.cpp
@@ -54,7 +54,7 @@ static constexpr uint64_t kDumpQueueBackpressureWaitCycles = PLATFORM_DFX_BACKPR
 
 static bool g_enable_dump_args = false;
 // Dump level latched from the header in dump_args_init(). The selective
-// (PARTIAL) and json-only (FULL_JSON_ONLY) modes are derived from it rather
+// (PARTIAL) and metadata-first (HYBRID) modes are derived from it rather
 // than tracked as separate flags — mirrors g_chip_swimlane_level.
 static DumpArgsLevel g_dump_args_level = DumpArgsLevel::OFF;
 
@@ -209,6 +209,10 @@ extern "C" void set_dump_args_enabled(bool enable) {
 extern "C" bool is_dump_args_enabled() { return g_enable_dump_args; }
 
 extern "C" bool is_dump_args_selective_mode() { return g_dump_args_level == DumpArgsLevel::PARTIAL; }
+
+extern "C" bool should_load_dump_args_task_masks() {
+    return g_dump_args_level == DumpArgsLevel::PARTIAL || g_dump_args_level == DumpArgsLevel::HYBRID;
+}
 
 extern "C" void set_dump_args_task_mask(uint64_t task_id, ArgsDumpArgMask mask, ArgsDumpArgMask flags) {
     if (mask == ARGS_DUMP_ARG_MASK_NONE) {
@@ -601,7 +605,8 @@ void dump_args_init(int num_dump_threads) {
 
     // Latch dump level from the host-written header before any task is dumped.
     // PARTIAL → selective (only Arg::dump()-marked args); FULL → every task;
-    // FULL_JSON_ONLY → every task, metadata only (no payload copied into arena).
+    // HYBRID → every task's metadata; payload is copied only for
+    // arguments selected through the same per-task mask as PARTIAL.
     g_dump_args_level = static_cast<DumpArgsLevel>(s_dump_header->dump_args_level);
 
     LOG_INFO("Initializing args dump for %d threads", num_dump_threads);
@@ -675,10 +680,13 @@ int dump_arg_record(int thread_idx, const ArgsDumpInfo &info) {
     bool truncated = false;
     bool is_contiguous = dump_arg_is_contiguous(info);
     bool is_scalar = kind == ArgsDumpKind::SCALAR;
+    ArgsDumpArgMask task_dump_arg_mask = ARGS_DUMP_ARG_MASK_NONE;
+    if (g_dump_args_level == DumpArgsLevel::HYBRID) {
+        get_dump_args_task_masks(info.task_id, &task_dump_arg_mask, nullptr);
+    }
+    bool capture_payload = has_dump_arg_flag(task_dump_arg_mask, static_cast<int32_t>(info.arg_index));
 
-    if (is_scalar || g_dump_args_level == DumpArgsLevel::FULL_JSON_ONLY) {
-        // JSON-only level captures full metadata but no payload, so the
-        // record carries shape/dtype/strides with payload_size == 0.
+    if (is_scalar || (g_dump_args_level == DumpArgsLevel::HYBRID && !capture_payload)) {
         copy_bytes = 0;
     } else if (bytes > state->arena_size) {
         // ChipTensor larger than entire arena — copy a partial sample

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -245,10 +245,9 @@ void ArgsDumpCollector::start_writer_thread_once() {
     std::string run_dir_name = "args_dump";
     run_dir_ = std::filesystem::path(output_prefix_) / run_dir_name;
     std::filesystem::create_directories(run_dir_);
-    // FULL_JSON_ONLY captures no payload (device sets payload_size == 0), so
-    // there is nothing to stream — skip the .bin file rather than leaving a
-    // 0-byte artifact next to the manifest.
-    if (dump_args_level_ != DumpArgsLevel::FULL_JSON_ONLY) {
+    // Hybrid Level 3 opens args.bin lazily if an Arg::dump()-selected tensor
+    // emits payload; an unmarked run remains metadata-only.
+    if (dump_args_level_ != DumpArgsLevel::HYBRID) {
         bin_file_.open(run_dir_ / "args.bin", std::ios::binary);
     }
     next_bin_offset_ = 0;
@@ -601,6 +600,9 @@ void ArgsDumpCollector::writer_loop() {
         }
 
         if (!request.bytes.empty()) {
+            if (!bin_file_.is_open()) {
+                bin_file_.open(run_dir_ / "args.bin", std::ios::binary);
+            }
             bin_file_.write(
                 reinterpret_cast<const char *>(request.bytes.data()), static_cast<std::streamsize>(request.bytes.size())
             );
@@ -745,6 +747,7 @@ int ArgsDumpCollector::export_dump_files() {
     json << "    \"type\": \"logical_contiguous\",\n";
     json << "    \"byte_order\": \"little_endian\"\n";
     json << "  },\n";
+    json << "  \"dump_args_level\": " << static_cast<uint32_t>(dump_args_level_) << ",\n";
     json << "  \"total_args\": " << collected_.size() << ",\n";
     json << "  \"before_dispatch\": " << num_before_dispatch << ",\n";
     json << "  \"after_completion\": " << num_after_completion << ",\n";
@@ -754,7 +757,7 @@ int ArgsDumpCollector::export_dump_files() {
     json << "  \"truncated_args\": " << total_truncated_count_.load(std::memory_order_relaxed) << ",\n";
     json << "  \"dropped_records\": " << total_dropped_record_count_.load(std::memory_order_relaxed) << ",\n";
     json << "  \"dropped_overwrite\": " << total_overwrite_count_.load(std::memory_order_relaxed) << ",\n";
-    if (dump_args_level_ == DumpArgsLevel::FULL_JSON_ONLY) {
+    if (dump_args_level_ == DumpArgsLevel::HYBRID && bytes_written_.load() == 0) {
         json << "  \"bin_file\": null,\n";
     } else {
         json << "  \"bin_file\": \"args.bin\",\n";

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -18,6 +18,7 @@ use the unified schema, and no legacy args-only manifest is emitted.
 """
 
 import json
+import struct
 import subprocess
 import sys
 import time
@@ -36,7 +37,7 @@ class TestArgsDump(SceneTestCase):
     """args_dump capture smoke, level-aware on the ``--dump-args`` level.
 
     Uses ``partial_dump_orch`` (5 tasks; four carry ``dump(...)`` markers) so a
-    single orchestration exercises both modes:
+    single orchestration exercises all three enabled levels:
 
     - ``--dump-args 1`` (partial): only marked args are captured — task
       ``0x..00`` via no-arg ``dump()`` (all tensor + scalar args), task
@@ -46,6 +47,9 @@ class TestArgsDump(SceneTestCase):
       Mode is latched host-side before dispatch, so it is race-free regardless
       of submission order.
     - ``--dump-args 2`` (full): markers are ignored, every task is dumped.
+    - ``--dump-args 3`` (hybrid): every task is present in JSON, while
+      only tensors selected by those same ``dump(...)`` markers contribute
+      payload bytes to ``args.bin``.
 
     The dump level comes straight from the CLI ``--dump-args`` value
     (no per-case override).
@@ -119,16 +123,12 @@ class TestArgsDump(SceneTestCase):
         bin_name = data.get("bin_file")
         tensors = data.get("args", [])
         assert tensors, f"args_dump.json has no entries: {data}"
-        if level == 3:
-            # full_json_only: metadata only, no payload and no .bin file.
-            assert bin_name is None, f"level 3 manifest should have bin_file=null: {data}"
-            assert not (dump_dir / "args.bin").exists(), "level 3 must not write args.bin"
-            assert all(t.get("bin_size") == 0 for t in tensors), tensors
-        else:
-            assert bin_name, f"manifest missing bin_file field: {data}"
-            bin_path = dump_dir / bin_name
-            assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
-            assert bin_path.stat().st_size > 0, "args.bin is empty"
+        assert data.get("dump_args_level") == level
+        assert "payload_filter" not in data
+        assert bin_name, f"manifest missing bin_file field: {data}"
+        bin_path = dump_dir / bin_name
+        assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
+        assert bin_path.stat().st_size > 0, "args.bin is empty"
 
         # Unified manifest (#792): tensors and scalar args share one
         # args_dump.json keyed by a "kind" field; no separate legacy sidecar files.
@@ -196,8 +196,34 @@ class TestArgsDump(SceneTestCase):
             ]
             assert ambiguous_scalars == [("0x0000000100000002", 3)]
         else:
-            # Full (level 2 or 3): markers ignored — every one of the 5 tasks is dumped.
-            assert len(task_ids) >= 5, f"full dump should cover all 5 tasks, got {sorted(task_ids)}"
+            # Full and hybrid both record every task; hybrid still uses the
+            # markers above to select tensor payload.
+            assert len(task_ids) >= 5, f"level {level} should cover all 5 tasks, got {sorted(task_ids)}"
+            if level == 3:
+                selected_tensor_slots = {
+                    ("0x0000000100000000", 0),
+                    ("0x0000000100000000", 1),
+                    ("0x0000000100000002", 0),
+                    ("0x0000000100000002", 2),
+                    ("0x0000000100000003", 0),
+                    ("0x0000000100000003", 1),
+                    ("0x0000000100000003", 2),
+                }
+                for entry in tensor_entries:
+                    selected = (entry["task_id"], entry["arg_index"]) in selected_tensor_slots
+                    assert (entry.get("bin_size", 0) > 0) == selected, entry
+
+                restored_input = next(
+                    entry
+                    for entry in tensor_entries
+                    if entry["task_id"] == "0x0000000100000000"
+                    and entry["arg_index"] == 0
+                    and entry["stage"] == "before_dispatch"
+                )
+                with bin_path.open("rb") as payload_file:
+                    payload_file.seek(restored_input["bin_offset"])
+                    payload = payload_file.read(restored_input["bin_size"])
+                assert payload == struct.pack("<f", 5.0) * (128 * 128)
 
         # ---- Tool smoke: dump_viewer ----
         # Exit-code-only check; the no-filter default lists every captured

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -36,7 +36,7 @@ class TestArgsDump(SceneTestCase):
     """args_dump capture smoke, level-aware on the ``--dump-args`` level.
 
     Uses ``partial_dump_orch`` (5 tasks; four carry ``dump(...)`` markers) so a
-    single orchestration exercises both modes:
+    single orchestration exercises all three enabled levels:
 
     - ``--dump-args 1`` (partial): only marked args are captured — task
       ``0x..00`` via no-arg ``dump()`` (all tensor + scalar args), task
@@ -46,6 +46,10 @@ class TestArgsDump(SceneTestCase):
       Mode is latched host-side before dispatch, so it is race-free regardless
       of submission order.
     - ``--dump-args 2`` (full): markers are ignored, every task is dumped.
+    - ``--dump-args 3`` (hybrid): every task is
+      present in JSON, while only tensors selected by those same ``dump(...)``
+      markers contribute payload bytes to ``args.bin``. The A5 payload values
+      remain untrusted until #1560 is fixed.
 
     The dump level comes straight from the CLI ``--dump-args`` value
     (no per-case override).
@@ -119,16 +123,12 @@ class TestArgsDump(SceneTestCase):
         bin_name = data.get("bin_file")
         tensors = data.get("args", [])
         assert tensors, f"args_dump.json has no entries: {data}"
-        if level == 3:
-            # full_json_only: metadata only, no payload and no .bin file.
-            assert bin_name is None, f"level 3 manifest should have bin_file=null: {data}"
-            assert not (dump_dir / "args.bin").exists(), "level 3 must not write args.bin"
-            assert all(t.get("bin_size") == 0 for t in tensors), tensors
-        else:
-            assert bin_name, f"manifest missing bin_file field: {data}"
-            bin_path = dump_dir / bin_name
-            assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
-            assert bin_path.stat().st_size > 0, "args.bin is empty"
+        assert data.get("dump_args_level") == level
+        assert "payload_filter" not in data
+        assert bin_name, f"manifest missing bin_file field: {data}"
+        bin_path = dump_dir / bin_name
+        assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
+        assert bin_path.stat().st_size > 0, "args.bin is empty"
 
         # Unified manifest (#792): tensors and scalar args share one
         # args_dump.json keyed by a "kind" field; no separate legacy sidecar files.
@@ -196,8 +196,9 @@ class TestArgsDump(SceneTestCase):
             ]
             assert ambiguous_scalars == [("0x0000000100000002", 3)]
         else:
-            # Full (level 2 or 3): markers ignored — every one of the 5 tasks is dumped.
-            assert len(task_ids) >= 5, f"full dump should cover all 5 tasks, got {sorted(task_ids)}"
+            # Full and hybrid both record every task; hybrid still uses the
+            # markers above to select tensor payload.
+            assert len(task_ids) >= 5, f"level {level} should cover all 5 tasks, got {sorted(task_ids)}"
 
         # ---- Tool smoke: dump_viewer ----
         # Exit-code-only check; the no-filter default lists every captured

--- a/tests/ut/cpp/a2a3/test_args_dump.cpp
+++ b/tests/ut/cpp/a2a3/test_args_dump.cpp
@@ -262,3 +262,69 @@ TEST_F(ArgsDumpTest, ArenaBackpressureChecksBeforePayloadOverwrite) {
 
     set_platform_dump_base(0);
 }
+
+TEST_F(ArgsDumpTest, Level3UsesTaskMaskForTensorPayload) {
+    constexpr size_t kDumpMemSize = sizeof(DumpDataHeader) + sizeof(DumpBufferState);
+    alignas(64) uint8_t dump_mem[kDumpMemSize] = {};
+    alignas(64) DumpMetaBuffer meta_buf{};
+    constexpr size_t kArenaSize = 4096;
+    alignas(uint64_t) uint8_t arena[kArenaSize] = {};
+    uint64_t src_data[4] = {10, 20, 30, 40};
+
+    DumpDataHeader *hdr = get_dump_header(dump_mem);
+    hdr->magic = ARGS_DUMP_MAGIC;
+    hdr->dump_args_level = static_cast<uint32_t>(DumpArgsLevel::HYBRID);
+    hdr->num_dump_threads = 1;
+
+    DumpBufferState *state = get_dump_buffer_state(dump_mem, 0);
+    state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&meta_buf);
+    state->free_queue.tail = 1;
+    state->arena_base = reinterpret_cast<uint64_t>(arena);
+    state->arena_size = kArenaSize;
+
+    set_platform_dump_base(reinterpret_cast<uint64_t>(dump_mem));
+    set_dump_args_enabled(true);
+    constexpr uint64_t kTaskId = 0;
+    set_dump_args_task_mask(kTaskId, uint64_t{1} << 6, ARGS_DUMP_ARG_MASK_NONE);
+
+    dump_args_init(1);
+
+    ArgsDumpArgMask mask = ARGS_DUMP_ARG_MASK_NONE;
+    get_dump_args_task_masks(kTaskId, &mask, nullptr);
+    EXPECT_EQ(mask, uint64_t{1} << 6);
+
+    ArgsDumpInfo info = {};
+    info.task_id = kTaskId;
+    info.role = ArgsDumpRole::INPUT;
+    info.stage = ArgsDumpStage::BEFORE_DISPATCH;
+    info.dtype = static_cast<uint8_t>(DataType::UINT64);
+    info.ndims = 1;
+    info.arg_index = 6;
+    info.buffer_addr = reinterpret_cast<uint64_t>(src_data);
+    info.shapes[0] = 4;
+    info.strides[0] = 1;
+    info.kind = static_cast<uint8_t>(ArgsDumpKind::TENSOR);
+    info.func_count = 3;
+    info.func_ids[0] = 0;
+    info.func_ids[1] = 1;
+    info.func_ids[2] = 1;
+
+    ASSERT_EQ(dump_arg_record(0, info), 0);
+    EXPECT_EQ(meta_buf.records[0].payload_size, sizeof(src_data));
+
+    info.arg_index = 7;
+    ASSERT_EQ(dump_arg_record(0, info), 0);
+    EXPECT_EQ(meta_buf.records[1].payload_size, 0u);
+
+    info.kind = static_cast<uint8_t>(ArgsDumpKind::SCALAR);
+    info.scalar_value = 99;
+    ASSERT_EQ(dump_arg_record(0, info), 0);
+    EXPECT_EQ(meta_buf.records[2].payload_size, 0u);
+    EXPECT_EQ(meta_buf.records[2].scalar_value, 99u);
+
+    EXPECT_EQ(state->arena_write_offset, sizeof(src_data));
+    EXPECT_EQ(meta_buf.count, 3u);
+    EXPECT_EQ(memcmp(arena, src_data, sizeof(src_data)), 0);
+
+    set_platform_dump_base(0);
+}

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -49,9 +49,7 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     constexpr int kShardCount = DumpModule::kMaxCollectorThreads;
     ArgsDumpCollector collector;
     ASSERT_EQ(
-        collector.initialize(
-            kShardCount, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL_JSON_ONLY
-        ),
+        collector.initialize(kShardCount, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::HYBRID),
         0
     );
 
@@ -94,6 +92,8 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     std::ifstream manifest_file(manifest_path);
     ASSERT_TRUE(manifest_file.is_open());
     const std::string manifest{std::istreambuf_iterator<char>(manifest_file), std::istreambuf_iterator<char>()};
+    EXPECT_NE(manifest.find("\"dump_args_level\": 3"), std::string::npos);
+    EXPECT_NE(manifest.find("\"bin_file\": null"), std::string::npos);
     EXPECT_NE(manifest.find("\"total_args\": " + std::to_string(kShardCount * kRecordsPerShard)), std::string::npos);
 
     collector.finalize(nullptr, test_free);

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -42,7 +42,7 @@ class TestCallConfig:
         config.enable_chip_swimlane = False
         assert config.enable_chip_swimlane == 0
         # enable_dump_args is likewise a level (0=off, 1=partial, 2=full,
-        # 3=full_json_only): `True` maps to level 1 (partial), explicit ints
+        # 3=hybrid): `True` maps to level 1 (partial), explicit ints
         # select the level.
         config.enable_dump_args = True
         assert config.enable_dump_args == 1

--- a/tests/ut/py/test_core_swimlane.py
+++ b/tests/ut/py/test_core_swimlane.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Contract tests for payload restoration in simpler_setup.tools.core_swimlane."""
+
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from simpler_setup.tools import core_swimlane
+
+
+def _tensor_record(  # noqa: PLR0913
+    *,
+    slot=6,
+    dtype="UINT8",
+    shape=None,
+    strides=None,
+    start_offset=0,
+    stage="before_dispatch",
+    role="input",
+    bin_offset=0,
+    bin_size=4,
+    truncated=False,
+    overwritten=False,
+):
+    shape = [4] if shape is None else shape
+    strides = [1] if strides is None else strides
+    return {
+        "task_id": "0x0",
+        "func_id": [0, 1, 1],
+        "role": role,
+        "stage": stage,
+        "arg_index": slot,
+        "kind": "tensor",
+        "dtype": dtype,
+        "shape": shape,
+        "strides": strides,
+        "start_offset": start_offset,
+        "bin_offset": bin_offset,
+        "bin_size": bin_size,
+        "truncated": truncated,
+        "overwritten": overwritten,
+    }
+
+
+def _write_dump(
+    tmp_path: Path,
+    records,
+    payload=b"",
+    *,
+    bin_file: Optional[str] = "args.bin",
+    bin_format=None,
+):
+    dump_dir = tmp_path / "args_dump"
+    dump_dir.mkdir()
+    manifest = dump_dir / "args_dump.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "bin_format": bin_format
+                or {
+                    "type": "logical_contiguous",
+                    "byte_order": "little_endian",
+                },
+                "bin_file": bin_file,
+                "dump_args_level": 3,
+                "args": records,
+            }
+        )
+    )
+    if bin_file is not None:
+        (dump_dir / bin_file).write_bytes(payload)
+    return manifest
+
+
+def _reconstruct(manifest):
+    _, tensor_count, kargs, _ = core_swimlane.reconstruct_task_args(manifest, [0, 1])
+    return tensor_count, kargs
+
+
+def test_restore_arg_loads_before_dispatch_payload_and_emits_memcpy(tmp_path):
+    before = _tensor_record(bin_offset=0, bin_size=4)
+    after = _tensor_record(
+        stage="after_completion",
+        role="inout",
+        bin_offset=4,
+        bin_size=4,
+    )
+    manifest = _write_dump(tmp_path, [after, before], b"\x01\x02\x03\x04\x09\x09\x09\x09")
+
+    tensor_count, kargs = _reconstruct(manifest)
+    core_swimlane.restore_arg_payloads(manifest, kargs, [6])
+
+    assert kargs[0]["restore_data"] == b"\x01\x02\x03\x04"
+    host = core_swimlane.emit_replay_host(tensor_count, kargs)
+    assert "static const unsigned char hbuf0[]" in host
+    assert "0x01, 0x02, 0x03, 0x04" in host
+    assert "aclrtMemcpy(d_t0, t0Bytes, hbuf0, sizeof(hbuf0)" in host
+    assert "aclrtMemset(d_t0" not in host
+
+
+def test_restore_arg_scatters_logical_payload_into_strided_physical_view(tmp_path):
+    logical = struct.pack("<4H", 10, 20, 30, 40)
+    record = _tensor_record(
+        dtype="UINT16",
+        shape=[2, 2],
+        strides=[3, 1],
+        start_offset=1,
+        bin_size=len(logical),
+    )
+    manifest = _write_dump(tmp_path, [record], logical)
+
+    _, kargs = _reconstruct(manifest)
+    core_swimlane.restore_arg_payloads(manifest, kargs, [6])
+
+    assert struct.unpack("<6H", kargs[0]["restore_data"]) == (0, 10, 20, 0, 30, 40)
+
+
+@pytest.mark.parametrize(
+    ("record_updates", "message"),
+    [
+        ({"stage": "after_completion", "role": "output"}, "no before_dispatch payload"),
+        ({"truncated": True}, "payload is truncated"),
+        ({"overwritten": True}, "payload was overwritten"),
+        ({"bin_size": 3}, "does not match logical tensor size"),
+    ],
+)
+def test_restore_arg_rejects_unusable_tensor_records(tmp_path, record_updates, message):
+    record = _tensor_record(**record_updates)
+    manifest = _write_dump(tmp_path, [record], b"\x01\x02\x03\x04")
+    _, kargs = _reconstruct(manifest)
+
+    with pytest.raises(ValueError, match=message):
+        core_swimlane.restore_arg_payloads(manifest, kargs, [6])
+
+
+def test_restore_arg_rejects_dump_without_payload(tmp_path):
+    record = _tensor_record(bin_size=0)
+    manifest = _write_dump(tmp_path, [record], bin_file=None)
+    _, kargs = _reconstruct(manifest)
+
+    with pytest.raises(ValueError, match="no bin_file"):
+        core_swimlane.restore_arg_payloads(manifest, kargs, [6])
+
+
+def test_restore_arg_rejects_unmarked_slot(tmp_path):
+    record = _tensor_record(bin_size=0)
+    manifest = _write_dump(tmp_path, [record])
+    _, kargs = _reconstruct(manifest)
+
+    with pytest.raises(ValueError, match=r"mark that tensor with CoreTaskArgs::dump"):
+        core_swimlane.restore_arg_payloads(manifest, kargs, [6])
+
+
+def test_restore_arg_rejects_missing_slot(tmp_path):
+    manifest = _write_dump(tmp_path, [_tensor_record()], b"\x01\x02\x03\x04")
+    _, kargs = _reconstruct(manifest)
+
+    with pytest.raises(ValueError, match="slot 7 is not an arg"):
+        core_swimlane.restore_arg_payloads(manifest, kargs, [7])
+
+
+def test_restore_arg_rejects_unknown_bin_format(tmp_path):
+    manifest = _write_dump(
+        tmp_path,
+        [_tensor_record()],
+        b"\x01\x02\x03\x04",
+        bin_format={"type": "physical", "byte_order": "little_endian"},
+    )
+    _, kargs = _reconstruct(manifest)
+
+    with pytest.raises(ValueError, match="type=logical_contiguous"):
+        core_swimlane.restore_arg_payloads(manifest, kargs, [6])
+
+
+def test_restore_arg_rejects_scalar_slot(tmp_path):
+    scalar = {
+        "task_id": "0x0",
+        "func_id": [0, 1, 1],
+        "role": "scalar",
+        "stage": "before_dispatch",
+        "arg_index": 17,
+        "kind": "scalar",
+        "dtype": "INT64",
+        "shape": [],
+        "strides": [],
+        "start_offset": 0,
+        "value": 9,
+        "bin_offset": 0,
+        "bin_size": 0,
+    }
+    manifest = _write_dump(tmp_path, [scalar], b"")
+    _, kargs = _reconstruct(manifest)
+
+    with pytest.raises(ValueError, match="is a scalar"):
+        core_swimlane.restore_arg_payloads(manifest, kargs, [17])
+
+
+def test_get_or_run_dump_uses_level3_without_payload_selector(tmp_path, monkeypatch):
+    commands = []
+    monkeypatch.setattr(core_swimlane, "PROJECT_ROOT", tmp_path)
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        dump_dir = tmp_path / "outputs" / "run_3" / "args_dump"
+        dump_dir.mkdir(parents=True)
+        (dump_dir / "args_dump.json").write_text("{}")
+
+    monkeypatch.setattr(core_swimlane.subprocess, "run", fake_run)
+    manifest = core_swimlane.get_or_run_dump(tmp_path / "test_case.py", "a2a3sim", "sim", None)
+
+    flag_index = commands[0].index("--dump-args")
+    assert commands[0][flag_index + 1] == "3"
+    assert not any(value.startswith("--dump-args-payload") for value in commands[0])
+    assert manifest.name == "args_dump.json"
+
+
+def test_replay_cmake_includes_shared_platform_headers():
+    cmake = core_swimlane.emit_cmakelists(
+        "a2a3",
+        "test",
+        core_swimlane.ARCH_CONFIG["a2a3"],
+        extra_include_dirs=["/sdk/asc/include"],
+    )
+
+    assert "${REPO_ROOT}/src/common/platform/include" in cmake
+    assert '"/sdk/asc/include"' in cmake
+
+
+def test_run_collect_forwards_msprof_timeout_in_minutes():
+    script = core_swimlane.emit_run_collect(
+        core_swimlane.ARCH_CONFIG["a2a3"],
+        "/pto-isa",
+        msprof_timeout=4,
+    )
+
+    assert "--timeout=4" in script
+    assert "__MSPROF_TIMEOUT__" not in script
+
+
+def test_cli_rejects_restore_and_set_on_the_same_slot(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "core_swimlane",
+            "--test",
+            "unused.py",
+            "--func-id",
+            "0,1",
+            "--restore-arg",
+            "6",
+            "--set-arg",
+            "6=1",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        core_swimlane.main()
+
+    assert "cannot use both --restore-arg and --set-arg" in capsys.readouterr().err
+
+
+def test_cli_rejects_a5_payload_restoration(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "core_swimlane",
+            "--test",
+            "unused.py",
+            "--func-id",
+            "0",
+            "--platform",
+            "a5sim",
+            "--restore-arg",
+            "6",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        core_swimlane.main()
+
+    assert "does not support a5/a5sim" in capsys.readouterr().err
+
+
+def test_default_tensor_initialization_remains_zero_fill():
+    tensor = {
+        "kind": "tensor",
+        "slot": 0,
+        "dtype": "UINT8",
+        "shape": [4],
+        "strides": [1],
+        "start_offset": 0,
+    }
+
+    host = core_swimlane.emit_replay_host(1, [tensor])
+
+    assert "aclrtMemset(d_t0, t0Bytes, 0, t0Bytes)" in host


### PR DESCRIPTION
Level 3 args dump keeps complete argument metadata while reusing the
Level 1 CoreTaskArgs::dump() mask to capture only marked tensor payloads.
Level 1 partial and Level 2 full record-selection and payload semantics
remain unchanged.

- Add --restore-arg SLOT to initialize A2/A3 replay tensors from captured
  before-dispatch bytes, including strided views.
- Add --msprof-timeout MINUTES and clarify --spmd-block-num for bounded,
  faithful simulator runs.
- Keep args.bin optional when Level 3 has no marked tensor payload, and
  record the resolved dump level in each manifest.
- Disable args dumping for multi-round scene runs to keep capture output
  within the single-round DFX lifecycle.
- Latch the dump level once in dump_args_init() and keep Level 2
  independent of Level 1/3 task-mask lookup.
- Reject A5 payload restoration while [#1560](https://github.com/hw-native-sys/simpler/issues/1560) is open; metadata-only and
  zero-filled Core replays remain supported.
- Cover payload capture, restoration, manifests, strided views, and error
  paths for [#1532](https://github.com/hw-native-sys/simpler/issues/1532).
  
Close #1532 