### PR TITLE
Fix: reject Buffer release while an in-flight run still references it

### DIFF
--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -351,6 +351,7 @@ class Orchestrator:
                 worker._child_prov_check_dispatch(child_ptrs, cpp_worker_id, api="submit_next_level")
             if worker is not None:
                 worker._adopt_remote_sidecar_refs((remote_sidecar,))
+                worker._record_touched_identities(c_args)
             _admit_task_submission(self._worker)
             self._o.submit_next_level(
                 digest, kind, target_namespace, c_args, cfg, cpp_worker_id, final_worker_ids, remote_sidecar
@@ -440,6 +441,9 @@ class Orchestrator:
                 worker._child_prov_check_dispatch(child_ptrs, target_worker_id, api="submit_next_level_group")
             if worker is not None and remote_sidecars is not None:
                 worker._adopt_remote_sidecar_refs(remote_sidecars)
+            if worker is not None:
+                for c_args in c_args_list:
+                    worker._record_touched_identities(c_args)
             _admit_task_submission(self._worker)
             self._o.submit_next_level_group(
                 digest, kind, target_namespace, c_args_list, cfg, worker_ids, worker_id_sets, remote_sidecars

--- a/python/simpler/remote_l3_session.py
+++ b/python/simpler/remote_l3_session.py
@@ -186,11 +186,16 @@ class _RemoteBufferEntry:
             # A Buffer always unlinks its own backing on close, so ``unlink`` does not apply here.
             # Releasing through the owning Worker is what additionally drops its registry entry; a
             # session-scoped Buffer has no such entry and closes directly.
-            owner, self.owner = self.owner, None
+            owner = self.owner
             if owner is None:
                 self.data.close()
             else:
-                owner._release_buffer(self.data)  # noqa: SLF001
+                # release_buffer() can raise (the Buffer is still referenced by an in-flight run):
+                # self.owner must stay set until it actually succeeds, or a retried close() would
+                # see owner=None and fall through to self.data.close() -- bypassing the in-flight
+                # guard entirely and leaving the owner's registry entry behind.
+                owner.release_buffer(self.data)
+            self.owner = None
             return
         if not isinstance(self.data, shared_memory.SharedMemory):
             self.owner = None

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -3493,6 +3493,10 @@ class _RunResources:
     pending_release_global_domains: list[GlobalCommDomainHandle] = field(default_factory=list)
     worker_chip_regions: list[Any] = field(default_factory=list)
     worker_chip_orch_comm_host_buffers: dict[int, int] = field(default_factory=dict)
+    # Every Buffer identity a NEXT_LEVEL dispatch (submit_next_level / _group) sent as a Tensor
+    # arg during this run. release_buffer() checks this set across every not-yet-settled run before
+    # releasing, so a Buffer never goes away while a dispatched task still names it.
+    touched_identities: set[CanonicalIdentity] = field(default_factory=set)
     # True once the owning run's fence has claimed the domains above. A release
     # that arrives after this has no fence left to run behind and frees inline.
     # Read and written only under `domain_lock`.
@@ -9228,6 +9232,20 @@ class Worker:
                 out.append((int.from_bytes(desc.body[:8], "little"), i))
         return out
 
+    def _record_touched_identities(self, args: Any) -> None:
+        """Add every tensor arg's identity in ``args`` to the current run's touched set.
+
+        A no-op when no run is being built (``_building_run_resources is None``) — tracking is
+        opportunistic, only meaningful inside ``submit_next_level``/``submit_next_level_group``'s
+        run context, per the ``current_resources = self._building_run_resources; if ... is not
+        None`` idiom used elsewhere for the same "attach to the open run, if any" shape.
+        """
+        resources = self._building_run_resources
+        if resources is None:
+            return
+        for i in range(args.tensor_count()):
+            resources.touched_identities.add(args.tensor(i).buffer.identity)
+
     def _child_prov_check_dispatch(self, child_ptrs: list[tuple[int, int]], target_worker_id: int, *, api: str) -> None:
         """Validate every child_memory pointer against its exact target worker."""
         if not child_ptrs:
@@ -9623,13 +9641,26 @@ class Worker:
             self._chip_import_registry.close()
             self._chip_import_registry = None
 
-    def _release_buffer(self, buffer: Buffer) -> None:
+    def release_buffer(self, buffer: Buffer) -> None:
         """Close + unlink one owner Buffer and drop its registry entry.
 
-        The entry survives a failed close, so ``_release_all_buffers`` still reports the leak at
-        close() rather than losing it here. Idempotent for a buffer already released. The slot is
-        dropped only when it still holds *this* buffer: a buffer_id minted elsewhere can collide
-        with a registry key, and evicting the live entry it names would strand that backing."""
+        Rejects outright if any currently in-flight run (not yet past ``_cleanup_published``) sent
+        this identity as a NEXT_LEVEL Tensor arg — a Buffer never goes away while a dispatched task
+        still names it. Takes ``_submit_mu`` first: a handle is visible in ``_accepted_run_handles``
+        before its orchestration callback (where ``touched_identities`` gets populated) has run, and
+        that callback is what ``_submit_mu`` already serializes graph construction against, so taking
+        it here means the check only ever runs between callbacks, never mid-callback with a
+        not-yet-complete touched set. Not checked once ``buffer`` is already closed, matching
+        ``Buffer.close()``'s own idempotency. The entry survives a failed close, so
+        ``_release_all_buffers`` still reports the leak at close() rather than losing it here. The
+        slot is dropped only when it still holds *this* buffer: a buffer_id minted elsewhere can
+        collide with a registry key, and evicting the live entry it names would strand that
+        backing."""
+        if not buffer.closed:
+            with self._submit_mu, self._hierarchical_start_cv:
+                for handle in self._accepted_run_handles:
+                    if not handle._cleanup_published and buffer.identity in handle._resources.touched_identities:
+                        raise RuntimeError(f"release_buffer: {buffer.identity} is still referenced by an in-flight run")
         buffer.close()
         with self._registry_lock:
             buffer_id = int(buffer.identity.buffer_id)

--- a/tests/ut/py/test_remote_l3_lifecycle.py
+++ b/tests/ut/py/test_remote_l3_lifecycle.py
@@ -19,7 +19,7 @@ from typing import cast
 import pytest
 from simpler import remote_l3_session, remote_l3_worker
 from simpler.buffer import create_host_shared_buffer, mint_owner_instance_id
-from simpler.worker import Worker
+from simpler.worker import RunHandle, Worker, _RunResources
 
 
 def _manifest(**extra):
@@ -943,7 +943,7 @@ def test_serve_real_socket_survives_truncated_frame_then_serves_next(monkeypatch
 
 
 def _bare_l3_worker():
-    """An L3 Worker with the state ``_create_buffer_locked`` and ``_release_buffer`` read — no
+    """An L3 Worker with the state ``_create_buffer_locked`` and ``release_buffer`` read — no
     fork, no device, no ``init()``."""
     w = Worker.__new__(Worker)
     w.level = 3
@@ -954,6 +954,10 @@ def _bare_l3_worker():
     w._owner_instance_id = mint_owner_instance_id()
     w._buffer_id_counter = 1
     w._buffers = {}
+    w._hierarchical_start_mu = threading.Lock()
+    w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
+    w._accepted_run_handles = set()
+    w._submit_mu = threading.Lock()
     return w
 
 
@@ -972,6 +976,35 @@ def test_owner_buffer_entry_reads_the_buffer_backing():
     entry.close(unlink=True)
     assert buffer.shm is None  # closed and unlinked by its owner
     assert not w._buffers  # and the owner's registry entry went with it
+    assert entry.owner is None
+
+
+def test_owner_buffer_entry_retains_owner_across_a_rejected_release():
+    # close() must not clear self.owner before release_buffer() actually succeeds: if it raises
+    # (an in-flight run still references this identity), a retried close() has to go through the
+    # guard again, not fall through to a direct self.data.close() that bypasses it.
+    w = _bare_l3_worker()
+    buffer = w._create_buffer_locked(64)
+    entry = remote_l3_session._RemoteBufferEntry(
+        buffer, 64, 1, remote_l3_session.RemoteAddressSpace.REMOTE_DEVICE, owner=w
+    )
+    resources = _RunResources()
+    resources.touched_identities.add(buffer.identity)
+    handle = RunHandle(w, run_id=1, keepalive=())
+    handle._resources = resources
+    handle._cleanup_published = False
+    w._accepted_run_handles.add(handle)
+
+    with pytest.raises(RuntimeError, match="in-flight run"):
+        entry.close(unlink=True)
+    assert entry.owner is w
+    assert not buffer.closed
+    assert w._buffers  # registry entry survives the rejection too
+
+    handle._cleanup_published = True
+    entry.close(unlink=True)
+    assert buffer.closed
+    assert not w._buffers
     assert entry.owner is None
 
 

--- a/tests/ut/py/test_worker/test_create_buffer.py
+++ b/tests/ut/py/test_worker/test_create_buffer.py
@@ -34,6 +34,10 @@ def _bare_worker(level: int, *, chip: int = 0, sub: int = 0, next_level: int = 0
     w._owner_instance_id = mint_owner_instance_id()
     w._buffer_id_counter = 1
     w._buffers = {}
+    w._hierarchical_start_mu = threading.Lock()
+    w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
+    w._accepted_run_handles = set()
+    w._submit_mu = threading.Lock()
     return w
 
 
@@ -123,11 +127,11 @@ def test_release_buffer_drops_only_its_own_entry():
     try:
         keep = w._create_buffer_locked(32)
         drop = w._create_buffer_locked(32)
-        w._release_buffer(drop)
+        w.release_buffer(drop)
         assert drop.shm is None
         assert list(w._buffers.values()) == [keep]
         # A second release of the same buffer is a no-op, not a KeyError on the registry.
-        w._release_buffer(drop)
+        w.release_buffer(drop)
         assert list(w._buffers.values()) == [keep]
     finally:
         _drain(w)
@@ -146,7 +150,7 @@ def test_release_buffer_keeps_the_entry_when_close_fails():
 
     bad.close = boom  # type: ignore[method-assign]
     with pytest.raises(OSError, match="close failed"):
-        w._release_buffer(bad)
+        w.release_buffer(bad)
     assert bad_id in w._buffers
     bad.close = real_close  # type: ignore[method-assign]
     _drain(w)

--- a/tests/ut/py/test_worker/test_release_buffer.py
+++ b/tests/ut/py/test_worker/test_release_buffer.py
@@ -1,0 +1,194 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""``Worker.release_buffer()``: rejects release while an in-flight run still references the
+buffer's identity, and how that identity gets tracked in the first place.
+
+L2 never needs this: a run completes synchronously inside ``submit()`` (``RunHandle._completed``),
+so there is never an in-flight window. Tracking hooks the two L3+ async dispatch entry points,
+``Orchestrator.submit_next_level`` / ``.submit_next_level_group``, device-free via the same
+fake-C++-orchestrator harness ``test_child_addr_guard.py`` already established.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from _task_interface import DataType, TensorArgType
+from simpler.buffer import create_host_shared_buffer, mint_owner_instance_id
+from simpler.orchestrator import Orchestrator
+from simpler.task_interface import TaskArgs
+from simpler.worker import RunHandle, Worker, _RunResources
+
+_F32 = 0  # DataType.FLOAT32 value
+_OID = mint_owner_instance_id()
+
+
+def _l3() -> Worker:
+    return Worker(level=3, num_sub_workers=0, platform="a2a3sim", runtime="tensormap_and_ringbuffer")
+
+
+def _buffer_args(buf) -> TaskArgs:
+    args = TaskArgs()
+    args.add_tensor(buf.tensor(shapes=(16,), dtype=DataType.FLOAT32), TensorArgType.INPUT)
+    return args
+
+
+def _fake_orchestrator(w: Worker, monkeypatch: pytest.MonkeyPatch) -> Orchestrator:
+    import simpler.orchestrator as orch_mod  # noqa: PLC0415
+
+    def _fake_require_handle(callable_handle, **_kw):
+        return (b"d" * 32, "NEXT_LEVEL", "LOCAL_CHIP", (0,))
+
+    monkeypatch.setattr(orch_mod, "_require_handle", _fake_require_handle)
+    return Orchestrator(MagicMock(), w)
+
+
+class TestTouchedIdentityTracking:
+    def test_submit_next_level_records_touched_identity(self, monkeypatch):
+        w = _l3()
+        o = _fake_orchestrator(w, monkeypatch)
+        w._building_run_resources = _RunResources()
+        buf = create_host_shared_buffer(64, _OID, buffer_id=1)
+        try:
+            o.submit_next_level(object(), _buffer_args(buf), None, worker=0)
+            assert buf.identity in w._building_run_resources.touched_identities
+        finally:
+            buf.close()
+
+    def test_submit_next_level_group_records_touched_identity_per_member(self, monkeypatch):
+        w = _l3()
+        w._chip_shms = [object(), object()]
+        o = _fake_orchestrator(w, monkeypatch)
+        w._building_run_resources = _RunResources()
+        buf_a = create_host_shared_buffer(64, _OID, buffer_id=2)
+        buf_b = create_host_shared_buffer(64, _OID, buffer_id=3)
+        try:
+            o.submit_next_level_group(object(), [_buffer_args(buf_a), _buffer_args(buf_b)], None, workers=[0, 1])
+            touched = w._building_run_resources.touched_identities
+            assert buf_a.identity in touched
+            assert buf_b.identity in touched
+        finally:
+            buf_a.close()
+            buf_b.close()
+
+    def test_no_current_run_is_a_no_op(self, monkeypatch):
+        # submit_next_level runs fine with no _building_run_resources open (e.g. a direct call
+        # outside a run's orchestration callback) -- tracking is opportunistic, not required.
+        w = _l3()
+        o = _fake_orchestrator(w, monkeypatch)
+        assert w._building_run_resources is None
+        buf = create_host_shared_buffer(64, _OID, buffer_id=4)
+        try:
+            o.submit_next_level(object(), _buffer_args(buf), None, worker=0)  # must not raise
+        finally:
+            buf.close()
+
+
+def _in_flight_handle(w: Worker, identity, *, done: bool) -> RunHandle:
+    resources = _RunResources()
+    resources.touched_identities.add(identity)
+    handle = RunHandle(w, run_id=1, keepalive=())
+    handle._resources = resources
+    handle._cleanup_published = done
+    return handle
+
+
+def _l3_with_registered_buffer(nbytes: int = 64):
+    """An L3 Worker (one fake chip child, so create_buffer's topology gate passes) plus one
+    buffer already registered in w._buffers, the way Worker.create_buffer() would leave it."""
+    w = _l3()
+    w._chip_shms = [object()]
+    buf = w._create_buffer_locked(nbytes)
+    return w, buf
+
+
+class TestReleaseBuffer:
+    def test_rejects_while_in_flight(self):
+        w, buf = _l3_with_registered_buffer()
+        w._accepted_run_handles.add(_in_flight_handle(w, buf.identity, done=False))
+        with pytest.raises(RuntimeError, match="in-flight run"):
+            w.release_buffer(buf)
+        assert not buf.closed
+        buffer_id = int(buf.identity.buffer_id)
+        assert w._buffers.get(buffer_id) is buf  # rejection must not half-apply the registry drop
+        w._accepted_run_handles.clear()
+        w.release_buffer(buf)  # cleanup
+
+    def test_succeeds_once_run_completed(self):
+        w, buf = _l3_with_registered_buffer()
+        w._accepted_run_handles.add(_in_flight_handle(w, buf.identity, done=True))
+        w.release_buffer(buf)
+        assert buf.closed
+        assert int(buf.identity.buffer_id) not in w._buffers
+
+    def test_succeeds_with_no_in_flight_runs(self):
+        w, buf = _l3_with_registered_buffer()
+        w.release_buffer(buf)
+        assert buf.closed
+        assert int(buf.identity.buffer_id) not in w._buffers
+
+    def test_is_idempotent(self):
+        w, buf = _l3_with_registered_buffer()
+        w.release_buffer(buf)
+        w.release_buffer(buf)  # must not raise
+        assert buf.closed
+
+    def test_serializes_with_a_racing_orchestration_callback(self):
+        # _submit_l3_locked adds a run's handle to _accepted_run_handles (worker.py:9910) BEFORE
+        # its orchestration callback runs -- the callback is what eventually records
+        # touched_identities via submit_next_level. Without taking _submit_mu (the same lock that
+        # already serializes graph construction, worker.py:9741), release_buffer could observe the
+        # handle with an empty touched_identities mid-callback and release a Buffer the callback is
+        # about to dispatch a Tensor over. This drives that exact window directly.
+        w, buf = _l3_with_registered_buffer()
+        resources = _RunResources()
+        handle = RunHandle(w, run_id=1, keepalive=())
+        handle._resources = resources
+        handle._cleanup_published = False
+
+        entered_callback = threading.Event()
+        proceed = threading.Event()
+        release_returned = threading.Event()
+
+        def fake_orchestration_callback():
+            with w._submit_mu:
+                with w._hierarchical_start_cv:
+                    w._accepted_run_handles.add(handle)
+                entered_callback.set()
+                proceed.wait(timeout=5)  # simulates the callback still building its graph
+                # simulates submit_next_level's _record_touched_identities -- _submit_mu held
+                # continuously from before the handle is visible until this point, exactly as
+                # _submit_l3_locked holds it across the whole orchestration callback.
+                resources.touched_identities.add(buf.identity)
+
+        callback_thread = threading.Thread(target=fake_orchestration_callback)
+        callback_thread.start()
+        assert entered_callback.wait(timeout=5)
+
+        def try_release():
+            try:
+                w.release_buffer(buf)
+            except RuntimeError:
+                pass
+            finally:
+                release_returned.set()
+
+        releaser = threading.Thread(target=try_release)
+        releaser.start()
+        # release_buffer must block behind _submit_mu, not race past it while touched_identities
+        # is still empty.
+        assert not release_returned.wait(timeout=0.3)
+
+        proceed.set()
+        callback_thread.join(timeout=5)
+        releaser.join(timeout=5)
+        assert release_returned.is_set()
+        assert not buf.closed  # correctly rejected once it could finally check -- not released mid-race


### PR DESCRIPTION
## Summary

The memory-model design doc's P1-B lifecycle table wants a released Buffer's `release_buffer()` to refuse the release while an unfinished consumer still holds a reference. That check didn't exist. Mid-implementation I found `Worker._release_buffer()` (private) already closes a Buffer and drops its registry entry — used by `_release_all_buffers()` at `Worker.close()` and by `remote_l3_session.py`'s `RemoteBufferHandle.close()` for a session-scoped buffer — so this builds on that instead of adding a second, parallel public method:

- **`_RunResources` gains `touched_identities`**: every identity a NEXT_LEVEL `Tensor` arg carries during a run's orchestration. L2 never needs this — a run completes synchronously inside `submit()` (`RunHandle._completed`, never added to `_accepted_run_handles`), so there's never an in-flight window there. `Orchestrator.submit_next_level`/`.submit_next_level_group` already walk every tensor arg once per call (for the existing device-pointer provenance guard); a new `Worker._record_touched_identities` walks the same args once more into the current run's touched set.
- **`_release_buffer` is renamed to public `release_buffer`** (the design doc's literal ask) and now checks, before closing: is this identity in the touched set of any accepted-but-not-yet-cleaned-up run? If so it raises immediately — reject, not block, matching the codebase's existing fail-fast admission-fence style.

**Two other pieces of the same design-doc epic were explicitly scoped out** after checking the code:
- `buffer_id` reuse + a generation bump on reuse — `buffer_id` is a `uint64_t` that `_next_buffer_id()` only ever increments; no resource-exhaustion pressure justifies building reuse machinery nothing needs.
- Broadcasting release to consumer processes so they proactively drop a cached import — needs a cross-process mechanism similar to `Worker.unregister`'s callable-cleanup broadcast. A consumer that later re-resolves a released identity fails loudly instead of corrupting silently, so leaving this for a separate change is not unsafe.

## Test plan

- [x] New tests (`tests/ut/py/test_worker/test_release_buffer.py`): `submit_next_level`/`_group` correctly record touched identities device-free (reusing `test_child_addr_guard.py`'s fake-C++-orchestrator harness) and are a no-op with no run context open; `release_buffer` rejects while a fake in-flight handle references the identity (registry entry survives the rejection), succeeds once that handle is done/absent, stays idempotent
- [x] `pytest tests/ut` — 1295 passed / 13 skipped / 0 failed
- [x] `ruff check` / `ruff format --check` clean
- [x] Real onboard a2a3 run (`test_l3_tensor_dispatch.py`, 2 devices) exercising the touched-identity walk on the real dispatch path
- [x] `test_l3_create_buffer.py` under its own `a2a3sim` platform restriction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
