### PR TITLE
Add: return a live handle from the direct-chip submit

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <cerrno>
 #include <array>
+#include <cmath>
 #include <condition_variable>
 #include <cstring>
 #include <cstdint>
@@ -2023,6 +2024,32 @@ NB_MODULE(_task_interface, m) {
         .def_prop_ro("lane_poisoned", &ChipRun::lane_poisoned)
         .def_prop_ro("preparation_disposition", &ChipRun::preparation_disposition)
         .def(
+            "wait",
+            [](ChipRun &self, double timeout) {
+                // NaN compares false against everything, so it reaches the cast
+                // unless it is rejected by name. Converting a non-finite or
+                // out-of-range double to the clock's integral rep is undefined,
+                // and this timeout comes straight from Python.
+                if (std::isnan(timeout)) throw std::invalid_argument("ChipRun.wait timeout must not be NaN");
+                if (timeout < 0) return self.wait_until(ChipRun::Deadline::max());
+                const std::chrono::duration<double> requested(timeout);
+                const auto limit =
+                    std::chrono::duration_cast<std::chrono::duration<double>>(ChipRun::Clock::duration::max());
+                // Saturate rather than reject: a caller asking to wait longer
+                // than the clock can express means "effectively forever", and
+                // the unbounded path is the one that blocks on the device
+                // instead of polling.
+                if (requested >= limit) return self.wait_until(ChipRun::Deadline::max());
+                return self.wait_until(
+                    ChipRun::Clock::now() + std::chrono::duration_cast<ChipRun::Clock::duration>(requested)
+                );
+            },
+            nb::arg("timeout") = -1.0, nb::call_guard<nb::gil_scoped_release>(),
+            "Wait for this run's completion fence. A negative timeout waits without a deadline and blocks on the "
+            "device rather than polling, as does one past the clock's range. Rejects NaN. Returns whether the run "
+            "reached terminal; raises the run's error."
+        )
+        .def(
             "_raise_if_failed",
             [](ChipRun &self) {
                 if (!self.done()) throw std::logic_error("ChipRun is not terminal");
@@ -2133,6 +2160,15 @@ NB_MODULE(_task_interface, m) {
         .def(
             "_close_chip_run_lane", &ChipWorker::close_chip_run_lane, nb::call_guard<nb::gil_scoped_release>(),
             "Drain active native ownership, abandon unlaunched work, and close the chip run lane."
+        )
+        .def(
+            "_submit_chip_run_direct",
+            [](ChipWorker &self, int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config) {
+                return self.submit_chip_run(callable_id, args, config);
+            },
+            nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::call_guard<nb::gil_scoped_release>(),
+            "Submit materialized task args to the chip native-run lane without a pipeline lease and return the live "
+            "run. The lane admits at capacity one: this call drains its predecessor before admitting."
         )
         .def(
             "_prepare_native_run_materialized",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -4166,6 +4166,11 @@ class Worker:
 
         # Level-2 internals
         self._chip_worker: ChipWorker | None = None
+        # Live direct-chip runs by the run id their RunHandle carries. The lane
+        # is the admission authority and holds its own FIFO; this only maps a
+        # handle back to its run so waiting and finalization can find it.
+        self._chip_runs: dict[int, Any] = {}
+        self._chip_run_seq: int = 0
 
         # Level-3+ internals
         self._worker: _Worker | None = None
@@ -9705,8 +9710,7 @@ class Worker:
         if self.level == 2:
             assert self._chip_worker is not None
             state = self._resolve_handle(callable, expected_namespace="LOCAL_CHIP")
-            self._run_l2_materialized(state.slot_id, args, cfg)
-            return RunHandle._completed(self)
+            return self._submit_l2_locked(state.slot_id, args, cfg)
 
         with self._submit_mu:
             # Graph callbacks stay serialized, so a predecessor's callback has
@@ -9900,6 +9904,29 @@ class Worker:
                     return handle
         return None
 
+    def _submit_l2_locked(self, callable_id: int, args, cfg: CallConfig) -> RunHandle:
+        """Admit one direct-chip run and return a handle to it while it runs.
+
+        The lane is the sole admission authority and takes runs at capacity one:
+        submitting drains the predecessor first, so a second submit blocks here
+        rather than overlapping device work. What the handle adds is that the
+        *first* submit no longer waits — the caller owns the completion fence
+        through :meth:`RunHandle.wait`.
+        """
+        assert self._chip_worker is not None
+        chip_args = self._materialize_l2_args(args)
+        chip_run = self._chip_worker._impl._submit_chip_run_direct(callable_id, chip_args, cfg)
+        self._chip_run_seq += 1
+        run_id = self._chip_run_seq
+        self._chip_runs[run_id] = chip_run
+        # chip_args is kept alive by the handle: the lane copies the args into
+        # its own storage, but the keepalive also pins the buffers the resolved
+        # descriptors point at for as long as the run can still read them.
+        return RunHandle(self, run_id, (callable_id, args, cfg, chip_args))
+
+    def _chip_run_for(self, run_id: int) -> Any | None:
+        return self._chip_runs.get(run_id)
+
     def _submit_l3_locked(self, callable, args, cfg: CallConfig) -> RunHandle:
         assert self._orch is not None
         assert self._worker is not None
@@ -9957,10 +9984,18 @@ class Worker:
         return handle
 
     def _run_handle_done(self, run_id: int) -> bool:
+        chip_run = self._chip_run_for(run_id)
+        if chip_run is not None:
+            return chip_run.done()
         assert self._orch is not None
         return self._orch._run_done(run_id)
 
     def _wait_run_handle(self, run_id: int, timeout: float | None) -> bool:
+        chip_run = self._chip_run_for(run_id)
+        if chip_run is not None:
+            # Negative means "no deadline" to the binding, which then blocks on
+            # the device instead of polling.
+            return chip_run.wait(-1.0 if timeout is None else max(0.0, timeout))
         assert self._orch is not None
         if timeout is None:
             self._orch._wait_run(run_id)
@@ -9980,6 +10015,16 @@ class Worker:
         _after_step: Any | None = None,
     ) -> BaseException | None:
         """Run fence-owned cleanup exactly once and return the cached result."""
+        # A direct-chip run owns no orchestration state: the lane finalized the
+        # native run as part of reaching terminal, and this worker built no
+        # domains, remote slots or chip regions for it. Retiring the lane entry
+        # is the whole of its cleanup, so it never enters the cursor below —
+        # driving those steps here would report a cleanup failure for state that
+        # was never created.
+        if run_id in self._chip_runs:
+            del self._chip_runs[run_id]
+            return native_error
+
         # Two different failures, deliberately not merged. A task that failed is
         # this run's business and says nothing about the worker; a cleanup that
         # failed leaves collective device state nobody can describe, and poisons
@@ -10081,8 +10126,8 @@ class Worker:
         # the reason the worker is now shut.
         return handle._finalization_error
 
-    def _run_l2_materialized(self, callable_id: int, args, cfg) -> None:
-        """Materialize an L2 leaf's tensor args to a chip-POD blob in-process and run the kernel.
+    def _materialize_l2_args(self, args) -> Any:
+        """Resolve an L2 leaf's tensor args to a chip-POD blob in this process.
 
         The user builds args as ``TaskArgs`` (``Tensor``) at every level; an L2 leaf is the consumer of
         its own args, so it does exactly what a chip child does — resolve each ref's embedded descriptor
@@ -10102,7 +10147,11 @@ class Worker:
         if args is None:
             args = TaskArgs()
         resolved = registry.materialize_args(args)
-        chip_args = materialize_task_args(args, resolved)
+        return materialize_task_args(args, resolved)
+
+    def _run_l2_materialized(self, callable_id: int, args, cfg) -> None:
+        """Materialize an L2 leaf's tensor args and run the kernel to completion."""
+        chip_args = self._materialize_l2_args(args)
         assert self._chip_worker is not None
         self._chip_worker._impl.run_materialized(callable_id, chip_args, cfg)
 
@@ -10693,6 +10742,27 @@ class Worker:
 
             def _finalize_chip() -> None:
                 if self._chip_worker:
+                    # Close the lane before finalizing the worker: a handle the
+                    # caller never waited on still owns device work, and the
+                    # lane drains it here while the device is still up.
+                    #
+                    # The lane rethrows its poison on close. Whether that is
+                    # news depends on who has already seen it: waiting on a
+                    # handle delivers the run's error and retires its entry, so
+                    # a remaining entry is a run whose failure nobody has been
+                    # told about, and only then is close the first report. With
+                    # every run waited, the poison is the error those waits
+                    # already raised, and re-raising it here would turn a
+                    # handled run failure into an unhandled close failure.
+                    impl = getattr(self._chip_worker, "_impl", None)
+                    if impl is not None:
+                        undelivered = bool(self._chip_runs)
+                        try:
+                            impl._close_chip_run_lane()
+                        except Exception:
+                            if undelivered:
+                                raise
+                    self._chip_runs.clear()
                     self._chip_worker.finalize()
                     self._chip_worker = None
 

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -509,8 +509,7 @@ void ChipWorker::run(
     int32_t accepted_value
 ) {
     if (args == nullptr) throw std::runtime_error("run requires task args");
-    if (run_lane_ == nullptr) throw std::runtime_error("ChipWorker run lane is not initialized");
-    ChipRun run = run_lane_->submit(callable_id, *args, config, accepted_state, accepted_value);
+    ChipRun run = submit_chip_run(callable_id, *args, config, accepted_state, accepted_value);
     (void)run.wait_until(ChipRun::Deadline::max());
 }
 
@@ -708,6 +707,14 @@ ChipRun ChipWorker::submit_chip_run(
     return run_lane_->submit(
         callable_id, args, config, lease, run_id, dispatch_id, accepted_state, accepted_value, activated
     );
+}
+
+ChipRun ChipWorker::submit_chip_run(
+    int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config, volatile int32_t *accepted_state,
+    int32_t accepted_value
+) {
+    if (run_lane_ == nullptr) throw std::runtime_error("ChipWorker run lane is not initialized");
+    return run_lane_->submit(callable_id, args, config, accepted_state, accepted_value);
 }
 
 void ChipWorker::close_chip_run_lane() {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -136,6 +136,13 @@ public:
         uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0,
         bool activated = true
     );
+    // Direct submission: no pipeline lease, so the lane admits at capacity one
+    // by draining its predecessor before this run enters the FIFO. run() is the
+    // blocking composition of this call and ChipRun::wait_until.
+    ChipRun submit_chip_run(
+        int32_t callable_id, const ChipStorageTaskArgs &args, const CallConfig &config,
+        volatile int32_t *accepted_state = nullptr, int32_t accepted_value = 0
+    );
     void close_chip_run_lane();
 
     // Per-callable_id preparation. Requires init() first and a callable_id

--- a/tests/ut/py/test_worker/_harness.py
+++ b/tests/ut/py/test_worker/_harness.py
@@ -102,6 +102,43 @@ def chip_callable(func_name: str = "x", binary: bytes = b"\x00") -> ChipCallable
     return ChipCallable.build(signature=[], func_name=func_name, binary=binary, children=[])
 
 
+class _FakeChipRun:
+    """The live handle a direct submit returns (native ``_ChipRun``).
+
+    A fake chip never executes its payload, so the run is already at its
+    completion fence; what it still has to model is that the handle is the
+    caller's, that waiting on it is idempotent, and that a failed run delivers
+    its error to whoever waits.
+    """
+
+    def __init__(self, error: BaseException | None = None) -> None:
+        self.wait_count = 0
+        self.error = error
+
+    def done(self) -> bool:
+        return True
+
+    def wait(self, timeout: float = -1.0) -> bool:
+        self.wait_count += 1
+        if self.error is not None:
+            raise self.error
+        return True
+
+    def activate(self) -> None:
+        pass
+
+    def abandon(self) -> None:
+        pass
+
+    @property
+    def launched(self) -> bool:
+        return True
+
+    @property
+    def lane_poisoned(self) -> bool:
+        return False
+
+
 class _FakeChipImpl:
     """The native-handle half of :class:`FakeChipWorker` (``cw._impl``)."""
 
@@ -109,6 +146,15 @@ class _FakeChipImpl:
 
     def __init__(self, register_error: str | None = None) -> None:
         self._register_error = register_error
+        self.submitted: list[tuple[int, Any]] = []
+        self.lane_closed = False
+        self.finalized = False
+        # Assigned by a test to make every subsequently submitted run deliver
+        # this error from wait(), the way a failed native run does.
+        self.run_error: BaseException | None = None
+        # Set when _close_chip_run_lane ran while the device was still up.
+        # Draining after finalize would wait on a device that is already gone.
+        self.lane_closed_before_finalize: bool | None = None
 
     def register_callable_from_blob(self, cid: int, addr: int) -> None:
         if self._register_error is not None:
@@ -116,6 +162,17 @@ class _FakeChipImpl:
 
     def run_materialized(self, *_a, **_k) -> None:
         """An L2 submit reaches the native handle here, with its args already materialized."""
+
+    def _submit_chip_run_direct(self, cid: int, args: Any, cfg: Any) -> _FakeChipRun:
+        """A direct submit admits at capacity one and returns the run while it runs."""
+        run = _FakeChipRun(self.run_error)
+        self.submitted.append((cid, run))
+        return run
+
+    def _close_chip_run_lane(self) -> None:
+        self.lane_closed = True
+        if self.lane_closed_before_finalize is None:
+            self.lane_closed_before_finalize = not self.finalized
 
 
 class FakeChipWorker:
@@ -175,7 +232,7 @@ class FakeChipWorker:
         pass
 
     def finalize(self) -> None:
-        pass
+        self._impl.finalized = True
 
 
 def fake_chip_worker(*, script: str = "ok", register_error: str | None = None):

--- a/tests/ut/py/test_worker/test_startup_readiness.py
+++ b/tests/ut/py/test_worker/test_startup_readiness.py
@@ -53,6 +53,15 @@ _TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
 _hard_timeout = hard_timeout
 
 
+def _raiser(exc: BaseException):
+    """A stand-in whose call always raises ``exc``."""
+
+    def _fn(*_a, **_k):
+        raise exc
+
+    return _fn
+
+
 def _run_catch(fn):
     """Run ``fn`` in a thread body, returning None on success or the exception."""
     try:
@@ -731,7 +740,7 @@ class TestLevel2Lifecycle:
             # A second close is a clean no-op (does not re-block on the epoch cv).
             w.close()
 
-    def test_l2_submit_returns_completed_handle(self, monkeypatch):
+    def test_l2_submit_returns_live_handle(self, monkeypatch):
         from simpler.task_interface import ChipCallable  # noqa: PLC0415
 
         w = self._make_l2(monkeypatch)
@@ -741,9 +750,125 @@ class TestLevel2Lifecycle:
             w.init()
             run_handle = w.submit(callable_handle)
             assert isinstance(run_handle, RunHandle)
+            # The handle is backed by a live lane run rather than born terminal:
+            # a fake chip reaches its fence immediately, so `done` says nothing
+            # here, but the run must be registered and waiting must reach it.
+            run_id = run_handle._run_id
+            assert run_id is not None
+            assert w._chip_run_for(run_id) is not None
+            assert run_handle.wait() is None
+            # Waiting retires the lane entry; the handle stays terminal and
+            # waiting again is idempotent rather than a second submit.
+            assert w._chip_run_for(run_id) is None
             assert run_handle.done
             assert run_handle.wait() is None
             w.close()
+
+    @pytest.mark.parametrize("timeout", [float("nan"), float("inf")])
+    def test_l2_wait_rejects_unrepresentable_timeout_before_the_binding(self, monkeypatch, timeout):
+        """A timeout the steady clock cannot express never reaches ``duration_cast``.
+
+        ``_ChipRun.wait`` converts a ``double`` to the clock's integral
+        representation, and converting NaN or an infinity that way is
+        undefined. The public surface never gets there: ``RunHandle._deadline``
+        rejects both as non-finite first, so this pins the outer gate that makes
+        the binding's own check defence in depth rather than the only guard.
+        """
+        from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+        w = self._make_l2(monkeypatch)
+        callable_handle = w.register(ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[]))
+        with _hard_timeout(_TEST_WALL_BUDGET_S):
+            w.init()
+            handle = w.submit(callable_handle)
+            with pytest.raises(ValueError, match="non-negative finite"):
+                handle.wait(timeout)
+            handle.wait()
+            w.close()
+
+    def test_l2_run_equals_submit_then_wait(self, monkeypatch):
+        """``run`` is the blocking composition of ``submit`` and ``wait``."""
+        from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+        w = self._make_l2(monkeypatch)
+        callable = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+        callable_handle = w.register(callable)
+        with _hard_timeout(_TEST_WALL_BUDGET_S):
+            w.init()
+            assert w._chip_worker is not None
+            impl = w._chip_worker._impl
+            w.run(callable_handle)
+            w.submit(callable_handle).wait()
+            # Both forms admit through the same lane entry point, so the direct
+            # path has one authority rather than a blocking bypass beside it.
+            assert len(impl.submitted) == 2
+            assert all(run.wait_count >= 1 for _cid, run in impl.submitted)
+            w.close()
+
+    def test_l2_unwaited_handle_is_drained_by_close(self, monkeypatch):
+        """A handle the caller drops still owns device work until close drains it."""
+        from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+        w = self._make_l2(monkeypatch)
+        callable = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+        callable_handle = w.register(callable)
+        with _hard_timeout(_TEST_WALL_BUDGET_S):
+            w.init()
+            assert w._chip_worker is not None
+            impl = w._chip_worker._impl
+            w.submit(callable_handle)  # deliberately never waited
+            assert not impl.lane_closed
+            w.close()
+            # close() drives the lane's own drain, where a failure is reported
+            # through the cleanup journal instead of being swallowed by the
+            # lane destructor — and it does so while the device is still up,
+            # since draining after finalize would wait on a device that is gone.
+            assert impl.lane_closed
+            assert impl.lane_closed_before_finalize is True
+
+    def test_l2_close_reports_lane_failure_only_when_undelivered(self, monkeypatch):
+        """Close re-raises the lane's poison only if no wait already delivered it.
+
+        The lane rethrows its poison on every close. A run whose handle was
+        waited on has already raised that error at the wait, so repeating it at
+        close would turn a failure the caller handled into an unhandled one —
+        which is what the onboard fault-injection scene tests do: they assert
+        ``run()`` raises and then close in a ``finally``.
+        """
+        from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+        callable = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+        boom = RuntimeError("chip run lane is poisoned")
+
+        # Waited: the error reached the caller at wait(), so close is silent.
+        w = self._make_l2(monkeypatch)
+        handle = w.register(callable)
+        with _hard_timeout(_TEST_WALL_BUDGET_S):
+            w.init()
+            assert w._chip_worker is not None
+            impl = w._chip_worker._impl
+            # The run itself fails, so waiting on the handle raises boom — the
+            # lane's poison and the caller's error are the same failure, which
+            # is what makes the close below a repeat rather than news.
+            impl.run_error = boom
+            monkeypatch.setattr(impl, "_close_chip_run_lane", _raiser(boom))
+            with pytest.raises(RuntimeError, match="poisoned"):
+                w.submit(handle).wait()
+            assert not w._chip_runs
+            w.close()
+
+        # Never waited: nobody has been told, so close is the first report.
+        w2 = self._make_l2(monkeypatch)
+        handle2 = w2.register(callable)
+        with _hard_timeout(_TEST_WALL_BUDGET_S):
+            w2.init()
+            assert w2._chip_worker is not None
+            impl2 = w2._chip_worker._impl
+            monkeypatch.setattr(impl2, "_close_chip_run_lane", _raiser(boom))
+            w2.submit(handle2)
+            assert w2._chip_runs
+            with pytest.raises(RuntimeError, match="poisoned"):
+                w2.close()
 
     def test_l2_close_without_init_is_noop(self, monkeypatch):
         w = self._make_l2(monkeypatch)


### PR DESCRIPTION
## Summary

`Worker.submit()` on an L2 worker ran the kernel to completion and returned `RunHandle._completed(...)` — a handle that was terminal before the caller ever saw it. Every other level already returned a handle whose run was still in flight, so the direct-chip path was the one place where `submit` and `run` meant the same thing. This is **W1b** of the worker async-pipeline track.

The lane already had the shape this needs. `ChipRunLane`'s unleased `submit` overload admits at capacity one — it drains the current front before taking the next run — and returns a `ChipRun` without waiting; `ChipWorker::run` is exactly that call composed with `ChipRun::wait_until`. So the change is to stop composing the two behind the caller's back: the Python direct path submits, and `RunHandle.wait()` owns the completion fence.

**Admission is unchanged.** A second submit still blocks until the first run is drained, because that is where the lane's capacity-one rule lives. What moves is only *when the first submit returns*. Successor policy is deliberately not part of this change — that is W1c.

## Ownership questions a live handle forces

Because the handle can now outlive the call that made it, two things get explicit answers rather than inherited ones:

- **Cleanup.** A direct-chip run owns no orchestration state, and the lane finalizes its native run as part of reaching terminal. So a chip-backed handle retires its lane entry instead of entering the run-finalization cursor; driving those steps for it would report a cleanup failure for state that was never built.
- **Close.** `close()` now drains the lane *while the device is still up*, so a handle the caller dropped is settled where its failure is reported rather than in the lane destructor, which swallows exceptions. The lane rethrows its poison on close, so close re-raises **only when a run's error has not already been delivered**: waiting on a handle raises that error and retires the entry, and re-raising it again would turn a run failure the caller *handled* into an unhandled close failure.

That last point is not hypothetical — it is a real defect this PR found and fixed. The onboard fault-injection scene tests are exactly that shape (assert `run()` raises, then `close()` in a `finally`), and an unconditional rethrow failed 12 of them on hardware. Both directions now have a regression test.

`run()` keeps its meaning as `submit(...).wait()` and remains the blocking composition of the same lane entry point, so the direct path still has one admission authority rather than a bypass beside it.

## Testing

| Suite | Result |
| --- | --- |
| Python UT (`tests/ut/py`) | **1284 passed**, 13 skipped |
| C++ UT (`ctest -LE requires_hardware`, CI's filter) | **91/91** |
| a2a3 onboard sweep (`task-submit`, device lock held) | **56 passed** + 24 passed / 2 skipped resource phase, 0 failures |
| a2a3sim sweep | **46 passed** / 1 skipped |

All match the pre-change baseline on `main`. The onboard and sim runs were repeated after the rebase onto `24d8e8fc`, since the base moved (#1747 merged) while this was in progress.

New coverage, each verified to fail against the old behavior before being kept:

- `test_l2_submit_returns_live_handle` — the handle is backed by a live lane run, and waiting retires it
- `test_l2_run_equals_submit_then_wait` — both forms admit through the same lane entry point
- `test_l2_unwaited_handle_is_drained_by_close` — pins that the drain happens *before* device finalize
- `test_l2_close_reports_lane_failure_only_when_undelivered` — both directions of the close-rethrow rule

## Note on one observed flake

`TestNextLevelStartupFailure::test_second_child_failure_reaps_first` failed once in six full-suite runs on this branch and passed 4/4 afterwards; it passes 3/3 on `main`. It is an L4→L3 fork/reap test with no chip worker and no L2, so it cannot reach this change's code path — but six runs is not enough to call it pre-existing, so I am flagging it rather than claiming it is unrelated.
