### PR TITLE
Refactor: centralize endpoint progress in Scheduler

### DIFF
--- a/docs/callable-identity-registration.md
+++ b/docs/callable-identity-registration.md
@@ -520,7 +520,7 @@ WorkerDispatch: task_slot, group_index, dispatch_id, prepare_only
 task-frame trailer: protocol, run_id, pipeline_slot, generation, dispatch_id
 ```
 
-`WorkerThread` assigns `dispatch_id` only after its queue insertion succeeds.
+`WorkerThread` assigns `dispatch_id` under its lane lock before endpoint submission.
 The callable digest remains part of the immutable payload, while the trailer
 lets both sides reject a stale activation, acceptance, or completion from an
 older use of the same pipeline frame. `FRAME_STAGED` confirms that this exact

--- a/docs/hierarchical-level-runtime.md
+++ b/docs/hierarchical-level-runtime.md
@@ -99,12 +99,13 @@ See [orchestrator.md](orchestrator.md) for the 7-step submit flow and state mach
 
 ### Scheduler (Scheduler thread)
 
-The **DAG executor**. A dedicated C++ thread that handles:
+The **DAG executor and endpoint progress owner**. A dedicated C++ thread that handles:
 
 - **directed NEXT_LEVEL queues** — one single-task FIFO per stable worker ID
   plus one all-targets-ready group FIFO
 - **shared SUB queue** — freely select idle SUB WorkerThreads
 - **completion queue** — slots whose worker finished; release fanout, wake downstream consumers, retire slot
+- **endpoint progress** — submit, activate, poll, and stop every endpoint lane
 
 The Scheduler never inspects task data — it just moves slot ids between queues
 and consults TaskSlotState metadata.
@@ -113,14 +114,14 @@ See [scheduler.md](scheduler.md) for the dispatch loop and coordination.
 
 ### Worker / WorkerManager / WorkerThread
 
-The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`s
-(next-level pool and sub pool). Each `WorkerThread` owns one std::thread that
-owns one shared-memory mailbox region and returns explicit progress/completion
-events to the Scheduler. Compatibility endpoints encode one task in the base
-frame and wait for `TASK_DONE`. Direct A2/A3 onboard chip endpoints instead
-multiplex two task frames: the same progress owner can poll the active native
-run while validating a staged successor, then activate that successor only
-after the predecessor's native finalization fence.
+The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`
+endpoint-lane objects (next-level pool and sub pool). The Scheduler thread owns
+progress across those lanes; each local lane owns one shared-memory mailbox
+region and returns explicit progress/completion events. Compatibility endpoints
+encode one task in the base frame and wait for `TASK_DONE`. Direct A2/A3 onboard
+chip endpoints instead multiplex two task frames: the same Scheduler progress
+owner can poll the active native run while validating a staged successor, then
+activate that successor only after the predecessor's native finalization fence.
 
 - Next-level (chip) children run `_chip_process_loop`, which constructs a
   `ChipWorker` and dispatches each kernel through it.
@@ -138,7 +139,7 @@ what flows through `ChipWorker::run`.
 ## 3. Component Coordination
 
 ```text
-                   Orch thread                    Scheduler thread             Worker threads
+                   Orch thread                    Scheduler thread             Endpoint lanes
                    ───────────                    ────────────────             ──────────────
   User code ──► Orchestrator                      Scheduler
                  │                                 │
@@ -170,7 +171,7 @@ Communication channels:
 | ---- | --------- | ------- |
 | Orchestrator/Scheduler → ready queues | direct `enqueue_ready` queue push | slot id |
 | Orchestrator/Scheduler → Scheduler loop | condition-variable notification | ready wake-up |
-| Scheduler → WorkerThread | WorkerThread internal queue | slot id |
+| Scheduler → WorkerThread | direct endpoint-lane submission | slot id |
 | WorkerThread → Scheduler | completion_queue (mutex + CV) | slot id + group index + outcome |
 | WorkerThread ↔ child | shm mailbox (state + error + task data) | encoded blob |
 | Python ↔ C++ | nanobind bindings | TaskArgs / CallConfig / callable handle |

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -193,8 +193,8 @@ success/failure outcome.
 ## Fork-Safe Remote Process Model
 
 The remote runtime must preserve the repository's fork ordering invariant:
-all chip/sub child processes are forked before any C++ Scheduler,
-`WorkerThread`, transport, or health threads are started.
+all chip/sub child processes are forked before any C++ Scheduler, transport, or
+health threads are started.
 
 Use a two-process remote model:
 

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -590,11 +590,11 @@ reclaim independently of outer-scope tasks. See
 
 ## 8. Data flow on completion
 
-When the child finishes the kernel, it writes `TASK_DONE` to the mailbox;
-`LocalMailboxEndpoint::run` exits its spin-poll, reads the mailbox error
-fields, and returns a `WorkerCompletion`. `MAILBOX_OFF_ERROR == 0` maps to
-success; a non-zero child error maps to task failure. The parent
-`WorkerThread` pushes that completion onto `Scheduler::completion_queue_`.
+When the child finishes the kernel, it writes `TASK_DONE` to the mailbox. The
+Scheduler calls `LocalMailboxEndpoint::poll_progress`, which reads the mailbox
+error fields and returns a `WorkerCompletion`. `MAILBOX_OFF_ERROR == 0` maps to
+success; a non-zero child error maps to task failure. The endpoint lane reports
+that completion through `Scheduler::worker_done`.
 
 At this point:
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -1,4 +1,4 @@
-# Worker Manager — Pool, Threading, and Dispatch
+# Worker Manager — Pool, Progress, and Dispatch
 
 Local task frames carry the submitted callable's 32-byte digest. The child
 resolves that digest to its private execution slot; no child-local slot crosses
@@ -48,11 +48,12 @@ public:
 
     // Lifecycle
     void start(Ring *ring, OnCompleteFn on_complete,
-               OnAcceptFn on_accept);              // starts all WorkerThreads
-    void stop_workers();                            // joins, retains pool entries
+               OnAcceptFn on_accept);              // creates all endpoint lanes
+    void stop_workers();                            // marks lanes stopping
     void stop();
 
     // Scheduler API
