### PR TITLE
Fix: mint owner_instance_id after fork; check device backing owner

### DIFF
--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -49,6 +49,7 @@ __all__ = [
     "Buffer",
     "BufferDescriptor",
     "CanonicalIdentity",
+    "ImportContext",
     "ImportRegistry",
     "ImportedBuffer",
     "MappedArg",
@@ -496,6 +497,30 @@ class MappedArgs(Sequence):
         return self._scalars[i]
 
 
+@dataclass(frozen=True)
+class ImportContext:
+    """What owner nonce this endpoint may materialize a DEVICE ``address_space`` backing under.
+
+    A host endpoint (Python SUB, or any host-process consumer) may never materialize a DEVICE
+    backing — no device VA is ever valid there. A device (chip) endpoint may materialize one only
+    if the descriptor's ``owner_instance_id`` matches ``owning_chip_instance_id``.
+
+    This is a Worker-level check, not a chip-level one: ``owner_instance_id`` is minted once per
+    Worker incarnation (in ``Worker.init()``), not once per chip, so a Worker with more than one
+    entry in ``device_ids`` gives every one of its chip children the same nonce here — the wire
+    ``BufferDescriptor`` has no field that distinguishes sibling chips (``owner_worker_id`` is
+    host-side-only free/copy provenance, never serialized). A DEVICE backing minted for chip 0
+    of such a Worker therefore also passes this check on sibling chip 1. It still rejects a
+    *different* Worker's device buffer, and any host endpoint outright. The exact-chip half of
+    the endpoint x address_space matrix is enforced at submit time by the
+    ``(target_worker_id, ptr)`` check in ``orchestrator.py``; this is a backstop for a path that
+    reaches ``materialize`` without going through it, not a replacement for that check.
+    """
+
+    is_host_endpoint: bool
+    owning_chip_instance_id: bytes | None = None
+
+
 class ImportRegistry:
     """Per-consumer-endpoint lazy import cache: materialize a ``Tensor``'s embedded descriptor to a
     local base on first receipt (map-once), keyed by canonical identity.
@@ -510,8 +535,9 @@ class ImportRegistry:
     still describes the backing that was mapped, so one identity can never come to mean two things.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, context: ImportContext | None = None) -> None:
         self._by_identity: dict[CanonicalIdentity, ImportedBuffer] = {}
+        self._context = context
 
     def materialize(self, desc: BufferDescriptor) -> ImportedBuffer:
         """Map ``desc``'s backing into this process on first sight of its identity; reuse the
@@ -526,9 +552,11 @@ class ImportRegistry:
         POSIX shm object smaller than the ``nbytes`` its descriptor claims — every view bound check
         is computed against that number, so an unverified one makes them all vacuous.
 
-        Adds no endpoint check of its own: a DEVICE backing resolved here yields a device pointer,
-        which is only meaningful on its owner chip. The endpoint x ``address_space`` matrix is a
-        separate change; until it lands, that invariant rests on the caller.
+        A DEVICE backing is rejected unless ``context`` names this endpoint's owning Worker: the
+        endpoint x ``address_space`` matrix's materialize-side half, the backstop for a path that
+        reaches here without going through submit-time dispatch. This check is Worker-grained, not
+        chip-grained (see ``ImportContext``) — it cannot by itself tell apart two chips forked from
+        the same multi-device Worker.
         """
         key = desc.identity
         cached = self._by_identity.get(key)
@@ -544,6 +572,16 @@ class ImportRegistry:
                     f"this is refused"
                 )
             return cached
+        if desc.address_space == AddressSpace.DEVICE:
+            if self._context is None or self._context.is_host_endpoint:
+                raise ValueError(
+                    f"ImportRegistry: refusing to materialize a DEVICE backing ({desc.identity}) on a host endpoint"
+                )
+            if bytes(desc.identity.owner_instance_id) != self._context.owning_chip_instance_id:
+                raise ValueError(
+                    f"ImportRegistry: refusing to materialize a DEVICE backing ({desc.identity}) "
+                    f"minted for a different chip's owner"
+                )
         if desc.backend_kind in (
             BackendKind.FORK_SHM,
             BackendKind.FORK_COW,
@@ -554,7 +592,9 @@ class ImportRegistry:
             # FORK_SHM / FORK_COW: a host VA inherited across the fork, so the child already holds
             # the same address (they differ in write semantics, not in how they resolve).
             # DEVICE_MALLOC / VMM_WINDOW: a device pointer valid on the chip that allocated / carved
-            # it (the tensor must only reach that chip — a topology invariant).
+            # it (the tensor must only reach that chip — a topology invariant). The check above
+            # enforces the owning-Worker half of that (see ImportContext); the exact-chip half for
+            # a Worker with several chips is submit-time's job, not this cache's.
             base = int.from_bytes(desc.body, "little")
             imported = ImportedBuffer(desc.identity, base, desc.nbytes, desc.address_space, None, desc)
         elif desc.backend_kind == BackendKind.POSIX_SHM:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -110,6 +110,7 @@ from .buffer import (
     Buffer,
     BufferDescriptor,
     CanonicalIdentity,
+    ImportContext,
     ImportRegistry,
     create_host_shared_buffer,
     host_ptr_nbytes,
@@ -1833,7 +1834,8 @@ def _sub_worker_loop(
     completion, which the run's waiter rethrows as ``std::runtime_error``.
     """
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
-    import_registry = ImportRegistry()  # lazy per-endpoint import cache: canonical identity -> local base
+    # SUB is a Python host process: no device VA is ever valid here.
+    import_registry = ImportRegistry(ImportContext(is_host_endpoint=True))
 
     def handle_task(task_buf) -> tuple[int, str]:
         digest = _read_task_digest(task_buf)
@@ -2442,6 +2444,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     registry: dict[int, Any],
     identity_table: dict[bytes, int],
     identity_refs: dict[bytes, int],
+    owner_instance_id: bytes,
     *,
     chip_platform: str,
     chip_runtime: str = "",
@@ -2463,10 +2466,13 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     via ``prepared``), and callables registered dynamically after startup
     arrive via ``_CTRL_PREPARE``. A task frame for an unprepared slot is a
     control-flow error and fails rather than lazily preparing it.
