### PR TITLE
Refactor: derive tmr scheduler thread/core dims from platform_config

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -51,7 +51,7 @@
 // =============================================================================
 
 #define RUNTIME_MAX_ARGS 128
-#define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
+#define RUNTIME_MAX_WORKER PLATFORM_MAX_CORES  // 24 AIC + 48 AIV cores
 #define RUNTIME_MAX_FUNC_ID 1024
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -312,7 +312,7 @@ void SchedulerContext::log_stall_diagnostics(
     // round-robin assignment in assign_cores_to_threads.
     int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
-        int32_t offset = cli * 3;
+        int32_t offset = cli * PLATFORM_CORES_PER_BLOCKDIM;
         int32_t aic_id = tracker.get_aic_core_id(offset);
         int32_t aiv0_id = tracker.get_aiv0_core_id(offset);
         int32_t aiv1_id = tracker.get_aiv1_core_id(offset);
@@ -800,7 +800,7 @@ void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32
 // set instead of a contiguous slice.
 void SchedulerContext::handshake_owned_clusters(Runtime *runtime, int32_t tidx, int32_t active_threads) {
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
-    const int32_t aic_n = cores_total_num_ / 3;
+    const int32_t aic_n = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
 
     int32_t owned[RUNTIME_MAX_WORKER];
     int32_t own_n = 0;
@@ -900,7 +900,7 @@ void SchedulerContext::handshake_owned_clusters(Runtime *runtime, int32_t tidx, 
 // right after handshaking its own clusters, with no all-thread barrier.
 // =============================================================================
 void SchedulerContext::assign_own_clusters(int32_t tidx) {
-    const int32_t aic_n = cores_total_num_ / 3;
+    const int32_t aic_n = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
     const int32_t active = active_sched_threads_;
 
     CoreTracker &tracker = core_trackers_[tidx];
@@ -930,7 +930,7 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     // Per-cluster GlobalContext sub_block_id (mirrors post_handshake_init) for
     // this thread's owned cores only — a thread only ever dispatches to its own.
     for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-        int32_t cluster_offset = c * 3;
+        int32_t cluster_offset = c * PLATFORM_CORES_PER_BLOCKDIM;
         int32_t aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
         int32_t aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
         payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;
@@ -942,8 +942,8 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     // Per-dispatch AsyncCtx constant prefill + one-time slab clear for owned cores
     // (mirrors post_handshake_init's all-core loop, restricted to this thread's).
     for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-        for (int32_t sub = 0; sub < 3; sub++) {
-            int32_t core_id = tracker.get_core_id_by_offset(c * 3 + sub);
+        for (int32_t sub = 0; sub < PLATFORM_CORES_PER_BLOCKDIM; sub++) {
+            int32_t core_id = tracker.get_core_id_by_offset(c * PLATFORM_CORES_PER_BLOCKDIM + sub);
             for (int32_t buf = 0; buf < 2; buf++) {
                 PTO2DispatchPayload &dp = payload_per_core_[core_id][buf];
                 AsyncCtx &ac = dp.local_context.async_ctx;
@@ -994,7 +994,7 @@ bool SchedulerContext::assign_cores_to_threads() {
 
     // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
     int32_t max_clusters_per_thread = (cluster_count + active_sched_threads_ - 1) / active_sched_threads_;
-    int32_t thread_cores_num = max_clusters_per_thread * 3;
+    int32_t thread_cores_num = max_clusters_per_thread * PLATFORM_CORES_PER_BLOCKDIM;
 
     if (thread_cores_num > CoreTracker::MAX_CORE_PER_THREAD) {
         LOG_ERROR("Can't assign more then 64 cores in per scheduler");
@@ -1151,8 +1151,11 @@ int32_t SchedulerContext::pre_handshake_init(
     // AIV cores [3*(N/3), N) in no cluster — unhandshaked, their windows never open,
     // and the run hangs at the op-execute timeout. assign_cores_to_threads pairs
     // aiv_worker_ids_[2*ci]/[2*ci+1] on the serial path too, so this holds for both.
-    if (cores_total_num_ % 3 != 0) {
-        LOG_ERROR("cores_total_num %d is not a multiple of 3 (blocked 1 AIC : 2 AIV layout)", cores_total_num_);
+    if (cores_total_num_ % PLATFORM_CORES_PER_BLOCKDIM != 0) {
+        LOG_ERROR(
+            "cores_total_num %d is not a multiple of %d (blocked 1 AIC : 2 AIV layout)", cores_total_num_,
+            PLATFORM_CORES_PER_BLOCKDIM
+        );
         return -1;
     }
     // Blocked core layout ([0,N/3) AIC, [N/3,N) AIV) with a fixed 1:2 AIC:AIV
@@ -1258,7 +1261,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     for (int32_t t = 0; t < sched_thread_num_; t++) {
         CoreTracker &tracker = core_trackers_[t];
         for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
+            int32_t cluster_offset = c * PLATFORM_CORES_PER_BLOCKDIM;  // Each cluster = 1 AIC + 2 AIV
             auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
             auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
             payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -26,7 +26,7 @@
 // (it pulls in Handshake which we only forward-declare).  Mirror the
 // authoritative values so the class layout compiles standalone.
 #ifndef RUNTIME_MAX_WORKER
-#define RUNTIME_MAX_WORKER 72
+#define RUNTIME_MAX_WORKER PLATFORM_MAX_CORES
 #endif
 #ifndef RUNTIME_MAX_FUNC_ID
 #define RUNTIME_MAX_FUNC_ID 1024

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1184,7 +1184,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // signalled inline here. The ready queue is MPMC, and the fanout path
         // uses per-slot locks/atomics, so multiple scheduler threads can share
         // the dependency-only resolve work.
-        if (thread_idx < 3) {
+        if (thread_idx < PLATFORM_MAX_AICPU_THREADS - 1) {
             constexpr int DUMMY_DRAIN_BATCH = 8;
             PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -496,7 +496,7 @@ public:
     int32_t get_core_id_by_offset(int32_t offset) const { return core_id_map_[offset]; }
 
     const int32_t *core_ids() const { return core_id_map_; }
-    int32_t core_num() const { return cluster_count_ * 3; }
+    int32_t core_num() const { return cluster_count_ * PLATFORM_CORES_PER_BLOCKDIM; }
 
 private:
     int32_t cluster_count_;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -50,7 +50,7 @@
 // =============================================================================
 
 #define RUNTIME_MAX_ARGS 128
-#define RUNTIME_MAX_WORKER 108  // 36 AIC + 72 AIV cores
+#define RUNTIME_MAX_WORKER PLATFORM_MAX_CORES  // 36 AIC + 72 AIV cores
 #define RUNTIME_MAX_FUNC_ID 1024
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -318,7 +318,7 @@ void SchedulerContext::log_stall_diagnostics(
     // round-robin assignment in assign_cores_to_threads.
     int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
-        int32_t offset = cli * 3;
+        int32_t offset = cli * PLATFORM_CORES_PER_BLOCKDIM;
         int32_t aic_id = tracker.get_aic_core_id(offset);
         int32_t aiv0_id = tracker.get_aiv0_core_id(offset);
         int32_t aiv1_id = tracker.get_aiv1_core_id(offset);
@@ -797,7 +797,7 @@ void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32
 // set instead of a contiguous slice.
 void SchedulerContext::handshake_owned_clusters(Runtime *runtime, int32_t tidx, int32_t active_threads) {
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
-    const int32_t aic_n = cores_total_num_ / 3;
+    const int32_t aic_n = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
 
     int32_t owned[RUNTIME_MAX_WORKER];
     int32_t own_n = 0;
@@ -897,7 +897,7 @@ void SchedulerContext::handshake_owned_clusters(Runtime *runtime, int32_t tidx, 
 // right after handshaking its own clusters, with no all-thread barrier.
 // =============================================================================
 void SchedulerContext::assign_own_clusters(int32_t tidx) {
-    const int32_t aic_n = cores_total_num_ / 3;
+    const int32_t aic_n = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
     const int32_t active = active_sched_threads_;
 
     CoreTracker &tracker = core_trackers_[tidx];
@@ -927,7 +927,7 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     // Per-cluster GlobalContext sub_block_id (mirrors post_handshake_init) for
     // this thread's owned cores only — a thread only ever dispatches to its own.
     for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-        int32_t cluster_offset = c * 3;
+        int32_t cluster_offset = c * PLATFORM_CORES_PER_BLOCKDIM;
         int32_t aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
         int32_t aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
         payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;
@@ -939,8 +939,8 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     // Per-dispatch AsyncCtx constant prefill + one-time slab clear for owned cores
     // (mirrors post_handshake_init's all-core loop, restricted to this thread's).
     for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-        for (int32_t sub = 0; sub < 3; sub++) {
-            int32_t core_id = tracker.get_core_id_by_offset(c * 3 + sub);
+        for (int32_t sub = 0; sub < PLATFORM_CORES_PER_BLOCKDIM; sub++) {
+            int32_t core_id = tracker.get_core_id_by_offset(c * PLATFORM_CORES_PER_BLOCKDIM + sub);
             for (int32_t buf = 0; buf < 2; buf++) {
                 PTO2DispatchPayload &dp = payload_per_core_[core_id][buf];
                 AsyncCtx &ac = dp.local_context.async_ctx;
@@ -995,7 +995,7 @@ bool SchedulerContext::assign_cores_to_threads() {
 
     // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
     int32_t max_clusters_per_thread = (cluster_count + active_sched_threads_ - 1) / active_sched_threads_;
-    int32_t thread_cores_num = max_clusters_per_thread * 3;
+    int32_t thread_cores_num = max_clusters_per_thread * PLATFORM_CORES_PER_BLOCKDIM;
 
     if (thread_cores_num > CoreTracker::MAX_CORE_PER_THREAD) {
         LOG_ERROR("Can't assign more then 64 cores in per scheduler");
@@ -1132,8 +1132,11 @@ int32_t SchedulerContext::pre_handshake_init(
     // AIV cores [3*(N/3), N) in no cluster — unhandshaked, their windows never open,
     // and the run hangs at the op-execute timeout. assign_cores_to_threads pairs
     // aiv_worker_ids_[2*ci]/[2*ci+1] on the serial path too, so this holds for both.
-    if (cores_total_num_ % 3 != 0) {
-        LOG_ERROR("cores_total_num %d is not a multiple of 3 (blocked 1 AIC : 2 AIV layout)", cores_total_num_);
+    if (cores_total_num_ % PLATFORM_CORES_PER_BLOCKDIM != 0) {
+        LOG_ERROR(
+            "cores_total_num %d is not a multiple of %d (blocked 1 AIC : 2 AIV layout)", cores_total_num_,
+            PLATFORM_CORES_PER_BLOCKDIM
+        );
         return -1;
     }
     // Blocked core layout ([0,N/3) AIC, [N/3,N) AIV) with a fixed 1:2 AIC:AIV
@@ -1232,7 +1235,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     for (int32_t t = 0; t < sched_thread_num_; t++) {
         CoreTracker &tracker = core_trackers_[t];
         for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
+            int32_t cluster_offset = c * PLATFORM_CORES_PER_BLOCKDIM;  // Each cluster = 1 AIC + 2 AIV
             auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
             auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
             payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -25,7 +25,7 @@
 // (it pulls in Handshake which we only forward-declare).  Mirror the
 // authoritative values so the class layout compiles standalone.
 #ifndef RUNTIME_MAX_WORKER
-#define RUNTIME_MAX_WORKER 108
+#define RUNTIME_MAX_WORKER PLATFORM_MAX_CORES
 #endif
 #ifndef RUNTIME_MAX_FUNC_ID
 #define RUNTIME_MAX_FUNC_ID 1024

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1025,7 +1025,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // signalled inline here. The ready queue is MPMC, and the fanout path
         // uses per-slot locks/atomics, so multiple scheduler threads can share
         // the dependency-only resolve work.
-        if (thread_idx < 4) {
+        if (thread_idx < PLATFORM_MAX_AICPU_THREADS - 1) {
             constexpr int DUMMY_DRAIN_BATCH = 8;
             PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -471,7 +471,7 @@ public:
     int32_t get_core_id_by_offset(int32_t offset) const { return core_id_map_[offset]; }
 
     const int32_t *core_ids() const { return core_id_map_; }
-    int32_t core_num() const { return cluster_count_ * 3; }
+    int32_t core_num() const { return cluster_count_ * PLATFORM_CORES_PER_BLOCKDIM; }
 
 private:
     int32_t cluster_count_;


### PR DESCRIPTION
Fixes #1734

Three hardware-derived dimensions in the `tensormap_and_ringbuffer` scheduler were written as bare numeric literals even though `platform_config.h` already defines the exact named constant they equal. The literals obscured that a2a3 and a5 share one rule, read as divergences when they are not, and would go silently wrong if a platform constant changed. Landed across both trees in one commit per `codestyle.md` rule 10.

**No behavior change** — every derived value equals the current literal on both arches today (`PLATFORM_MAX_AICPU_THREADS` = 4/5, `PLATFORM_CORES_PER_BLOCKDIM` = 3, `PLATFORM_MAX_CORES` = 72/108).

## Changes

**G — dummy-drain thread gate** (`scheduler_dispatch.cpp`)
`thread_idx < 3` (a2a3) / `thread_idx < 4` (a5) → `thread_idx < PLATFORM_MAX_AICPU_THREADS - 1` — "every scheduler thread except the last".

**M1 — `RUNTIME_MAX_WORKER`** (`runtime.h` + `scheduler_context.h`)
`72` / `108` → `PLATFORM_MAX_CORES`. Both the authoritative unguarded define in `runtime.h` **and** the `#ifndef` fallback in `scheduler_context.h` are changed: the `runtime.h` define is unguarded, so leaving it a literal while the fallback expands to the constant is a mismatched macro redefinition that `-Werror` rejects. (The issue's Location listed only `scheduler_context.h`; `runtime.h` had to move with it for the tree to compile.)

**M2 — cores-per-cluster `3`** (`scheduler_types.h` + `scheduler_cold_path.cpp`)
The semantic `cluster_count_ * 3` (`core_num()`), the two `cores_total_num_ / 3`, and the `% 3 != 0` validity check → `PLATFORM_CORES_PER_BLOCKDIM`; the "multiple of 3" error text now interpolates the constant with `%d`. The self-documenting `bit(i*3+k)` / `core_id_map_[cluster_idx*3+k]` bitmask-layout arithmetic is left as-is, per the issue's scope note.

Both trees now read identically at every changed site.

## Testing

Rebuilt both runtimes (`pip install --no-build-isolation -e .`) and ran tmr sim scene tests on both arches:

| Test | a2a3sim | a5sim | Exercises |
| ---- | ------- | ----- | --------- |
| `dummy_task` | ✅ | ✅ | G dummy-drain gate |
| `available_aicore_counts` | ✅ | ✅ | M2 core-count / multiple-of-3 validation |
| `mixed_example` | ✅ | ✅ | general scheduling / dispatch |