### PR TITLE
Add: support Graph Execution on A5

### DIFF
--- a/src/a5/docs/runtimes.md
+++ b/src/a5/docs/runtimes.md
@@ -14,6 +14,8 @@ Two runtime implementations live under `src/a5/runtime/`, each providing a diffe
 ## host_build_graph
 
 See [host_build_graph/docs/RUNTIME_LOGIC.md](../runtime/host_build_graph/docs/RUNTIME_LOGIC.md).
+Graph recording and replay are documented in
+[GRAPH_EXECUTION.md](../runtime/host_build_graph/docs/GRAPH_EXECUTION.md).
 
 ## tensormap_and_ringbuffer (PTO2)
 

--- a/src/a5/runtime/host_build_graph/common/pto_runtime_status.h
+++ b/src/a5/runtime/host_build_graph/common/pto_runtime_status.h
@@ -38,6 +38,7 @@
 #define PTO2_ERROR_ASYNC_COMPLETION_INVALID 101
 #define PTO2_ERROR_ASYNC_WAIT_OVERFLOW 102
 #define PTO2_ERROR_ASYNC_REGISTRATION_FAILED 103
+#define PTO2_ERROR_READY_QUEUE_OVERFLOW 104  // push into a ready queue found no free slot (full, or window > capacity)
 
 static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
     if (orch_error_code != PTO2_ERROR_NONE) {

--- a/src/a5/runtime/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/a5/runtime/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -1,0 +1,351 @@
+# Graph Execution
+
+Graph Execution is available only in the `host_build_graph` runtime. A Graph is
+a composite incore task: it is submitted and completed once like an AIC, AIV,
+MIX, or SPMD task, but contains a recorded task DAG.
+
+The first invocation executes normally and records the DAG. A later invocation
+places one `GRAPH` task in the host task window. The device Scheduler expands
+the saved topology and dispatches its internal nodes; the Host Orchestrator does
+not submit those nodes again.
+
+## Step-1 API
+
+A Graph uses `CoreTaskArgs`, the existing incore argument type:
+
+```cpp
+void graph_function(const CoreTaskArgs &args, int variant) {
+    const ChipTensor &input = args.tensor(0).ref();
+    const ChipTensor &weight = args.tensor(1).ref();
+    const ChipTensor &output = args.tensor(2).ref();
+
+    const std::array<uint32_t, 1> shape{input.shapes[0]};
+    TensorCreateInfo intermediate(
+        shape.data(), static_cast<uint32_t>(shape.size()), input.dtype
+    );
+
+    CoreTaskArgs matmul_args;
+    matmul_args.add_input(input, weight);
+    matmul_args.add_output(intermediate);
+    matmul_args.add_scalar(uint32_t{16});  // fixed Definition data
+    TaskOutputTensors matmul = rt_submit_aic_task(
+        variant == 0 ? FUNC_MATMUL : FUNC_MATMUL_TRANSPOSED,
+        matmul_args
+    );
+
+    CoreTaskArgs activation_args;
+    activation_args.add_input(matmul.get_ref(0));
+    activation_args.add_output(output);
+    rt_submit_aiv_task(FUNC_ACTIVATION, activation_args);
+}
+
+void submit_layer(const CoreTaskArgs &args) {
+    rt_submit_graph(&graph_function, args, /*variant=*/0);
+}
+```
+
+The function pointer is the default Graph identity. Trailing integral,
+`float`, `double`, and `bool` construction parameters are forwarded to the
+Graph function and hashed by value into the cache key. They are separate from
+execution scalars in `CoreTaskArgs`: changing a construction parameter selects a
+different Definition rather than patching an existing one.
+
+An explicit identity is available for call sites that need a stable name:
+
+```cpp
+rt_submit_graph(
+    GRAPH_KEY("qwen_decoder_layer_v1"),
+    &graph_function,
+    args,
+    /*variant=*/0
+);
+```
+
+An explicit `GRAPH_KEY` must be unique for every distinct Graph function in an
+orchestration callable. The explicit-key overload deliberately excludes the
+Graph function pointer from the cache identity so the key remains stable; using
+the same key for different functions can select the wrong recorded topology.
+
+There are no public `GraphArgs`, `GraphBindings`, `Patch`, or `ScalarRef`
+types. The boundary is represented by `CoreTaskArgs`.
+
+## Supported dynamic and static data
+
+Step 1 deliberately supports a narrow, safe contract:
+
+- Boundary ChipTensor addresses may change for every invocation.
+- A Graph boundary contains at least one ChipTensor.
+- Construction parameters are part of Graph identity and may control the
+  function's task count, kernel selection, or other structural choices.
+- Boundary ChipTensor shape, stride, dtype, size, direction, contiguity, and alias
+  partition must match the first invocation.
+- Scalars inside internal task args are fixed Definition data.
+- Scalars in the boundary `CoreTaskArgs` are not cacheable yet. Such a call uses
+  the ordinary task-submit path.
+- Boundary storage is caller-owned. `INPUT`, `INOUT`, `OUTPUT_EXISTING`, and
+  `NO_DEP` are supported. A boundary `TensorCreateInfo` tagged `OUTPUT` is not.
+- Early-resolve hints apply while recording the first invocation. Replayed
+  internal nodes use the saved completion topology without the hint.
+- A recorded task may depend on a Graph-external producer when that producer
+  is the creator of a boundary ChipTensor. The outer Graph owns that dependency on
+  replay; arbitrary cross-boundary explicit dependencies remain unsupported.
+
+Structural or alias mismatch logs a warning and executes the Graph function
+normally for that invocation. It never reuses heap offsets recorded for a
+different shape. Debug builds also assert at these unsupported boundaries so
+development catches a violated fixed-shape contract immediately; the ordinary
+path remains the defensive release-build behavior.
+
+## Qwen decoder-layer example
+
+The upper layer packages all ChipTensor I/O in `CoreTaskArgs`; the wrapper has no
+separate `hidden`, `weight`, or `output` parameters:
+
+```cpp
+void qwen_decoder_layer(const CoreTaskArgs &args) {
+    const ChipTensor &hidden = args.tensor(0).ref();
+    const ChipTensor &attention_weight = args.tensor(1).ref();
+    const ChipTensor &mlp_weight = args.tensor(2).ref();
+    const ChipTensor &output = args.tensor(3).ref();
+
+    const std::array<uint32_t, 1> hidden_shape{hidden.shapes[0]};
+    TensorCreateInfo attention_out(
+        hidden_shape.data(), static_cast<uint32_t>(hidden_shape.size()), hidden.dtype
+    );
+
+    CoreTaskArgs attention_args;
+    attention_args.add_input(hidden, attention_weight);
+    attention_args.add_output(attention_out);
+    attention_args.add_scalar(uint32_t{16});  // fixed model configuration
+    TaskOutputTensors attention =
+        rt_submit_aic_task(FUNC_ATTENTION, attention_args);
+
+    MixedKernels mlp;
+    mlp.aic_kernel_id = FUNC_MLP_AIC;
+    mlp.aiv0_kernel_id = FUNC_MLP_AIV;
+
+    CoreTaskArgs mlp_args;
+    mlp_args.add_input(attention.get_ref(0), mlp_weight);
+    mlp_args.add_output(output);
+    rt_submit_task(mlp, mlp_args);
+}
+
+void submit_qwen_decoder_layer(const CoreTaskArgs &args) {
+    rt_submit_graph(&qwen_decoder_layer, args);
+}
+
+void decode_three_layers(
+    const std::array<ChipTensor, 3> &hidden,
+    const std::array<ChipTensor, 3> &attention_weight,
+    const std::array<ChipTensor, 3> &mlp_weight,
+    const std::array<ChipTensor, 3> &output
+) {
+    for (std::size_t layer = 0; layer < hidden.size(); ++layer) {
+        CoreTaskArgs args;
+        args.add_input(
+            hidden[layer],
+            attention_weight[layer],
+            mlp_weight[layer]
+        );
+        args.add_output(output[layer]);
+        submit_qwen_decoder_layer(args);
+    }
+}
+```
+
+The first layer records ordinary task submissions. Layers two and three submit
+one Graph task each when their ChipTensor metadata matches. A per-layer or
+per-token scalar is not dynamic in step 1; use ordinary submission or a
+different fixed Graph function/key until dynamic scalar support is added.
+
+## Definition
+
+Recording uses host-only C++ state:
+
+- `std::vector` for nodes, tensors, scalars, fanins, and pending uploads;
+- `std::unordered_map` for the per-run Definition cache;
+- `std::unique_ptr` for the active recording.
+
+The cache stores at most 16 Definitions and allocates each entry to its actual
+serialized size. No fixed maximum-size recording array is copied on a cache
+hit.
+
+At `graph_end`, recording is compacted into one contiguous, pointer-free POD
+Definition. It contains:
+
+- node order and AIC/AIV/MIX/SPMD kernel metadata;
+- `root_indices` plus both directions of the immutable topology:
+  fanin CSR and fanout CSR;
+- one packed-heap offset per node;
+- each node's ChipTensor source:
+  `BOUNDARY_EXACT`, `BOUNDARY_VIEW`, `INTERNAL`, or `OWN_OUTPUT`;
+- fixed scalar values;
+- fixed boundary signatures and alias representatives.
+
+The header also carries a content hash of the complete Definition image. The
+device execution pool requires this hash, the Graph key, and the node count to
+all match before reusing a resident Definition. A new run may record different
+metadata under the same function identity, so key-only reuse is not safe.
+
+All references are 32-bit offsets from the Definition base. Cross-boundary
+Tensors use the fixed-width `GraphTensor` wire POD rather than the
+64-byte-aligned C++ `ChipTensor` object. The upload is therefore one contiguous
+copy with no raw Host pointers and no relocation pass.
+
+Before materialization, the Scheduler recomputes the Definition content hash
+and validates section ranges, topology indices, node heap offsets, the outer
+heap extent, ChipTensor metadata, and ChipTensor-source bounds. Invalid wire data is
+rejected before an offset participates in pointer arithmetic.
+
+There is no cache schema version. The cache is per run and starts empty, so a
+persistent-format version would currently have no effect.
+
+## Cache hit and memory
+
+For a cache hit, the Host Orchestrator:
+
+1. validates the fixed boundary contract;
+2. reserves one task-window slot;
+3. reserves one heap block large enough for every internal intermediate;
+4. computes only external fanin and boundary tensormap effects;
+5. emits one outer `GRAPH` task;
+6. stages the exact-size POD submission image for upload after orchestration;
+7. asks the host runtime for an aligned execution block sized from the recorded
+   node count, tensor-address patch count, and Definition bytes, then writes
+   that device address into the submission wire image.
+
+Internal nodes consume no ring task-window slots. Their descriptor, payload,
+and slot state are built in host-owned GM. The runtime retains one grow-only
+block per `(pipeline slot, Graph key, occurrence index)`: repeated runs on the
+same slot reuse the allocation, repeated uses of one key within a run receive
+distinct blocks, and the two pipeline slots never share an active block. Every
+allocation goes through the Worker's tracked `MemoryAllocator`, contributes to
+`committed_device_memory()`, and is released when the Worker is finalized.
+
+The `GraphSubmission` wire POD carries the aligned device address and usable
+byte capacity explicitly. The Scheduler validates both before placement-
+constructing `GraphExecution`; it never allocates execution storage from the
+AICPU process heap. A block whose prior Definition key and content hash match
+retains the local Definition, static node fields, and the address patch table
+generated during its first materialization. That graph-affine replay skips
+topology binding, per-node count/offset validation, tensor-source
+classification, tensor wire validation, static field stores, and scalar
+copies. It refreshes only task IDs, packed-buffer bases, boundary/internal
+tensor addresses, scheduling state, dispatch atomics, and wake registrations.
+
+The retained blocks are addressed directly by `(pipeline slot, Graph key,
+occurrence index)`. Occurrence numbering restarts deterministically for every
+run, so repeated layers map back to the same block in their pipeline slot;
+affinity does not depend on a recycler selecting a recently freed block.
+
+## Scheduler flow
+
+Host orchestration builds the complete task image before device execution. At
+the end of orchestration, the Host uploads every exact-size Graph POD image,
+relocates the task and payload pointers in the shared-memory image, copies the
+complete shared-memory/runtime-arena image to the device, and then launches the
+resident Scheduler.
+
+All AICPU threads classify disjoint slices of the completed task window behind
+one startup barrier. A Graph task enters preparation and external-fanin
+classification during that scan, so Graph execution is interleaved with other
+ready tasks at the same scheduling level once the Scheduler starts.
+
+This design does not overlap orchestration and scheduling within one run.
+Prepared-successor pipelining can overlap preparation of run N+1 with device
+execution of run N, while Graph cache hits reduce repeated orchestration work
+inside a run.
+
+A Graph is placed in two independent control flows:
+
+- `graph_prepare_queue`: materialize the saved nodes even while external fanin
+  is still pending;
+- `graph_ready_queue`: signal that the outer Graph's external fanin is ready.
+
+Core-owning Scheduler threads pop at most one item from each queue per loop. A
+prepare call expands at most four nodes and requeues unfinished work,
+interleaving Graph expansion with normal scheduling.
+
+Preparation and external readiness set two bits in one atomic activation gate.
+Whichever operation sets the second bit activates the saved root nodes exactly
+once.
+
+Internal dependency readiness borrows the completion-state polling idea, but
+dependency wiring remains an Orchestrator responsibility:
+
+- recording constructs both fanin and fanout CSR in the immutable Definition;
+- first materialization builds static runnable node state plus a compact
+  boundary/internal address patch table; affine replay applies that table and
+  resets only dynamic runnable state;
+- materialization registers each non-root on one producer selected from its
+  saved fanin CSR;
+- a node's release/acquire `task_state` is its Graph-local completion flag, so
+  internal nodes need neither ring completion flags nor task-window slots;
+- producer completion closes and drains only its current wake-list rather than
+  traversing the saved fanout CSR;
+- a woken consumer scans its saved fanin CSR and either enters its shape queue
+  or registers on the next incomplete producer;
+- `WAKE_LIST_SENTINEL` closes the completion/registration race: a failed
+  registration observes completion and immediately rescans.
+
+The runtime wake-list registration is a transient polling subscription, not
+dependency discovery or Graph rewiring. Fanout CSR remains in the Definition
+as part of the complete recorded topology and for DFX, but readiness does not
+walk it.
+
+```text
+outer GRAPH
+  -> activate root_indices[]
+  -> producer completion drains its current wake-list
+  -> each waiter polls saved fanin completion state
+  -> ready waiter enters its ordinary shape queue
+     or registers on another incomplete producer
+  -> final internal completion completes the outer GRAPH
+```
+
+Internal nodes count as zero outer ring tasks. The final node completes
+the one outer Graph task, publishes the outer ring completion flag, wakes
+external consumers, and contributes one to the host-visible completion count.
+
+Localization or materialization failure is fail-fast: the Scheduler latches an
+error instead of leaving an already-submitted outer Graph unable to complete.
+
+## Current unsupported cases
+
+These cases assert in debug builds and execute through the ordinary path in a
+release build:
+
+- dynamic boundary scalars;
+- an empty Graph boundary;
+- variable ChipTensor shape or metadata;
+- changed boundary aliasing;
+- runtime-allocated boundary outputs;
+- nested Graph recording;
+- dispatch predicates;
+- cross-boundary explicit dependencies that are not represented by a boundary
+  ChipTensor's creator;
+- an unclassifiable internal ChipTensor source;
+- more than 16 Definitions, 1024 internal nodes, or 32 boundary Tensors;
+- insufficient task-window or heap capacity detected before outer submission.
+
+An AICPU execution-pool or materialization failure happens after the outer
+Graph has already been submitted. It therefore latches a Scheduler fatal error
+instead of falling back; leaving the outer task pending would otherwise wedge
+completion.
+
+Explicit dependencies between recorded internal nodes are preserved when they
+are otherwise supported; ordinary ChipTensor dependencies are always preserved.
+
+## DFX
+
+With L2 swimlane level 4:
+
+- `Graph Execution` spans an outer Graph execution;
+- `AICPU Scheduler` shows bounded `graph_prepare` slices separately from normal
+  dispatch;
+- existing Scheduler and Worker lanes show the expanded internal tasks.
+
+The scene coverage under `tests/st/a5/host_build_graph/graph_execution`
+includes an AIV fanin/fanout DAG, an AIC/AIV fanout/fanin DAG, and a three-slot
+multi-block MIX/SPMD Graph. Every scene invokes the same fixed Graph three
+times: one recording execution followed by two outer-Graph submissions.

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -43,13 +43,18 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 #include "../common/pto_runtime_status.h"
 #include "../runtime/common.h"
 #include "../runtime/dep_gen_host_graph.h"
+#include "../runtime/graph_execution.h"
+#include "../runtime/graph_host_state.h"
 #include "../runtime/host_tensor_access.h"
 #include "../runtime/pto_orchestrator.h"
 #include "../runtime/pto_runtime2.h"
@@ -446,6 +451,70 @@ static bool relocate_host_orch_image(
     return ok;
 }
 
+bool upload_graph_submissions(Runtime *runtime, const HostApi *api, GraphHostState &graph_state) {
+    std::unordered_map<uint64_t, uint32_t> occurrences;
+    const size_t count = graph_host_upload_count(graph_state);
+    for (size_t index = 0; index < count; ++index) {
+        std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
+        if (!upload.has_value() || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->outer_slot->task == nullptr) {
+            LOG_ERROR("host-orch: invalid pending Graph POD image");
+            return false;
+        }
+        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
+        const GraphDefinition *definition = graph_submission_definition(*submission);
+        size_t execution_bytes = 0;
+        if (definition == nullptr || definition->full_key != submission->graph_key || definition->task_count == 0 ||
+            definition->task_count > GRAPH_MAX_NODES ||
+            !graph_execution_storage_bytes(
+                static_cast<int32_t>(definition->task_count), definition->tensor_arg_count, definition->total_bytes,
+                &execution_bytes
+            )) {
+            LOG_ERROR("host-orch: invalid Graph execution storage request");
+            return false;
+        }
+        const uint32_t occurrence = occurrences[submission->graph_key]++;
+        void *execution_storage = api->acquire_graph_execution_buffer(
+            submission->graph_key, occurrence, execution_bytes, alignof(GraphNodeStorage)
+        );
+        if (execution_storage == nullptr) {
+            LOG_ERROR(
+                "host-orch: failed to retain %zu bytes for Graph execution key=%#llx occurrence=%u", execution_bytes,
+                static_cast<unsigned long long>(submission->graph_key), occurrence
+            );
+            return false;
+        }
+        submission->execution_storage = reinterpret_cast<uint64_t>(execution_storage);
+        submission->execution_storage_bytes = execution_bytes;
+        submission->local_execution = 0;
+        submission->activation_gate = 0;
+
+        void *device_submission = api->device_malloc(upload->bytes);
+        if (device_submission == nullptr) {
+            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
+            return false;
+        }
+        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
+            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
+            api->device_free(device_submission);
+            return false;
+        }
+        upload->outer_slot->graph_context = device_submission;
+        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
+    }
+    return true;
+}
+
+struct GraphHostStateBinding {
+    explicit GraphHostStateBinding(PTO2OrchestratorState &orchestrator, GraphHostState *state) :
+        orchestrator(orchestrator) {
+        orchestrator.graph_host_state = state;
+    }
+    ~GraphHostStateBinding() { orchestrator.graph_host_state = nullptr; }
+
+    PTO2OrchestratorState &orchestrator;
+};
+
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
     const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
@@ -475,6 +544,13 @@ int32_t run_host_orchestration(
         return -1;
     }
 
+    GraphHostStatePtr graph_state = make_graph_host_state();
+    if (!graph_state) {
+        LOG_ERROR("host-orch: failed to allocate Graph recording state");
+        return -1;
+    }
+    GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
+
     // Install the ops table (host s_runtime_ops) and latch this run's cluster
     // counts. worker_count is published by DeviceRunner::prepare_launch_shape
     // before this bind, so the host orchestrator sees the same geometry the