+
+    ``owner_instance_id`` is the parent Worker's nonce — the only owner whose
+    DEVICE_MALLOC/VMM_WINDOW backings this chip may materialize.
     """
     prepared = prepared if prepared is not None else set()
     worker_chip_region_store = _HostWorkerChipRegionStore()
-    import_registry = ImportRegistry()  # lazy per-endpoint import cache: canonical identity -> local base
+    import_registry = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=owner_instance_id))
     global_domain_store = _L2GlobalDomainStore()
 
     def handle_task(task_buf) -> tuple[int, str]:
@@ -2928,6 +2934,7 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
     registry: dict[int, Any],
     identity_table: dict[bytes, int],
     identity_refs: dict[bytes, int],
+    owner_instance_id: bytes,
     log_level: int = 25,
     platform: str = "",
     runtime: str = "",
@@ -3005,6 +3012,7 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
             registry,
             identity_table,
             identity_refs,
+            owner_instance_id,
             chip_platform=platform,
             chip_runtime=runtime,
             prepared=prepared,
@@ -4250,9 +4258,12 @@ class Worker:
         # since the nonce is opaque, `owner_worker_path_id` is diagnostic by contract, and
         # `address_space` does not say which card.
         #
-        # Both identities therefore share this mint point. Moving it — to after fork/adoption, as
-        # owner-authority work requires — changes endpoint identity as well as buffer identity, so
-        # the two must move in one change.
+        # Both identities share this mint point. init() re-mints it (see the
+        # `_lifecycle = _Lifecycle.INITIALIZING` assignment) rather than trusting the value from
+        # here: for a next-level child, init() only ever runs inside the process that forked to
+        # host it, so that later mint is the one that names the real incarnation and is never older
+        # than its fork. The value assigned here exists only so a Worker that never reaches init()
+        # (e.g. a test double that pokes `_lifecycle` directly) still has a well-formed nonce.
         self._owner_instance_id: bytes = mint_owner_instance_id()
         self._buffer_id_counter: int = 1
         self._buffers: dict[int, Buffer] = {}
@@ -6783,6 +6794,11 @@ class Worker:
             if _startup_deadline is None:
                 self._assign_shm_namespace()
             self._lifecycle = _Lifecycle.INITIALIZING
+            # Generated after this Worker's own fork: a next-level child's init() runs only inside
+            # the process that forked to host it (see _start_hierarchical), so this nonce is never
+            # older than the incarnation it names. Buffer and endpoint identity share this mint
+            # point (see the Owner-side Buffer state comment in __init__).
+            self._owner_instance_id: bytes = mint_owner_instance_id()
             if self.level >= 3:
                 self._is_startup_root = _startup_deadline is None
                 own_deadline = time.monotonic() + self._startup_timeout_s
@@ -7088,6 +7104,7 @@ class Worker:
                                 callable_kind="CHIP_CALLABLE",
                                 target_namespace="LOCAL_CHIP",
                             ),
+                            self._owner_instance_id,
                             log_level=chip_log_level,
                             platform=str(self._config["platform"]),
                             runtime=str(self._config["runtime"]),
@@ -10077,7 +10094,10 @@ class Worker:
         """
         registry = self._chip_import_registry
         if registry is None:
