### PR TITLE
Rename: simpler_setup.Tensor -> simpler_setup.TensorArg

### DIFF
--- a/.claude/rules/project-layout.md
+++ b/.claude/rules/project-layout.md
@@ -7,15 +7,16 @@ How this repo organizes Python packages, the build system, and example / test di
 | Package | Source | What's in wheel | Use for |
 | ------- | ------ | --------------- | ------- |
 | `simpler` | `python/simpler/` | `task_interface`, `worker`, `env_manager` only | Runtime user API: `Worker` plus the task/callable types |
-| `simpler_setup` | `simpler_setup/` | All files + `_assets/{src,build/lib}` | **Also user-facing**, not internal-only: `KernelCompiler`, `SceneTestCase` / `scene_test`, `Tensor`, `Scalar`, `TaskArgsBuilder`, `ensure_pto_isa_root`, `make_chip_tensor_arg`, plus the `simpler_setup.tools` CLIs. A kernel cannot be compiled without it |
+| `simpler_setup` | `simpler_setup/` | All files + `_assets/{src,build/lib}` | **Also user-facing**, not internal-only: `KernelCompiler`, `SceneTestCase` / `scene_test`, `TensorArg`, `Scalar`, `TaskArgsBuilder`, `ensure_pto_isa_root`, `make_chip_tensor_arg`, plus the `simpler_setup.tools` CLIs. A kernel cannot be compiled without it |
 | `_task_interface` | `python/bindings/` | nanobind `.so` at wheel root | Internal nanobind module |
 
 `simpler` exposes `Worker` and the `task_interface` submodule lazily (PEP 562
 `__getattr__`), so `from simpler import Worker` works while `import simpler`
 still costs nothing and does not require the `_task_interface` extension.
 `simpler.task_interface.ChipTensor` is the GM-address-bearing device descriptor
