### PR TITLE
Refactor: publish a2a3 stream ownership outside the arming block

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -601,11 +601,6 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
                         core_types[i] = runtime.get_workers()[i].core_type;
                     chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
                 }
-                int rc = run_stream_slots_.mark_submitted(slot);
-                if (rc != 0) {
-                    LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
-                    return rc;
-                }
 
                 // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
                 // so the two arches stay symmetric. First-launch latency optimization +
@@ -629,6 +624,14 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
             } catch (...) {
                 LOG_ERROR("launch_run: arming failed before any stream submission");
                 return -1;
+            }
+
+            // Publishing query/drain ownership is a state change, so it sits past
+            // the arming block: everything the block covers is rollback-free.
+            int rc = run_stream_slots_.mark_submitted(slot);
+            if (rc != 0) {
+                LOG_ERROR("launch_run: failed to publish stream set %u: %d", slot, rc);
+                return rc;
             }
 
             LOG_INFO("=== launch_aicore_kernel ===");

--- a/src/common/worker/native_run_execution.h
+++ b/src/common/worker/native_run_execution.h
@@ -129,14 +129,18 @@ struct LaunchTransactionResult {
  * Consumes an identity-bound permit, then submits AICore and AICPU in that
  * order. Only both submissions succeeding produces a `LaunchReceipt`.
  *
+ * A failure before the first execution-visible stream submission is safe: the
+ * run touched no stream, so it rolls back and admission stays clean. Once the
+ * AICore submission succeeds, an AICPU failure leaves execution uncertain, so
+ * the run is `Partial` — resources stay retained and admission is poisoned
+ * until a later drain or teardown proves quiescence.
+ *
  * Callback contract: a submit callback owns everything it does before it
  * attempts its real device submission, and must report such a failure as a
  * non-zero return rather than an exception. An escaping exception is therefore
- * evidence that the submission itself was attempted, and the run is classified
- * `Partial` — uncertain execution, which retains resources and poisons
- * admission. Returning non-zero from `submit_aicore` is by contrast a failure
- * before any execution-visible submission, so it stays `NotStarted` and is safe
- * to roll back.
+ * evidence that the submission itself was attempted, and grades the run
+ * `Partial`. Returning non-zero from `submit_aicore` is by contrast a
+ * before-first-submission failure, so it stays `NotStarted`.
  */
 template <typename AicoreSubmit, typename AicpuSubmit>
 struct ExactLaunchTransaction {


### PR DESCRIPTION
## Summary

Review follow-up to #1714 (merged as `0e3851a4`). Two points from that review, no behavior change.

**`mark_submitted()` moves out of a2a3's arming block.** #1714 wrapped the AICore
submit callback's arming prologue in `try`/`catch` so an allocation or thread-spawn
failure is reported as an rc rather than grading the run `Partial`. That block
ended up spanning `run_stream_slots_.mark_submitted(slot)`, which is not arming —
it publishes the slot as owned by query and drain. Nothing is broken today: the
only statement after it inside the block is the non-throwing `aicore_done` clearing
loop, and the rollback path runs `retire_aicore(slot, Unproven)`, which clears
`submitted`. But the block's invariant — everything here is rollback-free — held
only by inspection of what happened to follow, and a2a3 and a5 drew the boundary in
different places for no stated reason. a5 already publishes its poll state after
the `catch`; a2a3 now does the same with its stream ownership, so the two arches
are structurally identical and the invariant is local.

**The safe-versus-uncertain rule is restated on `ExactLaunchTransaction`.** #1714's
PR body cited `contracts.md` for it, which is not a file in this repository — it
lives in untracked working state, so the citation resolved to nothing for any
reader. The docblock already carried the callback half of the contract; it now also
states the rule the callback exists to serve: a failure before the first
execution-visible submission rolls back clean, while an AICPU failure after a
successful AICore submission is uncertain execution that retains resources and
poisons admission.

## Testing

- [x] C++ unit tests — 89/89 pass
- [x] Simulation — `native_run_lifecycle` (the prepared-collector regression barrier
      added in #1714) passes on `a2a3sim`

Not re-run on hardware. The moved statement is on the a2a3 onboard launch path, so
CI's `st-onboard-a2a3` is the check that matters here; the full local onboard sweep
was skipped deliberately rather than held up behind a busy shared box.

Two notes carried over from the #1714 review for the record:

- The reviewer suggested the prepared-collector regression test would fail pre-fix
  under `a2a3sim` and so cost no device time. It does not — I re-injected the
  pre-fix gate and the case still passes on sim, because only the two *onboard*
  runners ever gated collector release on `launched`; sim's
  `abandon_prepared_execution` has always released them unconditionally via
  `cleanup_active_run()`. The barrier is real but onboard-only, which is how it was
  verified in #1714.
- The differing catch-message tails (`…before any stream submission` vs `…before any
  simulated core started`) are left as-is: they name their real mechanism, and
  `arming failed` is a common greppable stem across all four.
