### PR TITLE
Optimize: serialize provenance-guarded device ops per worker, not process-wide

### DIFF
--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -429,14 +429,16 @@ inline void bind_worker(nb::module_ &m) {
             [](Worker &self, int worker_id, size_t size) {
                 return self.malloc(worker_id, size);
             },
-            nb::arg("worker_id"), nb::arg("size"), "Allocate device memory on next-level worker."
+            nb::arg("worker_id"), nb::arg("size"), nb::call_guard<nb::gil_scoped_release>(),
+            "Allocate device memory on next-level worker."
         )
         .def(
             "free",
             [](Worker &self, int worker_id, uint64_t ptr) {
                 self.free(worker_id, ptr);
             },
-            nb::arg("worker_id"), nb::arg("ptr"), "Free device memory on next-level worker."
+            nb::arg("worker_id"), nb::arg("ptr"), nb::call_guard<nb::gil_scoped_release>(),
+            "Free device memory on next-level worker."
         )
         .def(
             "copy_to",
@@ -444,6 +446,7 @@ inline void bind_worker(nb::module_ &m) {
                 self.copy_to(worker_id, dst, src, nbytes);
             },
             nb::arg("worker_id"), nb::arg("dst"), nb::arg("src"), nb::arg("nbytes"),
+            nb::call_guard<nb::gil_scoped_release>(),
             "H2D copy: host `src` into device `dst`, both named by descriptor. The child resolves each "
             "through its ImportRegistry, so neither end is an address minted in this process."
         )
@@ -453,6 +456,7 @@ inline void bind_worker(nb::module_ &m) {
                 self.copy_from(worker_id, dst, src, nbytes);
             },
             nb::arg("worker_id"), nb::arg("dst"), nb::arg("src"), nb::arg("nbytes"),