-a `ChipWorker` consumes; `simpler_setup.Tensor` is the address-free scene-test
-arg spec `NamedTuple`. They are separate types in separate namespaces.
+a `ChipWorker` consumes; `simpler_setup.TensorArg` is the address-free
+scene-test arg spec `NamedTuple`. They are separate types in separate
+namespaces.
 
 The 4 files `kernel_compiler.py`, `runtime_compiler.py`, `toolchain.py`, `elf_parser.py` exist in **both** `python/simpler/` and `simpler_setup/` during transition. The `simpler_setup/` copies are authoritative; the `python/simpler/` copies are excluded from wheel via `pyproject.toml::wheel.exclude`. New code must `import` from `simpler_setup.*`, not `simpler.*`, for these four.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -617,7 +617,7 @@ Create a `test_*.py` file using the `@scene_test` decorator:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -644,8 +644,8 @@ class TestMyKernel(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("x", torch.ones(1024, dtype=torch.float32)),
-            Tensor("y", torch.zeros(1024, dtype=torch.float32)),
+            TensorArg("x", torch.ones(1024, dtype=torch.float32)),
+            TensorArg("y", torch.zeros(1024, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -31,16 +31,13 @@ Both `simpler` and `simpler_setup` are part of the surface you write against:
 - **`simpler`** — the runtime itself. `Worker`, and the task/callable types in
   `simpler.task_interface`.
 - **`simpler_setup`** — compilation and test scaffolding: `KernelCompiler`,
-  `SceneTestCase` / `scene_test`, `Tensor`, `TaskArgsBuilder`,
+  `SceneTestCase` / `scene_test`, `TensorArg`, `TaskArgsBuilder`,
   `ensure_pto_isa_root`, `make_chip_tensor_arg`. Also the analysis CLIs under
   `simpler_setup.tools`.
 
 You cannot compile a kernel without `simpler_setup`, so treat both as yours to
 use. `from simpler import Worker` works; the task and callable types come from
-`simpler.task_interface`. One name to watch:
-`simpler.task_interface.Tensor` is a device tensor descriptor while
-`simpler_setup.Tensor` is a scene-test argument spec — same name, different
-types.
+`simpler.task_interface`.
 
 ## Where the worked examples live
 

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -95,7 +95,10 @@ class TestBenchmarkBgemm(SceneTestCase):
         C = torch.zeros(incore_loop * num_groups, tile_size, tile_size, dtype=torch.float32)
         config = torch.tensor([tile_size, grid_k, num_groups, incore_loop], dtype=torch.int64)
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()), Tensor("B", B.flatten()), Tensor("C", C.flatten()), Tensor("config", config)
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            TensorArg("config", config),
         )
 
     def compute_golden(self, args, params):

--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
@@ -26,7 +26,7 @@ output out of the golden comparison.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 TILES = 8
 M = 128
@@ -67,10 +67,10 @@ class TestMergePipelineBarrier(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("x", torch.arange(SIZE, dtype=torch.float32) / 7.0),
-            Tensor("sync", torch.zeros(NBLK, dtype=torch.int32)),  # barrier slots / counter (zero-init)
-            Tensor("out", torch.zeros(SIZE, dtype=torch.float32)),
-            Tensor("timing", torch.zeros(NBLK * 32, dtype=torch.int32)),  # per-block gaps (32-int32 stride)
+            TensorArg("x", torch.arange(SIZE, dtype=torch.float32) / 7.0),
+            TensorArg("sync", torch.zeros(NBLK, dtype=torch.int32)),  # barrier slots / counter (zero-init)
+            TensorArg("out", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("timing", torch.zeros(NBLK * 32, dtype=torch.int32)),  # per-block gaps (32-int32 stride)
         )
 
     def compute_golden(self, args, params):

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -173,16 +173,16 @@ class TestPagedAttention(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -178,16 +178,16 @@ class TestPagedAttentionManualScope(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -17,7 +17,7 @@ INOUT tensors, bfloat16, and AIC+AIV mixed execution.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden  # noqa: PLC0415
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs  # noqa: PLC0415
 
@@ -96,16 +96,16 @@ class TestPagedAttentionRingbuffer(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -112,16 +112,16 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/test_prefetch_async_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/test_prefetch_async_demo.py
@@ -33,7 +33,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 N = 128
 
@@ -73,8 +73,8 @@ class TestPrefetchAsyncDemo(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("src", torch.arange(N, dtype=torch.float32) / 8.0),
-            Tensor("out", torch.full((N,), -1.0, dtype=torch.float32)),
+            TensorArg("src", torch.arange(N, dtype=torch.float32) / 8.0),
+            TensorArg("out", torch.full((N,), -1.0, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
@@ -16,7 +16,7 @@ Get/Set round-trips, WAW+WAR dependency auto-wait, and external tensor WAR.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -56,13 +56,13 @@ class TestScalarData(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.arange(SIZE, dtype=torch.float32)),
-            Tensor("result", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.arange(SIZE, dtype=torch.float32)),
+            TensorArg("result", torch.zeros(SIZE, dtype=torch.float32)),
             # Exactly 9 slots: the orchestration writes check[0..8] via
             # set_tensor_data. Output-tensor slots are not seeded from the host,
             # so any extra slot reads undefined device memory.
-            Tensor("check", torch.zeros(9, dtype=torch.float32)),
+            TensorArg("check", torch.zeros(9, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -58,9 +58,9 @@ class TestVectorExample(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py
@@ -16,7 +16,7 @@ Cube core (AIC) for matmul, Vector core (AIV) for accumulation.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 TILE_M, TILE_K, TILE_N = 64, 64, 64
 GRID_M, GRID_K, GRID_N = 4, 4, 4
@@ -72,7 +72,7 @@ class TestBgemm(SceneTestCase):
         A = torch.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K, dtype=torch.float32) * 0.01
         B = torch.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N, dtype=torch.float32) * 0.01
         C = torch.zeros(BATCH, GRID_M, GRID_N, TILE_M, TILE_N, dtype=torch.float32)
-        return TaskArgsBuilder(Tensor("A", A.flatten()), Tensor("B", B.flatten()), Tensor("C", C.flatten()))
+        return TaskArgsBuilder(TensorArg("A", A.flatten()), TensorArg("B", B.flatten()), TensorArg("C", C.flatten()))
 
     def compute_golden(self, args, params):
         A = args.A.reshape(BATCH, GRID_M, GRID_K, TILE_M, TILE_K)

--- a/examples/a5/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
+++ b/examples/a5/tensormap_and_ringbuffer/merge_pipeline_barrier/test_merge_pipeline_barrier.py
@@ -26,7 +26,7 @@ output out of the golden comparison.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 TILES = 8
 M = 128
@@ -67,10 +67,10 @@ class TestMergePipelineBarrier(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("x", torch.arange(SIZE, dtype=torch.float32) / 7.0),
-            Tensor("sync", torch.zeros(NBLK, dtype=torch.int32)),  # barrier slots / counter (zero-init)
-            Tensor("out", torch.zeros(SIZE, dtype=torch.float32)),
-            Tensor("timing", torch.zeros(NBLK * 32, dtype=torch.int32)),  # per-block gaps (32-int32 stride)
+            TensorArg("x", torch.arange(SIZE, dtype=torch.float32) / 7.0),
+            TensorArg("sync", torch.zeros(NBLK, dtype=torch.int32)),  # barrier slots / counter (zero-init)
+            TensorArg("out", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("timing", torch.zeros(NBLK * 32, dtype=torch.int32)),  # per-block gaps (32-int32 stride)
         )
 
     def compute_golden(self, args, params):

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
@@ -16,7 +16,7 @@ Production-scale cases for A5 hardware validation.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -179,16 +179,16 @@ class TestPagedAttention(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention_manual_scope.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -131,16 +131,16 @@ class TestPagedAttentionManualScope(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -17,7 +17,7 @@ INOUT tensors, bfloat16, and AIC+AIV mixed execution.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden  # noqa: PLC0415
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs  # noqa: PLC0415
 
@@ -96,16 +96,16 @@ class TestPagedAttentionRingbuffer(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -143,16 +143,16 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/examples/a5/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
+++ b/examples/a5/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
@@ -16,7 +16,7 @@ Get/Set round-trips, WAW+WAR dependency auto-wait, and external tensor WAR.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -56,13 +56,13 @@ class TestScalarData(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.arange(SIZE, dtype=torch.float32)),
-            Tensor("result", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.arange(SIZE, dtype=torch.float32)),
+            TensorArg("result", torch.zeros(SIZE, dtype=torch.float32)),
             # Exactly 9 slots: the orchestration writes check[0..8] via
             # set_tensor_data. Output-tensor slots are not seeded from the host,
             # so any extra slot reads undefined device memory.
-            Tensor("check", torch.zeros(9, dtype=torch.float32)),
+            TensorArg("check", torch.zeros(9, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/test_vector_example.py
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/test_vector_example.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -58,9 +58,9 @@ class TestVectorExample(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/simpler_setup/__init__.py
+++ b/simpler_setup/__init__.py
@@ -13,7 +13,7 @@ from .kernel_compiler import KernelCompiler
 from .platform_info import parse_platform
 from .pto_isa import ensure_pto_isa_root
 from .runtime_builder import RuntimeBuilder
-from .scene_test import CallableNamespace, Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from .scene_test import CallableNamespace, Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from .torch_interop import make_chip_tensor_arg, torch_dtype_to_datatype
 
 __all__ = [
@@ -22,7 +22,7 @@ __all__ = [
     "RuntimeBuilder",
     "Scalar",
     "SceneTestCase",
-    "Tensor",
+    "TensorArg",
     "TaskArgsBuilder",
     "ensure_pto_isa_root",
     "extract_text_section",

--- a/simpler_setup/goldens/qwen3_14b_decode.py
+++ b/simpler_setup/goldens/qwen3_14b_decode.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import torch
 
-from simpler_setup.scene_test import TaskArgsBuilder, Tensor
+from simpler_setup.scene_test import TaskArgsBuilder, TensorArg
 
 # ── Model architecture (Qwen3-14B) ──
 NUM_HEADS = 40
@@ -172,8 +172,8 @@ def generate_inputs(
         "w_down": s0(rn([INTERMEDIATE, HIDDEN], 0.0004).to(torch.bfloat16)),
         "post_rms_weight": s0(rn([1, HIDDEN], 0.1, 1.0).float()),
     }
-    specs = [Tensor(name, tensors[name]) for name in INPUT_NAMES]
-    specs.append(Tensor("out", torch.zeros([BATCH, HIDDEN], dtype=torch.bfloat16)))
+    specs = [TensorArg(name, tensors[name]) for name in INPUT_NAMES]
+    specs.append(TensorArg("out", torch.zeros([BATCH, HIDDEN], dtype=torch.bfloat16)))
     return TaskArgsBuilder(*specs)
 
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -134,8 +134,8 @@ def _golden_thread_cap():
 # ---------------------------------------------------------------------------
 
 
-class Tensor(NamedTuple):
-    """Tensor argument spec."""
+class TensorArg(NamedTuple):
+    """Named torch.Tensor argument spec."""
 
     name: str
     value: Any  # torch.Tensor
@@ -162,9 +162,9 @@ class TaskArgsBuilder:
     Usage::
 
         args = TaskArgsBuilder(
-            Tensor("a", torch.full((N,), 2.0)),
-            Tensor("b", torch.full((N,), 3.0)),
-            Tensor("f", torch.zeros(N)),
+            TensorArg("a", torch.full((N,), 2.0)),
+            TensorArg("b", torch.full((N,), 3.0)),
+            TensorArg("f", torch.zeros(N)),
             Scalar("scale", ctypes.c_float(1.5)),
         )
         args.a  # → tensor
@@ -176,20 +176,20 @@ class TaskArgsBuilder:
         self._data: dict[str, Any] = {}
         self._has_scalar = False
         for spec in specs:
-            if isinstance(spec, Tensor):
+            if isinstance(spec, TensorArg):
                 self._add_tensor(spec)
             elif isinstance(spec, Scalar):
                 self._add_scalar(spec)
 
     def add_tensor(self, name: str, value: Any) -> None:
         """Add a tensor. Must be called before any add_scalar."""
-        self._add_tensor(Tensor(name, value))
+        self._add_tensor(TensorArg(name, value))
 
     def add_scalar(self, name: str, value: Any) -> None:
         """Add a scalar. After this, add_tensor is not allowed."""
         self._add_scalar(Scalar(name, value))
 
-    def _add_tensor(self, spec: Tensor) -> None:
+    def _add_tensor(self, spec: TensorArg) -> None:
         # Names are this container's lookup keys, so reject a bad name before any
         # mutation — a rejected add leaves the builder untouched.
         self._reject_bad_name(spec.name)
@@ -233,9 +233,9 @@ class TaskArgsBuilder:
         new._data = {}
         new._has_scalar = False
         for spec in self._specs:
-            if isinstance(spec, Tensor):
+            if isinstance(spec, TensorArg):
                 cloned = spec.value.clone() if isinstance(spec.value, torch.Tensor) else spec.value
-                new_spec = Tensor(spec.name, cloned)
+                new_spec = TensorArg(spec.name, cloned)
                 new._specs.append(new_spec)
                 new._data[spec.name] = cloned
             elif isinstance(spec, Scalar):
@@ -250,12 +250,12 @@ class TaskArgsBuilder:
 
     @property
     def specs(self) -> list:
-        """Ordered list of Tensor/Scalar specs."""
+        """Ordered list of TensorArg/Scalar specs."""
         return self._specs
 
     def tensor_names(self) -> list[str]:
         """Names of all tensor arguments, in order."""
-        return [s.name for s in self._specs if isinstance(s, Tensor)]
+        return [s.name for s in self._specs if isinstance(s, TensorArg)]
 
 
 class _RehostedTaskArgs:
@@ -292,17 +292,17 @@ class _RehostedTaskArgs:
                 # Only non-empty host tensors carry bytes across the process edge;
                 # an empty tensor is never dereferenced by the child, so it is
                 # left untouched rather than allocating a zero-length buffer.
-                if isinstance(spec, Tensor) and isinstance(spec.value, torch.Tensor) and spec.value.numel() > 0:
+                if isinstance(spec, TensorArg) and isinstance(spec.value, torch.Tensor) and spec.value.numel() > 0:
                     handle, view = self._rehost_one(spec.value)
                     self._originals[spec.name] = test_args._data[spec.name]
                     self._handles[spec.name] = handle
                     test_args._data[spec.name] = view
-                    new_specs.append(Tensor(spec.name, view))
+                    new_specs.append(TensorArg(spec.name, view))
                 else:
                     new_specs.append(spec)
             test_args._specs = new_specs
             # Expose the owning handles so the L3 arg builder can name each rehosted tensor as a
-            # Tensor (handle.ref); the L2 chip builder keeps using the raw views.
+            # TensorArg (handle.ref); the L2 chip builder keeps using the raw views.
             test_args._rehost_handles = self._handles
         except BaseException:
             self.release()
@@ -315,7 +315,7 @@ class _RehostedTaskArgs:
         torch = self._torch
         ranges: list = []  # (name, lo, hi)
         for spec in test_args._specs:
-            if not (isinstance(spec, Tensor) and isinstance(spec.value, torch.Tensor)):
+            if not (isinstance(spec, TensorArg) and isinstance(spec.value, torch.Tensor)):
                 continue
             t = spec.value
             if t.numel() == 0:
@@ -363,7 +363,7 @@ class _RehostedTaskArgs:
         for name, orig in self._originals.items():
             self._test_args._data[name] = orig
         self._test_args._specs = [
-            Tensor(s.name, self._originals[s.name]) if isinstance(s, Tensor) and s.name in self._originals else s
+            TensorArg(s.name, self._originals[s.name]) if isinstance(s, TensorArg) and s.name in self._originals else s
             for s in self._test_args._specs
         ]
         self._originals.clear()
@@ -429,15 +429,15 @@ class CallableNamespace:
 
 
 def _build_l2_ref_args(test_args: TaskArgsBuilder, orch_signature: list, worker):
-    """Build Tensor `TaskArgs` from `TaskArgsBuilder` for the L2 `Worker.run` path.
+    """Build TensorArg `TaskArgs` from `TaskArgsBuilder` for the L2 `Worker.run` path.
 
-    An L2 leaf consumes its own args: `Worker.run(handle, args, cfg)` materializes each Tensor to a
+    An L2 leaf consumes its own args: `Worker.run(handle, args, cfg)` materializes each TensorArg to a
     local base in-process. Each tensor is named via ``worker.make_tensor_arg`` (a host tensor;
     at L2 there is no fork, so any host tensor resolves in-process); the direction tag is inert at L2
     but set for parity with the L3 path.
 
     Returns:
-        args: TaskArgs (Tensor)
+        args: TaskArgs (TensorArg)
         output_names: list of tensor names that are OUTPUT or INOUT
     """
     from simpler.task_interface import ArgDirection, TaskArgs, TensorArgType, scalar_to_uint64  # noqa: PLC0415
@@ -453,10 +453,10 @@ def _build_l2_ref_args(test_args: TaskArgsBuilder, orch_signature: list, worker)
     output_names: list[str] = []
     tensor_idx = 0
     for spec in test_args.specs:
-        if isinstance(spec, Tensor):
+        if isinstance(spec, TensorArg):
             if tensor_idx >= len(orch_signature):
                 raise ValueError(
-                    f"Tensor '{spec.name}' at index {tensor_idx} has no matching entry in "
+                    f"TensorArg '{spec.name}' at index {tensor_idx} has no matching entry in "
                     f"orchestration signature (length {len(orch_signature)}). "
                     f"Update CALLABLE['orchestration']['signature'] to match generate_args()."
                 )
@@ -476,7 +476,7 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
 
     Used by the direct chip API (`ChipWorker._run_slot(slot, chip_args, config)`, e.g. the
     prepared-callable tests): the chip worker expects the runtime.so ABI-shaped POD directly (no tags).
-    The `Worker.run` L2 path instead builds Tensor args via `_build_l2_ref_args`.
+    The `Worker.run` L2 path instead builds TensorArg args via `_build_l2_ref_args`.
 
     Returns:
         chip_args: ChipStorageTaskArgs (POD)
@@ -489,7 +489,7 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
     )
 
     # make_chip_tensor_arg builds the chip POD (ChipTensor, carries an address) for the direct
-    # ChipWorker path — distinct from Worker.make_tensor_arg, which names a wire Tensor.
+    # ChipWorker path — distinct from Worker.make_tensor_arg, which names a wire TensorArg.
     from simpler_setup.torch_interop import make_chip_tensor_arg  # noqa: PLC0415
 
     chip_args = ChipStorageTaskArgs()
@@ -497,10 +497,10 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
 
     tensor_idx = 0
     for spec in test_args.specs:
-        if isinstance(spec, Tensor):
+        if isinstance(spec, TensorArg):
             if tensor_idx >= len(orch_signature):
                 raise ValueError(
-                    f"Tensor '{spec.name}' at index {tensor_idx} has no matching entry in "
+                    f"TensorArg '{spec.name}' at index {tensor_idx} has no matching entry in "
                     f"orchestration signature (length {len(orch_signature)}). "
                     f"Update CALLABLE['orchestration']['signature'] to match generate_args()."
                 )
@@ -516,7 +516,7 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
 
 
 def _rehosted_ref_for(test_args: TaskArgsBuilder, tensor):
-    """A ``Tensor`` over the rehosted ``tensor``'s owning handle, matched by its backing address.
+    """A ``TensorArg`` over the rehosted ``tensor``'s owning handle, matched by its backing address.
 
     Like ``_rehosted_ref`` but keyed by the (rehosted) tensor object a hand-written orch already holds,
     rather than its name — the rehosted view's ``data_ptr`` is its create_buffer handle's base.
@@ -531,7 +531,7 @@ def _rehosted_ref_for(test_args: TaskArgsBuilder, tensor):
 
 
 def _l3_ref(test_args: TaskArgsBuilder, name: str, worker=None):
-    """A ``Tensor`` naming the L3 tensor arg ``name``.
+    """A ``TensorArg`` naming the L3 tensor arg ``name``.
 
     Two ways a scene test's host tensor becomes child-visible: the framework rehosts it into a
     create_buffer (POSIX shm) — use that handle; or a test pre-allocates a ``share_memory_()`` tensor
@@ -553,7 +553,7 @@ def _l3_ref(test_args: TaskArgsBuilder, name: str, worker=None):
 
 
 def _rehosted_ref(test_args: TaskArgsBuilder, name: str):
-    """A ``Tensor`` over the rehosted tensor ``name`` (framework rehost only). For a hand-written
+    """A ``TensorArg`` over the rehosted tensor ``name`` (framework rehost only). For a hand-written
     L3 orch naming one rehosted tensor as a task arg (e.g. the chip output as a sub-task INPUT)."""
     return _l3_ref(test_args, name, worker=None)
 
@@ -562,7 +562,7 @@ def _build_l3_task_args(test_args: TaskArgsBuilder, orch_signature: list, worker
     """Build a tagged `TaskArgs` (Tensors) from a `TaskArgsBuilder` for the L3 path
     (`orch.submit_next_level`); the tags drive dependency inference.
 
-    Names each tensor as a Tensor over its framework-rehosted create_buffer handle, or — for a test
+    Names each tensor as a TensorArg over its framework-rehosted create_buffer handle, or — for a test
     that pre-allocates ``share_memory_()`` tensors before ``init()`` — via ``worker.make_tensor_arg`` when
     ``worker`` is passed.
 
@@ -583,17 +583,17 @@ def _build_l3_task_args(test_args: TaskArgsBuilder, orch_signature: list, worker
         ArgDirection.INOUT: TensorArgType.INOUT,
     }
 
-    # Each rehosted tensor is named as a Tensor over its owning create_buffer handle (the child
+    # Each rehosted tensor is named as a TensorArg over its owning create_buffer handle (the child
     # maps it by canonical identity); tags drive dependency inference.
     chip_args = TaskArgs()
     output_names: list[str] = []
 
     tensor_idx = 0
     for spec in test_args.specs:
-        if isinstance(spec, Tensor):
+        if isinstance(spec, TensorArg):
             if tensor_idx >= len(orch_signature):
                 raise ValueError(
-                    f"Tensor '{spec.name}' at index {tensor_idx} has no matching entry in "
+                    f"TensorArg '{spec.name}' at index {tensor_idx} has no matching entry in "
                     f"orchestration signature (length {len(orch_signature)}). "
                     f"Update CALLABLE['orchestration']['signature'] to match generate_args()."
                 )
@@ -1232,7 +1232,7 @@ class SceneTestCase:
     RUNTIME_ENV: dict = {}
 
     def generate_args(self, params) -> TaskArgsBuilder:
-        """Return TaskArgsBuilder with ordered Tensor/Scalar specs."""
+        """Return TaskArgsBuilder with ordered TensorArg/Scalar specs."""
         raise NotImplementedError
 
     def compute_golden(self, args: TaskArgsBuilder, params) -> None:

--- a/tests/st/a2a3/host_build_graph/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a2a3/host_build_graph/available_aicore_counts/test_available_aicore_counts.py
@@ -34,7 +34,7 @@ silently disabled.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -92,8 +92,8 @@ class TestAvailableAicoreCounts(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("shape", torch.zeros(2, dtype=torch.int32)),
+            TensorArg("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("shape", torch.zeros(2, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/bgemm/test_bgemm.py
+++ b/tests/st/a2a3/host_build_graph/bgemm/test_bgemm.py
@@ -16,7 +16,7 @@ Tests AIC (Cube) + AIV (Vector) cooperation with tile-first memory layout.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 TILE_M = 64
 TILE_K = 64
@@ -74,9 +74,9 @@ class TestBgemmHostBuildGraph(SceneTestCase):
         C = torch.full((BATCH, GRID_M, GRID_N, TILE_M, TILE_N), C_BASE, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("C", C.flatten()),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py
@@ -26,7 +26,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -131,9 +131,9 @@ class TestDepGenHostBuildGraph(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -243,9 +243,9 @@ class TestDepGenHostBuildGraphEdgeSources(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("x", torch.full((16,), -1.0, dtype=torch.float32)),
-            Tensor("y", torch.full((16,), -1.0, dtype=torch.float32)),
-            Tensor("gate", torch.full((16,), -1, dtype=torch.int32)),
+            TensorArg("x", torch.full((16,), -1.0, dtype=torch.float32)),
+            TensorArg("y", torch.full((16,), -1.0, dtype=torch.float32)),
+            TensorArg("gate", torch.full((16,), -1, dtype=torch.int32)),
             Scalar("case", int(params["case"])),
         )
 

--- a/tests/st/a2a3/host_build_graph/dump_args/test_dump_args_example.py
+++ b/tests/st/a2a3/host_build_graph/dump_args/test_dump_args_example.py
@@ -17,7 +17,7 @@ Demonstrates the two dump-args metadata registration APIs:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -57,9 +57,9 @@ class TestDumpArgsExample(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -66,11 +66,11 @@ class TestGraphExecutionHostBuildGraph(SceneTestCase):
     def generate_args(self, params):
         shape = params["shape"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full(shape, 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full(shape, 3.0, dtype=torch.float32)),
-            Tensor("output_1", torch.zeros(shape, dtype=torch.float32)),
-            Tensor("output_3", torch.zeros(shape, dtype=torch.float32)),
-            Tensor("output_5", torch.zeros(shape, dtype=torch.float32)),
+            TensorArg("a", torch.full(shape, 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full(shape, 3.0, dtype=torch.float32)),
+            TensorArg("output_1", torch.zeros(shape, dtype=torch.float32)),
+            TensorArg("output_3", torch.zeros(shape, dtype=torch.float32)),
+            TensorArg("output_5", torch.zeros(shape, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -64,12 +64,12 @@ class TestGraphExecutionAicAivHostBuildGraph(SceneTestCase):
         input_value = torch.exp(torch.tensor(4.0)).item()
         weight_value = 1.0 / (2 * columns)
         return TaskArgsBuilder(
-            Tensor("input", torch.full((size,), input_value, dtype=torch.float16)),
-            Tensor("weight_1", torch.full((size,), weight_value, dtype=torch.float16)),
-            Tensor("weight_2", torch.full((size,), weight_value, dtype=torch.float16)),
-            Tensor("output_1", torch.zeros(size, dtype=torch.float32)),
-            Tensor("output_2", torch.zeros(size, dtype=torch.float32)),
-            Tensor("output_3", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("input", torch.full((size,), input_value, dtype=torch.float16)),
+            TensorArg("weight_1", torch.full((size,), weight_value, dtype=torch.float16)),
+            TensorArg("weight_2", torch.full((size,), weight_value, dtype=torch.float16)),
+            TensorArg("output_1", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("output_2", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("output_3", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -64,9 +64,9 @@ class TestGraphExecutionMixSpmdHostBuildGraph(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("blocks_1", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
-            Tensor("blocks_2", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
-            Tensor("blocks_3", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
+            TensorArg("blocks_1", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
+            TensorArg("blocks_2", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
+            TensorArg("blocks_3", torch.zeros(TOTAL_FLOATS, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/matmul/test_matmul.py
+++ b/tests/st/a2a3/host_build_graph/matmul/test_matmul.py
@@ -16,7 +16,7 @@ Diamond topology: t0(AIV) -> t1(AIC), t2(AIC) -> t3(AIV).
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -76,10 +76,10 @@ class TestMatmulHostBuildGraph(SceneTestCase):
         f = torch.zeros(SIZE, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("a", a),
-            Tensor("w1", w1),
-            Tensor("w2", w2),
-            Tensor("f", f),
+            TensorArg("a", a),
+            TensorArg("w1", w1),
+            TensorArg("w2", w2),
+            TensorArg("f", f),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -15,7 +15,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 from simpler_setup.tools.strace_timing import group_invocations, parse_spans
 
@@ -61,9 +61,9 @@ class TestNativeRunLifecycle(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("a", torch.full((_SIZE,), params["a"], dtype=torch.float32)),
-            Tensor("b", torch.full((_SIZE,), params["b"], dtype=torch.float32)),
-            Tensor("out", torch.zeros(_SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((_SIZE,), params["a"], dtype=torch.float32)),
+            TensorArg("b", torch.full((_SIZE,), params["b"], dtype=torch.float32)),
+            TensorArg("out", torch.zeros(_SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py
@@ -16,7 +16,7 @@ Templated kernels support variable tile sizes via runtime dispatch.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden  # noqa: PLC0415
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs  # noqa: PLC0415
 
@@ -139,16 +139,16 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a2a3/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a2a3/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
@@ -31,7 +31,7 @@ never stalls on it. Chain:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 POISON = 999.0  # what the clobber writes if the predicate lets it dispatch
@@ -105,9 +105,9 @@ class TestPredicatedDispatch(SceneTestCase):
         y = torch.full((16,), INIT_VAL, dtype=torch.float32)
         gate = torch.full((16,), -1, dtype=torch.int32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
-            Tensor("gate", gate),
+            TensorArg("x", x),
+            TensorArg("y", y),
+            TensorArg("gate", gate),
             Scalar("case", int(params["case"])),
         )
 

--- a/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -22,7 +22,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 
 _VECTOR_KERNELS = "../vector_example/kernels"
@@ -98,9 +98,9 @@ class TestPreparedCallableHbg(SceneTestCase):
         size = 128 * 128
         a, b = params["a"], params["b"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), a, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), b, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
+++ b/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
@@ -29,7 +29,7 @@ import torch
 from simpler.task_interface import ArgDirection as D
 from simpler.worker import Worker
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _build_l2_ref_args, _compare_outputs
 
 _VECTOR_KERNELS = "../vector_example/kernels"
@@ -114,9 +114,9 @@ class TestRunStreamReuseHbg(SceneTestCase):
     def generate_args(self, params):
         size = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -142,7 +142,7 @@ class TestRunStreamReuseHbg(SceneTestCase):
     def _run_registered(self, worker, handle, *, subtract):
         params = self.CASES[0]["params"]
         test_args = self.generate_args(params)
-        # Worker.run takes Tensor args and materializes them in-process; the runtime.so-ABI POD is
+        # Worker.run takes TensorArg args and materializes them in-process; the runtime.so-ABI POD is
         # the direct chip API's shape, used by the lease path below.
         args, output_names = _build_l2_ref_args(test_args, self.CALLABLE["orchestration"]["signature"], worker)
         golden_args = test_args.clone()

--- a/tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py
+++ b/tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py
@@ -16,7 +16,7 @@ Tests host_build_graph runtime with intermediate tensors allocated from HeapRing
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -69,9 +69,9 @@ class TestVectorExampleHostBuildGraph(SceneTestCase):
         f = torch.zeros(SIZE, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("a", a),
-            Tensor("b", b),
-            Tensor("f", f),
+            TensorArg("a", a),
+            TensorArg("b", b),
+            TensorArg("f", f),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py
@@ -18,7 +18,7 @@ import ctypes
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -89,12 +89,12 @@ class TestAlternatingMatmulAdd(SceneTestCase):
         Z = torch.zeros(batch, N, add_rows, add_cols, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("C", C.flatten()),
-            Tensor("X", X.flatten()),
-            Tensor("Y", Y.flatten()),
-            Tensor("Z", Z.flatten()),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            TensorArg("X", X.flatten()),
+            TensorArg("Y", Y.flatten()),
+            TensorArg("Z", Z.flatten()),
             Scalar("batch", ctypes.c_int64(batch)),
             Scalar("M_val", ctypes.c_int64(M)),
             Scalar("N_val", ctypes.c_int64(N)),

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -27,7 +27,7 @@ expected, and the tail is zero on both sides.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -85,8 +85,8 @@ class TestAvailableAicoreCounts(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("shape", torch.zeros(2, dtype=torch.int32)),
+            TensorArg("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("shape", torch.zeros(2, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -188,16 +188,16 @@ class TestBatchPagedAttention(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -26,7 +26,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -94,9 +94,9 @@ class TestArgsDump(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -179,7 +179,7 @@ class TestArgsDump(SceneTestCase):
             # 0 + 2, not arg 1 (e).
             t02 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000002")
             assert t02 == [0, 2]
-            # Tensor-only task granularity: dump() captured all three tensor args.
+            # TensorArg-only task granularity: dump() captured all three tensor args.
             t03 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000003")
             assert t03 == [0, 1, 2]
             scalar_by_task = {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
@@ -27,7 +27,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 from ._swimlane_validate import validate_perf_artifact
 
@@ -89,9 +89,9 @@ class TestChipSwimlane(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
@@ -31,7 +31,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 from ._swimlane_validate import validate_perf_artifact
@@ -100,14 +100,14 @@ class TestChipSwimlaneMixed(SceneTestCase):
         E = torch.randn(_TILE_ELEMS, dtype=torch.float32) * 0.01
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("D", D_t),
-            Tensor("E", E),
-            Tensor("ws_aic", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
-            Tensor("ws_aiv", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
-            Tensor("aic_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
-            Tensor("aiv_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("D", D_t),
+            TensorArg("E", E),
+            TensorArg("ws_aic", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
+            TensorArg("ws_aiv", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
+            TensorArg("aic_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
+            TensorArg("aiv_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_early_local_owner.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_early_local_owner.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.tools.swimlane_converter import read_perf_data
 
 FLOATS_PER_CACHE_LINE = 16
@@ -109,7 +109,7 @@ class TestSyncStartEarlyLocalOwner(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(OUTPUT_CACHE_LINES * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("output", torch.zeros(OUTPUT_CACHE_LINES * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
             Scalar("mode", int(params["mode"])),
             Scalar("consumer_blocks", int(params["consumer_blocks"])),
         )

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -38,7 +38,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -95,9 +95,9 @@ class TestDepGen(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -153,7 +153,7 @@ class TestDepGen(SceneTestCase):
         )
         with deps_path.open() as f:
             deps = json.load(f)
-        # Strided-Tensor schema: annotated edges with tasks[] / tensors[]
+        # Strided-TensorArg schema: annotated edges with tasks[] / tensors[]
         # sidecars carrying strided slice descriptors (start_offset +
         # stride[]). Project annotated edges down to a (pred, succ) set for
         # the existing structural checks; the annotation sanity check below

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -36,7 +36,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 # Path is relative to this file's directory (the SceneTestCase build helper
@@ -116,8 +116,8 @@ class TestDepGenChain(SceneTestCase):
         x = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
         y = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
+            TensorArg("x", x),
+            TensorArg("y", y),
             Scalar("n", int(params["n"])),
         )
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
@@ -24,7 +24,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -76,9 +76,9 @@ class TestPmu(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -28,7 +28,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -101,9 +101,9 @@ class TestScopeStats(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -36,7 +36,7 @@ The orchestration submits one of four scenes, controlled by params["case"]:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 INIT_VAL = -1.0  # so unmodified Y is distinguishable from the sentinel
@@ -110,9 +110,9 @@ class TestDummyTask(SceneTestCase):
         y = torch.full((16,), INIT_VAL, dtype=torch.float32)
         w = torch.full((16,), INIT_VAL, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
-            Tensor("w", w),
+            TensorArg("x", x),
+            TensorArg("y", y),
+            TensorArg("w", w),
             Scalar("case", int(params["case"])),
         )
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -31,7 +31,7 @@ from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import CallConfig, ChipCallable
 from simpler.worker import Worker
 
-from simpler_setup import TaskArgsBuilder, Tensor
+from simpler_setup import TaskArgsBuilder, TensorArg
 from simpler_setup.kernel_compiler import KernelCompiler
 from simpler_setup.scene_test import _build_l3_task_args
 
@@ -106,9 +106,9 @@ def _unique_py_callable(index: int):
 def _make_args(a: float, b: float) -> TaskArgsBuilder:
     size = 128 * 128
     return TaskArgsBuilder(
-        Tensor("a", torch.full((size,), a, dtype=torch.float32).share_memory_()),
-        Tensor("b", torch.full((size,), b, dtype=torch.float32).share_memory_()),
-        Tensor("f", torch.zeros(size, dtype=torch.float32).share_memory_()),
+        TensorArg("a", torch.full((size,), a, dtype=torch.float32).share_memory_()),
+        TensorArg("b", torch.full((size,), b, dtype=torch.float32).share_memory_()),
+        TensorArg("f", torch.zeros(size, dtype=torch.float32).share_memory_()),
     )
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -20,7 +20,7 @@ import ctypes
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -63,8 +63,8 @@ class TestFaninLookupPerf(SceneTestCase):
         producer_count = int(params["producer_count"])
         consumer_count = int(params["consumer_count"])
         return TaskArgsBuilder(
-            Tensor("producer_out", torch.full((producer_count * slot_elems,), -1.0, dtype=torch.float32)),
-            Tensor("consumer_out", torch.full((consumer_count * slot_elems,), -1.0, dtype=torch.float32)),
+            TensorArg("producer_out", torch.full((producer_count * slot_elems,), -1.0, dtype=torch.float32)),
+            TensorArg("consumer_out", torch.full((consumer_count * slot_elems,), -1.0, dtype=torch.float32)),
             Scalar("producer_count", ctypes.c_int64(producer_count)),
             Scalar("consumer_count", ctypes.c_int64(consumer_count)),
             Scalar("use_real_kernels", ctypes.c_int64(int(params["use_real_kernels"]))),

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
@@ -17,7 +17,7 @@ when ring 1 is limited to 1.5 MiB.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 INIT_VAL = -1.0
@@ -72,8 +72,8 @@ class TestHeapEmptyRingRebase(SceneTestCase):
         y1 = torch.full((16,), INIT_VAL, dtype=torch.float32)
         y2 = torch.full((16,), INIT_VAL, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("y1", y1),
-            Tensor("y2", y2),
+            TensorArg("y1", y1),
+            TensorArg("y2", y2),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
@@ -15,7 +15,7 @@ Args layout (15 tensors): [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 MATMUL_SIZE = 128
 TILE_ELEMS = 128 * 128
@@ -122,21 +122,21 @@ class TestMixedExample(SceneTestCase):
             return torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("C", z()),
-            Tensor("D", D_t),
-            Tensor("E", E),
-            Tensor("F", z()),
-            Tensor("G", G),
-            Tensor("H", H),
-            Tensor("I", z()),
-            Tensor("J", z()),
-            Tensor("K", z()),
-            Tensor("L", z()),
-            Tensor("M", z()),
-            Tensor("N", z()),
-            Tensor("O", z()),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", z()),
+            TensorArg("D", D_t),
+            TensorArg("E", E),
+            TensorArg("F", z()),
+            TensorArg("G", G),
+            TensorArg("H", H),
+            TensorArg("I", z()),
+            TensorArg("J", z()),
+            TensorArg("K", z()),
+            TensorArg("L", z()),
+            TensorArg("M", z()),
+            TensorArg("N", z()),
+            TensorArg("O", z()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
@@ -15,7 +15,7 @@ Run with --rounds 10 --skip-golden for benchmarking.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -134,16 +134,16 @@ class TestMultiRoundPagedAttention(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
@@ -32,7 +32,7 @@ missing dlopen on first run) shows up as wrong output or a runtime failure.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 _VECTOR_KERNELS = "../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
 
@@ -102,9 +102,9 @@ class TestOrchSoCache(SceneTestCase):
         a = params["a"]
         b = params["b"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), a, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), b, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -112,16 +112,16 @@ class TestPagedAttentionUnroll(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
@@ -17,7 +17,7 @@ Orchestration with N_UNROLL=64, 4 tasks per group, online softmax accumulation.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -120,7 +120,7 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
             if isinstance(val, torch.Tensor):
                 if name in ("query", "out"):
                     val = val.reshape(batch, 1, num_heads, head_dim)
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
@@ -129,7 +129,7 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
         batch = params["batch"]
         num_heads = params["num_heads"]
         head_dim = params["head_dim"]
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         # Reshape 4D out to 3D for shared golden, then restore
         out_4d = tensors["out"]
         tensors["out"] = out_4d.reshape(batch, num_heads, head_dim)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
@@ -22,7 +22,7 @@ import itertools
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _build_l2_ref_args, _compare_outputs
 
 _VECTOR_KERNELS = "../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -79,9 +79,9 @@ class TestPipelineSlotsTmr(SceneTestCase):
     def generate_args(self, params):
         size = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -91,7 +91,7 @@ class TestPipelineSlotsTmr(SceneTestCase):
     def _run(self, worker, handle, *, slot_id=None):
         """One run, on the ordinary path or through a lease, result checked.
 
-        The two entry points take different argument types: ``Worker.run`` takes ``Tensor`` args and
+        The two entry points take different argument types: ``Worker.run`` takes ``TensorArg`` args and
         materializes them in-process, while the lease is the direct chip API and takes the
         runtime.so-ABI POD.
         """

--- a/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
@@ -31,7 +31,7 @@ never stalls on it. Chain:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 POISON = 999.0  # what the clobber writes if the predicate lets it dispatch
@@ -105,9 +105,9 @@ class TestPredicatedDispatch(SceneTestCase):
         y = torch.full((16,), INIT_VAL, dtype=torch.float32)
         gate = torch.full((16,), -1, dtype=torch.int32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
-            Tensor("gate", gate),
+            TensorArg("x", x),
+            TensorArg("y", y),
+            TensorArg("gate", gate),
             Scalar("case", int(params["case"])),
         )
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -26,7 +26,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 
 _VECTOR_KERNELS = "../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -85,9 +85,9 @@ class TestPreparedCallable(SceneTestCase):
         size = 128 * 128
         a, b = params["a"], params["b"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), a, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), b, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -21,7 +21,7 @@ Output layout (float32[48], 3 cache lines):
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 
@@ -74,7 +74,7 @@ class TestSpmdBasic(SceneTestCase):
 
     def generate_args(self, params):
         output = torch.zeros(3 * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
-        return TaskArgsBuilder(Tensor("output", output))
+        return TaskArgsBuilder(TensorArg("output", output))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
@@ -22,7 +22,7 @@ Output tensor: 2 * 48 * 3 = 288 cache lines = 4608 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -72,7 +72,7 @@ class TestSpmdBatchDispatchOob(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
@@ -16,7 +16,7 @@ Output tensor: 188 cache lines = 3008 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 TASKS = [(4, 0), (16, 4), (24, 20), (48, 44), (96, 92)]
@@ -55,7 +55,7 @@ class TestSpmdMultiblockAiv(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
@@ -16,7 +16,7 @@ Output tensor: 282 cache lines = 4512 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -73,7 +73,7 @@ class TestSpmdMultiblockMix(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -110,16 +110,16 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 KERNEL_DIR = Path(__file__).resolve().parent / "kernels"
 sys.path.insert(0, str(KERNEL_DIR))
@@ -328,21 +328,21 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
         ws = workspace_sizes(batch, num_heads, head_dim, head_dim, block_dim)
 
         return TaskArgsBuilder(
-            Tensor("query", q),
-            Tensor("key_cache", k_page),
-            Tensor("value_cache", v_page),
-            Tensor("block_table", block_table),
-            Tensor("out", torch.zeros(batch, num_heads, head_dim, dtype=dtype)),
-            Tensor("s_gm", torch.zeros(ws["s"], dtype=torch.uint8)),
-            Tensor("p_gm", torch.zeros(ws["p"], dtype=torch.uint8)),
-            Tensor("o_tmp_gm", torch.zeros(ws["o_tmp"], dtype=torch.uint8)),
-            Tensor("go_gm", torch.zeros(ws["go"], dtype=torch.uint8)),
-            Tensor("o_core_tmp_gm", torch.zeros(ws["o_core_tmp"], dtype=torch.uint8)),
-            Tensor("l_gm", torch.zeros(ws["l"], dtype=torch.uint8)),
-            Tensor("gm_k16", torch.zeros(ws["k16"], dtype=torch.uint8)),
-            Tensor("gm_v16", torch.zeros(ws["v16"], dtype=torch.uint8)),
-            Tensor("tiling", tiling),
-            Tensor("null", torch.zeros(1, dtype=torch.uint8)),
+            TensorArg("query", q),
+            TensorArg("key_cache", k_page),
+            TensorArg("value_cache", v_page),
+            TensorArg("block_table", block_table),
+            TensorArg("out", torch.zeros(batch, num_heads, head_dim, dtype=dtype)),
+            TensorArg("s_gm", torch.zeros(ws["s"], dtype=torch.uint8)),
+            TensorArg("p_gm", torch.zeros(ws["p"], dtype=torch.uint8)),
+            TensorArg("o_tmp_gm", torch.zeros(ws["o_tmp"], dtype=torch.uint8)),
+            TensorArg("go_gm", torch.zeros(ws["go"], dtype=torch.uint8)),
+            TensorArg("o_core_tmp_gm", torch.zeros(ws["o_core_tmp"], dtype=torch.uint8)),
+            TensorArg("l_gm", torch.zeros(ws["l"], dtype=torch.uint8)),
+            TensorArg("gm_k16", torch.zeros(ws["k16"], dtype=torch.uint8)),
+            TensorArg("gm_v16", torch.zeros(ws["v16"], dtype=torch.uint8)),
+            TensorArg("tiling", tiling),
+            TensorArg("null", torch.zeros(1, dtype=torch.uint8)),
             Scalar("effective_block_dim", ctypes.c_int64(effective_block_dim)),
         )
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
@@ -15,7 +15,7 @@ Total: 252 CL = 4032 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -90,7 +90,7 @@ class TestSpmdStarvation(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
@@ -19,7 +19,7 @@ device the platform allows and only the used prefix carries data.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -76,8 +76,8 @@ class TestSpmdSyncStart(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
@@ -18,7 +18,7 @@ geometry; `output` is sized for the widest device the platform allows.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 NUM_TASKS = 4
@@ -60,8 +60,8 @@ class TestSpmdSyncStartAiv(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
@@ -21,7 +21,7 @@ producer stays wider than the device on purpose — it carries no sync_start.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 PRODUCER_BLOCKS = 50
@@ -84,8 +84,8 @@ class TestSpmdSyncStartEarlyDispatch(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(1, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(1, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
@@ -18,7 +18,7 @@ geometry; `output` is sized for the widest device the platform allows.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -74,8 +74,8 @@ class TestSpmdSyncStartEdge(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
@@ -24,7 +24,7 @@ widths in `layout` and the golden is rebuilt from them.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3  # MIX consumer block writes 3 cache lines: AIC slot 0, AIV0 slot 1, AIV1 slot 2
@@ -89,8 +89,8 @@ class TestSpmdSyncStartMixSpill(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
@@ -18,7 +18,7 @@ reported widths; `output` is sized for the widest device the platform allows.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 ROUNDS = 6
@@ -106,8 +106,8 @@ class TestSpmdSyncStartStress(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(4, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(4, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
@@ -18,7 +18,7 @@ import torch
 from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import TaskArgs, TensorArgType
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_l3_task_args, _rehosted_ref
 
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -93,9 +93,9 @@ class TestL3Dependency(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
@@ -19,7 +19,7 @@ import torch
 from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import TaskArgs, TensorArgType
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _rehosted_ref_for
 
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -104,12 +104,12 @@ class TestL3Group(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a0", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
-            Tensor("b0", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
-            Tensor("f0", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
-            Tensor("a1", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
-            Tensor("b1", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
-            Tensor("f1", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
+            TensorArg("a0", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
+            TensorArg("b0", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
+            TensorArg("f0", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
+            TensorArg("a1", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
+            TensorArg("b1", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
+            TensorArg("f1", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_launch_acceptance.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_launch_acceptance.py
@@ -27,7 +27,7 @@ from simpler.worker import (
     _mailbox_load_i32,
 )
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_l3_task_args
 
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
@@ -91,9 +91,9 @@ class TestL3LaunchAcceptance(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("a", torch.full((_SIZE,), 2.0, dtype=torch.float32).share_memory_()),
-            Tensor("b", torch.full((_SIZE,), 3.0, dtype=torch.float32).share_memory_()),
-            Tensor("f", torch.zeros(_SIZE, dtype=torch.float32).share_memory_()),
+            TensorArg("a", torch.full((_SIZE,), 2.0, dtype=torch.float32).share_memory_()),
+            TensorArg("b", torch.full((_SIZE,), 3.0, dtype=torch.float32).share_memory_()),
+            TensorArg("f", torch.zeros(_SIZE, dtype=torch.float32).share_memory_()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/host_build_graph/dump_args/test_dump_args_example.py
+++ b/tests/st/a5/host_build_graph/dump_args/test_dump_args_example.py
@@ -17,7 +17,7 @@ Demonstrates the two dump-args metadata registration APIs:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -57,9 +57,9 @@ class TestDumpArgsExampleA5(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/host_build_graph/paged_attention/test_paged_attention.py
+++ b/tests/st/a5/host_build_graph/paged_attention/test_paged_attention.py
@@ -16,7 +16,7 @@ Production-scale cases for A5 hardware validation.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -186,16 +186,16 @@ class TestPagedAttentionHostBuildGraphA5(SceneTestCase):
         specs = []
         for name, val in inputs:
             if isinstance(val, torch.Tensor):
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -22,7 +22,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 
 _VECTOR_KERNELS = "../vector_example/kernels"
@@ -98,9 +98,9 @@ class TestPreparedCallableHbgA5(SceneTestCase):
         size = 128 * 128
         a, b = params["a"], params["b"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), a, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), b, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/host_build_graph/vector_example/test_vector_example.py
+++ b/tests/st/a5/host_build_graph/vector_example/test_vector_example.py
@@ -16,7 +16,7 @@ Tests host_build_graph runtime with intermediate tensors allocated from HeapRing
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -69,9 +69,9 @@ class TestVectorExampleHostBuildGraphA5(SceneTestCase):
         f = torch.zeros(SIZE, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("a", a),
-            Tensor("b", b),
-            Tensor("f", f),
+            TensorArg("a", a),
+            TensorArg("b", b),
+            TensorArg("f", f),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py
@@ -18,7 +18,7 @@ import ctypes
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -89,12 +89,12 @@ class TestAlternatingMatmulAdd(SceneTestCase):
         Z = torch.zeros(batch, N, add_rows, add_cols, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("C", C.flatten()),
-            Tensor("X", X.flatten()),
-            Tensor("Y", Y.flatten()),
-            Tensor("Z", Z.flatten()),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            TensorArg("X", X.flatten()),
+            TensorArg("Y", Y.flatten()),
+            TensorArg("Z", Z.flatten()),
             Scalar("batch", ctypes.c_int64(batch)),
             Scalar("M_val", ctypes.c_int64(M)),
             Scalar("N_val", ctypes.c_int64(N)),

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/test_available_aicore_counts.py
@@ -27,7 +27,7 @@ expected, and the tail is zero on both sides.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -85,8 +85,8 @@ class TestAvailableAicoreCounts(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("shape", torch.zeros(2, dtype=torch.int32)),
+            TensorArg("blocks", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("shape", torch.zeros(2, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -188,16 +188,16 @@ class TestBatchPagedAttention(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -25,7 +25,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -94,9 +94,9 @@ class TestArgsDump(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -179,7 +179,7 @@ class TestArgsDump(SceneTestCase):
             # 0 + 2, not arg 1 (e).
             t02 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000002")
             assert t02 == [0, 2]
-            # Tensor-only task granularity: dump() captured all three tensor args.
+            # TensorArg-only task granularity: dump() captured all three tensor args.
             t03 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000003")
             assert t03 == [0, 1, 2]
             scalar_by_task = {

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
@@ -27,7 +27,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 from ._swimlane_validate import validate_perf_artifact
 
@@ -89,9 +89,9 @@ class TestChipSwimlane(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
@@ -31,7 +31,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 from ._swimlane_validate import validate_perf_artifact
@@ -100,14 +100,14 @@ class TestChipSwimlaneMixed(SceneTestCase):
         E = torch.randn(_TILE_ELEMS, dtype=torch.float32) * 0.01
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("D", D_t),
-            Tensor("E", E),
-            Tensor("ws_aic", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
-            Tensor("ws_aiv", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
-            Tensor("aic_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
-            Tensor("aiv_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("D", D_t),
+            TensorArg("E", E),
+            TensorArg("ws_aic", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
+            TensorArg("ws_aiv", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
+            TensorArg("aic_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
+            TensorArg("aiv_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_early_local_owner.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_early_local_owner.py
@@ -26,7 +26,7 @@ from pathlib import Path
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.tools.swimlane_converter import read_perf_data
 
 FLOATS_PER_CACHE_LINE = 16
@@ -103,7 +103,7 @@ class TestSyncStartEarlyLocalOwner(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(OUTPUT_CACHE_LINES * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("output", torch.zeros(OUTPUT_CACHE_LINES * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
             Scalar("mode", int(params["mode"])),
             Scalar("consumer_blocks", int(params["consumer_blocks"])),
         )

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -38,7 +38,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -95,9 +95,9 @@ class TestDepGen(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -153,7 +153,7 @@ class TestDepGen(SceneTestCase):
         )
         with deps_path.open() as f:
             deps = json.load(f)
-        # Strided-Tensor schema: annotated edges with tasks[] / tensors[]
+        # Strided-TensorArg schema: annotated edges with tasks[] / tensors[]
         # sidecars carrying strided slice descriptors (start_offset +
         # stride[]). Project annotated edges down to a (pred, succ) set for
         # the existing structural checks; the annotation sanity check below

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -36,7 +36,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 # Path is relative to this file's directory (the SceneTestCase build helper
@@ -112,8 +112,8 @@ class TestDepGenChain(SceneTestCase):
         x = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
         y = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
+            TensorArg("x", x),
+            TensorArg("y", y),
             Scalar("n", int(params["n"])),
         )
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
@@ -24,7 +24,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -76,9 +76,9 @@ class TestPmu(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -28,7 +28,7 @@ import time
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -101,9 +101,9 @@ class TestScopeStats(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -36,7 +36,7 @@ The orchestration submits one of four scenes, controlled by params["case"]:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 INIT_VAL = -1.0  # so unmodified Y is distinguishable from the sentinel
@@ -106,9 +106,9 @@ class TestDummyTask(SceneTestCase):
         y = torch.full((16,), INIT_VAL, dtype=torch.float32)
         w = torch.full((16,), INIT_VAL, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
-            Tensor("w", w),
+            TensorArg("x", x),
+            TensorArg("y", y),
+            TensorArg("w", w),
             Scalar("case", int(params["case"])),
         )
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -31,7 +31,7 @@ from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import CallConfig, ChipCallable
 from simpler.worker import Worker
 
-from simpler_setup import TaskArgsBuilder, Tensor
+from simpler_setup import TaskArgsBuilder, TensorArg
 from simpler_setup.kernel_compiler import KernelCompiler
 from simpler_setup.scene_test import _build_l3_task_args
 
@@ -106,9 +106,9 @@ def _unique_py_callable(index: int):
 def _make_args(a: float, b: float) -> TaskArgsBuilder:
     size = 128 * 128
     return TaskArgsBuilder(
-        Tensor("a", torch.full((size,), a, dtype=torch.float32).share_memory_()),
-        Tensor("b", torch.full((size,), b, dtype=torch.float32).share_memory_()),
-        Tensor("f", torch.zeros(size, dtype=torch.float32).share_memory_()),
+        TensorArg("a", torch.full((size,), a, dtype=torch.float32).share_memory_()),
+        TensorArg("b", torch.full((size,), b, dtype=torch.float32).share_memory_()),
+        TensorArg("f", torch.zeros(size, dtype=torch.float32).share_memory_()),
     )
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -20,7 +20,7 @@ import ctypes
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -63,8 +63,8 @@ class TestFaninLookupPerf(SceneTestCase):
         producer_count = int(params["producer_count"])
         consumer_count = int(params["consumer_count"])
         return TaskArgsBuilder(
-            Tensor("producer_out", torch.full((producer_count * slot_elems,), -1.0, dtype=torch.float32)),
-            Tensor("consumer_out", torch.full((consumer_count * slot_elems,), -1.0, dtype=torch.float32)),
+            TensorArg("producer_out", torch.full((producer_count * slot_elems,), -1.0, dtype=torch.float32)),
+            TensorArg("consumer_out", torch.full((consumer_count * slot_elems,), -1.0, dtype=torch.float32)),
             Scalar("producer_count", ctypes.c_int64(producer_count)),
             Scalar("consumer_count", ctypes.c_int64(consumer_count)),
             Scalar("use_real_kernels", ctypes.c_int64(int(params["use_real_kernels"]))),

--- a/tests/st/a5/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
@@ -17,7 +17,7 @@ when ring 1 is limited to 1.5 MiB.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 INIT_VAL = -1.0
@@ -71,8 +71,8 @@ class TestHeapEmptyRingRebase(SceneTestCase):
         y1 = torch.full((16,), INIT_VAL, dtype=torch.float32)
         y2 = torch.full((16,), INIT_VAL, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("y1", y1),
-            Tensor("y2", y2),
+            TensorArg("y1", y1),
+            TensorArg("y2", y2),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
@@ -15,7 +15,7 @@ Args layout (15 tensors): [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 MATMUL_SIZE = 128
 TILE_ELEMS = 128 * 128
@@ -119,21 +119,21 @@ class TestMixedExample(SceneTestCase):
             return torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
 
         return TaskArgsBuilder(
-            Tensor("A", A.flatten()),
-            Tensor("B", B.flatten()),
-            Tensor("C", z()),
-            Tensor("D", D_t),
-            Tensor("E", E),
-            Tensor("F", z()),
-            Tensor("G", G),
-            Tensor("H", H),
-            Tensor("I", z()),
-            Tensor("J", z()),
-            Tensor("K", z()),
-            Tensor("L", z()),
-            Tensor("M", z()),
-            Tensor("N", z()),
-            Tensor("O", z()),
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", z()),
+            TensorArg("D", D_t),
+            TensorArg("E", E),
+            TensorArg("F", z()),
+            TensorArg("G", G),
+            TensorArg("H", H),
+            TensorArg("I", z()),
+            TensorArg("J", z()),
+            TensorArg("K", z()),
+            TensorArg("L", z()),
+            TensorArg("M", z()),
+            TensorArg("N", z()),
+            TensorArg("O", z()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
@@ -15,7 +15,7 @@ Run with --rounds 10 --skip-golden for benchmarking.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -134,16 +134,16 @@ class TestMultiRoundPagedAttention(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/test_mx_fp_gemm.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/test_mx_fp_gemm.py
@@ -22,7 +22,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.mx_fp_gemm import make_mx_fp4_case, make_mx_fp8_case
 
 M, K, N = 128, 64, 64
@@ -89,11 +89,11 @@ class TestMxFpGemm(SceneTestCase):
                 pytest.skip("torch.float4_e2m1fn_x2 / float8_e8m0fnu required")
             a, a_s, b, b_s, c, _ = make_mx_fp4_case(M, K, N)
         return TaskArgsBuilder(
-            Tensor("A", a.reshape(-1)),
-            Tensor("As", a_s.reshape(-1)),
-            Tensor("B", b.reshape(-1)),
-            Tensor("Bs", b_s.reshape(-1)),
-            Tensor("C", c.reshape(-1)),
+            TensorArg("A", a.reshape(-1)),
+            TensorArg("As", a_s.reshape(-1)),
+            TensorArg("B", b.reshape(-1)),
+            TensorArg("Bs", b_s.reshape(-1)),
+            TensorArg("C", c.reshape(-1)),
             Scalar("mode", mode),
         )
 

--- a/tests/st/a5/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/orch_so_cache/test_orch_so_cache.py
@@ -32,7 +32,7 @@ missing dlopen on first run) shows up as wrong output or a runtime failure.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 _VECTOR_KERNELS = "../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
 
@@ -102,9 +102,9 @@ class TestOrchSoCache(SceneTestCase):
         a = params["a"]
         b = params["b"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), a, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), b, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -12,7 +12,7 @@
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -112,16 +112,16 @@ class TestPagedAttentionUnroll(SceneTestCase):
         specs = []
         for name, value in result:
             if isinstance(value, torch.Tensor):
-                specs.append(Tensor(name, value))
+                specs.append(TensorArg(name, value))
             else:
                 specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         _pa_compute_golden(tensors, params)
         for s in args.specs:
-            if isinstance(s, Tensor) and s.name in tensors:
+            if isinstance(s, TensorArg) and s.name in tensors:
                 getattr(args, s.name)[:] = tensors[s.name]
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
@@ -17,7 +17,7 @@ Orchestration with N_UNROLL=64, 4 tasks per group, online softmax accumulation.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
@@ -120,7 +120,7 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
             if isinstance(val, torch.Tensor):
                 if name in ("query", "out"):
                     val = val.reshape(batch, 1, num_heads, head_dim)
-                specs.append(Tensor(name, val))
+                specs.append(TensorArg(name, val))
             else:
                 specs.append(Scalar(name, val))
         return TaskArgsBuilder(*specs)
@@ -129,7 +129,7 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
         batch = params["batch"]
         num_heads = params["num_heads"]
         head_dim = params["head_dim"]
-        tensors = {s.name: s.value for s in args.specs if isinstance(s, Tensor)}
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
         # Reshape 4D out to 3D for shared golden, then restore
         out_4d = tensors["out"]
         tensors["out"] = out_4d.reshape(batch, num_heads, head_dim)

--- a/tests/st/a5/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
@@ -19,7 +19,7 @@ import itertools
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _build_l2_ref_args, _compare_outputs
 
 _VECTOR_KERNELS = "../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -76,9 +76,9 @@ class TestPipelineSlotsTmr(SceneTestCase):
     def generate_args(self, params):
         size = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), 2.0, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), 3.0, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):
@@ -88,7 +88,7 @@ class TestPipelineSlotsTmr(SceneTestCase):
     def _run(self, worker, handle, *, slot_id=None):
         """Run normally or through a lease, then check the result.
 
-        The two entry points take different argument types: ``Worker.run`` takes ``Tensor`` args and
+        The two entry points take different argument types: ``Worker.run`` takes ``TensorArg`` args and
         materializes them in-process, while the lease is the direct chip API and takes the
         runtime.so-ABI POD.
         """

--- a/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
@@ -31,7 +31,7 @@ never stalls on it. Chain:
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 SENTINEL = 42.0
 POISON = 999.0  # what the clobber writes if the predicate lets it dispatch
@@ -105,9 +105,9 @@ class TestPredicatedDispatch(SceneTestCase):
         y = torch.full((16,), INIT_VAL, dtype=torch.float32)
         gate = torch.full((16,), -1, dtype=torch.int32)
         return TaskArgsBuilder(
-            Tensor("x", x),
-            Tensor("y", y),
-            Tensor("gate", gate),
+            TensorArg("x", x),
+            TensorArg("y", y),
+            TensorArg("gate", gate),
             Scalar("case", int(params["case"])),
         )
 

--- a/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -27,7 +27,7 @@ import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 
 _VECTOR_KERNELS = "../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -86,9 +86,9 @@ class TestPreparedCallable(SceneTestCase):
         size = 128 * 128
         a, b = params["a"], params["b"]
         return TaskArgsBuilder(
-            Tensor("a", torch.full((size,), a, dtype=torch.float32)),
-            Tensor("b", torch.full((size,), b, dtype=torch.float32)),
-            Tensor("f", torch.zeros(size, dtype=torch.float32)),
+            TensorArg("a", torch.full((size,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((size,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/test_simt_basic.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/test_simt_basic.py
@@ -18,7 +18,7 @@ budget, sync) rather than at the scatter index semantics.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 TILE_ROWS = 8
 TILE_COLS = 32
@@ -65,9 +65,9 @@ class TestSimtBasic(SceneTestCase):
         indices = torch.arange(DST_LEN, dtype=torch.int32)
         out = torch.zeros(DST_LEN, dtype=torch.float32)
         return TaskArgsBuilder(
-            Tensor("src", src),
-            Tensor("indices", indices),
-            Tensor("out", out),
+            TensorArg("src", src),
+            TensorArg("indices", indices),
+            TensorArg("out", out),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -21,7 +21,7 @@ Output layout (float32[48], 3 cache lines):
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 
@@ -74,7 +74,7 @@ class TestSpmdBasic(SceneTestCase):
 
     def generate_args(self, params):
         output = torch.zeros(3 * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
-        return TaskArgsBuilder(Tensor("output", output))
+        return TaskArgsBuilder(TensorArg("output", output))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
@@ -22,7 +22,7 @@ Output tensor: 2 * 48 * 3 = 288 cache lines = 4608 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -72,7 +72,7 @@ class TestSpmdBatchDispatchOob(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
@@ -16,7 +16,7 @@ Output tensor: 188 cache lines = 3008 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 TASKS = [(4, 0), (16, 4), (24, 20), (48, 44), (96, 92)]
@@ -48,7 +48,7 @@ class TestSpmdMultiblockAiv(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
@@ -16,7 +16,7 @@ Output tensor: 282 cache lines = 4512 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -69,7 +69,7 @@ class TestSpmdMultiblockMix(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
@@ -15,7 +15,7 @@ Total: 252 CL = 4032 float32.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -90,7 +90,7 @@ class TestSpmdStarvation(SceneTestCase):
     ]
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         out = args.output

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
@@ -19,7 +19,7 @@ device the platform allows and only the used prefix carries data.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -76,8 +76,8 @@ class TestSpmdSyncStart(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
@@ -18,7 +18,7 @@ geometry; `output` is sized for the widest device the platform allows.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 NUM_TASKS = 4
@@ -58,8 +58,8 @@ class TestSpmdSyncStartAiv(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
@@ -21,7 +21,7 @@ producer stays wider than the device on purpose — it carries no sync_start.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 PRODUCER_BLOCKS = 50
@@ -89,8 +89,8 @@ class TestSpmdSyncStartEarlyDispatch(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(1, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(1, dtype=torch.int32)),
             Scalar("early_on", int(params.get("early_on", 1))),
         )
 

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
@@ -18,7 +18,7 @@ geometry; `output` is sized for the widest device the platform allows.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -74,8 +74,8 @@ class TestSpmdSyncStartEdge(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
@@ -23,7 +23,7 @@ widths in `layout` and the golden is rebuilt from them.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_BLOCK = 3
@@ -92,8 +92,8 @@ class TestSpmdSyncStartMixSpill(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2, dtype=torch.int32)),
             Scalar("early_on", int(params.get("early_on", 1))),
         )
 

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
@@ -18,7 +18,7 @@ reported widths; `output` is sized for the widest device the platform allows.
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 ROUNDS = 6
@@ -106,8 +106,8 @@ class TestSpmdSyncStartStress(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(4, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(4, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/test_l3_dependency.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/test_l3_dependency.py
@@ -18,7 +18,7 @@ import torch
 from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import TaskArgs, TensorArgType
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_l3_task_args, _rehosted_ref
 
 KERNELS_BASE = "../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
@@ -93,9 +93,9 @@ class TestL3Dependency(SceneTestCase):
     def generate_args(self, params):
         SIZE = 128 * 128
         return TaskArgsBuilder(
-            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
-            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
-            Tensor("f", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
+++ b/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
@@ -23,7 +23,7 @@ drain, and the AIV cohort agree on block-to-core mapping when a single scheduler
 import torch
 from simpler.task_interface import ArgDirection as D
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 FLOATS_PER_CACHE_LINE = 16
 SLOTS_PER_MIX_BLOCK = 3
@@ -95,8 +95,8 @@ class TestHostBuildGraphWideDispatch(SceneTestCase):
 
     def generate_args(self, params):
         return TaskArgsBuilder(
-            Tensor("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
-            Tensor("layout", torch.zeros(2, dtype=torch.int32)),
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2, dtype=torch.int32)),
         )
 
     def compute_golden(self, args, params):

--- a/tests/st/worker/collectives/_helpers.py
+++ b/tests/st/worker/collectives/_helpers.py
@@ -20,7 +20,7 @@ import ctypes
 import torch
 from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
 
-from simpler_setup import Tensor as STensor
+from simpler_setup import TensorArg as STensor
 from simpler_setup.scene_test import TaskArgsBuilder, _rehosted_ref_for
 
 _F32 = DataType.FLOAT32

--- a/tests/st/worker/collectives/all_to_all/test_all_to_all.py
+++ b/tests/st/worker/collectives/all_to_all/test_all_to_all.py
@@ -21,7 +21,7 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import Scalar as SScalar
 from simpler_setup import SceneTestCase, TaskArgsBuilder, scene_test
-from simpler_setup import Tensor as STensor
+from simpler_setup import TensorArg as STensor
 
 from .._helpers import (
     COUNT_PER_RANK,

--- a/tests/st/worker/collectives/allgather/test_allgather.py
+++ b/tests/st/worker/collectives/allgather/test_allgather.py
@@ -21,7 +21,7 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import Scalar as SScalar
 from simpler_setup import SceneTestCase, TaskArgsBuilder, scene_test
-from simpler_setup import Tensor as STensor
+from simpler_setup import TensorArg as STensor
 
 from .._helpers import (
     COUNT_PER_RANK,

--- a/tests/st/worker/collectives/broadcast/test_broadcast.py
+++ b/tests/st/worker/collectives/broadcast/test_broadcast.py
@@ -21,7 +21,7 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import Scalar as SScalar
 from simpler_setup import SceneTestCase, TaskArgsBuilder, scene_test
-from simpler_setup import Tensor as STensor
+from simpler_setup import TensorArg as STensor
 
 from .._helpers import (
     COUNT_PER_RANK,

--- a/tests/st/worker/collectives/group_reservation/test_group_reservation.py
+++ b/tests/st/worker/collectives/group_reservation/test_group_reservation.py
@@ -14,7 +14,7 @@ from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import CommBufferSpec, TaskArgs, TensorArgType
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, scene_test
-from simpler_setup import Tensor as STensor
+from simpler_setup import TensorArg as STensor
 from simpler_setup.scene_test import _rehosted_ref_for
 
 FIRST_GROUP = 0

--- a/tests/st/worker/collectives/reduce_scatter/test_reduce_scatter.py
+++ b/tests/st/worker/collectives/reduce_scatter/test_reduce_scatter.py
@@ -21,7 +21,7 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import Scalar as SScalar
 from simpler_setup import SceneTestCase, TaskArgsBuilder, scene_test
-from simpler_setup import Tensor as STensor
+from simpler_setup import TensorArg as STensor
 
 from .._helpers import (
     COUNT_PER_RANK,

--- a/tests/ut/py/test_scene_test_golden_hooks.py
+++ b/tests/ut/py/test_scene_test_golden_hooks.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg
 
 _SCENE_TEST_MOD = sys.modules["simpler_setup.scene_test"]
 
@@ -39,7 +39,7 @@ class _Recorder(SceneTestCase):
         self.compare_calls = []
 
     def generate_args(self, params):
-        return TaskArgsBuilder(Tensor("y", torch.zeros(4, dtype=torch.float32)))
+        return TaskArgsBuilder(TensorArg("y", torch.zeros(4, dtype=torch.float32)))
 
     def compute_golden(self, args, params):
         self.golden_calls += 1
@@ -107,7 +107,7 @@ def test_compare_outputs_override_replaces_the_default_allclose():
         CASES = []
 
         def generate_args(self, params):
-            return TaskArgsBuilder(Tensor("y", torch.zeros(4, dtype=torch.float32)))
+            return TaskArgsBuilder(TensorArg("y", torch.zeros(4, dtype=torch.float32)))
 
         def compute_golden(self, args, params):
             args.y[:] = 1.0  # deliberately unequal to the un-run test tensor
@@ -126,7 +126,7 @@ def test_default_compare_outputs_raises_on_mismatch():
         CASES = []
 
         def generate_args(self, params):
-            return TaskArgsBuilder(Tensor("y", torch.zeros(4, dtype=torch.float32)))
+            return TaskArgsBuilder(TensorArg("y", torch.zeros(4, dtype=torch.float32)))
 
         def compute_golden(self, args, params):
             args.y[:] = 1.0

--- a/tests/ut/py/test_scene_test_rehost.py
+++ b/tests/ut/py/test_scene_test_rehost.py
@@ -23,7 +23,7 @@ from multiprocessing.shared_memory import SharedMemory
 import pytest
 import torch
 
-from simpler_setup.scene_test import Scalar, TaskArgsBuilder, Tensor, _RehostedTaskArgs
+from simpler_setup.scene_test import Scalar, TaskArgsBuilder, TensorArg, _RehostedTaskArgs
 
 
 class _FakeHandle:
@@ -65,8 +65,8 @@ class _FakeWorker:
 
 def test_rehost_preserves_values_and_frees_lifo():
     ta = TaskArgsBuilder(
-        Tensor("a", torch.arange(4, dtype=torch.float32)),
-        Tensor("b", torch.zeros(4, dtype=torch.float32)),
+        TensorArg("a", torch.arange(4, dtype=torch.float32)),
+        TensorArg("b", torch.zeros(4, dtype=torch.float32)),
     )
     w = _FakeWorker()
     rehosted = _RehostedTaskArgs(w, ta)
@@ -92,9 +92,9 @@ def test_rehost_partial_failure_rolls_back():
     orig_a = torch.zeros(4, dtype=torch.float32)
     orig_b = torch.ones(4, dtype=torch.float32)
     ta = TaskArgsBuilder(
-        Tensor("a", orig_a),
-        Tensor("b", orig_b),
-        Tensor("c", torch.zeros(4, dtype=torch.float32)),
+        TensorArg("a", orig_a),
+        TensorArg("b", orig_b),
+        TensorArg("c", torch.zeros(4, dtype=torch.float32)),
     )
     w = _FakeWorker(fail_on_create=2)  # third allocation fails
     with pytest.raises(RuntimeError, match="injected create_buffer failure"):
@@ -104,12 +104,12 @@ def test_rehost_partial_failure_rolls_back():
     assert len(w.freed) == 2
     assert ta.a is orig_a
     assert ta.b is orig_b
-    assert [s.value for s in ta.specs if isinstance(s, Tensor)][:2] == [orig_a, orig_b]
+    assert [s.value for s in ta.specs if isinstance(s, TensorArg)][:2] == [orig_a, orig_b]
 
 
 def test_rehost_rejects_aliased_tensors():
     base = torch.zeros(8, dtype=torch.float32)
-    ta = TaskArgsBuilder(Tensor("a", base[:4]), Tensor("b", base[2:6]))
+    ta = TaskArgsBuilder(TensorArg("a", base[:4]), TensorArg("b", base[2:6]))
     w = _FakeWorker()
     with pytest.raises(ValueError, match="alias overlapping storage"):
         _RehostedTaskArgs(w, ta)
@@ -120,7 +120,7 @@ def test_rehost_rejects_aliased_tensors():
 
 def test_rehost_skips_empty_tensor():
     empty = torch.zeros(0, dtype=torch.float32)
-    ta = TaskArgsBuilder(Tensor("a", torch.arange(4, dtype=torch.float32)), Tensor("e", empty))
+    ta = TaskArgsBuilder(TensorArg("a", torch.arange(4, dtype=torch.float32)), TensorArg("e", empty))
     w = _FakeWorker()
     rehosted = _RehostedTaskArgs(w, ta)
     try:
@@ -134,7 +134,7 @@ def test_rehost_skips_empty_tensor():
 def test_rehost_rejects_noncontiguous():
     noncontig = torch.zeros(4, 4, dtype=torch.float32)[:, ::2]
     assert not noncontig.is_contiguous()
-    ta = TaskArgsBuilder(Tensor("a", noncontig))
+    ta = TaskArgsBuilder(TensorArg("a", noncontig))
     w = _FakeWorker()
     with pytest.raises(ValueError, match="contiguous"):
         _RehostedTaskArgs(w, ta)
@@ -170,8 +170,8 @@ def _make_chip_tensor_arg(t):
 
 
 def test_char_singleton_stride_dropped_by_make_chip_tensor_arg():
-    # The wire Tensor's strides are a pure function of shape (row-major), so a
-    # size-1 dimension's stride value never survives into the Tensor. Two tensors
+    # The wire TensorArg's strides are a pure function of shape (row-major), so a
+    # size-1 dimension's stride value never survives into the TensorArg. Two tensors
     # equal in shape+values but differing ONLY in their singleton-dim stride get
     # identical consumer-visible geometry (shape / stride / start_offset); the
     # inactive-dim and padding bytes are unspecified, so this is a geometry
@@ -204,7 +204,7 @@ def test_char_singleton_stride_dropped_by_rehost():
     base = torch.arange(4, dtype=torch.float32)
     weird = base.as_strided((4, 1), (1, 7))
     assert weird.stride() == (1, 7)  # pin fixture (see note above)
-    ta = TaskArgsBuilder(Tensor("a", weird))
+    ta = TaskArgsBuilder(TensorArg("a", weird))
     w = _FakeWorker()
     rehosted = _RehostedTaskArgs(w, ta)
     try:
@@ -222,7 +222,7 @@ def test_char_nonoverlapping_shared_storage_not_rejected():
     base = torch.zeros(8, dtype=torch.float32)
     a, b = base[:4], base[4:]  # non-overlapping byte ranges, same storage
     assert a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
-    ta = TaskArgsBuilder(Tensor("a", a), Tensor("b", b))
+    ta = TaskArgsBuilder(TensorArg("a", a), TensorArg("b", b))
     w = _FakeWorker()
     rehosted = _RehostedTaskArgs(w, ta)
     try:
@@ -260,15 +260,15 @@ def test_char_make_chip_tensor_arg_carries_backing_as_addr_only():
 def test_builder_constructor_rejects_duplicate_tensor():
     with pytest.raises(ValueError, match="duplicate argument name 'a'"):
         TaskArgsBuilder(
-            Tensor("a", torch.zeros(4)),
-            Tensor("a", torch.ones(4)),
+            TensorArg("a", torch.zeros(4)),
+            TensorArg("a", torch.ones(4)),
         )
 
 
 def test_builder_constructor_rejects_tensor_scalar_name_clash():
     with pytest.raises(ValueError, match="duplicate argument name 'x'"):
         TaskArgsBuilder(
-            Tensor("x", torch.zeros(4)),
+            TensorArg("x", torch.zeros(4)),
             Scalar("x", ctypes.c_float(1.0)),
         )
 
@@ -277,16 +277,16 @@ def test_builder_rejects_name_shadowing_builder_attribute():
     # A name that resolves to a real attribute/method would shadow it, so
     # `args.specs` returns the property instead of the argument. Reject it.
     with pytest.raises(ValueError, match="conflicts with builder attributes/methods"):
-        TaskArgsBuilder(Tensor("specs", torch.zeros(4)))
+        TaskArgsBuilder(TensorArg("specs", torch.zeros(4)))
     with pytest.raises(ValueError, match="conflicts with builder attributes/methods"):
         TaskArgsBuilder(Scalar("clone", ctypes.c_int64(1)))
     # A name that is not a builder member is still accepted.
-    ta = TaskArgsBuilder(Tensor("value", torch.zeros(4)))
+    ta = TaskArgsBuilder(TensorArg("value", torch.zeros(4)))
     assert torch.equal(ta.value, torch.zeros(4))
 
 
 def test_builder_incremental_add_rejects_duplicate():
-    ta = TaskArgsBuilder(Tensor("a", torch.zeros(4)))
+    ta = TaskArgsBuilder(TensorArg("a", torch.zeros(4)))
     with pytest.raises(ValueError, match="duplicate argument name 'a'"):
         ta.add_tensor("a", torch.ones(4))
 
@@ -294,7 +294,7 @@ def test_builder_incremental_add_rejects_duplicate():
 def test_builder_duplicate_scalar_leaves_state_unchanged():
     # A rejected duplicate scalar must not flip `_has_scalar`, so a legal tensor
     # can still be added afterwards (tensor-before-scalar ordering intact).
-    ta = TaskArgsBuilder(Tensor("a", torch.zeros(4)))
+    ta = TaskArgsBuilder(TensorArg("a", torch.zeros(4)))
     ta.add_scalar("s", ctypes.c_int64(7))
     with pytest.raises(ValueError, match="duplicate argument name 's'"):
         ta.add_scalar("s", ctypes.c_int64(9))
@@ -307,7 +307,7 @@ def test_builder_duplicate_scalar_leaves_state_unchanged():
     # tensor. Fresh tensor-only builder → reject a name-clashing scalar → a
     # subsequent add_tensor must still succeed. (Catches moving the
     # `_has_scalar = True` assignment ahead of the duplicate check.)
-    tb = TaskArgsBuilder(Tensor("a", torch.zeros(4)))
+    tb = TaskArgsBuilder(TensorArg("a", torch.zeros(4)))
     orig_a = tb.a
     with pytest.raises(ValueError, match="duplicate argument name 'a'"):
         tb.add_scalar("a", ctypes.c_int64(3))
@@ -318,8 +318,8 @@ def test_builder_duplicate_scalar_leaves_state_unchanged():
 
 def test_builder_valid_args_order_named_access_and_clone():
     ta = TaskArgsBuilder(
-        Tensor("a", torch.arange(4, dtype=torch.float32)),
-        Tensor("b", torch.ones(4, dtype=torch.float32)),
+        TensorArg("a", torch.arange(4, dtype=torch.float32)),
+        TensorArg("b", torch.ones(4, dtype=torch.float32)),
         Scalar("scale", ctypes.c_float(1.5)),
     )
     assert [s.name for s in ta.specs] == ["a", "b", "scale"]


### PR DESCRIPTION
## Summary

- `simpler_setup.Tensor` (the `NamedTuple` test-arg spec used by `TaskArgsBuilder`) and `simpler.task_interface.Tensor` (the wire-ABI struct #1729 finished wiring up) name two unrelated public types the same thing in two importable namespaces — a violation of `.claude/rules/codestyle.md` rule 13 (public C++/Python types share one canonical name and semantics), flagged as a deferred follow-up in #1729.
- #1729 landed with **zero Python call sites** on the ABI-side `Tensor`, so renaming the long-established, 119-call-site test-tooling type is the low-risk direction — a mechanical rename with no behavior change, rather than fighting the design docs' canonical name for the wire element.
- Renamed the class in `simpler_setup/scene_test.py`, its export in `simpler_setup/__init__.py`, and every constructor/`isinstance` call site across `examples/`, `tests/`, plus prose references in `docs/testing.md`, `docs/user/README.md`, and `.claude/rules/project-layout.md`. `docs/user/README.md`'s "one name to watch" caveat about the collision is removed since it no longer applies.

## Test plan

- [x] `ruff check` / `ruff format --check` clean on `simpler_setup/`, `examples/`, `tests/`
- [x] `pytest tests/ut` — 1251 passed, 13 skipped, 0 failed
- [x] Live sim run through the renamed spec end-to-end: `pytest examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py --platform a2a3sim` — 1 passed
- [x] Broader `--platform a2a3sim` sweep across `examples/a2a3` and `examples/a5` (the sim-eligible subset) — all green