### PR TITLE
Fix: check the parts of a buffer descriptor that were taken on trust

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -99,7 +99,8 @@ it is the resolved `addr` + `size`. That is the whole of what materialization do
 **Dead on the device** (`Tensor`-only): `magic` discriminates untrusted bytes at
 a decode boundary the device does not have. `identity` / `backend_kind` / `body`
 / `body_len` are the *recipe* for finding the backing — spent once at
-materialization, never consulted again. `access` has no device enforcement point
+materialization, never consulted again; what a body may contain is fixed per
+backend, see [Backends](#backends). `access` has no device enforcement point
 (it is checked at submit). `owner_worker_path_id` is diagnostic.
 
 **Meaningless before materialization** (`ChipTensor`-only): `buffer.addr` is the
@@ -260,14 +261,31 @@ gates, or keys on it.
 
 ## Backends
 
-| Backend | Materializes to | Used for |
-| ------- | --------------- | -------- |
-| `POSIX_SHM` | a named shm mapped into the consumer | `create_buffer` / `alloc_shared_tensor` |
-| `FORK_SHM` | the same VA, no map | a pre-fork `MAP_SHARED` host buffer (e.g. `share_memory_()`), writable from the child |
-| `FORK_COW` | the same VA, no map | a pre-fork plain host buffer: copy-on-write, so **READ only** |
-| `VMM_WINDOW` | the device VA of the window carved by `allocate_domain`, no map | communication-domain window / buffer |
-| `DEVICE_MALLOC` | the device pointer, no map (chip-local) | `alloc_child_tensor` |
-| `REMOTE_SIDECAR` | (P2) resolved via the remote transport | an arg to a remote L3; the descriptor rides in the sidecar |
+| Backend | Materializes to | `body` must be | Used for |
+| ------- | --------------- | -------------- | -------- |
+| `POSIX_SHM` | a named shm mapped into the consumer | the shm name: 1–32 bytes of printable ASCII, no `/` | `create_buffer` / `alloc_shared_tensor` |
+| `FORK_SHM` | the same VA, no map | exactly 8 bytes, a non-zero u64 LE base | a pre-fork `MAP_SHARED` host buffer (e.g. `share_memory_()`), writable from the child |
+| `FORK_COW` | the same VA, no map | exactly 8 bytes, a non-zero u64 LE base | a pre-fork plain host buffer: copy-on-write, so **READ only** |
+| `VMM_WINDOW` | the device VA of the window carved by `allocate_domain`, no map | exactly 8 bytes, a non-zero u64 LE base | communication-domain window / buffer |
+| `DEVICE_MALLOC` | the device pointer, no map (chip-local) | exactly 8 bytes, a non-zero u64 LE base | `alloc_child_tensor` |
+| `REMOTE_SIDECAR` | (P2) resolved via the remote transport | empty | an arg to a remote L3; the descriptor rides in the sidecar |
+
+**The body rule is enforced, not advisory.** `backend_kind` is what selects how a
+consumer reads `body`, so a body that does not fit that reading is not a smaller
+backing — it is a different value, and a short address body reads as a truncated
+pointer indistinguishable from a real one. Construction and every decode run the
+same check, so a descriptor that breaks the table above cannot be built or
+received. Two consequences worth knowing:
+
+- **Bytes past `body_len` must be zero**, as must a `Tensor`'s `shapes` /
+  `strides` slots past `ndims`. Both are regions a producer chose not to fill,
+  and the whole struct crosses the process boundary, so whatever the owner's
+  memory held there would cross with it. The `_pad` fields are *not* covered:
+  they are alignment slack, and `CanonicalIdentity`'s is deliberately tolerated
+  so two decodes of one backing still key alike.
+- **A POSIX shm object smaller than the descriptor's `nbytes` is refused at
+  import.** Every view bound check is `byte_offset + extent <= nbytes`, so an
+  unverified `nbytes` makes all of them vacuous.
 
 ## What a submit checks
 

--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -399,6 +399,24 @@ def wrap_vmm_window(
     )
 
 
+def _descriptor_delta(a: BufferDescriptor, b: BufferDescriptor) -> str:
+    """The fields on which two descriptors differ, as ``name: old -> new``.
+
+    A whole ``repr`` of both would carry a 32-byte body twice for what is usually a one-field
+    disagreement, and the reader still has to diff them by eye.
+    """
+    fields = (
+        ("nbytes", a.nbytes, b.nbytes),
+        ("access", a.access, b.access),
+        ("backend_kind", a.backend_kind, b.backend_kind),
+        ("address_space", a.address_space, b.address_space),
+        ("owner_worker_path_id", a.owner_worker_path_id, b.owner_worker_path_id),
+        ("body", a.body, b.body),
+    )
+    diff = [f"{name}: {old!r} -> {new!r}" for name, old, new in fields if old != new]
+    return ", ".join(diff) if diff else "no field differs"
+
+
 @dataclass
 class ImportedBuffer:
     """A buffer materialized into the consumer's address space: identity -> local base."""
@@ -408,6 +426,12 @@ class ImportedBuffer:
     nbytes: int
     address_space: AddressSpace = AddressSpace.HOST
     shm: SharedMemory | None = None  # the consumer's own mapping for shm backends
+    # The descriptor this mapping was created from. Identity alone does not pin a backing: it says
+    # WHICH allocation, not how big it is or how to reach it, so a second descriptor carrying the
+    # same identity and a different nbytes / access / backend / body describes something the first
+    # mapping is not. Keeping it is what lets `materialize` detect that instead of silently handing
+    # back the earlier mapping.
+    descriptor: BufferDescriptor | None = None
 
 
 class ImportRegistry:
@@ -419,6 +443,9 @@ class ImportRegistry:
     (a bumped generation is a distinct identity, materialized fresh). Keyed by the canonical identity
     itself so lookups are exact — never a numeric-range guess, and never split by the wire padding
     the identity's equality and hashing deliberately ignore.
+
+    Map-once is a cache, not a trust boundary: a cache hit re-checks that the incoming descriptor
+    still describes the backing that was mapped, so one identity can never come to mean two things.
     """
 
     def __init__(self) -> None:
@@ -433,13 +460,27 @@ class ImportRegistry:
         there is no Python path from raw bytes to a descriptor at all, which is what keeps
         ``validate_buffer_descriptor`` a gate rather than a habit.
 
+        Rejects a descriptor that conflicts with the one already mapped under its identity, and a
+        POSIX shm object smaller than the ``nbytes`` its descriptor claims — every view bound check
+        is computed against that number, so an unverified one makes them all vacuous.
+
         Adds no endpoint check of its own: a DEVICE backing resolved here yields a device pointer,
-        which is only meaningful on its owner chip. The endpoint × ``address_space`` matrix is a
+        which is only meaningful on its owner chip. The endpoint x ``address_space`` matrix is a
         separate change; until it lands, that invariant rests on the caller.
         """
         key = desc.identity
         cached = self._by_identity.get(key)
         if cached is not None:
+            # Field-wise, so wire padding and the unused tail of `body` do not make one backing look
+            # like two. The mapping that exists wins: it is the one already handed out, and callers
+            # may hold addresses into it.
+            if cached.descriptor is not None and cached.descriptor != desc:
+                raise ValueError(
+                    f"ImportRegistry: identity {desc.identity} is already materialized from a "
+                    f"different descriptor ({_descriptor_delta(cached.descriptor, desc)}); one "
+                    f"identity names one backing, so the mapping already handed out is kept and "
+                    f"this is refused"
+                )
             return cached
         if desc.backend_kind in (
             BackendKind.FORK_SHM,
@@ -453,10 +494,20 @@ class ImportRegistry:
             # DEVICE_MALLOC / VMM_WINDOW: a device pointer valid on the chip that allocated / carved
             # it (the tensor must only reach that chip — a topology invariant).
             base = int.from_bytes(desc.body, "little")
-            imported = ImportedBuffer(desc.identity, base, desc.nbytes, desc.address_space, None)
+            imported = ImportedBuffer(desc.identity, base, desc.nbytes, desc.address_space, None, desc)
         elif desc.backend_kind == BackendKind.POSIX_SHM:
             shm = SharedMemory(name=desc.body.decode("utf-8"))
-            imported = ImportedBuffer(desc.identity, _shm_base_addr(shm), desc.nbytes, desc.address_space, shm)
+            # `validate_tensor` admits a view when byte_offset + extent <= nbytes, so a backing
+            # smaller than the nbytes its own descriptor advertises turns every one of those checks
+            # into a comparison against a number no memory stands behind. The object's real size is
+            # the only thing here the owner cannot overstate.
+            if shm.size < desc.nbytes:
+                shm.close()
+                raise ValueError(
+                    f"ImportRegistry: shm object {desc.body.decode('utf-8')!r} is {shm.size} bytes, "
+                    f"short of the {desc.nbytes} its descriptor claims"
+                )
+            imported = ImportedBuffer(desc.identity, _shm_base_addr(shm), desc.nbytes, desc.address_space, shm, desc)
         elif desc.backend_kind == BackendKind.REMOTE_SIDECAR:
             raise ValueError("ImportRegistry: REMOTE_SIDECAR backend is reserved for P2")
         else:

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -44,6 +44,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "../task_interface/buffer.h"
 #include "../task_interface/call_config.h"
 #include "remote_wire.h"
 #include "types.h"
@@ -168,6 +169,16 @@ static_assert(
                                  static_cast<size_t>(CHIP_MAX_TENSOR_ARGS) * sizeof(ChipTensor) +
                                  static_cast<size_t>(CHIP_MAX_SCALAR_ARGS) * sizeof(uint64_t),
     "mailbox args region must hold the largest TaskArgs blob the runtime accepts (issue #1024)"
+);
+// The same bound against the wire element. `Tensor` is 144 B where `ChipTensor` is 128 B, so the
+// assert above does not cover it: the wire cutover swaps the blob's element without touching either
+// cap, and the region only has to grow by 16 B x 256 for the frame to overflow. Asserting it here
+// means a frozen descriptor size and a frame size that cannot hold 256 of them fail the build rather
+// than the first 256-tensor task.
+static_assert(
+    MAILBOX_ARGS_CAPACITY >= TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(CHIP_MAX_TENSOR_ARGS) * sizeof(Tensor) +
+                                 static_cast<size_t>(CHIP_MAX_SCALAR_ARGS) * sizeof(uint64_t),
+    "mailbox args region must hold 256 wire Tensors, the element the blob carries after the cutover"
 );
 
 // Control sub-commands (written at MAILBOX_OFF_CALLABLE when state == CONTROL_*)

--- a/src/common/task_interface/buffer.h
+++ b/src/common/task_interface/buffer.h
@@ -69,6 +69,10 @@ inline constexpr uint32_t OWNER_INSTANCE_ID_BYTES = 8;
 // stores a single u64 address.
 inline constexpr uint32_t DESC_MAX_BYTES = 32;
 
+// Body width of every address-bearing backend: one u64 little-endian base. Exact, not a maximum —
+// a shorter body reads as a truncated pointer indistinguishable from a real one.
+inline constexpr uint32_t BACKEND_ADDRESS_BODY_BYTES = 8;
+
 // Memory space of a backing. Orthogonal to location (local/remote, derived) and to visibility.
 enum class AddressSpace : uint8_t {
     HOST = 0,
@@ -272,7 +276,8 @@ inline uint64_t tensor_extent_bytes(const Tensor &r) {
  * The descriptor half of the tensor gate below, split out because a descriptor also arrives on its
  * own — construction from Python and blob descriptor extraction both hand one over with no view
  * attached. `body_len` is bounded against `DESC_MAX_BYTES` here, mirroring what the fixed-length
- * `CanonicalIdentity` gets structurally. Throws `std::invalid_argument` naming the field.
+ * `CanonicalIdentity` gets structurally, and the body itself is checked against the schema its
+ * `backend_kind` implies. Throws `std::invalid_argument` naming the field.
  *
  * `REMOTE_SIDECAR` is a legal wire value and passes: an arg bound for a remote worker rides the wire
  * with no local backing, and it is *materialization* that refuses it in P1.
@@ -304,6 +309,55 @@ inline void validate_buffer_descriptor(const BufferDescriptor &h) {
     // sees, so a write grant over FORK_COW would be silently unobservable rather than an error.
     if (backend == BackendKind::FORK_COW && h.access != static_cast<uint8_t>(AccessMode::READ)) {
         reject("invalid BufferDescriptor: FORK_COW grants READ only (a child's write would not reach the owner)");
+    }
+
+    // Per-backend body schema. `backend_kind` says how the consumer reads `body`, so a body that
+    // does not fit the reading is not a smaller backing — it is a different value. A DEVICE_MALLOC
+    // body of 3 bytes reads as a TRUNCATED pointer with nothing to distinguish it from a real one.
+    switch (backend) {
+    case BackendKind::FORK_SHM:
+    case BackendKind::FORK_COW:
+    case BackendKind::DEVICE_MALLOC:
+    case BackendKind::VMM_WINDOW: {
+        if (h.body_len != BACKEND_ADDRESS_BODY_BYTES)
+            reject("invalid BufferDescriptor: an address-bearing backend body must be exactly 8 bytes");
+        uint64_t base = 0;
+        std::memcpy(&base, h.body, BACKEND_ADDRESS_BODY_BYTES);
+        // No backing is mapped or allocated at 0, so a zero body is an unfilled one.
+        if (base == 0) reject("invalid BufferDescriptor: address-bearing backend body is a null base");
+        break;
+    }
+    case BackendKind::POSIX_SHM: {
+        // The consumer opens this by name, and the Python side decodes it as UTF-8 before the open.
+        // Restricting the name to printable ASCII other than '/' makes that decode total instead of
+        // a second, weaker schema: it is a UTF-8 subset, so bytes that pass here always decode. '/'
+        // is excluded because shm_open forbids it inside a name; space and the control range because
+        // the name is rendered into paths and diagnostics.
+        if (h.body_len == 0) reject("invalid BufferDescriptor: POSIX_SHM body must carry a shm name");
+        for (uint16_t i = 0; i < h.body_len; ++i) {
+            const auto c = static_cast<unsigned char>(h.body[i]);
+            if (c < 0x21 || c > 0x7E || c == '/') {
+                reject("invalid BufferDescriptor: POSIX_SHM shm name must be printable ASCII without '/'");
+            }
+        }
+        break;
+    }
+    case BackendKind::REMOTE_SIDECAR:
+        // The authoritative descriptor rides in the per-task sidecar, so nothing belongs here.
+        if (h.body_len != 0) reject("invalid BufferDescriptor: REMOTE_SIDECAR carries no body in P1");
+        break;
+    }
+
+    // The unused tail of `body` crosses a process boundary with the descriptor, so whatever the
+    // owner's memory held there would cross with it.
+    //
+    // The rule covers the regions a PRODUCER chooses not to fill — this tail, and a Tensor's
+    // shape/stride slots past `ndims` (see validate_tensor). It does NOT cover the `_pad` fields:
+    // those are alignment slack no producer selects, and `CanonicalIdentity::_pad` in particular is
+    // deliberately tolerated so two decodes of one backing still key alike. Equality stays field-wise
+    // for that reason, so a descriptor is never canonical byte-for-byte, only field-for-field.
+    for (uint32_t i = h.body_len; i < DESC_MAX_BYTES; ++i) {
+        if (h.body[i] != 0) reject("invalid BufferDescriptor: reserved bytes past body_len must be zero");
     }
 }
 
@@ -339,6 +393,16 @@ inline void validate_tensor(const Tensor &r) {
     for (uint32_t i = 0; i < r.ndims; ++i) {
         if (r.shapes[i] == 0) reject("invalid Tensor: shape dimension is zero");
         if (r.strides[i] == 0) reject("invalid Tensor: stride must be > 0 (broadcast and negative step unsupported)");
+    }
+    // Slots past `ndims` are the same case as the descriptor's body tail: a producer chose not to
+    // fill them, and the blob memcpy carries all 144 bytes across the process boundary regardless.
+    // Requiring them zero is also what makes two encodings of one view agree over the active fields
+    // AND the inactive ones, so a decoded element can be compared as bytes. (`_pad` is excluded, as
+    // in the descriptor — it is alignment slack, not a slot anyone selects.)
+    for (uint32_t i = r.ndims; i < static_cast<uint32_t>(MAX_TENSOR_DIMS); ++i) {
+        if (r.shapes[i] != 0 || r.strides[i] != 0) {
+            reject("invalid Tensor: shape/stride slots past ndims must be zero");
+        }
     }
     const uint64_t extent_bytes = tensor_extent_bytes(r);
     if (extent_bytes == TENSOR_EXTENT_UNREPRESENTABLE) {

--- a/tests/ut/cpp/types/test_buffer.cpp
+++ b/tests/ut/cpp/types/test_buffer.cpp
@@ -36,12 +36,17 @@ CanonicalIdentity make_identity() {
     return id;
 }
 
+// A POSIX_SHM body is the shm name the consumer opens; a valid descriptor always carries one.
+constexpr const char *kShmName = "psm_deadbeef";
+
 Tensor make_tensor() {
     Tensor r{};
     r.buffer.magic = BUFFER_DESCRIPTOR_MAGIC;
     r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::POSIX_SHM);
     r.buffer.identity = make_identity();
     r.buffer.nbytes = 8192;  // must cover byte_offset + the strided extent below
+    r.buffer.body_len = static_cast<uint16_t>(std::strlen(kShmName));
+    std::memcpy(r.buffer.body, kShmName, r.buffer.body_len);
     r.byte_offset = 4096;
     r.ndims = 3;
     r.shapes[0] = 2;
@@ -51,6 +56,21 @@ Tensor make_tensor() {
     r.strides[1] = 8;
     r.strides[2] = 1;
     r.dtype = DataType::FLOAT16;
+    return r;
+}
+
+// An address-bearing backend body is exactly one u64 LE base.
+void set_address_body(Tensor &r, uint64_t base) {
+    std::memset(r.buffer.body, 0, DESC_MAX_BYTES);
+    r.buffer.body_len = static_cast<uint16_t>(BACKEND_ADDRESS_BODY_BYTES);
+    std::memcpy(r.buffer.body, &base, sizeof(base));
+}
+
+Tensor make_device_tensor() {
+    Tensor r = make_tensor();
+    r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::DEVICE_MALLOC);
+    r.buffer.address_space = static_cast<uint8_t>(AddressSpace::DEVICE);
+    set_address_body(r, 0xDEAD0000ULL);
     return r;
 }
 
@@ -167,6 +187,7 @@ TEST(BufferAbi, ForkCowGrantsReadOnly) {
     Tensor r = make_tensor();
     r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::FORK_COW);
     r.buffer.access = static_cast<uint8_t>(AccessMode::READ);
+    set_address_body(r, 0x7F0000000000ULL);  // a fork-inherited host VA, not a shm name
     EXPECT_NO_THROW(validate_tensor(r));
 
     // A write grant over copy-on-write would land in a private copy the owner never sees, so it is
@@ -223,6 +244,7 @@ TEST(BufferAbi, DecodeRejectsEveryCorruptedField) {
         {"unknown dtype", offsetof(Tensor, dtype), {0x7F}},
         {"stride must be > 0", offsetof(Tensor, strides), {0, 0, 0, 0}},
         {"byte_offset is not a multiple", offsetof(Tensor, byte_offset), {0x03, 0, 0, 0, 0, 0, 0, 0}},
+        {"reserved bytes past body_len", offsetof(BufferDescriptor, body) + DESC_MAX_BYTES - 1, {0x01}},
     };
     for (const auto &c : cases) {
         SCOPED_TRACE(c.what);
@@ -230,6 +252,88 @@ TEST(BufferAbi, DecodeRejectsEveryCorruptedField) {
             validate_tensor(decode_with_corruption(c.offset, c.value.data(), c.value.size())), std::invalid_argument
         );
     }
+}
+
+// `backend_kind` says how the consumer reads `body`, so a body that does not fit that reading is not
+// a smaller backing — it is a different value. The address case is the sharp one: a short body reads
+// as a TRUNCATED pointer with nothing about it to distinguish it from a real one.
+TEST(BufferAbi, DecodeRejectsABodyThatDoesNotMatchItsBackend) {
+    Tensor dev = make_device_tensor();
+    EXPECT_NO_THROW(validate_tensor(dev));
+
+    for (uint16_t bad_len : {uint16_t{0}, uint16_t{3}, uint16_t{7}, uint16_t{9}, uint16_t{DESC_MAX_BYTES}}) {
+        SCOPED_TRACE(bad_len);
+        Tensor r = make_device_tensor();
+        r.buffer.body_len = bad_len;
+        EXPECT_THROW(validate_tensor(r), std::invalid_argument);
+    }
+
+    // Nothing is mapped or allocated at 0, so a zero base is an unfilled body rather than a location.
+    Tensor null_base = make_device_tensor();
+    set_address_body(null_base, 0);
+    EXPECT_THROW(validate_tensor(null_base), std::invalid_argument);
+
+    // POSIX_SHM carries a name the consumer opens, and the Python side decodes it as UTF-8 first.
+    // Restricting it to printable ASCII makes that decode total: bytes that pass here always decode.
+    Tensor no_name = make_tensor();
+    no_name.buffer.body_len = 0;
+    EXPECT_THROW(validate_tensor(no_name), std::invalid_argument);
+
+    for (auto bad : {'\0', '\x01', ' ', '/', '\x7F', '\xFF'}) {
+        SCOPED_TRACE(static_cast<int>(static_cast<unsigned char>(bad)));
+        Tensor bad_name = make_tensor();
+        bad_name.buffer.body[2] = bad;
+        EXPECT_THROW(validate_tensor(bad_name), std::invalid_argument);
+    }
+
+    // A REMOTE_SIDECAR arg's authoritative descriptor rides in the per-task sidecar, so a body here
+    // is a second, unread source of truth.
+    Tensor sidecar = make_tensor();
+    sidecar.buffer.backend_kind = static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR);
+    EXPECT_THROW(validate_tensor(sidecar), std::invalid_argument);
+    sidecar.buffer.body_len = 0;
+    std::memset(sidecar.buffer.body, 0, DESC_MAX_BYTES);
+    EXPECT_NO_THROW(validate_tensor(sidecar));
+}
+
+// The unused tail of `body` crosses a process boundary with the descriptor, so whatever the owner's
+// memory held there crosses with it. Distinct from the struct's `_pad`, which equality and hashing
+// ignore on purpose so two decodes of one backing key alike.
+TEST(BufferAbi, DecodeRejectsNonZeroReservedTail) {
+    Tensor r = make_tensor();
+    EXPECT_NO_THROW(validate_tensor(r));
+
+    for (uint32_t i : {r.buffer.body_len + 0u, DESC_MAX_BYTES / 2, DESC_MAX_BYTES - 1}) {
+        SCOPED_TRACE(i);
+        Tensor dirty = make_tensor();
+        dirty.buffer.body[i] = static_cast<char>(0xA5);
+        EXPECT_THROW(validate_tensor(dirty), std::invalid_argument);
+    }
+}
+
+// A Tensor's shape/stride slots past `ndims` are the same case as the descriptor's body tail: the
+// blob memcpy carries all 144 bytes whatever a producer chose to fill. Without this, two encodings
+// of one view differ over the inactive slots while every active field agrees.
+TEST(BufferAbi, DecodeRejectsNonZeroSlotsPastNdims) {
+    Tensor r = make_tensor();  // ndims == 3, so slots 3 and 4 are inactive
+    EXPECT_NO_THROW(validate_tensor(r));
+
+    for (uint32_t i = r.ndims; i < static_cast<uint32_t>(MAX_TENSOR_DIMS); ++i) {
+        SCOPED_TRACE(i);
+        Tensor dirty_shape = make_tensor();
+        dirty_shape.shapes[i] = 7;
+        EXPECT_THROW(validate_tensor(dirty_shape), std::invalid_argument);
+
+        Tensor dirty_stride = make_tensor();
+        dirty_stride.strides[i] = 7;
+        EXPECT_THROW(validate_tensor(dirty_stride), std::invalid_argument);
+    }
+
+    // The extent is unchanged by an inactive slot, so nothing else in the gate would have caught it.
+    Tensor dirty = make_tensor();
+    dirty.shapes[4] = 7;
+    dirty.strides[4] = 7;
+    EXPECT_EQ(tensor_extent_bytes(dirty), tensor_extent_bytes(r));
 }
 
 TEST(BufferAbi, DecodeRejectsAViewPastItsBacking) {

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -66,6 +66,15 @@ def _identity(oid=_OID, buffer_id=7, generation=2):
     return CanonicalIdentity(oid, buffer_id, generation)
 
 
+def _legal_body(backend: BackendKind) -> bytes:
+    """A body that satisfies ``backend``'s schema, so a rejection is attributable to something else."""
+    if backend == BackendKind.POSIX_SHM:
+        return b"psm_legal"
+    if backend == BackendKind.REMOTE_SIDECAR:
+        return b""
+    return (0x1000).to_bytes(8, "little")  # the four address-bearing backends
+
+
 def test_identity_rejects_bad_oid_width():
     with pytest.raises(ValueError):
         CanonicalIdentity(b"\x00" * (OWNER_INSTANCE_ID_BYTES + 1), 1, 1)
@@ -85,6 +94,7 @@ def _descriptor_with_path_id(path_id: int) -> BufferDescriptor:
         access=AccessMode.READWRITE,
         backend_kind=BackendKind.POSIX_SHM,
         nbytes=8,
+        body=b"psm_diag",  # POSIX_SHM's body is the name a consumer opens
         owner_worker_path_id=path_id,
     )
 
@@ -207,6 +217,72 @@ def test_materialize_remote_sidecar_rejected():
         reg.materialize(desc)
 
 
+# --- map-once is a cache, not a trust boundary ------------------------------------------------
+
+
+def _device_descriptor(oid: bytes, buffer_id: int, nbytes: int, ptr: int = 0xDEAD0000) -> BufferDescriptor:
+    return wrap_device_malloc(ptr, nbytes, oid, buffer_id=buffer_id).to_descriptor()
+
+
+def test_materialize_rejects_a_conflicting_descriptor_for_a_live_identity():
+    # Identity says WHICH allocation, not how big it is or how to reach it. A second descriptor
+    # carrying the same identity and a different nbytes describes something the existing mapping is
+    # not, so returning that mapping would hand back a base under a size nothing stands behind.
+    oid = mint_owner_instance_id()
+    reg = ImportRegistry()
+    first = reg.materialize(_device_descriptor(oid, 1, nbytes=4096))
+
+    for conflicting in (
+        _device_descriptor(oid, 1, nbytes=8192),  # same identity, bigger claim
+        _device_descriptor(oid, 1, nbytes=4096, ptr=0xBEEF0000),  # same identity, other backing
+    ):
+        with pytest.raises(ValueError, match="different descriptor"):
+            reg.materialize(conflicting)
+
+    # The mapping already handed out survives: callers may hold addresses into it, so the conflict
+    # is refused rather than resolved by replacing it.
+    assert reg.resolve(first.identity) is first
+    assert reg.materialize(_device_descriptor(oid, 1, nbytes=4096)) is first
+
+
+def test_conflict_error_names_only_the_fields_that_differ():
+    # A whole repr of both descriptors would carry a 32-byte body twice for what is usually a
+    # one-field disagreement, and leave the reader to diff them by eye.
+    oid = mint_owner_instance_id()
+    reg = ImportRegistry()
+    reg.materialize(_device_descriptor(oid, 1, nbytes=4096))
+    with pytest.raises(ValueError) as excinfo:
+        reg.materialize(_device_descriptor(oid, 1, nbytes=8192))
+    message = str(excinfo.value)
+    assert "nbytes: 4096 -> 8192" in message
+    assert "backend_kind" not in message  # unchanged fields stay out of it
+
+
+def test_materialize_rejects_an_shm_object_shorter_than_its_descriptor():
+    # Every view bound check is `byte_offset + extent <= nbytes`, so an unverified nbytes makes all
+    # of them vacuous. The object's real size is the one thing here the owner cannot overstate.
+    oid = mint_owner_instance_id()
+    buffer = create_host_shared_buffer(nbytes=128, owner_instance_id=oid, buffer_id=1)
+    reg = ImportRegistry()
+    try:
+        honest = buffer.to_descriptor()
+        assert reg.materialize(honest).nbytes == 128  # the truthful one maps
+
+        overstated = BufferDescriptor(
+            identity=CanonicalIdentity(oid, 2, 1),  # a fresh identity, so this is not the conflict path
+            address_space=AddressSpace.HOST,
+            access=AccessMode.READWRITE,
+            backend_kind=BackendKind.POSIX_SHM,
+            nbytes=1 << 20,
+            body=honest.body,  # the same 128-byte object
+        )
+        with pytest.raises(ValueError, match="short of the"):
+            reg.materialize(overstated)
+    finally:
+        reg.close()
+        buffer.close()
+
+
 def test_owner_instance_ids_are_distinct():
     ids = {mint_owner_instance_id() for _ in range(64)}
     assert len(ids) == 64
@@ -224,7 +300,8 @@ def test_owner_instance_ids_are_distinct():
 )
 def test_descriptor_rejects_bad_capability_combo(space, backend):
     # §4.1 capability matrix: an unsupported address_space×backend_kind fails at construction (before
-    # dispatch, before it can ride the wire).
+    # dispatch, before it can ride the wire). The body is a legal one for the backend, so the
+    # rejection is attributable to the combination and not to the body schema.
     with pytest.raises(ValueError, match="capability"):
         BufferDescriptor(
             identity=_identity(),
@@ -232,7 +309,7 @@ def test_descriptor_rejects_bad_capability_combo(space, backend):
             access=AccessMode.READWRITE,
             backend_kind=backend,
             nbytes=64,
-            body=b"",
+            body=_legal_body(backend),
         )
 
 
@@ -245,7 +322,47 @@ def test_descriptor_accepts_legal_combos():
         (AddressSpace.HOST, BackendKind.REMOTE_SIDECAR),
         (AddressSpace.DEVICE, BackendKind.REMOTE_SIDECAR),
     ]:
-        BufferDescriptor(_identity(), space, AccessMode.READWRITE, backend, 64, b"")
+        BufferDescriptor(_identity(), space, AccessMode.READWRITE, backend, 64, _legal_body(backend))
+
+
+# --- G2: the body must fit the reading its backend_kind implies --------------------------------
+#
+# The exhaustive per-backend cases live in tests/ut/cpp/types/test_buffer.cpp, which can build the
+# malformed bytes Python cannot (a body_len that disagrees with the body, a non-zero reserved tail).
+# What is checked here is that the gate is reachable from construction.
+
+
+def test_construction_rejects_an_address_body_that_is_not_eight_bytes():
+    # A short body reads as a truncated pointer with nothing to distinguish it from a real one.
+    for bad in (b"", b"\x00\x01\x02", b"\x00" * 7, b"\x00" * 9):
+        with pytest.raises(ValueError, match="exactly 8 bytes"):
+            BufferDescriptor(_identity(), AddressSpace.DEVICE, AccessMode.READWRITE, BackendKind.DEVICE_MALLOC, 64, bad)
+
+
+def test_construction_rejects_a_null_address_body():
+    # Nothing is mapped or allocated at 0, so a zero base is an unfilled body, not a location.
+    with pytest.raises(ValueError, match="null base"):
+        BufferDescriptor(
+            _identity(), AddressSpace.DEVICE, AccessMode.READWRITE, BackendKind.DEVICE_MALLOC, 64, b"\x00" * 8
+        )
+
+
+def test_construction_rejects_a_shm_name_outside_printable_ascii():
+    # The name is decoded as UTF-8 before the shm open, so the wire schema restricts it to a UTF-8
+    # subset: bytes that pass validation always decode. A NUL would additionally truncate the name
+    # at the first C API it reaches, letting two distinct names open one object.
+    for bad in (b"psm\x00abc", b"psm abc", b"psm/abc", b"psm\xffabc", b"psm\x7fabc"):
+        with pytest.raises(ValueError, match="printable ASCII"):
+            BufferDescriptor(_identity(), AddressSpace.HOST, AccessMode.READWRITE, BackendKind.POSIX_SHM, 64, bad)
+
+
+def test_construction_rejects_a_remote_sidecar_body():
+    # The authoritative descriptor rides in the per-task sidecar; a body here is a second source of
+    # truth that nothing reads.
+    with pytest.raises(ValueError, match="no body"):
+        BufferDescriptor(
+            _identity(), AddressSpace.HOST, AccessMode.READWRITE, BackendKind.REMOTE_SIDECAR, 64, b"\x01" * 8
+        )
 
 
 # --- the shared validator, on the paths Python can reach --------------------------------------

--- a/tests/ut/py/test_worker/test_remote_zero_residual.py
+++ b/tests/ut/py/test_worker/test_remote_zero_residual.py
@@ -157,7 +157,7 @@ def _remote_spec(port: int, *, num_sub_workers: int = 0) -> RemoteWorkerSpec:
     return RemoteWorkerSpec(
         endpoint=f"127.0.0.1:{port}",
         platform="a2a3sim",
-        transport="sim",
+        transport="host_tcp",
         num_sub_workers=num_sub_workers,
     )
 


### PR DESCRIPTION
## Three places a buffer descriptor was taken on trust

The wire ABI froze its layout, and `validate_buffer_descriptor` is the gate every receive boundary
runs. Three things it was documented to establish, it did not check. **No field, offset, or enum
value changes** — every `static_assert` in `buffer.h` is untouched, so this is a tightening of what
the existing bytes are allowed to say.

### A cached mapping was returned without looking at the descriptor that asked for it

Identity says WHICH allocation, not how big it is or how to reach it. A second descriptor carrying
one identity and a different `nbytes` / `access` / `backend_kind` / `body` describes something the
existing mapping is not, and the caller got that mapping with no sign anything differed:

```text
before:  materialize(id=X, nbytes=4096)  -> base B
         materialize(id=X, nbytes=8192)  -> base B      # silently, under a size nothing backs
after:   materialize(id=X, nbytes=8192)  -> ValueError: ... already materialized from a different
                                                        descriptor (nbytes: 4096 -> 8192)
```

The mapping already handed out wins — callers may hold addresses into it — so a conflict is refused
rather than resolved by replacing it. Map-once stays a cache; it is not a trust boundary.

### A POSIX shm object was mapped without checking it is as large as claimed

Every view bound check is `byte_offset + extent <= nbytes`. An unverified `nbytes` makes all of them
comparisons against a number no memory stands behind — including the overflow-safe ones #1703 just
landed. The object's real size is the one quantity here an owner cannot overstate:

```text
128-byte object, descriptor claims 1 MiB  ->  ValueError: shm object 'psm_…' is 128 bytes, short of
                                                          the 1048576 its descriptor claims
```

### A body was accepted whatever the backend that reads it says it should be

`body_len` was bounded and nothing else. But `backend_kind` is what selects how a consumer reads
`body`, so a body that does not fit that reading is not a smaller backing — it is a different value.
The sharp case is an address: a `DEVICE_MALLOC` body of three bytes reads as a **truncated pointer**,
indistinguishable from a real one, which `materialize` then hands out as a base.

| backend | body |
| --- | --- |
| `FORK_SHM` / `FORK_COW` / `DEVICE_MALLOC` / `VMM_WINDOW` | **exactly 8 bytes**, non-zero base — nothing is mapped or allocated at 0, so a zero body is an unfilled one |
| `POSIX_SHM` | 1–32 bytes of printable ASCII, no `/` |
| `REMOTE_SIDECAR` | empty — its authoritative descriptor rides in the per-task sidecar |

The `POSIX_SHM` charset is what makes one field stop having two schemas: the native validator
accepted any non-NUL bytes while the Python side decodes the same field as UTF-8 before the open, so
`b"\xff"` passed here and failed there. Printable ASCII is a strict UTF-8 subset, so the decode is
total by construction rather than by a second check that could drift. `/` is excluded because
`shm_open` forbids it inside a name; space and the control range because the name is rendered into
paths and diagnostics.

**Bytes a producer chose not to fill must be zero** — the tail of `body` past `body_len`, and a
`Tensor`'s shape/stride slots past `ndims`. Both cross the process boundary with the struct (the blob
memcpy carries all 144 bytes regardless), so whatever the owner's memory held there would cross with
it. The `_pad` fields are deliberately *not* covered, and the comment says why rather than leaving it
to be inferred: they are alignment slack no producer selects, and `CanonicalIdentity`'s is tolerated
on purpose so two decodes of one backing still key alike.