@@ -495,6 +571,7 @@ int32_t run_host_orchestration(
     // into the host address space.
 
     const HostOrchEntryPoints *eps = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
+    rt->active_callable_hash = reinterpret_cast<uint64_t>(eps->entry);
     if (eps->bind != nullptr) {
         rt->tensor_access = &tensor_access;
         // Binds the orchestration .so's own framework_current_runtime, which its
@@ -514,6 +591,7 @@ int32_t run_host_orchestration(
     rt_orchestration_done(rt);
 
     int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
+    if (!upload_graph_submissions(runtime, api, *graph_state)) return -1;
 
     // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
     // on the host, before the SM and arena leave for the device. Pointers into

--- a/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -30,10 +30,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <cstring>
 #include <type_traits>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
+#include "graph_cache.h"         // Graph Execution key and result helpers
 #include "pto_runtime2_types.h"  // PTO2_ERROR_*
 #include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
 #include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType
@@ -91,6 +93,9 @@ typedef struct PTO2RuntimeOps {
     // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
+    GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args);
+    void (*graph_end)(PTO2Runtime *rt);
+    void (*graph_commit)(PTO2Runtime *rt);
 
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -206,6 +211,30 @@ static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
         return TaskOutputTensors{};
     }
     return rt->ops->submit_dummy_task(rt, args);
+}
+
+static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const CoreTaskArgs &args) {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->is_fatal(rt) || rt->ops->graph_begin == nullptr) {
+        return GraphScopeResult{};
+    }
+    return rt->ops->graph_begin(rt, graph_key, args);
+}
+
+static inline void rt_graph_end() {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->is_fatal(rt) || rt->ops->graph_end == nullptr) {
+        return;
+    }
+    rt->ops->graph_end(rt);
+}
+
+static inline void rt_graph_commit() {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->is_fatal(rt) || rt->ops->graph_commit == nullptr) {
+        return;
+    }
+    rt->ops->graph_commit(rt);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
@@ -342,6 +371,84 @@ public:
 private:
     PTO2Runtime *rt_;
 };
+
+// Define or submit a Graph Execution. On a cache miss the function executes
+// normally and its sub-DAG is recorded. On a hit the function is skipped and
+// one Graph task is submitted; Scheduler expands the cached topology with the
+// current invocation's CoreTaskArgs.
+using GraphFunction = void (*)(const CoreTaskArgs &);
+
+template <typename Function>
+static inline uint64_t rt_graph_function_id(Function function) {
+    static_assert(std::is_pointer_v<Function>, "Graph function identity requires a function pointer");
+    static_assert(sizeof(function) <= sizeof(uint64_t), "Graph function pointer must fit in a 64-bit identity");
+    uint64_t function_id = 0;
+    std::memcpy(&function_id, &function, sizeof(function));
+    return function_id;
+}
+
+template <typename Invoke>
+static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const CoreTaskArgs &args, Invoke invoke) {
+    debug_assert(!args.has_error && "Graph boundary CoreTaskArgs construction failed");
+    debug_assert(
+        args.tensor_count() <= static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS) &&
+        "Graph boundary exceeds the step-1 tensor limit"
+    );
+    debug_assert(args.scalar_count() == 0 && "Dynamic Graph boundary scalars are not supported in step 1");
+    debug_assert(
+        args.explicit_dep_count() == 0 && "Explicit dependencies crossing the Graph boundary are not supported"
+    );
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        debug_assert(
+            args.tag(i) != TensorArgType::OUTPUT &&
+            "Runtime-allocated TensorCreateInfo is not supported at the Graph boundary"
+        );
+    }
+    if (!rt_graph_args_cacheable(args)) {
+        invoke();
+        rt_graph_commit();
+        return GraphSubmitResult{};
+    }
+    GraphScopeResult result = rt_graph_begin(graph_key, args);
+    if (result.execute_block) invoke();
+    if (result.recording) {
+        rt_graph_end();
+    }
+    rt_graph_commit();
+    return result;
+}
+
+static inline GraphSubmitResult rt_submit_graph(uint64_t graph_id, GraphFunction function, const CoreTaskArgs &args) {
+    debug_assert(function != nullptr && "Graph function must not be null");
+    if (function == nullptr) return GraphSubmitResult{};
+    return rt_submit_graph_impl(rt_graph_make_key(graph_id), args, [&]() {
+        function(args);
+    });
+}
+
+static inline GraphSubmitResult rt_submit_graph(GraphFunction function, const CoreTaskArgs &args) {
+    return rt_submit_graph(rt_graph_function_id(function), function, args);
+}
+
+template <typename... Config>
+using GraphFunctionWithConfig = void (*)(const CoreTaskArgs &, Config...);
+
+template <typename... Config>
+static inline GraphSubmitResult rt_submit_graph(
+    uint64_t graph_id, GraphFunctionWithConfig<Config...> function, const CoreTaskArgs &args, Config... config
+) {
+    debug_assert(function != nullptr && "Graph function must not be null");
+    if (function == nullptr) return GraphSubmitResult{};
+    return rt_submit_graph_impl(rt_graph_make_key(graph_id, config...), args, [&]() {
+        function(args, config...);
+    });
+}
+
+template <typename... Config>
+static inline GraphSubmitResult
+rt_submit_graph(GraphFunctionWithConfig<Config...> function, const CoreTaskArgs &args, Config... config) {
+    return rt_submit_graph(rt_graph_function_id(function), function, args, config...);
+}
 
 #define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)

--- a/src/a5/runtime/host_build_graph/runtime/graph_cache.h
+++ b/src/a5/runtime/host_build_graph/runtime/graph_cache.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <type_traits>
+
+#include "pto_task_id.h"
+#include "pto_types.h"
+
+inline constexpr uint32_t GRAPH_MAX_TENSOR_ARGS = 32;
+
+struct GraphScopeResult {
+    bool execute_block{true};
+    bool recording{false};
+    PTO2TaskId task_id{PTO2TaskId::invalid()};
+};
+
+using GraphSubmitResult = GraphScopeResult;
+
+constexpr uint64_t graph_hash_byte(uint64_t h, uint8_t b) { return (h ^ static_cast<uint64_t>(b)) * 1099511628211ULL; }
+
+inline uint64_t graph_hash_bytes(uint64_t h, const void *data, size_t bytes) {
+    const auto *p = static_cast<const uint8_t *>(data);
+    for (size_t i = 0; i < bytes; ++i) {
+        h = graph_hash_byte(h, p[i]);
+    }
+    return h;
+}
+
+constexpr uint64_t graph_const_hash_impl(const char *s, uint64_t h) {
+    return (*s == '\0') ? h : graph_const_hash_impl(s + 1, graph_hash_byte(h, static_cast<uint8_t>(*s)));
+}
+
+constexpr uint64_t GRAPH_KEY(const char *s) { return graph_const_hash_impl(s, 1469598103934665603ULL); }
+
+inline bool rt_graph_args_cacheable(const CoreTaskArgs &args) {
+    // Step 1 supports dynamic tensor addresses only. Kernel scalars are
+    // literals inside the Graph function and become immutable Definition data.
+    if (args.has_error || args.tensor_count() <= 0 ||
+        args.tensor_count() > static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS) || args.scalar_count() != 0) {
+        return false;
+    }
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        // A Graph boundary is caller-owned storage. Runtime-allocated
+        // TensorCreateInfo outputs remain on the ordinary submit path.
+        if (args.tag(i) == TensorArgType::OUTPUT) return false;
+    }
+    return true;
+}
+
+inline uint64_t rt_graph_make_key(uint64_t graph_id) { return graph_id; }
+
+template <typename T>
+inline uint64_t graph_hash_config_value(uint64_t hash, T value) {
+    using Value = std::remove_cv_t<std::remove_reference_t<T>>;
+    static_assert(
+        std::is_integral_v<Value> || std::is_same_v<Value, float> || std::is_same_v<Value, double>,
+        "Graph construction parameters must be integral, float, or double values"
+    );
+    constexpr uint8_t category = std::is_same_v<Value, bool> ? 1 :
+                                 std::is_integral_v<Value>   ? (std::is_signed_v<Value> ? 2 : 3) :
+                                                               4;
+    constexpr uint8_t width = sizeof(Value);
+    hash = graph_hash_byte(hash, category);
+    hash = graph_hash_byte(hash, width);
+    return graph_hash_bytes(hash, &value, sizeof(value));
+}
+
+template <typename... Config>
+inline uint64_t rt_graph_make_key(uint64_t graph_id, Config... config) {
+    uint64_t hash = graph_hash_bytes(1469598103934665603ULL, &graph_id, sizeof(graph_id));
+    const uint32_t count = sizeof...(Config);
+    hash = graph_hash_bytes(hash, &count, sizeof(count));
+    ((hash = graph_hash_config_value(hash, config)), ...);
+    return hash;
+}

--- a/src/a5/runtime/host_build_graph/runtime/graph_execution.h
+++ b/src/a5/runtime/host_build_graph/runtime/graph_execution.h
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <type_traits>
+
+#include "pto_runtime2_types.h"
+#include "tensor.h"
+
+inline constexpr uint32_t GRAPH_MAX_NODES = 1024;
+inline constexpr int32_t GRAPH_MATERIALIZE_SLICE_NODES = 4;
+
+enum class GraphTensorSource : uint8_t {
+    BOUNDARY_EXACT = 0,
+    BOUNDARY_VIEW = 1,
+    INTERNAL = 2,
+    OWN_OUTPUT = 3,
+};
+
+// Wire representation of ChipTensor. ChipTensor itself is a host/runtime C++ type with
+// 64-byte alignment and helper methods; placing it inside vector<std::byte>
+// would not guarantee that alignment. Keep the boundary image C-compatible and
+// copy only semantic fields into this naturally 8-byte-aligned POD.
+struct GraphTensor {
+    uint64_t buffer_addr;
+    uint64_t buffer_size;
+    uint64_t owner_task_id;
+    uint64_t start_offset;
+    uint64_t extent_elem;
+    int32_t version;
+    uint32_t shapes[MAX_TENSOR_DIMS];
+    uint32_t strides[MAX_TENSOR_DIMS];
+    uint8_t ndims;
+    uint8_t dtype;
+    uint8_t manual_dep;
+    uint8_t is_contiguous;
+    uint8_t address_space;
+    uint8_t reserved[3];
+};
+
+// Everything from GraphTensorSourceRef through GraphSubmission is copied
+// across the host-device boundary. Keep it pointer-free, fixed-width and
+// position-independent: every reference is an offset from its owning header.
+struct GraphTensorSourceRef {
+    uint8_t source;
+    uint8_t reserved;
+    uint16_t source_index;
+    uint32_t reserved2;
+    uint64_t packed_offset;
+};
+
+struct GraphNodeDefinition {
+    int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
+    uint8_t active_mask;
+    uint8_t task_attrs;
+    int16_t logical_block_num;
+    int16_t total_required_subtasks;
+    uint16_t reserved;
+    int32_t tensor_count;
+    int32_t scalar_count;
+    int32_t total_output_size;
+    uint32_t tensor_offset;
+    uint32_t scalar_offset;
+};
+
+struct GraphBoundarySignature {
+    uint64_t buffer_size;
+    uint32_t shapes[MAX_TENSOR_DIMS];
+    uint32_t strides[MAX_TENSOR_DIMS];
+    uint16_t alias_rep;
+    uint8_t ndims;
+    uint8_t dtype;
+    uint8_t tag;
+    uint8_t manual_dep;
+    uint8_t is_contiguous;
+    uint8_t reserved;
+};
+
+struct GraphDefinition {
+    uint64_t full_key;
+    uint64_t content_hash;
+    uint64_t required_heap;
+    uint32_t total_bytes;
+    uint32_t task_count;
+    uint32_t edge_count;
+    uint32_t root_count;
+    uint32_t boundary_count;
+    uint32_t tensor_arg_count;
+    uint32_t scalar_arg_count;
+    uint32_t off_fanout_offsets;
+    uint32_t off_fanout_indices;
+    uint32_t off_fanin_offsets;
+    uint32_t off_fanin_indices;
+    uint32_t off_root_indices;
+    uint32_t off_node_offsets;
+    uint32_t off_nodes;
+    uint32_t off_tensors;
+    uint32_t off_tensor_sources;
+    uint32_t off_scalars;
+    uint32_t off_boundary_signatures;
+};
+
+struct GraphSubmission {
+    uint64_t graph_key;
+    uint64_t execution_storage;
+    uint64_t execution_storage_bytes;
+    uint64_t local_execution;
+    uint32_t activation_gate;
+    uint32_t total_bytes;
+    uint32_t definition_offset;
+    uint32_t tensors_offset;
+    uint32_t tensor_count;
+    uint32_t reserved;
+};
+
+static_assert(std::is_trivially_copyable_v<GraphTensorSourceRef>);
+static_assert(std::is_standard_layout_v<GraphTensorSourceRef>);
+static_assert(std::is_trivially_copyable_v<GraphTensor>);
+static_assert(std::is_standard_layout_v<GraphTensor>);
+static_assert(std::is_trivially_copyable_v<GraphNodeDefinition>);
+static_assert(std::is_standard_layout_v<GraphNodeDefinition>);
+static_assert(std::is_trivially_copyable_v<GraphBoundarySignature>);
+static_assert(std::is_standard_layout_v<GraphBoundarySignature>);
+static_assert(std::is_trivially_copyable_v<GraphDefinition>);
+static_assert(std::is_standard_layout_v<GraphDefinition>);
+static_assert(std::is_trivially_copyable_v<GraphSubmission>);
+static_assert(std::is_standard_layout_v<GraphSubmission>);
+
+inline GraphTensor graph_tensor_pack(const ChipTensor &tensor) {
+    GraphTensor packed{};
+    packed.buffer_addr = tensor.buffer.addr;
+    packed.buffer_size = tensor.buffer.size;
+    packed.owner_task_id = tensor.owner_task_id.raw;
+    packed.start_offset = tensor.start_offset;
+    packed.extent_elem = tensor.extent_elem_cache;
+    packed.version = tensor.version;
+    for (uint32_t i = 0; i < tensor.ndims; ++i) {
+        packed.shapes[i] = tensor.shapes[i];
+        packed.strides[i] = tensor.strides[i];
+    }
+    packed.ndims = static_cast<uint8_t>(tensor.ndims);
+    packed.dtype = static_cast<uint8_t>(tensor.dtype);
+    packed.manual_dep = tensor.manual_dep ? 1 : 0;
+    packed.is_contiguous = tensor.is_contiguous ? 1 : 0;
+    packed.address_space = static_cast<uint8_t>(tensor.address_space);
+    return packed;
+}
+
+inline void graph_tensor_unpack(const GraphTensor &packed, ChipTensor *tensor) {
+    tensor->buffer = PTOBufferHandle{packed.buffer_addr, packed.buffer_size};
+    tensor->owner_task_id = PTO2TaskId{packed.owner_task_id};
+    tensor->start_offset = packed.start_offset;
+    tensor->extent_elem_cache = packed.extent_elem;
+    tensor->version = packed.version;
+    tensor->ndims = packed.ndims;
+    tensor->dtype = static_cast<DataType>(packed.dtype);
+    tensor->manual_dep = packed.manual_dep != 0;
+    tensor->is_contiguous = packed.is_contiguous != 0;
+    tensor->address_space = static_cast<AddressSpace>(packed.address_space);
+    for (uint32_t i = 0; i < MAX_TENSOR_DIMS; ++i) {
+        tensor->shapes[i] = packed.shapes[i];
+        tensor->strides[i] = packed.strides[i];
+    }
+    for (uint8_t &byte : tensor->_pad_cl2)
+        byte = 0;
+}
+
+inline bool graph_tensor_wire_valid(const GraphTensor &tensor) {
+    if (tensor.buffer_addr == 0 || tensor.ndims == 0 || tensor.ndims > MAX_TENSOR_DIMS ||
+        tensor.dtype >= static_cast<uint8_t>(DataType::DATA_TYPE_NUM) || tensor.manual_dep > 1 ||
+        tensor.is_contiguous > 1 || tensor.address_space > 1) {
+        return false;
+    }
+
+    uint64_t extent = 1;
+    uint64_t expected_stride = 1;
+    bool contiguous = true;
+    for (int32_t i = static_cast<int32_t>(tensor.ndims) - 1; i >= 0; --i) {
+        const uint64_t shape = tensor.shapes[i];
+        const uint64_t stride = tensor.strides[i];
+        if (shape == 0 || stride == 0) return false;
+        contiguous &= stride == expected_stride;
+        if (shape - 1 > (UINT64_MAX - extent) / stride || expected_stride > UINT64_MAX / shape) return false;
+        extent += (shape - 1) * stride;
+        expected_stride *= shape;
+    }
+    if (extent != tensor.extent_elem || contiguous != (tensor.is_contiguous != 0)) return false;
+
+    const uint64_t element_size = get_element_size(static_cast<DataType>(tensor.dtype));
+    const uint64_t buffer_elements = tensor.buffer_size / element_size;
+    return tensor.start_offset <= buffer_elements && tensor.extent_elem <= buffer_elements - tensor.start_offset;
+}
+
+template <typename T>
+inline const T *graph_definition_array(const GraphDefinition &definition, uint32_t offset, uint32_t count) {
+    if (offset == 0 || offset > definition.total_bytes || offset % alignof(T) != 0) return nullptr;
+    const size_t remaining = static_cast<size_t>(definition.total_bytes - offset);
+    if (count > remaining / sizeof(T)) return nullptr;
+    return reinterpret_cast<const T *>(reinterpret_cast<const uint8_t *>(&definition) + offset);
+}
+
+template <typename T>
+inline const T *graph_definition_ptr(const GraphDefinition &definition, uint32_t offset) {
+    return graph_definition_array<T>(definition, offset, 1);
+}
+
+inline GraphSubmission *graph_submission_from_slot(PTO2TaskSlotState &slot) {
+    return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphSubmission *>(slot.graph_context) : nullptr;
+}
+
+inline const GraphDefinition *graph_submission_definition(const GraphSubmission &submission) {
+    if (submission.definition_offset == 0 || submission.definition_offset % alignof(GraphDefinition) != 0 ||
+        submission.definition_offset > submission.total_bytes ||
+        sizeof(GraphDefinition) > submission.total_bytes - submission.definition_offset) {
+        return nullptr;
+    }
+    return reinterpret_cast<const GraphDefinition *>(
+        reinterpret_cast<const uint8_t *>(&submission) + submission.definition_offset
+    );
+}
+
+inline const GraphTensor *graph_submission_tensors(const GraphSubmission &submission) {
+    if (submission.tensors_offset == 0 || submission.tensors_offset % alignof(GraphTensor) != 0 ||
+        submission.tensors_offset > submission.total_bytes ||
+        submission.tensor_count > (submission.total_bytes - submission.tensors_offset) / sizeof(GraphTensor)) {
+        return nullptr;
+    }
+    return reinterpret_cast<const GraphTensor *>(
+        reinterpret_cast<const uint8_t *>(&submission) + submission.tensors_offset
+    );
+}
+
+enum class GraphExecutionState : uint8_t {
+    SUBMITTED = 0,
+    MATERIALIZING = 1,
+    PREPARED = 2,
+    ACTIVE = 3,
+    COMPLETED = 4,
+};
+
+enum class GraphMaterializeResult : uint8_t {
+    INVALID = 0,
+    BUSY = 1,
+    PENDING = 2,
+    PREPARED = 3,
+};
+
+enum class GraphTensorAddressSource : uint8_t {
+    BOUNDARY = 0,
+    INTERNAL = 1,
+};
+
+// Precomputed on the first materialization and retained next to the node
+// storage. Affine replay walks this compact POD instead of re-reading and
+// classifying GraphTensorSourceRef entries from the Definition.
+struct GraphTensorAddressPatch {
+    uint64_t address_offset;
+    uint16_t source_index;
+    uint8_t source;
+    uint8_t reserved[5];
+};
+
+static_assert(std::is_trivially_copyable_v<GraphTensorAddressPatch>);
+static_assert(std::is_standard_layout_v<GraphTensorAddressPatch>);
+static_assert(sizeof(GraphTensorAddressPatch) == 16);
+
+struct alignas(64) GraphNodeStorage {
+    PTO2TaskDescriptor task;
+    PTO2TaskPayload payload;
+    PTO2TaskSlotState slot;
+};
+
+inline constexpr uint64_t GRAPH_EXECUTION_STORAGE_MAGIC = 0x4752415048455845ULL;
+inline constexpr uint64_t GRAPH_EXECUTION_INITIALIZING = 1;
+
+struct GraphExecution {
+    uint64_t storage_magic{0};
+    std::atomic<GraphExecutionState> state{GraphExecutionState::SUBMITTED};
+    std::atomic<uint8_t> materialize_busy{0};
+    std::atomic<int32_t> remaining_nodes{0};
+    std::atomic<int32_t> retired_nodes{0};
+    int32_t node_count{0};
+    int32_t node_capacity{0};
+    int32_t materialized_nodes{0};
+    int32_t materialized_node_count{0};
+    int32_t constructed_nodes{0};
+    uint32_t tensor_patch_capacity{0};
+    uint32_t materialized_tensor_patches{0};
+    uint32_t materialized_tensor_patch_count{0};
+    size_t allocation_bytes{0};
+    size_t definition_capacity{0};
+    uint64_t graph_key{0};
+    uint64_t definition_hash{0};
+    uint64_t materialized_graph_key{0};
+    uint64_t materialized_definition_hash{0};
+    uintptr_t materialized_outer_base{0};
+    bool definition_affine_reuse{false};
+    PTO2TaskSlotState *outer_slot{nullptr};
+    GraphNodeStorage *nodes{nullptr};
+    GraphNodeStorage *node_storage{nullptr};
+    GraphTensorAddressPatch *tensor_patches{nullptr};
+    void *definition_storage{nullptr};
+    const GraphDefinition *definition{nullptr};
+    const uint32_t *fanin_offsets{nullptr};
+    const uint16_t *fanin_indices{nullptr};
+    const GraphTensor *boundary_tensors{nullptr};
+    uint32_t boundary_tensor_count{0};
+};
+
+static_assert(std::is_trivially_destructible_v<GraphNodeStorage>);
+static_assert(std::is_trivially_destructible_v<GraphExecution>);
+
+inline bool graph_execution_storage_layout(
+    int32_t node_capacity, uint32_t tensor_patch_capacity, size_t definition_capacity, size_t *nodes_offset,
+    size_t *tensor_patches_offset, size_t *definition_offset, size_t *storage_bytes
+) {
+    if (nodes_offset == nullptr || tensor_patches_offset == nullptr || definition_offset == nullptr ||
+        storage_bytes == nullptr || node_capacity <= 0 ||
+        static_cast<size_t>(node_capacity) > SIZE_MAX / sizeof(GraphNodeStorage) ||
+        tensor_patch_capacity > GRAPH_MAX_NODES * MAX_TENSOR_ARGS) {
+        return false;
+    }
+    auto checked_align_up = [](size_t value, size_t alignment, size_t *result) {
+        if (alignment == 0 || value > SIZE_MAX - (alignment - 1)) return false;
+        *result = (value + alignment - 1) & ~(alignment - 1);
+        return true;
+    };
+    const size_t nodes_bytes = static_cast<size_t>(node_capacity) * sizeof(GraphNodeStorage);
+    const size_t tensor_patches_bytes = static_cast<size_t>(tensor_patch_capacity) * sizeof(GraphTensorAddressPatch);
+    if (!checked_align_up(sizeof(GraphExecution), alignof(GraphNodeStorage), nodes_offset) ||
+        *nodes_offset > SIZE_MAX - nodes_bytes ||
+        !checked_align_up(*nodes_offset + nodes_bytes, alignof(GraphTensorAddressPatch), tensor_patches_offset) ||
+        *tensor_patches_offset > SIZE_MAX - tensor_patches_bytes ||
+        !checked_align_up(*tensor_patches_offset + tensor_patches_bytes, alignof(GraphDefinition), definition_offset) ||
+        *definition_offset > SIZE_MAX - definition_capacity) {
+        return false;
+    }
+    return checked_align_up(*definition_offset + definition_capacity, alignof(GraphNodeStorage), storage_bytes);
+}
+
+inline bool graph_execution_storage_bytes(
+    int32_t node_capacity, uint32_t tensor_patch_capacity, size_t definition_capacity, size_t *storage_bytes
+) {
+    size_t nodes_offset = 0;
+    size_t tensor_patches_offset = 0;
+    size_t definition_offset = 0;
+    return graph_execution_storage_layout(
+        node_capacity, tensor_patch_capacity, definition_capacity, &nodes_offset, &tensor_patches_offset,
+        &definition_offset, storage_bytes
+    );
+}
+
+GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot);
+GraphMaterializeResult graph_execution_materialize_slice(
+    PTO2TaskSlotState &outer_slot, GraphExecution &execution, int32_t max_nodes, int32_t *nodes_materialized = nullptr
+);
+
+inline GraphExecution *graph_execution_from_slot(PTO2TaskSlotState &slot) {
+    return slot.task_kind == TaskKind::GRAPH_NODE ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
+}
+
+inline bool graph_execution_complete_node(GraphExecution &execution) {
+    return execution.remaining_nodes.fetch_sub(1, std::memory_order_acq_rel) == 1;
+}
+
+inline void graph_execution_mark_completed(GraphExecution &execution) {
+    execution.state.store(GraphExecutionState::COMPLETED, std::memory_order_release);
+}
+
+inline void graph_execution_retire_node(GraphExecution &execution) {
+    execution.retired_nodes.fetch_add(1, std::memory_order_release);
+}
+
+inline bool graph_submission_signal(GraphSubmission &submission, uint32_t bit) {
+    constexpr uint32_t BOTH = 0x3;
+    uint32_t observed = __atomic_fetch_or(&submission.activation_gate, bit, __ATOMIC_ACQ_REL);
+    return (observed | bit) == BOTH;
+}
+
+inline GraphExecution *graph_submission_local_execution(GraphSubmission &submission) {
+    uint64_t raw = __atomic_load_n(&submission.local_execution, __ATOMIC_ACQUIRE);
+    if (raw <= GRAPH_EXECUTION_INITIALIZING) return nullptr;
+    return reinterpret_cast<GraphExecution *>(static_cast<uintptr_t>(raw));
+}
+
+inline bool graph_submission_execution_initializing(const GraphSubmission &submission) {
+    return __atomic_load_n(&submission.local_execution, __ATOMIC_ACQUIRE) == GRAPH_EXECUTION_INITIALIZING;
+}

