### PR TITLE
feat(a5): add scheduler L2 phase telemetry

### DIFF
--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -45,11 +45,12 @@ available.
   `chip_swimlane_records.json` with `deps.json` from
   [`dep_gen`](dep-gen.md) at post-process time; see
   [§3.5](#35-dependency-arrows-from-dep_gen).
-- **AICPU scheduler phases** — per-iteration breakdown into six
+- **AICPU scheduler phases** — per-iteration breakdown into seven
   mutually time-exclusive **outer** phases (`complete` / `async_poll`
-  / `dispatch` / `release` / `dummy` / `early_dispatch`), one logical
-  **inner** phase (`resolve`, parent = Complete or Dummy) rendered on a
-  sibling scheduler sub-lane with the same `Sched_N` label and adjacent tid,
+  / `dispatch` / `release` / `dummy` / `early_dispatch` / `drain`), plus
+  `resolve`, `drain_prepare`, and `drain_publish` **inner** phases. `resolve`
+  is rendered on a sibling scheduler sub-lane with the same `Sched_N` label,
+  while the drain sub-phases are nested within their `drain` bar,
   and two **separate-lane**
   phases (`dummy_task` and `predicated_skip`, sampled immediately before
   `on_task_complete()` begins dependency resolution and rendered as synthetic
@@ -261,7 +262,10 @@ field but render differently in Perfetto:
 | `release` | outer | sched | deferred-release slots drained this iter |
 | `dummy` | outer | sched | `dummy_ready_queue` entries handled this iter (explicit dummies and false-predicate tasks) |
 | `early_dispatch` | outer | sched | blocks staged by speculative early-dispatch this pass |
+| `drain` | outer | sched | blocks staged by this thread's global sync-start drain pass |
 | `resolve` | inner | sched sub-lane, same `Sched_N` label as its outer lane | consumers visited in `on_task_complete` |
+| `drain_prepare` | inner | sched, nested in `drain` | subtasks prepared for global sync-start publication |
+| `drain_publish` | inner | sched, nested in `drain` | subtasks published during global sync-start staging |
 | `dummy_task` | separate-lane | Worker View AICPU_N (pid=4) | one dummy entering `on_task_complete()`; full identity is in `task_id` |
 | `predicated_skip` | separate-lane | Worker View AICPU_N (pid=4) | one real task retired inline after its dispatch predicate evaluated false; full identity is in `task_id` |
 
@@ -270,12 +274,11 @@ orchestrator submit path, so it has no swimlane lane. Read its cost
 from `g_orch_fanin_cycle` in the device-log orch breakdown (the
 `fanin` line) instead.
 
-Outer phases are mutually time-exclusive within an iter — each
-emit advances the per-thread phase anchor (`_t0_phase`). Inner
-phases (`resolve`) don't advance the anchor; the converter renders
-them on a sibling `Sched_N` tid so flow arrows attach to the outer
-`complete`/`dummy` lane instead of being visually captured by the inner
-slice. Separate-lane phases are routed to a different lane by the converter
+Outer phases are mutually time-exclusive within an iter. The converter renders
+`resolve` on a sibling `Sched_N` tid so flow arrows attach to the outer
+`complete`/`dummy` lane; `drain_prepare` and `drain_publish` remain on the
+scheduler lane and are time-contained by `drain`. Separate-lane phases are
+routed to a different lane by the converter
 (Worker View AICPU_N), so they never overlap visually with the sched lane
 bars even when their timestamps fall inside an outer span.
 
@@ -319,11 +322,10 @@ in. The trace contains:
 - **Orchestrator** (pid=1) — per-submit `orch_submit` envelope
   blocks (level >= 4).
 - **AICPU Scheduler** (pid=2) — per-iteration scheduler phase
-  blocks coloured by `phase` (level >= 3). The five outer phases
-  (`complete` / `dispatch` / `release` / `dummy` /
-  `early_dispatch`) appear as sibling bars on each scheduler
-  thread's first `Sched_N` lane; the `resolve` inner phase appears on an
-  adjacent `Sched_N` sub-lane.
+  blocks coloured by `phase` (level >= 3). Outer phases appear as sibling bars
+  on each scheduler thread's first `Sched_N` lane. `resolve` appears on an
+  adjacent `Sched_N` sub-lane, while `drain_prepare` and `drain_publish` nest
+  within `drain`.
 - **Scheduler View** (pid=3) — task-execution overlay using AICPU
   dispatch/finish timestamps (level >= 2), with the same labels
   as Worker View.
@@ -591,8 +593,8 @@ What the swimlane shows:
   dependency arrows independently use each view's earliest visible slice per
   `(func_id, task_id)` group as the anchor.
 - **Scheduler-loop time decomposition.** Per-iteration AICPU
-  phase records show how long the scheduler spent in each of
-  its two work phases (complete / dispatch); idle is recovered
+  phase records show how long the scheduler spent in recorded work phases;
+  idle is recovered
   from the gap between records.
 - **Orchestrator overhead breakdown.** Per-submit envelope
   records (`orch_submit`) pin "which submit is slow"; cumulative

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1089,7 +1089,7 @@ struct PTO2SchedulerState {
 #if SIMPLER_SCHED_PROFILING
     CompletionStats
 #else
-    void
+    uint32_t
 #endif
     on_task_complete(
         PTO2TaskSlotState &slot_state
@@ -1100,6 +1100,8 @@ struct PTO2SchedulerState {
     ) {
 #if SIMPLER_SCHED_PROFILING
         CompletionStats stats = {0, 0, 0, true};
+#else
+        uint32_t consumer_walk_count = 0;
 #endif
 #if SIMPLER_SCHED_PROFILING
         extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
@@ -1138,6 +1140,7 @@ struct PTO2SchedulerState {
                 stats.tasks_enqueued++;
             }
 #else
+            consumer_walk_count++;
             release_fanin_and_check_ready(consumer_slot, &rel_sink);
 #endif
             current = current->next;
@@ -1151,6 +1154,8 @@ struct PTO2SchedulerState {
         g_sched_push_wait_cycle[thread_idx] += push_wait;
         PTO2_SCHED_CYCLE_LAP(g_sched_fanout_cycle[thread_idx]);
         return stats;
+#else
+        return consumer_walk_count;
 #endif
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -172,15 +172,30 @@ void SchedulerContext::complete_slot_task(
             );
         }
 #endif
+#if SIMPLER_DFX
+        uint64_t resolve_t0 = (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
+#endif
 #if SIMPLER_SCHED_PROFILING
         // SCHED_PROFILING variant takes thread_idx for its per-thread atomic
         // counter side-effects (g_sched_*_atomic_count[thread_idx], consumed
-        // by the otc_* log lines). Its return value is unused.
-        (void)sched_->on_task_complete(slot_state, thread_idx);
+        // by the otc_* log lines). The returned fanout_edges feeds Resolve.
+        [[maybe_unused]] uint32_t consumers_resolved = sched_->on_task_complete(slot_state, thread_idx).fanout_edges;
 #else
-        sched_->on_task_complete(slot_state);
+        [[maybe_unused]] uint32_t consumers_resolved = sched_->on_task_complete(slot_state);
 #endif
 #if SIMPLER_DFX
+        if (resolve_t0 != 0) {
+            // The completion call above is the Resolve work. Keep the bar
+            // narrow and filter the short consumer walks that add no signal.
+            uint64_t resolve_t1 = get_sys_cnt_aicpu();
+            constexpr uint64_t RESOLVE_EMIT_MIN_CYCLES = PLATFORM_PROF_SYS_CNT_FREQ / 1'000'000;
+            if (resolve_t1 - resolve_t0 >= RESOLVE_EMIT_MIN_CYCLES) {
+                chip_swimlane_aicpu_record_sched_phase(
+                    thread_idx, ChipSwimlaneSchedPhaseKind::Resolve, resolve_t0, resolve_t1,
+                    chip_swimlane.sched_loop_count, consumers_resolved
+                );
+            }
+        }
         chip_swimlane.phase_complete_count++;
 #endif
         if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
@@ -188,8 +203,6 @@ void SchedulerContext::complete_slot_task(
         } else {
             while (deferred_release_count > 0) {
 #if SIMPLER_SCHED_PROFILING
-                // SCHED_PROFILING variant takes thread_idx for the per-thread
-                // atomic counter side-effects. The return value is unused.
                 (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
@@ -487,6 +500,10 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
             int32_t claim = slot_state->claim_block_range(block_num, avail, start);
             if (claim == 0) return;
             result.staged_blocks += claim;
+#if SIMPLER_DFX
+            bool sub_prof = record_drain_phases && chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES;
+            uint64_t prep_t0 = sub_prof ? get_sys_cnt_aicpu() : 0;
+#endif
             PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
             int handle_count = 0;
             int32_t claimed[CoreTracker::MAX_CLUSTERS * 3];
@@ -504,8 +521,16 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
             wmb();
             uint64_t dispatch_ts = 0;
 #if SIMPLER_DFX
+            uint64_t pub_t0 = 0;
+            if (sub_prof) {
+                pub_t0 = get_sys_cnt_aicpu();
+                chip_swimlane_aicpu_record_sched_phase(
+                    thread_idx, ChipSwimlaneSchedPhaseKind::DrainPrepare, prep_t0, pub_t0,
+                    sched_chip_swimlane_[thread_idx].sched_loop_count, static_cast<uint32_t>(handle_count)
+                );
+            }
             if (chip_swimlane_level_ >= ChipSwimlaneLevel::AICPU_TIMING) {
-                dispatch_ts = get_sys_cnt_aicpu();
+                dispatch_ts = pub_t0 != 0 ? pub_t0 : get_sys_cnt_aicpu();
             }
 #endif
             uint64_t my_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
@@ -525,6 +550,14 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
                     }
                 }
             }
+#if SIMPLER_DFX
+            if (sub_prof) {
+                chip_swimlane_aicpu_record_sched_phase(
+                    thread_idx, ChipSwimlaneSchedPhaseKind::DrainPublish, pub_t0, get_sys_cnt_aicpu(),
+                    sched_chip_swimlane_[thread_idx].sched_loop_count, static_cast<uint32_t>(handle_count)
+                );
+            }
+#endif
             sched_->record_published_blocks(*slot_state, claim);
             if (gated && shape != PTO2ResourceShape::MIX && !to_pending) result.running_cores += handle_count;
         }
@@ -543,10 +576,15 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
     return result;
 }
 
-void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] uint64_t *out_stage_wall_cycles) {
+void SchedulerContext::handle_drain_mode(
+    int32_t thread_idx, [[maybe_unused]] uint64_t *out_stage_wall_cycles, [[maybe_unused]] int32_t *out_staged_blocks
+) {
 #if SIMPLER_DFX
     bool drain_prof = (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES && out_stage_wall_cycles != nullptr);
     uint64_t drain_acked_ts = 0;
+#endif
+#if SIMPLER_DFX
+    if (out_staged_blocks != nullptr) *out_staged_blocks = 0;
 #endif
     int32_t block_num;
     do {
@@ -607,6 +645,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
         stage_sync_start_cores(slot_state, block_num, thread_idx, gated, /*record_drain_phases=*/true);
 #if SIMPLER_DFX
     if (drain_prof && drain_acked_ts != 0) *out_stage_wall_cycles = get_sys_cnt_aicpu() - drain_acked_ts;
+    if (out_staged_blocks != nullptr) *out_staged_blocks = staged.staged_blocks;
 #endif
     drain_state_.drain_running_staged.fetch_add(staged.running_cores, std::memory_order_acq_rel);
     drain_state_.drain_stage_done_mask.fetch_or(1u << thread_idx, std::memory_order_release);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -401,7 +401,9 @@ private:
     SyncStartStageResult stage_sync_start_cores(
         PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
     );
-    void handle_drain_mode(int32_t thread_idx, uint64_t *out_stage_wall_cycles = nullptr);
+    void handle_drain_mode(
+        int32_t thread_idx, uint64_t *out_stage_wall_cycles = nullptr, int32_t *out_staged_blocks = nullptr
+    );
 
     // =========================================================================
     // Cold path: exit checks, stall diagnostics, profiling (scheduler_cold_path.cpp)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1014,7 +1014,20 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Phase 2 drain check
         if (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
+#if SIMPLER_DFX
+            uint64_t drain_t0 = (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
+            uint64_t drain_stage_wall = 0;
+            int32_t drain_staged_blocks = 0;
+            handle_drain_mode(thread_idx, &drain_stage_wall, &drain_staged_blocks);
+            if (drain_t0 != 0 && drain_stage_wall != 0) {
+                chip_swimlane_aicpu_record_sched_phase(
+                    thread_idx, ChipSwimlaneSchedPhaseKind::Drain, drain_t0, get_sys_cnt_aicpu(),
+                    chip_swimlane.sched_loop_count, static_cast<uint32_t>(drain_staged_blocks)
+                );
+            }
+#else
             handle_drain_mode(thread_idx);
+#endif
             continue;
         }
 
@@ -1042,12 +1055,21 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                     (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
 #endif
 #if SIMPLER_SCHED_PROFILING
-                sched_->on_task_complete(dummy_slot, thread_idx);
+                [[maybe_unused]] uint32_t consumers_resolved =
+                    sched_->on_task_complete(dummy_slot, thread_idx).fanout_edges;
 #else
-                sched_->on_task_complete(dummy_slot);
+                [[maybe_unused]] uint32_t consumers_resolved = sched_->on_task_complete(dummy_slot);
 #endif
 #if SIMPLER_DFX
                 if (dummy_resolve_t0 != 0) {
+                    uint64_t resolve_t1 = get_sys_cnt_aicpu();
+                    constexpr uint64_t RESOLVE_EMIT_MIN_CYCLES = PLATFORM_PROF_SYS_CNT_FREQ / 1'000'000;
+                    if (resolve_t1 - dummy_resolve_t0 >= RESOLVE_EMIT_MIN_CYCLES) {
+                        chip_swimlane_aicpu_record_sched_phase(
+                            thread_idx, ChipSwimlaneSchedPhaseKind::Resolve, dummy_resolve_t0, resolve_t1,
+                            chip_swimlane.sched_loop_count, consumers_resolved
+                        );
+                    }
                     if (dummy_slot.task_attrs.has_predicate()) {
                         chip_swimlane_aicpu_record_predicated_skip(
                             thread_idx, dummy_resolve_t0, sched_chip_swimlane_[thread_idx].sched_loop_count,
@@ -1172,6 +1194,13 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             idle_iterations = 0;
             last_progress_ts = get_sys_cnt_aicpu();
         } else {
+#if SIMPLER_DFX
+            uint64_t release_t0 =
+                (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES && deferred_release_count > 0) ?
+                    get_sys_cnt_aicpu() :
+                    0;
+            uint32_t released_count = static_cast<uint32_t>(deferred_release_count);
+#endif
             while (deferred_release_count > 0) {
 #if SIMPLER_SCHED_PROFILING
                 (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
@@ -1179,6 +1208,14 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
             }
+#if SIMPLER_DFX
+            if (release_t0 != 0) {
+                chip_swimlane_aicpu_record_sched_phase(
+                    thread_idx, ChipSwimlaneSchedPhaseKind::Release, release_t0, get_sys_cnt_aicpu(),
+                    chip_swimlane.sched_loop_count, released_count
+                );
+            }
+#endif
             // Deferred consumed-head advances retry from the no-progress path.
             // During a ring-heap stall, a CONSUMED head with its pending bit
             // still set means no retry has acquired advance_lock and cleared

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
@@ -52,6 +52,7 @@ def validate_perf_artifact(
     since: float,
     expected_task_count: int | None = None,
     expected_complete_finishes: int | None = None,
+    required_sched_phases: tuple[str, ...] = (),
 ) -> None:
     """Locate this invocation's output dir for ``case_label`` and run the full
     capture-→-tools-→-differential sequence.
@@ -70,6 +71,8 @@ def validate_perf_artifact(
         expected_complete_finishes: when provided, assert the sum of
             Complete-phase ``tasks_processed`` values. This is a FIN/retire
             count, so an SPMD workload can exceed its logical task count.
+        required_sched_phases: scheduler phases that must each carry positive
+            ``tasks_processed`` work in this capture.
     """
     safe_label = _sanitize_for_filename(case_label)
     matches = [p for p in _outputs_dir().glob(f"{safe_label}_*") if p.stat().st_mtime >= since]
@@ -103,6 +106,12 @@ def validate_perf_artifact(
         assert complete_finishes == expected_complete_finishes, (
             f"got {complete_finishes} Complete FINs, expected {expected_complete_finishes} under {perf}"
         )
+    phase_records = [record for thread_records in data.get("aicpu_scheduler_phases", []) for record in thread_records]
+    for phase in required_sched_phases:
+        phase_work = sum(
+            int(record.get("tasks_processed", 0)) for record in phase_records if record.get("phase") == phase
+        )
+        assert phase_work > 0, f"scheduler phase {phase!r} carried no work under {perf}"
     # Spot-check a single record's required fields — guards against drift in
     # the swimlane schema that swimlane_converter.py / deps_viewer.py rely on.
     first = tasks[0]

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
@@ -77,12 +77,14 @@ class TestChipSwimlane(SceneTestCase):
             "name": "default",
             "platforms": ["a5sim", "a5"],
             "params": {},
+            "required_sched_phases": ("release",),
         },
         {
             "name": "aicpu_threads_2",
             "platforms": ["a5sim", "a5"],
             "config": {"aicpu_thread_num": 2},
             "params": {},
+            "required_sched_phases": ("release",),
         },
     ]
 
@@ -107,7 +109,10 @@ class TestChipSwimlane(SceneTestCase):
         for case in self.CASES:
             if st_platform in case["platforms"]:
                 validate_perf_artifact(
-                    f"TestChipSwimlane_{case['name']}", since=run_marker, expected_task_count=_EXPECTED_TASK_COUNT
+                    f"TestChipSwimlane_{case['name']}",
+                    since=run_marker,
+                    expected_task_count=_EXPECTED_TASK_COUNT,
+                    required_sched_phases=case["required_sched_phases"],
                 )
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_drain_phases.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_drain_phases.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Positive coverage for A5 global sync-start drain phase records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.tools.swimlane_converter import read_perf_data
+
+FLOATS_PER_CACHE_LINE = 16
+NUM_TASKS = 4
+MAX_AIV = 72
+MAX_TOTAL_CL = MAX_AIV // 12 + MAX_AIV // 3 + MAX_AIV // 12 + MAX_AIV // 2
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestSyncStartDrainPhases(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "../../spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SPMD_WRITE_AIV",
+                "source": "../../spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp",
+                "core_type": "aiv",
+            },
+        ],
+    }
+
+    CASES = [{"name": "global_aiv", "platforms": ["a5sim", "a5"], "params": {}}]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+        )
+
+    def compute_golden(self, args, params):
+        pass
+
+    def _build_config(self, config_dict, *args, **kwargs):
+        config = super()._build_config(config_dict, *args, **kwargs)
+        self._trace_perf_level = int(kwargs.get("enable_chip_swimlane", args[0] if args else 0))
+        output_prefix = kwargs.get("output_prefix", "")
+        self._trace_perf_path = Path(output_prefix) / "chip_swimlane_records.json" if output_prefix else None
+        return config
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        layout = [int(value) for value in test_args.layout]
+        expected = torch.zeros(MAX_TOTAL_CL, dtype=torch.float32)
+        for task_idx in range(NUM_TASKS):
+            block_num, base_cl = layout[2 * task_idx], layout[2 * task_idx + 1]
+            assert block_num >= 1, f"task {task_idx} reported block_num {block_num}"
+            for block_idx in range(block_num):
+                expected[base_cl + block_idx] = float(block_idx)
+        actual = test_args.output.reshape(MAX_TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        assert torch.equal(actual, expected), f"output disagrees with reported layout {layout}"
+
+        if getattr(self, "_trace_perf_level", 0) < 3:
+            return
+        perf_path = self._trace_perf_path
+        assert perf_path is not None and perf_path.exists(), "chip swimlane scheduler capture is missing"
+        perf = read_perf_data(perf_path)
+        phase_records = [record for thread in perf.get("aicpu_scheduler_phases", []) for record in thread]
+        sync_start_blocks = layout[0] + layout[2] + layout[2 * (NUM_TASKS - 1)]
+        phase_work = {}
+        for phase in ("drain", "drain_prepare", "drain_publish"):
+            records = [record for record in phase_records if record.get("phase") == phase]
+            phase_work[phase] = sum(int(record.get("tasks_processed", 0)) for record in records)
+            assert 0 < phase_work[phase] <= sync_start_blocks, (
+                f"{phase} reported {phase_work[phase]} blocks/subtasks for {sync_start_blocks} sync-start blocks; "
+                f"artifact={perf_path}"
+            )
+        assert len(set(phase_work.values())) == 1, f"drain phase workloads disagree: {phase_work}; artifact={perf_path}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -411,7 +411,12 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     dep_entries[1].next = &dep_entries[0];
     producer.fanout_head = &dep_entries[1];
 
-    sched.on_task_complete(producer);
+#if SIMPLER_SCHED_PROFILING
+    auto completion_stats = sched.on_task_complete(producer, /*thread_idx=*/0);
+    EXPECT_EQ(completion_stats.fanout_edges, 2U);
+#else
+    EXPECT_EQ(sched.on_task_complete(producer), 2U);
+#endif
 
     // Producer should be COMPLETED
     EXPECT_EQ(producer.task_state.load(), PTO2_TASK_COMPLETED);


### PR DESCRIPTION
## Summary

This PR extends A5 scheduler observability so chip-swimlane profiling can attribute scheduler-side work to the same sub-phases already exposed by A2/A3.

## What changed

- Record `Resolve` around task completion and report the number of fanout consumers traversed.
- Record `Drain` around successful sync-start drain staging and report the number of blocks staged by each scheduler thread.
- Split sync-start staging into `DrainPrepare` and `DrainPublish` records with published-subtask counts.
- Record deferred `Release` work on the no-progress flush path, matching the A2/A3 emission point.
- Return the fanout traversal count from the non-profiling `on_task_complete()` path.
- Keep deferred-release loops inline so the A5 scheduler remains structurally aligned with A2/A3.

## Tests and documentation

- Extend the existing A5 chip-swimlane scene to require positive `Resolve` and `Release` work.
- Add a global sync-start drain scene that checks `Drain`, `DrainPrepare`, and `DrainPublish` all report consistent, non-zero workload counts.
- Keep the fanout-count wiring test for both profiling and non-profiling signatures.
- Document the drain phase taxonomy, scheduler-lane nesting, and `tasks_processed` semantics.

## Verification

- A5SIM chip-swimlane DFX suite: 4 passed.
- A5SIM drain scene without profiling: 1 passed.
- Repository pre-commit checks passed.
- A local A5 onboard attempt was blocked before scene execution because the environment could not resolve the driver `halResMap` symbol; the PR CI hardware lane provides the authoritative onboard result.

## Relation

Related to #1582.
