### PR TITLE
Fix: release prepared collectors and keep arming failures safe

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -250,7 +250,7 @@ int DeviceRunner::prepare_execution(
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
-        cleanup_execution(*execution, /*launched=*/false, /*retire_aicore=*/false);
+        cleanup_execution(*execution, /*retire_aicore=*/false);
     });
     if (!run_stream_slots_.ready(selected_pipeline_slot)) {
         LOG_ERROR("run stream set %u was not provisioned during native prepare", selected_pipeline_slot);
@@ -471,7 +471,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     PreparedExecution &prepared = *active.prepared;
     const uint32_t pipeline_slot = prepared.pipeline_slot;
     auto drain_cleanup = RAIIScopeGuard([this, &prepared]() {
-        cleanup_execution(prepared, /*launched=*/true, /*retire_aicore=*/true);
+        cleanup_execution(prepared, /*retire_aicore=*/true);
     });
 
     int rc = reap_run(pipeline_slot);
@@ -493,12 +493,12 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     return 0;
 }
 
-void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched, bool retire_aicore) noexcept {
+void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool retire_aicore) noexcept {
     if (!prepared.resources_owned) return;
 
     // Collectors must stop before their backing arguments are released; the
     // per-run stream retires last. Each cleanup operation is idempotent.
-    if (launched) finalize_collectors();
+    finalize_collectors();
     (void)prepared.kernel_args.finalize_device_kernel_args();
     (void)prepared.kernel_args.finalize_runtime_args();
     if (prepared.kernel_args.args.pmu_reg_addrs != 0) {
@@ -517,7 +517,7 @@ void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched,
 }
 
 void DeviceRunner::abandon_prepared_execution(PreparedExecution &prepared) noexcept {
-    cleanup_execution(prepared, /*launched=*/false, /*retire_aicore=*/true);
+    cleanup_execution(prepared, /*retire_aicore=*/true);
 }
 
 int DeviceRunner::ensure_run_stream_set(unsigned slot) {
@@ -582,46 +582,54 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
     LaunchTransactionResult result = exact_launch_transaction(
         prepared.identity, std::move(permit),
         [&]() {
-            activate_launch_shape(runtime);
-            (void)arm_device_wall_buffer(prepared.kernel_args);
-            start_shared_collectors_for_run();
-            if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
-                auto thread_factory = [this](std::function<void()> fn) {
-                    return create_thread(std::move(fn));
-                };
-                dep_gen_collector_.start(thread_factory);
-            }
-            if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
-                std::vector<CoreType> core_types(num_aicore);
-                for (int i = 0; i < num_aicore; i++)
-                    core_types[i] = runtime.get_workers()[i].core_type;
-                chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
-            }
-            int rc = run_stream_slots_.mark_submitted(slot);
-            if (rc != 0) {
-                LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
-                return rc;
-            }
+            // Arming precedes any execution-visible submission, so its failures —
+            // including a thread-spawn or allocation throw — are reported as an rc
+            // and leave the run safely rollback-able.
+            try {
+                activate_launch_shape(runtime);
+                (void)arm_device_wall_buffer(prepared.kernel_args);
+                start_shared_collectors_for_run();
+                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                    auto thread_factory = [this](std::function<void()> fn) {
+                        return create_thread(std::move(fn));
+                    };
+                    dep_gen_collector_.start(thread_factory);
+                }
+                if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
+                    std::vector<CoreType> core_types(num_aicore);
+                    for (int i = 0; i < num_aicore; i++)
+                        core_types[i] = runtime.get_workers()[i].core_type;
+                    chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
+                }
+                int rc = run_stream_slots_.mark_submitted(slot);
+                if (rc != 0) {
+                    LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
+                    return rc;
+                }
 
-            // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
-            // so the two arches stay symmetric. First-launch latency optimization +
-            // op-timeout-family defense-in-depth: with the AICPU Run task launched first
-            // it occupies the device (spinning in the handshake), and the first AICore
-            // launch — which lazily loads the kernel binary onto the device inside
-            // rtKernelLaunchWithHandleV2 — is slow; launching AICore first does that load
-            // on an idle device. The handshake is launch-order-independent. The ~1.4 s
-            // slow-launch / 207001 wedge was measured on a5; this mirror is UNVERIFIED on
-            // a2a3 silicon (the dev box is a5-only), relying on CI. See
-            // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
-            // The AICore publishes aicore_done on launch (gated by nothing), and the
-            // workers region persists across runs in the pooled arena. Clearing each
-            // worker's aicore_done before the AICore kernel launches keeps the AICPU's
-            // handshake sweep from reading a prior run's report — which would open a
-            // window on that run's physical_core_id. Only aicore_done needs clearing; the
-            // AICore overwrites physical_core_id/core_type in the same report.
-            Handshake *workers = runtime.get_workers();
-            for (int i = 0; i < num_aicore; i++)
-                workers[i].aicore_done = 0;
+                // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
+                // so the two arches stay symmetric. First-launch latency optimization +
+                // op-timeout-family defense-in-depth: with the AICPU Run task launched first
+                // it occupies the device (spinning in the handshake), and the first AICore
+                // launch — which lazily loads the kernel binary onto the device inside
+                // rtKernelLaunchWithHandleV2 — is slow; launching AICore first does that load
+                // on an idle device. The handshake is launch-order-independent. The ~1.4 s
+                // slow-launch / 207001 wedge was measured on a5; this mirror is UNVERIFIED on
+                // a2a3 silicon (the dev box is a5-only), relying on CI. See
+                // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
+                // The AICore publishes aicore_done on launch (gated by nothing), and the
+                // workers region persists across runs in the pooled arena. Clearing each
+                // worker's aicore_done before the AICore kernel launches keeps the AICPU's
+                // handshake sweep from reading a prior run's report — which would open a
+                // window on that run's physical_core_id. Only aicore_done needs clearing; the
+                // AICore overwrites physical_core_id/core_type in the same report.
+                Handshake *workers = runtime.get_workers();
+                for (int i = 0; i < num_aicore; i++)
+                    workers[i].aicore_done = 0;
+            } catch (...) {
+                LOG_ERROR("launch_run: arming failed before any stream submission");
+                return -1;
+            }
 
             LOG_INFO("=== launch_aicore_kernel ===");
             int launch_rc = launch_aicore_kernel(streams.aicore, prepared.kernel_args.device_k_args_);

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -253,9 +253,11 @@ private:
     int destroy_run_stream_sets();
 
     // Release execution-owned resources in collector, runtime-argument,