--- a/src/a5/runtime/host_build_graph/runtime/graph_host_state.h
+++ b/src/a5/runtime/host_build_graph/runtime/graph_host_state.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+
+struct PTO2TaskSlotState;
+struct GraphHostState;
+
+inline constexpr size_t GRAPH_MAX_DEFINITIONS = 16;
+
+struct GraphHostStateDeleter {
+    void operator()(GraphHostState *state) const noexcept;
+};
+
+using GraphHostStatePtr = std::unique_ptr<GraphHostState, GraphHostStateDeleter>;
+
+struct GraphHostUpload {
+    PTO2TaskSlotState *outer_slot;
+    std::byte *data;
+    size_t bytes;
+};
+
+GraphHostStatePtr make_graph_host_state();
+size_t graph_host_upload_count(const GraphHostState &state);
+std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index);

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -28,10 +28,24 @@
 #include <string.h>
 #include <time.h>
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <new>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "dep_gen_host_graph.h"
 #include "pto_dep_compute.h"
+#include "graph_execution.h"
+#include "graph_host_state.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 #include "pto_tensormap.h"
@@ -251,6 +265,441 @@ void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, c
     va_end(args);
 }
 
+enum class GraphRecordedTensorSource : uint8_t {
+    BOUNDARY_EXACT,
+    BOUNDARY_VIEW,
+    INTERNAL,
+    OWN_OUTPUT,
+};
+
+struct GraphRecordedTensorSourceRef {
+    GraphRecordedTensorSource source{GraphRecordedTensorSource::BOUNDARY_EXACT};
+    size_t source_index{0};
+    uint64_t packed_offset{0};
+};
+
+struct GraphRecordedNode {
+    std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids{};
+    ActiveMask active_mask{};
+    TaskAttrs task_attrs{};
+    int16_t logical_block_num{1};
+    int16_t total_required_subtasks{0};
+    size_t total_output_size{0};
+    uintptr_t record_packed_base{0};
+    std::vector<ChipTensor> tensors;
+    std::vector<GraphRecordedTensorSourceRef> tensor_sources;
+    std::vector<uint64_t> scalars;
+    std::vector<size_t> internal_fanins;
+};
+
+struct GraphRecording {
+    uint64_t full_key{0};
+    int32_t start_local_task_id{0};
+    std::optional<size_t> current_task_index;
+    bool unsupported{false};
+    std::vector<size_t> current_fanins;
+    std::vector<ChipTensor> boundary_tensors;
+    std::vector<TensorArgType> boundary_types;
+    std::vector<GraphRecordedNode> nodes;
+};
+
+struct GraphPendingUpload {
+    PTO2TaskSlotState *outer_slot{nullptr};
+    std::vector<std::byte> image;
+};
+
+struct GraphHostState {
+    std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
+    std::unique_ptr<GraphRecording> recording;
+    std::vector<GraphPendingUpload> pending_uploads;
+};
+
+namespace {
+
+GraphHostState *graph_state_from(PTO2OrchestratorState *orch) {
+    return orch == nullptr ? nullptr : static_cast<GraphHostState *>(orch->graph_host_state);
+}
+
+uint64_t graph_full_key(uint64_t callable_hash, uint64_t graph_key) {
+    uint64_t h = 1469598103934665603ULL;
+    h = graph_hash_bytes(h, &callable_hash, sizeof(callable_hash));
+    return graph_hash_bytes(h, &graph_key, sizeof(graph_key));
+}
+
+bool graph_tensor_exact(const ChipTensor &lhs, const ChipTensor &rhs) {
+    if (lhs.ndims > MAX_TENSOR_DIMS || rhs.ndims > MAX_TENSOR_DIMS || lhs.buffer.addr != rhs.buffer.addr ||
+        lhs.buffer.size != rhs.buffer.size || lhs.start_offset != rhs.start_offset || lhs.version != rhs.version ||
+        lhs.ndims != rhs.ndims || lhs.dtype != rhs.dtype || lhs.manual_dep != rhs.manual_dep ||
+        lhs.is_contiguous != rhs.is_contiguous || lhs.address_space != rhs.address_space) {
+        return false;
+    }
+    return std::equal(std::begin(lhs.shapes), std::begin(lhs.shapes) + lhs.ndims, std::begin(rhs.shapes)) &&
+           std::equal(std::begin(lhs.strides), std::begin(lhs.strides) + lhs.ndims, std::begin(rhs.strides));
+}
+
+bool graph_tensor_from_boundary(
+    const GraphRecording &recording, const ChipTensor &tensor, GraphRecordedTensorSourceRef *source
+) {
+    for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        if (!graph_tensor_exact(tensor, recording.boundary_tensors[i])) continue;
+        source->source = GraphRecordedTensorSource::BOUNDARY_EXACT;
+        source->source_index = i;
+        source->packed_offset = 0;
+        return true;
+    }
+    for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        const ChipTensor &boundary = recording.boundary_tensors[i];
+        if (tensor.buffer.addr != boundary.buffer.addr || tensor.buffer.size != boundary.buffer.size ||
+            tensor.start_offset < boundary.start_offset) {
+            continue;
+        }
+        source->source = GraphRecordedTensorSource::BOUNDARY_VIEW;
+        source->source_index = i;
+        source->packed_offset = tensor.start_offset - boundary.start_offset;
+        return true;
+    }
+    return false;
+}
+
+bool graph_classify_tensor(
+    const GraphRecording &recording, const GraphRecordedNode &current, int32_t task_index, const ChipTensor &tensor,
+    GraphRecordedTensorSourceRef *source
+) {
+    if (graph_tensor_from_boundary(recording, tensor, source)) return true;
+    const uint64_t tensor_addr = tensor.buffer.addr;
+    for (int32_t producer_index = task_index; producer_index >= 0; --producer_index) {
+        const GraphRecordedNode &producer =
+            producer_index == task_index ? current : recording.nodes[static_cast<size_t>(producer_index)];
+        if (producer.record_packed_base == 0 || producer.total_output_size == 0 ||
+            producer.total_output_size > UINTPTR_MAX - producer.record_packed_base) {
+            continue;
+        }
+        const uintptr_t begin = producer.record_packed_base;
+        const uintptr_t end = begin + producer.total_output_size;
+        if (tensor_addr < begin || tensor_addr >= end) continue;
+        source->source =
+            producer_index == task_index ? GraphRecordedTensorSource::OWN_OUTPUT : GraphRecordedTensorSource::INTERNAL;
+        source->source_index = static_cast<size_t>(producer_index);
+        source->packed_offset = tensor_addr - begin;
+        return true;
+    }
+    return false;
+}
+
+void graph_record_begin_task(PTO2OrchestratorState *orch, PTO2TaskId task_id) {
+    GraphHostState *state = graph_state_from(orch);
+    if (state == nullptr || state->recording == nullptr || state->recording->unsupported) return;
+    GraphRecording &recording = *state->recording;
+    const int32_t index = static_cast<int32_t>(task_id.local()) - recording.start_local_task_id;
+    if (index < 0 || index >= static_cast<int32_t>(GRAPH_MAX_NODES) ||
+        index != static_cast<int32_t>(recording.nodes.size())) {
+        recording.unsupported = true;
+        return;
+    }
+    recording.current_task_index = static_cast<size_t>(index);
+    recording.current_fanins.clear();
+}
+
+void graph_record_note_fanin(PTO2OrchestratorState *orch, PTO2TaskSlotState *producer) {
+    GraphHostState *state = graph_state_from(orch);
+    if (state == nullptr || state->recording == nullptr || state->recording->unsupported) return;
+    GraphRecording &recording = *state->recording;
+    if (producer == nullptr || producer->task == nullptr || !recording.current_task_index.has_value()) {
+        recording.unsupported = true;
+        return;
+    }
+    const int32_t producer_index =
+        static_cast<int32_t>(producer->task->task_id.local()) - recording.start_local_task_id;
+    if (producer_index >= 0 && static_cast<size_t>(producer_index) >= *recording.current_task_index) {
+        recording.unsupported = true;
+        return;
+    }
+    if (producer_index >= 0) recording.current_fanins.push_back(static_cast<size_t>(producer_index));
+}
+
+void graph_record_mark_unsupported(PTO2OrchestratorState *orch) {
+    GraphHostState *state = graph_state_from(orch);
+    if (state != nullptr && state->recording != nullptr) state->recording->unsupported = true;
+}
+
+void graph_record_task(
+    PTO2OrchestratorState *orch, PTO2TaskId task_id, const PTO2TaskDescriptor &task, const PTO2TaskPayload &payload,
+    const PTO2TaskSlotState &slot, const CoreTaskArgs &args
+) {
+    GraphHostState *state = graph_state_from(orch);
+    if (state == nullptr || state->recording == nullptr || state->recording->unsupported) return;
+    GraphRecording &recording = *state->recording;
+    const int32_t task_index = static_cast<int32_t>(task_id.local()) - recording.start_local_task_id;
+    if (task_index < 0 || !recording.current_task_index.has_value() ||
+        static_cast<size_t>(task_index) != *recording.current_task_index ||
+        static_cast<size_t>(task_index) != recording.nodes.size() || args.predicate().op != PredicateOp::NONE) {
+        recording.unsupported = true;
+        return;
+    }
+    for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
+        const PTO2TaskId dep = args.explicit_dep(i);
+        const int32_t dep_index = static_cast<int32_t>(dep.local()) - recording.start_local_task_id;
+        if (!dep.is_valid() || dep.ring() != 0 || dep_index >= task_index) {
+            recording.unsupported = true;
+            return;
+        }
+        if (dep_index < 0) {
+            const bool represented_by_boundary = std::any_of(
+                recording.boundary_tensors.begin(), recording.boundary_tensors.end(), [dep](const ChipTensor &tensor) {
+                    return tensor.owner_task_id == dep;
+                }
+            );
+            if (!represented_by_boundary) {
+                recording.unsupported = true;
+                return;
+            }
+        }
+    }
+
+    GraphRecordedNode node;
+    std::copy_n(std::begin(task.kernel_id), PTO2_SUBTASK_SLOT_COUNT, node.kernel_ids.begin());
+    node.active_mask = slot.active_mask;
+    node.task_attrs = slot.task_attrs;
+    node.task_attrs.set_early_resolve(false);
+    node.logical_block_num = slot.logical_block_num;
+    node.total_required_subtasks = slot.total_required_subtasks;
+    const uintptr_t packed_base = reinterpret_cast<uintptr_t>(task.packed_buffer_base);
+    const uintptr_t packed_end = reinterpret_cast<uintptr_t>(task.packed_buffer_end);
+    if (packed_end < packed_base) {
+        recording.unsupported = true;
+        return;
+    }
+    node.total_output_size = packed_end - packed_base;
+    node.record_packed_base = packed_base;
+    node.tensors.assign(payload.tensors, payload.tensors + payload.tensor_count);
+    node.tensor_sources.resize(static_cast<size_t>(payload.tensor_count));
+    node.scalars.assign(payload.scalars, payload.scalars + payload.scalar_count);
+    for (int32_t i = 0; i < payload.tensor_count; ++i) {
+        if (!graph_classify_tensor(
+                recording, node, task_index, payload.tensors[i], &node.tensor_sources[static_cast<size_t>(i)]
+            )) {
+            recording.unsupported = true;
+            return;
+        }
+    }
+    for (size_t producer : recording.current_fanins) {
+        if (producer >= static_cast<size_t>(task_index)) {
+            recording.unsupported = true;
+            return;
+        }
+        node.internal_fanins.push_back(producer);
+    }
+    recording.nodes.push_back(std::move(node));
+    recording.current_task_index.reset();
+    recording.current_fanins.clear();
+}
+
+GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, TensorArgType type, uint16_t alias_rep) {
+    GraphBoundarySignature signature{};
+    signature.buffer_size = tensor.buffer.size;
+    std::copy(std::begin(tensor.shapes), std::end(tensor.shapes), std::begin(signature.shapes));
+    std::copy(std::begin(tensor.strides), std::end(tensor.strides), std::begin(signature.strides));
+    signature.alias_rep = alias_rep;
+    signature.ndims = static_cast<uint8_t>(tensor.ndims);
+    signature.dtype = static_cast<uint8_t>(tensor.dtype);
+    signature.tag = static_cast<uint8_t>(type);
+    signature.manual_dep = tensor.manual_dep ? 1 : 0;
+    signature.is_contiguous = tensor.is_contiguous ? 1 : 0;
+    return signature;
+}
+
+template <typename T>
+uint32_t graph_append_section(std::vector<std::byte> *image, const std::vector<T> &values) {
+    if (values.empty()) return 0;
+    if (image->size() > UINT32_MAX || values.size() > UINT32_MAX / sizeof(T)) return 0;
+    const size_t aligned = PTO2_ALIGN_UP(image->size(), alignof(T));
+    const size_t bytes = values.size() * sizeof(T);
+    if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return 0;
+    image->resize(aligned + bytes);
+    std::memcpy(image->data() + aligned, values.data(), bytes);
+    return static_cast<uint32_t>(aligned);
+}
+
+std::optional<GraphTensorSourceRef> graph_pack_tensor_source(const GraphRecordedTensorSourceRef &source) {
+    if (source.source_index > UINT16_MAX) return std::nullopt;
+
+    GraphTensorSourceRef packed{};
+    switch (source.source) {
+    case GraphRecordedTensorSource::BOUNDARY_EXACT:
+        packed.source = static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT);
+        break;
+    case GraphRecordedTensorSource::BOUNDARY_VIEW:
+        packed.source = static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW);
+        break;
+    case GraphRecordedTensorSource::INTERNAL:
+        packed.source = static_cast<uint8_t>(GraphTensorSource::INTERNAL);
+        break;
+    case GraphRecordedTensorSource::OWN_OUTPUT:
+        packed.source = static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
+        break;
+    }
+    packed.source_index = static_cast<uint16_t>(source.source_index);
+    packed.packed_offset = source.packed_offset;
+    return packed;
+}
+
+bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
+    if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
+        recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.size() > UINT16_MAX ||
+        recording.boundary_tensors.size() != recording.boundary_types.size() ||
+        std::any_of(recording.boundary_tensors.begin(), recording.boundary_tensors.end(), [](const ChipTensor &tensor) {
+            return tensor.ndims > MAX_TENSOR_DIMS;
+        })) {
+        return false;
+    }
+
+    std::vector<uint32_t> fanout_counts(recording.nodes.size(), 0);
+    std::vector<uint32_t> fanin_offsets(recording.nodes.size() + 1, 0);
+    std::vector<uint16_t> fanin_indices;
+    std::vector<uint16_t> roots;
+    std::vector<uint64_t> node_offsets(recording.nodes.size(), 0);
+    std::vector<GraphNodeDefinition> nodes(recording.nodes.size());
+    std::vector<GraphTensor> tensors;
+    std::vector<GraphTensorSourceRef> tensor_sources;
+    std::vector<uint64_t> scalars;
+
+    uint64_t required_heap = 0;
+    uint32_t edge_count = 0;
+    for (size_t i = 0; i < recording.nodes.size(); ++i) {
+        const GraphRecordedNode &source = recording.nodes[i];
+        if (source.total_output_size > static_cast<size_t>(INT32_MAX) ||
+            source.tensors.size() > static_cast<size_t>(INT32_MAX) ||
+            source.scalars.size() > static_cast<size_t>(INT32_MAX) || source.internal_fanins.size() > UINT16_MAX ||
+            source.tensors.size() != source.tensor_sources.size() ||
+            tensors.size() > UINT32_MAX - source.tensors.size() ||
+            tensor_sources.size() > UINT32_MAX - source.tensor_sources.size() ||
+            scalars.size() > UINT32_MAX - source.scalars.size() ||
+            std::any_of(source.tensors.begin(), source.tensors.end(), [](const ChipTensor &tensor) {
+                return tensor.ndims > MAX_TENSOR_DIMS;
+            })) {
+            return false;
+        }
+        node_offsets[i] = required_heap;
+        const uint64_t output_bytes = PTO2_ALIGN_UP(source.total_output_size, PTO2_ALIGN_SIZE);
+        if (required_heap > UINT64_MAX - output_bytes) return false;
+        required_heap += output_bytes;
+
+        fanin_offsets[i + 1] = fanin_offsets[i] + static_cast<uint32_t>(source.internal_fanins.size());
+        if (source.internal_fanins.empty()) roots.push_back(static_cast<uint16_t>(i));
+        for (size_t producer : source.internal_fanins) {
+            if (producer >= i) return false;
+            fanout_counts[producer]++;
+            fanin_indices.push_back(static_cast<uint16_t>(producer));
+            edge_count++;
+        }
+
+        GraphNodeDefinition &node = nodes[i];
+        std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(node.kernel_id));
+        node.active_mask = source.active_mask.raw();
+        node.task_attrs = source.task_attrs.raw();
+        node.logical_block_num = source.logical_block_num;
+        node.total_required_subtasks = source.total_required_subtasks;
+        node.tensor_count = static_cast<int32_t>(source.tensors.size());
+        node.scalar_count = static_cast<int32_t>(source.scalars.size());
+        node.total_output_size = static_cast<int32_t>(source.total_output_size);
+        node.tensor_offset = static_cast<uint32_t>(tensors.size());
+        node.scalar_offset = static_cast<uint32_t>(scalars.size());
+        for (const ChipTensor &tensor : source.tensors)
+            tensors.push_back(graph_tensor_pack(tensor));
+        for (const GraphRecordedTensorSourceRef &tensor_source : source.tensor_sources) {
+            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(tensor_source);
+            if (!packed_source.has_value()) return false;
+            tensor_sources.push_back(*packed_source);
+        }
+        scalars.insert(scalars.end(), source.scalars.begin(), source.scalars.end());
+    }
+
+    std::vector<uint32_t> fanout_offsets(recording.nodes.size() + 1, 0);
+    for (size_t i = 0; i < recording.nodes.size(); ++i)
+        fanout_offsets[i + 1] = fanout_offsets[i] + fanout_counts[i];
+    std::vector<uint16_t> fanout_indices(edge_count);
+    std::vector<uint32_t> cursors(fanout_offsets.begin(), fanout_offsets.end() - 1);
+    for (size_t consumer = 0; consumer < recording.nodes.size(); ++consumer) {
+        for (size_t producer : recording.nodes[consumer].internal_fanins) {
+            fanout_indices[cursors[producer]++] = static_cast<uint16_t>(consumer);
+        }
+    }
+
+    std::vector<GraphBoundarySignature> signatures;
+    signatures.reserve(recording.boundary_tensors.size());
+    for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        uint16_t alias_rep = static_cast<uint16_t>(i);
+        for (size_t j = 0; j < i; ++j) {
+            if (recording.boundary_tensors[j].buffer.addr == recording.boundary_tensors[i].buffer.addr &&
+                recording.boundary_tensors[j].buffer.size == recording.boundary_tensors[i].buffer.size) {
+                alias_rep = static_cast<uint16_t>(j);
+                break;
+            }
+        }
+        signatures.push_back(
+            graph_boundary_signature(recording.boundary_tensors[i], recording.boundary_types[i], alias_rep)
+        );
+    }
+
+    image->assign(sizeof(GraphDefinition), std::byte{0});
+    GraphDefinition definition{};
+    definition.full_key = recording.full_key;
+    definition.required_heap = required_heap;
+    definition.task_count = static_cast<uint32_t>(nodes.size());
+    definition.edge_count = edge_count;
+    definition.root_count = static_cast<uint32_t>(roots.size());
+    definition.boundary_count = static_cast<uint32_t>(signatures.size());
+    definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
+    definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
+    definition.off_fanout_offsets = graph_append_section(image, fanout_offsets);
+    definition.off_fanout_indices = graph_append_section(image, fanout_indices);
+    definition.off_fanin_offsets = graph_append_section(image, fanin_offsets);
+    definition.off_fanin_indices = graph_append_section(image, fanin_indices);
+    definition.off_root_indices = graph_append_section(image, roots);
+    definition.off_node_offsets = graph_append_section(image, node_offsets);
+    definition.off_nodes = graph_append_section(image, nodes);
+    definition.off_tensors = graph_append_section(image, tensors);
+    definition.off_tensor_sources = graph_append_section(image, tensor_sources);
+    definition.off_scalars = graph_append_section(image, scalars);
+    definition.off_boundary_signatures = graph_append_section(image, signatures);
+    if (definition.off_fanout_offsets == 0 || definition.off_fanin_offsets == 0 || definition.off_node_offsets == 0 ||
+        definition.off_nodes == 0 || definition.off_boundary_signatures == 0 ||
+        (!tensors.empty() && definition.off_tensors == 0) ||
+        (!tensor_sources.empty() && definition.off_tensor_sources == 0) ||
+        (!scalars.empty() && definition.off_scalars == 0) ||
+        (!fanout_indices.empty() && definition.off_fanout_indices == 0) ||
+        (!fanin_indices.empty() && definition.off_fanin_indices == 0) ||
+        (!roots.empty() && definition.off_root_indices == 0)) {
+        return false;
+    }
+    definition.total_bytes = static_cast<uint32_t>(image->size());
+    std::memcpy(image->data(), &definition, sizeof(definition));
+    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image->data(), image->size());
+    std::memcpy(image->data(), &definition, sizeof(definition));
+    return true;
+}
+
+const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {
+    if (image.size() < sizeof(GraphDefinition)) return nullptr;
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(image.data());
+    return definition->total_bytes == image.size() ? definition : nullptr;
+}
+
+}  // namespace
+
+GraphHostStatePtr make_graph_host_state() { return GraphHostStatePtr{new (std::nothrow) GraphHostState{}}; }
+
+void GraphHostStateDeleter::operator()(GraphHostState *state) const noexcept { delete state; }
+
+size_t graph_host_upload_count(const GraphHostState &state) { return state.pending_uploads.size(); }
+
+std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index) {
+    if (index >= state.pending_uploads.size()) return std::nullopt;
+    GraphPendingUpload &upload = state.pending_uploads[index];
+    if (upload.outer_slot == nullptr || upload.image.empty()) return std::nullopt;
+    return GraphHostUpload{upload.outer_slot, upload.image.data(), upload.image.size()};
+}
+
 static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
