### PR TITLE
CI: drop the redundant concurrency group from the pod job

### DIFF
--- a/.github/workflows/_st-pod.yml
+++ b/.github/workflows/_st-pod.yml
@@ -31,15 +31,6 @@ jobs:
     name: st-pod-onboard-${{ inputs.platform }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 60
-    # A runner claim covers only the machine the job landed on; the peer is
-    # driven over ssh and nothing else knows it is busy. Two runs of this job
-    # would then share the peer's devices and its POD_L3_DAEMON_PORT. The group
-    # is deliberately free of github.ref so runs from different PRs collide
-    # here, and cancel-in-progress stays false because a cancelled job is
-    # SIGKILLed before pod-teardown can clear the peer.
-    concurrency:
-      group: pod-${{ inputs.platform }}
-      cancel-in-progress: false
     env:
       SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
       SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"


### PR DESCRIPTION
## Summary

- Remove the `concurrency` group from the `st-pod-onboard` job in `_st-pod.yml`, along with the comment that only existed to explain it.

The group existed to stop two runs from sharing the peer machine's devices and its `POD_L3_DAEMON_PORT`, since a runner claim only covers the machine the job lands on and the peer is driven over ssh. That contention cannot actually occur: the sole caller passes `["self-hosted","Linux","ARM64","a2a3pod"]`, the `a2a3pod` label resolves to a single self-hosted runner, and a self-hosted runner executes one job at a time. The group therefore serialized nothing the runner claim did not already serialize, while making runs from unrelated PRs queue behind each other.

## Testing

- [x] `pre-commit run --files .github/workflows/_st-pod.yml` — all hooks pass (`check yaml` included)
- [ ] Simulation tests — not applicable (workflow-only change)
- [ ] Hardware tests — not applicable

## Note

This is only safe while `a2a3pod` maps to one runner. If a second pod pair is ever added under the same label, the guard has to come back.