### PR TITLE
Fix: harden the Buffer/Tensor wire gate and the create_buffer child check

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -138,8 +138,9 @@ whose own comment records the hazard.
 
 Both are called what they are, and by the **same** name in both languages, which
 is what [codestyle rule 13](../.claude/rules/codestyle.md) requires of a public
-type. The L3+ wire type is `Tensor` — `simpler.task_interface.Tensor` in Python,
-the global `Tensor` of `src/common/task_interface/buffer.h` in C++. The device
+type. The L3+ wire type is `Tensor` — `simpler.buffer.Tensor` in Python (it joins
+`simpler.task_interface` in the wire cutover, per the Status note above), the
+global `Tensor` of `src/common/task_interface/buffer.h` in C++. The device
 POD is `ChipTensor` in both, from `src/common/task_interface/tensor.h`.
 
 Rule 13 is what makes the plain names available: the device POD held the global
@@ -212,6 +213,14 @@ torch.frombuffer(h.shm.buf, dtype=torch.float32, count=n).fill_(5.0)  # before r
 worker.run(my_orch, ...)                                             # orch names tensors only
 result = torch.frombuffer(out_h.shm.buf, dtype=torch.float32, count=n)  # after run()
 ```
+
+> **`h.shm` is transitional — wrap it.** Byte access belongs on the view, not on the
+> backing object: a `POSIX_SHM` buffer has an `shm` and a device one never will, so
+> code written against `h.shm.buf` forks by backend and cannot be told "this backing
+> has no host mapping" — it just gets `None`. The accessor that replaces it lands with
+> the view algebra; until then, put `h.shm.buf` behind one helper of your own so the
+> switch is a one-line change. Note also that a `frombuffer` tensor keeps the
+> memoryview alive: drop it before `close()`, or the release raises `BufferError`.
 
 ## How a tensor reaches its consumer (three-way split)
 

--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -287,28 +287,31 @@ def wrap_fork_inherited(
     owner_worker_path: str = "",
     generation: int = 1,
     access: AccessMode = AccessMode.READ,
+    backend_kind: BackendKind = BackendKind.FORK_COW,
 ) -> Buffer:
     """Wrap a pre-fork, fork-inherited host allocation as a zero-copy ``Buffer``.
 
     Memory allocated before the children were forked is present in every child at the *same* virtual
     address; the backend body is that base VA (u64 LE) and the consumer materializes to the same VA
-    with no mapping and no copy. The backend tag follows the mmap the caller actually has, which is
-    what ``access`` states:
+    with no mapping and no copy. ``backend_kind`` states which mmap the caller actually holds, and is
+    a classification the caller must make rather than something inferred from ``access``:
 
-    * ``MAP_SHARED`` (e.g. a ``torch.Tensor.share_memory_()``) — a child's writes land in the pages
-      the parent reads, so it can serve as an OUTPUT. Pass ``access=READWRITE``; tagged FORK_SHM.
-    * plain ``MAP_PRIVATE`` — copy-on-write: a child's first write splits the page into a private
-      copy the parent never sees. Read-only, the default; tagged FORK_COW so the distinction is a
-      classification rather than something a reader has to infer from ``access``.
+    * ``FORK_SHM`` — ``MAP_SHARED`` (e.g. a ``torch.Tensor.share_memory_()``): a child's writes land
+      in the pages the parent reads, so it can serve as an OUTPUT. Any ``access`` is legal.
+    * ``FORK_COW`` — plain ``MAP_PRIVATE``: copy-on-write, so a child's first write splits the page
+      into a private copy the parent never sees. ``access`` must be ``READ``; the descriptor's
+      validator rejects anything else.
+
+    The two are not interchangeable and neither implies an ``access``: a ``MAP_SHARED`` backing
+    granted READ only is a legal, expressible combination.
     """
     identity = CanonicalIdentity(owner_instance_id, buffer_id, generation)
-    backend = BackendKind.FORK_SHM if access != AccessMode.READ else BackendKind.FORK_COW
     return Buffer(
         identity=identity,
         owner_worker_path_id=intern_worker_path(owner_worker_path),
         address_space=AddressSpace.HOST,
         access=access,
-        backend_kind=backend,
+        backend_kind=backend_kind,
         nbytes=nbytes,
         body=int(data_ptr).to_bytes(8, "little"),
         shm=None,
@@ -426,9 +429,13 @@ class ImportRegistry:
         cached ImportedBuffer thereafter (map-once).
 
         Takes the descriptor, never its bytes: every producer of one — an owner's ``to_descriptor()``,
-        a re-export, an element pulled out of a received TaskArgs — hands over the bound type, and a
-        caller holding raw bytes decodes them with ``BufferDescriptor.unpack`` so the decode is
-        visible at its call site.
+        a re-export, an element pulled out of a received TaskArgs — hands over the bound type, and
+        there is no Python path from raw bytes to a descriptor at all, which is what keeps
+        ``validate_buffer_descriptor`` a gate rather than a habit.
+
+        Adds no endpoint check of its own: a DEVICE backing resolved here yields a device pointer,
+        which is only meaningful on its owner chip. The endpoint × ``address_space`` matrix is a
+        separate change; until it lands, that invariant rests on the caller.
         """
         key = desc.identity
         cached = self._by_identity.get(key)
@@ -441,9 +448,10 @@ class ImportRegistry:
             BackendKind.VMM_WINDOW,
         ):
             # The body is the base pointer (u64 LE), already valid in this process — no mapping.
-            # FORK_SHM: a COW-inherited host VA. DEVICE_MALLOC / VMM_WINDOW: a device pointer valid on
-            # the chip that allocated / carved it (the tensor must only reach that chip — a topology
-            # invariant).
+            # FORK_SHM / FORK_COW: a host VA inherited across the fork, so the child already holds
+            # the same address (they differ in write semantics, not in how they resolve).
+            # DEVICE_MALLOC / VMM_WINDOW: a device pointer valid on the chip that allocated / carved
+            # it (the tensor must only reach that chip — a topology invariant).
             base = int.from_bytes(desc.body, "little")
             imported = ImportedBuffer(desc.identity, base, desc.nbytes, desc.address_space, None)
         elif desc.backend_kind == BackendKind.POSIX_SHM:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -8268,10 +8268,14 @@ class Worker:
 
     def _create_buffer_locked(self, nbytes: int) -> Buffer:
         # An L3+ buffer is consumed by a forked child that lazily maps it, so a childless L3+ buffer
-        # can reach no consumer. An L2 leaf has no children and materializes in-process, so it needs
-        # none.
-        if self.level >= 3 and not self._chip_shms and not self._sub_shms:
-            raise RuntimeError("create_buffer requires at least one forked chip or sub child (this Worker has none)")
+        # can reach no consumer. Every kind of forked child counts: a next-level Worker child maps a
+        # POSIX_SHM backing by name exactly as a chip or sub child does, so an L4 whose only children
+        # are local L3 Workers can consume one. An L2 leaf has no children and materializes
+        # in-process, so it needs none.
+        if self.level >= 3 and not self._chip_shms and not self._sub_shms and not self._next_level_shms:
+            raise RuntimeError(
+                "create_buffer requires at least one forked chip, sub, or next-level child (this Worker has none)"
+            )
         if nbytes <= 0:
             raise ValueError("create_buffer: nbytes must be positive")
         buffer_id = self._next_buffer_id()

--- a/src/common/task_interface/buffer.h
+++ b/src/common/task_interface/buffer.h
@@ -192,11 +192,14 @@ static_assert(offsetof(BufferDescriptor, body) == 56);
 
 // Field-wise, so neither the struct padding nor the unused tail of `body` takes part: two decodes of
 // one backing describe the same buffer whatever bytes sit outside the fields that carry meaning.
+// `body_len` is clamped rather than trusted: this is the one length field in the header, and an
+// unvalidated descriptor reaching a comparison must not be able to bound a read past `body`.
 inline bool operator==(const BufferDescriptor &a, const BufferDescriptor &b) {
+    const size_t body_len = a.body_len < DESC_MAX_BYTES ? a.body_len : DESC_MAX_BYTES;
     return a.identity == b.identity && a.address_space == b.address_space && a.access == b.access &&
            a.backend_kind == b.backend_kind && a.nbytes == b.nbytes &&
            a.owner_worker_path_id == b.owner_worker_path_id && a.body_len == b.body_len &&
-           std::memcmp(a.body, b.body, a.body_len) == 0;
+           std::memcmp(a.body, b.body, body_len) == 0;
 }
 inline bool operator!=(const BufferDescriptor &a, const BufferDescriptor &b) { return !(a == b); }
 
@@ -224,16 +227,43 @@ struct Tensor {
     uint8_t _pad[3];
 };
 
-// Byte extent of a (possibly strided) view: the last addressable element, plus one element. Summed
-// in u64 so a hostile shape/stride cannot wrap it. Callers that have not yet validated `r` must not
-// trust the result for anything but a bound.
+// Saturating u64 arithmetic. Every input below is wire-supplied, and `shapes[i]` and `strides[i]`
+// are each u32, so one product alone reaches ~2^64: an unsaturated sum would wrap to a SMALL extent
+// and pass the bound check in validate_tensor while the view really spans exabytes.
+inline uint64_t tensor_mul_sat(uint64_t a, uint64_t b) {
+#if defined(__clang__) || defined(__GNUC__)
+    uint64_t result = 0;
+    return __builtin_mul_overflow(a, b, &result) ? UINT64_MAX : result;
+#else
+    return (a != 0 && b > UINT64_MAX / a) ? UINT64_MAX : a * b;
+#endif
+}
+inline uint64_t tensor_add_sat(uint64_t a, uint64_t b) {
+#if defined(__clang__) || defined(__GNUC__)
+    uint64_t result = 0;
+    return __builtin_add_overflow(a, b, &result) ? UINT64_MAX : result;
+#else
+    return (a > UINT64_MAX - b) ? UINT64_MAX : a + b;
+#endif
+}
+
+// Sentinel `tensor_extent_bytes` returns when a view's extent does not fit 64 bits. No real backing
+// is 16 EiB, so a Tensor whose extent lands here describes no representable view and is rejected.
+inline constexpr uint64_t TENSOR_EXTENT_UNREPRESENTABLE = UINT64_MAX;
+
+// Byte extent of a (possibly strided) view: the last addressable element, plus one element.
+// Saturates at TENSOR_EXTENT_UNREPRESENTABLE rather than wrapping, so an extent a hostile
+// shape/stride cannot express is rejected instead of comparing as a small, in-bounds value.
+// Callers that have not yet validated `r` must not trust the result for anything but a bound.
 inline uint64_t tensor_extent_bytes(const Tensor &r) {
     uint64_t last_elem = 0;
     for (uint32_t i = 0; i < r.ndims && i < static_cast<uint32_t>(MAX_TENSOR_DIMS); ++i) {
         if (r.shapes[i] == 0) continue;
-        last_elem += static_cast<uint64_t>(r.shapes[i] - 1) * static_cast<uint64_t>(r.strides[i]);
+        last_elem = tensor_add_sat(
+            last_elem, tensor_mul_sat(static_cast<uint64_t>(r.shapes[i] - 1), static_cast<uint64_t>(r.strides[i]))
+        );
     }
-    return (last_elem + 1) * get_element_size(r.dtype);
+    return tensor_mul_sat(tensor_add_sat(last_elem, 1), get_element_size(r.dtype));
 }
 
 /**
@@ -280,9 +310,14 @@ inline void validate_buffer_descriptor(const BufferDescriptor &h) {
 /**
  * Reject any Tensor whose fields are not self-consistent, BEFORE any of them is trusted.
  *
- * This is the single implementation behind every trust boundary — construction, the builder
- * (`TaskArgs.add_tensor`, which accepts raw bytes), blob decode on receipt, and materialization —
- * so they can never drift apart. Throws `std::invalid_argument` naming the field.
+ * This is the single implementation behind the trust boundaries that build or decode a Tensor —
+ * construction and the builder (`TaskArgs.add_tensor`, which accepts raw bytes) today, blob decode
+ * on receipt when the wire carries a Tensor — so they can never drift apart. Throws
+ * `std::invalid_argument` naming the field.
+ *
+ * Materialization is NOT behind this gate yet: `ImportRegistry.materialize` takes an already-decoded
+ * descriptor and adds no endpoint check, so nothing there refuses a DEVICE backing handed to a host
+ * endpoint. That gate is a separate change; do not read this comment as covering it.
  *
  * `ndims` is bounded against `MAX_TENSOR_DIMS` here; the descriptor's own length-like field is
  * bounded by `validate_buffer_descriptor` above, which this runs first.
@@ -306,6 +341,9 @@ inline void validate_tensor(const Tensor &r) {
         if (r.strides[i] == 0) reject("invalid Tensor: stride must be > 0 (broadcast and negative step unsupported)");
     }
     const uint64_t extent_bytes = tensor_extent_bytes(r);
+    if (extent_bytes == TENSOR_EXTENT_UNREPRESENTABLE) {
+        reject("invalid Tensor: view extent overflows 64 bits (shape/stride not representable)");
+    }
     if (r.byte_offset > h.nbytes || extent_bytes > h.nbytes - r.byte_offset) {
         reject("invalid Tensor: view extends past the backing (byte_offset + extent > nbytes)");
     }
@@ -314,10 +352,11 @@ inline void validate_tensor(const Tensor &r) {
 // Do two views of the SAME backing touch a common byte? Compared as bounding ranges
 // [byte_offset, byte_offset + extent): a strided view's gaps are treated as occupied, so this is
 // conservative — it never misses a real overlap, and may report one for two interleaved views.
+// The end offsets saturate, so an unvalidated extent cannot wrap a range into a false "disjoint".
 inline bool tensors_overlap(const Tensor &a, const Tensor &b) {
     if (!(a.buffer.identity == b.buffer.identity)) return false;
-    const uint64_t a_end = a.byte_offset + tensor_extent_bytes(a);
-    const uint64_t b_end = b.byte_offset + tensor_extent_bytes(b);
+    const uint64_t a_end = tensor_add_sat(a.byte_offset, tensor_extent_bytes(a));
+    const uint64_t b_end = tensor_add_sat(b.byte_offset, tensor_extent_bytes(b));
     return a.byte_offset < b_end && b.byte_offset < a_end;
 }
 

--- a/tests/ut/cpp/types/test_buffer.cpp
+++ b/tests/ut/cpp/types/test_buffer.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -22,9 +23,6 @@
 #include <gtest/gtest.h>
 
 #include "buffer.h"
-#include <random>
-#include <vector>
-
 #include "task_args.h"
 
 namespace {
@@ -248,6 +246,53 @@ TEST(BufferAbi, DecodeRejectsAViewPastItsBacking) {
     EXPECT_THROW(validate_tensor(r), std::invalid_argument);
 }
 
+TEST(BufferAbi, DecodeRejectsAnExtentThatOverflows64Bits) {
+    // shapes[] and strides[] are each u32, so one (shape-1)*stride product alone reaches ~2^64. An
+    // extent summed without saturation wraps to a SMALL value, which then passes the bound check
+    // below while the view really spans exabytes — accepted here, the consumer would address far
+    // outside its backing. One dimension is enough to trigger it.
+    Tensor r = make_tensor();
+    r.dtype = DataType::FLOAT32;  // 4 B
+    r.byte_offset = 0;
+    r.ndims = 1;
+    r.shapes[0] = 2147483649u;   // 2^31 + 1
+    r.strides[0] = 2147483648u;  // 2^31   => (2^31)*(2^31)*4 == 2^64, wraps to 4 unsaturated
+    r.buffer.nbytes = 4;
+    EXPECT_EQ(tensor_extent_bytes(r), TENSOR_EXTENT_UNREPRESENTABLE);
+    EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+
+    // Multi-dimensional variant: two terms that sum past 2^64. Rejected on the extent itself, so a
+    // descriptor claiming an absurd nbytes cannot buy the view back.
+    r = make_tensor();
+    r.dtype = DataType::INT8;
+    r.byte_offset = 0;
+    r.ndims = 2;
+    r.shapes[0] = 4294967295u;
+    r.strides[0] = 4294967295u;
+    r.shapes[1] = 7u;
+    r.strides[1] = 2147483648u;
+    r.buffer.nbytes = UINT64_MAX;
+    EXPECT_EQ(tensor_extent_bytes(r), TENSOR_EXTENT_UNREPRESENTABLE);
+    EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+}
+
+// Two views of one backing that fully overlap must never be reported as disjoint: a saturating
+// extent keeps the end offsets from wrapping a range into a false "no overlap", which at the
+// dependency layer is a missed edge rather than a rejected argument.
+TEST(BufferAbi, OverlapSurvivesASaturatedExtent) {
+    Tensor a = make_tensor();
+    Tensor b = a;
+    EXPECT_TRUE(tensors_overlap(a, b));
+
+    a.ndims = 1;
+    a.shapes[0] = 4294967295u;
+    a.strides[0] = 4294967295u;
+    a.byte_offset = 1;  // nonzero, so the end offset is what overflows: 1 + saturated extent
+    b = a;
+    EXPECT_EQ(tensor_extent_bytes(a), TENSOR_EXTENT_UNREPRESENTABLE);
+    EXPECT_TRUE(tensors_overlap(a, b));
+}
+
 TEST(BufferAbi, ValidateNeverWalksOffArbitraryBytes) {
     // A peer can write anything of the right length. None of it may be accepted without passing
     // every field check, and none of it may read past the struct — the fixed-length identity and
@@ -270,6 +315,12 @@ TEST(BufferAbi, ValidateNeverWalksOffArbitraryBytes) {
         EXPECT_LE(r.buffer.body_len, DESC_MAX_BYTES);
         EXPECT_GT(r.ndims, 0u);
         EXPECT_LE(r.ndims, static_cast<uint32_t>(MAX_TENSOR_DIMS));
+        // The footprint invariant belongs here too: without it, an extent that wrapped to a small
+        // value survives as "in bounds" and the pass reports nothing.
+        const uint64_t extent = tensor_extent_bytes(r);
+        EXPECT_NE(extent, TENSOR_EXTENT_UNREPRESENTABLE);
+        ASSERT_LE(r.byte_offset, r.buffer.nbytes);
+        EXPECT_LE(extent, r.buffer.nbytes - r.byte_offset);
     }
 
     for (uint8_t fill : {uint8_t{0x00}, uint8_t{0xFF}}) {

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -6,11 +6,12 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Unit tests for simpler.buffer: identity/descriptor pack-unpack + create/import round trip.
+"""Unit tests for simpler.buffer: identity/descriptor construction + create/import round trip.
 
 The three wire types are the C++ structs of buffer.h bound directly, so what is pinned here is the
 Python-visible contract over them — construction rejects what `validate_buffer_descriptor` rejects,
-a round trip through `pack`/`unpack` is the identity, and equality and hashing ignore wire padding.
+and equality and hashing ignore wire padding. There is deliberately no `pack`/`unpack`: no Python
+path turns these types into bytes or back, which is what keeps construction the only way in.
 Imports come from `simpler.buffer` because that is where a caller reaches them, alongside the
 registry and the Buffer constructors that are genuinely defined there.
 """
@@ -30,6 +31,7 @@ from simpler.buffer import (
     mint_owner_instance_id,
     re_export,
     wrap_device_malloc,
+    wrap_fork_inherited,
 )
 from simpler.task_interface import ChipTensor
 
@@ -276,3 +278,38 @@ def test_construction_rejects_a_zero_stride():
             h.tensor(shapes=(4, 8), dtype=DataType.FLOAT32, strides=(8, 0))
     finally:
         h.close()
+
+
+def test_construction_rejects_an_extent_that_overflows():
+    # shapes/strides are u32 each, so one (shape-1)*stride product alone approaches 2^64. An extent
+    # summed without saturation wraps to a small value and the view passes as "in bounds" while
+    # really spanning exabytes — reachable straight from here.
+    h = create_host_shared_buffer(64, mint_owner_instance_id(), buffer_id=1)
+    try:
+        with pytest.raises(ValueError, match="overflows 64 bits"):
+            h.tensor(shapes=(2147483649,), dtype=DataType.FLOAT32, strides=(2147483648,))
+    finally:
+        h.close()
+
+
+def test_fork_backend_is_stated_not_inferred_from_access():
+    # FORK_SHM and FORK_COW are opposite kernel write semantics, so the caller states which mmap it
+    # holds; deriving it from `access` makes a read-only MAP_SHARED backing inexpressible.
+    oid = mint_owner_instance_id()
+    shared_ro = wrap_fork_inherited(
+        0x1000, 64, oid, buffer_id=1, access=AccessMode.READ, backend_kind=BackendKind.FORK_SHM
+    )
+    assert shared_ro.backend_kind == BackendKind.FORK_SHM
+    assert shared_ro.to_descriptor().access == AccessMode.READ
+
+    cow = wrap_fork_inherited(0x1000, 64, oid, buffer_id=2)  # the safe default pair
+    assert cow.backend_kind == BackendKind.FORK_COW
+    assert cow.base == 0x1000
+
+    # A write grant over copy-on-write would be silently unobservable by the owner, so the
+    # descriptor's validator refuses it rather than letting the pair exist.
+    bad = wrap_fork_inherited(
+        0x1000, 64, oid, buffer_id=3, access=AccessMode.READWRITE, backend_kind=BackendKind.FORK_COW
+    )
+    with pytest.raises(ValueError, match="FORK_COW"):
+        bad.to_descriptor()

--- a/tests/ut/py/test_worker/test_create_buffer.py
+++ b/tests/ut/py/test_worker/test_create_buffer.py
@@ -1,0 +1,131 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Owner-side ``Worker.create_buffer``: the child-topology gate and the identity it mints.
+
+``_create_buffer_locked`` reads only ``level``, the three child-shm lists, and the buffer registry
+state, so these run against a Worker built with ``__new__`` — no fork, no device, no ``init()``.
+The gate is the point: an L3+ backing is resolved by a forked child mapping the shm by name, and
+**every** kind of forked child can do that, so counting only chip and sub children refuses an L4
+whose children are local L3 Workers.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from simpler.buffer import AddressSpace, BackendKind, mint_owner_instance_id
+from simpler.worker import Worker
+
+
+def _bare_worker(level: int, *, chip: int = 0, sub: int = 0, next_level: int = 0) -> Worker:
+    w = Worker.__new__(Worker)
+    w.level = level
+    w._chip_shms = [object()] * chip
+    w._sub_shms = [object()] * sub
+    w._next_level_shms = [object()] * next_level
+    w._registry_lock = threading.Lock()
+    w._owner_instance_id = mint_owner_instance_id()
+    w._buffer_id_counter = 1
+    w._buffers = {}
+    return w
+
+
+def _drain(w: Worker) -> None:
+    for buffer in list(w._buffers.values()):
+        buffer.close()
+    w._buffers.clear()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"chip": 1},
+        {"sub": 1},
+        # An L4 whose only children are local L3 Workers: they are forked processes that map a
+        # POSIX_SHM backing by name exactly as a chip child does, so the buffer has a consumer.
+        {"next_level": 1},
+    ],
+    ids=["chip", "sub", "next_level"],
+)
+def test_any_forked_child_admits_a_buffer(kwargs):
+    w = _bare_worker(4, **kwargs)
+    try:
+        buffer = w._create_buffer_locked(64)
+        assert buffer.nbytes == 64
+        assert buffer.backend_kind == BackendKind.POSIX_SHM
+        assert buffer.address_space == AddressSpace.HOST
+    finally:
+        _drain(w)
+
+
+def test_childless_l3_plus_is_refused():
+    w = _bare_worker(3)
+    with pytest.raises(RuntimeError, match="at least one forked"):
+        w._create_buffer_locked(64)
+    assert not w._buffers
+
+
+def test_l2_leaf_needs_no_child():
+    # An L2 leaf materializes in-process, so it has nothing to hand the backing to and needs no child.
+    w = _bare_worker(2)
+    try:
+        assert w._create_buffer_locked(64).nbytes == 64
+    finally:
+        _drain(w)
+
+
+def test_rejects_nonpositive_size():
+    w = _bare_worker(2)
+    for nbytes in (0, -1):
+        with pytest.raises(ValueError, match="positive"):
+            w._create_buffer_locked(nbytes)
+    assert not w._buffers
+
+
+def test_buffer_ids_are_unique_within_one_incarnation():
+    w = _bare_worker(2)
+    try:
+        ids = [w._create_buffer_locked(32).identity.buffer_id for _ in range(4)]
+        assert len(set(ids)) == 4
+        assert all(b.identity.generation == 1 for b in w._buffers.values())
+        # One incarnation, one nonce: every buffer this Worker owns shares it.
+        nonces = {b.identity.owner_instance_id for b in w._buffers.values()}
+        assert len(nonces) == 1
+    finally:
+        _drain(w)
+
+
+def test_release_all_buffers_unlinks_and_empties_the_registry():
+    w = _bare_worker(2)
+    w._create_buffer_locked(32)
+    w._create_buffer_locked(32)
+    w._release_all_buffers()
+    assert not w._buffers
+
+
+def test_release_all_buffers_reports_the_failure_and_keeps_the_entry():
+    # Per-buffer best-effort: a failing close must neither strand the others nor be swallowed, and
+    # its registry entry stays so the cleanup journal can retry it.
+    w = _bare_worker(2)
+    ok = w._create_buffer_locked(32)
+    bad = w._create_buffer_locked(32)
+    bad_id = next(k for k, v in w._buffers.items() if v is bad)
+
+    def boom():
+        raise OSError("close failed")
+
+    bad.close = boom  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="close failed"):
+        w._release_all_buffers()
+    assert bad_id in w._buffers  # retryable
+    assert ok.shm is None  # the healthy one was still released
+    w._buffers.clear()
+    bad.shm.close()  # type: ignore[union-attr]
+    bad.shm.unlink()  # type: ignore[union-attr]


### PR DESCRIPTION
## Follow-up to #1599: the gate the ABI rests on

#1599 froze the byte layout and shipped `validate_tensor` as *the* receive-side gate — every later
boundary is meant to run it, and after the wire flip it runs on every argument that arrives. Three
things in it do not hold up, and a frozen ABI is the wrong place to leave them. None of this
changes a field, an offset, or an enum value: every `static_assert` in `buffer.h` is untouched.

### ① `validate_tensor` accepts a view that spans exabytes over a 4-byte backing

`tensor_extent_bytes` summed `(shapes[i]-1)*strides[i]` into a `uint64`. Both fields are `u32`, so a
single product already reaches ~2^64, and the multiply by the element size overflows on top of that.
The extent wrapped to a small value and the bound check passed. **One dimension is enough**, and it
is reachable straight from Python:

```python
h.tensor(shapes=(2147483649,), dtype=DataType.FLOAT32, strides=(2147483648,))  # on a 4-byte buffer
```

```text
before:  tensor_extent_bytes = 4        validate_tensor(nbytes=4) -> ACCEPTED   # true span ~16 EiB
after:   tensor_extent_bytes = SAT      validate_tensor(nbytes=4) -> rejected
```

The arithmetic saturates, and an extent that lands on the sentinel is refused **by name** rather
than compared against `nbytes` — otherwise a descriptor claiming an absurd `nbytes` buys the view
back. This breaks design invariant 4 (`view footprint ⊆ nbytes`), which the design doc lists as
executable.

`tensors_overlap` inherited the same wrap, and there the consequence is worse than a rejected
argument: two fully overlapping views compare as **disjoint**, i.e. a missed dependency edge — the
old-address-key failure mode the identity key exists to remove. Its end offsets saturate too.

The 4096-iteration arbitrary-bytes pass did not catch this because its survivor assertions covered
`magic` / `generation` / `body_len` / `ndims` but **not the footprint invariant** — the one most at
risk. It asserts it now.

### ② `create_buffer` refuses an L4 whose children are local L3 Workers

The L3+ child check counted `_chip_shms` and `_sub_shms` only. A next-level Worker child is a forked
process that maps a `POSIX_SHM` backing by name exactly as a chip or sub child does, so it can
consume the buffer. `_next_level_shms` counts now.

`create_buffer` had no test at all; `tests/ut/py/test_worker/test_create_buffer.py` covers the gate
in each child shape, the childless refusal, the L2 leaf, id uniqueness within one incarnation, and
the per-buffer best-effort release (a failing close is reported, its entry kept for the journal to
retry).

### ③ `wrap_fork_inherited` inferred the backend from `access`

`FORK_SHM if access != READ else FORK_COW`. The two are opposite kernel write semantics, not two
spellings of one grant — putting the physical semantics in `backend_kind` rather than leaving it to
be inferred from an orthogonal field is the reason they are separate tags. Inferring it makes a
**read-only `MAP_SHARED` backing inexpressible**: it is tagged `FORK_COW`, whose READ-only rule then
locks it there. The caller holds the mmap and is the only party that knows which it is, so it states
the tag; the default pair stays the safe one. The function had no caller, so nothing depends on the
old signature.

### ④ Text that describes machinery which does not exist

- `ImportRegistry.materialize` pointed a caller holding raw bytes at `BufferDescriptor.unpack`, and
  `tests/ut/py/test_buffer.py` said it pins a `pack`/`unpack` round trip. **Neither exists** —
  withholding the encoding is exactly what makes construction the only way in.
- `validate_tensor`'s comment claimed it stands behind materialization. It does not:
  `ImportRegistry.materialize` takes an already-decoded descriptor and adds no endpoint check. The
  comment now says so and points at the separate change.
- `docs/buffer-abi.md` named the wire type `simpler.task_interface.Tensor`, contradicting the same
  page's status note, the module, and `test_wire_tensor_stays_off_the_public_submit_surface`.
- The `h.shm.buf` sample now records that it is transitional and why: byte access belongs on the
  view, since a device backing has no `shm` and code written against one forks by backend.
- `BufferDescriptor::operator==` bounded a `memcmp` by an unvalidated `body_len`; clamped. Not
  reachable today (construction validates), but it is the only length field in the header that
  bounds a read, and the cutover is what makes raw decoded descriptors exist.

## Verification

- [x] `cpput` `test_buffer` — **15/15**, including the two new overflow / overlap cases and the
      strengthened arbitrary-bytes pass
- [x] `pyut` full suite — **1142 passed, 13 skipped**
- [x] `tests/ut/py/test_buffer.py` + the new `test_create_buffer.py` — 31 passed
- [x] Build green (nanobind extension + all four arch×runtime trees)
- [x] clang-format / ruff check / ruff format clean; no added line over 120 chars
- [ ] Hardware (onboard) — not run; no runtime path is touched

## Deliberately not here

Each is a separate concern, and the first two are the ones I would take next:

- **The endpoint × `address_space` matrix.** `materialize` still returns a device VA to a host
  endpoint. That is a behavioural gate with its own test surface, not a comment fix.
- **The dead surface question.** `wrap_vmm_window`, `remote_sidecar_tensor`, `host_ptr_nbytes` and
  `tensors_overlap` still have no caller. Whether they survive the freeze is the author's call, not
  something to settle in a fix PR.
- `BufferDescriptor` / `Tensor` bind value equality without value hashing, and their `__eq__` is not
  `nb::is_operator()`, so a comparison against a foreign type raises `TypeError` instead of
  returning `NotImplemented`.
- `remote_sidecar_tensor` builds `owner_instance_id` from `owner_worker_id`, against the full-width
  random draw its own minting function requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
