### PR TITLE
CI: skip A5 SDMA tests on x86 runners

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -19,15 +19,17 @@ are markers on the tests, so mirror the sweep with `-m "not sdma"` rather than
 copying a path list. PTO-ISA reproducibility comes from the repo-root
 `pto_isa.pin`.
 
-**CI does not run one flat sweep.** Some tests are quarantined out of the
-general onboard sweep and run in a step of their own, after it, because they are
-only correct in isolation. Reproducing CI means reproducing that
+**CI does not run one flat sweep.** SDMA selection is marker-based on both
+platforms. On a2a3, marked tests are quarantined out of the general onboard
+sweep and run in a step of their own, after it, because they are only correct
+in isolation. On a5, ARM64 runs the full corpus while x86_64 deselects the
+marker. Reproducing a2a3 CI means reproducing that
 shape — a bare `pytest examples tests/st --platform a2a3` is *not* what CI runs
 and will report failures that CI never sees:
 
-| Quarantine | Excludes | Runs instead in |
-| ---------- | -------- | --------------- |
-| `@pytest.mark.sdma` | `sdma_async_completion_demo`, `prefetch_async_demo` | the "SDMA pytest (a2a3)" step, which runs after the sweep |
+| Marker | Tests | CI behavior |
+| ------ | ----- | ----------- |
+| `@pytest.mark.sdma` | a2a3: `sdma_async_completion_demo`, `prefetch_async_demo`; a5: `sdma_async_completion_demo` | a2a3: the dedicated SDMA step; a5: included on ARM64 and deselected on x86_64 |
 
 The SDMA demos provision 48 device-only STARS streams, which makes an AICore
 fault take ~306 s to tear down instead of ~0.3 s — so they must not share a
@@ -81,6 +83,12 @@ pytest examples tests/st -m "not sdma" --platform a2a3 --device <range> \
 # what the marker replaced.
 pytest examples tests/st -m sdma \
     --platform a2a3 --device <2 devs> --pto-session-timeout <timeout>
+
+# A5 ARM64 runs the full corpus; A5 x86_64 deselects SDMA tests.
+pytest examples tests/st --platform a5 --device <range> \
+    --pto-session-timeout <timeout>
+pytest examples tests/st -m "not sdma" --platform a5 --device <range> \
+    --pto-session-timeout <timeout>
 
 # Single runtime
 pytest examples tests/st --platform a2a3sim --runtime host_build_graph

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -50,6 +50,9 @@ jobs:
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa"
+          if [ "$(uname -m)" = "x86_64" ]; then
+            PYTEST="$PYTEST -m 'not sdma'"
+          fi
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 1200"
 
       - name: dep_gen smoke (a5)

