### PR TITLE
Test: pin the chip-run lane's blocking wait and drop its unused API

### DIFF
--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -268,22 +268,6 @@ bool ChipRun::wait_until(Deadline deadline) {
     }
 }
 
-bool ChipRun::wait_until_launched(Deadline deadline) {
-    if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
-    while (true) {
-        {
-            std::lock_guard<std::mutex> lk(lane_->mu);
-            if (run_->crossed_launch_fence) return true;
-            if (run_->phase == ChipRunState::Phase::TERMINAL) {
-                ChipRunLaneState::rethrow_run_error(run_);
-                return false;
-            }
-            (void)lane_->progress(run_);
-        }
-        if (Clock::now() >= deadline) return false;
-    }
-}
-
 void ChipRun::activate() {
     if (lane_ == nullptr || run_ == nullptr) throw std::runtime_error("empty ChipRun handle");
     std::lock_guard<std::mutex> lk(lane_->mu);

--- a/src/common/worker/chip_run_lane.h
+++ b/src/common/worker/chip_run_lane.h
@@ -37,7 +37,6 @@ public:
 
     bool done();
     bool wait_until(Deadline deadline);
-    bool wait_until_launched(Deadline deadline);
     void activate();
     void abandon();
 

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -39,6 +40,10 @@ std::array<int, 2> g_poll_rc{};
 std::array<int, 2> g_wait_rc{};
 std::array<int, 2> g_finalize_rc{};
 size_t g_poll_count{0};
+// When nonzero, the poll stub completes the run after this many polls. Only
+// UnboundedWaitBlocksInsteadOfPolling sets it, so that a regression there fails
+// on the poll count instead of looping forever.
+size_t g_poll_completes_after{0};
 std::vector<std::string> g_events;
 
 uint32_t slot_of(void *runtime) { return g_slots.at(runtime); }
@@ -62,6 +67,7 @@ int poll_run(void *, void *runtime) {
     ++g_poll_count;
     const uint32_t slot = slot_of(runtime);
     if (g_poll_rc[slot] != 0) return g_poll_rc[slot];
+    if (g_poll_completes_after != 0 && g_poll_count >= g_poll_completes_after) g_complete[slot] = true;
     return g_complete[slot] ? SIMPLER_NATIVE_RUN_POLL_COMPLETE : SIMPLER_NATIVE_RUN_POLL_NOT_READY;
 }
 
@@ -89,6 +95,7 @@ void prime_worker(ChipWorker &worker) {
     g_wait_rc = {};
     g_finalize_rc = {};
     g_poll_count = 0;
+    g_poll_completes_after = 0;
     g_events.clear();
     worker.initialized_ = true;
     worker.pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 2, {}};
@@ -282,6 +289,33 @@ TEST(ChipRunLaneTest, ExpiredWaitLeavesTheRunLive) {
     EXPECT_FALSE(run.done());
     g_complete[0] = true;
     EXPECT_TRUE(run.wait_until(ChipRunLane::Deadline::max()));
+    lane.close();
+    worker.finalize();
+}
+
+// An unbounded wait has no deadline to end its loop, so it must reach the
+// device's blocking wait rather than re-polling until the run completes. The
+// poll bound is what makes that observable: a re-polling implementation calls
+// poll_run without limit, and no assertion on the run's result can see it.
+TEST(ChipRunLaneTest, UnboundedWaitBlocksInsteadOfPolling) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipRun run = submit(lane, 101, 0);
+
+    // Nothing completes this run except wait_run, so a re-polling implementation
+    // would loop forever. The escape hatch keeps that a fast failure with a
+    // readable message rather than a wedged suite: past the bound the stub
+    // completes the run itself, and the assertions below report the poll count.
+    ASSERT_FALSE(g_complete[0]);
+    g_poll_count = 0;
+    g_poll_completes_after = 64;
+    EXPECT_TRUE(run.wait_until(ChipRunLane::Deadline::max()));
+    g_poll_completes_after = 0;
+
+    EXPECT_NE(std::find(g_events.begin(), g_events.end(), "wait0"), g_events.end())
+        << "unbounded wait never reached the device's blocking wait";
+    EXPECT_LE(g_poll_count, 1u) << "unbounded wait polled " << g_poll_count << " times instead of blocking";
     lane.close();
     worker.finalize();
 }


### PR DESCRIPTION
Two code-health items on `ChipRunLane`, both surfaced while reviewing #1650 and left open when it merged (`48dc78bf`).

## 1. The blocking wait had no test holding it in place

`ChipRun::wait_until(Deadline::max())` blocks on the device rather than re-polling — but nothing enforced that. The stubbed `poll_run` returns `COMPLETE` as soon as `g_complete` is set, so **every `wait_until` in all twelve cases returned on its first pass**, and `ExpiredWaitLeavesTheRunLive` passes an already-elapsed deadline so it too does one iteration.

A re-polling implementation would have passed the entire suite. That is exactly how the original spin — measured at **636,336 `poll_run` calls in a 200 ms run** (~3.2 M/s, each one an `rtSetDevice` plus a device read in production) — reached main behind a green CI.

`UnboundedWaitBlocksInsteadOfPolling` closes it. The run is completable **only** by `wait_run`, so the blocking path is the sole way for the wait to finish, and it asserts both halves:

- the device wait was actually reached (`wait0` in the event log)
- the poll count stays at most one

**On the escape hatch:** on that setup a re-polling implementation loops forever, and a hang is a poor CI failure — it burns the job timeout and reports nothing. So the poll stub completes the run itself past a bound (`g_poll_completes_after`, set by this one test). The regression then fails in milliseconds with

```
unbounded wait polled 64 times instead of blocking
```

**Verified non-vacuous by mutation:** with `block_on_front()` removed, the test without the hatch hangs (killed at 60 s); with the hatch it fails in 0 ms with the message above. Restored, all thirteen pass.

## 2. `ChipRun::wait_until_launched` is deleted

Zero callers, zero bindings — exported and untested from birth. Confirmed with a positive control, since an absence claim from one grep spelling is worth little:

```
$ git grep -c wait_until_launched
src/common/worker/chip_run_lane.cpp:1     # the definition
src/common/worker/chip_run_lane.h:1       # the declaration
```

Note `ChipRun::launched()` is a **different** accessor — it reads `crossed_launch_fence`, is bound as a property, and the child loop does use it. That one stays.

W1b will expose a live `RunHandle` and may well want a launch-only wait; deciding its shape then, against a real caller, beats keeping one shaped by guesswork that no test covers.

## Validation

- **91/91** cpp UT (`ctest -LE requires_hardware` — CI's own filter, not `-L no_hardware`, which omits 18 tests including this one)
- **1277** passed / 13 skipped — full `tests/ut/py`
- a2a3 **onboard** sweep: 54 passed, plus 24 passed / 2 skipped in the resource phase

Both totals are unchanged from the base `48dc78bf`, which is expected and not a
sign of a stale measurement:

- **ctest counts binaries, not gtest cases.** This PR adds a case *inside*
  `test_chip_run_lane`, so `ctest` stays 91 while the binary itself goes
  **12 → 13** (`--gtest_list_tests`).
- **The Python total is identical because this PR touches zero `.py` files**
  (`git diff 48dc78bf...HEAD --name-only | grep '\.py$'` → empty). Measured
  1277 on the base as well, not inferred.

## Not in scope

Issue #1742 (`launched` semantics in `simpler_finalize_run`) is a **different** `launched` — a `bool` in the platform-layer C API, unrelated to the lane's accessor. Same defect *class*, different file and layer; left alone.