@@ -311,6 +760,7 @@ static bool append_fanin_or_fail(
     if (fanin_builder->mark_seen(prod_ring, prod_slot)) {
         return true;
     }
+    graph_record_note_fanin(orch, prod_state);
     if (fanin_builder->count >= PTO2_MAX_FANIN) {
         orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
@@ -416,6 +866,8 @@ static bool prepare_task(
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
 
+    graph_record_begin_task(orch, out->task_id);
+
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
     // Re-bind payload/task pointers each submit. Value is per-slot constant
@@ -445,6 +897,7 @@ static bool prepare_task(
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
     out->slot_state->task_attrs = task_attrs;
+    out->slot_state->task_kind = active_mask ? TaskKind::KERNEL : TaskKind::DUMMY;
     // Reclaim gate: seed last_consumer to self, so a producer with no consumers
     // is retirable once completed_watermark >= its own id. Each fanin edge bumps
     // it in append_fanin_or_fail. completion_flags for this slot are already 0
@@ -860,6 +1313,7 @@ static TaskOutputTensors submit_task_common(
     // of position-independent integers, none of this needs host->device pointer
     // relocation.
     payload.fanin_count = fanin_builder.count;
+    graph_record_task(orch, task_id, task, payload, *prepared.slot_state, args);
     (void)sched;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
@@ -874,6 +1328,264 @@ static TaskOutputTensors submit_task_common(
 #endif
     return result;
 }
+
+namespace {
+
+bool graph_boundary_matches(const GraphDefinition &definition, const CoreTaskArgs &args) {
+    if (args.scalar_count() != 0 || args.explicit_dep_count() != 0 ||
+        args.tensor_count() != static_cast<int32_t>(definition.boundary_count)) {
+        LOG_WARN(
+            "[GraphExecution] fixed boundary contract mismatch: tensors=%d/%u scalars=%d explicit_deps=%u",
+            args.tensor_count(), definition.boundary_count, args.scalar_count(), args.explicit_dep_count()
+        );
+        return false;
+    }
+    const auto *signatures = graph_definition_array<GraphBoundarySignature>(
+        definition, definition.off_boundary_signatures, definition.boundary_count
+    );
+    if (signatures == nullptr) return false;
+
+    bool alias_mismatch = false;
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        const ChipTensor &tensor = args.tensor(i).ref();
+        const GraphBoundarySignature &signature = signatures[i];
+        if (tensor.ndims > MAX_TENSOR_DIMS) {
+            debug_assert(tensor.ndims <= MAX_TENSOR_DIMS && "Graph boundary ChipTensor rank is not supported");
+            LOG_WARN("[GraphExecution] ChipTensor rank %u exceeds the fixed Graph boundary limit", tensor.ndims);
+            return false;
+        }
+        const auto shape_end = std::begin(tensor.shapes) + tensor.ndims;
+        const auto stride_end = std::begin(tensor.strides) + tensor.ndims;
+        const bool metadata_match = tensor.buffer.size == signature.buffer_size && tensor.ndims == signature.ndims &&
+                                    static_cast<uint8_t>(tensor.dtype) == signature.dtype &&
+                                    static_cast<uint8_t>(args.tag(i)) == signature.tag &&
+                                    static_cast<uint8_t>(tensor.manual_dep ? 1 : 0) == signature.manual_dep &&
+                                    static_cast<uint8_t>(tensor.is_contiguous ? 1 : 0) == signature.is_contiguous &&
+                                    std::equal(std::begin(tensor.shapes), shape_end, std::begin(signature.shapes)) &&
+                                    std::equal(std::begin(tensor.strides), stride_end, std::begin(signature.strides));
+        if (!metadata_match) {
+            debug_assert(metadata_match && "Variable Graph boundary tensor shape/metadata is not supported");
+            LOG_WARN(
+                "[GraphExecution] fixed tensor shape/metadata mismatch at boundary arg %d; using ordinary path", i
+            );
+            return false;
+        }
+        uint16_t alias_rep = static_cast<uint16_t>(i);
+        for (int32_t j = 0; j < i; ++j) {
+            const ChipTensor &other = args.tensor(j).ref();
+            if (other.buffer.addr == tensor.buffer.addr && other.buffer.size == tensor.buffer.size) {
+                alias_rep = static_cast<uint16_t>(j);
+                break;
+            }
+        }
+        alias_mismatch |= alias_rep != signature.alias_rep;
+    }
+    if (alias_mismatch) {
+        debug_assert(!alias_mismatch && "Changing the Graph boundary alias partition is not supported");
+        LOG_WARN("%s", "[GraphExecution] boundary alias partition differs from recording; using ordinary path");
+        return false;
+    }
+    return true;
+}
+
+void graph_reset_outer_payload(PTO2TaskPayload &payload) {
+    payload.tensor_count = 0;
+    payload.scalar_count = 0;
+    payload.fanin_count = 0;
+    payload.predicate = DispatchPredicate{};
+    payload.early_dispatch_state.store(PTO2_EARLY_DISPATCH_NONE, std::memory_order_relaxed);
+    for (auto &word : payload.staged_core_mask)
+        word.store(0, std::memory_order_relaxed);
+    payload.dispatch_fanin.store(0, std::memory_order_relaxed);
+    payload.dispatch_propagated.store(0, std::memory_order_relaxed);
+    payload.published_block_count.store(0, std::memory_order_relaxed);
+    payload.early_dispatch_launch_state.store(PTO2_EARLY_DISPATCH_LAUNCH_NONE, std::memory_order_relaxed);
+    payload.running_slot_count.store(0, std::memory_order_relaxed);
+    payload.early_sync_drain_state.store(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
+}
+
+bool graph_build_submission_image(
+    const std::vector<std::byte> &definition_image, const CoreTaskArgs &args, std::vector<std::byte> *submission_image
+) {
+    if (submission_image == nullptr || graph_definition(definition_image) == nullptr) return false;
+    const size_t definition_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphDefinition));
+    const size_t tensors_offset = PTO2_ALIGN_UP(definition_offset + definition_image.size(), alignof(GraphTensor));
+    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
+    if (definition_offset > UINT32_MAX || tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
+        return false;
+    }
+    submission_image->assign(tensors_offset + tensor_bytes, std::byte{0});
+    std::memcpy(submission_image->data() + definition_offset, definition_image.data(), definition_image.size());
+    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
+    for (int32_t i = 0; i < args.tensor_count(); ++i)
+        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
+
+    const GraphDefinition &definition = *graph_definition(definition_image);
+    GraphSubmission submission{};
+    submission.graph_key = definition.full_key;
+    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
+    submission.definition_offset = static_cast<uint32_t>(definition_offset);
+    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
+    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
+    std::memcpy(submission_image->data(), &submission, sizeof(submission));
+    return true;
+}
+
+bool graph_submit_definition(
+    PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
+    const CoreTaskArgs &args, PTO2TaskId *submitted_id
+) {
+    const GraphDefinition *definition = graph_definition(definition_image);
+    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
+        definition->required_heap > static_cast<uint64_t>(INT32_MAX)) {
+        return false;
+    }
+    auto &allocator = orch->ring.task_allocator;
+    if (allocator.active_count() + 1 >= allocator.window_size() ||
+        definition->required_heap > allocator.heap_available()) {
+        LOG_WARN("%s", "[GraphExecution] task-window/heap preflight failed; using ordinary path");
+        return false;
+    }
+
+    GraphPendingUpload pending;
+    if (!graph_build_submission_image(definition_image, args, &pending.image)) return false;
+
+    DepInputs boundary_inputs{
+        args.tensor_count(), args.tensor_data(), args.tag_data(), 0, nullptr,
+    };
+    const int32_t tensormap_needed = count_registrable_outputs(boundary_inputs, orch->in_manual_scope());
+    if (tensormap_needed > 0 && !ensure_tensormap_capacity(orch, tensormap_needed)) return false;
+    if (!check_scope_can_accept_task(orch, allocator, 0)) return false;
+
+    const PTO2TaskAllocResult allocation = allocator.alloc(static_cast<int32_t>(definition->required_heap));
+    if (allocation.failed()) {
+        orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
+        return false;
+    }
+    const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
+    PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
+    PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
+    PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
+    PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
+
+    slot.bind_buffers(&payload, &task);
+    slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+    slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
+    slot.active_mask = ActiveMask{};
+    slot.task_attrs = TaskAttrs{};
+    slot.total_required_subtasks = 0;
+    slot.logical_block_num = 1;
+    slot.task_kind = TaskKind::GRAPH;
+    slot.graph_context = nullptr;
+    scope_tasks_push(orch, &slot);
+
+    task.task_id = task_id;
+    std::fill(std::begin(task.kernel_id), std::end(task.kernel_id), INVALID_KERNEL_ID);
+    task.packed_buffer_base = allocation.packed_base;
+    task.packed_buffer_end = allocation.packed_end;
+    graph_reset_outer_payload(payload);
+
+    PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
+    orch->tensor_map.sync_tensormap(task_id, ring.fc.last_task_alive.load(std::memory_order_acquire));
+    auto emit = [&](PTO2TaskId producer_id) -> bool {
+        const int32_t producer_local = static_cast<int32_t>(producer_id.local());
+        const int32_t producer_slot = ring.get_slot_by_task_id(producer_local);
+        PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
+        return append_fanin_or_fail(orch, producer_id.ring(), producer_slot, producer, producer_id, &fanin_builder);
+    };
+    if (!compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit)) return false;
+    register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
+    payload.fanin_count = fanin_builder.count;
+
+    pending.outer_slot = &slot;
+    state->pending_uploads.push_back(std::move(pending));
+    if (submitted_id != nullptr) *submitted_id = task_id;
+#if SIMPLER_DFX
+    orch->tasks_submitted++;
+#endif
+    return true;
+}
+
+}  // namespace
+
+GraphScopeResult
+PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args, uint64_t callable_hash) {
+    auto *orch = this;
+    GraphScopeResult result;
+    GraphHostState *state = graph_state_from(orch);
+    if (state == nullptr || !rt_graph_args_cacheable(args) || args.explicit_dep_count() != 0) {
+        debug_assert(args.scalar_count() == 0 && "Graph execution scalars are not supported in step 1");
+        debug_assert(args.explicit_dep_count() == 0 && "Graph boundary explicit dependencies are not supported");
+        return result;
+    }
+    if (state->recording != nullptr) {
+        state->recording->unsupported = true;
+        debug_assert(state->recording == nullptr && "Nested Graph recording is not supported");
+        LOG_WARN("%s", "[GraphExecution] nested Graph recording is not supported");
+        return result;
+    }
+
+    const uint64_t full_key = graph_full_key(callable_hash, graph_key);
+    auto definition_it = state->definitions.find(full_key);
+    if (definition_it != state->definitions.end()) {
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
+            result.execute_block = false;
+            result.task_id = submitted;
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+    if (state->definitions.size() >= GRAPH_MAX_DEFINITIONS) {
+        debug_assert(
+            state->definitions.size() < GRAPH_MAX_DEFINITIONS &&
+            "Graph Definition cache exceeds the supported per-worker limit"
+        );
+        LOG_WARN(
+            "[GraphExecution] Definition cache is full (%zu entries); using ordinary path", state->definitions.size()
+        );
+        return result;
+    }
+
+    auto recording = std::make_unique<GraphRecording>();
+    recording->full_key = full_key;
+    recording->start_local_task_id = orch->ring.task_allocator.active_count();
+    recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
+    recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        recording->boundary_tensors.push_back(args.tensor(i).ref());
+        recording->boundary_types.push_back(args.tag(i));
+    }
+    state->recording = std::move(recording);
+    result.recording = true;
+    return result;
+}
+
+void PTO2OrchestratorState::graph_end() {
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr || state->recording == nullptr) return;
+    std::unique_ptr<GraphRecording> recording = std::move(state->recording);
+    std::vector<std::byte> definition;
+    if (!graph_build_definition(*recording, &definition)) {
+        debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
+        LOG_WARN("%s", "[GraphExecution] unsupported construct observed; definition was not cached");
+        return;
+    }
+    const GraphDefinition *header = graph_definition(definition);
+    if (header == nullptr) return;
+    LOG_DEBUG(
+        "[GraphExecution] define key=0x%llx nodes=%u bytes=%u", static_cast<unsigned long long>(header->full_key),
+        header->task_count, header->total_bytes
+    );
+    state->definitions.emplace(header->full_key, std::move(definition));
+}
+
+void PTO2OrchestratorState::graph_commit() {}
 
 TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     auto *orch = this;
@@ -992,6 +1704,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const CoreTaskArgs &a
 
 TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
     auto *orch = this;
+    graph_record_mark_unsupported(orch);
     // Orchestration API should short-circuit after fatal, but keep this entry
     // robust as a no-op in case a caller reaches it directly.
     if (orch->fatal) {

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -98,6 +98,19 @@ static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskA
     return rt->orchestrator.submit_dummy_task(args);
 }
 
+static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args) {
+    if (rt == nullptr) return GraphScopeResult{};
+    return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
+}
+
+static void graph_end_impl(PTO2Runtime *rt) {
+    if (rt != nullptr) rt->orchestrator.graph_end();
+}
+
+static void graph_commit_impl(PTO2Runtime *rt) {
+    if (rt != nullptr) rt->orchestrator.graph_commit();
+}
+
 void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