I checked the construction path already zeroes those regions before tightening this, so nothing that
builds a descriptor today is affected. Two test fixtures were: both built a `POSIX_SHM` descriptor
with **no body at all**, a shape no real system produces.

### The 256-tensor bound was asserted against the wrong element

`MAILBOX_ARGS_CAPACITY` is checked against `ChipTensor`. `Tensor` is 144 B where `ChipTensor` is
128 B, so the wire cutover swaps the blob's element without touching either cap, and the region only
has to grow by 16 B × 256 for a full frame to overflow — with the descriptor size frozen, that is a
frame-size problem found by the first 256-tensor task. Asserting the wire element makes the pair fail
the build instead. It holds with room to spare: 37896 B of a 64016 B region.

## One unrelated fix, riding along

`simpler-remote-worker` accepts only the `host_tcp` transport (#1011). #1688 narrowed the remote unit
tests it knew about onto that profile; #1692 landed `test_remote_zero_residual.py` in the same window
still asking for `sim`. Two independently green PRs, red after the merge — every case in that file
failed its own setup, so the rollback each one exists to observe never ran.

It is one line, it touches nothing near buffers, and it is what keeps `ut` red on every PR in flight,
so it is here as its own commit. Say the word and I will split it out.

## Verification

- [x] `cpput` `test_buffer` — **18/18** (3 new: body schema per backend, non-zero reserved tail,
      non-zero slots past `ndims`)
- [x] `pyut` full suite — **1149 passed, 13 skipped, 0 failed** (the 3 remote-transport failures go
      green with the fix above)
- [x] Both import guards demonstrated firing against a live registry, not only asserted in tests
- [x] Reserved-zero verified on the construction path before tightening it
- [x] The wire-element assert compiles and holds; it fails the build if either size drifts
- [x] Build green; clang-format / ruff check / ruff format clean; no added line over 120 chars
- [ ] Hardware (onboard) — no runtime dispatch path is touched

## Not here

- **The endpoint × `address_space` matrix.** `materialize` still resolves a DEVICE backing for a host
  endpoint. That is a behavioural gate needing owner/registry context, with its own test surface.
- **Minting `owner_instance_id` after fork/adoption, and the release-path ordering** (a mapping-close
  failure must not skip the owner unlink; a released handle must not keep deriving `Tensor`s). Both
  are owner-authority and lifetime changes; doing them here would blur where this change ends.
- **No `SIMPLER_BUILD_COMMIT` change.** `buffer.h` justifies having no wire version field by citing
  that guard, so I checked it exists rather than assuming: `python/simpler/task_interface.py:95-133`
  compares the extension's stamp against `git rev-parse HEAD` and raises. It caught me during this
  work, after a `reset --hard` moved HEAD. The comment is accurate as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
