### PR TITLE
Fix: preserve native run drain context and acceptance checks

### DIFF
--- a/src/a2a3/runtime/host_build_graph/host/dep_gen_host_graph.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/dep_gen_host_graph.cpp
@@ -523,10 +523,10 @@ extern "C" int dep_gen_host_graph_emit(const char *deps_json_path) {
     if (!s.captured) {
         // An empty graph here is not "the orchestration submitted nothing" —
         // begin_task() would have set captured even for a graph of one task.
-        // It means capture was never armed or the run-owned snapshot was not
-        // adopted onto this progress thread before teardown.
+        // It means capture was never armed or prepare and drain did not execute
+        // on the same child progress thread.
         LOG_ERROR(
-            "dep_gen host graph: no capture was adopted on this thread — deps.json not written to %s", deps_json_path
+            "dep_gen host graph: no capture on the child progress thread — deps.json not written to %s", deps_json_path
         );
         return -3;
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/dep_gen_host_graph.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/dep_gen_host_graph.h
@@ -36,12 +36,10 @@
  * The runtime translation unit links weak no-op fallbacks (pto_orchestrator.cpp)
  * so the AICPU build, which has no host graph, resolves without this .cpp.
  *
- * The graph is per-thread state while it is being built. After bind, prepare
- * moves the completed graph into run-owned storage; launch adopts that snapshot
- * into the progress thread's local state before enqueue, and drain emits it.
- * This keeps capture lock-free while allowing serialized lifecycle calls to
- * use different host threads and preventing two prepared contexts on one
- * thread from overwriting one another.
+ * The graph remains in thread-local state from prepare through drain. Native
+ * prepare and drain therefore execute on the same child progress thread. The
+ * explicit take/adopt/destroy functions remain available to callers that
+ * deliberately transfer a capture, but the native lifecycle does not use them.
  *
  * Per-task producer dedup mirrors PTO2FaninBuilder, which keys on (ring, slot);
  * this keys on producer task id. The two agree only because host_build_graph is

--- a/src/a5/runtime/host_build_graph/host/dep_gen_host_graph.cpp
+++ b/src/a5/runtime/host_build_graph/host/dep_gen_host_graph.cpp
@@ -523,10 +523,10 @@ extern "C" int dep_gen_host_graph_emit(const char *deps_json_path) {
     if (!s.captured) {
         // An empty graph here is not "the orchestration submitted nothing" —
         // begin_task() would have set captured even for a graph of one task.
-        // It means capture was never armed or the run-owned snapshot was not
-        // adopted onto this progress thread before teardown.
+        // It means capture was never armed or prepare and drain did not execute
+        // on the same child progress thread.
         LOG_ERROR(
-            "dep_gen host graph: no capture was adopted on this thread — deps.json not written to %s", deps_json_path
+            "dep_gen host graph: no capture on the child progress thread — deps.json not written to %s", deps_json_path
         );
         return -3;
     }

--- a/src/a5/runtime/host_build_graph/runtime/dep_gen_host_graph.h
+++ b/src/a5/runtime/host_build_graph/runtime/dep_gen_host_graph.h
@@ -36,12 +36,10 @@
  * The runtime translation unit links weak no-op fallbacks (pto_orchestrator.cpp)
  * so the AICPU build, which has no host graph, resolves without this .cpp.
  *
- * The graph is per-thread state while it is being built. After bind, prepare
- * moves the completed graph into run-owned storage; launch adopts that snapshot
- * into the progress thread's local state before enqueue, and drain emits it.
- * This keeps capture lock-free while allowing serialized lifecycle calls to
- * use different host threads and preventing two prepared contexts on one
- * thread from overwriting one another.
+ * The graph remains in thread-local state from prepare through drain. Native
+ * prepare and drain therefore execute on the same child progress thread. The
+ * explicit take/adopt/destroy functions remain available to callers that
+ * deliberately transfer a capture, but the native lifecycle does not use them.
  *
  * Per-task producer dedup mirrors PTO2FaninBuilder, which keys on (ring, slot);
  * this keys on producer task id. The two agree only because host_build_graph is

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -816,12 +816,21 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Prepared) return -1;
     if (phase == NativeRunPhase::Complete) return state->completion_rc;
+    int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
+    if (attach_rc != 0) {
+        if (state->completion_rc == 0) state->completion_rc = attach_rc;
+        state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
+        emit_native_run_runner_wall(state);
+        return state->completion_rc;
+    }
     int drain_rc = -1;
     try {
         if (state->active_execution != nullptr) {
             drain_rc = state->runner->drain_execution(*state->active_execution);
         }
-    } catch (...) {}
+    } catch (...) {
+        LOG_ERROR("simpler_wait_run: drain_execution threw");
+    }
     if (state->completion_rc == 0) state->completion_rc = drain_rc;
     state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
     emit_native_run_runner_wall(state);
@@ -840,13 +849,20 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
 
+    int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
     int execution_rc = state->completion_rc;
     const bool launched = state->active_execution != nullptr;
     if (phase == NativeRunPhase::Running && launched) {
         int drain_rc = -1;
-        try {
-            drain_rc = state->runner->drain_execution(*state->active_execution);
-        } catch (...) {}
+        if (attach_rc == 0) {
+            try {
+                drain_rc = state->runner->drain_execution(*state->active_execution);
+            } catch (...) {
+                LOG_ERROR("simpler_finalize_run: drain_execution threw");
+            }
+        } else {
+            drain_rc = attach_rc;
+        }
         if (execution_rc == 0) execution_rc = drain_rc;
         state->completion_rc = execution_rc;
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
@@ -856,7 +872,6 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     int validation_rc = -1;
     try {
         if (!launched) state->runtime.set_gm_sm_ptr(nullptr);
-        int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
         if (attach_rc == 0) {
             {
                 STRACE("simpler_run.validate");

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -723,12 +723,21 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     if (phase == NativeRunPhase::Prepared) return -1;
     if (phase == NativeRunPhase::Complete) return state->completion_rc;
+    int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
+    if (attach_rc != 0) {
+        if (state->completion_rc == 0) state->completion_rc = attach_rc;
+        state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
+        emit_native_run_runner_wall(state);
+        return state->completion_rc;
+    }
     int drain_rc = -1;
     try {
         if (state->active_execution != nullptr) {
             drain_rc = state->runner->drain_execution(*state->active_execution);
         }
-    } catch (...) {}
+    } catch (...) {
+        LOG_ERROR("simpler_wait_run: drain_execution threw");
+    }
     if (state->completion_rc == 0) state->completion_rc = drain_rc;
     state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
     emit_native_run_runner_wall(state);
@@ -745,13 +754,20 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
 
+    int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
     int execution_rc = state->completion_rc;
     const bool launched = state->active_execution != nullptr;
     if (phase == NativeRunPhase::Running && launched) {
         int drain_rc = -1;
-        try {
-            drain_rc = state->runner->drain_execution(*state->active_execution);
-        } catch (...) {}
+        if (attach_rc == 0) {
+            try {
+                drain_rc = state->runner->drain_execution(*state->active_execution);
+            } catch (...) {
+                LOG_ERROR("simpler_finalize_run: drain_execution threw");
+            }
+        } else {
+            drain_rc = attach_rc;
+        }
         if (execution_rc == 0) execution_rc = drain_rc;
         state->completion_rc = execution_rc;
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
@@ -761,7 +777,6 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     int validation_rc = -1;
     try {
         if (!launched) state->runtime.set_gm_sm_ptr(nullptr);
-        int attach_rc = state->runner->attach_current_thread(state->runner->device_id());
         if (attach_rc == 0) {
             {
                 STRACE("simpler_run.validate");

--- a/src/common/worker/native_run_context.h
+++ b/src/common/worker/native_run_context.h
@@ -61,11 +61,7 @@ struct NativeRunContext {
 
     /** Publish acceptance only from this run's completed launch receipt. */
     bool publish_acceptance(const LaunchReceipt &receipt) const noexcept {
-        if (!receipt.matches(identity())) return false;
-        if (descriptor.accepted_state != nullptr) {
-            __atomic_store_n(descriptor.accepted_state, descriptor.accepted_value, __ATOMIC_RELEASE);
-        }
-        return true;
+        return publish_native_run_acceptance(receipt, identity(), descriptor.accepted_state, descriptor.accepted_value);
     }
 
     uint64_t magic{0};

--- a/src/common/worker/native_run_execution.h
+++ b/src/common/worker/native_run_execution.h
@@ -123,6 +123,18 @@ struct LaunchTransactionResult {
     bool poisoned() const { return progress == LaunchProgress::Partial; }
 };
 
+/** Publish acceptance only from a receipt bound to the selected native run. */
+inline bool publish_native_run_acceptance(
+    const LaunchReceipt &receipt, const NativeRunIdentity &identity, volatile int32_t *accepted_state,
+    int32_t accepted_value
+) noexcept {
+    if (!receipt.matches(identity)) return false;
+    if (accepted_state != nullptr) {
+        __atomic_store_n(accepted_state, accepted_value, __ATOMIC_RELEASE);
+    }
+    return true;
+}
+
 /**
  * The exact two-submission launch transaction.
  *

--- a/tests/ut/cpp/common/test_native_run_execution.cpp
+++ b/tests/ut/cpp/common/test_native_run_execution.cpp
@@ -176,6 +176,40 @@ TEST(NativeRunExecutionTest, BothSubmissionsProduceIdentityBoundReceipt) {
     EXPECT_FALSE(result.receipt.matches(stale));
 }
 
+TEST(NativeRunExecutionTest, MatchingReceiptPublishesAcceptance) {
+    volatile int32_t accepted_state = 0;
+    LaunchTransactionResult launched = exact_launch_transaction(
+        kIdentity, NativeRunExecutionTestPeer::mint(kIdentity),
+        []() {
+            return 0;
+        },
+        []() {
+            return 0;
+        }
+    );
+
+    ASSERT_TRUE(publish_native_run_acceptance(launched.receipt, kIdentity, &accepted_state, 17));
+    EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 17);
+}
+
+TEST(NativeRunExecutionTest, StaleReceiptDoesNotPublishAcceptance) {
+    volatile int32_t accepted_state = 5;
+    NativeRunIdentity stale = kIdentity;
+    stale.generation++;
+    LaunchTransactionResult launched = exact_launch_transaction(
+        stale, NativeRunExecutionTestPeer::mint(stale),
+        []() {
+            return 0;
+        },
+        []() {
+            return 0;
+        }
+    );
+
+    EXPECT_FALSE(publish_native_run_acceptance(launched.receipt, kIdentity, &accepted_state, 17));
+    EXPECT_EQ(__atomic_load_n(&accepted_state, __ATOMIC_ACQUIRE), 5);
+}
+
 TEST(NativeRunExecutionTest, PermitIsOneShot) {
     LaunchPermit permit = NativeRunExecutionTestPeer::mint(kIdentity);
     LaunchPermit first = std::move(permit);


### PR DESCRIPTION
Follow-up to #1694.

#1694 was merged while its review fixes were being prepared, so this PR carries only the remaining review corrections on top of the merged mainline.

Scope:
- attach the current thread before wait/finalize drain and propagate attach/drain failures;
- document and diagnose the child-progress-thread host-graph invariant;
- centralize receipt-bound acceptance publication;
- restore matching/stale receipt acceptance regression coverage.

Validation on LCW commit 2e6d639b:
- clang-format --dry-run --Werror: passed;
- test_native_run_execution build: passed;
- ctest -R ^test_native_run_execution$: 1/1 passed.