@@ -369,6 +382,9 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .submit_dummy_task = submit_dummy_task_impl,
     .available_cluster_count = available_cluster_count_impl,
     .available_aiv_count = available_aiv_count_impl,
+    .graph_begin = graph_begin_impl,
+    .graph_end = graph_end_impl,
+    .graph_commit = graph_commit_impl,
 #if SIMPLER_DFX
     .scope_set_site = scope_set_site_impl,
 #else

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -31,12 +31,15 @@
 #include "common/chip_swimlane_profiling.h"
 #include "utils/device_arena.h"
 #include "pto_ring_buffer.h"
+#include "graph_cache.h"
 #include "pto_runtime2_types.h"
 #include "pto_submit_types.h"
 #include "scheduler/pto_scheduler.h"
 #include "pto_shared_memory.h"
 #include "pto_tensormap.h"
 #include "pto_types.h"
+
+struct GraphHostState;
 
 /**
  * Layout descriptor produced by PTO2OrchestratorState::reserve_layout(). Holds
@@ -113,6 +116,10 @@ struct PTO2OrchestratorState {
     // after orchestration finishes so shutdown/profiling totals remain closed.
     int64_t inline_completed_tasks{0};
 
+    // This host-only state is cleared before the arena/shared-memory image
+    // crosses to the device.
+    GraphHostState *graph_host_state{nullptr};
+
     // === STATISTICS ===
 #if SIMPLER_DFX
     int64_t tasks_submitted;
@@ -154,6 +161,9 @@ struct PTO2OrchestratorState {
     TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
     TaskOutputTensors submit_dummy_task(const CoreTaskArgs &args);
     TaskOutputTensors alloc_tensors(const CoreTaskArgs &args);
+    GraphScopeResult graph_begin(uint64_t graph_key, const CoreTaskArgs &args, uint64_t callable_hash);
+    void graph_end();
+    void graph_commit();
     void mark_done();
 };
 

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -36,6 +36,7 @@
 
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
+#include "graph_cache.h"
 #include "pto_submit_types.h"
 #include "pto_shared_memory.h"
 #include "pto_ring_buffer.h"
@@ -95,6 +96,9 @@ struct PTO2RuntimeOps {
     // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
+    GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args);
+    void (*graph_end)(PTO2Runtime *rt);
+    void (*graph_commit)(PTO2Runtime *rt);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
@@ -151,6 +155,9 @@ struct PTO2Runtime {
 
     // Statistics
     int64_t total_cycles;
+    // Graph definitions are process-local host cache entries. The callable
+    // identity prevents two orchestration DSOs from sharing the same key.
+    uint64_t active_callable_hash;
 
     // Host views of the tensors this run staged, owned by the run that
     // registered them. Null on the AICPU path, which loads device addresses

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -164,6 +164,13 @@ struct PTO2TaskAllocResult {
     bool failed() const { return task_id < 0; }
 };
 
+enum class TaskKind : uint8_t {
+    KERNEL = 0,
+    DUMMY = 1,
+    GRAPH = 2,
+    GRAPH_NODE = 3,
+};
+
 struct PTO2OutputLayout {
     uint64_t offsets[MAX_TENSOR_ARGS] = {};
     uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
@@ -479,7 +486,7 @@ struct alignas(64) PTO2TaskSlotState {
     // MPSC-deferred completion. The release write is sequenced before
     // on_subtask_complete's acq_rel fetch_add and the acquire read after.
     std::atomic<bool> any_subtask_deferred{false};
-    uint8_t _async_pad{0};
+    TaskKind task_kind{TaskKind::KERNEL};
 
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
     int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
@@ -488,6 +495,11 @@ struct alignas(64) PTO2TaskSlotState {
     // can run concurrently after a partial staged release. All paths claim
     // ranges through claim_block_range().
     std::atomic<int16_t> next_block_idx{0};
+
+    // Graph scheduling metadata occupies the slot's tail padding. Ordinary
+    // ring tasks keep the index invalid and the context null.
+    int32_t graph_node_index{-1};
+    void *graph_context{nullptr};
 
     int32_t claim_block_range(int32_t block_limit, int32_t max_count, int32_t &start) {
         int16_t current = next_block_idx.load(std::memory_order_relaxed);
@@ -523,17 +535,24 @@ struct alignas(64) PTO2TaskSlotState {
 
     /**
      * Reset dynamic scheduling fields to their pristine values. Runs once per
-     * slot at init (pto_shared_memory.cpp) — whole-graph-resident hbg has no
-     * execution-time slot recycle. Skips payload/task (bound once) and
+     * slot at init (pto_shared_memory.cpp) and again during affine Graph replay;
+     * whole-graph-resident hbg has no execution-time slot recycle. Skips
+     * payload/task (bound once) and
      * task_state (the orchestrator sets PENDING when it populates the slot).
      * wake_list_head starts nullptr (open for registration), NOT SENTINEL.
+     * Affine Graph replay preserves the node's retained execution binding.
      */
-    void reset_for_reuse() {
+    void reset_for_reuse(bool preserve_graph_binding = false) {
         wake_list_head.store(nullptr, std::memory_order_relaxed);
         next_in_wake_list = nullptr;
         any_subtask_deferred.store(false, std::memory_order_relaxed);
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx.store(0, std::memory_order_relaxed);
+        if (!preserve_graph_binding) {
+            graph_node_index = -1;
+            graph_context = nullptr;
+            task_kind = TaskKind::KERNEL;
+        }
         // Note: active_mask and task_attrs are per-submit-constant fields
         // rewritten in prepare_task on every reuse, so they are not reset here.
         // last_consumer_local_id is seeded in prepare_task once the id is known.

--- a/src/a5/runtime/host_build_graph/runtime/pto_submit_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_submit_types.h
@@ -183,6 +183,10 @@ static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 class TaskAttrs {
 public:
     constexpr TaskAttrs() = default;
+    constexpr explicit TaskAttrs(uint8_t raw) :
+        raw_(raw) {}
+
+    uint8_t raw() const { return raw_; }
 
     bool allow_early_resolve() const { return (raw_ & BIT_EARLY_RESOLVE) != 0; }
     void set_early_resolve(bool v) {

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "graph_execution.h"
+
+#include <algorithm>
+#include <cstring>
+#include <new>
+
+#include "graph_cache.h"
+
+namespace {
+
+void destroy_execution_nodes(GraphExecution *execution) {
+    for (int32_t i = 0; i < execution->constructed_nodes; ++i) {
+        execution->node_storage[i].~GraphNodeStorage();
+    }
+    execution->constructed_nodes = 0;
+}
+
+void reset_execution(
+    GraphExecution *execution, int32_t node_count, uint32_t tensor_patch_count, uint64_t graph_key,
+    uint64_t definition_hash
+) {
+    size_t nodes_offset = 0;
+    size_t tensor_patches_offset = 0;
+    size_t definition_offset = 0;
+    size_t bytes = 0;
+    if (!graph_execution_storage_layout(
+            execution->node_capacity, execution->tensor_patch_capacity, execution->definition_capacity, &nodes_offset,
+            &tensor_patches_offset, &definition_offset, &bytes
+        )) {
+        return;
+    }
+    execution->definition_affine_reuse = graph_key != 0 && execution->materialized_graph_key == graph_key &&
+                                         execution->materialized_definition_hash == definition_hash &&
+                                         execution->materialized_node_count == node_count &&
+                                         execution->materialized_tensor_patch_count == tensor_patch_count &&
+                                         execution->constructed_nodes >= node_count;
+    execution->state.store(GraphExecutionState::SUBMITTED, std::memory_order_relaxed);
+    execution->materialize_busy.store(0, std::memory_order_relaxed);
+    execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
+    execution->retired_nodes.store(0, std::memory_order_relaxed);
+    execution->node_count = node_count;
+    execution->materialized_nodes = 0;
+    execution->materialized_tensor_patches = 0;
+    execution->allocation_bytes = bytes;
+    execution->graph_key = graph_key;
+    execution->definition_hash = definition_hash;
+    execution->outer_slot = nullptr;
+    execution->nodes = nullptr;
+    execution->node_storage =
+        reinterpret_cast<GraphNodeStorage *>(reinterpret_cast<uint8_t *>(execution) + nodes_offset);
+    execution->tensor_patches =
+        reinterpret_cast<GraphTensorAddressPatch *>(reinterpret_cast<uint8_t *>(execution) + tensor_patches_offset);
+    execution->definition_storage = reinterpret_cast<uint8_t *>(execution) + definition_offset;
+    if (!execution->definition_affine_reuse) {
+        execution->definition = nullptr;
+        execution->fanin_offsets = nullptr;
+        execution->fanin_indices = nullptr;
+    }
+    execution->boundary_tensors = nullptr;
+    execution->boundary_tensor_count = 0;
+}
+
+bool reusable_execution_header_valid(const GraphExecution &execution, size_t storage_bytes) {
+    if (execution.storage_magic != GRAPH_EXECUTION_STORAGE_MAGIC || execution.node_capacity <= 0 ||
+        execution.node_capacity > static_cast<int32_t>(GRAPH_MAX_NODES) || execution.definition_capacity == 0 ||
+        execution.tensor_patch_capacity > GRAPH_MAX_NODES * MAX_TENSOR_ARGS ||
+        execution.materialized_tensor_patch_count > execution.tensor_patch_capacity ||
+        execution.constructed_nodes < 0 || execution.constructed_nodes > execution.node_capacity ||
+        execution.node_count <= 0 || execution.node_count > execution.node_capacity ||
+        execution.state.load(std::memory_order_acquire) != GraphExecutionState::COMPLETED ||
+        execution.retired_nodes.load(std::memory_order_acquire) < execution.node_count) {
+        return false;
+    }
+    size_t expected_bytes = 0;
+    return graph_execution_storage_bytes(
+               execution.node_capacity, execution.tensor_patch_capacity, execution.definition_capacity, &expected_bytes
+           ) &&
+           execution.allocation_bytes == expected_bytes && expected_bytes <= storage_bytes;
+}
+
+GraphExecution *acquire_host_execution_storage(
+    GraphSubmission &submission, int32_t node_count, uint64_t graph_key, uint64_t definition_hash,
+    uint32_t tensor_patch_count, size_t definition_bytes
+) {
+    if (node_count <= 0 || node_count > static_cast<int32_t>(GRAPH_MAX_NODES) || definition_bytes == 0 ||
+        submission.execution_storage == 0 || submission.execution_storage_bytes > SIZE_MAX ||
+        submission.execution_storage % alignof(GraphNodeStorage) != 0) {
+        return nullptr;
+    }
+    const size_t storage_bytes = static_cast<size_t>(submission.execution_storage_bytes);
+    size_t required_bytes = 0;
+    if (!graph_execution_storage_bytes(node_count, tensor_patch_count, definition_bytes, &required_bytes) ||
+        required_bytes > storage_bytes) {
+        return nullptr;
+    }
+
+    auto *execution = reinterpret_cast<GraphExecution *>(static_cast<uintptr_t>(submission.execution_storage));
+    uint64_t observed_magic = 0;
+    std::memcpy(&observed_magic, execution, sizeof(observed_magic));
+    const bool has_existing_execution = observed_magic == GRAPH_EXECUTION_STORAGE_MAGIC;
+    const bool valid_header = has_existing_execution && reusable_execution_header_valid(*execution, storage_bytes);
+    if (has_existing_execution && !valid_header) return nullptr;
+    const bool capacities_fit = valid_header && execution->node_capacity >= node_count &&
+                                execution->tensor_patch_capacity >= tensor_patch_count &&
+                                execution->definition_capacity >= definition_bytes;
+    if (!capacities_fit) {
+        if (valid_header) destroy_execution_nodes(execution);
+        execution = new (execution) GraphExecution{};
+        execution->node_capacity = node_count;
+        execution->tensor_patch_capacity = tensor_patch_count;
+        execution->definition_capacity = definition_bytes;
+        execution->allocation_bytes = required_bytes;
+    }
+    reset_execution(execution, node_count, tensor_patch_count, graph_key, definition_hash);
+    execution->storage_magic = GRAPH_EXECUTION_STORAGE_MAGIC;
+    return execution;
+}
+
+void reset_graph_payload(PTO2TaskPayload &payload) {
+    payload.fanin_count = 0;
+    payload.predicate = DispatchPredicate{};
+    payload.early_dispatch_state.store(PTO2_EARLY_DISPATCH_NONE, std::memory_order_relaxed);
+    for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; ++w) {
+        payload.staged_core_mask[w].store(0, std::memory_order_relaxed);
+    }
+    payload.dispatch_fanin.store(0, std::memory_order_relaxed);
+    payload.dispatch_propagated.store(0, std::memory_order_relaxed);
+    payload.published_block_count.store(0, std::memory_order_relaxed);
+    payload.early_dispatch_launch_state.store(PTO2_EARLY_DISPATCH_LAUNCH_NONE, std::memory_order_relaxed);
+    payload.running_slot_count.store(0, std::memory_order_relaxed);
+    payload.early_sync_drain_state.store(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
+}
+
+bool bind_graph_topology(GraphExecution &execution) {
+    if (execution.definition == nullptr) return false;
+    const GraphDefinition &definition = *execution.definition;
+    const uint32_t *fanin_offsets =
+        graph_definition_array<uint32_t>(definition, definition.off_fanin_offsets, definition.task_count + 1);
+    const uint16_t *fanin_indices =
+        definition.edge_count == 0 ?
+            nullptr :
+            graph_definition_array<uint16_t>(definition, definition.off_fanin_indices, definition.edge_count);
+    const uint32_t *fanout_offsets =
+        graph_definition_array<uint32_t>(definition, definition.off_fanout_offsets, definition.task_count + 1);
+    const uint16_t *fanout_indices =
+        definition.edge_count == 0 ?
+            nullptr :
+            graph_definition_array<uint16_t>(definition, definition.off_fanout_indices, definition.edge_count);
+    const uint16_t *roots =
+        graph_definition_array<uint16_t>(definition, definition.off_root_indices, definition.root_count);
+    const GraphNodeDefinition *nodes =
+        graph_definition_array<GraphNodeDefinition>(definition, definition.off_nodes, definition.task_count);
+    const uint64_t *node_offsets =
+        graph_definition_array<uint64_t>(definition, definition.off_node_offsets, definition.task_count);
+    if (fanin_offsets == nullptr || fanout_offsets == nullptr || roots == nullptr || nodes == nullptr ||
+        node_offsets == nullptr ||
+        (definition.edge_count != 0 && (fanin_indices == nullptr || fanout_indices == nullptr)) ||
+        fanin_offsets[0] != 0 || fanout_offsets[0] != 0 ||
+        fanin_offsets[definition.task_count] != definition.edge_count ||
+        fanout_offsets[definition.task_count] != definition.edge_count) {
+        return false;
+    }
+
+    uint64_t required_heap = 0;
+    constexpr uint8_t VALID_ACTIVE_MASK = (1U << PTO2_SUBTASK_SLOT_COUNT) - 1U;
+    for (uint32_t i = 0; i < definition.task_count; ++i) {
+        const GraphNodeDefinition &node = nodes[i];
+        if (node_offsets[i] != required_heap || node.total_output_size < 0 || node.tensor_count < 0 ||
+            node.tensor_count > MAX_TENSOR_ARGS || node.scalar_count < 0 || node.scalar_count > MAX_SCALAR_ARGS ||
+            node.tensor_offset > definition.tensor_arg_count ||
+            static_cast<uint32_t>(node.tensor_count) > definition.tensor_arg_count - node.tensor_offset ||
+            node.scalar_offset > definition.scalar_arg_count ||
+            static_cast<uint32_t>(node.scalar_count) > definition.scalar_arg_count - node.scalar_offset ||
+            (node.active_mask & ~VALID_ACTIVE_MASK) != 0 || node.logical_block_num <= 0 ||
+            node.total_required_subtasks < 0) {
+            return false;
+        }
+        for (int32_t slot = 0; slot < PTO2_SUBTASK_SLOT_COUNT; ++slot) {
+            const bool active = (node.active_mask & (1U << slot)) != 0;
+            if (active != (node.kernel_id[slot] != INVALID_KERNEL_ID)) return false;
+        }
+        const uint64_t output_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(node.total_output_size), PTO2_ALIGN_SIZE);
+        if (output_bytes > definition.required_heap - required_heap) return false;
+        required_heap += output_bytes;
+    }
+    if (required_heap != definition.required_heap) return false;
+
+    uint32_t observed_roots = 0;
+    for (uint32_t consumer = 0; consumer < definition.task_count; ++consumer) {
+        const uint32_t begin = fanin_offsets[consumer];
+        const uint32_t end = fanin_offsets[consumer + 1];
+        if (begin > end || end > definition.edge_count) return false;
+        if (begin == end) observed_roots++;
+        for (uint32_t edge = begin; edge < end; ++edge) {
+            if (fanin_indices[edge] >= consumer) return false;
+        }
+    }
+    if (observed_roots != definition.root_count) return false;
+    for (uint32_t i = 0; i < definition.root_count; ++i) {
+        const uint16_t root = roots[i];
+        if (root >= definition.task_count || fanin_offsets[root] != fanin_offsets[root + 1]) return false;
+    }
+    for (uint32_t producer = 0; producer < definition.task_count; ++producer) {
+        const uint32_t begin = fanout_offsets[producer];
+        const uint32_t end = fanout_offsets[producer + 1];
+        if (begin > end || end > definition.edge_count) return false;
+        for (uint32_t edge = begin; edge < end; ++edge) {
+            if (fanout_indices[edge] <= producer || fanout_indices[edge] >= definition.task_count) return false;
+        }
+    }
+
+    execution.fanin_offsets = fanin_offsets;
+    execution.fanin_indices = fanin_indices;
+    return true;
+}
+
+bool graph_definition_hash_matches(const GraphDefinition &definition) {
+    if (definition.content_hash == 0 || definition.total_bytes < sizeof(GraphDefinition)) return false;
+    constexpr size_t HASH_OFFSET = offsetof(GraphDefinition, content_hash);
+    constexpr size_t HASH_END = HASH_OFFSET + sizeof(GraphDefinition::content_hash);
+    const auto *bytes = reinterpret_cast<const uint8_t *>(&definition);
+    uint64_t hash = graph_hash_bytes(1469598103934665603ULL, bytes, HASH_OFFSET);
+    const uint64_t zero_hash = 0;
+    hash = graph_hash_bytes(hash, &zero_hash, sizeof(zero_hash));
+    hash = graph_hash_bytes(hash, bytes + HASH_END, definition.total_bytes - HASH_END);
+    return hash == definition.content_hash;
+}
+
+bool register_initial_graph_waiter(GraphExecution &execution, int32_t consumer_index) {
+    const uint32_t begin = execution.fanin_offsets[consumer_index];
+    const uint32_t end = execution.fanin_offsets[consumer_index + 1];
+    if (begin == end) return true;
+
+    const uint16_t producer_index = execution.fanin_indices[begin];
+    PTO2TaskSlotState &producer = execution.node_storage[producer_index].slot;
+    PTO2TaskSlotState &consumer = execution.node_storage[consumer_index].slot;
+
+    // Orch has already wired the dependency as a producer index in fanin CSR.
+    // This only creates the execution-local polling subscription. Activation
+    // is gated on PREPARED, so no producer can close its list concurrently.
+    PTO2TaskSlotState *head = producer.wake_list_head.load(std::memory_order_relaxed);
+    if (head == WAKE_LIST_SENTINEL) return false;
+    consumer.next_in_wake_list = head;
+    producer.wake_list_head.store(&consumer, std::memory_order_relaxed);
+    return true;
+}
+
+}  // namespace
+
+GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
+    GraphSubmission *submission = graph_submission_from_slot(outer_slot);
+    if (submission == nullptr) return nullptr;
+    if (GraphExecution *existing = graph_submission_local_execution(*submission)) return existing;
+    if (graph_submission_execution_initializing(*submission)) return nullptr;
+
+    const GraphDefinition *definition = graph_submission_definition(*submission);
+    const GraphTensor *boundary_tensors = graph_submission_tensors(*submission);
+    if (definition == nullptr || definition->total_bytes == 0 || definition->task_count == 0 ||
+        definition->task_count > GRAPH_MAX_NODES ||
+        definition->total_bytes > submission->total_bytes - submission->definition_offset ||
+        submission->graph_key != definition->full_key || submission->tensor_count != definition->boundary_count ||
+        boundary_tensors == nullptr ||
+        submission->tensors_offset < submission->definition_offset + definition->total_bytes ||
+        !graph_definition_hash_matches(*definition) || outer_slot.task == nullptr ||
+        outer_slot.task->packed_buffer_base == nullptr || outer_slot.task->packed_buffer_end == nullptr) {
+        return nullptr;
+    }
+    const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
+    const uintptr_t outer_end = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_end);
+    if (outer_end < outer_base || definition->required_heap > outer_end - outer_base) return nullptr;
+    for (uint32_t i = 0; i < submission->tensor_count; ++i) {
+        if (!graph_tensor_wire_valid(boundary_tensors[i])) return nullptr;
+    }
+
+    uint64_t expected = 0;
+    if (!__atomic_compare_exchange_n(
+            &submission->local_execution, &expected, GRAPH_EXECUTION_INITIALIZING, false, __ATOMIC_ACQ_REL,
+            __ATOMIC_ACQUIRE
+        )) {
+        return expected > GRAPH_EXECUTION_INITIALIZING ?
+                   reinterpret_cast<GraphExecution *>(static_cast<uintptr_t>(expected)) :
+                   nullptr;
+    }
+
+    GraphExecution *execution = acquire_host_execution_storage(
+        *submission, static_cast<int32_t>(definition->task_count), submission->graph_key, definition->content_hash,
+        definition->tensor_arg_count, definition->total_bytes
+    );
+    if (execution == nullptr) {
+        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+        return nullptr;
+    }
+
+    if (!execution->definition_affine_reuse) {
+        std::memcpy(execution->definition_storage, definition, definition->total_bytes);
+        execution->definition = static_cast<const GraphDefinition *>(execution->definition_storage);
+        if (!bind_graph_topology(*execution)) {
+            execution->retired_nodes.store(execution->node_count, std::memory_order_relaxed);
+            execution->state.store(GraphExecutionState::COMPLETED, std::memory_order_release);
+            __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+            return nullptr;
+        }
+    }
+    execution->boundary_tensors = boundary_tensors;
+    execution->boundary_tensor_count = submission->tensor_count;
+    execution->outer_slot = &outer_slot;
+
+    const uint64_t desired = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(execution));
+    __atomic_store_n(&submission->local_execution, desired, __ATOMIC_RELEASE);
+    return execution;
+}
+
+GraphMaterializeResult graph_execution_materialize_slice(
+    PTO2TaskSlotState &outer_slot, GraphExecution &execution, int32_t max_nodes, int32_t *nodes_materialized
+) {
+    if (nodes_materialized != nullptr) *nodes_materialized = 0;
+    if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr ||
+        outer_slot.task->packed_buffer_base == nullptr || max_nodes <= 0 || execution.definition == nullptr ||
+        execution.node_storage == nullptr || execution.tensor_patches == nullptr) {
+        return GraphMaterializeResult::INVALID;
+    }
+
+    GraphExecutionState state = execution.state.load(std::memory_order_acquire);
+    if (state >= GraphExecutionState::PREPARED) return GraphMaterializeResult::PREPARED;
+
+    uint8_t expected_busy = 0;
+    if (!execution.materialize_busy.compare_exchange_strong(
+            expected_busy, 1, std::memory_order_acq_rel, std::memory_order_acquire
+        )) {
+        return GraphMaterializeResult::BUSY;
+    }
+
+    state = execution.state.load(std::memory_order_acquire);
+    if (state == GraphExecutionState::SUBMITTED) {
+        GraphExecutionState expected = GraphExecutionState::SUBMITTED;
+        if (!execution.state.compare_exchange_strong(
+                expected, GraphExecutionState::MATERIALIZING, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            execution.materialize_busy.store(0, std::memory_order_release);
+            return GraphMaterializeResult::BUSY;
+        }
+    } else if (state != GraphExecutionState::MATERIALIZING) {
+        execution.materialize_busy.store(0, std::memory_order_release);
+        return GraphMaterializeResult::INVALID;
+    }
+
+    const bool affine_reuse = execution.definition_affine_reuse;
+    const GraphDefinition &definition = *execution.definition;
+    const GraphNodeDefinition *nodes = nullptr;
+    const uint64_t *node_offsets = nullptr;
+    const GraphTensor *definition_tensors = nullptr;
+    const GraphTensorSourceRef *tensor_sources = nullptr;
+    const uint64_t *definition_scalars = nullptr;
+    if (!affine_reuse) {
+        nodes = graph_definition_array<GraphNodeDefinition>(definition, definition.off_nodes, definition.task_count);
+        node_offsets = graph_definition_array<uint64_t>(definition, definition.off_node_offsets, definition.task_count);
+        definition_tensors =
+            definition.tensor_arg_count == 0 ?
+                nullptr :
+                graph_definition_array<GraphTensor>(definition, definition.off_tensors, definition.tensor_arg_count);
+        tensor_sources = definition.tensor_arg_count == 0 ?
+                             nullptr :
+                             graph_definition_array<GraphTensorSourceRef>(
+                                 definition, definition.off_tensor_sources, definition.tensor_arg_count
+                             );
+        definition_scalars =
+            definition.scalar_arg_count == 0 ?
+                nullptr :
+                graph_definition_array<uint64_t>(definition, definition.off_scalars, definition.scalar_arg_count);
+        if (nodes == nullptr || node_offsets == nullptr ||
+            (definition.tensor_arg_count != 0 && (definition_tensors == nullptr || tensor_sources == nullptr)) ||
+            (definition.scalar_arg_count != 0 && definition_scalars == nullptr)) {
+            execution.materialize_busy.store(0, std::memory_order_release);
+            return GraphMaterializeResult::INVALID;
+        }
+    }
+
+    const int32_t first = execution.materialized_nodes;
+    const int32_t last = std::min(execution.node_count, first + max_nodes);
+    const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
+    for (int32_t i = first; i < last; ++i) {
+        GraphNodeStorage *storage = &execution.node_storage[i];
+        if (i >= execution.constructed_nodes) {
+            storage = new (storage) GraphNodeStorage;
+            execution.constructed_nodes++;
+        }
+        PTO2TaskDescriptor &task = storage->task;
+        PTO2TaskPayload &payload = storage->payload;
+        PTO2TaskSlotState &slot = storage->slot;
+
+        const uint32_t synthetic_local =
+            (static_cast<uint32_t>(outer_slot.task->task_id.local()) << 10) | static_cast<uint32_t>(i);
+        task.task_id = PTO2TaskId::make(1, synthetic_local);
+        uint64_t node_offset = 0;
+        uint64_t output_bytes = 0;
+        if (affine_reuse) {
+            const uintptr_t previous_base = reinterpret_cast<uintptr_t>(task.packed_buffer_base);
+            const uintptr_t previous_end = reinterpret_cast<uintptr_t>(task.packed_buffer_end);
+            node_offset = previous_base - execution.materialized_outer_base;
+            output_bytes = previous_end - previous_base;
+        } else {
+            const GraphNodeDefinition &source = nodes[i];
+            node_offset = node_offsets[i];
+            output_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(source.total_output_size), PTO2_ALIGN_SIZE);
+            for (int k = 0; k < PTO2_SUBTASK_SLOT_COUNT; ++k)
+                task.kernel_id[k] = source.kernel_id[k];
+        }
+        task.packed_buffer_base = reinterpret_cast<void *>(outer_base + node_offset);
+        task.packed_buffer_end = reinterpret_cast<void *>(outer_base + node_offset + output_bytes);
+
+        slot.reset_for_reuse(affine_reuse);
+        slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+        if (!affine_reuse) {
+            const GraphNodeDefinition &source = nodes[i];
+            slot.bind_buffers(&payload, &task);
+            slot.active_mask = ActiveMask(source.active_mask);
+            slot.task_attrs = TaskAttrs(source.task_attrs);
+            slot.total_required_subtasks = source.total_required_subtasks;
+            slot.logical_block_num = source.logical_block_num;
+            slot.graph_node_index = i;
+            slot.task_kind = TaskKind::GRAPH_NODE;
+            slot.graph_context = &execution;
+            payload.tensor_count = source.tensor_count;
+            payload.scalar_count = source.scalar_count;
+            if (source.tensor_count < 0 || source.tensor_count > MAX_TENSOR_ARGS || source.scalar_count < 0 ||
+                source.scalar_count > MAX_SCALAR_ARGS ||
+                static_cast<uint32_t>(source.tensor_count) > definition.tensor_arg_count ||
+                static_cast<uint32_t>(source.scalar_count) > definition.scalar_arg_count ||
+                source.tensor_offset > definition.tensor_arg_count - static_cast<uint32_t>(source.tensor_count) ||
+                source.scalar_offset > definition.scalar_arg_count - static_cast<uint32_t>(source.scalar_count)) {
+                execution.materialize_busy.store(0, std::memory_order_release);
+                return GraphMaterializeResult::INVALID;
+            }
+            for (int32_t j = 0; j < source.tensor_count; ++j) {
+                const uint32_t tensor_index = source.tensor_offset + static_cast<uint32_t>(j);
+                ChipTensor &tensor = payload.tensors[j];
+                GraphTensor rebound = definition_tensors[tensor_index];
+                GraphTensorAddressPatch patch{};
+                if (!graph_tensor_wire_valid(rebound)) {
+                    execution.materialize_busy.store(0, std::memory_order_release);
+                    return GraphMaterializeResult::INVALID;
+                }
+                const GraphTensorSourceRef &ref = tensor_sources[tensor_index];
+                if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
+                    if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) {
+                        execution.materialize_busy.store(0, std::memory_order_release);
+                        return GraphMaterializeResult::INVALID;
+                    }
+                    rebound = execution.boundary_tensors[ref.source_index];
+                    patch.source = static_cast<uint8_t>(GraphTensorAddressSource::BOUNDARY);
+                    patch.source_index = ref.source_index;
+                } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
+                    if (ref.source_index >= execution.boundary_tensor_count) {
+                        execution.materialize_busy.store(0, std::memory_order_release);
+                        return GraphMaterializeResult::INVALID;
+                    }
+                    const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
+                    if (ref.packed_offset > UINT64_MAX - boundary.start_offset) {
+                        execution.materialize_busy.store(0, std::memory_order_release);
+                        return GraphMaterializeResult::INVALID;
+                    }
+                    rebound.buffer_addr = boundary.buffer_addr;
+                    rebound.buffer_size = boundary.buffer_size;
+                    rebound.owner_task_id = boundary.owner_task_id;
+                    rebound.start_offset = boundary.start_offset + ref.packed_offset;
+                    rebound.version = boundary.version;
+                    rebound.address_space = boundary.address_space;
+                    patch.source = static_cast<uint8_t>(GraphTensorAddressSource::BOUNDARY);
+                    patch.source_index = ref.source_index;
+                } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
+                           ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
+                    const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
+                    const int32_t producer_index = own_output ? i : static_cast<int32_t>(ref.source_index);
+                    if (producer_index < 0 || producer_index > i || (own_output && ref.source_index != i) ||
+                        (!own_output && producer_index == i)) {
+                        execution.materialize_busy.store(0, std::memory_order_release);
+                        return GraphMaterializeResult::INVALID;
+                    }
+                    PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
+                    const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
+                    const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
+                    if (ref.packed_offset > producer_bytes ||
+                        rebound.buffer_size > producer_bytes - ref.packed_offset ||
+                        ref.packed_offset > UINTPTR_MAX - producer_base ||
+                        ref.packed_offset > UINT64_MAX - node_offsets[producer_index]) {
+                        execution.materialize_busy.store(0, std::memory_order_release);
+                        return GraphMaterializeResult::INVALID;
+                    }
+                    rebound.buffer_addr = producer_base + ref.packed_offset;
+                    rebound.owner_task_id = producer.task_id.raw;
+                    patch.source = static_cast<uint8_t>(GraphTensorAddressSource::INTERNAL);
+                    patch.address_offset = node_offsets[producer_index] + ref.packed_offset;
+                } else {
+                    execution.materialize_busy.store(0, std::memory_order_release);
+                    return GraphMaterializeResult::INVALID;
+                }
+                if (!graph_tensor_wire_valid(rebound) ||
+                    execution.materialized_tensor_patches >= execution.tensor_patch_capacity) {
+                    execution.materialize_busy.store(0, std::memory_order_release);
+                    return GraphMaterializeResult::INVALID;
+                }
+                execution.tensor_patches[execution.materialized_tensor_patches++] = patch;
+                graph_tensor_unpack(rebound, &tensor);
+            }
+            if (source.scalar_count > 0) {
+                std::memcpy(
+                    payload.scalars, definition_scalars + source.scalar_offset,
+                    static_cast<size_t>(source.scalar_count) * sizeof(uint64_t)
+                );
+            }
+        } else {
+            for (int32_t j = 0; j < payload.tensor_count; ++j) {
+                const GraphTensorAddressPatch &patch =
+                    execution.tensor_patches[execution.materialized_tensor_patches++];
+                if (patch.source == static_cast<uint8_t>(GraphTensorAddressSource::BOUNDARY)) {
+                    payload.tensors[j].buffer.addr = execution.boundary_tensors[patch.source_index].buffer_addr;
+                } else {
+                    payload.tensors[j].buffer.addr = outer_base + patch.address_offset;
+                }
+            }
+        }
+        reset_graph_payload(payload);
+        if (!register_initial_graph_waiter(execution, i)) {
+            execution.materialize_busy.store(0, std::memory_order_release);
+            return GraphMaterializeResult::INVALID;
+        }
+    }
+    execution.materialized_nodes = last;
+    if (nodes_materialized != nullptr) *nodes_materialized = last - first;
+
+    if (last < execution.node_count) {
+        execution.materialize_busy.store(0, std::memory_order_release);
+        return GraphMaterializeResult::PENDING;
+    }
+
+    const uint32_t expected_tensor_patches =
+        affine_reuse ? execution.materialized_tensor_patch_count : definition.tensor_arg_count;
+    if (execution.materialized_tensor_patches != expected_tensor_patches) {
+        execution.materialize_busy.store(0, std::memory_order_release);
+        return GraphMaterializeResult::INVALID;
+    }
+
+    // nodes is published before PREPARED. An activator that acquires the state
+    // may therefore route saved roots without observing partially built nodes.
+    execution.nodes = execution.node_storage;
+    execution.materialized_graph_key = execution.graph_key;
+    execution.materialized_definition_hash = execution.definition_hash;
+    execution.materialized_node_count = execution.node_count;
+    execution.materialized_tensor_patch_count = execution.materialized_tensor_patches;
+    execution.materialized_outer_base = outer_base;
+    execution.state.store(GraphExecutionState::PREPARED, std::memory_order_release);
+    execution.materialize_busy.store(0, std::memory_order_release);
+    return GraphMaterializeResult::PREPARED;
+}

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -37,6 +37,7 @@
 #include "utils/device_arena.h"
 #include "aicpu/platform_regs.h"  // get_reg_ptr / RegId for the early-dispatch doorbell
 #include "pto_async_wait.h"