+    void progress();
     WorkerThread *get_worker_by_id(WorkerType type, int32_t worker_id) const;
     std::vector<int32_t> next_level_worker_ids() const;
     WorkerThread *pick_idle_sub_excluding(
@@ -90,9 +91,11 @@ the public worker id from the local worker vector index.
   another NEXT_LEVEL worker
 - **SUB-only idle selection**: `pick_idle_sub_excluding` chooses an idle SUB
   worker not already used by the same SUB group
-- **Two-step stop**: `stop_workers()` joins the execution threads while
-  retaining their pool entries, so Scheduler completion callbacks still see
-  stable worker objects; `stop()` then clears the pools
+- **Scheduler-owned progress**: `progress()` advances every endpoint lane from
+  the single Scheduler thread
+- **Two-step stop**: `stop_workers()` marks lanes stopping while retaining their
+  pool entries; Scheduler progress drains terminal events, then `stop()` clears
+  the pools
 
 Callable and remote-buffer eligibility is validated against the exact target
 during Orchestrator submission. It is not scheduling metadata and is not
@@ -102,15 +105,16 @@ stored on the task slot.
 
 ## 2. `WorkerThread`
 
-There is one `WorkerThread` and one `std::thread` per endpoint (for a local
-endpoint, per forked child). The same thread owns its dispatch queue, lane
-records, activation, acceptance, and completion progress.
+There is one `WorkerThread` endpoint-lane object per endpoint (for a local
+endpoint, per forked child), but it does not own a thread or dispatch queue.
+The single Scheduler thread submits work and owns activation, acceptance,
+completion, and shutdown progress across every lane.
 
 ```cpp
 struct WorkerDispatch {
     TaskSlot task_slot;
     int32_t  group_index = 0;    // 0 for non-group; 0..N-1 for group members
-    uint64_t dispatch_id = 0;    // assigned by WorkerThread after queue commit
+    uint64_t dispatch_id = 0;    // assigned by WorkerThread on submission
     bool prepare_only = false;   // stage for the FIFO successor
 };
 
@@ -121,9 +125,10 @@ public:
                const std::function<void(WorkerDispatch)> &on_accept,
                std::unique_ptr<WorkerEndpoint> endpoint);
     void stop();
-    void dispatch(WorkerDispatch d);          // reserve the active lane
-    void dispatch_prepared(WorkerDispatch d); // reserve the staged lane
+    void dispatch(WorkerDispatch d);          // submit on the active lane
+    void dispatch_prepared(WorkerDispatch d); // submit on the staged lane
     bool activate_prepared(RunId run_id);
+    void progress();                          // called only by Scheduler
     bool idle() const;                        // active lane is free
     bool can_stage() const;                   // staged lane is free
     bool busy() const;                        // either lane owns work
@@ -133,19 +138,13 @@ public:
 private:
     Ring *ring_;                       // reads slot state via ring->slot_state(id)
     std::unique_ptr<WorkerEndpoint> endpoint_;
-    std::thread thread_;
-    std::queue<WorkerDispatch> queue_;
-    std::mutex mu_;
-    std::condition_variable cv_;
     std::atomic<uint32_t> inflight_;     // endpoint capacity accounting
     std::array<LaneState, 2> lanes_;     // active and staged identities
-
-    void loop();  // the sole progress owner for this endpoint
 };
 ```
 
-Every endpoint is progress-driven: the thread publishes queued work, forwards a
-latched activation when supported, and polls monotonic
+Every endpoint is progress-driven: Scheduler submission publishes work,
+forwards a latched activation when supported, and polls monotonic
 `FRAME_STAGED`, `ACCEPTED`, and `COMPLETED` events. The lane array owns task
 identity and disposition while `inflight_` independently enforces endpoint
 capacity. The forked child loop lives in Python (`_chip_process_loop`,
@@ -153,8 +152,8 @@ capacity. The forked child loop lives in Python (`_chip_process_loop`,
 parent does not fork children.
 
 `WorkerDispatch` begins with `{task_slot, group_index}`. `WorkerThread` assigns
-`dispatch_id` under the queue lock only after the queue insertion succeeds, so
-a failed insertion consumes neither capacity nor identity. It also sets
+`dispatch_id` under the lane lock before endpoint submission. A submission
+failure terminalizes that same identity exactly once. It also sets
 `prepare_only` for the one staged successor. The endpoint combines this carrier
 with `slot.run_id`, `slot.pipeline_lease`, `slot.callable`, `slot.task_args`,
 and `slot.config` read from `ring->slot_state(task_slot)`. The task frame's
@@ -208,8 +207,8 @@ advance their framed transport incrementally.
 
 `LocalMailboxEndpoint::submit_progress` copies `CallConfig`,
 `PipelineSlotLease`, the 32-byte callable digest, and the length-prefixed
-`TaskArgs` blob into task frame 0 and publishes `TASK_READY`. The owning
-`WorkerThread` keeps driving its endpoint and observes acceptance or completion
+`TaskArgs` blob into task frame 0 and publishes `TASK_READY`. The Scheduler
+keeps driving the owning endpoint lane and observes acceptance or completion
 through `poll_progress`; it does not wait inside one task call. A steady-clock
 liveness sample turns a child that exits before completion into
 `ENDPOINT_FAILURE`.
@@ -223,7 +222,7 @@ the separate frame prevents a control request from overwriting task state.
 
 A two-frame `LocalMailboxEndpoint` advertises `supports_frame_staging` and is
 driven through `submit_progress`, `activate_progress`, and `poll_progress`.
-The owning `WorkerThread` is the only parent-side progress owner. The child also
+The Scheduler thread is the only parent-side progress owner. The child also
 uses one `run_two_frame_loop`; it services the separate control base, stages
 both task frames, and owns the bounded active/prepared native lifecycles.
 

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -863,6 +863,21 @@ void RemoteL3Endpoint::report_progress_error(const std::string &reason) noexcept
     } catch (...) {}
 }
 
+bool RemoteL3Endpoint::report_submission_error(const WorkerDispatch &dispatch, const std::string &reason) noexcept {
+    try {
+        std::lock_guard<std::mutex> command_lk(command_mu_);
+        const bool endpoint_owned =
+            pending_task_.occupied && pending_task_.dispatch.dispatch_id == dispatch.dispatch_id;
+        progress_stop_requested_ = true;
+        progress_stop_reason_ = "RemoteL3Endpoint submission failed: " + reason;
+        command_cv_.notify_all();
+        transport_->shutdown();
+        return endpoint_owned;
+    } catch (...) {
+        return false;
+    }
+}
+
 remote_l3::ControlReplyPayload
 RemoteL3Endpoint::run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) {
     std::unique_lock<std::mutex> command_lk(command_mu_);

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -99,6 +99,7 @@ public:
     bool poll_progress(WorkerEndpointProgress &progress) override;
     void request_progress_stop() noexcept override;
     void report_progress_error(const std::string &reason) noexcept override;
+    bool report_submission_error(const WorkerDispatch &dispatch, const std::string &reason) noexcept override;
     void shutdown_child() override;
     void control_prepare(const uint8_t *digest) override;
     void control_remote_prepare_register(

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -121,6 +121,7 @@ void Scheduler::start(const Config &cfg) {
 
 void Scheduler::request_stop() {
     stop_requested_.store(true, std::memory_order_release);
+    if (running_.load(std::memory_order_acquire)) cfg_.manager->stop_workers();
     {
         std::lock_guard<std::mutex> lk(completion_mu_);
         ++wake_generation_;
@@ -137,7 +138,7 @@ void Scheduler::stop() {
 }
 
 // =============================================================================
-// WorkerThread completion callback (called from WorkerThread via Manager)
+// Endpoint completion callback
 // =============================================================================
 
 void Scheduler::worker_done(WorkerCompletion completion) {
@@ -258,11 +259,13 @@ void Scheduler::run() {
             auto ready = [this, &observed_wake_generation] {
                 return !completion_queue_.empty() || wake_generation_ != observed_wake_generation;
             };
-            const auto stall_deadline = reservation_stall_deadline();
-            if (stall_deadline.has_value()) {
-                completion_cv_.wait_until(lk, *stall_deadline, ready);
-            } else {
-                completion_cv_.wait(lk, ready);
+            if (!cfg_.manager->any_busy()) {
+                const auto stall_deadline = reservation_stall_deadline();
+                if (stall_deadline.has_value()) {
+                    completion_cv_.wait_until(lk, *stall_deadline, ready);
+                } else {
+                    completion_cv_.wait(lk, ready);
+                }
             }
             observed_wake_generation = wake_generation_;
         }
@@ -271,6 +274,8 @@ void Scheduler::run() {
         // compaction cannot free TaskSlotStates while on_task_complete or
         // dispatch_ready is still reading them.
         std::lock_guard<std::mutex> loop_lk(loop_mu_);
+
+        cfg_.manager->progress();
 
         // Phase 1: drain completions
         while (true) {
@@ -416,7 +421,7 @@ void Scheduler::try_consume(TaskSlot slot) {
 
 // The NEXT_LEVEL worker-id set is fixed by Worker::init() (NextLevelReadyQueues
 // is reset once, before scheduling starts) and every queued/targeted worker id
-// is validated in Orchestrator::submit_impl. WorkerThread resolves expected
+// is validated in Orchestrator::submit_impl. The endpoint lane resolves expected
 // lane/capacity/stopping rejections through exactly one complete_unpublished
 // call, under the same non-throwing completion-callback contract as ordinary
 // endpoint completion.
@@ -434,9 +439,15 @@ void Scheduler::dispatch_ready() {
 
     // Group reservations and every queue pop in one pass belong to the same
     // whole-run FIFO head, even if a completion advances the head mid-pass.
-    const NextLevelGroupDispatchResult group_result = dispatch_next_level_group(run_snapshot);
-    update_reservation_stall(group_result);
-    dispatch_next_level_singles(group_result.reserved_worker_ids, run_snapshot);
+    bool group_arrived_between_phases = false;
+    do {
+        const NextLevelGroupDispatchResult group_result = dispatch_next_level_group(run_snapshot);
+        update_reservation_stall(group_result);
+        if (cfg_.after_group_phase_cb) cfg_.after_group_phase_cb();
+        group_arrived_between_phases = dispatch_next_level_singles(
+            group_result.reserved_worker_ids, run_snapshot, group_result.blocked_group_slot == INVALID_SLOT
+        );
+    } while (group_arrived_between_phases);
     dispatch_sub_ready(run_snapshot);
 }
 
@@ -448,7 +459,7 @@ bool claim_for_dispatch(TaskSlotState &s) {
 }
 
 void Scheduler::dispatch_claimed(WorkerThread *worker, WorkerDispatch dispatch, bool prepared) {
-    // WorkerThread owns publication failure through its one terminal callback.
+    // The endpoint lane owns publication failure through one terminal callback.
     // Retrying here after that callback starts can duplicate a partially
     // published completion. The callback contract is the same non-throwing
     // contract used by ordinary endpoint completions.
@@ -472,6 +483,10 @@ void Scheduler::dispatch_preparable_next_level_singles() {
         if (worker == nullptr || !worker->can_stage()) continue;
         TaskSlot slot;
         if (!cfg_.ready_next_level_queues->try_pop_single(worker_id, run_id, slot)) continue;
+        if (!cfg_.ready_next_level_queues->groups_empty(run_id)) {
+            cfg_.enqueue_ready_cb(slot);
+            return;
+        }
         TaskSlotState &state = *cfg_.ring->slot_state(slot);
         if (state.state.load(std::memory_order_acquire) != TaskState::READY) continue;
         if (state.run_id != run_id || state.worker_type != WorkerType::NEXT_LEVEL || state.is_group() ||
@@ -684,8 +699,9 @@ std::optional<std::chrono::steady_clock::time_point> Scheduler::reservation_stal
     return reservation_stall_episode_->started_at + cfg_.reservation_stall_warn_after;
 }
 
-void Scheduler::dispatch_next_level_singles(
-    const std::unordered_set<int32_t> &reserved_worker_ids, const std::optional<RunId> &run_snapshot
+bool Scheduler::dispatch_next_level_singles(
+    const std::unordered_set<int32_t> &reserved_worker_ids, const std::optional<RunId> &run_snapshot,
+    bool verify_group_barrier
 ) {
     for (int32_t worker_id : cfg_.ready_next_level_queues->worker_ids()) {
         if (reserved_worker_ids.find(worker_id) != reserved_worker_ids.end()) continue;
@@ -707,6 +723,13 @@ void Scheduler::dispatch_next_level_singles(
                 cfg_.enqueue_ready_cb(slot);
                 break;
             }
+            const bool group_waiting =
+                verify_group_barrier && (run_snapshot ? !cfg_.ready_next_level_queues->groups_empty(*run_snapshot) :
+                                                        !cfg_.ready_next_level_queues->groups_empty());
+            if (group_waiting) {
+                cfg_.enqueue_ready_cb(slot);
+                return true;
+            }
             if (s.worker_type != WorkerType::NEXT_LEVEL || s.is_group() || s.target_worker_id(0) != worker_id) {
                 throw std::runtime_error("Scheduler::dispatch_next_level_singles: misrouted task slot");
             }
@@ -716,4 +739,5 @@ void Scheduler::dispatch_next_level_singles(
             break;
         }
     }
+    return false;
 }

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -15,28 +15,21 @@
  * The Scheduler thread routes tasks through the DAG lifecycle:
  *   ready_queue → dispatch (via WorkerManager) → completion → fanout release → new ready
  *
- * Worker pool management (WorkerThread creation and dispatch) is delegated to
- * WorkerManager. NEXT_LEVEL placement is fixed at submit; SUB remains free.
+ * Worker endpoint ownership and dispatch are delegated to WorkerManager.
+ * NEXT_LEVEL placement is fixed at submit; SUB remains free.
  *
  * Flow:
  *   Orch: submit() → directed NEXT_LEVEL queue or shared SUB queue + notify
  *
  *   Scheduler thread:
- *     wait on cv (completion queue OR unconsumed wake generation)
+ *     wait on cv while no endpoint is active
+ *     poll every active endpoint through WorkerManager
  *     drain completion_queue → on_task_complete → fanout release → ready_queue
  *     launch directed NEXT_LEVEL tasks, then freely scheduled SUB tasks
  *
- *   WorkerThread (managed by WorkerManager):
- *     loop: task_queue.pop() → endpoint.run(dispatch) →
- *           completion callback → Scheduler.worker_done(completion)
- *           → lane state published → idle callback → Scheduler.notify_ready()
- *
- * The wait is edge-triggered, so it carries an obligation on everything that
- * feeds it: any state change that turns already-queued work into placeable
- * work must push a completion or advance the wake generation. Queue occupancy
- * is no longer re-read by the predicate, so a change that only mutates it —
- * a requeue from dispatch, a worker publishing itself idle, a run reaching the
- * FIFO head — is invisible until someone posts the matching edge.
+ * The idle wait is edge-triggered, so any state change that turns already-
+ * queued work into placeable work must advance the wake generation. Active
+ * endpoints keep the loop running until all endpoint-owned work terminalizes.
  */
 
 #pragma once
@@ -119,6 +112,9 @@ public:
         // exercise the losing side of the claim has to be let in here.
         // Unset in production.
         std::function<void(TaskSlot)> before_claim_cb;
+        // Test seam for a group arriving after the group phase observed an
+        // empty queue but before this pass starts claiming singles.
+        std::function<void()> after_group_phase_cb;
     };
 
     void start(const Config &cfg);
@@ -130,8 +126,7 @@ public:
     // scheduler from one spinning on unplaceable work. Orders nothing.
     uint64_t dispatch_round_count() const { return dispatch_round_count_.load(std::memory_order_relaxed); }
 
-    // Called by WorkerManager (from WorkerThread) after endpoint run() reaches
-    // a terminal outcome.
+    // Called by WorkerManager after endpoint progress reaches a terminal outcome.
     void worker_done(WorkerCompletion completion);
 
     // Called by Orchestrator after it pushes a newly-ready root task. ReadyQueue
@@ -148,7 +143,7 @@ private:
     Config cfg_;
     std::mutex loop_mu_;
 
-    // Shared completion queue (WorkerThread → Scheduler)
+    // Endpoint completion queue owned and drained by the Scheduler thread.
     std::queue<WorkerCompletion> completion_queue_;
     std::mutex completion_mu_;
     std::condition_variable completion_cv_;
@@ -188,8 +183,9 @@ private:
     void dispatch_claimed(WorkerThread *worker, WorkerDispatch dispatch, bool prepared);
     void dispatch_preparable_next_level_singles();
     NextLevelGroupDispatchResult dispatch_next_level_group(const std::optional<RunId> &run_snapshot);
-    void dispatch_next_level_singles(
-        const std::unordered_set<int32_t> &reserved_worker_ids, const std::optional<RunId> &run_snapshot
+    bool dispatch_next_level_singles(
+        const std::unordered_set<int32_t> &reserved_worker_ids, const std::optional<RunId> &run_snapshot,
+        bool verify_group_barrier
     );
     void dispatch_sub_ready(const std::optional<RunId> &run_snapshot);
     void update_reservation_stall(const NextLevelGroupDispatchResult &dispatch_result);

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -281,6 +281,7 @@ bool NextLevelReadyQueues::try_front_group(RunId run_id, TaskSlot &out) { return
 bool NextLevelReadyQueues::try_pop_group(TaskSlot &out) { return group_queue_.try_pop(out); }
 bool NextLevelReadyQueues::try_pop_group(RunId run_id, TaskSlot &out) { return group_queue_.try_pop(run_id, out); }
 
+bool NextLevelReadyQueues::groups_empty() const { return group_queue_.empty(); }
 bool NextLevelReadyQueues::groups_empty(RunId run_id) const { return group_queue_.empty(run_id); }
 
 bool NextLevelReadyQueues::single_empty(int32_t worker_id, RunId run_id) const {

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -543,6 +543,7 @@ public:
     bool try_front_group(RunId run_id, TaskSlot &out);
     bool try_pop_group(TaskSlot &out);
     bool try_pop_group(RunId run_id, TaskSlot &out);
+    bool groups_empty() const;
     bool groups_empty(RunId run_id) const;
     bool single_empty(int32_t worker_id, RunId run_id) const;
     bool singles_empty(RunId run_id) const;

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -144,7 +144,7 @@ void Worker::add_remote_l3_socket(
 void Worker::init() {
     if (initialized_) throw std::runtime_error("Worker: already initialized");
 
-    // Start WorkerManager first — creates WorkerThreads.
+    // Start WorkerManager first — creates endpoint lanes.
     // The on_complete callback routes through the Scheduler's worker_done().
     manager_.start(
         &allocator_,
@@ -153,9 +153,6 @@ void Worker::init() {
         },
         [this](WorkerDispatch dispatch) {
             orchestrator_.mark_task_accepted(dispatch.task_slot);
-        },
-        [this] {
-            scheduler_.notify_ready();
         }
     );
     ready_next_level_queues_.reset(manager_.next_level_worker_ids());
@@ -196,7 +193,6 @@ void Worker::init() {
 void Worker::close() {
     if (!initialized_) return;
     scheduler_.request_stop();
-    manager_.stop_workers();
     scheduler_.stop();
     manager_.stop();
     allocator_.shutdown();

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -156,6 +156,10 @@ bool WorkerEndpoint::poll_progress(WorkerEndpointProgress &) { return false; }
 bool WorkerEndpoint::activate_progress(RunId) { return false; }
 void WorkerEndpoint::request_progress_stop() noexcept {}
 void WorkerEndpoint::report_progress_error(const std::string &) { request_progress_stop(); }
+bool WorkerEndpoint::report_submission_error(const WorkerDispatch &, const std::string &reason) {
+    report_progress_error(reason);
+    return false;
+}
 
 // =============================================================================
 // LocalMailboxEndpoint — mailbox helpers
@@ -276,14 +280,12 @@ char *LocalMailboxEndpoint::task_frame(size_t index) const {
 
 void WorkerThread::start(
     Ring *ring, const std::function<void(WorkerCompletion)> &on_complete,
-    const std::function<void(WorkerDispatch)> &on_accept, const std::function<void()> &on_idle,
-    std::unique_ptr<WorkerEndpoint> endpoint
+    const std::function<void(WorkerDispatch)> &on_accept, std::unique_ptr<WorkerEndpoint> endpoint
 ) {
     if (!endpoint) throw std::invalid_argument("WorkerThread::start: null endpoint");
     ring_ = ring;
     on_complete_ = on_complete;
     on_accept_ = on_accept;
-    on_idle_ = on_idle;
     endpoint_ = std::move(endpoint);
     shutdown_ = false;
     if (endpoint_->caps().max_inflight_tasks == 0) {
@@ -294,7 +296,6 @@ void WorkerThread::start(
         std::lock_guard<std::mutex> lane_lk(lane_mu_);
         lanes_ = {};
     }
-    thread_ = std::thread(&WorkerThread::loop, this);
 }
 
 void WorkerThread::dispatch(WorkerDispatch d) {
@@ -313,21 +314,21 @@ void WorkerThread::dispatch(WorkerDispatch d) {
         complete_unpublished(d, "WorkerThread::dispatch: active lane is occupied");
         return;
     }
-    EnqueueDispatchResult result;
+    SubmitDispatchResult result;
     try {
-        result = enqueue_dispatch(d, LaneKind::ACTIVE);
+        result = submit_dispatch(d, LaneKind::ACTIVE);
     } catch (const std::exception &e) {
         release_lane_unconditional(LaneKind::ACTIVE);
-        complete_unpublished(d, std::string("WorkerThread::dispatch: enqueue failed: ") + e.what());
+        complete_unpublished(d, std::string("WorkerThread::dispatch: submit failed: ") + e.what());
         return;
     } catch (...) {
         release_lane_unconditional(LaneKind::ACTIVE);
-        complete_unpublished(d, "WorkerThread::dispatch: enqueue failed");
+        complete_unpublished(d, "WorkerThread::dispatch: submit failed");
         return;
     }
-    if (result == EnqueueDispatchResult::QUEUED) return;
+    if (result == SubmitDispatchResult::SUBMITTED) return;
     release_lane_unconditional(LaneKind::ACTIVE);
-    if (result == EnqueueDispatchResult::STOPPING) {
+    if (result == SubmitDispatchResult::STOPPING) {
         complete_unpublished(d, "WorkerThread::dispatch: worker is stopping");
     } else {
         complete_unpublished(d, "WorkerThread::dispatch: endpoint capacity exceeded");
@@ -364,37 +365,37 @@ void WorkerThread::dispatch_prepared(WorkerDispatch d) {
         complete_unpublished(d, "WorkerThread::dispatch_prepared: worker already owns a staged run");
         return;
     }
-    EnqueueDispatchResult result;
+    SubmitDispatchResult result;
     try {
-        result = enqueue_dispatch(d, LaneKind::STAGED, slot->run_id);
+        result = submit_dispatch(d, LaneKind::STAGED, slot->run_id);
     } catch (const std::exception &e) {
         release_lane_unconditional(LaneKind::STAGED);
-        complete_unpublished(d, std::string("WorkerThread::dispatch_prepared: enqueue failed: ") + e.what());
+        complete_unpublished(d, std::string("WorkerThread::dispatch_prepared: submit failed: ") + e.what());
         return;
     } catch (...) {
         release_lane_unconditional(LaneKind::STAGED);
-        complete_unpublished(d, "WorkerThread::dispatch_prepared: enqueue failed");
+        complete_unpublished(d, "WorkerThread::dispatch_prepared: submit failed");
         return;
     }
-    if (result == EnqueueDispatchResult::QUEUED) return;
+    if (result == SubmitDispatchResult::SUBMITTED) return;
     release_lane_unconditional(LaneKind::STAGED);
-    if (result == EnqueueDispatchResult::STOPPING) {
+    if (result == SubmitDispatchResult::STOPPING) {
         complete_unpublished(d, "WorkerThread::dispatch_prepared: worker is stopping");
-    } else if (result == EnqueueDispatchResult::CAPACITY_EXCEEDED) {
+    } else if (result == SubmitDispatchResult::CAPACITY_EXCEEDED) {
         complete_unpublished(d, "WorkerThread::dispatch_prepared: endpoint capacity exceeded");
     } else {
-        complete_unpublished(d, "WorkerThread::dispatch_prepared: staged lane identity changed before enqueue");
+        complete_unpublished(d, "WorkerThread::dispatch_prepared: staged lane identity changed before submission");
     }
 }
 
-WorkerThread::EnqueueDispatchResult
-WorkerThread::enqueue_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expected_run_id) {
-    std::lock_guard<std::mutex> lk(mu_);
+WorkerThread::SubmitDispatchResult
+WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expected_run_id) {
+    std::lock_guard<std::mutex> admission_lk(admission_mu_);
     if (shutdown_.load(std::memory_order_acquire)) {
-        return EnqueueDispatchResult::STOPPING;
+        return SubmitDispatchResult::STOPPING;
     }
     if (inflight_.load(std::memory_order_acquire) >= endpoint_->caps().max_inflight_tasks) {
-        return EnqueueDispatchResult::CAPACITY_EXCEEDED;
+        return SubmitDispatchResult::CAPACITY_EXCEEDED;
     }
     d.dispatch_id = next_dispatch_id_;
     {
@@ -402,28 +403,26 @@ WorkerThread::enqueue_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expec
         LaneState &dispatch_lane = lane(lane_kind);
         if (!dispatch_lane.occupied || dispatch_lane.dispatch_id != 0 ||
             (expected_run_id != INVALID_RUN_ID && dispatch_lane.run_id != expected_run_id)) {
-            return EnqueueDispatchResult::STAGED_IDENTITY_CHANGED;
+            return SubmitDispatchResult::STAGED_IDENTITY_CHANGED;
         }
         dispatch_lane.dispatch_id = d.dispatch_id;
     }
-    try {
-        queue_.push(d);  // A failed allocation consumes neither capacity nor dispatch identity.
-    } catch (...) {
-        std::lock_guard<std::mutex> lane_lk(lane_mu_);
-        LaneState &dispatch_lane = lane(lane_kind);
-        if (dispatch_lane.dispatch_id == d.dispatch_id) {
-            dispatch_lane.dispatch_id = 0;
-        }
-        throw;
-    }
     ++next_dispatch_id_;
     inflight_.fetch_add(1, std::memory_order_release);
-    cv_.notify_one();
-    return EnqueueDispatchResult::QUEUED;
+    try {
+        endpoint_->submit_progress(ring_, d);
+    } catch (const std::exception &e) {
+        fail_submission(d, std::string("submit_progress failed: ") + e.what());
+    } catch (...) {
+        fail_submission(d, "submit_progress failed with unknown exception");
+    }
+    return SubmitDispatchResult::SUBMITTED;
 }
 
 bool WorkerThread::activate_prepared(RunId run_id) {
     if (run_id == INVALID_RUN_ID) return false;
+    std::lock_guard<std::mutex> admission_lk(admission_mu_);
+    if (shutdown_.load(std::memory_order_acquire)) return false;
     std::lock_guard<std::mutex> lane_lk(lane_mu_);
     LaneState &active = lane(LaneKind::ACTIVE);
     LaneState &staged = lane(LaneKind::STAGED);
@@ -433,7 +432,6 @@ bool WorkerThread::activate_prepared(RunId run_id) {
     active = staged;
     active.activation_requested = true;
     staged = {};
-    cv_.notify_one();
     return true;
 }
 
@@ -476,12 +474,8 @@ void WorkerThread::complete_unpublished(WorkerDispatch dispatch, const std::stri
 }
 
 void WorkerThread::stop() {
-    {
-        std::lock_guard<std::mutex> lk(mu_);
-        shutdown_ = true;
-    }
-    cv_.notify_all();
-    if (thread_.joinable()) thread_.join();
+    std::lock_guard<std::mutex> admission_lk(admission_mu_);
+    shutdown_.store(true, std::memory_order_release);
 }
 
 void WorkerThread::shutdown_child() {
@@ -496,101 +490,69 @@ const WorkerEndpointCaps &WorkerThread::caps() const {
 int32_t WorkerThread::worker_id() const { return caps().worker_id; }
 
 // =============================================================================
-// WorkerThread — main loop + per-mode dispatch
+// WorkerThread — Scheduler-owned endpoint progress
 // =============================================================================
 
-void WorkerThread::loop() {
-    while (true) {
-        WorkerDispatch dispatch;
-        bool have_dispatch = false;
-        {
-            std::unique_lock<std::mutex> lk(mu_);
-            if (queue_.empty() && inflight_.load(std::memory_order_acquire) == 0 &&
-                !shutdown_.load(std::memory_order_acquire)) {
-                cv_.wait(lk, [this] {
-                    return !queue_.empty() || shutdown_.load(std::memory_order_acquire);
-                });
-            }
-            if (!queue_.empty()) {
-                dispatch = queue_.front();
-                queue_.pop();
-                have_dispatch = true;
-            } else if (shutdown_.load(std::memory_order_acquire) && inflight_.load(std::memory_order_acquire) == 0) {
-                break;
-            }
-        }
+void WorkerThread::progress() {
+    if (shutdown_.load(std::memory_order_acquire)) {
+        // A child finishing a control handler may overwrite an earlier stop
+        // state, so the request remains level-triggered until terminalization.
+        endpoint_->request_progress_stop();
+    }
 
-        if (shutdown_.load(std::memory_order_acquire)) {
-            // Repeat until every frame terminalizes. A child finishing a
-            // control handler may publish CONTROL_DONE after an earlier
-            // SHUTDOWN store; the next pass restores the stop request.
-            endpoint_->request_progress_stop();
-        }
-
-        if (have_dispatch) {
-            if (shutdown_.load(std::memory_order_acquire)) {
-                WorkerEndpointProgress progress;
-                progress.kind = WorkerProgressKind::COMPLETED;
-                progress.dispatch = dispatch;
-                progress.completion = WorkerCompletion{
-                    dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
-                    "WorkerThread endpoint stopped before frame publication"
-                };
-                finish_progress_dispatch(progress);
-            } else {
+    RunId activated = INVALID_RUN_ID;
+    {
+        std::lock_guard<std::mutex> admission_lk(admission_mu_);
+        if (!shutdown_.load(std::memory_order_acquire)) {
+            {
+                std::lock_guard<std::mutex> lane_lk(lane_mu_);
+                const LaneState &active = lane(LaneKind::ACTIVE);
+                if (active.occupied && active.activation_requested) activated = active.run_id;
+            }
+            if (activated != INVALID_RUN_ID) {
                 try {
-                    endpoint_->submit_progress(ring_, dispatch);
+                    if (endpoint_->activate_progress(activated)) {
+                        std::lock_guard<std::mutex> lane_lk(lane_mu_);
+                        LaneState &active = lane(LaneKind::ACTIVE);
+                        if (active.occupied && active.run_id == activated) active.activation_requested = false;
+                    }
                 } catch (const std::exception &e) {
-                    WorkerEndpointProgress progress;
-                    progress.kind = WorkerProgressKind::COMPLETED;
-                    progress.dispatch = dispatch;
-                    progress.completion = WorkerCompletion{
-                        dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
-                        std::string("WorkerThread endpoint failed before frame publication: ") + e.what()
-                    };
-                    finish_progress_dispatch(progress);
+                    fail_progress_driver(std::string("activate_progress failed: ") + e.what());
                 } catch (...) {
-                    WorkerEndpointProgress progress;
-                    progress.kind = WorkerProgressKind::COMPLETED;
-                    progress.dispatch = dispatch;
-                    progress.completion = WorkerCompletion{
-                        dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
-                        "WorkerThread endpoint failed before frame publication with unknown exception"
-                    };
-                    finish_progress_dispatch(progress);
+                    fail_progress_driver("activate_progress failed with unknown exception");
                 }
             }
-        }
-
-        RunId activated = INVALID_RUN_ID;
-        {
-            std::lock_guard<std::mutex> lane_lk(lane_mu_);
-            const LaneState &active = lane(LaneKind::ACTIVE);
-            if (active.occupied && active.activation_requested) activated = active.run_id;
-        }
-        if (activated != INVALID_RUN_ID) {
-            try {
-                if (endpoint_->activate_progress(activated)) {
-                    std::lock_guard<std::mutex> lane_lk(lane_mu_);
-                    LaneState &active = lane(LaneKind::ACTIVE);
-                    if (active.occupied && active.run_id == activated) active.activation_requested = false;
-                }
-            } catch (const std::exception &e) {
-                fail_progress_driver(std::string("activate_progress failed: ") + e.what());
-            } catch (...) {
-                fail_progress_driver("activate_progress failed with unknown exception");
-            }
-        }
-
-        WorkerEndpointProgress progress;
-        try {
-            if (endpoint_->poll_progress(progress)) finish_progress_dispatch(progress);
-        } catch (const std::exception &e) {
-            fail_progress_driver(std::string("poll_progress failed: ") + e.what());
-        } catch (...) {
-            fail_progress_driver("poll_progress failed with unknown exception");
         }
     }
+
+    WorkerEndpointProgress progress;
+    try {
+        if (endpoint_->poll_progress(progress)) finish_progress_dispatch(progress);
+    } catch (const std::exception &e) {
+        fail_progress_driver(std::string("poll_progress failed: ") + e.what());
+    } catch (...) {
+        fail_progress_driver("poll_progress failed with unknown exception");
+    }
+}
+
+void WorkerThread::fail_submission(const WorkerDispatch &dispatch, const std::string &reason) {
+    shutdown_.store(true, std::memory_order_release);
+    bool endpoint_owned = false;
+    try {
+        endpoint_owned = endpoint_->report_submission_error(dispatch, reason);
+    } catch (...) {
+        endpoint_->request_progress_stop();
+    }
+    if (endpoint_owned) return;
+
+    WorkerEndpointProgress progress;
+    progress.kind = WorkerProgressKind::COMPLETED;
+    progress.dispatch = dispatch;
+    progress.completion = WorkerCompletion{
+        dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+        "WorkerThread endpoint rejected publication: " + reason
+    };
+    finish_progress_dispatch(progress);
 }
 
 void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progress) {
@@ -647,8 +609,6 @@ void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progre
         }
     }
     inflight_.fetch_sub(1, std::memory_order_acq_rel);
-    cv_.notify_one();
-    if (on_idle_) on_idle_();
 }
 
 void WorkerThread::fail_progress_driver(const std::string &reason) noexcept {
@@ -658,7 +618,6 @@ void WorkerThread::fail_progress_driver(const std::string &reason) noexcept {
     } catch (...) {
         endpoint_->request_progress_stop();
     }
-    cv_.notify_all();
 }
 
 void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dispatch) {
@@ -945,6 +904,16 @@ void LocalMailboxEndpoint::report_progress_error(const std::string &reason) {
     poison_progress("endpoint progress driver failed: " + reason);
 }
 
+bool LocalMailboxEndpoint::report_submission_error(const WorkerDispatch &dispatch, const std::string &reason) {
+    std::lock_guard<std::mutex> lk(progress_mu_);
+    bool endpoint_owned = false;
+    for (const FrameRecord &record : frames_) {
+        endpoint_owned = endpoint_owned || (record.occupied && record.dispatch.dispatch_id == dispatch.dispatch_id);
+    }
+    poison_progress("endpoint submission failed: " + reason);
+    return endpoint_owned;
+}
+
 // =============================================================================
 // WorkerManager
 // =============================================================================
@@ -965,9 +934,7 @@ void WorkerManager::add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endp
 
 void WorkerManager::add_sub(void *mailbox, int child_pid) { sub_entries_.push_back(LocalSubEntry{mailbox, child_pid}); }
 
-void WorkerManager::start(
-    Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept, const OnIdleFn &on_idle
-) {
+void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept) {
     if (ring == nullptr) throw std::invalid_argument("WorkerManager::start: null ring");
 
     std::vector<int32_t> next_level_worker_ids;
@@ -997,7 +964,7 @@ void WorkerManager::start(
             auto endpoint = std::make_unique<LocalMailboxEndpoint>(
                 entry.worker_id, entry.mailbox, entry.child_pid, entry.task_frame_count
             );
-            wt->start(ring, on_complete, on_accept, on_idle, std::move(endpoint));
+            wt->start(ring, on_complete, on_accept, std::move(endpoint));
             next_level_threads_.push_back(std::move(wt));
         }
     };
@@ -1008,14 +975,14 @@ void WorkerManager::start(
             auto endpoint = std::make_unique<LocalMailboxEndpoint>(
                 static_cast<int32_t>(i), entries[i].mailbox, entries[i].child_pid
             );
-            wt->start(ring, on_complete, on_accept, on_idle, std::move(endpoint));
+            wt->start(ring, on_complete, on_accept, std::move(endpoint));
             threads.push_back(std::move(wt));
         }
     };
     make_next_level_threads();
     for (auto &endpoint : next_level_endpoint_entries_) {
         auto wt = std::make_unique<WorkerThread>();
-        wt->start(ring, on_complete, on_accept, on_idle, std::move(endpoint));
+        wt->start(ring, on_complete, on_accept, std::move(endpoint));
         next_level_threads_.push_back(std::move(wt));
     }
     next_level_endpoint_entries_.clear();
@@ -1033,6 +1000,13 @@ void WorkerManager::stop() {
     stop_workers();
     next_level_threads_.clear();
     sub_threads_.clear();
+}
+
+void WorkerManager::progress() {
+    for (auto &worker : next_level_threads_)
+        worker->progress();
+    for (auto &worker : sub_threads_)
+        worker->progress();
 }
 
 WorkerThread *WorkerManager::get_worker_by_id(WorkerType type, int32_t worker_id) const {
@@ -1068,7 +1042,7 @@ WorkerThread *WorkerManager::pick_idle_sub_excluding(const std::vector<WorkerThr
 }
 
 // =============================================================================
-// LocalMailboxEndpoint — memory control (orch thread, concurrent with worker thread)
+// LocalMailboxEndpoint — memory control (orch thread, concurrent with Scheduler progress)
 // =============================================================================
 
 static void write_control_args(char *mbox, uint64_t sub_cmd, uint64_t a0 = 0) {
@@ -1875,7 +1849,7 @@ WorkerManager::broadcast_register_all(const void *blob_ptr, size_t blob_size, co
     PosixShmHolder shm(shm_name, blob_size);
     std::memcpy(shm.addr(), blob_ptr, blob_size);
 
-    // Fan out to every WorkerThread in parallel. Per-WorkerThread mailbox_mu_
+    // Fan out to every endpoint lane in parallel. Per-endpoint mailbox_mu_
     // is independent, so N control_register calls run concurrently — latency
     // is 1 × prepare_cost instead of N × prepare_cost.
     std::vector<std::thread> workers;

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -12,12 +12,12 @@
 /**
  * WorkerManager — worker pool lifecycle and dispatch.
  *
- * Owns WorkerThread instances (one per registered worker).
+ * Owns one endpoint lane per registered worker.
  * Provides idle-worker selection and dispatch to the Scheduler.
- * The Scheduler drives the DAG; the Manager drives the workers.
+ * The Scheduler drives both the DAG and endpoint progress through the Manager.
  *
- * Each WorkerThread owns one endpoint-progress loop. Every registered local
- * and remote endpoint advances through submit/poll without blocking that loop.
+ * Every registered local and remote endpoint advances through non-blocking
+ * submit/poll calls on the Scheduler thread.
  * A two-frame local endpoint may additionally publish one PREPARE_READY
  * successor while the active frame runs; FIFO promotion changes it to ACTIVATE.
  * The Python child resolves each frame's callable digest to a child-local slot
@@ -29,16 +29,13 @@
 #include <atomic>
 #include <array>
 #include <chrono>
-#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <string>
-#include <thread>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -325,11 +322,10 @@ public:
 
     virtual const WorkerEndpointCaps &caps() const = 0;
 
-    // Every endpoint is progress-driven: the owning WorkerThread drives it
-    // without a blocking call per frame. submit_progress publishes one complete
-    // frame; poll_progress reports monotonic events; activate_progress is a
-    // sticky FIFO-launch permission that may arrive before the child stages the
-    // frame.
+    // Every endpoint is progress-driven by the Scheduler without a blocking
+    // call per frame. submit_progress publishes one complete frame;
+    // poll_progress reports monotonic events; activate_progress is a sticky
+    // FIFO-launch permission that may arrive before the child stages the frame.
     virtual void submit_progress(Ring *ring, const WorkerDispatch &dispatch);
     virtual bool poll_progress(WorkerEndpointProgress &progress);
     virtual bool activate_progress(RunId run_id);
@@ -338,6 +334,10 @@ public:
     // Implementations must turn already-published work into terminal progress
     // only after their child/device resources are quiescent.
     virtual void report_progress_error(const std::string &reason);
+    // The return value says whether `dispatch` was published and will therefore
+    // produce terminal progress through poll_progress(). A false result leaves
+    // the unpublished dispatch with the caller after endpoint quiescence.
+    virtual bool report_submission_error(const WorkerDispatch &dispatch, const std::string &reason);
 
     virtual void shutdown_child() {}
     virtual uint64_t control_malloc(size_t size);
@@ -400,6 +400,7 @@ public:
     bool activate_progress(RunId run_id) override;
     void request_progress_stop() noexcept override;
     void report_progress_error(const std::string &reason) override;
+    bool report_submission_error(const WorkerDispatch &dispatch, const std::string &reason) override;
 
     void shutdown_child() override;
     uint64_t control_malloc(size_t size) override;
@@ -500,17 +501,17 @@ private:
 };
 
 // =============================================================================
-// WorkerThread — one worker, one std::thread, mailbox-IPC dispatch.
+// WorkerThread — one Scheduler-driven endpoint lane.
 // =============================================================================
 
 class WorkerThread {
 public:
     WorkerThread() = default;
-    ~WorkerThread() { stop(); }
+    ~WorkerThread() = default;
     WorkerThread(const WorkerThread &) = delete;
     WorkerThread &operator=(const WorkerThread &) = delete;
 
-    // Start the worker thread.
+    // Initialize the endpoint lane.
     //
     // `mailbox` points to a MAILBOX_SIZE-byte MAP_SHARED region managed
     // by the Python facade — the real worker (a `ChipWorker` for
@@ -518,24 +519,15 @@ public:
     // and consumes the mailbox via `_chip_process_loop` / `_sub_worker_loop`.
     //
     // `ring` is a borrowed pointer to the engine's slot-state pool —
-    // the thread reads callable/args/config from
+    // the Scheduler thread reads callable/args/config from
     // `ring->slot_state(task_slot)` on each dispatch.
-    // on_complete(completion) is called (in the WorkerThread) after each
-    // endpoint run().
-    //
-    // on_idle() is called (in the WorkerThread) after the lane state for a
-    // finished dispatch is published, so `idle()` and `busy()` already report
-    // the post-completion values when it runs. on_complete() runs strictly
-    // before that publication — a scheduler that treats the completion as its
-    // only wake can therefore still observe this worker as occupied, and
-    // on_idle() is the edge that says otherwise.
+    // on_complete(completion) is called after each endpoint run.
     void start(
         Ring *ring, const std::function<void(WorkerCompletion)> &on_complete,
-        const std::function<void(WorkerDispatch)> &on_accept, const std::function<void()> &on_idle,
-        std::unique_ptr<WorkerEndpoint> endpoint
+        const std::function<void(WorkerDispatch)> &on_accept, std::unique_ptr<WorkerEndpoint> endpoint
     );
 
-    // Enqueue a dispatch for the worker. Non-blocking.
+    // Submit a dispatch to the endpoint. Non-blocking.
     void dispatch(WorkerDispatch d);
     void dispatch_prepared(WorkerDispatch d);
     // Complete a slot the scheduler already claimed when publication fails.
@@ -544,6 +536,7 @@ public:
     void complete_unpublished(WorkerDispatch d, const std::string &error_message);
     bool has_staged_run(RunId run_id) const;
     bool activate_prepared(RunId run_id);
+    void progress();
 
     // The active lane and staged-successor lane are intentionally distinct.
     // A staged successor must not make a second task from the active run
@@ -560,7 +553,7 @@ public:
     // Does NOT waitpid — the Python facade owns the child PID.
     void shutdown_child();
 
-    // Memory control — callable from the orch thread while the worker thread
+    // Memory control — callable from the orch thread while the Scheduler thread
     // may be running a task. Commands serialize with each other on
     // `mailbox_mu_`. Task dispatch uses separate task frames, so the single
     // child progress owner may observe a control request while a task is active.
@@ -629,8 +622,8 @@ public:
     void control_worker_chip_region_release(uint64_t region_id);
 
 private:
-    enum class EnqueueDispatchResult : uint8_t {
-        QUEUED,
+    enum class SubmitDispatchResult : uint8_t {
+        SUBMITTED,
         STOPPING,
         CAPACITY_EXCEEDED,
         STAGED_IDENTITY_CHANGED,
@@ -652,27 +645,23 @@ private:
     std::unique_ptr<WorkerEndpoint> endpoint_;
     std::function<void(WorkerCompletion)> on_complete_;
     std::function<void(WorkerDispatch)> on_accept_;
-    std::function<void()> on_idle_;
-
-    std::thread thread_;
-    std::queue<WorkerDispatch> queue_;
-    std::mutex mu_;
-    std::condition_variable cv_;
     std::atomic<bool> shutdown_{false};
     std::atomic<uint32_t> inflight_{0};
     uint64_t next_dispatch_id_{1};
+    // Linearizes stop with endpoint publication and prepared activation.
+    std::mutex admission_mu_;
     mutable std::mutex lane_mu_;
     std::array<LaneState, 2> lanes_{};
     std::unordered_set<uint64_t> accepted_dispatch_ids_;
     std::unordered_map<uint64_t, std::string> accept_errors_;
 
-    void loop();
-    EnqueueDispatchResult enqueue_dispatch(WorkerDispatch d, LaneKind lane, RunId expected_run_id = INVALID_RUN_ID);
+    SubmitDispatchResult submit_dispatch(WorkerDispatch d, LaneKind lane, RunId expected_run_id = INVALID_RUN_ID);
     LaneState &lane(LaneKind kind) { return lanes_[static_cast<size_t>(kind)]; }
     const LaneState &lane(LaneKind kind) const { return lanes_[static_cast<size_t>(kind)]; }
     void release_lane(LaneKind kind, uint64_t dispatch_id);
     void release_lane_unconditional(LaneKind kind);
     void finish_progress_dispatch(const WorkerEndpointProgress &progress);
+    void fail_submission(const WorkerDispatch &dispatch, const std::string &reason);
     void fail_progress_driver(const std::string &reason) noexcept;
 };
 
@@ -684,7 +673,6 @@ class WorkerManager {
 public:
     using OnCompleteFn = std::function<void(WorkerCompletion)>;
     using OnAcceptFn = std::function<void(WorkerDispatch)>;
-    using OnIdleFn = std::function<void()>;
 
     // Register a worker. `mailbox` is a MAILBOX_SIZE-byte MAP_SHARED
     // region; the real worker (a `ChipWorker` for NEXT_LEVEL, a Python
@@ -696,21 +684,16 @@ public:
     void add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint);
     void add_sub(void *mailbox, int child_pid = -1);
 
-    // `on_complete` and `on_accept` are non-throwing contracts: WorkerThread invokes
+    // `on_complete` and `on_accept` are non-throwing contracts: the endpoint lane invokes
     // `on_complete` after endpoint ownership has ended, so no lower layer can
     // reconstruct run accounting if it unwinds. `on_accept` advances the run's
     // launch fence; pass an empty function only when nothing waits on that
     // fence, since an omitted callback leaves pending_accepts non-zero forever.
     // No default: the choice is the caller's.
-    //
-    // `on_idle` fires once per finished dispatch, after that worker's lane
-    // state is published. An edge-triggered scheduler must supply it: a
-    // completion alone does not prove the worker is dispatchable again. It is
-    // defaulted empty because pools driven by no scheduler have nothing to
-    // wake.
-    void start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept, const OnIdleFn &on_idle = {});
+    void start(Ring *ring, const OnCompleteFn &on_complete, const OnAcceptFn &on_accept);
     void stop_workers();
     void stop();
+    void progress();
 
     WorkerThread *get_worker_by_id(WorkerType type, int32_t worker_id) const;
     std::vector<int32_t> next_level_worker_ids() const;
@@ -725,7 +708,7 @@ public:
 
     // Forward CTRL_PREPARE to a specific NEXT_LEVEL worker. Thin wrapper
     // over WorkerThread::control_prepare; exposed at manager level so the
-    // Python facade can prewarm without reaching into individual WorkerThreads.
+    // Python facade can prewarm without reaching into individual endpoint lanes.
     void control_prepare(int worker_id, const uint8_t *digest);
 
     // Forward CTRL_ALLOC_DOMAIN / CTRL_RELEASE_DOMAIN to a specific NEXT_LEVEL
@@ -777,7 +760,7 @@ public:
     // Broadcast CTRL_REGISTER for `digest` to every NEXT_LEVEL worker in
     // parallel. Stages `blob_size` bytes from `blob_ptr` into a per-call
     // POSIX shm under name "simpler-cb-<pid>-<counter>", spawns one
-    // std::thread per WorkerThread, and joins. Returns one ControlResult per
+    // std::thread per endpoint lane, and joins. Returns one ControlResult per
     // target so the Python facade can clean up only targets that confirmed
     // install/refcount increment on a partial failure.
     std::vector<ControlResult> broadcast_register_all(const void *blob_ptr, size_t blob_size, const uint8_t *digest);

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -318,6 +318,17 @@ public:
 
     void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override {
         ProgressCall call(*this);
+        {
+            std::unique_lock<std::mutex> gate_lk(submit_gate_mu_);
+            if (block_submit_) {
+                submit_entered_ = true;
+                submit_gate_cv_.notify_all();
+                submit_gate_cv_.wait(gate_lk, [this] {
+                    return release_submit_;
+                });
+                block_submit_ = false;
+            }
+        }
         RunId run_id = INVALID_RUN_ID;
         if (ring != nullptr) {
             TaskSlotState *slot = ring->slot_state(dispatch.task_slot);
@@ -327,6 +338,10 @@ public:
         submitted_.push_back(dispatch);
         outstanding_.emplace(dispatch.dispatch_id, Outstanding{dispatch, run_id});
         cv_.notify_all();
+        if (throw_submit_after_publication_) {
+            throw_submit_after_publication_ = false;
+            throw std::runtime_error("injected submit failure after publication");
+        }
     }
 
     bool poll_progress(WorkerEndpointProgress &progress) override {
@@ -376,6 +391,16 @@ public:
         cv_.notify_all();
     }
 
+    bool report_submission_error(const WorkerDispatch &dispatch, const std::string &reason) override {
+        ProgressCall call(*this);
+        std::lock_guard<std::mutex> lk(mu_);
+        const bool endpoint_owned = outstanding_.count(dispatch.dispatch_id) != 0;
+        progress_error_ = reason;
+        terminalize_outstanding_locked();
+        cv_.notify_all();
+        return endpoint_owned;
+    }
+
     bool wait_submitted(size_t count, std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
         std::unique_lock<std::mutex> lk(mu_);
         return cv_.wait_for(lk, timeout, [this, count] {
@@ -405,6 +430,31 @@ public:
     void throw_on_next_poll() {
         std::lock_guard<std::mutex> lk(mu_);
         throw_poll_once_ = true;
+    }
+
+    void block_next_submit() {
+        std::lock_guard<std::mutex> lk(submit_gate_mu_);
+        block_submit_ = true;
+        submit_entered_ = false;
+        release_submit_ = false;
+    }
+
+    bool wait_submit_entered(std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
+        std::unique_lock<std::mutex> lk(submit_gate_mu_);
+        return submit_gate_cv_.wait_for(lk, timeout, [this] {
+            return submit_entered_;
+        });
+    }
+
+    void release_blocked_submit() {
+        std::lock_guard<std::mutex> lk(submit_gate_mu_);
+        release_submit_ = true;
+        submit_gate_cv_.notify_all();
+    }
+
+    void throw_after_next_submit_publication() {
+        std::lock_guard<std::mutex> lk(mu_);
+        throw_submit_after_publication_ = true;
     }
 
     bool wait_progress_error(std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
@@ -452,6 +502,10 @@ public:
     bool progress_owner_changed() const {
         std::lock_guard<std::mutex> lk(owner_mu_);
         return progress_owner_changed_;
+    }
+    std::thread::id progress_owner() const {
+        std::lock_guard<std::mutex> lk(owner_mu_);
+        return progress_owner_;
     }
 
 private:
@@ -515,7 +569,13 @@ private:
     size_t stop_request_count_{0};
     size_t stop_terminalization_request_{1};
     bool throw_poll_once_{false};
+    bool throw_submit_after_publication_{false};
     std::string progress_error_;
+    std::mutex submit_gate_mu_;
+    std::condition_variable submit_gate_cv_;
+    bool block_submit_{false};
+    bool submit_entered_{false};
+    bool release_submit_{false};
     std::atomic<int> concurrent_calls_{0};
     std::atomic<int> max_concurrent_calls_{0};
     mutable std::mutex owner_mu_;
@@ -832,9 +892,6 @@ struct SchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orch.mark_task_accepted(dispatch.task_slot);
-            },
-            [this] {
-                sched.notify_ready();
             }
         );
         rq_next_level.reset(manager.next_level_worker_ids());
@@ -919,6 +976,76 @@ TEST(WorkerManagerTest, StartRejectsDuplicateNextLevelWorkerId) {
     EXPECT_TRUE(threw);
 }
 
+TEST(WorkerManagerTest, SchedulerOwnsProgressAcrossWorkerEndpoints) {
+    Ring allocator;
+    ReadyQueue ready_sub;
+    NextLevelReadyQueues ready_next;
+    WorkerManager manager;
+    Scheduler scheduler;
+    allocator.init(/*heap_bytes=*/0);
+
+    auto endpoint0 = std::make_unique<DeterministicProgressEndpoint>(0, 1);
+    auto endpoint1 = std::make_unique<DeterministicProgressEndpoint>(1, 1);
+    DeterministicProgressEndpoint *endpoint0_ptr = endpoint0.get();
+    DeterministicProgressEndpoint *endpoint1_ptr = endpoint1.get();
+    manager.add_next_level_endpoint(std::move(endpoint0));
+    manager.add_next_level_endpoint(std::move(endpoint1));
+    manager.start(
+        &allocator,
+        [&scheduler](WorkerCompletion completion) {
+            scheduler.worker_done(std::move(completion));
+        },
+        [](WorkerDispatch) {}
+    );
+    ready_next.reset(manager.next_level_worker_ids());
+
+    auto enqueue = [&](int32_t worker_id, RunId run_id) {
+        TaskSlot slot = make_progress_slot(allocator, run_id, /*pipeline_slot=*/0, /*generation=*/run_id);
+        TaskSlotState &state = *allocator.slot_state(slot);
+        state.worker_type = WorkerType::NEXT_LEVEL;
+        state.target_worker_ids.push_back(worker_id);
+        state.state.store(TaskState::READY, std::memory_order_release);
+        ready_next.push_single(worker_id, slot);
+        return slot;
+    };
+    TaskSlot slot0 = enqueue(/*worker_id=*/0, /*run_id=*/81);
+    TaskSlot slot1 = enqueue(/*worker_id=*/1, /*run_id=*/82);
+
+    Scheduler::Config config;
+    config.ring = &allocator;
+    config.ready_sub_queue = &ready_sub;
+    config.ready_next_level_queues = &ready_next;
+    config.manager = &manager;
+    config.enqueue_ready_cb = [&](TaskSlot slot) {
+        TaskSlotState &state = *allocator.slot_state(slot);
+        ready_next.push_single(state.target_worker_id(0), slot);
+    };
+    scheduler.start(config);
+
+    ASSERT_TRUE(endpoint0_ptr->wait_submitted(1));
+    ASSERT_TRUE(endpoint1_ptr->wait_submitted(1));
+    WorkerDispatch dispatch0 = endpoint0_ptr->submitted().front();
+    WorkerDispatch dispatch1 = endpoint1_ptr->submitted().front();
+    endpoint0_ptr->emit(WorkerProgressKind::COMPLETED, dispatch0);
+    endpoint1_ptr->emit(WorkerProgressKind::COMPLETED, dispatch1);
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while ((allocator.slot_state(slot0)->state.load(std::memory_order_acquire) != TaskState::COMPLETED ||
+            allocator.slot_state(slot1)->state.load(std::memory_order_acquire) != TaskState::COMPLETED) &&
+           std::chrono::steady_clock::now() < deadline) {}
+    EXPECT_EQ(allocator.slot_state(slot0)->state.load(std::memory_order_acquire), TaskState::COMPLETED);
+    EXPECT_EQ(allocator.slot_state(slot1)->state.load(std::memory_order_acquire), TaskState::COMPLETED);
+    EXPECT_EQ(endpoint0_ptr->progress_owner(), endpoint1_ptr->progress_owner());
+
+    scheduler.request_stop();
+    scheduler.stop();
+    EXPECT_EQ(endpoint0_ptr->progress_owner(), endpoint1_ptr->progress_owner());
+    EXPECT_FALSE(endpoint0_ptr->progress_owner_changed());
+    EXPECT_FALSE(endpoint1_ptr->progress_owner_changed());
+    manager.stop();
+    allocator.shutdown();
+}
+
 TEST(WorkerManagerTest, SingleFrameSuccessorIsNotReportedAsStageable) {
     Ring allocator;
     allocator.init(/*heap_bytes=*/0);
@@ -936,113 +1063,6 @@ TEST(WorkerManagerTest, SingleFrameSuccessorIsNotReportedAsStageable) {
     EXPECT_FALSE(worker->can_stage());
 
     manager.stop();
-    allocator.shutdown();
-}
-
-// The scheduler's wait is edge-triggered, so the wake it consumes for a
-// finished dispatch has to imply the worker can take the next one. A
-// completion cannot carry that: it is published before the lane state, on
-// purpose, so a stopping scheduler never reads a worker as no longer busy
-// while its last completion is still unqueued. These two pin the ordering the
-// idle edge restores — one per endpoint driving mode.
-TEST(WorkerManagerTest, IdleCallbackFollowsTheLanePublicationOnBlockingEndpoints) {
-    Ring allocator;
-    allocator.init(/*heap_bytes=*/0);
-    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/71, /*pipeline_slot=*/0, /*generation=*/1);
-    ASSERT_NE(slot, INVALID_SLOT);
-
-    WorkerManager manager;
-    manager.add_next_level_endpoint(std::make_unique<FakeEndpoint>(0));
-
-    std::mutex mu;
-    std::condition_variable cv;
-    int completions = 0;
-    int idle_calls = 0;
-    bool completion_seen_first = false;
-    bool worker_readable_as_idle = false;
-
-    manager.start(
-        &allocator,
-        [&](WorkerCompletion) {
-            std::lock_guard<std::mutex> lk(mu);
-            ++completions;
-        },
-        [](WorkerDispatch) {},
-        [&] {
-            WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
-            std::lock_guard<std::mutex> lk(mu);
-            ++idle_calls;
-            completion_seen_first = completions == 1;
-            worker_readable_as_idle = worker != nullptr && worker->idle() && !worker->busy();
-            cv.notify_all();
-        }
-    );
-
-    WorkerThread *worker = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
-    ASSERT_NE(worker, nullptr);
-    worker->dispatch(WorkerDispatch{slot, 0});
-
-    {
-        std::unique_lock<std::mutex> lk(mu);
-        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(3), [&] {
-            return idle_calls == 1;
-        })) << "the worker never signalled that its lane freed up";
-        EXPECT_TRUE(completion_seen_first) << "the idle edge must not precede the completion it belongs to";
-        EXPECT_TRUE(worker_readable_as_idle) << "a dispatch placed on this edge would find the worker occupied";
-    }
-
-    manager.stop();
-    allocator.shutdown();
-}
-
-TEST(WorkerManagerTest, IdleCallbackFollowsTheLanePublicationOnProgressEndpoints) {
-    Ring allocator;
-    allocator.init(/*heap_bytes=*/0);
-    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/72, /*pipeline_slot=*/0, /*generation=*/1);
-    ASSERT_NE(slot, INVALID_SLOT);
-
-    WorkerThread worker;
-    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
-    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
-
-    std::mutex mu;
-    std::condition_variable cv;
-    int completions = 0;
-    int idle_calls = 0;
-    bool completion_seen_first = false;
-    bool worker_readable_as_idle = false;
-
-    worker.start(
-        &allocator,
-        [&](WorkerCompletion) {
-            std::lock_guard<std::mutex> lk(mu);
-            ++completions;
-        },
-        [](WorkerDispatch) {},
-        [&] {
-            std::lock_guard<std::mutex> lk(mu);
-            ++idle_calls;
-            completion_seen_first = completions == 1;
-            worker_readable_as_idle = worker.idle() && !worker.busy();
-            cv.notify_all();
-        },
-        std::move(endpoint)
-    );
-
-    worker.dispatch(WorkerDispatch{slot, 0});
-    ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
-    endpoint_ptr->force_stop_terminalization();
-
-    {
-        std::unique_lock<std::mutex> lk(mu);
-        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(3), [&] {
-            return idle_calls == 1;
-        })) << "the worker never signalled that its lane freed up";
-        EXPECT_TRUE(completion_seen_first) << "the idle edge must not precede the completion it belongs to";
-        EXPECT_TRUE(worker_readable_as_idle) << "a dispatch placed on this edge would find the worker occupied";
-    }
-
-    worker.stop();
     allocator.shutdown();
 }
 
@@ -1073,7 +1093,7 @@ TEST(WorkerManagerTest, WorkerThreadUsesOneProgressOwnerForActiveAndStagedLanes)
             accepted.push_back(dispatch);
             callback_cv.notify_all();
         },
-        {}, std::move(endpoint)
+        std::move(endpoint)
     );
 
     worker.dispatch(WorkerDispatch{active_slot, 0});
@@ -1089,6 +1109,8 @@ TEST(WorkerManagerTest, WorkerThreadUsesOneProgressOwnerForActiveAndStagedLanes)
 
     endpoint_ptr->emit(WorkerProgressKind::ACCEPTED, submitted[0]);
     endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted[0]);
+    worker.progress();
+    worker.progress();
     {
         std::unique_lock<std::mutex> lk(callback_mu);
         EXPECT_TRUE(callback_cv.wait_for(lk, std::chrono::seconds(3), [&] {
@@ -1098,10 +1120,13 @@ TEST(WorkerManagerTest, WorkerThreadUsesOneProgressOwnerForActiveAndStagedLanes)
     EXPECT_TRUE(worker.idle());
     EXPECT_TRUE(worker.busy());
     EXPECT_TRUE(worker.activate_prepared(/*run_id=*/12));
+    worker.progress();
     EXPECT_TRUE(endpoint_ptr->wait_activated(/*run_id=*/12));
 
     endpoint_ptr->emit(WorkerProgressKind::ACCEPTED, submitted[1]);
     endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted[1]);
+    worker.progress();
+    worker.progress();
     {
         std::unique_lock<std::mutex> lk(callback_mu);
         EXPECT_TRUE(callback_cv.wait_for(lk, std::chrono::seconds(3), [&] {
@@ -1147,7 +1172,7 @@ TEST(WorkerManagerTest, AdmissionRejectionsCompleteClaimedDispatchesWithoutThrow
             accepted.push_back(dispatch);
             callback_cv.notify_all();
         },
-        {}, std::move(endpoint)
+        std::move(endpoint)
     );
 
     worker.dispatch(WorkerDispatch{active_slot, 0});
@@ -1179,6 +1204,8 @@ TEST(WorkerManagerTest, AdmissionRejectionsCompleteClaimedDispatchesWithoutThrow
     WorkerDispatch active = endpoint_ptr->submitted().front();
     endpoint_ptr->emit(WorkerProgressKind::ACCEPTED, active);
     endpoint_ptr->emit(WorkerProgressKind::COMPLETED, active);
+    worker.progress();
+    worker.progress();
     {
         std::unique_lock<std::mutex> lk(callback_mu);
         ASSERT_TRUE(callback_cv.wait_for(lk, std::chrono::seconds(3), [&] {
@@ -1195,6 +1222,130 @@ TEST(WorkerManagerTest, AdmissionRejectionsCompleteClaimedDispatchesWithoutThrow
         EXPECT_EQ(completed.back().outcome, EndpointOutcome::ENDPOINT_FAILURE);
         EXPECT_EQ(completed.back().task_slot, stopping_rejected);
     }
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, StopLinearizesWithEndpointSubmission) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot submitted_slot = make_progress_slot(allocator, /*run_id=*/17, /*pipeline_slot=*/0, /*generation=*/1);
+    TaskSlot rejected_slot = make_progress_slot(allocator, /*run_id=*/18, /*pipeline_slot=*/0, /*generation=*/2);
+    ASSERT_NE(submitted_slot, INVALID_SLOT);
+    ASSERT_NE(rejected_slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>(/*worker_id=*/0, /*max_inflight_tasks=*/1);
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    endpoint_ptr->block_next_submit();
+    std::mutex completion_mu;
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            std::lock_guard<std::mutex> lk(completion_mu);
+            completed.push_back(std::move(completion));
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+
+    std::thread submitter([&] {
+        worker.dispatch(WorkerDispatch{submitted_slot, 0});
+    });
+    ASSERT_TRUE(endpoint_ptr->wait_submit_entered());
+
+    std::promise<void> stop_returned;
+    std::future<void> stop_future = stop_returned.get_future();
+    std::thread stopper([&] {
+        worker.stop();
+        stop_returned.set_value();
+    });
+    EXPECT_EQ(stop_future.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout)
+        << "stop must not linearize while endpoint publication is still in progress";
+
+    endpoint_ptr->release_blocked_submit();
+    submitter.join();
+    ASSERT_EQ(stop_future.wait_for(std::chrono::seconds(3)), std::future_status::ready);
+    stopper.join();
+    ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
+
+    worker.dispatch(WorkerDispatch{rejected_slot, 0});
+    EXPECT_EQ(endpoint_ptr->submitted().size(), 1u) << "nothing may publish after stop returns";
+
+    worker.progress();
+    worker.progress();
+    {
+        std::lock_guard<std::mutex> lk(completion_mu);
+        EXPECT_EQ(completed.size(), 2u);
+    }
+    EXPECT_FALSE(worker.busy());
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, StopBeforeProgressDoesNotActivatePreparedSuccessor) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot active_slot = make_progress_slot(allocator, /*run_id=*/19, /*pipeline_slot=*/0, /*generation=*/1);
+    TaskSlot staged_slot = make_progress_slot(allocator, /*run_id=*/20, /*pipeline_slot=*/1, /*generation=*/1);
+    ASSERT_NE(active_slot, INVALID_SLOT);
+    ASSERT_NE(staged_slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            completed.push_back(std::move(completion));
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+    worker.dispatch(WorkerDispatch{active_slot, 0});
+    worker.dispatch_prepared(WorkerDispatch{staged_slot, 0});
+    ASSERT_TRUE(endpoint_ptr->wait_submitted(2));
+    std::vector<WorkerDispatch> submitted = endpoint_ptr->submitted();
+    endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted[0]);
+    worker.progress();
+    ASSERT_TRUE(worker.activate_prepared(/*run_id=*/20));
+
+    worker.stop();
+    worker.progress();
+    EXPECT_FALSE(endpoint_ptr->wait_activated(/*run_id=*/20, std::chrono::milliseconds(20)))
+        << "stop must fence activation even after the staged lane moved to active";
+    worker.progress();
+    EXPECT_EQ(completed.size(), 2u);
+    EXPECT_FALSE(worker.busy());
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, SubmitExceptionQuiescesEndpointOwnedPublication) {
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/21, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    endpoint_ptr->throw_after_next_submit_publication();
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            completed.push_back(std::move(completion));
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+
+    worker.dispatch(WorkerDispatch{slot, 0});
+    EXPECT_TRUE(endpoint_ptr->wait_progress_error());
+    EXPECT_TRUE(completed.empty()) << "endpoint-owned work must terminalize through endpoint progress";
+    EXPECT_TRUE(worker.busy());
+
+    worker.progress();
+    ASSERT_EQ(completed.size(), 1u);
+    EXPECT_EQ(completed[0].outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    EXPECT_FALSE(worker.busy());
     allocator.shutdown();
 }
 
@@ -1307,7 +1458,7 @@ TEST(WorkerManagerTest, ThirdDispatchCannotMutateTwoOccupiedFrames) {
             ++completion_count;
             completion_cv.notify_all();
         },
-        [](WorkerDispatch) {}, {},
+        [](WorkerDispatch) {},
         std::make_unique<LocalMailboxEndpoint>(
             /*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/2
         )
@@ -1343,6 +1494,10 @@ TEST(WorkerManagerTest, ThirdDispatchCannotMutateTwoOccupiedFrames) {
     set_test_frame_accepted(frame1);
     set_test_frame_state(frame0, MailboxState::TASK_DONE);
     set_test_frame_state(frame1, MailboxState::TASK_DONE);
+    worker.progress();
+    worker.progress();
+    worker.progress();
+    worker.progress();
     {
         std::unique_lock<std::mutex> lk(completion_mu);
         EXPECT_TRUE(completion_cv.wait_for(lk, std::chrono::seconds(3), [&] {
@@ -1544,23 +1699,16 @@ TEST(WorkerManagerTest, StopTerminalizesOutstandingProgress) {
             completed.push_back(std::move(completion));
             completion_cv.notify_all();
         },
-        [](WorkerDispatch) {}, {}, std::move(endpoint)
+        [](WorkerDispatch) {}, std::move(endpoint)
     );
     worker.dispatch(WorkerDispatch{active_slot, 0});
     worker.dispatch_prepared(WorkerDispatch{staged_slot, 0});
     EXPECT_TRUE(endpoint_ptr->wait_submitted(2));
 
-    std::promise<void> stopped;
-    std::future<void> stop_done = stopped.get_future();
-    std::thread stopper([&] {
-        worker.stop();
-        stopped.set_value();
-    });
+    worker.stop();
+    worker.progress();
     EXPECT_TRUE(endpoint_ptr->wait_stop_requested());
-    std::future_status stop_status = stop_done.wait_for(std::chrono::seconds(3));
-    EXPECT_EQ(stop_status, std::future_status::ready);
-    if (stop_status != std::future_status::ready) endpoint_ptr->force_stop_terminalization();
-    stopper.join();
+    worker.progress();
     {
         std::lock_guard<std::mutex> lk(completion_mu);
         ASSERT_EQ(completed.size(), 2u);
@@ -1589,21 +1737,14 @@ TEST(WorkerManagerTest, ProgressStopRepeatsUntilOutstandingWorkTerminalizes) {
             std::lock_guard<std::mutex> lk(completion_mu);
             completed.push_back(std::move(completion));
         },
-        [](WorkerDispatch) {}, {}, std::move(endpoint)
+        [](WorkerDispatch) {}, std::move(endpoint)
     );
     worker.dispatch(WorkerDispatch{slot, 0});
     EXPECT_TRUE(endpoint_ptr->wait_submitted(1));
 
-    std::promise<void> stopped;
-    std::future<void> stop_done = stopped.get_future();
-    std::thread stopper([&] {
-        worker.stop();
-        stopped.set_value();
-    });
-    std::future_status stop_status = stop_done.wait_for(std::chrono::seconds(3));
-    EXPECT_EQ(stop_status, std::future_status::ready);
-    if (stop_status != std::future_status::ready) endpoint_ptr->force_stop_terminalization();
-    stopper.join();
+    worker.stop();
+    worker.progress();
+    worker.progress();
 
     EXPECT_EQ(endpoint_ptr->stop_request_count(), 2u)
         << "the first stop request may be overwritten by an in-flight control completion";
@@ -1636,10 +1777,12 @@ TEST(WorkerManagerTest, PollExceptionTerminalizesOutstandingProgressAndStopsTheD
             completed.push_back(std::move(completion));
             completion_cv.notify_all();
         },
-        [](WorkerDispatch) {}, {}, std::move(endpoint)
+        [](WorkerDispatch) {}, std::move(endpoint)
     );
     worker.dispatch(WorkerDispatch{slot, 0});
     EXPECT_TRUE(endpoint_ptr->wait_submitted(1));
+    worker.progress();
+    worker.progress();
     EXPECT_TRUE(endpoint_ptr->wait_progress_error());
 
     bool completion_ready = false;
@@ -1652,16 +1795,7 @@ TEST(WorkerManagerTest, PollExceptionTerminalizesOutstandingProgressAndStopsTheD
     EXPECT_TRUE(completion_ready);
     if (!completion_ready) endpoint_ptr->force_stop_terminalization();
 
-    std::promise<void> stopped;
-    std::future<void> stop_done = stopped.get_future();
-    std::thread stopper([&] {
-        worker.stop();
-        stopped.set_value();
-    });
-    std::future_status stop_status = stop_done.wait_for(std::chrono::seconds(3));
-    EXPECT_EQ(stop_status, std::future_status::ready);
-    if (stop_status != std::future_status::ready) endpoint_ptr->force_stop_terminalization();
-    stopper.join();
+    worker.stop();
 
     EXPECT_EQ(endpoint_ptr->progress_error(), "poll_progress failed: injected poll failure");
     {
@@ -1696,10 +1830,7 @@ TEST(WorkerManagerTest, StopKeepsWorkerBusyUntilItsLastCompletionIsPublished) {
             allow_completion_future.wait();
             scheduler.worker_done(std::move(completion));
         },
-        [](WorkerDispatch) {},
-        [&scheduler] {
-            scheduler.notify_ready();
-        }
+        [](WorkerDispatch) {}
     );
 
     ReadyQueue ready_sub;
@@ -1772,9 +1903,6 @@ struct ProgressSchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orchestrator.mark_task_accepted(dispatch.task_slot);
-            },
-            [this] {
-                scheduler.notify_ready();
             }
         );
         ready_next.reset(manager.next_level_worker_ids());
@@ -2389,6 +2517,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
     std::chrono::milliseconds reservation_stall_warn_after{std::chrono::seconds(5)};
     Scheduler::ReservationStallSink reservation_stall_sink{nullptr};
     void *reservation_stall_sink_context{nullptr};
+    std::function<void()> after_group_phase_hook;
 
     std::vector<TaskSlot> consumed_slots;
     std::mutex consumed_mu;
@@ -2415,9 +2544,6 @@ struct GroupSchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orch.mark_task_accepted(dispatch.task_slot);
-            },
-            [this] {
-                sched.notify_ready();
             }
         );
         rq_next_level.reset(manager.next_level_worker_ids());
@@ -2451,6 +2577,9 @@ struct GroupSchedulerFixture : public ::testing::Test {
         c.reservation_stall_warn_after = reservation_stall_warn_after;
         c.reservation_stall_sink = reservation_stall_sink;
         c.reservation_stall_sink_context = reservation_stall_sink_context;
+        c.after_group_phase_cb = [this] {
+            if (after_group_phase_hook) after_group_phase_hook();
+        };
         sched.start(c);
     }
 
@@ -2764,10 +2893,7 @@ TEST(SchedulerDispatchPassTest, ActiveRunSwitchCannotBypassSuccessorGroupReserva
         [&sched](WorkerCompletion completion) {
             sched.worker_done(std::move(completion));
         },
-        [](WorkerDispatch) {},
-        [&sched] {
-            sched.notify_ready();
-        }
+        [](WorkerDispatch) {}
     );
     rq_next_level.reset(manager.next_level_worker_ids());
 
@@ -2962,9 +3088,6 @@ TEST_F(GroupSchedulerFixture, TearDownDrainsCurrentAndQueuedDispatches) {
     EXPECT_TRUE(sub_worker_b.is_running.load(std::memory_order_acquire));
 }
 
-// The shape that hangs when the idle edge is missing: a second task queued for
-// the only worker that can run it. Its wake is the first task's completion,
-// which a dispatch pass can consume while that worker still reads as occupied.
 TEST_F(GroupSchedulerFixture, QueuedSingleRunsAfterItsWorkerFreesUp) {
     auto first = orch.submit_next_level(C(81), single_tensor_args(0x1A, TensorArgType::OUTPUT), cfg, 0);
     worker_a.wait_running();
@@ -2986,7 +3109,71 @@ TEST_F(GroupSchedulerFixture, QueuedSingleRunsAfterItsWorkerFreesUp) {
     wait_consumed(queued.task_slot);
 }
 
-TEST_F(GroupSchedulerFixture, BlockedGroupSleepsUntilWorkerCompletion) {
+TEST_F(GroupSchedulerFixture, GroupPublishedBetweenGroupAndSinglePhasesStillOwnsItsTargets) {
+    SubmitResult second_group;
+    SubmitResult single_a;
+    SubmitResult single_c;
+    std::atomic<bool> published{false};
+    std::promise<void> publication_done;
+    std::future<void> publication_future = publication_done.get_future();
+    after_group_phase_hook = [&] {
+        if (published.exchange(true, std::memory_order_acq_rel)) return;
+        second_group = orch.submit_next_level_group(
+            C(91), {single_tensor_args(0x202, TensorArgType::OUTPUT), single_tensor_args(0x203, TensorArgType::OUTPUT)},
+            cfg, {1, 2}
+        );
+        single_a = orch.submit_next_level(C(92), single_tensor_args(0x204, TensorArgType::OUTPUT), cfg, 0);
+        single_c = orch.submit_next_level(C(93), single_tensor_args(0x205, TensorArgType::OUTPUT), cfg, 2);
+        publication_done.set_value();
+    };
+
+    SubmitResult first_group = orch.submit_next_level_group(
+        C(90), {single_tensor_args(0x200, TensorArgType::OUTPUT), single_tensor_args(0x201, TensorArgType::OUTPUT)},
+        cfg, {0, 1}
+    );
+    ASSERT_EQ(publication_future.wait_for(std::chrono::seconds(3)), std::future_status::ready);
+    worker_a.wait_running();
+    worker_b.wait_running();
+    EXPECT_EQ(worker_c.dispatched_count(), 0)
+        << "the later single must not cross a group that appeared between dispatch phases";
+
+    worker_a.complete();
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (worker_a.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(worker_a.dispatched_count(), 2);
+    EXPECT_EQ(worker_a.dispatched[1].callable_hash0, 92u);
+    worker_a.complete();
+
+    worker_b.complete();
+    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while ((worker_b.dispatched_count() < 2 || worker_c.dispatched_count() < 1) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(worker_b.dispatched_count(), 2);
+    ASSERT_EQ(worker_c.dispatched_count(), 1);
+    EXPECT_EQ(worker_b.dispatched[1].callable_hash0, 91u);
+    EXPECT_EQ(worker_c.dispatched[0].callable_hash0, 91u);
+    worker_b.complete();
+    worker_c.complete();
+
+    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (worker_c.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(worker_c.dispatched_count(), 2);
+    EXPECT_EQ(worker_c.dispatched[1].callable_hash0, 93u);
+    worker_c.complete();
+
+    wait_consumed(first_group.task_slot);
+    wait_consumed(second_group.task_slot);
+    wait_consumed(single_a.task_slot);
+    wait_consumed(single_c.task_slot);
+}
+
+TEST_F(GroupSchedulerFixture, BlockedGroupRemainsReadyUntilWorkerCompletion) {
     auto running = orch.submit_next_level(C(78), single_tensor_args(0xFA, TensorArgType::OUTPUT), cfg, 0);
     worker_a.wait_running();
     EXPECT_TRUE(worker_a.is_running.load(std::memory_order_acquire));
@@ -3003,22 +3190,6 @@ TEST_F(GroupSchedulerFixture, BlockedGroupSleepsUntilWorkerCompletion) {
     }
     const uint64_t settled_rounds = sched.dispatch_round_count();
     ASSERT_GT(settled_rounds, rounds_before_blocked_group);
-    // The fix's property: with the group blocked, dispatch rounds stop
-    // advancing once the scheduler parks. Poll for a quiet window instead of
-    // a fixed sleep so a loaded runner cannot fail the check spuriously.
-    uint64_t quiet_rounds = settled_rounds;
-    bool parked = false;
-    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
-    while (std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        const uint64_t rounds_now = sched.dispatch_round_count();
-        if (rounds_now == quiet_rounds) {
-            parked = true;
-            break;
-        }
-        quiet_rounds = rounds_now;
-    }
-    EXPECT_TRUE(parked) << "scheduler did not park while the group head was blocked";
     EXPECT_EQ(S(blocked.task_slot).state.load(std::memory_order_acquire), TaskState::READY);
 
     worker_a.complete();
@@ -3056,16 +3227,13 @@ TEST_F(GroupSchedulerFixture, LaunchableGroupPrecedesConflictingSingles) {
         single_b = orch.submit_next_level(C(77), single_tensor_args(0xF9, TensorArgType::OUTPUT), cfg, 1);
         worker_a.complete();
         worker_b.complete();
-
-        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
-        while (manager.any_busy() && std::chrono::steady_clock::now() < deadline) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        ASSERT_FALSE(manager.any_busy());
     }
 
-    worker_a.wait_running();
-    worker_b.wait_running();
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while ((worker_a.dispatched_count() < 2 || worker_b.dispatched_count() < 2) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
     ASSERT_EQ(worker_a.dispatched_count(), 2);
     ASSERT_EQ(worker_b.dispatched_count(), 2);
     EXPECT_EQ(worker_a.dispatched[1].callable_hash0, 75u);
@@ -3075,7 +3243,7 @@ TEST_F(GroupSchedulerFixture, LaunchableGroupPrecedesConflictingSingles) {
     worker_b.complete();
     wait_consumed(group.task_slot);
 
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
     while ((worker_a.dispatched_count() < 3 || worker_b.dispatched_count() < 3) &&
            std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -3173,23 +3341,8 @@ TEST_F(GroupSchedulerFixture, InvalidGroupIndexFailsAndConsumesGroup) {
     wait_consumed(slot);
     EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 
-    {
-        // Wait for the invalid completion's dispatch round to finish, then
-        // make both terminalized group members idle while the scheduler loop
-        // is paused. Their completion callbacks must provide the next wake.
-        std::lock_guard<std::mutex> scheduler_pause(sched.loop_mutex());
-        worker_a.complete();
-        worker_b.complete();
-        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
-        WorkerThread *manager_worker_a = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0);
-        WorkerThread *manager_worker_b = manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 1);
-        while ((!manager_worker_a->idle() || !manager_worker_b->idle()) &&
-               std::chrono::steady_clock::now() < deadline) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        EXPECT_TRUE(manager_worker_a->idle());
-        EXPECT_TRUE(manager_worker_b->idle());
-    }
+    worker_a.complete();
+    worker_b.complete();
 
     auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
     while ((worker_a.dispatched_count() < 2 || worker_b.dispatched_count() < 2) &&
@@ -3389,9 +3542,6 @@ TEST(SchedulerWorkerTargetTest, NextLevelTargetUsesWorkerIdNotVectorIndex) {
         },
         [&orch](WorkerDispatch dispatch) {
             orch.mark_task_accepted(dispatch.task_slot);
-        },
-        [&sched] {
-            sched.notify_ready();
         }
     );
     rq_next_level.reset(manager.next_level_worker_ids());
@@ -3522,9 +3672,6 @@ struct MixedTypeSchedulerFixture : public ::testing::Test {
             },
             [this](WorkerDispatch dispatch) {
                 orch.mark_task_accepted(dispatch.task_slot);
-            },
-            [this] {
-                sched.notify_ready();
             }
         );
         rq_next_level.reset(manager.next_level_worker_ids());


### PR DESCRIPTION
## Summary
- make the Scheduler thread the single parent-side progress owner for every endpoint lane
- remove per-endpoint WorkerThread threads, dispatch queues, and idle-edge wakeups while preserving lane capacity and completion contracts
- linearize stop with endpoint publication/prepared activation and route submit failures through endpoint-owned quiescence
- prevent a newly published NEXT_LEVEL group from being bypassed between the group and single dispatch phases

## Behavioral note
- remote control commands remain serialized behind an in-flight remote task because both use the same command socket; task progress deadlines bound that wait

## Testing
- [x] `ctest --test-dir tests/ut/cpp/build --output-on-failure` (91/91, local macOS)
- [x] `tests/ut/cpp/build/test_scheduler` (66/66)
- [x] `tests/ut/cpp/build/test_remote_endpoint` (18/18)
- [x] relevant `pre-commit` hooks, including clang-tidy, cpplint, and clang-format
- [x] remote Linux `test_scheduler` on `liteserver-hps-148e` at previous head `aaaa6461` (62/62)