### PR TITLE
Add: enable direct-chip depth-two admission

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2168,7 +2168,8 @@ NB_MODULE(_task_interface, m) {
             },
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::call_guard<nb::gil_scoped_release>(),
             "Submit materialized task args to the chip native-run lane without a pipeline lease and return the live "
-            "run. The lane admits at capacity one: this call drains its predecessor before admitting."
+            "run. The lane follows the runtime PipelineContract: compatible runs admit one active plus one prepared "
+            "successor; otherwise this call drains its predecessor before admitting."
         )
         .def(
             "_prepare_native_run_materialized",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -9668,8 +9668,7 @@ class Worker:
         Dispatch:
           - L2: ``callable`` is a ``CallableHandle`` returned by
             ``Worker.register(chip_callable)``. Routes to the private slot
-            carried by the handle. The current L2 backend remains blocking, so
-            the returned handle is already complete.
+            carried by the handle and returns a live completion handle.
           - L3+: ``callable`` is a Python orch fn invoked with the
             ``Orchestrator`` handle. Graph construction completes synchronously;
             device completion is reported by the returned handle.
@@ -9907,11 +9906,10 @@ class Worker:
     def _submit_l2_locked(self, callable_id: int, args, cfg: CallConfig) -> RunHandle:
         """Admit one direct-chip run and return a handle to it while it runs.
 
-        The lane is the sole admission authority and takes runs at capacity one:
-        submitting drains the predecessor first, so a second submit blocks here
-        rather than overlapping device work. What the handle adds is that the
-        *first* submit no longer waits — the caller owns the completion fence
-        through :meth:`RunHandle.wait`.
+        The lane is the sole admission authority. Its runtime contract permits
+        one active plus one prepared compatible run; otherwise submission drains
+        the predecessor and retains depth-one behavior. The caller owns the
+        completion fence through :meth:`RunHandle.wait`.
         """
         assert self._chip_worker is not None
         chip_args = self._materialize_l2_args(args)

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -65,9 +65,13 @@ struct ChipRunLaneState {
         if (run->error != nullptr) std::rethrow_exception(run->error);
     }
 
-    bool permits_native_successor(const ChipRunState &predecessor, const ChipRunState &successor) const {
+    bool permits_native_successor(const ChipRunState &predecessor, const CallConfig &successor_config) const {
         return worker->supports_concurrent_native_prepare() && !predecessor.config.diagnostics_any() &&
-               !successor.config.diagnostics_any() && predecessor.phase == ChipRunState::Phase::LAUNCHED;
+               !successor_config.diagnostics_any() && predecessor.phase == ChipRunState::Phase::LAUNCHED;
+    }
+
+    bool permits_native_successor(const ChipRunState &predecessor, const ChipRunState &successor) const {
+        return permits_native_successor(predecessor, successor.config);
     }
 
     void prepare(const std::shared_ptr<ChipRunState> &run) {
@@ -155,7 +159,11 @@ struct ChipRunLaneState {
     bool progress(const std::shared_ptr<ChipRunState> &target) {
         if (target->phase == ChipRunState::Phase::TERMINAL) return true;
         if (fifo.empty()) throw std::runtime_error("chip run lane lost a nonterminal run");
-        if (fifo.front() != target) return false;
+        if (fifo.front() != target) {
+            (void)progress(fifo.front());
+            if (target->phase == ChipRunState::Phase::TERMINAL) return true;
+            if (fifo.empty() || fifo.front() != target) return false;
+        }
 
         launch_front();
         if (fifo.size() == 2 && fifo.front() == target) prepare_successor_if_eligible(fifo.back());
@@ -405,9 +413,34 @@ ChipRun ChipRunLane::submit(
 ) {
     std::lock_guard<std::mutex> lk(state_->mu);
     state_->require_usable();
-    if (!state_->fifo.empty()) state_->drain_front();
-    state_->require_usable();
     if (state_->generations.empty()) throw std::runtime_error("chip run lane has no runtime slots");
+
+    // Direct admission follows the runtime contract but keeps the lane as its
+    // only authority. A compatible active run may own one prepared successor;
+    // otherwise admission drains the front and retains depth-one behavior.
+    // In particular, the third submit waits here before a slot generation is
+    // minted or native preparation begins.
+    while (!state_->fifo.empty()) {
+        const bool has_successor_capacity =
+            state_->fifo.size() == 1 && state_->permits_native_successor(*state_->fifo.front(), config);
+        if (has_successor_capacity) break;
+        state_->drain_front();
+        state_->require_usable();
+        state_->launch_front();
+    }
+
+    uint32_t slot_id = 0;
+    for (; slot_id < state_->generations.size(); ++slot_id) {
+        const bool occupied = std::any_of(
+            state_->fifo.begin(), state_->fifo.end(), [slot_id](const std::shared_ptr<ChipRunState> &candidate) {
+                return candidate->lease.slot_id == slot_id;
+            }
+        );
+        if (!occupied) break;
+    }
+    if (slot_id == state_->generations.size()) {
+        throw std::runtime_error("chip run lane has no free direct runtime slot after admission");
+    }
     if (state_->direct_generation == std::numeric_limits<uint64_t>::max()) {
         throw std::overflow_error("chip run lane exhausted its direct generation space");
     }
@@ -417,13 +450,17 @@ ChipRun ChipRunLane::submit(
     run->callable_id = callable_id;
     run->args = args;
     run->config = config;
-    run->lease = PipelineSlotLease{0, 0, state_->direct_generation};
+    run->lease = PipelineSlotLease{slot_id, 0, state_->direct_generation};
     run->accepted_state = accepted_state;
     run->accepted_value = accepted_value;
     run->pipeline_leased = false;
     run->activated = true;
     state_->fifo.push_back(run);
-    state_->launch_front();
+    if (state_->fifo.front() == run) {
+        state_->launch_front();
+    } else {
+        state_->prepare_successor_if_eligible(run);
+    }
     return ChipRun(state_, std::move(run));
 }
 

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -11,9 +11,15 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <mutex>
+#include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -46,6 +52,11 @@ size_t g_poll_count{0};
 // UnboundedWaitBlocksInsteadOfPolling sets it, so that a regression there fails
 // on the poll count instead of looping forever.
 size_t g_poll_completes_after{0};
+bool g_supports_successor{true};
+std::mutex g_wait_mu;
+std::condition_variable g_wait_cv;
+bool g_wait_entered{false};
+bool g_release_wait{true};
 std::vector<std::string> g_events;
 
 uint32_t slot_of(void *runtime) { return g_slots.at(runtime); }
@@ -80,6 +91,14 @@ int poll_run(void *, void *runtime) {
 int wait_run(void *, void *runtime) {
     const uint32_t slot = slot_of(runtime);
     g_events.push_back("wait" + std::to_string(slot));
+    {
+        std::unique_lock<std::mutex> lk(g_wait_mu);
+        g_wait_entered = true;
+        g_wait_cv.notify_all();
+        g_wait_cv.wait(lk, [] {
+            return g_release_wait;
+        });
+    }
     g_complete[slot] = true;
     return g_wait_rc[slot];
 }
@@ -90,7 +109,7 @@ int finalize_run(void *, void *runtime) {
     return g_finalize_rc[slot];
 }
 
-int supports_successor(void *) { return 1; }
+int supports_successor(void *) { return g_supports_successor ? 1 : 0; }
 
 void prime_worker(ChipWorker &worker) {
     g_slots.clear();
@@ -104,6 +123,12 @@ void prime_worker(ChipWorker &worker) {
     g_reject_first_prepare = {};
     g_poll_count = 0;
     g_poll_completes_after = 0;
+    g_supports_successor = true;
+    {
+        std::lock_guard<std::mutex> lk(g_wait_mu);
+        g_wait_entered = false;
+        g_release_wait = true;
+    }
     g_events.clear();
     worker.initialized_ = true;
     worker.pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 2, {}};
@@ -270,6 +295,110 @@ TEST(ChipRunLaneTest, DirectGenerationDoesNotConsumeTheFirstPipelineLease) {
     EXPECT_TRUE(leased.launched());
     g_complete[0] = true;
     EXPECT_TRUE(leased.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, DirectCapacityTwoPreparesSuccessorAndBackpressuresThird) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipStorageTaskArgs args{};
+
+    ChipRun first = lane.submit(1, args, CallConfig{});
+    ChipRun second = lane.submit(1, args, CallConfig{});
+    EXPECT_TRUE(first.launched());
+    EXPECT_FALSE(second.launched());
+    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::NATIVE_PREPARED);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1"}));
+
+    {
+        std::lock_guard<std::mutex> lk(g_wait_mu);
+        g_release_wait = false;
+    }
+    std::optional<ChipRun> third;
+    std::exception_ptr submit_error;
+    std::thread submitter([&] {
+        try {
+            third.emplace(lane.submit(1, args, CallConfig{}));
+        } catch (...) {
+            submit_error = std::current_exception();
+        }
+    });
+
+    bool entered_wait = false;
+    {
+        std::unique_lock<std::mutex> lk(g_wait_mu);
+        entered_wait = g_wait_cv.wait_for(lk, std::chrono::seconds(1), [] {
+            return g_wait_entered;
+        });
+    }
+    EXPECT_TRUE(entered_wait);
+    EXPECT_EQ(g_prepare_count[0], 1u) << "third submit prepared before capacity released";
+    EXPECT_EQ(g_prepare_count[1], 1u);
+    {
+        std::lock_guard<std::mutex> lk(g_wait_mu);
+        g_release_wait = true;
+    }
+    g_wait_cv.notify_all();
+    submitter.join();
+
+    ASSERT_EQ(submit_error, nullptr);
+    ASSERT_TRUE(third.has_value());
+    EXPECT_TRUE(second.launched());
+    EXPECT_FALSE(third->launched());
+    EXPECT_EQ(third->preparation_disposition(), ChipRunPreparationDisposition::NATIVE_PREPARED);
+    EXPECT_EQ(g_prepare_count[0], 2u);
+
+    g_complete[1] = true;
+    EXPECT_TRUE(second.done());
+    EXPECT_TRUE(third->launched());
+    g_complete[0] = true;
+    EXPECT_TRUE(third->done());
+    EXPECT_TRUE(first.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, DirectIncompatibleSuccessorRetriesAfterPredecessorFence) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipStorageTaskArgs args{};
+
+    ChipRun first = lane.submit(1, args, CallConfig{});
+    g_reject_first_prepare[1] = true;
+    ChipRun second = lane.submit(1, args, CallConfig{});
+    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::VALIDATED_ONLY);
+    EXPECT_EQ(g_prepare_count[1], 1u);
+
+    g_complete[0] = true;
+    EXPECT_FALSE(second.done());
+    EXPECT_TRUE(first.done());
+    EXPECT_TRUE(second.launched());
+    EXPECT_EQ(g_prepare_count[1], 2u);
+    g_complete[1] = true;
+    EXPECT_TRUE(second.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, DirectRuntimeWithoutConcurrentPrepareRetainsDepthOne) {
+    ChipWorker worker;
+    prime_worker(worker);
+    g_supports_successor = false;
+    ChipRunLane lane(worker);
+    ChipStorageTaskArgs args{};
+
+    ChipRun first = lane.submit(1, args, CallConfig{});
+    ChipRun second = lane.submit(1, args, CallConfig{});
+
+    EXPECT_TRUE(first.done());
+    EXPECT_TRUE(second.launched());
+    EXPECT_EQ(g_prepare_count[0], 2u);
+    EXPECT_EQ(g_prepare_count[1], 0u);
+    g_complete[0] = true;
+    EXPECT_TRUE(second.done());
     lane.close();
     worker.finalize();
 }


### PR DESCRIPTION
## Summary

- let the direct-chip `ChipRunLane` follow the runtime `PipelineContract`: compatible runs admit one active run plus one prepared successor
- keep depth-one admission when the runtime cannot prepare concurrently or native preparation reports an incompatible successor
- backpressure the third direct submission before selecting a slot, minting a generation, or starting native preparation
- let a successor handle advance its FIFO predecessor during `done()` and bounded `wait()` calls

This is W1c on top of #1748. It does not add a Python-side FIFO or change endpoint, RequestSession, profiling, or cross-repository behavior.

## Testing

- `ctest --test-dir tests/ut/cpp/build-w1c -LE requires_hardware --output-on-failure` (91/91 passed)
- `ctest --test-dir tests/ut/cpp/build-w1c -R "^test_chip_run_lane$" --output-on-failure`
- `clang-format --dry-run --Werror src/common/worker/chip_run_lane.cpp tests/ut/cpp/hierarchical/test_chip_run_lane.cpp`
- `.venv/bin/python -m pyright python/simpler/worker.py`