+            nb::call_guard<nb::gil_scoped_release>(),
             "D2H copy: device `src` into host `dst`, both named by descriptor."
         )
         .def(

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -75,6 +75,7 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from multiprocessing import resource_tracker
 from multiprocessing.shared_memory import SharedMemory
@@ -764,6 +765,60 @@ class _ChildProvEntry:
 # it takes is not re-entrant — but the re-entrance is per Worker: a call that
 # reaches a *different* Worker owes that Worker its own reservation.
 _CONTROL_RESERVATION = threading.local()
+
+
+class _SharedExclusiveLock:
+    """Held by many in shared mode, or by one alone in exclusive mode.
+
+    Run admission and device control both need ordering against each other, but
+    not the same amount of it. A control command that belongs to no run needs
+    "no run may be admitted while I run" — a property of the worker. Two such
+    commands on different chips do not need to exclude *each other*, and making
+    them do so serializes every mailbox round-trip in the tree behind one
+    mutex. Admission takes this exclusively, control takes it shared.
+
+    Writer-preferring: once a submit is waiting, new shared holders queue behind
+    it, so a stream of control commands cannot starve admission.
+    """
+
+    def __init__(self) -> None:
+        self._cv = threading.Condition()
+        self._shared = 0
+        self._exclusive = False
+        self._waiting_exclusive = 0
+
+    @contextlib.contextmanager
+    def shared(self) -> Iterator[None]:
+        """Admit alongside other shared holders; excludes exclusive holders."""
+        with self._cv:
+            while self._exclusive or self._waiting_exclusive:
+                self._cv.wait()
+            self._shared += 1
+        try:
+            yield
+        finally:
+            with self._cv:
+                self._shared -= 1
+                if self._shared == 0:
+                    self._cv.notify_all()
+
+    @contextlib.contextmanager
+    def exclusive(self) -> Iterator[None]:
+        """Admit alone: waits out every shared holder and excludes new ones."""
+        with self._cv:
+            self._waiting_exclusive += 1
+            try:
+                while self._exclusive or self._shared:
+                    self._cv.wait()
+            finally:
+                self._waiting_exclusive -= 1
+            self._exclusive = True
+        try:
+            yield
+        finally:
+            with self._cv:
+                self._exclusive = False
+                self._cv.notify_all()
 
 
 def _held_control_reservations() -> set[int]:
@@ -4230,7 +4285,9 @@ class Worker:
         # may be admitted at once is the depth the child backends negotiated.
         # This gate serialises graph construction itself, which stays
         # synchronous on the submitting caller at any depth.
-        self._submit_mu = threading.Lock()
+        # Exclusive for run admission, shared for control that belongs to no run:
+        # such a command must exclude admission, but not other chips' commands.
+        self._submit_mu = _SharedExclusiveLock()
         # Guarded by _hierarchical_start_cv. Handles are installed before their
         # orchestration callback can enqueue work and retired after fence-owned
         # cleanup, so close() can drain the exact accepted set.
@@ -4365,6 +4422,11 @@ class Worker:
         # interrupted op never leaves a freed address live. Cleared on close().
         self._child_alloc_prov: dict[tuple[int, int], _ChildProvEntry] = {}
         self._child_prov_lock = threading.Lock()
+        # Per-worker locks for the *native* half of a provenance-guarded device op.
+        # ``_child_prov_lock`` stays the bookkeeping lock (short, process-wide); the
+        # long native call (malloc / free / copy) is serialized per worker instead, so
+        # ops on different chips overlap while same-worker ordering is unchanged.
+        self._child_prov_worker_locks: dict[int, threading.Lock] = {}
 
         # Owner-side Buffer state (P1-B): a per-incarnation opaque nonce, a monotonic buffer_id
         # (0 reserved), and the live handles this Worker owns. create_buffer allocates a handle whose
@@ -9275,6 +9337,19 @@ class Worker:
     # successful native alloc; revoke before the native free.
     # ------------------------------------------------------------------
 
+    def _child_prov_worker_lock(self, worker_id: int) -> threading.Lock:
+        """Return the lock serializing native device ops on *worker_id* alone.
+
+        Acquired *before* ``_child_prov_lock`` wherever both are needed; never the
+        other way round, so the two can never deadlock.
+        """
+        with self._child_prov_lock:
+            lock = self._child_prov_worker_locks.get(int(worker_id))
+            if lock is None:
+                lock = threading.Lock()
+                self._child_prov_worker_locks[int(worker_id)] = lock
+            return lock
+
     def _child_prov_record_malloc(self, worker_id: int, ptr: int, size: int) -> None:
         """Mark ``(worker_id, ptr)`` as a live malloc base spanning ``size`` bytes
         (after a successful malloc)."""
@@ -9487,10 +9562,11 @@ class Worker:
         with (
             self._operation_lease("alloc_child_tensor"),
             self._device_control_admission("alloc_child_tensor"),
-            self._child_prov_lock,
+            self._child_prov_worker_lock(int(worker_id)),
         ):
             ptr = int(self._worker.malloc(int(worker_id), int(nbytes)))
-            self._child_prov_record_malloc(int(worker_id), ptr, int(nbytes))
+            with self._child_prov_lock:
+                self._child_prov_record_malloc(int(worker_id), ptr, int(nbytes))
         return wrap_device_malloc(
             ptr,
             int(nbytes),
@@ -9512,11 +9588,14 @@ class Worker:
         if self.level != 2:
             self._check_chip_worker_id(wid)
         with self._operation_lease("free"), self._device_control_admission("free"):
-            with self._child_prov_lock:
+            with self._child_prov_worker_lock(wid):
                 # Safety-first commit barrier: revoke provenance BEFORE the native free so an async unwind
-                # after a successful free can never leave a freed address live.
-                self._child_prov_require_malloc_base(wid, ptr, api="free")
-                self._child_prov_clear_malloc(wid, ptr)
+                # after a successful free can never leave a freed address live. The revoke commits under
+                # ``_child_prov_lock``; the native call runs under this worker's lock only, so a free on
+                # one chip no longer blocks provenance or device ops on another.
+                with self._child_prov_lock:
+                    self._child_prov_require_malloc_base(wid, ptr, api="free")
+                    self._child_prov_clear_malloc(wid, ptr)
                 if self.level == 2:
                     assert self._chip_worker is not None
                     self._chip_worker.free(ptr)
@@ -9614,8 +9693,9 @@ class Worker:
             self._check_chip_worker_id(wid)
             host = self._require_buffer_host_side(host, "copy_to")
         with self._operation_lease("copy_to"), self._device_control_admission("copy_to"):
-            with self._child_prov_lock:
-                self._child_prov_require_live_range(wid, dptr, nbytes, api="copy_to")
+            with self._child_prov_worker_lock(wid):
+                with self._child_prov_lock:
+                    self._child_prov_require_live_range(wid, dptr, nbytes, api="copy_to")
                 if self.level == 2:
                     # No fork: the chip worker runs in this process, so the host address is valid.
                     assert self._chip_worker is not None
@@ -9639,8 +9719,9 @@ class Worker:
             self._check_chip_worker_id(wid)
             host = self._require_buffer_host_side(host, "copy_from")
         with self._operation_lease("copy_from"), self._device_control_admission("copy_from"):
-            with self._child_prov_lock:
-                self._child_prov_require_live_range(wid, sptr, nbytes, api="copy_from")
+            with self._child_prov_worker_lock(wid):
+                with self._child_prov_lock:
+                    self._child_prov_require_live_range(wid, sptr, nbytes, api="copy_from")
                 if self.level == 2:
                     # No fork: the chip worker runs in this process, so the host address is valid.
                     assert self._chip_worker is not None
@@ -9821,7 +9902,11 @@ class Worker:
         minted elsewhere can collide with a registry key, and evicting the live entry it names would
         strand that backing."""
         if not buffer.closed:
-            with self._submit_mu, self._hierarchical_start_cv:
+            # Exclusive, not shared: `shared()` would already exclude admission and so
+            # satisfy the "never mid-callback" argument above, but this keeps the
+            # ordering identical to the plain lock this used to be, and buffer release
+            # is not on a hot path, so there is nothing to win by weakening it.
+            with self._submit_mu.exclusive(), self._hierarchical_start_cv:
                 for handle in self._accepted_run_handles:
                     if not handle._cleanup_published and buffer.identity in handle._resources.touched_identities:
                         raise RuntimeError(f"release_buffer: {buffer.identity} is still referenced by an in-flight run")
@@ -9913,7 +9998,7 @@ class Worker:
             state = self._resolve_handle(callable, expected_namespace="LOCAL_CHIP")
             return self._submit_l2_locked(state.slot_id, args, cfg)
 
-        with self._submit_mu:
+        with self._submit_mu.exclusive():
             # Graph callbacks stay serialized, so a predecessor's callback has
             # always returned by the time we get here — which is what makes the
             # decision below a fact about that run rather than a guess about
@@ -10061,7 +10146,9 @@ class Worker:
         sampled check leaves the caller free to send its mailbox command after a
         submit admitted a run behind its back, so this takes the serializer
         submission itself holds — no run can be admitted between the check and
-        the command. Re-entrant per thread: one control call may be built out of
+        the command. It takes it *shared*: what the command needs is that no run
+        is admitted while it runs, which two commands on different chips can
+        guarantee at the same time. Re-entrant per thread: one control call may be built out of
         others (a queue out of a region), and the second must join the
         reservation rather than deadlock on it.
         """
@@ -10069,7 +10156,7 @@ class Worker:
         if id(self) in held:
             yield
             return
-        with self._submit_mu:
+        with self._submit_mu.shared():
             with self._hierarchical_start_cv:
                 if self._ordered_cleanup_error is not None:
                     raise RuntimeError(

--- a/tests/ut/py/test_remote_l3_lifecycle.py
+++ b/tests/ut/py/test_remote_l3_lifecycle.py
@@ -19,7 +19,7 @@ from typing import cast
 import pytest
 from simpler import remote_l3_session, remote_l3_worker
 from simpler.buffer import create_host_shared_buffer, mint_owner_instance_id
-from simpler.worker import RunHandle, Worker, _RunResources
+from simpler.worker import RunHandle, Worker, _RunResources, _SharedExclusiveLock
 
 
 def _manifest(**extra):
@@ -957,7 +957,9 @@ def _bare_l3_worker():
     w._hierarchical_start_mu = threading.Lock()
     w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
     w._accepted_run_handles = set()
-    w._submit_mu = threading.Lock()
+    # Run admission is shared/exclusive now, not a plain Lock: production code calls
+    # `.exclusive()` / `.shared()` on it, so the stand-in has to be the real type.
+    w._submit_mu = _SharedExclusiveLock()
     w._chip_run_touched_identities = {}
     w._chip_import_registry = None
     w._worker = None

--- a/tests/ut/py/test_shared_exclusive_lock.py
+++ b/tests/ut/py/test_shared_exclusive_lock.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for `_SharedExclusiveLock`, the serializer behind run admission.
+
+Control commands that belong to no run hold it shared — they must exclude
+admission, not each other — while a submit holds it alone. These are pure
+threading tests: no worker, no device.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from simpler.worker import _SharedExclusiveLock
+
+# Long enough that a genuinely blocked acquire is not mistaken for a slow one,
+# short enough that a broken lock fails the suite in seconds rather than hanging.
+BLOCKED_S = 0.3
+ACQUIRED_S = 5.0
+
+
+def _run(target) -> threading.Thread:
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_shared_holders_overlap() -> None:
+    """Every shared holder is admitted at once — the point of the split."""
+    lock = _SharedExclusiveLock()
+    holders = 8
+    inside = threading.Barrier(holders + 1)
+    release = threading.Event()
+
+    def hold() -> None:
+        with lock.shared():
+            inside.wait(timeout=ACQUIRED_S)
+            release.wait(timeout=ACQUIRED_S)
+
+    threads = [_run(hold) for _ in range(holders)]
+    # Barrier trips only if all `holders` are inside their `with` simultaneously.
+    inside.wait(timeout=ACQUIRED_S)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=ACQUIRED_S)
+        assert not thread.is_alive()
+
+
+def test_exclusive_excludes_shared() -> None:
+    lock = _SharedExclusiveLock()
+    held = threading.Event()
+    entered_shared = threading.Event()
+    release = threading.Event()
+
+    def hold_exclusive() -> None:
+        with lock.exclusive():
+            held.set()
+            release.wait(timeout=ACQUIRED_S)
+
+    def take_shared() -> None:
+        with lock.shared():
+            entered_shared.set()
+
+    writer = _run(hold_exclusive)
+    assert held.wait(timeout=ACQUIRED_S)
+    reader = _run(take_shared)
+    assert not entered_shared.wait(timeout=BLOCKED_S), "shared entered while exclusive was held"
+
+    release.set()
+    assert entered_shared.wait(timeout=ACQUIRED_S), "shared never entered after exclusive released"
+    for thread in (writer, reader):
+        thread.join(timeout=ACQUIRED_S)
+        assert not thread.is_alive()
+
+
+def test_shared_excludes_exclusive() -> None:
+    lock = _SharedExclusiveLock()
+    held = threading.Event()
+    entered_exclusive = threading.Event()
+    release = threading.Event()
+
+    def hold_shared() -> None:
+        with lock.shared():
+            held.set()
+            release.wait(timeout=ACQUIRED_S)
+
+    def take_exclusive() -> None:
+        with lock.exclusive():
+            entered_exclusive.set()
+
+    reader = _run(hold_shared)
+    assert held.wait(timeout=ACQUIRED_S)
+    writer = _run(take_exclusive)
+    assert not entered_exclusive.wait(timeout=BLOCKED_S), "exclusive entered while shared was held"
+
+    release.set()
+    assert entered_exclusive.wait(timeout=ACQUIRED_S), "exclusive never entered after shared released"
+    for thread in (reader, writer):
+        thread.join(timeout=ACQUIRED_S)
+        assert not thread.is_alive()
+
+
+def test_waiting_exclusive_blocks_new_shared() -> None:
+    """Writer-preferring: a stream of control commands cannot starve a submit."""
+    lock = _SharedExclusiveLock()
+    first_held = threading.Event()
+    entered_exclusive = threading.Event()
+    entered_late_shared = threading.Event()
+    release_first = threading.Event()
+
+    def hold_shared() -> None:
+        with lock.shared():
+            first_held.set()
+            release_first.wait(timeout=ACQUIRED_S)
+
+    def take_exclusive() -> None:
+        with lock.exclusive():
+            entered_exclusive.set()
+
+    def take_late_shared() -> None:
+        with lock.shared():
+            entered_late_shared.set()
+
+    reader = _run(hold_shared)
+    assert first_held.wait(timeout=ACQUIRED_S)
+    writer = _run(take_exclusive)
+    # Give the writer time to register itself as waiting before the late reader.
+    assert not entered_exclusive.wait(timeout=BLOCKED_S)
+    late_reader = _run(take_late_shared)
+    assert not entered_late_shared.wait(timeout=BLOCKED_S), "shared jumped the queue ahead of a waiting exclusive"
+
+    release_first.set()
+    assert entered_exclusive.wait(timeout=ACQUIRED_S)
+    assert entered_late_shared.wait(timeout=ACQUIRED_S)
+    for thread in (reader, writer, late_reader):
+        thread.join(timeout=ACQUIRED_S)
+        assert not thread.is_alive()

--- a/tests/ut/py/test_worker/test_child_addr_guard.py
+++ b/tests/ut/py/test_worker/test_child_addr_guard.py
@@ -582,22 +582,36 @@ class TestProvenanceTransactions:
             w.free(h)
 
     def test_free_holds_lock_across_native_free(self):
-        # Deterministic mutual-exclusion check: the native free runs while
-        # _child_prov_lock is held, so a concurrent free/copy/dispatch cannot
-        # interleave with a half-completed free.
+        # Deterministic mutual-exclusion check, in the narrower form this exclusion
+        # now takes: the native free runs under *that worker's* lock, so a
+        # concurrent free/copy/dispatch on the same chip still cannot interleave
+        # with a half-completed free — but `_child_prov_lock` is released, so a
+        # slow free on one chip no longer blocks provenance work for another.
+        # Safe because provenance is keyed by (worker_id, ptr) and the revoke
+        # commits first: a concurrent dispatch reading the table under
+        # `_child_prov_lock` finds this address already gone, or is about a
+        # different chip entirely.
         w, nw = _l3_ready(0x1000)
         h = w.alloc_child_tensor(0, (64,), DataType.UINT8)
-        held = {}
+        seen = {}
 
         def _sf(wid, p):
-            acquired = w._child_prov_lock.acquire(blocking=False)
-            held["locked_during_native"] = not acquired
-            if acquired:
+            worker_lock = w._child_prov_worker_lock(wid)
+            free_to_take = worker_lock.acquire(blocking=False)
+            seen["worker_lock_held"] = not free_to_take
+            if free_to_take:
+                worker_lock.release()
+            shared_free = w._child_prov_lock.acquire(blocking=False)
+            seen["shared_lock_released"] = shared_free
+            if shared_free:
                 w._child_prov_lock.release()
+            seen["revoke_committed"] = (wid, p) not in w._child_alloc_prov
 
         nw.free.side_effect = _sf
         w.free(h)
-        assert held["locked_during_native"] is True
+        assert seen["worker_lock_held"] is True
+        assert seen["shared_lock_released"] is True
+        assert seen["revoke_committed"] is True
 
     def test_capture_refs_after_provenance_analysis(self, _fake_handle, monkeypatch):
         # blocker: the kind4 provenance analysis must run BEFORE remote slot refs

--- a/tests/ut/py/test_worker/test_create_buffer.py
+++ b/tests/ut/py/test_worker/test_create_buffer.py
@@ -21,7 +21,7 @@ import threading
 
 import pytest
 from simpler.buffer import AddressSpace, BackendKind, mint_owner_instance_id
-from simpler.worker import Worker, _NoBufferConsumerError
+from simpler.worker import Worker, _NoBufferConsumerError, _SharedExclusiveLock
 
 
 def _bare_worker(level: int, *, chip: int = 0, sub: int = 0, next_level: int = 0) -> Worker:
@@ -37,7 +37,9 @@ def _bare_worker(level: int, *, chip: int = 0, sub: int = 0, next_level: int = 0
     w._hierarchical_start_mu = threading.Lock()
     w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
     w._accepted_run_handles = set()
-    w._submit_mu = threading.Lock()
+    # Run admission is shared/exclusive now, not a plain Lock: production code calls
+    # `.exclusive()` / `.shared()` on it, so the stand-in has to be the real type.
+    w._submit_mu = _SharedExclusiveLock()
     w._chip_run_touched_identities = {}
     w._chip_import_registry = None
     w._worker = None

--- a/tests/ut/py/test_worker/test_release_buffer.py
+++ b/tests/ut/py/test_worker/test_release_buffer.py
@@ -150,7 +150,8 @@ class TestReleaseBuffer:
     def test_serializes_with_a_racing_orchestration_callback(self):
         # _submit_l3_locked adds a run's handle to _accepted_run_handles (worker.py:9910) BEFORE
         # its orchestration callback runs -- the callback is what eventually records
-        # touched_identities via submit_next_level. Without taking _submit_mu (the same lock that
+        # touched_identities via submit_next_level. Without taking _submit_mu exclusively (the same
+        # serializer graph construction takes,
         # already serializes graph construction, worker.py:9741), release_buffer could observe the
         # handle with an empty touched_identities mid-callback and release a Buffer the callback is
         # about to dispatch a Tensor over. This drives that exact window directly.
@@ -165,7 +166,7 @@ class TestReleaseBuffer:
         release_returned = threading.Event()
 
         def fake_orchestration_callback():
-            with w._submit_mu:
+            with w._submit_mu.exclusive():
                 with w._hierarchical_start_cv:
                     w._accepted_run_handles.add(handle)
                 entered_callback.set()


### PR DESCRIPTION
Rebased onto current `main`. Two commits: a fix, and a **draft** for a second lock that can be dropped independently.

## The problem

`_child_prov_lock` is held across the *native* half of `malloc` / `free` / `copy_to` / `copy_from`, so every device op of every next-level worker serializes on one lock belonging to the parent worker. The bindings already release the GIL there, which makes it easy to miss: unrelated Python threads keep running, but a `copy_to` on chip 0 blocks a `malloc` on chip 1 for its whole duration.

Measured with per-shard timestamps on both sides of an 8-chip upload: all 8 orchestrator threads enter `Orchestrator.copy_to` within **14 µs** of each other, then each chip child starts its copy within **~1 ms of the previous one finishing**, each at full link speed. Inside `LocalMailboxEndpoint::control_copy_to`, `wait_lock` is `0.0000s` — the per-worker mailbox mutexes are never contended, the threads simply arrive one at a time.

## Commit 1 — per-worker provenance locks

`_child_prov_lock` stays the bookkeeping lock (each provenance mutation/read still atomic, safety-first ordering unchanged: record after a successful alloc, revoke before a native free); a **per-worker** lock now wraps the native call. Same-worker ops stay mutually exclusive, different workers overlap. The per-worker lock is always taken before `_child_prov_lock`, never the reverse, so the two cannot deadlock.

**This modifies an existing test.** `test_free_holds_lock_across_native_free` pinned the wide behaviour; it now asserts the narrower exclusion the code provides — that worker's lock held across the native free, `_child_prov_lock` released, revoke committed first. Sufficient because provenance is keyed by `(worker_id, ptr)` and the revoke commits before the native free, so a concurrent dispatch reads the table under `_child_prov_lock` and finds the address already gone, or is about a different chip. Flagged explicitly: it pins a deliberate decision, so if the reasoning does not hold, the answer is to revert the free path rather than to keep the test green another way.

## Commit 2 — draft: shared/exclusive run-admission lock

**This alone is not enough on this base**, as @YunjiQin identified: `_control_reservation` (#1541) takes `_submit_mu` and holds it across the same native call, at the same per-worker granularity. My original numbers were measured on `9922afdb`, which predates #1541 — corrected below.

A control command that belongs to no run needs "no run may be admitted while I run", a property of the *worker*; two commands on different chips can both have it at once. So `_submit_mu` becomes shared/exclusive: run admission takes it exclusively, control takes it shared. Writer-preferring, so control traffic cannot starve a submit; the reservation's thread-local re-entrancy short-circuits before the lock and is untouched.

Kept as a separate commit precisely so it can be dropped or replaced — it changes the serializer #1541 introduced, and the shape is the author's call.

## Measured

8 × 910B2, one upload thread per shard, fresh shared-memory bands so every page is read cold exactly once (reusing a band measures the warm path and inflates everything):

| base | threaded | serial |
|---|---:|---:|
| with #1541, commit 1 only | 6.5 – 8.0 GB/s | 8.6 – 10.3 GB/s |
| with #1541, both commits | **19.2 – 34.0 GB/s** | 9.4 – 10.5 GB/s |
| without #1541 (the base I first measured), commit 1 only | 22.7 – 30.7 GB/s | 8.6 – 10.5 GB/s |

Serial is identical across bases, so the difference is the lock and not the setup. For reference on the same node, 8 independent processes doing raw cold H2D from a shared mapping reach ~29–34 GB/s aggregate.

## Tests

- `tests/ut/py/test_shared_exclusive_lock.py` (new): shared holders overlap, each mode excludes the other, a waiting writer blocks new readers.
- `tests/ut/py/test_worker/test_child_addr_guard.py`: updated as described; the file passes in full (49 tests with the new one included).

## Open question

Whether "no run may be admitted while I run" is the *whole* invariant `_control_reservation` carries, or whether something also relies on control commands excluding each other. That decides commit 2 — happy to implement a different shape or hand it over.

`st-pod-onboard-a2a3` fails on `vector_add_mixed_l3` / `poll_native_run failed`; PR #1722 fails identically on the same job while #1709 / #1714 / #1718 / #1723 pass, so it reads as a pod-runner flake rather than this branch.

The dependent pypto change (hw-native-sys/pypto#2292) is a no-op without this, so there is no merge-order constraint between them.