### PR TITLE
Refactor: converge A2A3 and A5 TMR internals

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -78,7 +78,7 @@ extern "C" void framework_bind_runtime(PTO2Runtime *rt);
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
 
-static int32_t read_pto2_runtime_status(Runtime *runtime) {
+static int32_t read_runtime_status(Runtime *runtime) {
     if (runtime == nullptr) {
         return 0;
     }
@@ -505,7 +505,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         uint64_t orch_cycle_start = 0;
 #endif
 #if SIMPLER_ORCH_PROFILING
-        int32_t pto2_submitted_tasks = -1;
+        int32_t submitted_tasks = -1;
 #endif
         // Orchestrator thread: load + run the device orchestration SO. The braces
         // scope the per-callable dlopen / SO-table locals to this block.
@@ -803,7 +803,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if SIMPLER_ORCH_PROFILING
-            pto2_submitted_tasks = total_tasks;
+            submitted_tasks = total_tasks;
 #endif
 
             // Signal completion to the orchestrator state machine
@@ -823,9 +823,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             static_cast<uint64_t>(orch_cycle_start), static_cast<uint64_t>(orch_end_ts),
             cycles_to_us(orch_end_ts - orch_cycle_start)
         );
-        if (pto2_submitted_tasks >= 0) {
+        if (submitted_tasks >= 0) {
             LOG_INFO(
-                "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
+                "PTO2 total submitted tasks = %d, already executed %d tasks", submitted_tasks,
                 sched_ctx_.completed_tasks_count()
             );
         }
@@ -1012,9 +1012,9 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     // threads are still draining) open the window at its early exit, so the
     // cross-thread max(end)-min(start) reduction would absorb the orch-waits-for-
     // sched overlap into post_orch — inflating it well past the actual teardown.
-    // read_pto2_runtime_status is two atomic loads every thread needs, so it
+    // read_runtime_status is two atomic loads every thread needs, so it
     // stays outside the scope.
-    int32_t runtime_rc = read_pto2_runtime_status(runtime);
+    int32_t runtime_rc = read_runtime_status(runtime);
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         AicpuPhaseScope post_orch(AicpuPhase::PostOrch);
         LOG_INFO("aicpu_execute: Last thread finished, cleaning up");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -71,7 +71,7 @@ Each sub-level macro requires `SIMPLER_DFX=1`:
 
 **What's compiled:**
 
-- Base timing counters for the scheduler loop (`sched_complete/dispatch/idle/scan`)
+- Base timing counters for the scheduler loop (`sched_complete/dispatch/idle`)
 - Host-side phase windows: each sched/orch thread publishes its
   start/end window via `aicpu_phase_set_window`, which the host reduces
   into the `Orch` / `Sched` `[STRACE]` markers
@@ -111,7 +111,7 @@ Each sub-level macro requires `SIMPLER_DFX=1`:
 
 - All Level 1 features
 - Detailed scheduler phase counters
-- Phase-specific statistics (complete, scan, dispatch, idle)
+- Phase-specific statistics (complete, dispatch, idle)
 - Hit rate tracking (complete poll, ready queue pop)
 
 **Log output (per scheduler thread, normal run):** the `sched_start/sched_end/
@@ -135,7 +135,6 @@ Thread X:   dispatch       : XXXus (XX.X%)
 Thread X:     poll         : XXXus (XX.X%)
 Thread X:     pop          : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     setup        : XXXus (XX.X%)
-Thread X:   scan           : XXXus (XX.X%)
 Thread X:   idle           : XXXus (XX.X%)
 Thread X:   avg/complete   : XXXus
 Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -357,7 +357,8 @@ private:
 #define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
 
-#define PTO2_SCOPE_GUARD() [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)
+#define PTO2_SCOPE_GUARD(...) \
+    [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__) { __VA_ARGS__ }
 
 /**
  * Scoped block macro:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -25,8 +25,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef PTO_ORCHESTRATOR_H
-#define PTO_ORCHESTRATOR_H
+#pragma once
 
 #include "common/chip_swimlane_profiling.h"
 #include "utils/device_arena.h"
@@ -139,7 +138,7 @@ struct PTO2OrchestratorState {
     // Phase 1: declare every sub-region (per-ring fanin pool, scope arrays,
     // tensor_map sub-layout) on the supplied arena. task_window_sizes feeds
     // the nested tensor_map layout. Returned layout is consumed by
-    // init_from_layout.
+    // init_data_from_layout.
     static PTO2OrchestratorLayout reserve_layout(
         DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
@@ -211,5 +210,3 @@ struct PTO2OrchProfilingData {
 
 PTO2OrchProfilingData orchestrator_get_profiling();
 #endif
-
-#endif  // PTO_ORCHESTRATOR_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -67,7 +67,7 @@ struct Segment {
 
 /**
  * Layout descriptor produced by PTO2TensorMap::reserve_layout(). Stores the
- * region offsets returned by DeviceArena::reserve() so init_from_layout()
+ * region offsets returned by DeviceArena::reserve() so init_data_from_layout()
  * can fetch the matching pointers after the arena is committed.
  *
  * All offsets are relative to the arena's base.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -22,8 +22,7 @@
  * without type conflicts (Handshake, TensorLease, HostApi).
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_
+#pragma once
 
 #include <stdint.h>
 #include <string.h>
@@ -133,8 +132,6 @@ private:
     // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
     const ChipTensor *tensors_[MAX_TENSOR_ARGS];
 };
-
-using TaskSubmitResult = TaskOutputTensors;
 
 // =============================================================================
 // Argument Types (for pto_submit_task API)
@@ -663,5 +660,3 @@ struct ChipTaskArgs : Arg<CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS> {
         }
     }
 };
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -385,8 +385,8 @@ struct alignas(64) PTO2ReadyQueue {
 // as non-member so PTO2ReadyQueue stays a POD-like struct with cache-line
 // alignment. Storage is owned by the caller-supplied arena.
 //   reserve_layout: declare the slots[] region on the arena (must precede commit)
-//   init_from_layout: bind slots pointer from arena.region_ptr(off) and
-//                     initialize sequence counters
+//   init_data_from_layout: initialize sequence counters and queue metadata
+//   wire_arena_pointers: bind slots pointer from arena.region_ptr(off)
 //   destroy: forget the slots pointer (arena owns the buffer)
 size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity);
 // Writes everything *except* the arena-internal `slots` pointer field
@@ -412,7 +412,7 @@ struct CompletionStats {
 /**
  * Layout descriptor produced by PTO2SchedulerState::reserve_layout(). Holds
  * the arena offsets of every sub-region the scheduler needs plus the
- * capacities used at layout time (init_from_layout reuses them).
+ * capacities used at layout time (init_data_from_layout reuses them).
  */
 struct PTO2SchedulerLayout {
     size_t off_ready_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
@@ -1352,10 +1352,6 @@ struct PTO2SchedulerState {
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
     static PTO2SchedulerLayout
     reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
-    static PTO2SchedulerLayout reserve_layout(
-        DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH],
-        const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]
-    );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -121,28 +121,14 @@ void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
 
 PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity) {
     int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         dep_pool_capacities[r] = dep_pool_capacity;
-        task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
     }
-    return reserve_layout(arena, dep_pool_capacities, task_window_sizes);
+    return reserve_layout(arena, dep_pool_capacities);
 }
 
 PTO2SchedulerLayout
 PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]) {
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
-    }
-    return reserve_layout(arena, dep_pool_capacities, task_window_sizes);
-}
-
-PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(
-    DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH],
-    const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]
-) {
-    (void)task_window_sizes;
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -552,7 +538,7 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         task_window_sizes_i32[r] = static_cast<int32_t>(task_window_sizes[r]);
     }
     layout.offsets.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
-    layout.offsets.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacities, task_window_sizes_i32);
+    layout.offsets.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacities);
     layout.offsets.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
     layout.offsets.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -31,7 +31,7 @@ task_id.raw = (ring_id << 32) | local_id
 
 | API | Purpose |
 | --- | ------- |
-| `pto2_make_task_id(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
+| `PTO2TaskId::make(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
 | `task_id.ring()` | Extract `ring_id` (bits 63-32) |
 | `task_id.local()` | Extract `local_id` (bits 31-0) |
 | `task_id.raw` | Access the packed 64-bit encoding |

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -97,12 +97,16 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 TRB bind normally allocates one device buffer per ordinary non-child tensor
 during host-side argument staging, copies input bytes as needed, records
 copy-back metadata, and frees those temporary buffers during runtime
-validation. TRB replaces those per-run malloc/free pairs with a single
-retained buffer, owned per pipeline slot, that its runs reuse. This is always on for
-TRB — an internal allocation optimization, not user-facing configuration.
+validation. TRB replaces those per-run malloc/free pairs with a retained buffer
+that its runs reuse. This is always on for TRB — an internal allocation
+optimization, not user-facing configuration.
+
+The buffer is owned per pipeline slot, not per runner: TRB's task args are
+`HOST_PER_RUN`, so two runs holding different slot leases stage through
+different buffers even though they share arena bank 0 for device scratch.
 
 The platform side is deliberately thin: `DeviceRunnerBase` only remembers a
-`{addr, size}` slot across runs, exposed through two HostApi callbacks —
+`{addr, size}` slot per pipeline slot, exposed through two HostApi callbacks —
 `get_retained_temp_buffer` and `set_retained_temp_buffer`. It is not an
 allocator; all grow/pack/slice logic lives in `runtime_maker.cpp`
 (`RetainedTempBump`).
@@ -124,8 +128,8 @@ On each trb bind, `RetainedTempBump`:
   falls back to `device_malloc` mid-run.
 
 Slices are recorded as `BufferNoop` leases: per-tensor release is a no-op, and
-the retained buffer is neither freed at end of run nor per run — it lives on
-the runner and is freed once in `finalize`. The uniform host-runtime contract
+the retained buffer is neither freed at end of run nor per run — each slot's
+buffer lives on the runner and is freed once in `finalize`. The uniform host-runtime contract
 requires the retained-buffer callbacks on every backend; bind has no
 per-tensor allocation fallback.
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -71,7 +71,7 @@ Each sub-level macro requires `SIMPLER_DFX=1`:
 
 **What's compiled:**
 
-- Base timing counters for the scheduler loop (`sched_complete/dispatch/idle/scan`)
+- Base timing counters for the scheduler loop (`sched_complete/dispatch/idle`)
 - Host-side phase windows: each sched/orch thread publishes its
   start/end window via `aicpu_phase_set_window`, which the host reduces
   into the `Orch` / `Sched` `[STRACE]` markers
@@ -111,7 +111,7 @@ Each sub-level macro requires `SIMPLER_DFX=1`:
 
 - All Level 1 features
 - Detailed scheduler phase counters
-- Phase-specific statistics (complete, scan, dispatch, idle)
+- Phase-specific statistics (complete, dispatch, idle)
 - Hit rate tracking (complete poll, ready queue pop)
 
 **Log output (per scheduler thread, normal run):** the `sched_start/sched_end/
@@ -135,7 +135,6 @@ Thread X:   dispatch       : XXXus (XX.X%)
 Thread X:     poll         : XXXus (XX.X%)
 Thread X:     pop          : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     setup        : XXXus (XX.X%)
-Thread X:   scan           : XXXus (XX.X%)
 Thread X:   idle           : XXXus (XX.X%)
 Thread X:   avg/complete   : XXXus
 Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
@@ -236,10 +235,40 @@ header just like on onboard.
 | Level | Collects |
 | ----- | -------- |
 | 0 | Nothing (disabled) |
-| 1 | AICore timing only (start/end/task_id/func_id/core_type) |
+| 1 | AICore timing only (start/end/task_token_raw) — AICPU `complete_task` is bypassed |
 | 2 | + dispatch_time, finish_time |
 | 3 | + Scheduler phases (`SCHED_*`) |
 | 4 | + Orchestrator phases (full) |
+
+At level 1 the AICore record carries the full PTO2 `task_token_raw`
+(`(ring_id << 32) | local_id`), read straight from
+`LocalContext.async_ctx.task_token.raw` inside the AICore helper —
+already in cache from the dispatch payload, so no extra GM load.
+Identity fields the AICPU side used to write at level 1 (`func_id`,
+`core_type`) are derived host-side:
+
+- `func_id` ← `deps.json`'s per-task `kernel_ids[]`, joined by
+  `task_id` at post-process by `swimlane_converter.py`. Same model
+  `fanout` already uses.
+- `core_type` ← per-core static table published by the host into the
+  collector (`ChipSwimlaneCollector::set_core_types`).
+
+AICore buffer rotation no longer piggy-backs on `complete_task`. AICPU
+counts dispatches per core in the dispatch path (scheduler_dispatch in
+tensormap_and_ringbuffer; aicpu_executor in host_build_graph) and rotates
+the AICore buffer when the count is about to cross a
+`PLATFORM_AICORE_BUFFER_SIZE` boundary — strictly before
+`write_reg(DATA_MAIN_BASE)` for the first task of the new batch. The
+hook is `chip_swimlane_aicpu_on_aicore_dispatch`. No AICore-side signal is
+needed: AICPU has full dispatch visibility on its own. Race safety comes
+from the completion-before-dispatch invariant (AICore per core is
+single-threaded and AICPU does not dispatch task K+1 until K FIN'd), which
+guarantees AICore has FIN'd — and `dcci`'d out — every record in the old
+buffer by rotation time. This decoupling is what lets level 1 skip
+`complete_task` without losing rotations.
+
+Fanout edges are no longer carried on the device hot path — `swimlane_converter.py`
+joins them from the sibling `deps.json` (produced by dep_gen) at post-process time.
 
 Bare `--enable-chip-swimlane` = level 4 (backward compatible).
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -511,19 +511,6 @@ static bool check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAll
     return false;
 }
 
-static void prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count, int32_t scalar_count) {
-    for (int32_t i = 0; i < tensor_count; i++) {
-        __builtin_prefetch(&payload->tensors[i], 1, 3);
-        __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
-    }
-    for (int32_t i = 0; i < scalar_count; i += 8) {
-        __builtin_prefetch(&payload->scalars[i], 1, 3);
-    }
-    __builtin_prefetch(payload, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char *>(payload) + 64, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char *>(payload) + 128, 1, 3);
-}
-
 static bool prepare_task(
     PTO2OrchestratorState *orch, const CoreTaskArgs &args, int32_t total_output_size, ActiveMask active_mask,
     TaskAttrs task_attrs, PTO2PreparedTask *out
@@ -560,7 +547,7 @@ static bool prepare_task(
     out->slot_state->reset_for_reuse();
     out->slot_state->fanin_count = 0;
 
-    prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
+    out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
     // Re-bind payload/task pointers each submit. Value is per-slot constant
     // (same as &task_payloads[slot] / &task_descriptors[slot]), but writing

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -22,8 +22,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
-#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -366,7 +365,7 @@ static_assert(
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
  *
  * Consolidates all hot-path scheduling fields into a single cache-friendly
- * structure (32 bytes = half a cache line). Accessing any field of a task's
+ * structure (64 bytes = one cache line). Accessing any field of a task's
  * slot state brings all related fields into the same cache line.
  *
  * Concurrency notes:
@@ -587,5 +586,3 @@ struct alignas(64) PTO2TaskSlotState {
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
-
-#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -67,7 +67,7 @@ struct Segment {
 
 /**
  * Layout descriptor produced by PTO2TensorMap::reserve_layout(). Stores the
- * region offsets returned by DeviceArena::reserve() so init_from_layout()
+ * region offsets returned by DeviceArena::reserve() so init_data_from_layout()
  * can fetch the matching pointers after the arena is committed.
  *
  * All offsets are relative to the arena's base.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -386,8 +386,8 @@ struct alignas(64) PTO2ReadyQueue {
 // as non-member so PTO2ReadyQueue stays a POD-like struct with cache-line
 // alignment. Storage is owned by the caller-supplied arena.
 //   reserve_layout: declare the slots[] region on the arena (must precede commit)
-//   init_from_layout: bind slots pointer from arena.region_ptr(off) and
-//                     initialize sequence counters
+//   init_data_from_layout: initialize sequence counters and queue metadata
+//   wire_arena_pointers: bind slots pointer from arena.region_ptr(off)
 //   destroy: forget the slots pointer (arena owns the buffer)
 size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity);
 // Writes everything *except* the arena-internal `slots` pointer field
@@ -413,7 +413,7 @@ struct CompletionStats {
 /**
  * Layout descriptor produced by PTO2SchedulerState::reserve_layout(). Holds
  * the arena offsets of every sub-region the scheduler needs plus the
- * capacities used at layout time (init_from_layout reuses them).
+ * capacities used at layout time (init_data_from_layout reuses them).
  */
 struct PTO2SchedulerLayout {
     size_t off_ready_queue_slots[PTO2_NUM_RESOURCE_SHAPES];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -506,8 +506,7 @@ void SchedulerContext::log_chip_swimlane_summary(int32_t thread_idx, [[maybe_unu
     );
 
     uint64_t sched_total = chip_swimlane.sched_complete_cycle + chip_swimlane.sched_async_cycle +
-                           chip_swimlane.sched_scan_cycle + chip_swimlane.sched_dispatch_cycle +
-                           chip_swimlane.sched_idle_cycle;
+                           chip_swimlane.sched_dispatch_cycle + chip_swimlane.sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;
 
     {
@@ -603,11 +602,6 @@ void SchedulerContext::log_chip_swimlane_summary(int32_t thread_idx, [[maybe_unu
             "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(chip_swimlane.sched_dispatch_setup_cycle),
             chip_swimlane.sched_dispatch_setup_cycle * 100.0 / d_parent
-        );
-
-        LOG_INFO(
-            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(chip_swimlane.sched_scan_cycle),
-            chip_swimlane.sched_scan_cycle * 100.0 / sched_total
         );
 
         LOG_INFO(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -8,8 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#ifndef SCHEDULER_TYPES_H
-#define SCHEDULER_TYPES_H
+#pragma once
 
 #include <atomic>
 #include <cstddef>
@@ -504,7 +503,6 @@ struct SlotTransition {
 struct alignas(64) SchedChipSwimlaneCounters {
     bool chip_swimlane_enabled{false};
     uint64_t sched_start_ts{0};
-    uint64_t sched_scan_cycle{0};
     uint64_t sched_complete_cycle{0};
     uint64_t sched_dispatch_cycle{0};
     uint64_t sched_idle_cycle{0};
@@ -565,5 +563,3 @@ inline uint64_t sync_start_drain_next_attempt(uint64_t attempt) {
 inline uint64_t sync_start_drain_ack_subtree_token(uint64_t attempt) {
     return attempt | SYNC_START_DRAIN_ACK_SUBTREE_READY;
 }
-
-#endif  // SCHEDULER_TYPES_H

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -34,11 +34,13 @@ extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; 
 
 struct FakeRuntime {
     const PTO2RuntimeOps *ops;
+    PTO2ScopeMode pending_scope_mode = PTO2ScopeMode::AUTO;
     bool fatal = false;
     int submit_calls = 0;
     int alloc_calls = 0;
     int scope_begin_calls = 0;
     int scope_end_calls = 0;
+    PTO2ScopeMode last_scope_mode = PTO2ScopeMode::AUTO;
     int get_calls = 0;
     int set_calls = 0;
     int report_fatal_calls = 0;
@@ -56,7 +58,11 @@ TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const CoreT
     return TaskOutputTensors{};
 }
 
-void fake_scope_begin(PTO2Runtime *rt) { as_fake(rt)->scope_begin_calls++; }
+void fake_scope_begin(PTO2Runtime *rt) {
+    FakeRuntime *fake = as_fake(rt);
+    fake->scope_begin_calls++;
+    fake->last_scope_mode = fake->pending_scope_mode;
+}
 void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
 void fake_orchestration_done(PTO2Runtime *) {}
 bool fake_is_fatal(PTO2Runtime *rt) { return as_fake(rt)->fatal; }
@@ -177,6 +183,30 @@ TEST(A2A3Fatal, ExplicitFatalRoutesThroughOps) {
     CoreTaskArgs args;
     EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_EQ(runtime.submit_calls, 0);
+}
+
+TEST(A2A3Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    {
+        PTO2_SCOPE_GUARD();
+        EXPECT_EQ(runtime.scope_begin_calls, 1);
+        EXPECT_EQ(runtime.scope_end_calls, 0);
+        EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::AUTO);
+    }
+
+    EXPECT_EQ(runtime.scope_end_calls, 1);
+
+    {
+        PTO2_SCOPE_GUARD(PTO2ScopeMode::MANUAL);
+        EXPECT_EQ(runtime.scope_begin_calls, 2);
+        EXPECT_EQ(runtime.scope_end_calls, 1);
+        EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::MANUAL);
+    }
+
+    EXPECT_EQ(runtime.scope_end_calls, 2);
 }
 
 TEST(A2A3Fatal, AllocTensorConvenienceReportsInvalidArgsInsteadOfAsserting) {


### PR DESCRIPTION
## Summary

Converge the remaining low-risk A2/A3 and A5 `tensormap_and_ringbuffer` runtime differences identified in #1582.

## What changed

- Complete the #568 scope API alignment by allowing A2/A3 `PTO2_SCOPE_GUARD(...)` to forward `PTO2ScopeMode`, with AUTO/MANUAL lifetime coverage.
- Reuse A5 `PTO2TaskPayload::prefetch()`, remove the duplicate helper, dead A2/A3 aliases/overloads, stale internal names, and A5's always-zero `sched_scan_cycle` leftover from the cleanup scoped to A2/A3 in #869.
- Convert all remaining TMR include guards to `#pragma once` and correct stale `init_data_from_layout` references.
- Fix A5 multi-ring, slot-size, retained-buffer, and chip-swimlane profiling documentation.

The cleanup is intentionally limited to the TMR runtime; `host_build_graph` is unchanged.

## Verification

- Built all A2A3SIM and A5SIM runtimes.
- `pre-commit run --files $(git diff --name-only upstream/main...)` passed, including clang-tidy, cpplint, and markdownlint.
- Fresh C++ UT build passed.
- `ctest -LE requires_hardware --output-on-failure`: 89/89 passed.
- Focused A2/A3 scope-guard test passed after adding both AUTO and MANUAL coverage.
- `git diff --check` and residual-symbol/header scans passed.

`mkdocs build --strict` was not available locally because `mkdocs` is not installed in the current environment; Markdown lint passed and CI will run the repository docs job.

Related to #1582.