-    // register-buffer, then stream order. Prepared-only cleanup must not touch
-    // collector state owned by an active predecessor.
-    void cleanup_execution(PreparedExecution &prepared, bool launched, bool retire_aicore) noexcept;
+    // register-buffer, then stream order. The collectors this releases were
+    // initialized by prepare_execution() for this run alone; an overlapping
+    // predecessor cannot own any, because a prepared successor is admitted only
+    // when both runs declare no diagnostics.
+    void cleanup_execution(PreparedExecution &prepared, bool retire_aicore) noexcept;
 
     // The kernel submission boundary is separate from the stream wait and
     // post-run teardown: launch_run() submits and drain_execution() reaps.

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -526,36 +526,46 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
     LaunchTransactionResult result = exact_launch_transaction(
         prepared->identity, std::move(permit),
         [&]() {
-            set_platform_regs_func_(kernel_args_.regs);
-            if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
-            set_platform_dump_base_func_(kernel_args_.dump_data_base);
-            set_dump_args_enabled_func_(enable_dump_args_);
-            set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
-            set_platform_chip_swimlane_aicore_rotation_table_func_(kernel_args_.chip_swimlane_aicore_rotation_table);
-            set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
-            set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
-            set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);
-            set_pmu_enabled_func_(enable_pmu_);
-            set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
-            set_dep_gen_enabled_func_(enable_dep_gen_ && !dep_gen_host_graph_active());
-            set_scope_stats_enabled_func_(enable_scope_stats_);
-            set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
+            // Arming precedes any simulated-core thread, so its failures — including
+            // a thread-spawn or allocation throw — are reported as an rc and leave
+            // the run safely rollback-able.
+            try {
+                set_platform_regs_func_(kernel_args_.regs);
+                if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
+                set_platform_dump_base_func_(kernel_args_.dump_data_base);
+                set_dump_args_enabled_func_(enable_dump_args_);
+                set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
+                set_platform_chip_swimlane_aicore_rotation_table_func_(
+                    kernel_args_.chip_swimlane_aicore_rotation_table
+                );
+                set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
+                set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+                set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);
+                set_pmu_enabled_func_(enable_pmu_);
+                set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
+                set_dep_gen_enabled_func_(enable_dep_gen_ && !dep_gen_host_graph_active());
+                set_scope_stats_enabled_func_(enable_scope_stats_);
+                set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-            auto thread_factory = [this](std::function<void()> fn) {
-                return create_thread(std::move(fn));
-            };
-            if (enable_chip_swimlane_) chip_swimlane_collector_.start(thread_factory);
-            if (enable_dump_args_) dump_collector_.start(thread_factory);
-            if (enable_pmu_) pmu_collector_.start(thread_factory);
-            if (enable_dep_gen_ && !dep_gen_host_graph_active()) dep_gen_collector_.start(thread_factory);
-            if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
+                auto thread_factory = [this](std::function<void()> fn) {
+                    return create_thread(std::move(fn));
+                };
+                if (enable_chip_swimlane_) chip_swimlane_collector_.start(thread_factory);
+                if (enable_dump_args_) dump_collector_.start(thread_factory);
+                if (enable_pmu_) pmu_collector_.start(thread_factory);
+                if (enable_dep_gen_ && !dep_gen_host_graph_active()) dep_gen_collector_.start(thread_factory);
+                if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
 
-            if (kernel_args_.device_wall_data_base != 0) {
-                *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
+                if (kernel_args_.device_wall_data_base != 0) {
+                    *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
+                }
+                set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
+                sim_t0 = std::chrono::steady_clock::now();
+                run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
+            } catch (...) {
+                LOG_ERROR("launch_execution: arming failed before any simulated core started");
+                return -1;
             }
-            set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
-            sim_t0 = std::chrono::steady_clock::now();
-            run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
 
             LOG_INFO("Launching %d AICore thread(s)", num_aicore);
             for (int i = 0; i < num_aicore; i++) {

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -335,50 +335,58 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
     LaunchTransactionResult transaction = exact_launch_transaction(
         prepared->identity, std::move(permit),
         [&]() {
-            activate_launch_shape(runtime);
-            (void)arm_device_wall_buffer(prepared->kernel_args);
+            // Arming precedes any execution-visible submission, so its failures —
+            // including a thread-spawn or allocation throw — are reported as an rc
+            // and leave the run safely rollback-able.
+            try {
+                activate_launch_shape(runtime);
+                (void)arm_device_wall_buffer(prepared->kernel_args);
+                start_shared_collectors_for_run();
+                if (enable_dep_gen_) {
+                    auto thread_factory = [this](std::function<void()> fn) {
+                        return create_thread(std::move(fn));
+                    };
+                    dep_gen_collector_.start(thread_factory);
+                }
+                if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
+                    std::vector<CoreType> core_types(num_aicore);
+                    for (int i = 0; i < num_aicore; i++)
+                        core_types[i] = runtime.get_workers()[i].core_type;
+                    chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
+                }
+
+                // Launch the AICore worker BEFORE the AICPU Run task. This is a first-launch
+                // latency optimization, not a correctness requirement (the handshake is
+                // launch-order-independent). When the AICPU Run task is launched first it
+                // immediately occupies the device (spinning in handshake_all_cores), and the
+                // first AICore launch — which lazily loads the kernel binary onto the device
+                // inside rtKernelLaunchWithHandleV2 — then takes ~1.4 s instead of ~0.4 ms
+                // (measured a5; the exact device-side contention is not pinned, see the
+                // investigation doc). Submitting the AICore first does that load on an idle
+                // device, then the AICPU spins and finds the AICore already up.
+                //
+                // Defense-in-depth for the op-timeout family (#1019): that ~1.4 s slow launch
+                // is what trips the op-execute timeout when it is tight. #1035 widened the
+                // timeout 1 s -> 3 s so the slow launch no longer wedges, but this ordering
+                // removes the slow launch itself, so the wedge cannot return if the timeout
+                // is ever tightened or a slower device pushes the launch past it. See
+                // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
+                // The AICore publishes aicore_done on launch (gated by nothing), and the
+                // workers region persists across runs in the pooled arena. Clearing each
+                // worker's aicore_done before the AICore kernel launches keeps the AICPU's
+                // handshake sweep from reading a prior run's report — which would open a
+                // window on that run's physical_core_id. Only aicore_done needs clearing; the
+                // AICore overwrites physical_core_id/core_type in the same report.
+                Handshake *workers = runtime.get_workers();
+                for (int i = 0; i < num_aicore; i++)
+                    workers[i].aicore_done = 0;
+            } catch (...) {
+                LOG_ERROR("launch_execution: arming failed before any stream submission");
+                return -1;
+            }
+
             run_poll_slot_.store(prepared->pipeline_slot, std::memory_order_relaxed);
             run_poll_state_.store(RunPollState::Enqueuing, std::memory_order_release);
-            start_shared_collectors_for_run();
-            if (enable_dep_gen_) {
-                auto thread_factory = [this](std::function<void()> fn) {
-                    return create_thread(std::move(fn));
-                };
-                dep_gen_collector_.start(thread_factory);
-            }
-            if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
-                std::vector<CoreType> core_types(num_aicore);
-                for (int i = 0; i < num_aicore; i++)
-                    core_types[i] = runtime.get_workers()[i].core_type;
-                chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
-            }
-
-            // Launch the AICore worker BEFORE the AICPU Run task. This is a first-launch
-            // latency optimization, not a correctness requirement (the handshake is
-            // launch-order-independent). When the AICPU Run task is launched first it
-            // immediately occupies the device (spinning in handshake_all_cores), and the
-            // first AICore launch — which lazily loads the kernel binary onto the device
-            // inside rtKernelLaunchWithHandleV2 — then takes ~1.4 s instead of ~0.4 ms
-            // (measured a5; the exact device-side contention is not pinned, see the
-            // investigation doc). Submitting the AICore first does that load on an idle
-            // device, then the AICPU spins and finds the AICore already up.
-            //
-            // Defense-in-depth for the op-timeout family (#1019): that ~1.4 s slow launch
-            // is what trips the op-execute timeout when it is tight. #1035 widened the
-            // timeout 1 s -> 3 s so the slow launch no longer wedges, but this ordering
-            // removes the slow launch itself, so the wedge cannot return if the timeout
-            // is ever tightened or a slower device pushes the launch past it. See
-            // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
-            // The AICore publishes aicore_done on launch (gated by nothing), and the
-            // workers region persists across runs in the pooled arena. Clearing each
-            // worker's aicore_done before the AICore kernel launches keeps the AICPU's
-            // handshake sweep from reading a prior run's report — which would open a
-            // window on that run's physical_core_id. Only aicore_done needs clearing; the
-            // AICore overwrites physical_core_id/core_type in the same report.
-            Handshake *workers = runtime.get_workers();
-            for (int i = 0; i < num_aicore; i++)
-                workers[i].aicore_done = 0;
-
             LOG_INFO("=== launch_aicore_kernel ===");
             run_poll_state_.store(RunPollState::Submitted, std::memory_order_release);
             int launch_rc = launch_aicore_kernel(stream_aicore_, prepared->kernel_args.device_k_args_);
@@ -494,7 +502,7 @@ void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched)
     if (!prepared.resources_owned) return;
 
     // Collectors stop before device/runtime arguments and register buffers.
-    if (launched) finalize_collectors();
+    finalize_collectors();
     (void)prepared.kernel_args.finalize_device_kernel_args();
     (void)prepared.kernel_args.finalize_runtime_args();
     if (prepared.kernel_args.args.regs != 0) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -212,8 +212,11 @@ private:
     std::atomic<RunPollState> run_poll_state_{RunPollState::Idle};
     std::atomic<uint32_t> run_poll_slot_{PTO_PIPELINE_MAX_DEPTH};
 
-    // Release execution-owned per-run resources and publish a sticky terminal
-    // state. Idempotent so enqueue rollback and drain share one path.
+    // Release execution-owned per-run resources. Idempotent so prepare rollback
+    // and drain share one path. `launched` publishes the sticky terminal poll
+    // state, which only a run that reached the streams may claim; the collectors
+    // are released either way, since prepare_execution() initialized them for
+    // this run alone.
     void cleanup_execution(PreparedExecution &prepared, bool launched) noexcept;
 
     // On an AICore launch/sync error, best-effort drain the device so a later

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -452,35 +452,45 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
     LaunchTransactionResult result = exact_launch_transaction(
         prepared->identity, std::move(permit),
         [&]() {
-            set_platform_regs_func_(kernel_args_.regs);
-            if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
-            set_platform_dump_base_func_(kernel_args_.dump_data_base);
-            set_dump_args_enabled_func_(enable_dump_args_);
-            set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
-            set_platform_chip_swimlane_aicore_rotation_table_func_(kernel_args_.chip_swimlane_aicore_rotation_table);
-            set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
-            set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
-            set_pmu_enabled_func_(enable_pmu_);
-            set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
-            set_dep_gen_enabled_func_(enable_dep_gen_);
-            set_scope_stats_enabled_func_(enable_scope_stats_);
-            set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
+            // Arming precedes any simulated-core thread, so its failures — including
+            // a thread-spawn or allocation throw — are reported as an rc and leave
+            // the run safely rollback-able.
+            try {
+                set_platform_regs_func_(kernel_args_.regs);
+                if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
+                set_platform_dump_base_func_(kernel_args_.dump_data_base);
+                set_dump_args_enabled_func_(enable_dump_args_);
+                set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
+                set_platform_chip_swimlane_aicore_rotation_table_func_(
+                    kernel_args_.chip_swimlane_aicore_rotation_table
+                );
+                set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
+                set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+                set_pmu_enabled_func_(enable_pmu_);
+                set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
+                set_dep_gen_enabled_func_(enable_dep_gen_);
+                set_scope_stats_enabled_func_(enable_scope_stats_);
+                set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-            auto thread_factory = [this](std::function<void()> fn) {
-                return create_thread(std::move(fn));
-            };
-            if (enable_chip_swimlane_) chip_swimlane_collector_.start(thread_factory);
-            if (enable_dump_args_) dump_collector_.start(thread_factory);
-            if (enable_pmu_) pmu_collector_.start(thread_factory);
-            if (enable_dep_gen_) dep_gen_collector_.start(thread_factory);
-            if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
+                auto thread_factory = [this](std::function<void()> fn) {
+                    return create_thread(std::move(fn));
+                };
+                if (enable_chip_swimlane_) chip_swimlane_collector_.start(thread_factory);
+                if (enable_dump_args_) dump_collector_.start(thread_factory);
+                if (enable_pmu_) pmu_collector_.start(thread_factory);
+                if (enable_dep_gen_) dep_gen_collector_.start(thread_factory);
+                if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
 
-            if (kernel_args_.device_wall_data_base != 0) {
-                *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
+                if (kernel_args_.device_wall_data_base != 0) {
+                    *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
+                }
+                set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
+                sim_t0 = std::chrono::steady_clock::now();
+                run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
+            } catch (...) {
+                LOG_ERROR("launch_execution: arming failed before any simulated core started");
+                return -1;
             }
-            set_platform_phase_base_func_(reinterpret_cast<uint64_t>(run->phase_buf.data()));
-            sim_t0 = std::chrono::steady_clock::now();
-            run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
 
             LOG_INFO("Launching %d AICore thread(s)", num_aicore);
             for (int i = 0; i < num_aicore; i++) {

--- a/src/common/worker/native_run_execution.h
+++ b/src/common/worker/native_run_execution.h
@@ -123,6 +123,21 @@ struct LaunchTransactionResult {
     bool poisoned() const { return progress == LaunchProgress::Partial; }
 };
 
+/**
+ * The exact two-submission launch transaction.
+ *
+ * Consumes an identity-bound permit, then submits AICore and AICPU in that
+ * order. Only both submissions succeeding produces a `LaunchReceipt`.
+ *
+ * Callback contract: a submit callback owns everything it does before it
+ * attempts its real device submission, and must report such a failure as a
+ * non-zero return rather than an exception. An escaping exception is therefore
+ * evidence that the submission itself was attempted, and the run is classified
+ * `Partial` — uncertain execution, which retains resources and poisons
+ * admission. Returning non-zero from `submit_aicore` is by contrast a failure
+ * before any execution-visible submission, so it stays `NotStarted` and is safe
+ * to roll back.
+ */
 template <typename AicoreSubmit, typename AicpuSubmit>
 struct ExactLaunchTransaction {
     static LaunchTransactionResult
@@ -135,8 +150,6 @@ struct ExactLaunchTransaction {
             result.rc = std::forward<AicoreSubmit>(submit_aicore)();
         } catch (...) {
             result.rc = -1;
-            // Submission callbacks may throw after starting work. Without a
-            // receipt, the caller must retain resources and poison admission.
             result.progress = LaunchProgress::Partial;
             return result;
         }

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -74,7 +74,9 @@ class TestNativeRunLifecycle(SceneTestCase):
 
         spans = list(parse_spans(capfd.readouterr().err.splitlines()))
         invocations = [inv for inv in group_invocations(spans) if "simpler_run" in inv.by_name()]
-        expected_invocations = 3 if st_platform.endswith("sim") else 7
+        # Two of these are the abandoned diagnostic prepares below, which record a
+        # simpler_run invocation without ever reaching simpler_run.runner_run.
+        expected_invocations = 5 if st_platform.endswith("sim") else 9
         assert len(invocations) == expected_invocations
 
         common_depths = {
@@ -165,6 +167,23 @@ class TestNativeRunLifecycle(SceneTestCase):
             assert torch.count_nonzero(test_args.out) == 0
             chip_worker._unregister_slot(_SLOT)
             chip_worker._register_callable_at_slot(_SLOT, callable_obj)
+
+            # Prepare initializes this run's diagnostics collectors, so abandoning
+            # it must release them. Each collector refuses a second initialize()
+            # while its shared memory is still mapped, so a collector retained by
+            # an abandoned run makes the next prepare on this runner fail.
+            with tempfile.TemporaryDirectory(prefix="simpler-abandon-diagnostics-") as abandon_dir:
+                abandon_config = self._build_config(case["config"])
+                abandon_config.enable_scope_stats = True
+                abandon_config.output_prefix = abandon_dir
+                abandon_args = self.generate_args(case["params"])
+                abandon_chip_args, _ = _build_chip_task_args(abandon_args, self.CALLABLE["orchestration"]["signature"])
+                for _ in range(2):
+                    abandoned = chip_worker._prepare_native_run_with_pipeline_lease(
+                        _SLOT, abandon_chip_args, _SLOT, _GENERATION, config=abandon_config
+                    )
+                    chip_worker._finalize_native_run(abandoned)
+                assert torch.count_nonzero(abandon_args.out) == 0
 
             test_args = self.generate_args(case["params"])
             chip_args, output_names = _build_chip_task_args(test_args, self.CALLABLE["orchestration"]["signature"])

--- a/tests/ut/cpp/common/test_native_run_execution.cpp
+++ b/tests/ut/cpp/common/test_native_run_execution.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <new>
 #include <type_traits>
 #include <utility>
 
@@ -66,6 +67,32 @@ TEST(NativeRunExecutionTest, AicoreFailureIsSafePrelaunchFailure) {
     EXPECT_EQ(result.progress, LaunchProgress::NotStarted);
     EXPECT_EQ(aicpu_submissions, 0);
     EXPECT_FALSE(result.poisoned());
+}
+
+TEST(NativeRunExecutionTest, ArmingFailureReportedAsRcStaysSafe) {
+    int aicpu_submissions = 0;
+    LaunchTransactionResult result = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        [&]() -> int {
+            // The shape every real submit callback uses: the arming prologue
+            // catches its own throws and reports them as an rc, so the failure
+            // stays on the safe side of the first submission.
+            try {
+                throw std::bad_alloc();
+            } catch (...) {
+                return -1;
+            }
+        },
+        [&]() {
+            ++aicpu_submissions;
+            return 0;
+        }
+    );
+
+    EXPECT_EQ(result.rc, -1);
+    EXPECT_EQ(result.progress, LaunchProgress::NotStarted);
+    EXPECT_FALSE(result.poisoned());
+    EXPECT_EQ(aicpu_submissions, 0);
 }
 
 TEST(NativeRunExecutionTest, AicoreExceptionPoisonsWithoutTryingAicpu) {


### PR DESCRIPTION
## Summary

Follow-up to #1700, fixing two defects in the launch seam it introduced.

**Prepared collectors were never released unless the run launched.** A prepared
execution initializes its diagnostics collectors during native prepare, but
`cleanup_execution()` gated `finalize_collectors()` on a `launched` flag that
`abandon_prepared_execution()` and the prepare rollback both pass as false. Three
reachable paths leaked as a result:

- prepare fails after one or more `init_*` succeeded;
- the run is prepared but never launched (finalize without launch, or the
  `!entered_run` abandon after an `attach_current_thread` failure);
- launch returns `NotStarted` after the AICore closure already started the
  collectors — `mark_submitted` failure, or `launch_aicore_kernel` failure, i.e.
  the 207001 path this file carries a recovery routine for. Here the mgmt/poll
  **threads are already running** and nothing stops them.

Each leaked the collector's shared memory and its host registration, and left
`is_initialized()` set — and every collector refuses a second `initialize()` while
its shm is still mapped (`return -1`), so a leaked collector makes the *next*
prepare on that runner fail outright.

The gate was guarding against a state that cannot occur: an overlapping
predecessor can own no collector, because `try_reserve_native_run` admits a
prepared successor only when the successor declares no diagnostics *and* the
predecessor's own `permits_prepared_successor` says the same. With no overlap
possible, every `finalize_collectors()` branch is already `is_initialized()`-guarded
and is a no-op in exactly the case the gate was protecting. Released on every path
now. a5 keeps the flag for the sticky terminal poll state, which only a launched
run may publish.

**An arming failure poisoned the device.** `ExactLaunchTransaction` classified any
exception escaping the AICore step as an uncertain partial launch. But that step
arms the run before it submits — latching launch shape, resetting the device-wall
buffer, starting collectors, publishing stream ownership, and on sim the whole
dlsym'd setter block — so a `std::bad_alloc` from the `core_types` vector or a
`std::system_error` from `create_thread` marked the device unusable and forced a
reset at finalize, with no stream ever touched. `contracts.md`: *"Failure before the
first stream submission is `FAILED_SAFE`."*

Each submit callback now catches its own arming failures and returns non-zero, so
the transaction's exception path means what the contract says: the submission
itself was attempted and the outcome is uncertain. The callback contract is stated
on `ExactLaunchTransaction`.

## Testing

**Regression barrier for the collector leak** — `test_native_run_lifecycle.py` gains
a diagnostics-enabled prepare → finalize-without-launch → prepare cycle. The leak is
**onboard-only** (sim's `abandon_prepared_execution` already released collectives
unconditionally via `cleanup_active_run()`), so it was verified on a2a3 silicon both
ways:

- with the `launched` gate restored byte-for-byte, on devices 3,5 —
  **fails**, with exactly the error the leak causes:
  ```
  ERROR init: [scope_stats_collector.cpp:62] ScopeStatsCollector already initialized
  ERROR prepare_execution: [device_runner.cpp:425] init_scope_stats failed: -1
  RuntimeError: prepare_native_run failed with code -1 (... run_epoch=4)
  ```
- with the fix — **passes**.

The test's STRACE invocation counts move 3→5 (sim) and 7→9 (onboard); the two extra
invocations are the abandoned prepares, which never reach `simpler_run.runner_run`,
so `launched_count` is unchanged.

**The arming-classification fix ships without a regression test.** The
`ArmingFailureReportedAsRcStaysSafe` case added here documents the callback contract,
but it passes against the pre-fix code too — the `if (result.rc != 0) return result;`
early return predates this change — so it is not a barrier. Guarding it would mean
injecting an allocation or thread-spawn failure into the production closures, which
has no hook today. Flagging rather than implying coverage.

Other evidence, all on the current head:

- [x] C++ unit tests — 89/89 pass
- [x] Simulation — `a2a3sim` and `a5sim` scene suites exit 0
- [x] Hardware — a2a3 onboard suite via `task-submit` on free devices, exit 0

An earlier onboard run on `--device auto` reported three `507018`s; all were at
`LoadAicpuOp::BootstrapDispatcher` inside `simpler_init`, before any run is prepared
or launched, and all on device 1, which `task-submit --list` showed held by another
user's live task. Re-running pinned to free devices is the green result above.
