### PR TITLE
Change: decode a chip child's mailbox blob once per dispatch

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2224,7 +2224,7 @@ NB_MODULE(_task_interface, m) {
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"), nb::arg("accepted_state_addr") = 0,
             nb::arg("accepted_value") = 0, nb::arg("pipeline_slot") = 0, nb::arg("pipeline_generation") = 0,
             "Launch a callable_id from the runtime.so-ABI POD a chip-child mailbox loop built with "
-            "materialize_tensor_blob, so no Python code re-implements the tensor/scalar layout."
+            "materialize_task_args, so no Python code re-implements the tensor/scalar layout."
         )
         .def(
             "unregister_callable",
@@ -2379,28 +2379,6 @@ NB_MODULE(_task_interface, m) {
     // --- Standalone blob helpers ---
 
     m.def(
-        "materialize_tensor_blob",
-        [](uint64_t blob_ptr, size_t capacity, nb::dict resolved) -> ChipStorageTaskArgs {
-            TaskArgsView view = read_blob(reinterpret_cast<const uint8_t *>(blob_ptr), capacity);
-            ChipStorageTaskArgs args;
-            for (int32_t i = 0; i < view.tensor_count; i++) {
-                args.add_tensor(materialize_one(view.tensors(i), resolved));
-            }
-            for (int32_t i = 0; i < view.scalar_count; i++) {
-                args.add_scalar(view.scalars[i]);
-            }
-            return args;
-        },
-        nb::arg("blob_ptr"), nb::arg("capacity"), nb::arg("resolved"),
-        "Materialize a Tensor blob into the runtime.so-ABI ChipStorageTaskArgs POD. Each tensor's "
-        "embedded buffer identity is resolved via `resolved` {CanonicalIdentity: (local_base, "
-        "address_space)}; addr = base + byte_offset. The caller pre-populates `resolved` by "
-        "materializing each embedded descriptor (see read_args_from_blob) on first receipt. "
-        "Strided views (transpose / permute / step-slice) materialize to strided ChipTensors. "
-        "Rejects an unknown identity and a non-dtype-aligned byte_offset."
-    );
-
-    m.def(
         "materialize_task_args",
         [](const TaskArgs &args, nb::dict resolved) -> ChipStorageTaskArgs {
             ChipStorageTaskArgs out;
@@ -2414,8 +2392,13 @@ NB_MODULE(_task_interface, m) {
         },
         nb::arg("args"), nb::arg("resolved"),
         "Materialize a TaskArgs held in this process into the runtime.so-ABI ChipStorageTaskArgs "
-        "POD. An L2 leaf consumes its own args, so it takes this path instead of the mailbox blob; "
-        "`resolved` has the same shape as for materialize_tensor_blob."
+        "POD — the sole path to that POD, whether the args are an L2 leaf's own or a chip child's "
+        "read back from its mailbox with read_args_from_blob. Each tensor's embedded buffer "
+        "identity is resolved via `resolved` {CanonicalIdentity: (local_base, address_space)}; "
+        "addr = base + byte_offset. The caller pre-populates `resolved` by materializing each "
+        "embedded descriptor on first receipt. Strided views (transpose / permute / step-slice) "
+        "materialize to strided ChipTensors. Rejects an unknown identity and a non-dtype-aligned "
+        "byte_offset."
     );
 
     m.def(

--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -634,19 +634,9 @@ class ImportRegistry:
         self._by_identity[key] = imported
         return imported
 
-    def materialize_blob(self, blob_ptr: int, capacity: int) -> dict[CanonicalIdentity, tuple[int, int]]:
-        """Materialize every embedded descriptor in a task-args blob and return the resolved map:
-        identity -> (local base, address_space), scoped to this call's own tensors."""
-        args = read_args_from_blob(blob_ptr, capacity)
-        resolved: dict[CanonicalIdentity, tuple[int, int]] = {}
-        for i in range(args.tensor_count()):
-            desc = args.tensor(i).buffer
-            imported = self.materialize(desc)
-            resolved[desc.identity] = (imported.base, int(imported.address_space))
-        return resolved
-
     def materialize_args(self, args) -> dict[CanonicalIdentity, tuple[int, int]]:
-        """The same, for a ``TaskArgs`` already held in this process (the L2-leaf path)."""
+        """Materialize every embedded descriptor in a ``TaskArgs`` and return the resolved map:
+        identity -> (local base, address_space), scoped to this call's own tensors."""
         resolved: dict[CanonicalIdentity, tuple[int, int]] = {}
         for i in range(args.tensor_count()):
             desc = args.tensor(i).buffer

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -98,7 +98,6 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     _worker_host_mapped_region_peek_cleanup_error,
     get_element_size,
     materialize_task_args,
-    materialize_tensor_blob,
     read_args_from_blob,
 )
 
@@ -2501,13 +2500,14 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             )
             if pipeline_reserved != 0:
                 raise RuntimeError(f"chip_process dev={device_id}: invalid pipeline lease reserved field")
-            # Materialize the tensor args into a chip-POD blob the runtime reads: resolve
-            # each ref's embedded handle to a local base (map-once, cached by canonical
-            # identity), then build the chip blob at those bases. Replaces the former
-            # parent-VA range rewrite — identities resolve exactly, not by numeric range.
+            # The mailbox bytes decode once, into the wire TaskArgs; the mapping pass and the
+            # chip-POD build both read that object. Each tensor's embedded handle resolves to a
+            # local base by canonical identity (map-once, cached), and the POD is built at those
+            # bases — an exact resolution, not the parent-VA numeric-range rewrite it replaced.
             args_ptr = task_addr + _OFF_TASK_ARGS_BLOB
-            resolved = import_registry.materialize_blob(args_ptr, _MAILBOX_ARGS_CAPACITY)
-            chip_args = materialize_tensor_blob(args_ptr, _MAILBOX_ARGS_CAPACITY, resolved)
+            args = read_args_from_blob(args_ptr, _MAILBOX_ARGS_CAPACITY)
+            resolved = import_registry.materialize_args(args)
+            chip_args = materialize_task_args(args, resolved)
             # The acceptance flag lives in the mailbox, not in the materialized args, so
             # the fence still publishes through the address the parent polls.
             cw._impl.run_materialized(
@@ -2759,13 +2759,15 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
 
         def submit_frame(frame: _StagedFrame) -> None:
             _protocol, run_id, slot_id, generation, dispatch_id = frame.identity
-            # The frame carries the wire blob; the runtime reads the chip POD. Resolve each
-            # tensor's descriptor to a local base (map-once, cached by canonical identity) and
-            # rebuild at those bases, as the non-pipelined task path does. The lane copies the
-            # args into its own storage, so this POD need not outlive the call.
+            # The frame carries the wire blob; the runtime reads the chip POD. The bytes decode
+            # once into the wire TaskArgs, whose tensors resolve to local bases (map-once, cached
+            # by canonical identity) and rebuild at those bases, as the non-pipelined task path
+            # does. The lane copies the args into its own storage, so this POD need not outlive
+            # the call.
             args_ptr = frame.frame_addr + _OFF_TASK_ARGS_BLOB
-            resolved = import_registry.materialize_blob(args_ptr, _MAILBOX_ARGS_CAPACITY)
-            chip_args = materialize_tensor_blob(args_ptr, _MAILBOX_ARGS_CAPACITY, resolved)
+            args = read_args_from_blob(args_ptr, _MAILBOX_ARGS_CAPACITY)
+            resolved = import_registry.materialize_args(args)
+            chip_args = materialize_task_args(args, resolved)
             frame.chip_run = cw._impl._submit_chip_run_materialized(
                 frame.cid,
                 chip_args,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_tensor_dispatch.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_tensor_dispatch.py
@@ -11,9 +11,9 @@
 
 The L3 orch is a pure DAG builder over views: it names task args as Tensors built from handles
 (create_buffer + handle.ref), never touching data. torch is used only OUTSIDE run() to fill inputs
-and read the output. The owner writes a Tensor blob to the chip mailbox; the chip child
-materializes it back to Tensors (ImportRegistry -> materialize_tensor_blob) and runs the kernel;
-the result lands in the shared output buffer with no per-run copy.
+and read the output. The owner writes a Tensor blob to the chip mailbox; the chip child materializes
+it back to Tensors (read_args_from_blob -> ImportRegistry -> materialize_task_args) and runs the
+kernel; the result lands in the shared output buffer with no per-run copy.
 """
 
 import torch


### PR DESCRIPTION
## One decode per dispatch

Both chip-child dispatch paths read the same mailbox bytes twice: once through
`ImportRegistry.materialize_blob` to reach each tensor's descriptor and build the identity ->
local-base map, then again through `materialize_tensor_blob` to produce the
`ChipStorageTaskArgs` the runtime ABI reads.

```python
# before
resolved   = import_registry.materialize_blob(args_ptr, cap)     # decode #1
chip_args  = materialize_tensor_blob(args_ptr, cap, resolved)    # decode #2, same bytes

# after
args       = read_args_from_blob(args_ptr, cap)                  # the only decode
resolved   = import_registry.materialize_args(args)
chip_args  = materialize_task_args(args, resolved)
```

Per tensor that removes one 144 B copy and one full `validate_tensor`; at the 256-arg ceiling
(`CHIP_MAX_TENSOR_ARGS`) it is 36 KiB of copying plus 256 validations per dispatch.

**No binding grows a parameter.** `read_args_from_blob` and `materialize_task_args` both already
existed — the L2-leaf path runs this exact three-step shape today. `materialize_tensor_blob` is
deleted outright, and `materialize_blob` collapses into `materialize_args`, whose body it
duplicated except for the leading decode. Two functions out, none in.

**Validation coverage is unchanged.** `TaskArgsView::tensors` is the sole gate on a blob element,
and the surviving decode runs it over the same elements the deleted one did.

`materialize_task_args` is now the only path to the chip POD, so the `resolved` map's shape is
documented on it rather than by reference to a function that no longer exists.

## Verification

- [x] Build green — four arch x runtime trees plus the nanobind extension
- [x] `pyut` — 1304 passed, 6 skipped, identical to the base commit's own run
- [x] `a2a3sim` full scene suite — rc=0, 0 failures, including
      `TestPostForkHostBufferZeroCopy` (19.2 s), which exercises this path
- [x] **onboard `test_l3_tensor_dispatch` on real a2a3 silicon** — PASS, under a `task-submit`
      device lock. This is the end-to-end owner-writes-blob / chip-child-materializes case
- [x] pre-commit green
- [ ] `a5sim` full scene suite — running locally at push time; CI covers it
- [ ] Dispatch-latency comparison — not run. What this removes is one memcpy plus one validation
      per tensor, and the scene tests carry 3-5 tensors, so any delta would sit inside host
      dispatch noise. The case for the change is one fewer decode path and two fewer functions;
      a measurable win needs a large-arg-count workload, which none of the suites here is

The static check the change has to satisfy:

```console
$ grep -rn "materialize_tensor_blob\|materialize_blob\b" --include=*.py --include=*.cpp .
$ grep -n "read_blob(" python/bindings/task_interface.cpp
2407:            TaskArgsView view = read_blob(...);   # read_args_from_blob, the one remaining caller
```

## Context

Deferred from #1729 review item 6, and again by #1747 on the grounds that closing it would need
`materialize_tensor_blob` to take an already-parsed view — a signature change on a hot binding.
That turned out not to be the shape of the fix: the parsed-view consumer is `materialize_task_args`,
which already exists, so the hot path moves to it and the re-reading function is simply deleted.
