### PR TITLE
Refactor: make worker endpoints uniformly progressable

### DIFF
--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -36,8 +36,8 @@ For where dispatched tasks come from, see [scheduler.md](scheduler.md).
 ```cpp
 class WorkerManager {
 public:
-    // Registration (before init). `task_frame_count` selects the blocking
-    // compatibility path (1) or the two-frame progress path (2).
+    // Registration (before init). `task_frame_count` selects capacity one or
+    // the two-frame endpoint that can stage one successor.
     void add_next_level(void *mailbox, int child_pid = -1,
                         uint32_t task_frame_count = 1);
     void add_next_level_at(int32_t worker_id, void *mailbox,
@@ -103,9 +103,8 @@ stored on the task slot.
 ## 2. `WorkerThread`
 
 There is one `WorkerThread` and one `std::thread` per endpoint (for a local
-endpoint, per forked child). A two-frame endpoint does not add a thread per
-frame: the same thread owns its dispatch queue, both frame records, activation,
-acceptance, and completion progress.
+endpoint, per forked child). The same thread owns its dispatch queue, lane
+records, activation, acceptance, and completion progress.
 
 ```cpp
 struct WorkerDispatch {
@@ -138,6 +137,8 @@ private:
     std::queue<WorkerDispatch> queue_;
     std::mutex mu_;
     std::condition_variable cv_;
+    std::atomic<uint32_t> inflight_;     // endpoint capacity accounting
+    std::array<LaneState, 2> lanes_;     // active and staged identities
 
     void loop();  // the sole progress owner for this endpoint
     WorkerCompletion dispatch_process(WorkerDispatch d,
@@ -145,12 +146,13 @@ private:
 };
 ```
 
-For a blocking endpoint the thread pumps its queue and calls
-`endpoint->run_with_accept(...)` once per dispatch. For a progressable endpoint
-it publishes queued frames, forwards a latched activation, and polls monotonic
-`FRAME_STAGED`, `ACCEPTED`, and `COMPLETED` events. The forked child loop lives
-in Python (`_chip_process_loop`, `_child_worker_loop`, or `_sub_worker_loop` in
-`python/simpler/worker.py`); the parent does not fork children.
+Registered local and remote endpoints are progressable: the thread publishes
+queued work, forwards a latched activation when supported, and polls monotonic
+`FRAME_STAGED`, `ACCEPTED`, and `COMPLETED` events. The lane array owns task
+identity and disposition while `inflight_` independently enforces endpoint
+capacity. The forked child loop lives in Python (`_chip_process_loop`,
+`_child_worker_loop`, or `_sub_worker_loop` in `python/simpler/worker.py`); the
+parent does not fork children.
 
 `WorkerDispatch` begins with `{task_slot, group_index}`. `WorkerThread` assigns
 `dispatch_id` under the queue lock only after the queue insertion succeeds, so
@@ -169,8 +171,8 @@ The two capacity lanes have different meanings:
 - The **staged-successor lane** accepts at most the first eligible single
   NEXT_LEVEL task from the prepared FIFO successor. It remains staged until
   that run becomes the FIFO head and `activate_prepared(run_id)` succeeds.
-- Prepared groups retain the blocking path after FIFO promotion; they are not
-  split across staged lanes.
+- Prepared groups dispatch normally after FIFO promotion; they are not split
+  across staged lanes.
 
 For a group slot with `group_size() == N`, the Scheduler pushes N ordinary
 `WorkerDispatch` entries onto N exact NEXT_LEVEL targets, or N distinct idle
@@ -189,10 +191,10 @@ and the child polls the mailbox for the lifetime of the worker.
 
 The region currently consists of three equal `MAILBOX_FRAME_SIZE` frames:
 
-| Frame | Two-frame chip endpoint | Single-frame compatibility endpoint |
-| ----- | ----------------------- | ----------------------------------- |
-| Base (0) | Startup and control state only | Startup, control, and the one blocking task round trip |
-| Task 0 (1) | Pipeline lease slot 0 | Unused |
+| Frame | Two-frame chip endpoint | Single-frame endpoint |
+| ----- | ----------------------- | --------------------- |
+| Base (0) | Startup and control state | Startup and control state |
+| Task 0 (1) | Pipeline lease slot 0 | The active task |
 | Task 1 (2) | Pipeline lease slot 1 | Unused |
 
 `task_frame_count` is an endpoint contract, not a count inferred from the
@@ -200,22 +202,24 @@ allocation size. Parent registration uses each direct chip child's own
 published depth, while whole-run admission uses the minimum depth across the
 chip set. The current Python facade selects two frames only for a direct A2/A3
 onboard chip child whose published pipeline depth is at least two. SUB,
-nested-Worker, remote, A5, simulation, and depth-one local endpoints use the
-single-frame blocking contract.
+nested-Worker, A5, simulation, and depth-one local endpoints use one task frame
+and do not advertise successor staging. Remote endpoints have capacity one and
+advance their framed transport incrementally.
 
-### 3.1 Single-frame compatibility path
+### 3.1 Single-frame progress path
 
-`LocalMailboxEndpoint::run_with_accept` serializes task and control use of the
-base frame. It copies `CallConfig`, `PipelineSlotLease`, the 32-byte callable
-digest, and the length-prefixed `TaskArgs` blob, publishes `TASK_READY`, then
-spin-polls the base state to `TASK_DONE`. This dispatch wait never sleeps because
-task latency passes through it. A steady-clock liveness sample turns a child
-that exits before completion into `ENDPOINT_FAILURE`.
+`LocalMailboxEndpoint::submit_progress` copies `CallConfig`,
+`PipelineSlotLease`, the 32-byte callable digest, and the length-prefixed
+`TaskArgs` blob into task frame 0 and publishes `TASK_READY`. The owning
+`WorkerThread` keeps driving its endpoint and observes acceptance or completion
+through `poll_progress`; it does not wait inside one task call. A steady-clock
+liveness sample turns a child that exits before completion into
+`ENDPOINT_FAILURE`.
 
-The child uses `_run_mailbox_loop`, resolves the digest to a private local slot,
-executes the task synchronously, writes its error tuple, and then publishes
-`TASK_DONE`. This path retains the established behavior for endpoints that do
-not advertise `supports_frame_staging`.
+The child uses `_run_mailbox_loop`, polls the base control state and task frame
+0, resolves the digest to a private local slot, executes the task synchronously,
+writes its error tuple, and then publishes `TASK_DONE`. Capacity remains one;
+the separate frame prevents a control request from overwriting task state.
 
 ### 3.2 Two-frame progress path
 
@@ -352,10 +356,10 @@ terminal events, brings its in-flight count to zero, and joins the one progress
 thread. The Scheduler is joined only after worker threads can no longer invoke
 completion callbacks, and `WorkerManager::stop()` then clears the pools.
 
-A single-frame endpoint has no staged frame to cancel; its blocking round trip
-finishes before its dispatcher thread joins. The Python facade owns every child
-PID. After native worker teardown it broadcasts `SHUTDOWN` to all child base
-frames, reaps them under one shared deadline, and closes their shared-memory
+A single-frame endpoint has no staged frame to cancel; its active task
+terminalizes before its dispatcher thread joins. The Python facade owns every
+child PID. After native worker teardown it broadcasts `SHUTDOWN` to all child
+base frames, reaps them under one shared deadline, and closes their shared-memory
 objects. C++ endpoint code may observe or reap an early child exit for liveness
 diagnostics, but it does not own the normal `waitpid()` lifecycle.
 
@@ -380,11 +384,17 @@ transport-neutral endpoint under `WorkerThread`: `LocalMailboxEndpoint` wraps
 this local mailbox path, while `RemoteL3Endpoint` sends framed TASK, CONTROL,
 COMPLETION, HEALTH, and SHUTDOWN messages over the negotiated transport.
 
-The implemented `RemoteL3Endpoint` sends TASK and CONTROL frames, waits for
-COMPLETION and CONTROL_REPLY frames through `RemoteL3Transport`, and monitors
-an independent simulation health lane. Python remote worker specs open a
-session through `simpler-remote-worker`; the endpoint is schedulable only after
-the session runner reports `HELLO READY`.
+The implemented `RemoteL3Endpoint` incrementally sends TASK frames and polls
+COMPLETION frames through `RemoteL3Transport`. CONTROL/CONTROL_REPLY exchanges
+remain serialized on the same ordered command lane, and an independent
+simulation health lane is monitored throughout. Python remote worker specs open
+a session through `simpler-remote-worker`; the endpoint is schedulable only
+after the session runner reports `HELLO READY`.
+
+A control request issued while a remote task is in flight waits for that task
+to complete or for endpoint progress to stop. The command and task share one
+ordered socket lane, so the remaining task runtime is part of the control
+request's worst-case latency.
 
 ### 4.1 Nested fork ordering (L4+ Worker children)
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -1781,7 +1781,7 @@ def _run_mailbox_loop(
     chip processes all reach the parent through this one loop, differing only
     in what they do with a task and which control sub-commands they accept.
 
-    `handle_task()` and `handle_control(sub_cmd)` each return an
+    `handle_task(task_buf)` and `handle_control(sub_cmd)` each return an
     ``(error_code, message)`` pair and are responsible for catching their own
     exceptions, because the message wording is what the parent re-raises and
     only the caller knows its own context. The pair is published to the
@@ -1805,34 +1805,49 @@ def _run_mailbox_loop(
     parent_pid = os.getppid()
     liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
     shutdown_addr = _buffer_field_addr(buf, _OFF_SHUTDOWN)
-    while True:
-        state = _mailbox_load_i32(state_addr)
-        if state == _SHUTDOWN or _mailbox_load_i32(shutdown_addr) == _SHUTDOWN_REQUESTED:
-            if on_shutdown is not None:
-                on_shutdown()
-            break
-        if state == _TASK_READY:
-            code, msg = handle_task()
-            _write_error(buf, code, msg)
-            _mailbox_store_i32(state_addr, _TASK_DONE)
-        elif state == _CONTROL_REQUEST:
-            sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
-            code, msg = handle_control(int(sub_cmd))
-            _write_error(buf, code, msg)
-            _mailbox_store_i32(state_addr, _CONTROL_DONE)
-        else:
-            liveness_countdown -= 1
-            if liveness_countdown <= 0:
-                liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
-                # Comparing against the pid captured at entry rather than
-                # testing for pid 1: a subreaper (container init, systemd
-                # user session) adopts orphans instead of init, so the pid
-                # changes but never becomes 1. A live parent's pid cannot
-                # change, so this cannot fire spuriously.
-                if os.getppid() != parent_pid:
-                    if on_shutdown is not None:
-                        on_shutdown()
-                    break
+    task_buf = None
+    task_state_addr = None
+    if len(buf) >= 2 * MAILBOX_FRAME_SIZE:
+        task_buf = buf[MAILBOX_FRAME_SIZE : 2 * MAILBOX_FRAME_SIZE]
+        task_state_addr = _buffer_field_addr(task_buf, _OFF_STATE)
+    try:
+        while True:
+            state = _mailbox_load_i32(state_addr)
+            if state == _SHUTDOWN or _mailbox_load_i32(shutdown_addr) == _SHUTDOWN_REQUESTED:
+                if on_shutdown is not None:
+                    on_shutdown()
+                break
+            if task_buf is not None and _mailbox_load_i32(task_state_addr) == _TASK_READY:
+                code, msg = handle_task(task_buf)
+                _write_error(task_buf, code, msg)
+                _mailbox_store_i32(task_state_addr, _TASK_DONE)
+            elif state == _TASK_READY:
+                # Compatibility for a direct endpoint.run() caller. WorkerThread
+                # dispatches use the dedicated task frame.
+                code, msg = handle_task(buf)
+                _write_error(buf, code, msg)
+                _mailbox_store_i32(state_addr, _TASK_DONE)
+            elif state == _CONTROL_REQUEST:
+                sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
+                code, msg = handle_control(int(sub_cmd))
+                _write_error(buf, code, msg)
+                _mailbox_store_i32(state_addr, _CONTROL_DONE)
+            else:
+                liveness_countdown -= 1
+                if liveness_countdown <= 0:
+                    liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
+                    # Comparing against the pid captured at entry rather than
+                    # testing for pid 1: a subreaper (container init, systemd
+                    # user session) adopts orphans instead of init, so the pid
+                    # changes but never becomes 1. A live parent's pid cannot
+                    # change, so this cannot fire spuriously.
+                    if os.getppid() != parent_pid:
+                        if on_shutdown is not None:
+                            on_shutdown()
+                        break
+    finally:
+        if task_buf is not None:
+            task_buf.release()
 
 
 def _sub_worker_loop(
@@ -1852,16 +1867,16 @@ def _sub_worker_loop(
     host_buf_table: dict[int, tuple[SharedMemory, int, int, int]] = {}
     host_buf_ranges: list[tuple[int, int, int]] = []
 
-    def handle_task() -> tuple[int, str]:
-        digest = _read_task_digest(buf)
+    def handle_task(task_buf) -> tuple[int, str]:
+        digest = _read_task_digest(task_buf)
         cid = identity_table.get(digest)
         fn = registry.get(int(cid)) if cid is not None else None
         if fn is None:
             return 1, f"sub_worker: callable hash {_format_digest(digest)} not registered"
         try:
             if host_buf_ranges:
-                _rewrite_blob_host_addrs(buf, _OFF_TASK_ARGS_BLOB, host_buf_ranges)
-            args = _read_args_from_mailbox(buf)
+                _rewrite_blob_host_addrs(task_buf, _OFF_TASK_ARGS_BLOB, host_buf_ranges)
+            args = _read_args_from_mailbox(task_buf)
             fn(args)
         except Exception as e:  # noqa: BLE001
             return 1, _format_exc("sub_worker", e)
@@ -2262,10 +2277,11 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     host_buf_table: dict[int, tuple[SharedMemory, int, int, int]] = {}  # token -> (shm, lo, hi, child_base)
     host_buf_ranges: list[tuple[int, int, int]] = []  # (parent_lo, parent_hi, child_base)
 
-    def handle_task() -> tuple[int, str]:
-        digest = _read_task_digest(buf)
+    def handle_task(task_buf) -> tuple[int, str]:
+        task_addr = ctypes.addressof(ctypes.c_char.from_buffer(task_buf))
+        digest = _read_task_digest(task_buf)
         cid = identity_table.get(digest)
-        cfg = _read_config_from_mailbox(buf)
+        cfg = _read_config_from_mailbox(task_buf)
 
         code = 0
         msg = ""
@@ -2286,9 +2302,9 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             # blob to this child's own mapping before the runtime reads it.
             # No-op when nothing is registered.
             if host_buf_ranges:
-                _rewrite_blob_host_addrs(buf, _OFF_TASK_ARGS_BLOB, host_buf_ranges)
+                _rewrite_blob_host_addrs(task_buf, _OFF_TASK_ARGS_BLOB, host_buf_ranges)
             pipeline_slot, pipeline_reserved, pipeline_generation = _PIPELINE_LEASE_FMT.unpack_from(
-                buf, _OFF_PIPELINE_LEASE
+                task_buf, _OFF_PIPELINE_LEASE
             )
             if pipeline_reserved != 0:
                 raise RuntimeError(f"chip_process dev={device_id}: invalid pipeline lease reserved field")
@@ -2299,10 +2315,10 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             # is the source of truth.
             cw._impl.run_from_blob(
                 cid,
-                mailbox_addr + _OFF_TASK_ARGS_BLOB,
+                task_addr + _OFF_TASK_ARGS_BLOB,
                 _MAILBOX_ARGS_CAPACITY,
                 cfg,
-                mailbox_addr + _OFF_ACCEPTED,
+                task_addr + _OFF_ACCEPTED,
                 _TASK_ACCEPTED,
                 pipeline_slot,
                 pipeline_generation,
@@ -2992,15 +3008,15 @@ def _child_worker_loop(
     """
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
 
-    def handle_task() -> tuple[int, str]:
-        digest = _read_task_digest(buf)
+    def handle_task(task_buf) -> tuple[int, str]:
+        digest = _read_task_digest(task_buf)
         cid = identity_table.get(digest)
         orch_fn = registry.get(int(cid)) if cid is not None else None
         if orch_fn is None:
             return 1, f"child_worker: callable hash {_format_digest(digest)} not registered"
         try:
-            args = _read_args_from_mailbox(buf)
-            cfg = _read_config_from_mailbox(buf)
+            args = _read_args_from_mailbox(task_buf)
+            cfg = _read_config_from_mailbox(task_buf)
             inner_worker.run(orch_fn, args, cfg)
         except Exception as e:  # noqa: BLE001
             return 1, _format_exc(f"child_worker level={inner_worker.level}", e)

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -453,16 +453,16 @@ void RemoteL3SocketTransport::start_health_monitor(uint64_t session_id, int32_t 
         };
 
         try {
-            static constexpr size_t HEADER_BYTES = 40;
             while (!health_stop_.load(std::memory_order_acquire)) {
-                std::vector<uint8_t> frame(HEADER_BYTES);
-                if (!read_exact(frame.data(), HEADER_BYTES)) return;
+                std::vector<uint8_t> frame(remote_l3::FRAME_HEADER_BYTES);
+                if (!read_exact(frame.data(), remote_l3::FRAME_HEADER_BYTES)) return;
                 uint32_t payload_bytes = read_le_u32(frame.data() + 32);
                 if (payload_bytes > remote_l3::MAX_FRAME_PAYLOAD_BYTES) {
                     throw std::runtime_error("HEALTH payload exceeds maximum");
                 }
-                frame.resize(HEADER_BYTES + payload_bytes);
-                if (payload_bytes != 0 && !read_exact(frame.data() + HEADER_BYTES, payload_bytes)) return;
+                frame.resize(remote_l3::FRAME_HEADER_BYTES + payload_bytes);
+                if (payload_bytes != 0 && !read_exact(frame.data() + remote_l3::FRAME_HEADER_BYTES, payload_bytes))
+                    return;
                 auto decoded = remote_l3::decode_frame(frame);
                 if (decoded.header.frame_type != remote_l3::FrameType::HEALTH) {
                     throw std::runtime_error("non-HEALTH frame on health lane");
@@ -536,12 +536,11 @@ void RemoteL3SocketTransport::write_all(
 }
 
 std::vector<uint8_t> RemoteL3SocketTransport::read_frame(std::chrono::steady_clock::time_point deadline) {
-    static constexpr size_t HEADER_BYTES = 40;
-    std::vector<uint8_t> frame(HEADER_BYTES);
+    std::vector<uint8_t> frame(remote_l3::FRAME_HEADER_BYTES);
     size_t off = 0;
-    while (off < HEADER_BYTES) {
+    while (off < remote_l3::FRAME_HEADER_BYTES) {
         wait_readable(deadline);
-        ssize_t n = ::recv(fd_, frame.data() + off, HEADER_BYTES - off, 0);
+        ssize_t n = ::recv(fd_, frame.data() + off, remote_l3::FRAME_HEADER_BYTES - off, 0);
         if (n < 0) {
             if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) continue;
             throw std::runtime_error(
@@ -555,8 +554,8 @@ std::vector<uint8_t> RemoteL3SocketTransport::read_frame(std::chrono::steady_clo
     if (payload_bytes > remote_l3::MAX_FRAME_PAYLOAD_BYTES) {
         throw std::runtime_error("RemoteL3SocketTransport: frame payload exceeds maximum");
     }
-    frame.resize(HEADER_BYTES + payload_bytes);
-    off = HEADER_BYTES;
+    frame.resize(remote_l3::FRAME_HEADER_BYTES + payload_bytes);
+    off = remote_l3::FRAME_HEADER_BYTES;
     while (off < frame.size()) {
         wait_readable(deadline);
         ssize_t n = ::recv(fd_, frame.data() + off, frame.size() - off, 0);
@@ -596,18 +595,111 @@ void RemoteL3SocketTransport::expect_hello_ready(
 
 void RemoteL3SocketTransport::submit_frame(const std::vector<uint8_t> &frame) {
     if (fd_ < 0) throw std::runtime_error("RemoteL3SocketTransport: socket is closed");
+    if (progress_command_active_) {
+        throw std::logic_error("RemoteL3SocketTransport: progress command is active");
+    }
     // Each runtime command gets a fresh runtime-timeout budget, independent of
     // the (already-spent) attach deadline.
     write_all(frame.data(), frame.size(), deadline_from_now(runtime_timeout_s_));
 }
 
 std::vector<uint8_t> RemoteL3SocketTransport::wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) {
+    if (progress_command_active_) {
+        throw std::logic_error("RemoteL3SocketTransport: progress command is active");
+    }
     auto frame_bytes = read_frame(deadline_from_now(runtime_timeout_s_));
     auto frame = remote_l3::decode_frame(frame_bytes);
     if (frame.header.frame_type != frame_type || frame.header.sequence != sequence) {
         throw std::runtime_error("RemoteL3SocketTransport: reply frame type or sequence mismatch");
     }
     return frame_bytes;
+}
+
+void RemoteL3SocketTransport::submit_progress_frame(const std::vector<uint8_t> &frame) {
+    if (fd_ < 0) throw std::runtime_error("RemoteL3SocketTransport: socket is closed");
+    if (progress_command_active_) {
+        throw std::logic_error("RemoteL3SocketTransport: progress command is already active");
+    }
+    progress_write_ = frame;
+    progress_write_offset_ = 0;
+    progress_read_.assign(remote_l3::FRAME_HEADER_BYTES, 0);
+    progress_read_offset_ = 0;
+    progress_read_size_ = remote_l3::FRAME_HEADER_BYTES;
+    progress_deadline_ = deadline_from_now(runtime_timeout_s_);
+    progress_command_active_ = true;
+}
+
+bool RemoteL3SocketTransport::poll_progress_reply(
+    remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply
+) {
+    if (!progress_command_active_) {
+        throw std::logic_error("RemoteL3SocketTransport: no progress command is active");
+    }
+    try {
+        check_health();
+        if (std::chrono::steady_clock::now() >= progress_deadline_) {
+            throw std::runtime_error("RemoteL3SocketTransport: progress command timed out");
+        }
+
+        while (progress_write_offset_ < progress_write_.size()) {
+            ssize_t n = send_no_sigpipe(
+                fd_, progress_write_.data() + progress_write_offset_, progress_write_.size() - progress_write_offset_
+            );
+            if (n < 0) {
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) return false;
+                throw std::runtime_error(
+                    std::string("RemoteL3SocketTransport: progress send failed: ") + std::strerror(errno)
+                );
+            }
+            if (n == 0) throw std::runtime_error("RemoteL3SocketTransport: socket closed while writing progress frame");
+            progress_write_offset_ += static_cast<size_t>(n);
+        }
+
+        while (progress_read_offset_ < progress_read_size_) {
+            ssize_t n = ::recv(
+                fd_, progress_read_.data() + progress_read_offset_, progress_read_size_ - progress_read_offset_, 0
+            );
+            if (n < 0) {
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) return false;
+                throw std::runtime_error(
+                    std::string("RemoteL3SocketTransport: progress recv failed: ") + std::strerror(errno)
+                );
+            }
+            if (n == 0) throw std::runtime_error("RemoteL3SocketTransport: socket closed while reading progress frame");
+            progress_read_offset_ += static_cast<size_t>(n);
+            if (progress_read_offset_ == remote_l3::FRAME_HEADER_BYTES &&
+                progress_read_size_ == remote_l3::FRAME_HEADER_BYTES) {
+                uint32_t payload_bytes = read_le_u32(progress_read_.data() + 32);
+                if (payload_bytes > remote_l3::MAX_FRAME_PAYLOAD_BYTES) {
+                    throw std::runtime_error("RemoteL3SocketTransport: progress frame payload exceeds maximum");
+                }
+                progress_read_size_ += payload_bytes;
+                progress_read_.resize(progress_read_size_);
+            }
+        }
+
+        auto decoded = remote_l3::decode_frame(progress_read_);
+        if (decoded.header.frame_type != frame_type || decoded.header.sequence != sequence) {
+            throw std::runtime_error("RemoteL3SocketTransport: progress reply frame type or sequence mismatch");
+        }
+        reply = std::move(progress_read_);
+        reset_progress_command();
+        return true;
+    } catch (...) {
+        reset_progress_command();
+        throw;
+    }
+}
+
+void RemoteL3SocketTransport::reset_progress_command() noexcept {
+    progress_write_.clear();
+    progress_write_offset_ = 0;
+    progress_read_.clear();
+    progress_read_offset_ = 0;
+    progress_read_size_ = remote_l3::FRAME_HEADER_BYTES;
+    progress_command_active_ = false;
 }
 
 void RemoteL3SocketTransport::shutdown() { close_socket(); }
@@ -715,9 +807,113 @@ WorkerCompletion RemoteL3Endpoint::run(Ring *ring, const WorkerDispatch &dispatc
     return completion;
 }
 
+void RemoteL3Endpoint::finish_progress_command(uint64_t sequence) {
+    if (sequence != 0 && command_lane_.in_flight()) command_lane_.finish_reply(sequence);
+    pending_task_ = {};
+    command_cv_.notify_all();
+}
+
+void RemoteL3Endpoint::submit_progress(Ring *ring, const WorkerDispatch &dispatch) {
+    if (ring == nullptr) throw std::invalid_argument("RemoteL3Endpoint::submit_progress: null ring");
+    TaskSlotState *slot = ring->slot_state(dispatch.task_slot);
+    if (slot == nullptr) throw std::out_of_range("RemoteL3Endpoint::submit_progress: invalid task slot");
+    auto payload = remote_l3::encode_task_payload(build_task_payload(*slot, dispatch.group_index));
+
+    std::lock_guard<std::mutex> command_lk(command_mu_);
+    if (pending_task_.occupied || command_lane_.in_flight()) {
+        throw std::runtime_error("RemoteL3Endpoint::submit_progress: command lane is occupied");
+    }
+    uint64_t sequence = command_lane_.begin_command();
+    try {
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::TASK;
+        header.session_id = session_id_;
+        header.worker_id = caps_.worker_id;
+        header.sequence = sequence;
+        transport_->submit_progress_frame(remote_l3::encode_frame(header, payload));
+        pending_task_.occupied = true;
+        pending_task_.dispatch = dispatch;
+        pending_task_.sequence = sequence;
+    } catch (...) {
+        try {
+            command_lane_.finish_reply(sequence);
+        } catch (...) {}
+        throw;
+    }
+}
+
+bool RemoteL3Endpoint::poll_progress(WorkerEndpointProgress &progress) {
+    std::lock_guard<std::mutex> command_lk(command_mu_);
+    if (!pending_task_.occupied) return false;
+
+    const WorkerDispatch dispatch = pending_task_.dispatch;
+    const uint64_t sequence = pending_task_.sequence;
+    progress.kind = WorkerProgressKind::COMPLETED;
+    progress.dispatch = dispatch;
+    progress.completion.task_slot = dispatch.task_slot;
+    progress.completion.group_index = dispatch.group_index;
+    if (progress_stop_requested_) {
+        progress.completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+        progress.completion.error_message =
+            progress_stop_reason_.empty() ? "RemoteL3Endpoint progress stopped" : progress_stop_reason_;
+        finish_progress_command(sequence);
+        return true;
+    }
+
+    try {
+        std::vector<uint8_t> reply_bytes;
+        if (!transport_->poll_progress_reply(remote_l3::FrameType::COMPLETION, sequence, reply_bytes)) return false;
+        auto reply = remote_l3::decode_frame(reply_bytes);
+        if (reply.header.session_id != session_id_ || reply.header.worker_id != caps_.worker_id) {
+            throw std::runtime_error("completion session or worker mismatch");
+        }
+        auto decoded = remote_l3::decode_completion(reply.payload.data(), reply.payload.size(), sequence);
+        if (decoded.error_code == 0) {
+            progress.completion.outcome = EndpointOutcome::SUCCESS;
+        } else {
+            progress.completion.outcome = EndpointOutcome::TASK_FAILURE;
+            progress.completion.error_message = decoded.error_message;
+        }
+    } catch (const std::exception &e) {
+        progress.completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+        progress.completion.error_message =
+            std::string("RemoteL3Endpoint progress(worker_id=") + std::to_string(caps_.worker_id) + "): " + e.what();
+    }
+    finish_progress_command(sequence);
+    return true;
+}
+
+void RemoteL3Endpoint::request_progress_stop() noexcept {
+    try {
+        std::lock_guard<std::mutex> command_lk(command_mu_);
+        progress_stop_requested_ = true;
+        progress_stop_reason_ = "RemoteL3Endpoint progress stopped";
+        command_cv_.notify_all();
+        transport_->shutdown();
+    } catch (...) {}
+}
+
+void RemoteL3Endpoint::report_progress_error(const std::string &reason) noexcept {
+    try {
+        std::lock_guard<std::mutex> command_lk(command_mu_);
+        progress_stop_requested_ = true;
+        progress_stop_reason_ = "RemoteL3Endpoint progress driver failed: " + reason;
+        command_cv_.notify_all();
+        transport_->shutdown();
+    } catch (...) {}
+}
+
 remote_l3::ControlReplyPayload
 RemoteL3Endpoint::run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) {
     std::unique_lock<std::mutex> command_lk(command_mu_);
+    command_cv_.wait(command_lk, [this] {
+        return !pending_task_.occupied || progress_stop_requested_;
+    });
+    if (progress_stop_requested_) {
+        throw std::runtime_error(
+            progress_stop_reason_.empty() ? "RemoteL3Endpoint progress stopped" : progress_stop_reason_
+        );
+    }
     uint64_t sequence = 0;
     try {
         sequence = command_lane_.begin_command();
@@ -938,6 +1134,13 @@ void RemoteL3Endpoint::shutdown_child() {
     if (!transport_) return;
     try {
         std::lock_guard<std::mutex> command_lk(command_mu_);
+        if (pending_task_.occupied) {
+            progress_stop_requested_ = true;
+            progress_stop_reason_ = "RemoteL3Endpoint shut down with a task in flight";
+            command_cv_.notify_all();
+            transport_->shutdown();
+            return;
+        }
         uint64_t sequence = command_lane_.begin_command();
         remote_l3::FrameHeader header;
         header.frame_type = remote_l3::FrameType::SHUTDOWN;

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <string>
 #include <thread>
 #include <vector>
@@ -27,6 +28,9 @@ public:
     virtual ~RemoteL3Transport() = default;
     virtual void submit_frame(const std::vector<uint8_t> &frame) = 0;
     virtual std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) = 0;
+    virtual void submit_progress_frame(const std::vector<uint8_t> &frame) = 0;
+    virtual bool
+    poll_progress_reply(remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply) = 0;
     virtual void shutdown() {}
 };
 
@@ -41,6 +45,8 @@ public:
     void expect_hello_ready(uint64_t session_id, int32_t worker_id, const std::string &comm_profile);
     void submit_frame(const std::vector<uint8_t> &frame) override;
     std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) override;
+    void submit_progress_frame(const std::vector<uint8_t> &frame) override;
+    bool poll_progress_reply(remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply) override;
     void shutdown() override;
 
 private:
@@ -61,6 +67,13 @@ private:
     std::atomic<bool> health_failed_{false};
     std::mutex health_mu_;
     std::string health_error_;
+    std::vector<uint8_t> progress_write_;
+    size_t progress_write_offset_{0};
+    std::vector<uint8_t> progress_read_;
+    size_t progress_read_offset_{0};
+    size_t progress_read_size_{remote_l3::FRAME_HEADER_BYTES};
+    std::chrono::steady_clock::time_point progress_deadline_{};
+    bool progress_command_active_{false};
 
     void connect_socket();
     void close_socket();
@@ -72,6 +85,7 @@ private:
     void wait_writable(std::chrono::steady_clock::time_point deadline);
     void write_all(const uint8_t *data, size_t size, std::chrono::steady_clock::time_point deadline);
     std::vector<uint8_t> read_frame(std::chrono::steady_clock::time_point deadline);
+    void reset_progress_command() noexcept;
 };
 
 class RemoteL3Endpoint : public WorkerEndpoint {
@@ -82,6 +96,11 @@ public:
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
     WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
+    bool progressable() const override { return true; }
+    void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override;
+    bool poll_progress(WorkerEndpointProgress &progress) override;
+    void request_progress_stop() noexcept override;
+    void report_progress_error(const std::string &reason) noexcept override;
     void shutdown_child() override;
     void control_prepare(const uint8_t *digest) override;
     void control_remote_prepare_register(
@@ -117,8 +136,19 @@ private:
     std::unique_ptr<RemoteL3Transport> transport_;
     remote_l3::OrderedCommandLane command_lane_;
     std::mutex command_mu_;
+    std::condition_variable command_cv_;
+
+    struct PendingTask {
+        bool occupied{false};
+        WorkerDispatch dispatch{};
+        uint64_t sequence{0};
+    } pending_task_;
+    bool progress_stop_requested_{false};
+    std::string progress_stop_reason_;
 
     remote_l3::TaskPayloadWire build_task_payload(const TaskSlotState &slot, int32_t group_index) const;
+    // The caller holds command_mu_; this mutates pending_task_ and wakes waiters.
+    void finish_progress_command(uint64_t sequence);
     remote_l3::ControlReplyPayload
     run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
 };

--- a/src/common/hierarchical/remote_wire.cpp
+++ b/src/common/hierarchical/remote_wire.cpp
@@ -19,7 +19,6 @@ namespace remote_l3 {
 namespace {
 
 static constexpr uint8_t MAGIC[4] = {'S', 'L', 'R', '3'};
-static constexpr size_t FRAME_HEADER_BYTES = 40;
 
 void ensure(bool condition, const std::string &message) {
     if (!condition) throw std::runtime_error(message);

--- a/src/common/hierarchical/remote_wire.h
+++ b/src/common/hierarchical/remote_wire.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -25,6 +26,7 @@ namespace remote_l3 {
 // 2: CallConfig lost its block_dim field — a run always takes the whole
 // device, so the payload is one int32 shorter than v1's.
 static constexpr uint32_t PROTOCOL_VERSION = 2;
+inline constexpr size_t FRAME_HEADER_BYTES = 40;
 static constexpr uint32_t MAX_FRAME_PAYLOAD_BYTES = 16U * 1024U * 1024U;
 static constexpr uint32_t MAX_STRING_BYTES = 1024U;
 static constexpr uint32_t MAX_ERROR_BYTES = 4096U;

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -290,40 +290,43 @@ void WorkerThread::start(
         throw std::invalid_argument("WorkerThread::start: endpoint capacity is zero");
     }
     inflight_.store(0, std::memory_order_relaxed);
-    active_inflight_.store(false, std::memory_order_relaxed);
     {
         std::lock_guard<std::mutex> lane_lk(lane_mu_);
-        staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
-        staged_dispatch_id_ = 0;
-        activated_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
-        activated_dispatch_id_ = 0;
+        lanes_ = {};
     }
     thread_ = std::thread(&WorkerThread::loop, this);
 }
 
 void WorkerThread::dispatch(WorkerDispatch d) {
     d.prepare_only = false;
-    bool expected = false;
-    if (!active_inflight_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+    bool lane_occupied = false;
+    {
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        LaneState &active = lane(LaneKind::ACTIVE);
+        if (active.occupied) {
+            lane_occupied = true;
+        } else {
+            active.occupied = true;
+        }
+    }
+    if (lane_occupied) {
         complete_unpublished(d, "WorkerThread::dispatch: active lane is occupied");
         return;
     }
     EnqueueDispatchResult result;
     try {
-        result = enqueue_dispatch(d);
+        result = enqueue_dispatch(d, LaneKind::ACTIVE);
     } catch (const std::exception &e) {
-        // Restore admission before formatting or publishing the failure: both
-        // operations may allocate, and neither may strand the active lane.
-        active_inflight_.store(false, std::memory_order_release);
+        release_lane_unconditional(LaneKind::ACTIVE);
         complete_unpublished(d, std::string("WorkerThread::dispatch: enqueue failed: ") + e.what());
         return;
     } catch (...) {
-        active_inflight_.store(false, std::memory_order_release);
+        release_lane_unconditional(LaneKind::ACTIVE);
         complete_unpublished(d, "WorkerThread::dispatch: enqueue failed");
         return;
     }
     if (result == EnqueueDispatchResult::QUEUED) return;
-    active_inflight_.store(false, std::memory_order_release);
+    release_lane_unconditional(LaneKind::ACTIVE);
     if (result == EnqueueDispatchResult::STOPPING) {
         complete_unpublished(d, "WorkerThread::dispatch: worker is stopping");
     } else {
@@ -349,38 +352,32 @@ void WorkerThread::dispatch_prepared(WorkerDispatch d) {
     bool staged_lane_occupied = false;
     {
         std::lock_guard<std::mutex> lane_lk(lane_mu_);
-        if (staged_run_id_.load(std::memory_order_relaxed) != INVALID_RUN_ID) {
+        LaneState &staged = lane(LaneKind::STAGED);
+        if (staged.occupied) {
             staged_lane_occupied = true;
         } else {
-            staged_run_id_.store(slot->run_id, std::memory_order_relaxed);
-            staged_dispatch_id_ = 0;
+            staged.occupied = true;
+            staged.run_id = slot->run_id;
         }
     }
     if (staged_lane_occupied) {
         complete_unpublished(d, "WorkerThread::dispatch_prepared: worker already owns a staged run");
         return;
     }
-    auto release_staged_lane = [&] {
-        std::lock_guard<std::mutex> lane_lk(lane_mu_);
-        if (staged_run_id_.load(std::memory_order_relaxed) == slot->run_id) {
-            staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
-            staged_dispatch_id_ = 0;
-        }
-    };
     EnqueueDispatchResult result;
     try {
-        result = enqueue_dispatch(d, slot->run_id);
+        result = enqueue_dispatch(d, LaneKind::STAGED, slot->run_id);
     } catch (const std::exception &e) {
-        release_staged_lane();
+        release_lane_unconditional(LaneKind::STAGED);
         complete_unpublished(d, std::string("WorkerThread::dispatch_prepared: enqueue failed: ") + e.what());
         return;
     } catch (...) {
-        release_staged_lane();
+        release_lane_unconditional(LaneKind::STAGED);
         complete_unpublished(d, "WorkerThread::dispatch_prepared: enqueue failed");
         return;
     }
     if (result == EnqueueDispatchResult::QUEUED) return;
-    release_staged_lane();
+    release_lane_unconditional(LaneKind::STAGED);
     if (result == EnqueueDispatchResult::STOPPING) {
         complete_unpublished(d, "WorkerThread::dispatch_prepared: worker is stopping");
     } else if (result == EnqueueDispatchResult::CAPACITY_EXCEEDED) {
@@ -390,7 +387,8 @@ void WorkerThread::dispatch_prepared(WorkerDispatch d) {
     }
 }
 
-WorkerThread::EnqueueDispatchResult WorkerThread::enqueue_dispatch(WorkerDispatch d, RunId staged_run_id) {
+WorkerThread::EnqueueDispatchResult
+WorkerThread::enqueue_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expected_run_id) {
     std::lock_guard<std::mutex> lk(mu_);
     if (shutdown_.load(std::memory_order_acquire)) {
         return EnqueueDispatchResult::STOPPING;
@@ -399,22 +397,22 @@ WorkerThread::EnqueueDispatchResult WorkerThread::enqueue_dispatch(WorkerDispatc
         return EnqueueDispatchResult::CAPACITY_EXCEEDED;
     }
     d.dispatch_id = next_dispatch_id_;
-    if (staged_run_id != INVALID_RUN_ID) {
+    {
         std::lock_guard<std::mutex> lane_lk(lane_mu_);
-        if (staged_run_id_.load(std::memory_order_relaxed) != staged_run_id || staged_dispatch_id_ != 0) {
+        LaneState &dispatch_lane = lane(lane_kind);
+        if (!dispatch_lane.occupied || dispatch_lane.dispatch_id != 0 ||
+            (expected_run_id != INVALID_RUN_ID && dispatch_lane.run_id != expected_run_id)) {
             return EnqueueDispatchResult::STAGED_IDENTITY_CHANGED;
         }
-        staged_dispatch_id_ = d.dispatch_id;
+        dispatch_lane.dispatch_id = d.dispatch_id;
     }
     try {
         queue_.push(d);  // A failed allocation consumes neither capacity nor dispatch identity.
     } catch (...) {
-        if (staged_run_id != INVALID_RUN_ID) {
-            std::lock_guard<std::mutex> lane_lk(lane_mu_);
-            if (staged_run_id_.load(std::memory_order_relaxed) == staged_run_id &&
-                staged_dispatch_id_ == d.dispatch_id) {
-                staged_dispatch_id_ = 0;
-            }
+        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+        LaneState &dispatch_lane = lane(lane_kind);
+        if (dispatch_lane.dispatch_id == d.dispatch_id) {
+            dispatch_lane.dispatch_id = 0;
         }
         throw;
     }
@@ -427,30 +425,43 @@ WorkerThread::EnqueueDispatchResult WorkerThread::enqueue_dispatch(WorkerDispatc
 bool WorkerThread::activate_prepared(RunId run_id) {
     if (run_id == INVALID_RUN_ID) return false;
     std::lock_guard<std::mutex> lane_lk(lane_mu_);
-    if (staged_run_id_.load(std::memory_order_relaxed) != run_id || staged_dispatch_id_ == 0 ||
-        activated_run_id_.load(std::memory_order_relaxed) == run_id) {
+    LaneState &active = lane(LaneKind::ACTIVE);
+    LaneState &staged = lane(LaneKind::STAGED);
+    if (!staged.occupied || staged.run_id != run_id || staged.dispatch_id == 0 || active.occupied) {
         return false;
     }
-    bool expected = false;
-    if (!active_inflight_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-        return false;
-    }
-    activated_run_id_.store(run_id, std::memory_order_release);
-    activated_dispatch_id_ = staged_dispatch_id_;
-    staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
-    staged_dispatch_id_ = 0;
+    active = staged;
+    active.activation_requested = true;
+    staged = {};
     cv_.notify_one();
     return true;
 }
 
 bool WorkerThread::has_staged_run(RunId run_id) const {
     std::lock_guard<std::mutex> lane_lk(lane_mu_);
-    return staged_run_id_.load(std::memory_order_relaxed) == run_id;
+    const LaneState &staged = lane(LaneKind::STAGED);
+    return staged.occupied && staged.run_id == run_id;
 }
 
 bool WorkerThread::can_stage() const {
     std::lock_guard<std::mutex> lane_lk(lane_mu_);
-    return caps().supports_frame_staging && staged_run_id_.load(std::memory_order_relaxed) == INVALID_RUN_ID;
+    return caps().supports_frame_staging && !lane(LaneKind::STAGED).occupied;
+}
+
+bool WorkerThread::idle() const {
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    return !lane(LaneKind::ACTIVE).occupied;
+}
+
+void WorkerThread::release_lane(LaneKind kind, uint64_t dispatch_id) {
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    LaneState &dispatch_lane = lane(kind);
+    if (dispatch_lane.dispatch_id == dispatch_id) dispatch_lane = {};
+}
+
+void WorkerThread::release_lane_unconditional(LaneKind kind) {
+    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+    lane(kind) = {};
 }
 
 void WorkerThread::complete_unpublished(WorkerDispatch dispatch, const std::string &error_message) {
@@ -553,10 +564,19 @@ void WorkerThread::loop() {
                 }
             }
 
-            RunId activated = activated_run_id_.load(std::memory_order_acquire);
+            RunId activated = INVALID_RUN_ID;
+            {
+                std::lock_guard<std::mutex> lane_lk(lane_mu_);
+                const LaneState &active = lane(LaneKind::ACTIVE);
+                if (active.occupied && active.activation_requested) activated = active.run_id;
+            }
             if (activated != INVALID_RUN_ID) {
                 try {
-                    (void)endpoint_->activate_progress(activated);
+                    if (endpoint_->activate_progress(activated)) {
+                        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+                        LaneState &active = lane(LaneKind::ACTIVE);
+                        if (active.occupied && active.run_id == activated) active.activation_requested = false;
+                    }
                 } catch (const std::exception &e) {
                     fail_progress_driver(std::string("activate_progress failed: ") + e.what());
                 } catch (...) {
@@ -633,7 +653,7 @@ void WorkerThread::loop() {
         // scheduler placing work sees a stale non-idle lane — which is what
         // on_idle_ closes.
         on_complete_(std::move(completion));
-        active_inflight_.store(false, std::memory_order_release);
+        release_lane(LaneKind::ACTIVE, d.dispatch_id);
         inflight_.fetch_sub(1, std::memory_order_acq_rel);
         cv_.notify_one();
         if (on_idle_) on_idle_();
@@ -684,18 +704,14 @@ void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progre
     }
 
     on_complete_(std::move(completion));
-    if (dispatch.prepare_only) {
+    {
         std::lock_guard<std::mutex> lane_lk(lane_mu_);
-        if (dispatch.dispatch_id == staged_dispatch_id_) {
-            staged_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
-            staged_dispatch_id_ = 0;
-        } else if (dispatch.dispatch_id == activated_dispatch_id_) {
-            activated_run_id_.store(INVALID_RUN_ID, std::memory_order_relaxed);
-            activated_dispatch_id_ = 0;
-            active_inflight_.store(false, std::memory_order_release);
+        for (LaneState &dispatch_lane : lanes_) {
+            if (dispatch_lane.occupied && dispatch_lane.dispatch_id == dispatch.dispatch_id) {
+                dispatch_lane = {};
+                break;
+            }
         }
-    } else {
-        active_inflight_.store(false, std::memory_order_release);
     }
     inflight_.fetch_sub(1, std::memory_order_acq_rel);
     cv_.notify_one();
@@ -866,7 +882,7 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
         throw std::runtime_error("remote task sidecar is not supported by local mailbox");
     }
     if (state.run_id == INVALID_RUN_ID || state.pipeline_lease.reserved != 0 || state.pipeline_lease.generation == 0 ||
-        state.pipeline_lease.slot_id >= task_frame_count_) {
+        (task_frame_count_ > 1 && state.pipeline_lease.slot_id >= task_frame_count_)) {
         throw std::runtime_error("task frame has an invalid pipeline lease identity");
     }
     const size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ChipTensor) +
@@ -878,7 +894,7 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
         );
     }
 
-    const size_t frame_index = state.pipeline_lease.slot_id;
+    const size_t frame_index = task_frame_count_ == 1 ? 0 : state.pipeline_lease.slot_id;
     // Linearize task-frame publication against base-frame controls. The
     // control mutex is released immediately after the task state release-store;
     // controls may still execute while the native run is active, subject to

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -16,13 +16,12 @@
  * Provides idle-worker selection and dispatch to the Scheduler.
  * The Scheduler drives the DAG; the Manager drives the workers.
  *
- * Each WorkerThread owns one endpoint-progress loop. Compatibility endpoints
- * serialize a blocking TASK_READY -> TASK_DONE exchange. A two-frame local
- * endpoint may additionally publish one PREPARE_READY successor while the
- * active frame runs; FIFO promotion changes it to ACTIVATE. The Python child
- * resolves each frame's callable digest to a child-local slot and executes it
- * on its `ChipWorker` (NEXT_LEVEL). SUB and unsupported platform/runtime paths
- * retain the serialized exchange.
+ * Each WorkerThread owns one endpoint-progress loop. Every registered local
+ * and remote endpoint advances through submit/poll without blocking that loop.
+ * A two-frame local endpoint may additionally publish one PREPARE_READY
+ * successor while the active frame runs; FIFO promotion changes it to ACTIVATE.
+ * The Python child resolves each frame's callable digest to a child-local slot
+ * and executes it on its `ChipWorker` (NEXT_LEVEL).
  */
 
 #pragma once
@@ -288,8 +287,8 @@ public:
 
     virtual const WorkerEndpointCaps &caps() const = 0;
     virtual WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) = 0;
-    // Endpoints with an earlier launch boundary override this. The default is a
-    // conservative completion-time acceptance for remote, SUB and A5 paths.
+    // Compatibility endpoints without progress support use completion-time
+    // acceptance unless they override this boundary.
     virtual WorkerCompletion
     run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept);
 
@@ -364,7 +363,7 @@ public:
     WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
     WorkerCompletion
     run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept) override;
-    bool progressable() const override { return task_frame_count_ > 1; }
+    bool progressable() const override { return true; }
     void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override;
     bool poll_progress(WorkerEndpointProgress &progress) override;
     bool activate_progress(RunId run_id) override;
@@ -518,7 +517,7 @@ public:
     // The active lane and staged-successor lane are intentionally distinct.
     // A staged successor must not make a second task from the active run
     // dispatchable on the same device.
-    bool idle() const { return !active_inflight_.load(std::memory_order_acquire); }
+    bool idle() const;
     bool can_stage() const;
     bool busy() const { return inflight_.load(std::memory_order_acquire) != 0; }
     const WorkerEndpointCaps &caps() const;
@@ -532,10 +531,8 @@ public:
 
     // Memory control — callable from the orch thread while the worker thread
     // may be running a task. Commands serialize with each other on
-    // `mailbox_mu_`. A compatibility endpoint also serializes task dispatch on
-    // that mutex; a two-frame endpoint has a separate base control frame, so
-    // its single child progress owner may service control while a native run is
-    // active.
+    // `mailbox_mu_`. Task dispatch uses separate task frames, so the single
+    // child progress owner may observe a control request while a task is active.
     uint64_t control_malloc(size_t size);
     uint64_t control_committed_device_memory();
     void control_free(uint64_t ptr);
@@ -549,9 +546,9 @@ public:
     // Dynamic post-init register/unregister of a ChipCallable identity.
     // `shm_name` is the (NUL-terminated, ≤ CTRL_SHM_NAME_BYTES-1) POSIX shm
     // name where the ChipCallable bytes are staged; `blob_size` is the exact
-    // byte span to read from that shm. Both methods hold mailbox_mu_; on a
-    // two-frame endpoint the child additionally preserves any callable still
-    // referenced by an outstanding task frame.
+    // byte span to read from that shm. Both methods hold mailbox_mu_; a child
+    // additionally preserves any callable still referenced by an outstanding
+    // task frame.
     void control_register(const char *shm_name, size_t blob_size, const uint8_t *digest);
     void control_unregister(const uint8_t *digest);
     void control_remote_prepare_register(
@@ -588,7 +585,7 @@ public:
     // writes its (device_ctx, local_window_base, buffer_ptrs) into
     // `reply_shm_name`.  Both names are NUL-terminated and ≤
     // CTRL_SHM_NAME_BYTES-1. Holds mailbox_mu_ so control commands serialize;
-    // two-frame task dispatch uses distinct frame state.
+    // task dispatch uses distinct frame state.
     void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name);
     void control_release_domain(const char *request_shm_name);
 
@@ -606,6 +603,18 @@ private:
         STAGED_IDENTITY_CHANGED,
     };
 
+    enum class LaneKind : uint8_t {
+        ACTIVE = 0,
+        STAGED = 1,
+    };
+
+    struct LaneState {
+        bool occupied{false};
+        bool activation_requested{false};
+        RunId run_id{INVALID_RUN_ID};
+        uint64_t dispatch_id{0};
+    };
+
     Ring *ring_{nullptr};
     std::unique_ptr<WorkerEndpoint> endpoint_;
     std::function<void(WorkerCompletion)> on_complete_;
@@ -618,19 +627,19 @@ private:
     std::condition_variable cv_;
     std::atomic<bool> shutdown_{false};
     std::atomic<uint32_t> inflight_{0};
-    std::atomic<bool> active_inflight_{false};
     uint64_t next_dispatch_id_{1};
     mutable std::mutex lane_mu_;
-    std::atomic<RunId> staged_run_id_{INVALID_RUN_ID};
-    uint64_t staged_dispatch_id_{0};
-    std::atomic<RunId> activated_run_id_{INVALID_RUN_ID};
-    uint64_t activated_dispatch_id_{0};
+    std::array<LaneState, 2> lanes_{};
     std::unordered_set<uint64_t> accepted_dispatch_ids_;
     std::unordered_map<uint64_t, std::string> accept_errors_;
 
     void loop();
     WorkerCompletion dispatch_process(WorkerDispatch d, const std::function<void()> &on_accept);
-    EnqueueDispatchResult enqueue_dispatch(WorkerDispatch d, RunId staged_run_id = INVALID_RUN_ID);
+    EnqueueDispatchResult enqueue_dispatch(WorkerDispatch d, LaneKind lane, RunId expected_run_id = INVALID_RUN_ID);
+    LaneState &lane(LaneKind kind) { return lanes_[static_cast<size_t>(kind)]; }
+    const LaneState &lane(LaneKind kind) const { return lanes_[static_cast<size_t>(kind)]; }
+    void release_lane(LaneKind kind, uint64_t dispatch_id);
+    void release_lane_unconditional(LaneKind kind);
     void finish_progress_dispatch(const WorkerEndpointProgress &progress);
     void fail_progress_driver(const std::string &reason) noexcept;
 };

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -23,6 +23,7 @@
 #include <csignal>
 #include <chrono>
 #include <cstring>
+#include <future>
 #include <memory>
 #include <stdexcept>
 #include <thread>
@@ -264,17 +265,70 @@ start_delayed_reply_server(std::thread &server_thread, std::atomic<bool> &stop, 
     return port;
 }
 
+uint16_t start_split_header_reply_server(
+    std::thread &server_thread, std::atomic<bool> &stop, std::atomic<bool> &prefix_sent, std::atomic<bool> &send_suffix,
+    uint64_t sequence
+) {
+    uint16_t port = 0;
+    int listener = make_loopback_listener(port);
+    server_thread = std::thread([listener, &stop, &prefix_sent, &send_suffix, sequence]() {
+        int fd = accept_until_stop(listener, stop);
+        if (fd >= 0) {
+            remote_l3::FrameHeader header;
+            header.frame_type = remote_l3::FrameType::COMPLETION;
+            header.session_id = 1;
+            header.worker_id = 0;
+            header.sequence = sequence;
+            std::vector<uint8_t> frame = remote_l3::encode_frame(header, {});
+            const size_t prefix_size = remote_l3::FRAME_HEADER_BYTES / 2;
+            size_t offset = 0;
+            while (offset < prefix_size) {
+                ssize_t n = ::send(fd, frame.data() + offset, prefix_size - offset, MSG_NOSIGNAL);
+                if (n <= 0) break;
+                offset += static_cast<size_t>(n);
+            }
+            if (offset == prefix_size) {
+                prefix_sent.store(true, std::memory_order_release);
+                while (!send_suffix.load(std::memory_order_acquire) && !stop.load(std::memory_order_acquire)) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+                if (!stop.load(std::memory_order_acquire)) {
+                    while (offset < frame.size()) {
+                        ssize_t n = ::send(fd, frame.data() + offset, frame.size() - offset, MSG_NOSIGNAL);
+                        if (n <= 0) break;
+                        offset += static_cast<size_t>(n);
+                    }
+                }
+            }
+            ::close(fd);
+        }
+        ::close(listener);
+    });
+    return port;
+}
+
 class FakeRemoteTransport : public RemoteL3Transport {
 public:
     int32_t next_error_code{0};
     std::string next_error_message;
     std::vector<uint8_t> next_control_result_bytes;
     std::vector<uint8_t> last_frame;
+    int progress_polls_before_ready{0};
     remote_l3::ControlName last_control_name{remote_l3::ControlName::PREPARE_CALLABLE};
     remote_l3::RemoteRegistryTarget last_target_registry{remote_l3::RemoteRegistryTarget::REMOTE_TASK_DISPATCHER};
     CallableKind last_callable_kind{CallableKind::PYTHON_IMPORT};
 
     void submit_frame(const std::vector<uint8_t> &frame) override { last_frame = frame; }
+    void submit_progress_frame(const std::vector<uint8_t> &frame) override { submit_frame(frame); }
+
+    bool poll_progress_reply(remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply) override {
+        if (progress_polls_before_ready > 0) {
+            --progress_polls_before_ready;
+            return false;
+        }
+        reply = wait_for_reply(frame_type, sequence);
+        return true;
+    }
 
     std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) override {
         auto submitted = remote_l3::decode_frame(last_frame);
@@ -375,6 +429,57 @@ TEST(RemoteEndpoint, SuccessCompletionMapsToSuccess) {
 
     EXPECT_EQ(completion.outcome, EndpointOutcome::SUCCESS);
     EXPECT_FALSE(transport->last_frame.empty());
+    ring.shutdown();
+}
+
+TEST(RemoteEndpoint, TaskDispatchUsesProgressSubmissionAndPolling) {
+    Ring ring;
+    ring.init(1ULL << 20);
+    TaskSlot slot = make_slot(ring, scalar_args());
+
+    auto *transport = new FakeRemoteTransport();
+    transport->progress_polls_before_ready = 1;
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+    ASSERT_TRUE(endpoint.progressable());
+
+    WorkerDispatch dispatch;
+    dispatch.task_slot = slot;
+    dispatch.dispatch_id = 7;
+    endpoint.submit_progress(&ring, dispatch);
+
+    WorkerEndpointProgress progress;
+    EXPECT_FALSE(endpoint.poll_progress(progress));
+    ASSERT_TRUE(endpoint.poll_progress(progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::COMPLETED);
+    EXPECT_EQ(progress.dispatch.dispatch_id, 7u);
+    EXPECT_EQ(progress.completion.outcome, EndpointOutcome::SUCCESS);
+    ring.shutdown();
+}
+
+TEST(RemoteEndpoint, ProgressStopReleasesWaitingControl) {
+    Ring ring;
+    ring.init(1ULL << 20);
+    TaskSlot slot = make_slot(ring, scalar_args());
+
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+    WorkerDispatch dispatch;
+    dispatch.task_slot = slot;
+    endpoint.submit_progress(&ring, dispatch);
+
+    std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> digest{};
+    auto control = std::async(std::launch::async, [&] {
+        endpoint.control_prepare(digest.data());
+    });
+    EXPECT_EQ(control.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
+
+    endpoint.request_progress_stop();
+    if (control.wait_for(std::chrono::milliseconds(500)) != std::future_status::ready) {
+        WorkerEndpointProgress progress;
+        EXPECT_TRUE(endpoint.poll_progress(progress));
+    }
+    ASSERT_EQ(control.wait_for(std::chrono::milliseconds(500)), std::future_status::ready);
+    EXPECT_THROW(control.get(), std::runtime_error);
     ring.shutdown();
 }
 
@@ -587,6 +692,98 @@ TEST(RemoteSocketTransport, RuntimeReadSurvivesElapsedAttachDeadline) {
 
     transport.shutdown();
     server.stop_and_join();
+}
+
+TEST(RemoteSocketTransport, ProgressPollDoesNotWaitForDelayedReply) {
+    ScopedServerThread server;
+    uint16_t port = start_delayed_reply_server(server.thread(), server.stop_flag(), /*delay_ms=*/500, /*sequence=*/1);
+    RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, /*attach*/ 1.0, /*runtime*/ 2.0);
+
+    remote_l3::FrameHeader header;
+    header.frame_type = remote_l3::FrameType::TASK;
+    header.session_id = 1;
+    header.worker_id = 0;
+    header.sequence = 1;
+    transport.submit_progress_frame(remote_l3::encode_frame(header, {}));
+
+    std::vector<uint8_t> reply;
+    auto t0 = std::chrono::steady_clock::now();
+    EXPECT_FALSE(transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply));
+    double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+    EXPECT_LT(elapsed, 0.2);
+
+    bool complete = false;
+    for (int i = 0; i < 100 && !complete; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        complete = transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply);
+    }
+    EXPECT_TRUE(complete);
+    EXPECT_FALSE(reply.empty());
+    transport.shutdown();
+    server.stop_and_join();
+}
+
+TEST(RemoteSocketTransport, ProgressPollResumesAfterPartialHeader) {
+    std::atomic<bool> prefix_sent{false};
+    std::atomic<bool> send_suffix{false};
+    ScopedServerThread server;
+    uint16_t port =
+        start_split_header_reply_server(server.thread(), server.stop_flag(), prefix_sent, send_suffix, /*sequence=*/1);
+    RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, /*attach*/ 1.0, /*runtime*/ 2.0);
+
+    remote_l3::FrameHeader header;
+    header.frame_type = remote_l3::FrameType::TASK;
+    header.session_id = 1;
+    header.worker_id = 0;
+    header.sequence = 1;
+    transport.submit_progress_frame(remote_l3::encode_frame(header, {}));
+
+    for (int i = 0; i < 100 && !prefix_sent.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(prefix_sent.load(std::memory_order_acquire));
+    std::vector<uint8_t> reply;
+    EXPECT_FALSE(transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply));
+
+    send_suffix.store(true, std::memory_order_release);
+    bool complete = false;
+    for (int i = 0; i < 100 && !complete; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        complete = transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply);
+    }
+    EXPECT_TRUE(complete);
+    EXPECT_EQ(reply.size(), remote_l3::FRAME_HEADER_BYTES);
+    transport.shutdown();
+    server.stop_and_join();
+}
+
+TEST(RemoteSocketTransport, ProgressErrorClearsActiveCommand) {
+    ScopedServerThread server;
+    uint16_t port = start_closing_server(server.thread(), server.stop_flag());
+    RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, /*attach*/ 1.0, /*runtime*/ 1.0);
+    server.stop_and_join();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    remote_l3::FrameHeader header;
+    header.frame_type = remote_l3::FrameType::TASK;
+    header.session_id = 1;
+    header.worker_id = 0;
+    header.sequence = 1;
+    std::vector<uint8_t> frame = remote_l3::encode_frame(header, {});
+    transport.submit_progress_frame(frame);
+
+    std::vector<uint8_t> reply;
+    bool saw_error = false;
+    for (int i = 0; i < 3 && !saw_error; ++i) {
+        try {
+            (void)transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply);
+        } catch (const std::runtime_error &) {
+            saw_error = true;
+        }
+    }
+    ASSERT_TRUE(saw_error);
+    EXPECT_NO_THROW(transport.submit_progress_frame(frame));
+    transport.shutdown();
 }
 
 TEST(RemoteSocketTransport, RuntimeWriteToStalledReaderTimesOut) {

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -137,9 +137,11 @@ struct MockMailboxWorker {
 
     // The child publishes acceptance into the sticky word, not the state.
     void write_task_accepted() {
-        auto *ptr = reinterpret_cast<int32_t *>(static_cast<char *>(mailbox_ptr()) + MAILBOX_OFF_ACCEPTED);
         int32_t v = MAILBOX_TASK_ACCEPTED;
-        __atomic_store(ptr, &v, __ATOMIC_RELEASE);
+        auto *base_ptr = reinterpret_cast<int32_t *>(mailbox.data() + MAILBOX_OFF_ACCEPTED);
+        auto *task_ptr = reinterpret_cast<int32_t *>(task_frame() + MAILBOX_OFF_ACCEPTED);
+        __atomic_store(base_ptr, &v, __ATOMIC_RELEASE);
+        __atomic_store(task_ptr, &v, __ATOMIC_RELEASE);
     }
 
     void wait_running(int timeout_ms = 500) {
@@ -170,20 +172,37 @@ private:
         __atomic_store_n(ptr, static_cast<int32_t>(s), __ATOMIC_RELEASE);
     }
 
+    char *task_frame() { return mailbox.data() + MAILBOX_FIRST_TASK_FRAME * MAILBOX_FRAME_SIZE; }
+
+    MailboxState read_task_state() const {
+        const auto *ptr = reinterpret_cast<const volatile int32_t *>(
+            mailbox.data() + MAILBOX_FIRST_TASK_FRAME * MAILBOX_FRAME_SIZE + MAILBOX_OFF_STATE
+        );
+        int32_t v = __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+        return static_cast<MailboxState>(v);
+    }
+
+    void write_task_state(MailboxState state) {
+        auto *ptr = reinterpret_cast<volatile int32_t *>(task_frame() + MAILBOX_OFF_STATE);
+        __atomic_store_n(ptr, static_cast<int32_t>(state), __ATOMIC_RELEASE);
+    }
+
     void loop() {
         while (true) {
             if (stop_flag.load(std::memory_order_acquire)) return;
             MailboxState s = read_state();
-            if (s == MailboxState::TASK_READY) {
-                uint8_t callable_hash0 = static_cast<uint8_t>(mailbox[MAILBOX_OFF_TASK_CALLABLE_HASH]);
+            MailboxState task_state = read_task_state();
+            if (task_state == MailboxState::TASK_READY || s == MailboxState::TASK_READY) {
+                const bool progress_frame = task_state == MailboxState::TASK_READY;
+                char *frame = progress_frame ? task_frame() : mailbox.data();
+                uint8_t callable_hash0 = static_cast<uint8_t>(frame[MAILBOX_OFF_TASK_CALLABLE_HASH]);
                 int32_t t_count = 0;
-                std::memcpy(&t_count, mailbox.data() + MAILBOX_OFF_TASK_ARGS_BLOB, sizeof(int32_t));
+                std::memcpy(&t_count, frame + MAILBOX_OFF_TASK_ARGS_BLOB, sizeof(int32_t));
                 uint64_t tensor_key = 0;
                 if (t_count > 0) {
                     ChipTensor first{};
                     std::memcpy(
-                        &first, mailbox.data() + MAILBOX_OFF_TASK_ARGS_BLOB + TASK_ARGS_BLOB_HEADER_SIZE,
-                        sizeof(ChipTensor)
+                        &first, frame + MAILBOX_OFF_TASK_ARGS_BLOB + TASK_ARGS_BLOB_HEADER_SIZE, sizeof(ChipTensor)
                     );
                     tensor_key = first.buffer.addr;
                 }
@@ -212,13 +231,17 @@ private:
                 }
                 is_running.store(false, std::memory_order_release);
 
-                std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR, &error_code, sizeof(int32_t));
-                std::memset(mailbox.data() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+                std::memcpy(frame + MAILBOX_OFF_ERROR, &error_code, sizeof(int32_t));
+                std::memset(frame + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
                 if (!error_msg.empty()) {
                     size_t n = std::min(error_msg.size(), MAILBOX_ERROR_MSG_SIZE - 1);
-                    std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR_MSG, error_msg.data(), n);
+                    std::memcpy(frame + MAILBOX_OFF_ERROR_MSG, error_msg.data(), n);
                 }
-                write_state(MailboxState::TASK_DONE);
+                if (progress_frame) {
+                    write_task_state(MailboxState::TASK_DONE);
+                } else {
+                    write_state(MailboxState::TASK_DONE);
+                }
             } else if (s == MailboxState::CONTROL_REQUEST) {
                 // Acknowledge the control request so a future test using
                 // WorkerThread::control_* doesn't hang on the spin-poll.
@@ -1174,6 +1197,36 @@ TEST(WorkerManagerTest, TwoFrameLeaseSlotsDoNotDefineFifoOrAcceptance) {
     ASSERT_TRUE(endpoint.poll_progress(progress));
     EXPECT_EQ(progress.kind, WorkerProgressKind::ACCEPTED);
     EXPECT_EQ(progress.dispatch.dispatch_id, 42u);
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, CapacityOneMailboxUsesTheProgressTaskFrame) {
+    alignas(8) std::array<char, MAILBOX_SIZE> mailbox{};
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot task_slot = make_progress_slot(allocator, /*run_id=*/21, /*pipeline_slot=*/1, /*generation=*/7);
+    ASSERT_NE(task_slot, INVALID_SLOT);
+
+    LocalMailboxEndpoint endpoint(/*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/1);
+    EXPECT_TRUE(endpoint.progressable());
+    EXPECT_FALSE(endpoint.caps().supports_frame_staging);
+
+    WorkerDispatch dispatch{task_slot, 0, /*dispatch_id=*/41, /*prepare_only=*/false};
+    endpoint.submit_progress(&allocator, dispatch);
+
+    char *frame = test_task_frame(mailbox, 0);
+    EXPECT_EQ(test_frame_state(frame), MailboxState::TASK_READY);
+    EXPECT_EQ(test_frame_dispatch_id(frame), 41u);
+
+    set_test_frame_accepted(frame);
+    WorkerEndpointProgress progress;
+    ASSERT_TRUE(endpoint.poll_progress(progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::ACCEPTED);
+
+    set_test_frame_state(frame, MailboxState::TASK_DONE);
+    ASSERT_TRUE(endpoint.poll_progress(progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::COMPLETED);
+    EXPECT_EQ(progress.completion.outcome, EndpointOutcome::SUCCESS);
     allocator.shutdown();
 }
 
@@ -2689,6 +2742,7 @@ TEST(SchedulerDispatchPassTest, ActiveRunSwitchCannotBypassSuccessorGroupReserva
         TaskSlotState &state = *allocator.slot_state(allocation.slot);
         state.reset();
         state.run_id = run_id;
+        state.pipeline_lease = PipelineSlotLease{/*slot_id=*/0, /*reserved=*/0, /*generation=*/run_id};
         state.worker_type = WorkerType::NEXT_LEVEL;
         state.callable = C(callable_seed);
         state.target_worker_ids.push_back(worker_id);

--- a/tests/ut/py/test_worker/test_host_buffer_registration.py
+++ b/tests/ut/py/test_worker/test_host_buffer_registration.py
@@ -180,10 +180,15 @@ def test_l3_sub_worker_maps_rewrites_and_unmaps_host_buffer(monkeypatch):
         # The loop polls two words per iteration; only the state word is
         # scripted, so the sticky shutdown word always reads "not requested".
         shutdown_addr = worker_mod._buffer_field_addr(mailbox_buf, worker_mod._OFF_SHUTDOWN)
+        task_state_addr = (
+            worker_mod._buffer_field_addr(mailbox_buf, worker_mod._OFF_STATE) + worker_mod.MAILBOX_FRAME_SIZE
+        )
 
         def load_state(state_addr):
             if state_addr == shutdown_addr:
                 return 0
+            if state_addr == task_state_addr:
+                return worker_mod._IDLE
             state = next(states)
             if state == worker_mod._TASK_READY:
                 start = worker_mod._OFF_TASK_CALLABLE_HASH


### PR DESCRIPTION
## Summary
- replace parallel active/staged worker state with explicit lane records and independent endpoint-capacity accounting
- drive capacity-one local endpoints (sim, A5, L4+, and SUB) through the dedicated task frame without enabling successor staging
- preserve logical pipeline lease identity on capacity-one endpoints while mapping the run onto physical task frame 0
- make remote TASK traffic progressable with incremental non-blocking socket send/receive while preserving the ordered control lane

Remote control requests share the ordered command socket, so a control operation now waits for an in-flight remote task to complete or stop. Its worst-case added latency includes the task's remaining runtime, bounded by the progress deadline/stop path.

## Testing
- `pre-commit run --files <changed files>` (all hooks passed)
- `ctest --test-dir tests/ut/cpp/build-pr1694-followup -LE requires_hardware --output-on-failure` (90/90)
- `pytest tests/ut -m "not requires_hardware" -q` (1175 passed, 13 skipped, 14 deselected)
- targeted former failures in `test_host_worker.py`, `test_admission_fence.py`, and `test_host_buffer_registration.py` (4 passed)
- a2a3sim and a5sim vector examples
- a2a3 hardware vector example via `task-submit` (`task_20260806_201128_193519427714`)
