### PR TITLE
Fix: skip unused task-timing tail readback

### DIFF
--- a/docs/dfx/device-phases.md
+++ b/docs/dfx/device-phases.md
@@ -49,9 +49,10 @@ deep-dive — see [l2-timing.md](l2-timing.md).
 
 ### Buffer layout & flow
 
-* Host allocates one `AicpuPhaseRecord[NUM_AICPU_PHASES]` per launched AICPU
-  thread (**thread-major**), resets it each run, and publishes its address into
-  the AICPU SO via `set_platform_phase_base()` — a plain global + `extern "C"`
+* Host allocates one fixed buffer with layout `DevicePhaseBufferHeader |
+  AicpuPhaseRecord[] | TaskTimingRecord[]`. Both record regions are
+  **thread-major**. It resets the whole buffer each run and publishes its address
+  into the AICPU SO via `set_platform_phase_base()` — a plain global + `extern "C"`
   setter, exactly like `set_platform_dump_base` / `set_platform_chip_swimlane_base`
   (onboard: `kernel.cpp` from `KernelArgs::device_wall_data_base`; sim: the host
   dlsym's the setter). **No C++ `thread_local`** (per
@@ -62,8 +63,14 @@ deep-dive — see [l2-timing.md](l2-timing.md).
   stamp `Preamble`/`SoLoad`/`GraphBuild`/`PostOrch`/`OrchWindow`/`SchedWindow`
   via `get_platform_phase_base()` + the affinity index — no change to any
   `extern "C"` signature.
-* Host reduces each phase across threads as `max(end) - min(start)` on readback
-  (`DeviceRunnerBase::read_device_wall_ns`), caches per-phase ns
+* After every AICPU thread arrives at the existing completion gate, the last
+  thread scans the task-timing dispatch records once and writes the header's
+  `task_timing_tail_used` bit. This is outside the scheduler dispatch hot path;
+  capture-disabled runs only pay a null-base check at this once-per-run point.
+* Host first reads only the header + phase prefix and reduces each phase across
+  threads as `max(end) - min(start)` (`DeviceRunnerBase::read_device_wall_ns`).
+  It copies the larger task-timing tail only when the header says at least one
+  tagged task was dispatched. It caches per-phase ns
   (`last_device_phase_ns`), and emits each non-zero phase as a `clk=dev`
   `[STRACE]` marker nested under `simpler_run.runner_run.device_wall`
   (see [host-trace.md](host-trace.md)).
@@ -181,9 +188,11 @@ threads, no per-task AICore records, works in `SIMPLER_DFX=0`. See
   `PTO2TaskSlotState` in the `TaskAttrs` byte (bit 3 `is_timed` + bits 4-7 the
   0..15 tag), co-located with the other per-task scheduling flags. The 16 slots
   are a fixed `TaskTimingRecord[16]` **tail** appended after the `AicpuPhaseRecord`
-  region in the same device buffer — same base pointer, same per-run H2D reset
-  and post-sync D2H readback. It is a distinct record type (dispatch/finish, not
-  start/end) reduced by **min(dispatch) / max(finish)**, not an `AicpuPhase`
+  region in the same device buffer — same base pointer and per-run H2D reset.
+  A 16-byte header at the front lets the host skip the tail D2H entirely when
+  no task was tagged (saving 1536 bytes on a2a3 and 3584 bytes on a5 per run).
+  The tail is a distinct record type (dispatch/finish, not start/end) reduced by
+  **min(dispatch) / max(finish)**, not an `AicpuPhase`
   (those fire once per run/thread; a slot takes many block/subtask events).
 * **Boundaries (match the chip swimlane).** `dispatch` = the earliest Scheduler
   publication of `DATA_MAIN_BASE` (after payload publish, immediately before the
@@ -199,7 +208,10 @@ threads, no per-task AICore records, works in `SIMPLER_DFX=0`. See
   `finish(B) − dispatch(A)`. A **MIX** task's AIC/AIV0/AIV1 subtasks and an
   **SPMD** task's blocks (dispatched by different Scheduler threads) all fold
   into the one tagged slot.
-* **Emission & reset.** Every complete slot (dispatch set, finish > dispatch) is
+* **Emission & reset.** The last AICPU thread marks the header used when it sees
+  any dispatch, including a dispatched-but-incomplete task; the existing
+  completeness check still decides what is emitted. Every complete slot
+  (dispatch set, finish > dispatch) is
   emitted as a stable `clk=dev` span
   `simpler_run.runner_run.device_wall.task_slot_<N>`, retaining start and
   duration so cross-slot intervals are recoverable; `Worker.run()` still returns

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -26,15 +26,11 @@
 #include "aicpu/args_dump_aicpu.h"
 #include "runtime.h"
 
-// Run-wall capture: the host allocates a device buffer addressed by
-// KernelArgs.device_wall_data_base holding one { start_cycle, end_cycle } pair
-// per launched AICPU thread (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH pairs,
-// raw sys-counter cycles), and resets it to { UINT64_MAX, 0 } before each run.
-// Every surviving simpler_aicpu_exec thread writes its own start/end into its
-// own slot (indexed by platform_aicpu_affinity_thread_idx()) — plain stores,
-// no cross-thread atomics. The host reads the whole array and reduces once:
-// wall = max(end) - min(start). No single-threaded pre-pass is needed to
-// seed the start.
+// Device timing capture: KernelArgs.device_wall_data_base addresses a fixed
+// header followed by per-thread phase records and an optional task-timing tail.
+// Every surviving simpler_aicpu_exec thread writes its own phase slot with
+// plain stores. The final thread publishes whether the tail was used, allowing
+// the host to skip that D2H when no task was tagged.
 
 // Forward declaration of aicpu_execute (implemented in aicpu_executor.cpp).
 // simpler_aicpu_register_callable is NOT declared/forwarded here: it is

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -84,7 +84,7 @@ struct DeviceRunner::ActiveRun {
     void *pmu_reg_blocks{nullptr};
     std::vector<std::thread> aicpu_threads;
     std::vector<std::thread> aicore_threads;
-    std::vector<AicpuPhaseRecord> phase_buf;
+    DevicePhaseBufferStorage<PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH> phase_buf{};
 
     void join() noexcept {
         for (auto &thread : aicpu_threads) {
@@ -493,11 +493,6 @@ int DeviceRunner::prepare_execution(
     }
 
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
-    constexpr size_t kTailRecs = static_cast<size_t>(task_timing_buffer_slots(kPhaseThreads));
-    static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
-    active_run_->phase_buf.assign(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
     active_run_->aicpu_threads.reserve(over_launch);
     active_run_->aicore_threads.reserve(num_aicore);
     execution->num_aicore = num_aicore;
@@ -559,7 +554,8 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 if (kernel_args_.device_wall_data_base != 0) {
                     *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
                 }
-                set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
+                reset_device_phase_buffer(&run->phase_buf, over_launch);
+                set_platform_phase_base_func_(reinterpret_cast<uint64_t>(&run->phase_buf));
                 sim_t0 = std::chrono::steady_clock::now();
                 run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
             } catch (...) {
@@ -641,8 +637,8 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     uint64_t phase_start[NUM_AICPU_PHASES];
     uint64_t phase_cycles[NUM_AICPU_PHASES];
     constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
-    reduce_aicpu_phase_windows(active_run_->phase_buf.data(), kPhaseThreads, phase_start, phase_cycles);
+    const void *phase_buffer = &active_run_->phase_buf;
+    reduce_aicpu_phase_windows(device_phase_records(phase_buffer), kPhaseThreads, phase_start, phase_cycles);
     auto cyc_to_ns = [](uint64_t c) {
         return static_cast<uint64_t>(c * 1'000'000'000.0 / static_cast<double>(PLATFORM_PROF_SYS_CNT_FREQ));
     };
@@ -660,12 +656,14 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     }
     device_phase_ns_[static_cast<int>(AicpuPhase::RunWall)] = device_wall_ns_;
 
-    // Resolve the task-timing tail on the phase `origin` timeline (shared logic
-    // in device_phase.h). Sim-specific here: the tail lives inline in phase_buf
-    // (in-process, no D2H) and `cyc_to_ns` uses the sim sys-counter frequency.
-    const TaskTimingRecord *tail =
-        reinterpret_cast<const TaskTimingRecord *>(active_run_->phase_buf.data() + kPhaseRecs);
-    resolve_task_timing_slots_ns(tail, kPhaseThreads, origin, cyc_to_ns, task_slot_dispatch_ns_, task_slot_finish_ns_);
+    std::fill_n(task_slot_dispatch_ns_, NUM_TASK_TIMING_SLOTS, uint64_t{0});
+    std::fill_n(task_slot_finish_ns_, NUM_TASK_TIMING_SLOTS, uint64_t{0});
+    if (device_phase_buffer_header(phase_buffer)->task_timing_tail_used != 0) {
+        const TaskTimingRecord *tail = task_timing_tail_records(phase_buffer, kPhaseThreads);
+        resolve_task_timing_slots_ns(
+            tail, kPhaseThreads, origin, cyc_to_ns, task_slot_dispatch_ns_, task_slot_finish_ns_
+        );
+    }
 
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "aicpu/device_time.h"
+#include "aicpu/device_phase_aicpu.h"
 #include "callable_protocol.h"
 #include "pto2_dispatch_payload.h"
 #include "runtime.h"
@@ -352,6 +353,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO("Thread %d: Completed", thread_idx);
 
     completion_gate_.arrive_and_finalize_if_last(aicpu_thread_num_, [&] {
+        aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.
         if (rt != nullptr) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -870,6 +870,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
     if (prev_finished + 1 == aicpu_thread_num_) {
+        aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         finished_.store(true, std::memory_order_release);
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -26,15 +26,11 @@
 #include "aicpu/args_dump_aicpu.h"
 #include "runtime.h"
 
-// Run-wall capture: the host allocates a device buffer addressed by
-// KernelArgs.device_wall_data_base holding one { start_cycle, end_cycle } pair
-// per launched AICPU thread (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH pairs,
-// raw sys-counter cycles), and resets it to { UINT64_MAX, 0 } before each run.
-// Every surviving simpler_aicpu_exec thread writes its own start/end into its
-// own slot (indexed by platform_aicpu_affinity_thread_idx()) — plain stores,
-// no cross-thread atomics. The host reads the array and reduces once:
-// wall = max(end) - min(start). No single-threaded pre-pass is needed to
-// seed the start.
+// Device timing capture: KernelArgs.device_wall_data_base addresses a fixed
+// header followed by per-thread phase records and an optional task-timing tail.
+// Every surviving simpler_aicpu_exec thread writes its own phase slot with
+// plain stores. The final thread publishes whether the tail was used, allowing
+// the host to skip that D2H when no task was tagged.
 
 // Forward declaration of aicpu_execute (implemented in aicpu_executor.cpp).
 // simpler_aicpu_register_callable is NOT declared/forwarded here: it is

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -75,7 +75,7 @@ struct DeviceRunner::ActiveRun {
     void *reg_blocks{nullptr};
     std::vector<std::thread> aicpu_threads;
     std::vector<std::thread> aicore_threads;
-    std::vector<AicpuPhaseRecord> phase_buf;
+    DevicePhaseBufferStorage<PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH> phase_buf{};
 
     void join() noexcept {
         for (auto &thread : aicpu_threads) {
@@ -419,11 +419,6 @@ int DeviceRunner::prepare_execution(
     }
 
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
-    constexpr size_t kTailRecs = static_cast<size_t>(task_timing_buffer_slots(kPhaseThreads));
-    static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
-    active_run_->phase_buf.assign(kPhaseRecs + kTailRecs, AicpuPhaseRecord{kPhaseUnset, 0});
     active_run_->aicpu_threads.reserve(over_launch);
     active_run_->aicore_threads.reserve(num_aicore);
     execution->num_aicore = num_aicore;
@@ -484,7 +479,8 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 if (kernel_args_.device_wall_data_base != 0) {
                     *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
                 }
-                set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
+                reset_device_phase_buffer(&run->phase_buf, over_launch);
+                set_platform_phase_base_func_(reinterpret_cast<uint64_t>(&run->phase_buf));
                 sim_t0 = std::chrono::steady_clock::now();
                 run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
             } catch (...) {
@@ -567,8 +563,8 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     uint64_t phase_start[NUM_AICPU_PHASES];
     uint64_t phase_cycles[NUM_AICPU_PHASES];
     constexpr int kPhaseThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr size_t kPhaseRecs = static_cast<size_t>(kPhaseThreads) * NUM_AICPU_PHASES;
-    reduce_aicpu_phase_windows(active_run_->phase_buf.data(), kPhaseThreads, phase_start, phase_cycles);
+    const void *phase_buffer = &active_run_->phase_buf;
+    reduce_aicpu_phase_windows(device_phase_records(phase_buffer), kPhaseThreads, phase_start, phase_cycles);
     auto cyc_to_ns = [](uint64_t c) {
         return static_cast<uint64_t>(c * 1'000'000'000.0 / static_cast<double>(PLATFORM_PROF_SYS_CNT_FREQ));
     };
@@ -586,12 +582,14 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     }
     device_phase_ns_[static_cast<int>(AicpuPhase::RunWall)] = device_wall_ns_;
 
-    // Resolve the task-timing tail on the phase `origin` timeline (shared logic
-    // in device_phase.h). Sim-specific here: the tail lives inline in phase_buf
-    // (in-process, no D2H) and `cyc_to_ns` uses the sim sys-counter frequency.
-    const TaskTimingRecord *tail =
-        reinterpret_cast<const TaskTimingRecord *>(active_run_->phase_buf.data() + kPhaseRecs);
-    resolve_task_timing_slots_ns(tail, kPhaseThreads, origin, cyc_to_ns, task_slot_dispatch_ns_, task_slot_finish_ns_);
+    std::fill_n(task_slot_dispatch_ns_, NUM_TASK_TIMING_SLOTS, uint64_t{0});
+    std::fill_n(task_slot_finish_ns_, NUM_TASK_TIMING_SLOTS, uint64_t{0});
+    if (device_phase_buffer_header(phase_buffer)->task_timing_tail_used != 0) {
+        const TaskTimingRecord *tail = task_timing_tail_records(phase_buffer, kPhaseThreads);
+        resolve_task_timing_slots_ns(
+            tail, kPhaseThreads, origin, cyc_to_ns, task_slot_dispatch_ns_, task_slot_finish_ns_
+        );
+    }
 
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "aicpu/device_time.h"
+#include "aicpu/device_phase_aicpu.h"
 #include "callable_protocol.h"
 #include "pto2_dispatch_payload.h"
 #include "runtime.h"
@@ -359,6 +360,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO("Thread %d: Completed", thread_idx);
 
     completion_gate_.arrive_and_finalize_if_last(aicpu_thread_num_, [&] {
+        aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.
         if (rt != nullptr) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -872,6 +872,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
     if (prev_finished + 1 == aicpu_thread_num_) {
+        aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         finished_.store(true, std::memory_order_release);
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries

--- a/src/common/platform/include/aicpu/device_phase_aicpu.h
+++ b/src/common/platform/include/aicpu/device_phase_aicpu.h
@@ -12,8 +12,9 @@
  * @file device_phase_aicpu.h
  * @brief AICPU-side stamping into the fixed device-phase buffer.
  *
- * The buffer (AicpuPhaseRecord[NUM_AICPU_PHASES] per AICPU thread, thread-major)
- * is host-allocated; its base address is published into the AICPU SO via
+ * The buffer (header + AicpuPhaseRecord[NUM_AICPU_PHASES] per AICPU thread +
+ * optional task-timing tail) is host-allocated; its base address is published
+ * into the AICPU SO via
  * `set_platform_phase_base()` (onboard: kernel.cpp from KernelArgs; sim: the
  * host dlsym's the setter), exactly like the dump / chip_swimlane / pmu bases.
  * The per-thread slot is resolved from `platform_aicpu_affinity_thread_idx()`
@@ -28,8 +29,7 @@
  * thread slot is out of range, so call sites need no extra guards.
  */
 
-#ifndef PLATFORM_AICPU_DEVICE_PHASE_AICPU_H_
-#define PLATFORM_AICPU_DEVICE_PHASE_AICPU_H_
+#pragma once
 
 #include <cstdint>
 
@@ -55,7 +55,8 @@ inline AicpuPhaseRecord *aicpu_phase_records(uint64_t buffer_base, int thread_id
     if (buffer_base == 0 || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
         return nullptr;
     }
-    return reinterpret_cast<AicpuPhaseRecord *>(buffer_base) + thread_idx * NUM_AICPU_PHASES;
+    AicpuPhaseRecord *records = device_phase_records(reinterpret_cast<void *>(buffer_base));
+    return records + thread_idx * NUM_AICPU_PHASES;
 }
 
 /** This thread's phase records, resolved from the published base + affinity idx. */
@@ -108,8 +109,26 @@ inline TaskTimingRecord *aicpu_task_timing_records(uint64_t buffer_base, int thr
     if (buffer_base == 0 || thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
         return nullptr;
     }
-    uint64_t tail = buffer_base + task_timing_tail_offset(PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
-    return reinterpret_cast<TaskTimingRecord *>(tail) + thread_idx * NUM_TASK_TIMING_SLOTS;
+    TaskTimingRecord *tail =
+        task_timing_tail_records(reinterpret_cast<void *>(buffer_base), PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+    return tail + thread_idx * NUM_TASK_TIMING_SLOTS;
+}
+
+/**
+ * Publish whether any task-timing record was dispatched this run. Call only
+ * from the last surviving AICPU thread, after an acquire/release completion
+ * gate has made every scheduler thread's record writes visible. The scan stays
+ * out of the dispatch hot path and runs once per capture-enabled run.
+ */
+inline void aicpu_publish_task_timing_tail_usage(int active_threads) {
+    uint64_t buffer_base = get_platform_phase_base();
+    if (buffer_base == 0 || active_threads <= 0 || active_threads > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
+        return;
+    }
+
+    void *buffer = reinterpret_cast<void *>(buffer_base);
+    const TaskTimingRecord *tail = task_timing_tail_records(buffer, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+    device_phase_buffer_header(buffer)->task_timing_tail_used = task_timing_tail_used(tail, active_threads) ? 1 : 0;
 }
 
 /**
@@ -174,5 +193,3 @@ public:
 private:
     AicpuPhase phase_;
 };
-
-#endif  // PLATFORM_AICPU_DEVICE_PHASE_AICPU_H_

--- a/src/common/platform/include/common/device_phase.h
+++ b/src/common/platform/include/common/device_phase.h
@@ -28,15 +28,17 @@
  * nesting) do NOT belong here — they need a rotating ring and live in the
  * chip swimlane orch/sched pools instead.
  *
- * Layout per AICPU thread: AicpuPhaseRecord[NUM_AICPU_PHASES]. The buffer is
- * thread-major: thread t occupies records [t*NUM_AICPU_PHASES, (t+1)*N).
+ * The buffer layout is a fixed header followed by thread-major phase records
+ * and a thread-major task-timing tail. The header lets the host decide whether
+ * the optional tail contains any dispatched task before copying it from the
+ * device.
  */
 
-#ifndef PLATFORM_COMMON_DEVICE_PHASE_H_
-#define PLATFORM_COMMON_DEVICE_PHASE_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 // Fixed AICPU run phases. Each fires once per run per thread. RunWall (slot 0)
 // is the whole-run wall preserved from the original device_wall buffer; the
@@ -70,6 +72,28 @@ struct AicpuPhaseRecord {
 };
 
 constexpr uint64_t kPhaseUnset = UINT64_MAX;
+
+static_assert(sizeof(AicpuPhaseRecord) == 16, "AicpuPhaseRecord layout must stay 16 bytes");
+static_assert(
+    std::is_trivially_copyable_v<AicpuPhaseRecord> && std::is_standard_layout_v<AicpuPhaseRecord>,
+    "AicpuPhaseRecord must remain a POD wire type"
+);
+
+// One per-run header at the front of the device buffer. The last AICPU thread
+// sets task_timing_tail_used after all scheduler threads have stopped writing
+// task-timing records. Zero means the host may skip the tail D2H.
+struct DevicePhaseBufferHeader {
+    uint64_t task_timing_tail_used;
+    uint64_t reserved;
+};
+
+static_assert(sizeof(DevicePhaseBufferHeader) == 16, "DevicePhaseBufferHeader layout must stay 16 bytes");
+static_assert(
+    std::is_trivially_copyable_v<DevicePhaseBufferHeader> && std::is_standard_layout_v<DevicePhaseBufferHeader>,
+    "DevicePhaseBufferHeader must remain a POD wire type"
+);
+
+constexpr size_t aicpu_phase_buffer_offset() { return sizeof(DevicePhaseBufferHeader); }
 
 // Total record count for a buffer sized to `max_threads` AICPU threads.
 constexpr int aicpu_phase_buffer_slots(int max_threads) { return max_threads * NUM_AICPU_PHASES; }
@@ -106,7 +130,8 @@ reduce_aicpu_phase_windows(const AicpuPhaseRecord *buf, int threads, uint64_t *o
 // =============================================================================
 //
 // A fixed tail appended after the AicpuPhaseRecord region in the SAME device
-// buffer (same base pointer, same per-run H2D reset and post-sync D2H copy).
+// buffer (same base pointer and per-run H2D reset). The header controls whether
+// the host performs the tail's separate post-sync D2H copy.
 // Orchestration tags selected tasks with a slot id 0..NUM_TASK_TIMING_SLOTS-1;
 // the scheduler folds each tagged task's AICPU dispatch/finish cycles into that
 // slot. Unlike AicpuPhase (one {start,end} per run per thread), a slot receives
@@ -130,22 +155,119 @@ struct TaskTimingRecord {
 };
 
 static_assert(sizeof(TaskTimingRecord) == 16, "TaskTimingRecord layout must stay 16 bytes for the fixed tail");
+static_assert(
+    std::is_trivially_copyable_v<TaskTimingRecord> && std::is_standard_layout_v<TaskTimingRecord>,
+    "TaskTimingRecord must remain a POD wire type"
+);
 
 // Task-timing tail is thread-major, same as the phase region: thread t occupies
 // records [t*NUM_TASK_TIMING_SLOTS, (t+1)*N).
 constexpr int task_timing_buffer_slots(int max_threads) { return max_threads * NUM_TASK_TIMING_SLOTS; }
 
-// Byte offset of the task-timing tail from the device buffer base: it sits
-// immediately after the AicpuPhaseRecord region sized for `max_threads`.
+// Byte offset of the task-timing tail from the device buffer base.
 constexpr size_t task_timing_tail_offset(int max_threads) {
-    return static_cast<size_t>(aicpu_phase_buffer_slots(max_threads)) * sizeof(AicpuPhaseRecord);
+    return aicpu_phase_buffer_offset() +
+           static_cast<size_t>(aicpu_phase_buffer_slots(max_threads)) * sizeof(AicpuPhaseRecord);
 }
 
-// Total device buffer bytes: phase region + task-timing tail, both sized for
-// `max_threads` AICPU threads.
+// Total device buffer bytes: header + phase region + task-timing tail.
 constexpr size_t device_phase_buffer_bytes(int max_threads) {
     return task_timing_tail_offset(max_threads) +
            static_cast<size_t>(task_timing_buffer_slots(max_threads)) * sizeof(TaskTimingRecord);
+}
+
+template <int MaxThreads>
+struct DevicePhaseBufferPrefixStorage {
+    static_assert(MaxThreads > 0, "device-phase buffer requires at least one thread");
+
+    DevicePhaseBufferHeader header;
+    AicpuPhaseRecord phases[aicpu_phase_buffer_slots(MaxThreads)];
+};
+
+template <int MaxThreads>
+struct DevicePhaseBufferStorage {
+    static_assert(MaxThreads > 0, "device-phase buffer requires at least one thread");
+
+    DevicePhaseBufferHeader header;
+    AicpuPhaseRecord phases[aicpu_phase_buffer_slots(MaxThreads)];
+    TaskTimingRecord tail[task_timing_buffer_slots(MaxThreads)];
+};
+
+static_assert(
+    std::is_trivially_copyable_v<DevicePhaseBufferPrefixStorage<1>> &&
+        std::is_standard_layout_v<DevicePhaseBufferPrefixStorage<1>>,
+    "DevicePhaseBufferPrefixStorage must remain a POD wire type"
+);
+static_assert(
+    std::is_trivially_copyable_v<DevicePhaseBufferStorage<1>> && std::is_standard_layout_v<DevicePhaseBufferStorage<1>>,
+    "DevicePhaseBufferStorage must remain a POD wire type"
+);
+static_assert(
+    sizeof(DevicePhaseBufferPrefixStorage<1>) == task_timing_tail_offset(1), "device-phase prefix layout drift"
+);
+static_assert(sizeof(DevicePhaseBufferStorage<1>) == device_phase_buffer_bytes(1), "device-phase buffer layout drift");
+
+template <typename ReadTail>
+inline int read_task_timing_tail_if_used(const DevicePhaseBufferHeader &header, ReadTail &&read_tail) {
+    if (header.task_timing_tail_used == 0) return 0;
+    return read_tail();
+}
+
+inline DevicePhaseBufferHeader *device_phase_buffer_header(void *buffer_base) {
+    return static_cast<DevicePhaseBufferHeader *>(buffer_base);
+}
+
+inline const DevicePhaseBufferHeader *device_phase_buffer_header(const void *buffer_base) {
+    return static_cast<const DevicePhaseBufferHeader *>(buffer_base);
+}
+
+inline AicpuPhaseRecord *device_phase_records(void *buffer_base) {
+    return reinterpret_cast<AicpuPhaseRecord *>(static_cast<uint8_t *>(buffer_base) + aicpu_phase_buffer_offset());
+}
+
+inline const AicpuPhaseRecord *device_phase_records(const void *buffer_base) {
+    return reinterpret_cast<const AicpuPhaseRecord *>(
+        static_cast<const uint8_t *>(buffer_base) + aicpu_phase_buffer_offset()
+    );
+}
+
+inline TaskTimingRecord *task_timing_tail_records(void *buffer_base, int max_threads) {
+    return reinterpret_cast<TaskTimingRecord *>(
+        static_cast<uint8_t *>(buffer_base) + task_timing_tail_offset(max_threads)
+    );
+}
+
+inline const TaskTimingRecord *task_timing_tail_records(const void *buffer_base, int max_threads) {
+    return reinterpret_cast<const TaskTimingRecord *>(
+        static_cast<const uint8_t *>(buffer_base) + task_timing_tail_offset(max_threads)
+    );
+}
+
+// Initialize one host or simulator mirror before publishing/copying it to the
+// AICPU. Unset dispatches remain distinguishable from a valid cycle value of 0.
+inline void reset_device_phase_buffer(void *buffer_base, int max_threads) {
+    if (buffer_base == nullptr) return;
+
+    *device_phase_buffer_header(buffer_base) = DevicePhaseBufferHeader{0, 0};
+
+    AicpuPhaseRecord *phases = device_phase_records(buffer_base);
+    for (int i = 0; i < aicpu_phase_buffer_slots(max_threads); ++i) {
+        phases[i] = AicpuPhaseRecord{kPhaseUnset, 0};
+    }
+
+    TaskTimingRecord *tail = task_timing_tail_records(buffer_base, max_threads);
+    for (int i = 0; i < task_timing_buffer_slots(max_threads); ++i) {
+        tail[i] = TaskTimingRecord{kPhaseUnset, 0};
+    }
+}
+
+// A dispatched-but-incomplete task still makes the tail relevant: the host
+// copies it and lets the existing completeness checks decide which slots emit.
+inline bool task_timing_tail_used(const TaskTimingRecord *tail, int threads) {
+    for (int i = 0; i < task_timing_buffer_slots(threads); ++i) {
+        if (tail[i].dispatch_cycle != kPhaseUnset) return true;
+    }
+    return false;
 }
 
 // Reduce a thread-major task-timing tail: for each slot, report the reduced
@@ -209,5 +331,3 @@ inline void resolve_task_timing_slots_ns(
         }
     }
 }
-
-#endif  // PLATFORM_COMMON_DEVICE_PHASE_H_

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1274,7 +1274,7 @@ void DeviceRunnerBase::ensure_device_wall_buffer(KernelArgsHelper &kernel_args) 
         kernel_args.args.device_wall_data_base = 0;
         return;
     }
-    // Per-thread fixed AICPU phase records (thread-major:
+    // Fixed header followed by per-thread AICPU phase records (thread-major:
     // AicpuPhaseRecord[NUM_AICPU_PHASES] per launched AICPU thread). Slot
     // AicpuPhase::RunWall keeps the original whole-run wall; the rest subdivide
     // the on-NPU portion. Each surviving AICPU thread writes its own records
@@ -1282,7 +1282,10 @@ void DeviceRunnerBase::ensure_device_wall_buffer(KernelArgsHelper &kernel_args) 
     // max(end) - min(start) and surfaces the other phases as trace markers. The
     // buffer is allocated once (lazy) but RESET every run so a stale prior run
     // cannot leak into the reduction.
-    constexpr size_t kBytes = device_phase_buffer_bytes(PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+    constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    using BufferImage = DevicePhaseBufferStorage<kThreads>;
+    constexpr size_t kBytes = device_phase_buffer_bytes(kThreads);
+    static_assert(sizeof(BufferImage) == kBytes, "device-phase buffer layout drift");
     if (device_wall_dev_ptr_ == nullptr) {
         device_wall_dev_ptr_ = allocate_tensor(kBytes);
     }
@@ -1292,16 +1295,15 @@ void DeviceRunnerBase::ensure_device_wall_buffer(KernelArgsHelper &kernel_args) 
 }
 
 int DeviceRunnerBase::arm_device_wall_buffer(KernelArgsHelper &kernel_args) {
-    if (device_wall_dev_ptr_ == nullptr) return 0;
+    if (device_wall_dev_ptr_ == nullptr || kernel_args.args.device_wall_data_base == 0) return 0;
     constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    static_assert(sizeof(AicpuPhaseRecord) == sizeof(TaskTimingRecord), "phase/tail records must share size");
-    constexpr int kRecords = kThreads * NUM_AICPU_PHASES + task_timing_buffer_slots(kThreads);
-    AicpuPhaseRecord init[kRecords];
-    for (int i = 0; i < kRecords; ++i) {
-        init[i].start_cycle = kPhaseUnset;  // start/dispatch: sentinel so min()/unset-check ignore unused slots
-        init[i].end_cycle = 0;              // end/finish: 0 so max() ignores unused slots
-    }
-    if (copy_to_device(device_wall_dev_ptr_, init, sizeof(init)) != 0) {
+    using BufferImage = DevicePhaseBufferStorage<kThreads>;
+    static const BufferImage init = [] {
+        BufferImage image{};
+        reset_device_phase_buffer(&image, kThreads);
+        return image;
+    }();
+    if (copy_to_device(device_wall_dev_ptr_, &init, sizeof(init)) != 0) {
         // Reset failed — disable capture for this run so stale slot data
         // can't leak into the reduction. Keep the shared allocation alive:
         // an earlier run may still reference it, and the next run retries reset.
@@ -1430,9 +1432,10 @@ void DeviceRunnerBase::read_device_wall_ns() {
     if (device_wall_dev_ptr_ == nullptr) return;
 
     constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-    constexpr int kRecords = kThreads * NUM_AICPU_PHASES;
-    AicpuPhaseRecord buf[kRecords] = {};
-    int wall_rc = rtMemcpy(buf, sizeof(buf), device_wall_dev_ptr_, sizeof(buf), RT_MEMCPY_DEVICE_TO_HOST);
+    using BufferPrefix = DevicePhaseBufferPrefixStorage<kThreads>;
+    static_assert(sizeof(BufferPrefix) == task_timing_tail_offset(kThreads), "device-phase prefix layout drift");
+    BufferPrefix buf{};
+    int wall_rc = rtMemcpy(&buf, sizeof(buf), device_wall_dev_ptr_, sizeof(buf), RT_MEMCPY_DEVICE_TO_HOST);
     if (wall_rc != 0) {
         LOG_WARN("rtMemcpy(device_phase) D2H failed: %d", wall_rc);
         return;
@@ -1443,7 +1446,7 @@ void DeviceRunnerBase::read_device_wall_ns() {
     // compatibility; its duration is the whole-run wall.
     uint64_t start_cycles[NUM_AICPU_PHASES];
     uint64_t span_cycles[NUM_AICPU_PHASES];
-    reduce_aicpu_phase_windows(buf, kThreads, start_cycles, span_cycles);
+    reduce_aicpu_phase_windows(buf.phases, kThreads, start_cycles, span_cycles);
 
     // Origin = earliest sub-phase start (Preamble..SchedWindow share the device
     // clock; RunWall is the bracket at offset 0). Sub-phase start offsets from
@@ -1463,25 +1466,28 @@ void DeviceRunnerBase::read_device_wall_ns() {
     }
     device_wall_ns_ = device_phase_ns_[static_cast<int>(AicpuPhase::RunWall)];
 
-    // Task-timing tail: D2H the per-slot records that follow the phase region,
-    // then resolve them on the phase `origin` timeline (shared logic in
-    // device_phase.h). Platform-specific here: the rtMemcpy and the cycle→ns
-    // conversion (real-silicon sys-counter frequency).
+    // A nonzero header means the last AICPU thread found at least one
+    // dispatched timing slot. The conditional callback D2Hs the optional tail
+    // and resolves it on the phase `origin` timeline.
     constexpr int kTailRecords = task_timing_buffer_slots(kThreads);
-    TaskTimingRecord tail[kTailRecords] = {};
-    const void *tail_src = reinterpret_cast<const uint8_t *>(device_wall_dev_ptr_) + task_timing_tail_offset(kThreads);
-    int tail_rc = rtMemcpy(tail, sizeof(tail), tail_src, sizeof(tail), RT_MEMCPY_DEVICE_TO_HOST);
+    int tail_rc = read_task_timing_tail_if_used(buf.header, [&]() {
+        TaskTimingRecord tail[kTailRecords] = {};
+        const void *tail_src =
+            reinterpret_cast<const uint8_t *>(device_wall_dev_ptr_) + task_timing_tail_offset(kThreads);
+        int rc = rtMemcpy(tail, sizeof(tail), tail_src, sizeof(tail), RT_MEMCPY_DEVICE_TO_HOST);
+        if (rc != 0) return rc;
+        resolve_task_timing_slots_ns(
+            tail, kThreads, origin,
+            [](uint64_t cyc) {
+                return static_cast<uint64_t>(cycles_to_us(cyc) * 1000.0);
+            },
+            task_slot_dispatch_ns_, task_slot_finish_ns_
+        );
+        return 0;
+    });
     if (tail_rc != 0) {
         LOG_WARN("rtMemcpy(task_timing) D2H failed: %d", tail_rc);
-        return;
     }
-    resolve_task_timing_slots_ns(
-        tail, kThreads, origin,
-        [](uint64_t cyc) {
-            return static_cast<uint64_t>(cycles_to_us(cyc) * 1000.0);
-        },
-        task_slot_dispatch_ns_, task_slot_finish_ns_
-    );
 }
 
 int DeviceRunnerBase::init_runtime_args_with_metadata(Runtime &runtime, KernelArgsHelper &kernel_args) {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -1101,14 +1101,12 @@ protected:
     // `nullptr` before init.
     rtStream_t stream_aicpu_{nullptr};
     rtStream_t stream_aicore_{nullptr};
-    // Platform-level device phase buffer: device-resident
-    // AicpuPhaseRecord[NUM_AICPU_PHASES] per launched AICPU thread (thread-
-    // major), whose address rides on `KernelArgs.device_wall_data_base`. AICPU
-    // stamps raw sys-counter cycles per phase through that pointer; subclass
-    // drain pulls it back via `read_device_wall_ns()` after stream sync and
-    // caches the per-phase ns spans for `last_device_phase_ns()` (and RunWall
-    // for `last_device_wall_ns()`). Allocated lazily on the first capture-enabled
-    // run and freed in the subclass `finalize()`.
+    // Platform-level device phase buffer: a header, thread-major phase records,
+    // and the optional task-timing tail. Its address rides on
+    // `KernelArgs.device_wall_data_base`. AICPU stamps raw sys-counter cycles;
+    // subclass drain always pulls back the header + phases after stream sync,
+    // and only pulls the tail when the header marks it used. Allocated lazily
+    // on the first capture-enabled run and freed in subclass `finalize()`.
     void *device_wall_dev_ptr_{nullptr};
     uint64_t device_wall_ns_{0};
     uint64_t device_phase_ns_[NUM_AICPU_PHASES] = {0};

--- a/tests/ut/cpp/a2a3/test_task_timing_slots.cpp
+++ b/tests/ut/cpp/a2a3/test_task_timing_slots.cpp
@@ -10,6 +10,7 @@
  */
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -23,24 +24,93 @@ namespace {
 
 TEST(TaskTimingSlots, RecordLayout) {
     EXPECT_EQ(NUM_TASK_TIMING_SLOTS, 16);
+    EXPECT_EQ(sizeof(DevicePhaseBufferHeader), 16u);
     EXPECT_EQ(sizeof(TaskTimingRecord), 16u);
     EXPECT_EQ(TASK_TIMING_SLOT_NONE, -1);
 }
 
-TEST(TaskTimingSlots, TailFollowsPhaseRegion) {
+TEST(TaskTimingSlots, HeaderPrecedesPhaseRegionAndTail) {
     for (int threads : {1, 4, 24}) {
-        // Tail begins exactly where the phase region ends.
+        EXPECT_EQ(aicpu_phase_buffer_offset(), sizeof(DevicePhaseBufferHeader));
         EXPECT_EQ(
             task_timing_tail_offset(threads),
-            static_cast<size_t>(aicpu_phase_buffer_slots(threads)) * sizeof(AicpuPhaseRecord)
+            aicpu_phase_buffer_offset() +
+                static_cast<size_t>(aicpu_phase_buffer_slots(threads)) * sizeof(AicpuPhaseRecord)
         );
-        // Total = phase region + tail, both sized for `threads`.
         EXPECT_EQ(
             device_phase_buffer_bytes(threads),
             task_timing_tail_offset(threads) +
                 static_cast<size_t>(task_timing_buffer_slots(threads)) * sizeof(TaskTimingRecord)
         );
     }
+}
+
+TEST(TaskTimingSlots, BufferResetClearsHeaderAndRecords) {
+    constexpr int kThreads = 3;
+    DevicePhaseBufferStorage<kThreads> storage{};
+    storage.header = DevicePhaseBufferHeader{123, 456};
+    std::fill_n(storage.phases, aicpu_phase_buffer_slots(kThreads), AicpuPhaseRecord{123, 456});
+    std::fill_n(storage.tail, task_timing_buffer_slots(kThreads), TaskTimingRecord{123, 456});
+
+    EXPECT_EQ(sizeof(storage), device_phase_buffer_bytes(kThreads));
+    EXPECT_EQ(device_phase_records(&storage), storage.phases);
+    EXPECT_EQ(task_timing_tail_records(&storage, kThreads), storage.tail);
+
+    reset_device_phase_buffer(&storage, kThreads);
+
+    const DevicePhaseBufferHeader *header = device_phase_buffer_header(&storage);
+    EXPECT_EQ(header->task_timing_tail_used, 0u);
+    EXPECT_EQ(header->reserved, 0u);
+
+    const AicpuPhaseRecord *phases = device_phase_records(&storage);
+    for (int i = 0; i < aicpu_phase_buffer_slots(kThreads); ++i) {
+        EXPECT_EQ(phases[i].start_cycle, kPhaseUnset);
+        EXPECT_EQ(phases[i].end_cycle, 0u);
+    }
+
+    const TaskTimingRecord *tail = task_timing_tail_records(&storage, kThreads);
+    for (int i = 0; i < task_timing_buffer_slots(kThreads); ++i) {
+        EXPECT_EQ(tail[i].dispatch_cycle, kPhaseUnset);
+        EXPECT_EQ(tail[i].finish_cycle, 0u);
+    }
+}
+
+TEST(TaskTimingSlots, TailReadSkippedWhenHeaderIsUnused) {
+    const DevicePhaseBufferHeader header{0, 0};
+    int read_count = 0;
+
+    const int rc = read_task_timing_tail_if_used(header, [&read_count]() {
+        ++read_count;
+        return 17;
+    });
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(read_count, 0);
+}
+
+TEST(TaskTimingSlots, TailReadRunsWhenHeaderIsUsed) {
+    const DevicePhaseBufferHeader header{1, 0};
+    int read_count = 0;
+
+    const int rc = read_task_timing_tail_if_used(header, [&read_count]() {
+        ++read_count;
+        return 17;
+    });
+
+    EXPECT_EQ(rc, 17);
+    EXPECT_EQ(read_count, 1);
+}
+
+TEST(TaskTimingSlots, TailUsageTracksAnyDispatchIncludingIncompleteTasks) {
+    constexpr int kThreads = 3;
+    std::vector<TaskTimingRecord> tail(
+        static_cast<size_t>(task_timing_buffer_slots(kThreads)), TaskTimingRecord{kPhaseUnset, 0}
+    );
+
+    EXPECT_FALSE(task_timing_tail_used(tail.data(), kThreads));
+
+    tail[2 * NUM_TASK_TIMING_SLOTS + 7] = {100, 0};
+    EXPECT_TRUE(task_timing_tail_used(tail.data(), kThreads));
 }
 
 // --- Cross-thread min/max reduction ---------------------------------------


### PR DESCRIPTION
## Summary

- Add a 16-byte device-phase header and publish whether any task-timing slot
  was dispatched from the last AICPU thread at the existing completion gate.
- Read back the header and fixed phase prefix first, and skip the optional
  task-timing tail D2H copy when no task was tagged.
- Use typed POD storage for the shared buffer in onboard and both simulators,
  with direct tests for the no-tail-read path and the wire layout.
- Keep the a2a3/a5 and host-build-graph/tensormap runtime paths aligned and
  document the split readback layout.

## Testing

- [x] Editable runtime build
- [x] C++ unit tests (86 targets; socket-backed test passed outside sandbox)
- [x] Full a2a3sim scene-test suite (137 selected)
- [x] Full a5sim scene-test suite (108 selected)
- [x] Pre-commit hooks for all changed files
- [ ] Onboard hardware tests (arch precheck could not identify silicon because
  `npu-smi` returned empty Chip/NPU names)

Fixes #1656