-            registry = ImportRegistry()
+            # This worker runs its own chip in-process (no fork, no mailbox): it is its own device
+            # endpoint, so DEVICE backings it materializes must be its own.
+            context = ImportContext(is_host_endpoint=False, owning_chip_instance_id=self._owner_instance_id)
+            registry = ImportRegistry(context)
             self._chip_import_registry = registry
         if args is None:
             args = TaskArgs()

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -24,6 +24,7 @@ from simpler.buffer import (
     BackendKind,
     BufferDescriptor,
     CanonicalIdentity,
+    ImportContext,
     ImportRegistry,
     Tensor,
     create_host_shared_buffer,
@@ -195,7 +196,7 @@ def test_device_malloc_wrap_materialize():
     assert h.backend_kind == BackendKind.DEVICE_MALLOC
     assert h.address_space == AddressSpace.DEVICE
     assert h.shm is None and h.base == 0xDEAD0000
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=oid))
     imp = reg.materialize(h.to_descriptor())
     assert imp.base == 0xDEAD0000
     assert imp.address_space == AddressSpace.DEVICE
@@ -227,7 +228,7 @@ def test_materialize_rejects_a_conflicting_descriptor_for_a_live_identity():
     # carrying the same identity and a different nbytes describes something the existing mapping is
     # not, so returning that mapping would hand back a base under a size nothing stands behind.
     oid = mint_owner_instance_id()
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=oid))
     first = reg.materialize(_device_descriptor(oid, 1, nbytes=4096))
 
     for conflicting in (
@@ -247,7 +248,7 @@ def test_conflict_error_names_only_the_fields_that_differ():
     # A whole repr of both descriptors would carry a 32-byte body twice for what is usually a
     # one-field disagreement, and leave the reader to diff them by eye.
     oid = mint_owner_instance_id()
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=oid))
     reg.materialize(_device_descriptor(oid, 1, nbytes=4096))
     with pytest.raises(ValueError) as excinfo:
         reg.materialize(_device_descriptor(oid, 1, nbytes=8192))

--- a/tests/ut/py/test_worker/test_endpoint_capability.py
+++ b/tests/ut/py/test_worker/test_endpoint_capability.py
@@ -19,6 +19,7 @@ import pytest
 from simpler.buffer import (
     AccessMode,
     AddressSpace,
+    ImportContext,
     ImportRegistry,
     mint_owner_instance_id,
     wrap_device_malloc,
@@ -94,3 +95,24 @@ def test_sub_worker_materialization_refuses_a_device_tensor():
             reg.mapped_args_from_blob(ctypes.addressof(src), len(blob))
     finally:
         reg.close()
+
+
+def test_host_endpoint_materialize_refuses_a_device_tensor_directly():
+    # The same backstop, exercised through materialize() itself rather than mapped_args_from_blob —
+    # any entry point onto a host ImportRegistry must refuse a DEVICE backing, not just the one that
+    # mapped_args_from_blob happens to guard.
+    dev = _device_handle()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
+    with pytest.raises(ValueError, match="host endpoint"):
+        reg.materialize(dev.to_descriptor())
+
+
+def test_chip_materialization_refuses_a_foreign_chips_device_tensor():
+    # Depth behind the submit-time provenance check (_child_prov_check_dispatch's exact
+    # (target_worker_id, ptr) match): handed a blob directly, a chip endpoint's own ImportRegistry
+    # still refuses a device backing minted for a different chip's owner.
+    dev = _device_handle()
+    foreign_chip_owner = mint_owner_instance_id()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=foreign_chip_owner))
+    with pytest.raises(ValueError, match="different chip's owner"):
+        reg.materialize(dev.to_descriptor())

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -170,6 +170,7 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
             {},
             {},
             {},
+            worker_mod.mint_owner_instance_id(),
             platform="a2a3",
             runtime="tensormap_and_ringbuffer",
         )
@@ -595,6 +596,7 @@ class _TwoFrameLoopHarness:
                 self.registry,
                 self.identity_table,
                 self.identity_refs,
