### PR TITLE
Test: mirror a2a3 scope-guard regression to a5 and fix stale TMR docs

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -27,7 +27,7 @@ Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 task_id.raw = (ring_id << 32) | local_id
 ```
 
-`PTO2TaskId` exposes direct accessors in `pto_runtime2_types.h`:
+`PTO2TaskId` exposes direct accessors in `src/common/task_interface/pto_task_id.h`:
 
 | API | Purpose |
 | --- | ------- |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -127,8 +127,8 @@ On each trb bind, `RetainedTempBump`:
   falls back to `device_malloc` mid-run.
 
 Slices are recorded as `BufferNoop` leases: per-tensor release is a no-op, and
-the retained buffer is neither freed at end of run nor per run — it lives on
-the runner and is freed once in `finalize`. The uniform host-runtime contract
+the retained buffer is neither freed at end of run nor per run — each slot's
+buffer lives on the runner and is freed once in `finalize`. The uniform host-runtime contract
 requires the retained-buffer callbacks on every backend; bind has no
 per-tensor allocation fallback.
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -27,7 +27,7 @@ Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 task_id.raw = (ring_id << 32) | local_id
 ```
 
-`PTO2TaskId` exposes direct accessors in `pto_runtime2_types.h`:
+`PTO2TaskId` exposes direct accessors in `src/common/task_interface/pto_task_id.h`:
 
 | API | Purpose |
 | --- | ------- |

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -50,6 +50,9 @@ struct FakeRuntime {
 };
 
 static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast below assumes ops is first member.
+static_assert(
+    offsetof(FakeRuntime, pending_scope_mode) == offsetof(PTO2Runtime, pending_scope_mode)
+);  // ...and pending_scope_mode follows ops, matching the PTO2Runtime prefix the inline scope wrappers pun through.
 
 FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
@@ -189,6 +192,8 @@ TEST(A2A3Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
     RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    runtime.pending_scope_mode = PTO2ScopeMode::MANUAL;
 
     {
         PTO2_SCOPE_GUARD();

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -28,11 +28,13 @@ extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; 
 
 struct FakeRuntime {
     const PTO2RuntimeOps *ops;
+    PTO2ScopeMode pending_scope_mode = PTO2ScopeMode::AUTO;
     bool fatal = false;
     int submit_calls = 0;
     int alloc_calls = 0;
     int scope_begin_calls = 0;
     int scope_end_calls = 0;
+    PTO2ScopeMode last_scope_mode = PTO2ScopeMode::AUTO;
     int get_calls = 0;
     int set_calls = 0;
     int report_fatal_calls = 0;
@@ -42,6 +44,9 @@ struct FakeRuntime {
 };
 
 static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast below assumes ops is first member.
+static_assert(
+    offsetof(FakeRuntime, pending_scope_mode) == offsetof(PTO2Runtime, pending_scope_mode)
+);  // ...and pending_scope_mode follows ops, matching the PTO2Runtime prefix the inline scope wrappers pun through.
 
 FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
@@ -50,7 +55,11 @@ TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const CoreT
     return TaskOutputTensors{};
 }
 
-void fake_scope_begin(PTO2Runtime *rt) { as_fake(rt)->scope_begin_calls++; }
+void fake_scope_begin(PTO2Runtime *rt) {
+    FakeRuntime *fake = as_fake(rt);
+    fake->scope_begin_calls++;
+    fake->last_scope_mode = fake->pending_scope_mode;
+}
 void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
 void fake_orchestration_done(PTO2Runtime *) {}
 bool fake_is_fatal(PTO2Runtime *rt) { return as_fake(rt)->fatal; }
@@ -171,6 +180,32 @@ TEST(A5Fatal, ExplicitFatalRoutesThroughOps) {
     CoreTaskArgs args;
     EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_EQ(runtime.submit_calls, 0);
+}
+
+TEST(A5Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    runtime.pending_scope_mode = PTO2ScopeMode::MANUAL;
+
+    {
+        PTO2_SCOPE_GUARD();
+        EXPECT_EQ(runtime.scope_begin_calls, 1);
+        EXPECT_EQ(runtime.scope_end_calls, 0);
+        EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::AUTO);
+    }
+
+    EXPECT_EQ(runtime.scope_end_calls, 1);
+
+    {
+        PTO2_SCOPE_GUARD(PTO2ScopeMode::MANUAL);
+        EXPECT_EQ(runtime.scope_begin_calls, 2);
+        EXPECT_EQ(runtime.scope_end_calls, 1);
+        EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::MANUAL);
+    }
+
+    EXPECT_EQ(runtime.scope_end_calls, 2);
 }
 
 TEST(A5Fatal, AllocTensorConvenienceReportsInvalidArgsInsteadOfAsserting) {


### PR DESCRIPTION
## Summary

Closes the two P4/P5 residuals flagged in #1582's 2026-08-09 re-audit (after #1718 landed).

### R1 — a5 lacked the scope-guard regression test that a2a3 gained in #1718

a5's `PTO2_SCOPE_GUARD(...)` has been variadic (and its MANUAL path live — `rt_scope_begin` reads `pending_scope_mode` and forwards it to `begin_scope(mode)`) since the #1100 import, but `ut-a5` would not catch a regression in MANUAL forwarding. Mirrored `ScopeGuardForwardsModeUntilLexicalScopeExit` to `tests/ut/cpp/a5/test_a5_fatal.cpp`:

- `FakeRuntime` gains `pending_scope_mode` (immediately after `ops`, the prefix the inline wrappers pun through) and `last_scope_mode`.
- `fake_scope_begin` records the forwarded mode.
- The test asserts AUTO then MANUAL forwarding across lexical scope exit.

Both test files also extend the single `offsetof(FakeRuntime, ops) == 0` guard to a second one pinning `pending_scope_mode` at `sizeof(PTO2RuntimeOps *)`, since the `reinterpret_cast` now depends on the two-field `{ops, pending_scope_mode}` prefix, not one.

### R2 — a2a3 `RUNTIME_LOGIC.md` retained-buffer wording was stale

a2a3 described the retained temp buffer as a single runner-owned instance, but the shared host-runtime callback `get_retained_temp_buffer(runner_ctx, pipeline_slot, ...)` is per-slot and a5's matching paragraph already says so. Aligned a2a3 to a5's wording ("each slot's buffer lives on the runner").

### Bonus — stale accessor location in both trees' `MULTI_RING.md`

`PTO2TaskId`'s direct accessors live in `src/common/task_interface/pto_task_id.h`, not `pto_runtime2_types.h`. Fixed in both a2a3 and a5.

## Test plan

- [x] `cmake -S tests/ut/cpp -B build_ut -G Ninja` then `cmake --build build_ut --target test_a2a3_fatal test_a5_fatal` — both compile clean.
- [x] `./build_ut/test_a2a3_fatal` — 4/4 passed (incl. `A2A3Fatal.ScopeGuardForwardsModeUntilLexicalScopeExit`).
- [x] `./build_ut/test_a5_fatal` — 4/4 passed (incl. new `A5Fatal.ScopeGuardForwardsModeUntilLexicalScopeExit`).
- [ ] CI `ut-a2a3` / `ut-a5` green.

Refs #1582.