+#include "graph_execution.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
@@ -418,6 +419,8 @@ struct PTO2SchedulerLayout {
     size_t off_ready_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_ready_sync_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_dummy_ready_queue_slots;
+    size_t off_graph_ready_queue_slots;
+    size_t off_graph_prepare_queue_slots;
     size_t off_early_dispatch_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_early_sync_start_queue_slots;
     uint64_t ready_queue_capacity;
@@ -463,6 +466,12 @@ struct PTO2SchedulerState {
     // the dispatch loop and completed inline -- never goes to AICore.
     PTO2ReadyQueue dummy_ready_queue;
 
+    // An outer Graph is control work, never an AICore task. External dependency
+    // readiness and bounded materialization progress independently and meet at
+    // the submission's single atomic activation gate.
+    PTO2ReadyQueue graph_ready_queue;
+    PTO2ReadyQueue graph_prepare_queue;
+
     alignas(64) AsyncWaitList async_wait_list;
 
     // Statistics (cold path, isolated from hot-path fields)
@@ -480,14 +489,31 @@ struct PTO2SchedulerState {
     // the per-shape ready_sync_queues[] (drained as Tier-0); everything else to
     // ready_queues[].
     void push_ready_routed(PTO2TaskSlotState *slot_state) {
+        if (slot_state->task_kind == TaskKind::GRAPH) {
+            graph_ready_queue.push(slot_state);
+            return;
+        }
         PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+        bool pushed;
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
-            dummy_ready_queue.push(slot_state);
+            pushed = dummy_ready_queue.push(slot_state);
         } else if (slot_state->task_attrs.requires_sync_start()) {
-            ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
+            pushed = ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
         } else {
-            ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+            pushed = ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+        }
+        // A queue is sized for the whole task window and each task is routed to one
+        // queue exactly once, so push cannot legitimately fail. A false return means
+        // the target slot fell outside the shipped prefix, or the window genuinely
+        // exceeds queue capacity — either way the task is dropped and the run would
+        // otherwise stall. Latch a named error so it surfaces as READY_QUEUE_OVERFLOW
+        // rather than an anonymous forward-progress timeout.
+        if (!pushed) {
+            int32_t expected = PTO2_ERROR_NONE;
+            sm_header->sched_error_code.compare_exchange_strong(
+                expected, PTO2_ERROR_READY_QUEUE_OVERFLOW, std::memory_order_acq_rel, std::memory_order_acquire
+            );
         }
     }
 
@@ -822,6 +848,165 @@ struct PTO2SchedulerState {
     // scope reference. Kept as a no-op so the orchestrator call site is unchanged.
     void on_scope_end(PTO2TaskSlotState ** /*task_slot_states*/, int32_t /*count*/) {}
 
+    // Orch owns dependency discovery and saves the immutable fanin wire.
+    // Scheduler polling only chooses which already-wired producer a consumer
+    // waits on at this instant; it never recomputes producer relationships.
+    int32_t graph_first_unmet_producer(const GraphExecution &execution, const PTO2TaskSlotState &consumer) const {
+        const uint32_t node_index = static_cast<uint32_t>(consumer.graph_node_index);
+        const uint32_t begin = execution.fanin_offsets[node_index];
+        const uint32_t end = execution.fanin_offsets[node_index + 1];
+        for (uint32_t edge = begin; edge < end; ++edge) {
+            const uint16_t producer_index = execution.fanin_indices[edge];
+            const PTO2TaskSlotState &producer = execution.nodes[producer_index].slot;
+            if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
+                return static_cast<int32_t>(producer_index);
+            }
+        }
+        return -1;
+    }
+
+    void register_graph_wake(GraphExecution &execution, PTO2TaskSlotState *producer, PTO2TaskSlotState *consumer) {
+        while (true) {
+            PTO2TaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
+            while (expected != WAKE_LIST_SENTINEL) {
+                consumer->next_in_wake_list = expected;
+                if (producer->wake_list_head.compare_exchange_weak(
+                        expected, consumer, std::memory_order_acq_rel, std::memory_order_relaxed
+                    )) {
+                    return;
+                }
+            }
+
+            // The producer completed between fanin classification and the CAS.
+            // Retry against acquire-loaded task states until cache coherence
+            // exposes the completed producer, then route or retarget the waiter.
+            const int32_t unmet_producer = graph_first_unmet_producer(execution, *consumer);
+            if (unmet_producer < 0) {
+                push_ready_routed(consumer);
+                return;
+            }
+            producer = &execution.nodes[unmet_producer].slot;
+        }
+    }
+
+    uint32_t drain_graph_wake_list(GraphExecution &execution, PTO2TaskSlotState &producer) {
+        uint32_t consumers_rescanned = 0;
+        PTO2TaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
+        while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
+            PTO2TaskSlotState *next = waiter->next_in_wake_list;
+            const int32_t unmet_producer = graph_first_unmet_producer(execution, *waiter);
+            if (unmet_producer < 0) {
+                push_ready_routed(waiter);
+            } else {
+                register_graph_wake(execution, &execution.nodes[unmet_producer].slot, waiter);
+            }
+            consumers_rescanned++;
+            waiter = next;
+        }
+        return consumers_rescanned;
+    }
+
+    int32_t activate_prepared_graph(GraphExecution &execution) {
+        GraphExecutionState expected = GraphExecutionState::PREPARED;
+        if (!execution.state.compare_exchange_strong(
+                expected, GraphExecutionState::ACTIVE, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            return 0;
+        }
+        const GraphDefinition &definition = *execution.definition;
+        const uint16_t *roots =
+            graph_definition_array<uint16_t>(definition, definition.off_root_indices, definition.root_count);
+        if (roots == nullptr) return 0;
+        int32_t routed = 0;
+        for (uint32_t i = 0; i < definition.root_count; ++i) {
+            const uint16_t node_index = roots[i];
+            if (node_index >= static_cast<uint32_t>(execution.node_count)) continue;
+            // Roots have zero internal fanin and are routed only here. Every
+            // non-root is registered on one saved producer at a time.
+            push_ready_routed(&execution.nodes[node_index].slot);
+            routed++;
+        }
+        return routed;
+    }
+
+    GraphMaterializeResult prepare_graph_task(
+        PTO2TaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
+        int32_t *nodes_materialized = nullptr
+    ) {
+        GraphSubmission *submission = graph_submission_from_slot(outer_slot);
+        if (submission == nullptr) return GraphMaterializeResult::INVALID;
+        GraphExecution *execution = graph_execution_localize(outer_slot);
+        if (execution == nullptr) {
+            return graph_submission_execution_initializing(*submission) ? GraphMaterializeResult::BUSY :
+                                                                          GraphMaterializeResult::INVALID;
+        }
+        const GraphMaterializeResult result =
+            graph_execution_materialize_slice(outer_slot, *execution, max_nodes, nodes_materialized);
+        if (result == GraphMaterializeResult::PREPARED && graph_submission_signal(*submission, 0x1)) {
+            activate_prepared_graph(*execution);
+        }
+        return result;
+    }
+
+    int32_t activate_graph_task(PTO2TaskSlotState &outer_slot) {
+        GraphSubmission *submission = graph_submission_from_slot(outer_slot);
+        if (submission == nullptr || !graph_submission_signal(*submission, 0x2)) return 0;
+        GraphExecution *execution = graph_submission_local_execution(*submission);
+        return execution == nullptr ? 0 : activate_prepared_graph(*execution);
+    }
+
+    struct TaskCompletionOutcome {
+        uint32_t fanout_edges{0};
+        int32_t stream_tasks_completed{0};
+    };
+
+    TaskCompletionOutcome complete_task(
+        PTO2TaskSlotState &slot_state
+#if SIMPLER_SCHED_PROFILING
+        ,
+        int thread_idx
+#endif
+    ) {
+        TaskCompletionOutcome outcome;
+        if (slot_state.task_kind != TaskKind::GRAPH_NODE) {
+#if SIMPLER_SCHED_PROFILING
+            CompletionStats stats = on_task_complete(slot_state, thread_idx);
+            outcome.fanout_edges = static_cast<uint32_t>(stats.fanout_edges);
+#else
+            outcome.fanout_edges = on_task_complete(slot_state);
+#endif
+            outcome.stream_tasks_completed = 1;
+            return outcome;
+        }
+
+        GraphExecution *execution = graph_execution_from_slot(slot_state);
+        if (execution == nullptr || execution->definition == nullptr || execution->nodes == nullptr) return outcome;
+        const int32_t saved_node_index = slot_state.graph_node_index;
+        if (saved_node_index < 0) return outcome;
+        const uint32_t node_index = static_cast<uint32_t>(saved_node_index);
+        if (node_index >= static_cast<uint32_t>(execution->node_count)) return outcome;
+
+        // Publish completion before closing the wake list. A consumer that
+        // loses registration to the sentinel acquires this state when it
+        // rescans the Orch-built fanin wire, so no wakeup can be lost.
+        slot_state.mark_completed();
+        outcome.fanout_edges = drain_graph_wake_list(*execution, slot_state);
+
+        const bool graph_completed = graph_execution_complete_node(*execution);
+        graph_execution_retire_node(*execution);
+        if (!graph_completed) return outcome;
+
+        // Internal nodes count as zero stream tasks. The final node publishes
+        // the outer ring task exactly once, waking external consumers and
+        // contributing the one task the host actually submitted.
+        if (execution->outer_slot != nullptr) {
+            on_mixed_task_complete(*execution->outer_slot);
+            outcome.stream_tasks_completed = 1;
+        }
+        graph_execution_mark_completed(*execution);
+        return outcome;
+    }
+
     /**
      * Subtask completion: atomic counter model.
      * Called when a single subtask (AIC, AIV0, or AIV1) finishes on any block.
@@ -923,11 +1108,11 @@ AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &si
     // Return value (CompletionStats / consumer-walk count) discarded:
     // async-wait drain path has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING
-    (void)sink.sched->on_task_complete(slot_state, sink.thread_idx);
+    PTO2SchedulerState::TaskCompletionOutcome outcome = sink.sched->complete_task(slot_state, sink.thread_idx);
 #else
-    (void)sink.sched->on_task_complete(slot_state);
+    PTO2SchedulerState::TaskCompletionOutcome outcome = sink.sched->complete_task(slot_state);
 #endif
-    sink.inline_completed++;
+    sink.inline_completed += outcome.stream_tasks_completed;
     return true;
 }
 
@@ -988,12 +1173,12 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
             // Return value (CompletionStats / consumer-walk count) discarded:
             // deferred-completion drain has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING
-            (void)sched->on_task_complete(*entry.slot_state, thread_idx);
+            PTO2SchedulerState::TaskCompletionOutcome outcome = sched->complete_task(*entry.slot_state, thread_idx);
 #else
-            (void)sched->on_task_complete(*entry.slot_state);
+            PTO2SchedulerState::TaskCompletionOutcome outcome = sched->complete_task(*entry.slot_state);
 #endif
             // Polling: completion is fully published inline; no deferred release.
-            result.completed++;
+            result.completed += outcome.stream_tasks_completed;
 
             int32_t last = count - 1;
             if (i != last) entries[i] = entries[last];

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1120,20 +1120,10 @@ void SchedulerContext::on_orchestration_done(
 }
 
 // Polling initial classify (device boot), partitioned across all AICPU threads.
-// The host built the whole graph and no producer has executed yet — every
-// completion_flags byte is 0 except the hidden-alloc tasks the host completed
-// inline (pre-set to 1). Each thread classifies its contiguous slice of the
-// submitted-task range exactly once: route roots (all fanin met) to the ready
-// queues and register the rest on their first unmet producer's wake list.
-//
-// This is the same work the wiring model deferred to a device queue, now run
-// N-way parallel. push_ready_routed (MPMC ready queues) and register_wake
-// (lock-free wake-list CAS) are the same concurrency-safe primitives the
-// scheduler threads use during the run, and at boot no producer has completed
-// (wake_list heads are nullptr, never SENTINEL), so registration never
-// re-classifies. The caller barriers all threads here BEFORE any of them
-// publishes runtime_init_ready_, so the whole ready-set / wake-list graph is
-// fully seeded before the first dispatch.
+// Each thread classifies its contiguous slice of the submitted-task range
+// exactly once. Graph tasks additionally enter the bounded preparation queue;
+// their external fanin follows the same ready/wake classification as any other
+// outer task.
 void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) {
     if (completed_.load(std::memory_order_acquire) || sched_->ring_sched_state.ring == nullptr) {
         return;
@@ -1148,13 +1138,18 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         if (ring.is_completion_flag_set(id)) {
             continue;  // completed on the host (hidden alloc); nothing to dispatch
         }
-        PTO2TaskSlotState &s = ring.get_slot_state_by_task_id(id);
-        int32_t state = sched_->classify_fanin_state(&s);
+        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(id);
+        if (slot.task_kind == TaskKind::GRAPH) {
+            while (!sched_->graph_prepare_queue.push_tagged(&slot, slot.task->task_id.raw)) {
+                SPIN_WAIT_HINT();
+            }
+        }
+        int32_t state = sched_->classify_fanin_state(&slot);
         if (state < 0) {
-            sched_->push_ready_routed(&s);
+            sched_->push_ready_routed(&slot);
         } else {
-            int32_t prod_local = s.payload->fanin_local_ids[state];
-            sched_->register_wake(&ring.get_slot_state_by_task_id(prod_local), &s);
+            int32_t prod_local = slot.payload->fanin_local_ids[state];
+            sched_->register_wake(&ring.get_slot_state_by_task_id(prod_local), &slot);
         }
     }
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -907,15 +907,17 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
         }
 
         int32_t resolved_this_pass = 0;
+        bool resolved_any = false;
         for (int32_t s = 0; s < active_sched_threads_; s++) {
             PTO2TaskSlotState *slot;
             while ((slot = sp_queues_[s].pop()) != nullptr) {
 #if SIMPLER_SCHED_PROFILING
-                (void)sched_->on_task_complete(*slot, thread_idx);
+                PTO2SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*slot, thread_idx);
 #else
-                (void)sched_->on_task_complete(*slot);
+                PTO2SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*slot);
 #endif
-                resolved_this_pass++;
+                resolved_this_pass += outcome.stream_tasks_completed;
+                resolved_any = true;
             }
         }
 
@@ -943,6 +945,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
                 break;
             }
             resolved_this_pass += poll_result.completed;
+            resolved_any = resolved_any || poll_result.completed > 0;
         }
 
         // Dependency-only tasks (empty active_mask, or a predicate that failed)
@@ -956,23 +959,28 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
             while ((dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH)) > 0) {
                 for (int di = 0; di < dummy_got; di++) {
 #if SIMPLER_SCHED_PROFILING
-                    (void)sched_->on_task_complete(*dummy_batch[di], thread_idx);
+                    PTO2SchedulerState::TaskCompletionOutcome outcome =
+                        sched_->complete_task(*dummy_batch[di], thread_idx);
 #else
-                    (void)sched_->on_task_complete(*dummy_batch[di]);
+                    PTO2SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*dummy_batch[di]);
 #endif
-                    resolved_this_pass++;
+                    resolved_this_pass += outcome.stream_tasks_completed;
+                    resolved_any = true;
                 }
             }
         }
 
-        if (resolved_this_pass > 0) {
-            int32_t new_total =
-                completed_tasks_.fetch_add(resolved_this_pass, std::memory_order_relaxed) + resolved_this_pass;
+        if (resolved_any) {
+            int32_t new_total = completed_tasks_.load(std::memory_order_relaxed);
+            if (resolved_this_pass > 0) {
+                new_total =
+                    completed_tasks_.fetch_add(resolved_this_pass, std::memory_order_relaxed) + resolved_this_pass;
 #if SIMPLER_SCHED_PROFILING
-            // P owns the completion accounting, so it owns the profiling mirror too
-            // (the S threads' completed_this_turn no longer feeds it in P mode).
-            sched_->tasks_completed.fetch_add(resolved_this_pass, std::memory_order_relaxed);
+                // P owns the completion accounting, so it owns the profiling mirror too
+                // (the S threads' completed_this_turn no longer feeds it in P mode).
+                sched_->tasks_completed.fetch_add(resolved_this_pass, std::memory_order_relaxed);
 #endif
+            }
             last_progress_ts = get_sys_cnt_aicpu();
             if (total_tasks_ > 0 && new_total >= total_tasks_) {
                 completed_.store(true, std::memory_order_release);
@@ -1274,6 +1282,94 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             handle_drain_mode(thread_idx);
 #endif
             continue;
+        }
+
+        // Graph control work never consumes an AICore. External dependency
+        // readiness and bounded definition materialization progress
+        // independently, then meet at GraphSubmission::activation_gate.
+        //
+        // Keep this ahead of dummy/regular dispatch so a ready Graph can expose
+        // its root nodes without waiting for an otherwise unrelated dispatch
+        // pass. Limiting the work to one activation and one bounded prepare
+        // slice per loop prevents a large definition from monopolizing a
+        // scheduler thread.
+        if (thread_idx < active_sched_threads_) {
+            PTO2TaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
+            if (graph_slot != nullptr) {
+                if (graph_slot->task != nullptr && graph_slot->task_kind == TaskKind::GRAPH) {
+                    (void)sched_->activate_graph_task(*graph_slot);
+                    made_progress = true;
+                } else {
+                    int32_t expected = PTO2_ERROR_NONE;
+                    if (header->sched_error_code.compare_exchange_strong(
+                            expected, PTO2_ERROR_INVALID_ARGS, std::memory_order_acq_rel, std::memory_order_acquire
+                        )) {
+                        header->sched_error_thread.store(thread_idx, std::memory_order_release);
+                    }
+                    header->sched_error_bitmap.fetch_or(
+                        1U << static_cast<uint32_t>(thread_idx), std::memory_order_acq_rel
+                    );
+                    completed_.store(true, std::memory_order_release);
+                    break;
+                }
+            }
+
+            uint64_t prepare_task_id = 0;
+            PTO2TaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
+            if (prepare_slot != nullptr) {
+                const bool valid_slot = prepare_slot->task != nullptr && prepare_slot->task_kind == TaskKind::GRAPH &&
+                                        prepare_slot->task->task_id.raw == prepare_task_id;
+                if (!valid_slot) {
+                    int32_t expected = PTO2_ERROR_NONE;
+                    if (header->sched_error_code.compare_exchange_strong(
+                            expected, PTO2_ERROR_INVALID_ARGS, std::memory_order_acq_rel, std::memory_order_acquire
+                        )) {
+                        header->sched_error_thread.store(thread_idx, std::memory_order_release);
+                    }
+                    header->sched_error_bitmap.fetch_or(
+                        1U << static_cast<uint32_t>(thread_idx), std::memory_order_acq_rel
+                    );
+                    completed_.store(true, std::memory_order_release);
+                    break;
+                }
+#if SIMPLER_DFX
+                uint64_t graph_prepare_t0 =
+                    chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES ? get_sys_cnt_aicpu() : 0;
+#endif
+                int32_t nodes_materialized = 0;
+                GraphMaterializeResult result =
+                    sched_->prepare_graph_task(*prepare_slot, GRAPH_MATERIALIZE_SLICE_NODES, &nodes_materialized);
+                if (result == GraphMaterializeResult::PENDING || result == GraphMaterializeResult::BUSY) {
+                    while (!sched_->graph_prepare_queue.push_tagged(prepare_slot, prepare_task_id)) {
+                        SPIN_WAIT_HINT();
+                    }
+                } else if (result == GraphMaterializeResult::INVALID) {
+                    int32_t expected = PTO2_ERROR_NONE;
+                    if (header->sched_error_code.compare_exchange_strong(
+                            expected, PTO2_ERROR_INVALID_ARGS, std::memory_order_acq_rel, std::memory_order_acquire
+                        )) {
+                        header->sched_error_thread.store(thread_idx, std::memory_order_release);
+                    }
+                    header->sched_error_bitmap.fetch_or(
+                        1U << static_cast<uint32_t>(thread_idx), std::memory_order_acq_rel
+                    );
+                    completed_.store(true, std::memory_order_release);
+                    break;
+                }
+                if (nodes_materialized > 0 || result == GraphMaterializeResult::PREPARED) {
+                    made_progress = true;
+                }
+#if SIMPLER_DFX
+                if (graph_prepare_t0 != 0) {
+                    uint64_t graph_prepare_t1 = get_sys_cnt_aicpu();
+                    chip_swimlane_aicpu_record_graph_prepare(
+                        thread_idx, graph_prepare_t0, graph_prepare_t1, chip_swimlane.sched_loop_count, prepare_task_id,
+                        static_cast<uint32_t>(nodes_materialized)
+                    );
+                    _t0_phase = graph_prepare_t1;
+                }
+#endif
+            }
         }
 
         // Phase 3 (dependency-only dummy / predicate-failed retirement) runs on

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -112,6 +112,8 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena) {
         layout.off_ready_sync_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     }
     layout.off_dummy_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
+    layout.off_graph_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
+    layout.off_graph_prepare_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     }
@@ -154,6 +156,14 @@ bool PTO2SchedulerState::init_data_from_layout(
         )) {
         return false;
     }
+    if (!ready_queue_init_data_from_layout(
+            &sched->graph_ready_queue, arena, layout.off_graph_ready_queue_slots, layout.ready_queue_capacity
+        ) ||
+        !ready_queue_init_data_from_layout(
+            &sched->graph_prepare_queue, arena, layout.off_graph_prepare_queue_slots, layout.ready_queue_capacity
+        )) {
+        return false;
+    }
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         if (!ready_queue_init_data_from_layout(
                 &sched->early_dispatch_queues[i], arena, layout.off_early_dispatch_queue_slots[i],
@@ -182,6 +192,8 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
         ready_queue_wire_arena_pointers(&sched->ready_sync_queues[i], arena, layout.off_ready_sync_queue_slots[i]);
     }
     ready_queue_wire_arena_pointers(&sched->dummy_ready_queue, arena, layout.off_dummy_ready_queue_slots);
+    ready_queue_wire_arena_pointers(&sched->graph_ready_queue, arena, layout.off_graph_ready_queue_slots);
+    ready_queue_wire_arena_pointers(&sched->graph_prepare_queue, arena, layout.off_graph_prepare_queue_slots);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         ready_queue_wire_arena_pointers(
             &sched->early_dispatch_queues[i], arena, layout.off_early_dispatch_queue_slots[i]
@@ -200,6 +212,8 @@ void PTO2SchedulerState::destroy() {
         ready_queue_destroy(&sched->ready_sync_queues[i]);
     }
     ready_queue_destroy(&sched->dummy_ready_queue);
+    ready_queue_destroy(&sched->graph_ready_queue);
+    ready_queue_destroy(&sched->graph_prepare_queue);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         ready_queue_destroy(&sched->early_dispatch_queues[i]);
     }
@@ -364,6 +378,7 @@ PTO2Runtime *runtime_init_data_from_layout(
     rt->gm_heap_size = total_heap_size;
     rt->gm_heap_owned = false;
     rt->total_cycles = 0;
+    rt->active_callable_hash = 0;
 
     if (!rt->orchestrator.init_data_from_layout(
             layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_sizes[0], layout.task_window_sizes[0]

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_aic_aiv_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_aic_aiv_orch.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include <array>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_MATMUL 0
+#define FUNC_ADD 1
+
+namespace {
+
+// A5-native decoder-style topology:
+//
+//       +--> matmul(weight_1) --+
+// input |                       +--> add
+//       +--> matmul(weight_2) --+
+//
+// A cache miss records two AIC tasks and one AIV task. Cache hits submit one
+// outer Graph task and let Scheduler materialize this saved topology.
+void decoder_layer(const CoreTaskArgs &args) {
+    const ChipTensor &input = args.tensor(0).ref();
+    const ChipTensor &weight_1 = args.tensor(1).ref();
+    const ChipTensor &weight_2 = args.tensor(2).ref();
+    const ChipTensor &output = args.tensor(3).ref();
+
+    const std::array<uint32_t, 1> shape{input.shapes[0]};
+    TensorCreateInfo projected_info(shape.data(), static_cast<uint32_t>(shape.size()), DataType::FLOAT32);
+
+    CoreTaskArgs left_args;
+    left_args.add_input(input, weight_1);
+    left_args.add_output(projected_info);
+    TaskOutputTensors left_outputs = rt_submit_aic_task(FUNC_MATMUL, left_args);
+
+    CoreTaskArgs right_args;
+    right_args.add_input(input, weight_2);
+    right_args.add_output(projected_info);
+    TaskOutputTensors right_outputs = rt_submit_aic_task(FUNC_MATMUL, right_args);
+
+    CoreTaskArgs add_args;
+    add_args.add_input(left_outputs.get_ref(0), right_outputs.get_ref(0));
+    add_args.add_output(output);
+    rt_submit_aiv_task(FUNC_ADD, add_args);
+}
+
+void submit_layer(const CoreTaskArgs &args) { rt_submit_graph(&decoder_layer, args); }
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+    (void)args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 6,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
+    for (int32_t output_index = 3; output_index < 6; ++output_index) {
+        CoreTaskArgs layer_args;
+        layer_args.add_input(args.tensor(0).ref(), args.tensor(1).ref(), args.tensor(2).ref());
+        layer_args.add_output(args.tensor(output_index).ref());
+        submit_layer(layer_args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_mix_spmd_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_mix_spmd_orch.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_SPMD_MIX_AIC 0
+#define FUNC_SPMD_MIX_AIV0 1
+#define FUNC_SPMD_MIX_AIV1 2
+
+namespace {
+
+void mix_spmd_layer(const CoreTaskArgs &args) {
+    MixedKernels kernels;
+    kernels.aic_kernel_id = FUNC_SPMD_MIX_AIC;
+    kernels.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
+    kernels.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
+
+    CoreTaskArgs task_args;
+    task_args.add_inout(args.tensor(0).ref());
+    task_args.add_scalar(int64_t{0});
+    task_args.launch_spec.set_block_num(static_cast<int16_t>(rt_available_cluster_count()));
+    task_args.launch_spec.set_require_sync_start(true);
+    rt_submit_task(kernels, task_args);
+}
+
+void submit_layer(const CoreTaskArgs &args) { rt_submit_graph(&mix_spmd_layer, args); }
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+    (void)args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
+    for (int32_t output_index = 0; output_index < 3; ++output_index) {
+        CoreTaskArgs layer_args;
+        layer_args.add_inout(args.tensor(output_index).ref());
+        submit_layer(layer_args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include <array>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_ADD 0
+#define FUNC_ADD_SCALAR 1
+#define FUNC_MUL 2
+
+namespace {
+
+void layer(const CoreTaskArgs &args, float left_delta, float right_delta) {
+    const ChipTensor &a = args.tensor(0).ref();
+    const ChipTensor &b = args.tensor(1).ref();
+    const ChipTensor &output = args.tensor(2).ref();
+    const float ndim_delta = b.ndims == 1 ? 0.0F : 2.0F;
+
+    const std::array<uint32_t, 1> shape{a.shapes[0]};
+    TensorCreateInfo intermediate(shape.data(), static_cast<uint32_t>(shape.size()), DataType::FLOAT32);
+
+    CoreTaskArgs add_args;
+    add_args.add_input(a, b);
+    add_args.add_output(intermediate);
+    const std::array<PTO2TaskId, 1> external_dep{a.owner_task_id};
+    add_args.set_dependencies(external_dep.data(), static_cast<uint32_t>(external_dep.size()));
+    TaskOutputTensors add_outputs = rt_submit_aiv_task(FUNC_ADD, add_args);
+    ChipTensor sum = add_outputs.get_ref(0);
+
+    CoreTaskArgs fence_args;
+    fence_args.add_inout(sum);
+    rt_submit_dummy_task(fence_args);
+
+    CoreTaskArgs left_args;
+    left_args.add_input(sum);
+    left_args.add_output(intermediate);
+    left_args.add_scalar(left_delta + ndim_delta);
+    left_args.set_allow_early_resolve(true);
+    TaskOutputTensors left_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, left_args);
+    ChipTensor left = left_outputs.get_ref(0);
+
+    CoreTaskArgs right_args;
+    right_args.add_input(sum);
+    right_args.add_output(intermediate);
+    right_args.add_scalar(right_delta + ndim_delta);
+    TaskOutputTensors right_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, right_args);
+    ChipTensor right = right_outputs.get_ref(0);
+
+    CoreTaskArgs mul_args;
+    mul_args.add_input(left, right);
+    mul_args.add_output(output);
+    rt_submit_aiv_task(FUNC_MUL, mul_args);
+}
+
+void submit_layer(const CoreTaskArgs &args) { rt_submit_graph(&layer, args, 1.0F, 2.0F); }
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+    (void)args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 5,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
+    const ChipTensor &a = args.tensor(0).ref();
+    const ChipTensor &b = args.tensor(1).ref();
+
+    const std::array<uint32_t, 1> shape{a.shapes[0]};
+    TensorCreateInfo seeded_input_info(shape.data(), static_cast<uint32_t>(shape.size()), DataType::FLOAT32);
+    CoreTaskArgs seed_args;
+    seed_args.add_input(a);
+    seed_args.add_output(seeded_input_info);
+    seed_args.add_scalar(0.0F);
+    TaskOutputTensors seed_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, seed_args);
+    ChipTensor seeded_a = seed_outputs.get_ref(0);
+
+    for (int32_t output_index = 2; output_index < 5; ++output_index) {
+        CoreTaskArgs layer_args;
+        layer_args.add_input(seeded_a, b);
+        layer_args.add_output(args.tensor(output_index).ref());
+        submit_layer(layer_args);  // first call records; later calls submit one Graph task
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Graph Execution records once and replays topology with dynamic CoreTaskArgs tensors."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestGraphExecutionHostBuildGraphA5(SceneTestCase):
+    RTOL = 1e-5
+    ATOL = 1e-5
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/graph_execution_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT, D.OUT, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": "../vector_example/kernels/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": "../vector_example/kernels/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": "../vector_example/kernels/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "record_then_replay_1d",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {"shape": (128 * 128,)},
+        },
+        {
+            "name": "record_then_replay_2d",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {"shape": (128 * 128, 1)},
+        },
+    ]
+
+    def generate_args(self, params):
+        shape = params["shape"]
+        return TaskArgsBuilder(
+            TensorArg("a", torch.full(shape, 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full(shape, 3.0, dtype=torch.float32)),
+            TensorArg("output_1", torch.zeros(shape, dtype=torch.float32)),
+            TensorArg("output_3", torch.zeros(shape, dtype=torch.float32)),
+            TensorArg("output_5", torch.zeros(shape, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        base = args.a + args.b
+        ndim_delta = 0.0 if args.a.ndim == 1 else 2.0
+        expected = (base + 1.0 + ndim_delta) * (base + 2.0 + ndim_delta)
+        args.output_1[:] = expected
+        args.output_3[:] = expected
+        args.output_5[:] = expected
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Graph Execution replays an A5-native AIC/AIV fan-out and fan-in DAG."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestGraphExecutionAicAivHostBuildGraphA5(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/graph_execution_aic_aiv_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.OUT, D.OUT, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": "../../tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": "../../tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "record_then_replay_aic_aiv",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        size = 128 * 128
+        return TaskArgsBuilder(
+            TensorArg("input", torch.full((size,), 0.01, dtype=torch.float32)),
+            TensorArg("weight_1", torch.full((size,), 0.02, dtype=torch.float32)),
+            TensorArg("weight_2", torch.full((size,), 0.03, dtype=torch.float32)),
+            TensorArg("output_1", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("output_2", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("output_3", torch.zeros(size, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        input_matrix = args.input.reshape(128, 128)
+        left = torch.matmul(input_matrix, args.weight_1.reshape(128, 128))
+        right = torch.matmul(input_matrix, args.weight_2.reshape(128, 128))
+        expected = (left + right).flatten()
+        args.output_1[:] = expected
+        args.output_2[:] = expected
+        args.output_3[:] = expected
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Graph Execution preserves MIX active slots and multi-block SPMD metadata."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3
+MAX_CLUSTERS = 36
+TOTAL_FLOATS = MAX_CLUSTERS * SLOTS_PER_BLOCK * FLOATS_PER_CACHE_LINE
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestGraphExecutionMixSpmdHostBuildGraphA5(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/graph_execution_mix_spmd_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": "../../tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "source": "../../tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "source": "../../tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "record_then_replay_mix_spmd",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            TensorArg("blocks_1", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
+            TensorArg("blocks_2", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
+            TensorArg("blocks_3", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        # The exact whole-device cluster count is platform-provided. Validate
+        # it from the first execution and require both Graph replays to match.
+        pass
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        outputs = [test_args.blocks_1, test_args.blocks_2, test_args.blocks_3]
+        assert torch.equal(outputs[0], outputs[1])
+        assert torch.equal(outputs[0], outputs[2])
+
+        cache_line_heads = outputs[0].reshape(-1, FLOATS_PER_CACHE_LINE)[:, 0]
+        nonzero = torch.nonzero(cache_line_heads, as_tuple=False)
+        assert nonzero.numel() > 0, "SPMD Graph did not execute any non-zero block"
+        cluster_count = int(cache_line_heads.max().item()) + 1
+        assert 1 < cluster_count <= MAX_CLUSTERS
+
+        expected = torch.zeros_like(cache_line_heads)
+        for block_idx in range(cluster_count):
+            begin = block_idx * SLOTS_PER_BLOCK
+            expected[begin : begin + SLOTS_PER_BLOCK] = float(block_idx)
+        assert torch.equal(cache_line_heads, expected)
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -789,6 +789,10 @@ add_a2a3_hbg_runtime_test(test_graph_cache a2a3/test_graph_cache.cpp)
 target_sources(test_graph_cache PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
 )
+add_a5_hbg_runtime_test(test_a5_graph_cache a5/test_graph_cache.cpp)
+target_sources(test_a5_graph_cache PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
+)
 # PTO2TensorMap's out-of-line members (reserve_layout / init / valid_count) live
 # in this .cpp; no other add_a2a3_hbg_runtime_test target needs them.
 target_sources(test_hbg_tensormap PRIVATE

--- a/tests/ut/cpp/a5/test_graph_cache.cpp
+++ b/tests/ut/cpp/a5/test_graph_cache.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <new>
+#include <vector>
+
+#include "graph_cache.h"
+#include "graph_execution.h"
+
+namespace {
+
+template <typename T>
+uint32_t append_section(std::vector<std::byte> &image, const std::vector<T> &values) {
+    if (values.empty()) return 0;
+    const size_t offset = PTO2_ALIGN_UP(image.size(), alignof(T));
+    image.resize(offset + values.size() * sizeof(T));
+    std::memcpy(image.data() + offset, values.data(), values.size() * sizeof(T));
+    return static_cast<uint32_t>(offset);
+}
+
+GraphTensor make_test_tensor(uint64_t address) {
+    GraphTensor tensor{};
+    tensor.buffer_addr = address;
+    tensor.buffer_size = 64;
+    tensor.extent_elem = 1;
+    tensor.shapes[0] = 1;
+    tensor.strides[0] = 1;
+    tensor.ndims = 1;
+    tensor.dtype = static_cast<uint8_t>(DataType::FLOAT32);
+    tensor.is_contiguous = 1;
+    return tensor;
+}
+
+std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundary_address) {
+    std::vector<std::byte> image(sizeof(GraphDefinition));
+
+    std::vector<uint32_t> fanin_offsets{0, 0, 1};
+    std::vector<uint16_t> fanin_indices{0};
+    std::vector<uint32_t> fanout_offsets{0, 1, 1};
+    std::vector<uint16_t> fanout_indices{1};
+    std::vector<uint16_t> roots{0};
+    std::vector<uint64_t> node_offsets{0, 64};
+    std::vector<GraphNodeDefinition> nodes(2);
+    for (GraphNodeDefinition &node : nodes) {
+        std::fill(std::begin(node.kernel_id), std::end(node.kernel_id), INVALID_KERNEL_ID);
+        node.kernel_id[0] = 42;
+        node.active_mask = 1;
+        node.logical_block_num = 1;
+        node.total_required_subtasks = 1;
+        node.tensor_count = 1;
+        node.scalar_count = 1;
+        node.total_output_size = 64;
+    }
+    nodes[1].tensor_offset = 1;
+    nodes[1].scalar_offset = 1;
+    std::vector<GraphTensor> tensors{make_test_tensor(boundary_address), make_test_tensor(boundary_address)};
+    tensors[1].buffer_size = 32;
+    std::vector<GraphTensorSourceRef> tensor_sources(2);
+    tensor_sources[0].source = static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT);
+    tensor_sources[1].source = static_cast<uint8_t>(GraphTensorSource::INTERNAL);
+    tensor_sources[1].packed_offset = 16;
+    std::vector<uint64_t> scalars{17, 18};
+
+    GraphDefinition definition{};
+    definition.full_key = graph_key;
+    definition.required_heap = 128;
+    definition.task_count = 2;
+    definition.edge_count = 1;
+    definition.root_count = 1;
+    definition.boundary_count = 1;
+    definition.tensor_arg_count = 2;
+    definition.scalar_arg_count = 2;
+    definition.off_fanin_offsets = append_section(image, fanin_offsets);
+    definition.off_fanin_indices = append_section(image, fanin_indices);
+    definition.off_fanout_offsets = append_section(image, fanout_offsets);
+    definition.off_fanout_indices = append_section(image, fanout_indices);
+    definition.off_root_indices = append_section(image, roots);
+    definition.off_node_offsets = append_section(image, node_offsets);
+    definition.off_nodes = append_section(image, nodes);
+    definition.off_tensors = append_section(image, tensors);
+    definition.off_tensor_sources = append_section(image, tensor_sources);
+    definition.off_scalars = append_section(image, scalars);
+    definition.total_bytes = static_cast<uint32_t>(image.size());
+    std::memcpy(image.data(), &definition, sizeof(definition));
+
+    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image.data(), image.size());
+    std::memcpy(image.data(), &definition, sizeof(definition));
+    return image;
+}
+
+std::vector<std::byte> make_test_submission(
+    uint64_t graph_key, uint64_t boundary_address, uint64_t execution_storage, size_t execution_storage_bytes
+) {
+    const std::vector<std::byte> definition = make_test_definition(graph_key, boundary_address);
+    const size_t definition_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphDefinition));
+    const size_t tensors_offset = PTO2_ALIGN_UP(definition_offset + definition.size(), alignof(GraphTensor));
+    std::vector<std::byte> image(tensors_offset + sizeof(GraphTensor));
+    std::memcpy(image.data() + definition_offset, definition.data(), definition.size());
+    const GraphTensor boundary = make_test_tensor(boundary_address);
+    std::memcpy(image.data() + tensors_offset, &boundary, sizeof(boundary));
+
+    GraphSubmission submission{};
+    submission.graph_key = graph_key;
+    submission.execution_storage = execution_storage;
+    submission.execution_storage_bytes = execution_storage_bytes;
+    submission.total_bytes = static_cast<uint32_t>(image.size());
+    submission.definition_offset = static_cast<uint32_t>(definition_offset);
+    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
+    submission.tensor_count = 1;
+    std::memcpy(image.data(), &submission, sizeof(submission));
+    return image;
+}
+
+class AlignedStorage {
+public:
+    explicit AlignedStorage(size_t bytes) :
+        bytes_(bytes) {
+        data_ = ::operator new(bytes, std::align_val_t(alignof(GraphNodeStorage)));
+        std::memset(data_, 0, bytes);
+    }
+
+    ~AlignedStorage() { ::operator delete(data_, std::align_val_t(alignof(GraphNodeStorage))); }
+
+    void *data() const { return data_; }
+    size_t size() const { return bytes_; }
+
+private:
+    void *data_{nullptr};
+    size_t bytes_{0};
+};
+
+}  // namespace
+
+TEST(GraphCache, RejectsEmptyBoundary) {
+    CoreTaskArgs args;
+
+    EXPECT_FALSE(rt_graph_args_cacheable(args));
+}
+
+TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
+    constexpr int32_t NODE_COUNT = 7;
+    constexpr size_t DEFINITION_BYTES = 321;
+    constexpr uint32_t TENSOR_PATCH_COUNT = 11;
+    size_t nodes_offset = 0;
+    size_t tensor_patches_offset = 0;
+    size_t definition_offset = 0;
+    size_t storage_bytes = 0;
+
+    ASSERT_TRUE(graph_execution_storage_layout(
+        NODE_COUNT, TENSOR_PATCH_COUNT, DEFINITION_BYTES, &nodes_offset, &tensor_patches_offset, &definition_offset,
+        &storage_bytes
+    ));
+    EXPECT_EQ(nodes_offset % alignof(GraphNodeStorage), 0U);
+    EXPECT_EQ(tensor_patches_offset % alignof(GraphTensorAddressPatch), 0U);
+    EXPECT_EQ(definition_offset % alignof(GraphDefinition), 0U);
+    EXPECT_GE(tensor_patches_offset, nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
+    EXPECT_GE(definition_offset, tensor_patches_offset + TENSOR_PATCH_COUNT * sizeof(GraphTensorAddressPatch));
+    EXPECT_GE(storage_bytes, definition_offset + DEFINITION_BYTES);
+    EXPECT_EQ(storage_bytes % alignof(GraphNodeStorage), 0U);
+}
+
+TEST(GraphExecutionStorage, RejectsInvalidCapacity) {
+    size_t storage_bytes = 0;
+
+    EXPECT_FALSE(graph_execution_storage_bytes(0, 0, sizeof(GraphDefinition), &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(1, 0, SIZE_MAX, &storage_bytes));
+}
+
+TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
+    std::array<uint8_t, 128> first_heap{};
+    std::array<uint8_t, 128> second_heap{};
+    std::array<uint8_t, 64> first_boundary{};
+    std::array<uint8_t, 64> second_boundary{};
+
+    const std::vector<std::byte> definition =
+        make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()));
+    size_t execution_bytes = 0;
+    ASSERT_TRUE(graph_execution_storage_bytes(2, 2, definition.size(), &execution_bytes));
+    AlignedStorage execution_storage(execution_bytes);
+    std::vector<std::byte> submission_image = make_test_submission(
+        GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()),
+        reinterpret_cast<uint64_t>(execution_storage.data()), execution_storage.size()
+    );
+    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
+
+    PTO2TaskDescriptor outer_task{};
+    outer_task.task_id = PTO2TaskId::make(1, 7);
+    outer_task.packed_buffer_base = first_heap.data();
+    outer_task.packed_buffer_end = first_heap.data() + first_heap.size();
+    PTO2TaskSlotState outer_slot{};
+    outer_slot.task_kind = TaskKind::GRAPH;
+    outer_slot.task = &outer_task;
+    outer_slot.graph_context = &submission;
+
+    GraphExecution *execution = graph_execution_localize(outer_slot);
+    ASSERT_NE(execution, nullptr);
+    EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
+    GraphNodeStorage &node = execution->node_storage[0];
+    ASSERT_EQ(node.payload.scalar_count, 1);
+    ASSERT_EQ(node.payload.tensor_count, 1);
+
+    graph_execution_mark_completed(*execution);
+    execution->retired_nodes.store(2, std::memory_order_release);
+    submission.local_execution = 0;
+    outer_task.task_id = PTO2TaskId::make(1, 8);
+    outer_task.packed_buffer_base = second_heap.data();
+    outer_task.packed_buffer_end = second_heap.data() + second_heap.size();
+    auto *boundary = reinterpret_cast<GraphTensor *>(submission_image.data() + submission.tensors_offset);
+    boundary->buffer_addr = reinterpret_cast<uint64_t>(second_boundary.data());
+
+    execution = graph_execution_localize(outer_slot);
+    ASSERT_NE(execution, nullptr);
+    ASSERT_TRUE(execution->definition_affine_reuse);
+
+    // Write probes make an otherwise same-valued store observable. An affine
+    // replay must not touch these static fields; only the tensor address and
+    // per-run descriptor/scheduling state below are dynamic.
+    node.task.kernel_id[0] = 314;
+    node.slot.active_mask = ActiveMask(3);
+    node.payload.scalars[0] = 2718;
+    node.payload.tensors[0].version = 1618;
+    node.slot.completed_subtasks.store(1, std::memory_order_relaxed);
+    node.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
+
+    EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
+    EXPECT_EQ(node.task.kernel_id[0], 314);
+    EXPECT_EQ(node.slot.active_mask.raw(), 3);
+    EXPECT_EQ(node.payload.scalars[0], 2718U);
+    EXPECT_EQ(node.payload.tensors[0].version, 1618);
+    EXPECT_EQ(node.task.task_id, PTO2TaskId::make(1, (8U << 10U)));
+    EXPECT_EQ(node.task.packed_buffer_base, second_heap.data());
+    EXPECT_EQ(node.payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
+    EXPECT_EQ(
+        execution->node_storage[1].payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(second_heap.data() + 16)
+    );
+    EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
+}


### PR DESCRIPTION
## Summary

- Port the existing A2/A3 Host Build Graph Graph Execution implementation into A5 without changing the A2/A3 reference implementation.
- Add A5 Graph recording, submission upload, retained execution storage, materialization, activation, and completion lifecycle.
- Add A5 AIV, mixed AIC/AIV fan-out/fan-in, and MIX/SPMD record-and-replay scenes plus an A5 build of the reference graph-cache unit test.
- Keep the implementations architecture-local in this PR. Cross-architecture hardening is tracked in #1736 and common-logic extraction in #1737.

## Scope

This PR is intentionally a direct A5 port. It does not modify `src/a2a3/` or extract Graph Execution into `src/common/host_build_graph/`.

The A5-specific differences are limited to the existing A5 runtime lifecycle/core topology and A5-native test kernels.

## Follow-ups

- #1736: harden Graph Execution across A2/A3 and A5.
- #1737: deduplicate the architecture-local implementations after parity is established.
- The previous shared-implementation prototype is preserved on [`backup/issue-1715-a5-graph-shared-impl`](https://github.com/zmnobug/simpler/tree/backup/issue-1715-a5-graph-shared-impl).

## Testing

- [x] Editable runtime build
- [x] Full non-hardware C++ unit suite: 92/92 effective (the sandbox-blocked socket case passed outside the sandbox)
- [x] A5 Host Build Graph simulation suite: 18 passed
- [x] A5 Graph Execution simulation: 3 passed
- [x] Pre-commit checks on all changed files
- [ ] A5 onboard hardware CI

Fixes #1715