--- a/conftest.py
+++ b/conftest.py
@@ -431,15 +431,17 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "device_count(n): number of NPU devices needed")
     config.addinivalue_line(
         "markers",
-        "sdma: the test provisions the PTO-ISA async-SDMA workspace, so its "
-        "Worker is built with enable_sdma=True. Provisioning creates 48 "
+        "sdma: the test provisions the PTO-ISA async-SDMA workspace. "
+        "SceneTestCase fixtures build its Worker with enable_sdma=True; "
+        "standalone tests may use the platform's default SDMA backend. "
+        "Provisioning creates 48 "
         "device-only STARS streams that sit in the device fault domain, which "
         "makes a later AICore fault on that device cost minutes instead of "
         "~0.3 s (#1425). Two consequences follow from the one marker: such a "
         "test never shares an L2 Worker (the pool key carries the flag) and it "
         "sorts after every ordinary test, so fault-injection cases run on a "
-        "device that has never provisioned. CI additionally runs them in a step "
-        "of their own via -m sdma until #1425 is fixed",
+        "device that has never provisioned. The a2a3 CI additionally runs them "
+        "in a step of their own via -m sdma until #1425 is fixed",
     )
     config.addinivalue_line(
         "markers",

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -60,7 +60,7 @@ PullRequest
 | `ut-a2a3` | a2a3 self-hosted | `pytest tests/ut --platform a2a3` + `ctest -L "^requires_hardware(_a2a3)?$" --resource-spec-file ...` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (host + cross-compiled device SO, link smoke only) |
 | `st-onboard-a2a3` | a2a3 self-hosted | `pytest examples tests/st -m "not sdma" --platform a2a3 --device ...`, then a separate `-m sdma` step, then the DFX per-feature smokes |
 | `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + `ctest -L "^requires_hardware(_a5)?$"` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (link smoke only) |
-| `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st --platform a5 --device ...` |
+| `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st --platform a5 --device ...`; x86_64 runners add `-m "not sdma"` |
 | `st-pod-onboard-a2a3` | a pair of `a2a3pod` machines | the L4 mixed local/remote examples, one L3 per machine |
 
 ### Multi-machine pod jobs
@@ -139,8 +139,11 @@ benefit — device bin-packing for L3, xdist fanout for L2, and a shared
 pytest examples tests/st -m "not sdma" --platform a2a3 --device 4-7 -x
 pytest examples tests/st -m sdma --platform a2a3 --device 4-5 -x
 
-# Same for a5, which has no marker filter
+# A5 ARM64 runners run the full corpus
 pytest examples tests/st --platform a5 --device 0-7 -x
+
+# A5 x86_64 runners deselect SDMA tests
+pytest examples tests/st -m "not sdma" --platform a5 --device 0-7 -x
 ```
 
 `-x` (`--exitfirst`) is appropriate for CI, where aborting on first
@@ -241,9 +244,11 @@ runner pools, branched at run time on the host arch (`uname -m`):
   the runner — so the step runs `pytest`/`ctest` directly with
   `--device ${DEVICE_RANGE}`.
 
-a5 runners are ARM64-only and always use `task-submit`. Steps that only build
-(cmake, `RuntimeBuilder`, the `cann-examples` smokes) take no lock on either
-arch. The same device-lock rule applies to local onboard work — see
+a5 runners always use `task-submit`. The x86_64 A5 scene-test sweep deselects
+the `sdma` marker; ARM64 runs the full corpus, including SDMA tests. Steps that
+only build (cmake, `RuntimeBuilder`, the
+`cann-examples` smokes) take no lock on either arch. The same device-lock rule
+applies to local onboard work — see
 [.claude/rules/running-onboard.md](../.claude/rules/running-onboard.md).
 
 ## Test Sources

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,6 +54,10 @@ pytest examples tests/st -m "not sdma" --platform a2a3 --device 4-7  # hardware 
 # provisioned SDMA workspace (issue #1425)
 pytest examples tests/st -m sdma --platform a2a3 --device 4-5
 
+# A5 ARM64 runs the full corpus; A5 x86_64 deselects SDMA tests
+pytest examples tests/st --platform a5 --device 0-7
+pytest examples tests/st -m "not sdma" --platform a5 --device 0-7
+
 # Single scene test (standalone)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim
 

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -204,6 +204,7 @@ def run(
         worker.close()
 
 
+@pytest.mark.sdma
 @pytest.mark.platforms(["a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)


### PR DESCRIPTION
## Summary

- mark the A5 SDMA completion demo with the existing `sdma` pytest marker
- deselect SDMA tests only on x86_64 A5 runners
- keep the aarch64 A5 sweep unchanged so it continues to run SDMA coverage
- update the marker contract and CI/testing documentation

## Testing

- `python -m pytest examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo --collect-only --platform a5 -m sdma -q` (1 test collected)
- `python -m pytest examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo --collect-only --platform a5 -m "not sdma" -q` (1 test deselected)
- `python -m pre_commit run --files conftest.py examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py .github/workflows/_st-npu-a5.yml docs/ci.md docs/testing.md .claude/skills/testing/SKILL.md`
- A5 onboard not run locally: mandatory architecture precheck could not identify silicon because `npu-smi` returned no chip/NPU name