+                worker_mod.mint_owner_instance_id(),
             ),
             kwargs={
                 "chip_platform": "a2a3",
@@ -7299,6 +7301,7 @@ class TestChipMainLoopDigestRegister:
 
     @staticmethod
     def _spawn_loop(cw, buf, state_addr, registry=None, identity_table=None, identity_refs=None):
+        from simpler.buffer import mint_owner_instance_id  # noqa: PLC0415
         from simpler.worker import _run_chip_main_loop  # noqa: PLC0415
 
         if registry is None:
@@ -7309,7 +7312,7 @@ class TestChipMainLoopDigestRegister:
             identity_refs = {}
         t = threading.Thread(
             target=_run_chip_main_loop,
-            args=(cw, buf, 0, state_addr, 0, registry, identity_table, identity_refs),
+            args=(cw, buf, 0, state_addr, 0, registry, identity_table, identity_refs, mint_owner_instance_id()),
             kwargs={"chip_platform": ""},
             daemon=True,
         )


### PR DESCRIPTION
## Two gaps in the buffer identity / materialize path, both left open by #1729

### `owner_instance_id` was minted before the Worker it names existed

`Worker.__init__` minted the nonce at Python object construction time — before
`add_worker()`, before any `os.fork()`, before `init()`. For a next-level child
Worker that nonce is fixed in the parent process and only later copied (via
fork COW) into the child that actually becomes its owner, so nothing tied the
identity to a real fork having happened.

`Worker.init()` now re-mints `owner_instance_id` right after its
`NEW -> INITIALIZING` transition. A next-level child's `init()` runs only
inside the process that was forked to host it (`_start_hierarchical` calls
`inner.init(...)` only in the `os.fork()` child branch), so the nonce a
Worker's buffers and endpoint identity actually use is never older than its
own fork. `__init__` keeps its mint as a fallback: several test files build a
"ready" Worker by setting `_lifecycle` directly without ever calling `init()`,
and still need a well-formed nonce.

### `materialize()` trusted a raw device pointer with no endpoint check

`ImportRegistry.materialize()`'s `DEVICE_MALLOC`/`VMM_WINDOW` branch decoded
the descriptor body straight into a pointer and handed it back — its own
docstring said as much: *"a DEVICE backing resolved here yields a device
pointer, which is only meaningful on its owner chip. The endpoint x
address_space matrix is a separate change; until it lands, that invariant
rests on the caller."* Submit-time checks already reject a device tensor
before dispatch, but nothing stopped a caller that reaches `materialize()`
directly.

`ImportContext(is_host_endpoint, owning_chip_instance_id)` closes that:
`materialize()` now refuses any DEVICE backing on a host endpoint outright,
and on a device endpoint refuses one whose `owner_instance_id` doesn't match
the nonce that endpoint was set up to serve. Wired into the three
`ImportRegistry()` construction sites — `_sub_worker_loop` (host),
`_run_chip_main_loop` (device, given the parent's `owner_instance_id` at
fork), and `_run_l2_materialized` (a `device_ids`-bearing L2 leaf, checked
against its own nonce).

**Known bound (flagged by review, documented rather than closed here):** this
check is Worker-grained, not chip-grained. `owner_instance_id` is minted once
per Worker incarnation, not once per chip, so a Worker with more than one
entry in `device_ids` gives every one of its chip children the same nonce —
the wire `BufferDescriptor` has no field that distinguishes sibling chips
(`owner_worker_id` is host-side-only free/copy provenance, never serialized).
A DEVICE backing minted for chip 0 of such a Worker therefore also passes
this check on sibling chip 1. It still rejects a *different* Worker's device
buffer, and any host endpoint outright; the exact-chip half of the endpoint x
`address_space` matrix for a multi-device Worker stays with the existing
submit-time `(target_worker_id, ptr)` check in `orchestrator.py`, which this
backstop complements rather than replaces. Closing that gap fully needs
either a wire ABI field the frozen P1-A identity doesn't have, or a live
per-chip pointer allowlist — both bigger than a materialize-time backstop
should take on. `ImportContext`'s docstring now states this bound explicitly.

## Test plan

- [x] `pytest tests/ut` — 1279 passed, 13 skipped, 0 failed
- [x] `ruff check` / `ruff format --check`, `pyright` — clean
- [x] Two new tests exercise `materialize()` directly (bypassing submit),
      mirroring #1729's existing sub-worker test: a host endpoint rejects a
      DEVICE descriptor, and a device endpoint rejects one minted by a
      different chip's owner
- [x] Real a2a3 onboard run (2 devices) across `host_build_graph` and
      `tensormap_and_ringbuffer` examples — exercises the touched chip-fork
      path, no failures