### PR TITLE
Change: carry the wire Tensor as the remote-L3 per-argument record

### DIFF
--- a/docs/remote-l3-worker-design/buffers-and-transports.md
+++ b/docs/remote-l3-worker-design/buffers-and-transports.md
@@ -141,8 +141,10 @@ Endpoint rules:
   pointer.
 - `RemoteL3Endpoint` requires a sidecar for every tensor payload that crosses
   the remote protocol, including `HOST_INLINE` payloads.
-- Remote TASK frames write `TensorWire.data == 0`; parent virtual
-  addresses never cross the remote protocol.
+- Remote TASK frames carry each argument's `Tensor` verbatim, and that `Tensor`
+  is a `REMOTE_SIDECAR` placeholder: it names the remote backing but describes
+  none of its own. Parent virtual addresses and the parent's own backings never
+  cross the remote protocol.
 - A remote tensor with `child_memory=True` and no sidecar is invalid. Local
   child-memory pointers are meaningful only inside fork/shm topology.
 - The remote session runner translates each `RemoteTensorDesc` into a wire

--- a/docs/remote-l3-worker-design/implementation-plan.md
+++ b/docs/remote-l3-worker-design/implementation-plan.md
@@ -92,8 +92,7 @@ Status for the local PR #866 cut:
      bounded error payloads.
    - Include tests that reject unknown enum values, non-zero reserved fields,
      and truncated multi-byte fields.
-   - Include tests that reject non-zero `TensorWire.data` in remote
-     TASK frames.
+   - Include tests that reject a remote TASK argument carrying a local backing.
 
 6. Remote callable registry. **Implemented for dispatcher `PYTHON_IMPORT`,
    inner manifest/control `PYTHON_IMPORT`, and inner manifest/control inline
@@ -251,7 +250,7 @@ Status for the local PR #866 cut:
 | Remote import eligibility | Imported peer handle makes only the importer worker eligible. |
 | Remote import dep key | Owner and imported views use the same owner-based TensorMap key. |
 | Raw pointer rejection | Unstaged host pointer fails before slot commit. |
-| Wire data zero | Non-zero remote TASK tensor data is rejected. |
+| Wire backing-free | A remote TASK tensor carrying a local backing or a non-zero `byte_offset` is rejected on encode and on decode. |
 | HOST_INLINE desc | Inline payloads require a descriptor and bounds checks. |
 | Remote buffer copy | Host stages input, remote writes output, host pulls. |
 | Input-only free deferral | Released input buffer survives queued consumers. |

--- a/docs/remote-l3-worker-design/protocol.md
+++ b/docs/remote-l3-worker-design/protocol.md
@@ -88,24 +88,8 @@ encodes these fields explicitly and rejects drift through decode-time bounds
 checks. The local fork/shm mailbox continues to memcpy the packed `CallConfig`
 POD because it is same-binary IPC, not the cross-host protocol.
 
-`TensorWire v1` encodes tensor metadata explicitly. In remote TASK
-frames, `data` is not a transferable pointer; it is reserved and must be zero.
-
-```text
-data: uint64  # reserved in remote TASK frames; must be 0
-shapes: uint32[MAX_TENSOR_DIMS]
-ndims: uint32
-dtype: uint32
-child_memory: uint8
-reserved: uint8[7]
-```
-
-The wire carries only the contiguous-defining fields; it does **not** carry
-`strides` / `start_offset`, and `decode_tensor` rebuilds them as row-major.
-The remote wire is therefore **contiguous-only**: strided views round-trip
-solely over the local fork/shm mailbox blob (full 128 B `ChipTensor` memcpy).
-`encode_tensor` asserts `is_contiguous && start_offset == 0` so a strided
-tensor fails loudly rather than being silently flattened.
+A remote TASK argument is a `TensorWire`, defined with the rest of the TASK
+payload below.
 
 The session runner decodes these wire records into a local `CallConfig` and a
 wire `TaskArgs` before calling `inner_worker.run()`. Each tensor becomes a
@@ -152,7 +136,8 @@ args: RemoteTaskArgsWire v1
 
 The TASK payload has exactly these top-level fields: callable digest,
 `CallConfigWire`, and `RemoteTaskArgsWire`. `RemoteTaskArgsWire` then carries
-tensor metadata, remote tensor descriptors, scalars, and optional inline bytes.
+the argument tensors, remote tensor descriptors, scalars, and optional inline
+bytes.
 
 TASK frames carry the raw digest from the submitted parent-facing
 `CallableHandle.hashid`. Parent-side dependency inference has already consumed
@@ -165,7 +150,7 @@ the sidecar descriptors captured at submit time to name, on the session runner,
 the local backings the wire `TaskArgs` views.
 
 The current `RemoteL3Endpoint` implementation builds this payload from
-`TaskSlotState`, zeros every tensor metadata `data` field, and submits the
+`TaskSlotState`, carrying each argument's `Tensor` verbatim, and submits the
 encoded frame through `RemoteL3Transport`. The simulation session runner
 resolves the digest in its dispatcher registry, materializes the sidecar
 descriptors, and calls `inner_worker.run()`.
@@ -175,22 +160,28 @@ descriptors, and calls `inner_worker.run()`.
 ```text
 tensor_count: uint32
 scalar_count: uint32
-tensor_metadata: TensorWire[tensor_count]
+tensors: TensorWire[tensor_count]
 remote_desc: OptionalRemoteTensorDescWire[tensor_count]
 scalars: uint64[scalar_count]
 inline_payload_bytes_len: uint32
 inline_payload_bytes: uint8[inline_payload_bytes_len]
 ```
 
-For each tensor index, exactly one of these is true:
+`TensorWire` is the wire `Tensor` of `src/common/task_interface/buffer.h`: the
+embedded `BufferDescriptor` (identity nonce, `buffer_id`, `generation`,
+`address_space`, `access`, `backend_kind`, `nbytes`, `owner_worker_path_id`, a
+length-delimited backend body) followed by the view (`byte_offset`, `ndims`,
+`ndims`-many `shapes` and `strides`, `dtype`). Shapes and strides travel as
+`ndims`-many entries, so the slots past `ndims` that `validate_tensor` requires
+zero are never on the wire.
 
-- `remote_desc[i]` is present and names a remote buffer, imported peer buffer,
-  UB mapping, or allowed small `HOST_INLINE` payload.
-- The tensor is metadata-only and has no data pointer and no remote descriptor.
-
-`tensor_metadata[i].data` must be zero in both cases. Bare host pointers are
-rejected for remote endpoints unless an explicit staging API has produced a
-remote handle and sidecar descriptor.
+Every argument's `remote_desc[i]` is present and names a remote buffer,
+imported peer buffer, UB mapping, or allowed small `HOST_INLINE` payload. That
+sidecar is the sole authority for the argument's backing, so `tensors[i]` must
+carry no backing of its own: its `backend_kind` is `REMOTE_SIDECAR` and its
+`byte_offset` is zero, both rejected otherwise on encode and on decode. Bare
+host pointers are rejected for remote endpoints unless an explicit staging API
+has produced a remote handle and sidecar descriptor.
 
 `HOST_INLINE` is for small payloads that should travel inside the TASK frame.
 It still requires a `RemoteTensorDescWire` with `address_space=HOST_INLINE`;
@@ -221,14 +212,13 @@ RemoteTensorDescWire:
 
 Rules:
 
-- `ChipTensor` remains the L2 ABI. The session runner translates descriptors
-  into wire `Tensor` args immediately before `inner_worker.run()`; the L2 leaf
-  under it materializes those into `ChipTensor` as it does on every path.
-- When a descriptor is present, the incoming `TensorWire.data` is
-  reserved and must be zero. The session runner derives the executable local
-  address only from the validated descriptor and its live buffer/import
-  registry.
-- Metadata-only tensors also require `TensorWire.data == 0`.
+- `ChipTensor` remains the L2 ABI. The session runner rebuilds each incoming
+  `TensorWire`'s view over the local backing its descriptor names, immediately
+  before `inner_worker.run()`; the L2 leaf under it materializes those into
+  `ChipTensor` as it does on every path.
+- The incoming `TensorWire` carries no address and no local backing. The
+  session runner derives the executable local address only from the validated
+  descriptor and its live buffer/import registry.
 - Parent-side dependency keys use a stable logical start-address key derived at
   submit time:
   `(address_kind, owner_worker_id, buffer_id, generation, offset)`.
@@ -769,7 +759,8 @@ The frame codec must reject:
 - descriptor offsets outside the referenced handle;
 - `HOST_INLINE` payload offsets or lengths outside the inline byte arena;
 - non-`HOST_INLINE` descriptors with non-zero inline payload lengths;
-- non-zero `TensorWire.data` in remote TASK frames;
+- a remote TASK argument that carries a local backing (any `backend_kind` other
+  than `REMOTE_SIDECAR`) or a non-zero `TensorWire.byte_offset`;
 - stale generations;
 - unknown control names or control versions;
 - completion sequence mismatch;

--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -60,6 +60,7 @@ __all__ = [
     "intern_worker_path",
     "mint_owner_instance_id",
     "re_export",
+    "remote_backing_identity",
     "remote_sidecar_tensor",
     "worker_path_for_id",
     "wrap_device_malloc",
@@ -254,6 +255,20 @@ def re_export(source: BufferDescriptor) -> Buffer:
     )
 
 
+def remote_backing_identity(owner_worker_id: int, buffer_id: int, generation: int) -> CanonicalIdentity:
+    """The canonical identity of a backing that lives on another machine's worker.
+
+    A remote owner's ``owner_instance_id`` never crosses the remote L3 wire, so the nonce is the
+    owning worker's id instead. This is the single rule for naming a remote backing: the submitting
+    L4's ``REMOTE_SIDECAR`` placeholder and the importing session runner both derive from it, so one
+    remote backing carries one identity on both sides of the hop.
+    """
+    oid = int(owner_worker_id).to_bytes(OWNER_INSTANCE_ID_BYTES, "little")
+    # A HOST_INLINE placeholder has no backing and so no generation of its own; 0 is the reserved
+    # "uninitialized" value a decoder rejects, so it carries the initial generation instead.
+    return CanonicalIdentity(oid, int(buffer_id), int(generation) or 1)
+
+
 def remote_sidecar_tensor(
     shapes: tuple[int, ...],
     dtype: int,
@@ -271,13 +286,11 @@ def remote_sidecar_tensor(
     descriptor rides in the per-task RemoteTaskArgsSidecar). The identity encodes the remote buffer
     (``owner_worker_id`` folded into the opaque nonce, plus ``buffer_id`` / ``generation``) so
     dependency inference and routing stay stable across the hop.
+
+    This placeholder is what the remote L3 wire carries verbatim as the task's per-argument record.
     """
-    oid = int(owner_worker_id).to_bytes(OWNER_INSTANCE_ID_BYTES, "little")
-    # A HOST_INLINE placeholder has no backing and so no generation of its own; 0 is the reserved
-    # "uninitialized" value a decoder rejects, so the placeholder carries the initial generation.
-    identity = CanonicalIdentity(oid, buffer_id, int(generation) or 1)
     descriptor = BufferDescriptor(
-        identity=identity,
+        identity=remote_backing_identity(owner_worker_id, buffer_id, generation),
         owner_worker_path_id=intern_worker_path(f"remote/{owner_worker_id}"),
         address_space=address_space,
         access=AccessMode.READWRITE,

--- a/python/simpler/remote_l3_protocol.py
+++ b/python/simpler/remote_l3_protocol.py
@@ -15,17 +15,30 @@ import socket
 import struct
 from dataclasses import dataclass
 
-from .task_interface import MAX_TENSOR_DIMS, CallConfig, ChipTensor, DataType
+from .buffer import (
+    OWNER_INSTANCE_ID_BYTES,
+    AccessMode,
+    AddressSpace,
+    BackendKind,
+    BufferDescriptor,
+    CanonicalIdentity,
+    Tensor,
+)
+from .task_interface import MAX_TENSOR_DIMS, CallConfig, DataType
 
-# 2: CallConfig lost its block_dim field — a run always takes the whole
-# device, so the payload is one int32 shorter than v1's.
-PROTOCOL_VERSION = 2
+# 3: a TASK's per-argument record is the self-describing wire ``Tensor`` — the embedded
+# BufferDescriptor plus the strided view. Both ends of a run come from one ``pip install``,
+# so this constant is a mismatch alarm at the frame header, not a dual-decode selector.
+PROTOCOL_VERSION = 3
 MAX_FRAME_PAYLOAD_BYTES = 16 * 1024 * 1024
 MAX_STRING_BYTES = 1024
 MAX_ERROR_BYTES = 4096
 MAX_TENSORS = 4096
 MAX_SCALARS = 4096
 MAX_INLINE_PAYLOAD_BYTES = 1024 * 1024
+# Mirrors DESC_MAX_BYTES in src/common/task_interface/buffer.h. ``BufferDescriptor`` construction
+# re-checks it, so this bound only makes an over-long body fail at the field that carries it.
+MAX_BUFFER_DESCRIPTOR_BODY_BYTES = 32
 MAX_TRANSPORT_PROFILE_BYTES = 128
 MAX_TRANSPORT_DESCRIPTOR_BYTES = 4096
 HOST_TCP_TRANSPORT_PROFILE = "host_tcp"
@@ -146,7 +159,7 @@ class RemoteTensorSidecar:
 
 @dataclass(frozen=True)
 class RemoteTaskArgsWire:
-    tensor_metadata: tuple[ChipTensor, ...]
+    tensors: tuple[Tensor, ...]
     remote_desc: tuple[RemoteTensorSidecar, ...]
     scalars: tuple[int, ...]
     inline_payload: bytes
@@ -431,22 +444,47 @@ def decode_call_config(reader: _Reader) -> CallConfig:
     return cfg
 
 
-def decode_tensor(reader: _Reader) -> ChipTensor:
-    data = reader.u64()
-    if data != 0:
-        raise ValueError("remote_wire: remote TASK tensor data must be zero")
-    shapes = [reader.u32() for _ in range(MAX_TENSOR_DIMS)]
+def decode_tensor(reader: _Reader) -> Tensor:
+    """The wire ``Tensor`` a remote TASK carries per argument: embedded descriptor plus view.
+
+    Shapes and strides are ``ndims``-many, so the slots past ``ndims`` that ``validate_tensor``
+    requires zero are never on the wire. ``Tensor`` construction runs that validator, which is what
+    keeps this decode behind the same gate as every other Tensor trust boundary.
+    """
+    owner_instance_id = reader.raw(OWNER_INSTANCE_ID_BYTES, "buffer identity nonce")
+    buffer_id = reader.u64()
+    generation = reader.u32()
+    address_space = reader.u8()
+    access = reader.u8()
+    backend_kind = reader.u8()
+    # An arg bound for a remote worker has no local backing: the authoritative descriptor of its
+    # backing is the per-argument RemoteTensorDesc sidecar.
+    if backend_kind != int(BackendKind.REMOTE_SIDECAR):
+        raise ValueError("remote_wire: a remote TASK tensor must carry no local backing")
+    nbytes = reader.u64()
+    owner_worker_path_id = reader.u32()
+    body = reader.blob(MAX_BUFFER_DESCRIPTOR_BODY_BYTES, "BufferDescriptor.body")
+    byte_offset = reader.u64()
+    # The sidecar's own offset is where the view sits in the backing, so the record's view spans
+    # exactly the backing its descriptor advertises.
+    if byte_offset != 0:
+        raise ValueError("remote_wire: a remote TASK tensor must carry no byte_offset")
     ndims = reader.u32()
     if ndims == 0 or ndims > MAX_TENSOR_DIMS:
         raise ValueError("remote_wire: tensor ndims out of range")
+    shapes = tuple(reader.u32() for _ in range(ndims))
+    strides = tuple(reader.u32() for _ in range(ndims))
     dtype = DataType(reader.u32())
-    child_memory = reader.u8()
-    if child_memory not in (0, 1):
-        raise ValueError("remote_wire: tensor child_memory must be 0 or 1")
-    for _ in range(7):
-        if reader.u8() != 0:
-            raise ValueError("remote_wire: ChipTensor reserved bytes must be zero")
-    return ChipTensor.make(0, tuple(shapes[:ndims]), dtype, bool(child_memory))
+    descriptor = BufferDescriptor(
+        identity=CanonicalIdentity(owner_instance_id, buffer_id, generation),
+        address_space=AddressSpace(address_space),
+        access=AccessMode(access),
+        backend_kind=BackendKind(backend_kind),
+        nbytes=nbytes,
+        body=body,
+        owner_worker_path_id=owner_worker_path_id,
+    )
+    return Tensor(buffer=descriptor, byte_offset=byte_offset, shapes=shapes, strides=strides, dtype=dtype)
 
 
 def decode_remote_tensor_desc(reader: _Reader) -> RemoteTensorDesc:

--- a/python/simpler/remote_l3_session.py
+++ b/python/simpler/remote_l3_session.py
@@ -34,15 +34,14 @@ from multiprocessing import shared_memory
 from typing import Any, Callable
 
 from .buffer import (
-    OWNER_INSTANCE_ID_BYTES,
     AccessMode,
     AddressSpace,
     BackendKind,
     Buffer,
-    CanonicalIdentity,
     create_host_shared_buffer,
     intern_worker_path,
     mint_owner_instance_id,
+    remote_backing_identity,
 )
 from .callable_identity import (
     CallableHandle,
@@ -558,13 +557,13 @@ def _buffer_key(buffer_id: int, generation: int) -> tuple[int, int]:
 def _import_wire_buffer(export_desc: Any, shm_name: str, base: int) -> Buffer:
     """The wire ``Buffer`` naming an imported backing, whose owner is another worker's process.
 
-    The owner's ``owner_instance_id`` never crosses the remote wire, so the identity is rebuilt from
-    the export triple the same way the submitting L4's ``REMOTE_SIDECAR`` placeholder builds it —
-    the importing runner and the submitter therefore name one remote backing with one identity.
+    The backing is named by ``remote_backing_identity`` — the one rule the submitting L4's
+    ``REMOTE_SIDECAR`` placeholder also uses — so one remote backing carries one identity on both
+    sides of the hop. It is minted here, at IMPORT_BUFFER, because a local address for an imported
+    shm exists from then on and every later task over it must name the same backing.
     """
-    oid = int(export_desc.owner_worker_id).to_bytes(OWNER_INSTANCE_ID_BYTES, "little")
     return Buffer(
-        identity=CanonicalIdentity(oid, int(export_desc.buffer_id), int(export_desc.generation)),
+        identity=remote_backing_identity(export_desc.owner_worker_id, export_desc.buffer_id, export_desc.generation),
         owner_worker_path_id=intern_worker_path(f"remote/{int(export_desc.owner_worker_id)}"),
         address_space=AddressSpace.HOST,
         access=AccessMode.READWRITE,
@@ -585,31 +584,40 @@ def _materialize_task_args(
 ) -> tuple[TaskArgs, list[Buffer]]:
     """The wire ``TaskArgs`` a remote TASK's orchestration function receives.
 
-    Every element is a ``Tensor`` over a backing this runner holds, so an orchestration function
-    forwards its own args to a chip child exactly as one at any other level does. The returned
-    ``Buffer`` list is the session-scoped backings minted for this task's HOST_INLINE payloads; they
-    live no longer than the run and the caller closes them once it returns.
+    The wire carries each argument as the submitter's own ``REMOTE_SIDECAR`` ``Tensor``: its view
+    (shapes, strides, dtype) is taken verbatim, and the sidecar names the local backing that view is
+    rebuilt over. Every element is therefore a ``Tensor`` over a backing this runner holds, so an
+    orchestration function forwards its own args to a chip child exactly as one at any other level
+    does. The returned ``Buffer`` list is the session-scoped backings minted for this task's
+    HOST_INLINE payloads; they live no longer than the run and the caller closes them once it
+    returns.
     """
-    if len(args.remote_desc) != len(args.tensor_metadata):
-        raise ValueError("remote TASK descriptor count does not match tensor metadata count")
+    if len(args.remote_desc) != len(args.tensors):
+        raise ValueError("remote TASK descriptor count does not match tensor count")
     task_args = TaskArgs()
     inline_backings: list[Buffer] = []
 
     try:
-        for tensor, sidecar in zip(args.tensor_metadata, args.remote_desc):
+        for tensor, sidecar in zip(args.tensors, args.remote_desc):
             if not sidecar.present:
                 raise ValueError("remote TASK tensor payload requires a RemoteTensorRef sidecar")
             desc = sidecar.desc
             if desc is None:
                 raise ValueError("remote TASK descriptor is marked present but missing")
-            if desc.nbytes != tensor.nbytes():
-                raise ValueError("remote TASK descriptor nbytes does not match tensor metadata")
+            if desc.nbytes != tensor.buffer.nbytes:
+                raise ValueError("remote TASK descriptor nbytes does not match the tensor's backing")
+            # The sidecar is the sole authority for where the view sits in the backing, so the
+            # placeholder's own descriptor spans exactly the view and its byte_offset is zero.
+            if tensor.byte_offset != 0:
+                raise ValueError("remote TASK tensor must carry no byte_offset of its own")
             if desc.address_space == RemoteAddressSpace.HOST_INLINE:
                 backing, byte_offset = _materialize_inline_payload(args, desc, mint_inline_buffer)
                 inline_backings.append(backing)
             else:
                 backing, byte_offset = _resolve_session_backing(desc, buffers, worker_id)
-            task_args.add_tensor(backing.tensor(tuple(tensor.shapes), tensor.dtype, byte_offset=byte_offset))
+            task_args.add_tensor(
+                backing.tensor(tensor.shapes, tensor.dtype, strides=tensor.strides, byte_offset=byte_offset)
+            )
     except BaseException:
         # A rejected arg leaves the caller no list to release, so the backings minted for the args
         # that did decode are released here.

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -733,32 +733,28 @@ remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotSt
         );
     }
     payload.args.inline_payload = sidecar.inline_payload;
-    payload.args.tensor_metadata.reserve(static_cast<size_t>(a.tensor_count()));
+    payload.args.tensors.reserve(static_cast<size_t>(a.tensor_count()));
     payload.args.remote_desc.reserve(static_cast<size_t>(a.tensor_count()));
 
     for (int32_t i = 0; i < a.tensor_count(); ++i) {
         const Tensor &ref = a.tensor(i);
         RemoteTensorSidecar tensor_sidecar{};
         if (!sidecar.tensors.empty()) tensor_sidecar = sidecar.tensors[static_cast<size_t>(i)];
-        bool has_local_backing =
-            ref.buffer.nbytes != 0 && ref.buffer.backend_kind != static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR);
-        if (has_local_backing && !tensor_sidecar.present) {
+        // The sidecar is the sole authority for a remote argument's backing, so the sender's own
+        // backing never crosses: an arg bound for a remote worker is a REMOTE_SIDECAR placeholder
+        // whose identity names the remote buffer. Orchestrator::validate_remote_sidecars rejects a
+        // local backing alongside a sidecar at submit; this is the encoder's own guard.
+        if (ref.buffer.backend_kind != static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR)) {
             throw std::runtime_error(
-                "RemoteL3Endpoint::build_task_payload: local backing submitted without remote sidecar"
+                "RemoteL3Endpoint::build_task_payload: a remote task arg must carry no local backing"
             );
         }
-        if (ref.buffer.address_space == static_cast<uint8_t>(AddressSpace::DEVICE) && !tensor_sidecar.present) {
-            throw std::runtime_error(
-                "RemoteL3Endpoint::build_task_payload: device-memory tensor submitted without remote sidecar"
-            );
+        // Every argument's backing is named by its own sidecar, so an absent one leaves the
+        // placeholder naming nothing the runner could resolve.
+        if (!tensor_sidecar.present) {
+            throw std::runtime_error("RemoteL3Endpoint::build_task_payload: tensor submitted without remote sidecar");
         }
-        // Metadata is the ref's view geometry with a null address (the remote side re-materializes
-        // from remote_desc); shape/dtype travel, the backing does not.
-        ChipTensor meta = make_tensor_external(
-            nullptr, ref.shapes, ref.ndims, ref.dtype, /*manual_dep=*/false, /*version=*/0,
-            static_cast<AddressSpace>(ref.buffer.address_space)
-        );
-        payload.args.tensor_metadata.push_back(meta);
+        payload.args.tensors.push_back(ref);
         payload.args.remote_desc.push_back(tensor_sidecar);
     }
     payload.args.scalars.reserve(static_cast<size_t>(a.scalar_count()));

--- a/src/common/hierarchical/remote_wire.cpp
+++ b/src/common/hierarchical/remote_wire.cpp
@@ -335,50 +335,95 @@ CallConfig decode_call_config(const uint8_t *data, size_t size, size_t &offset) 
     return config;
 }
 
-// Wire format carries only the contiguous-defining fields (addr, shapes, ndims,
-// dtype, child_memory +
-// 7 reserved bytes). The unified ChipTensor's derived state (strides / start_offset
-// / is_contiguous) is recomputed as row-major on decode. The wire is therefore
-// contiguous-only: a strided ChipTensor would be silently flattened. Guard against
-// that here so the loss is loud, not silent — strided views only round-trip
-// over the local fork/shm mailbox blob, never this remote wire.
-std::vector<uint8_t> encode_tensor(const ChipTensor &tensor) {
+// The record is the wire `Tensor` itself: the embedded BufferDescriptor (identity, backing
+// properties, length-delimited backend body) followed by the strided view (byte_offset, ndims,
+// shapes, strides, dtype). Shapes and strides travel as ndims-many entries, so the slots past
+// `ndims` that validate_tensor requires zero are never on the wire and cannot arrive dirty.
+//
+// A remote TASK argument carries no local backing — the authoritative descriptor of its backing is
+// the per-argument RemoteTensorDesc sidecar — so the only backend this wire accepts is
+// REMOTE_SIDECAR, in both directions. That sidecar also carries where the view sits in the backing,
+// which is why the record's own `byte_offset` is zero: a non-zero one would name a second, weaker
+// origin for the same view. Both are rejected on encode and on decode.
+std::vector<uint8_t> encode_tensor(const Tensor &tensor) {
+    const BufferDescriptor &desc = tensor.buffer;
     ensure(
-        tensor.is_contiguous && tensor.start_offset == 0,
-        "remote_wire: only contiguous, zero-offset tensors are supported on the wire"
+        desc.backend_kind == static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR),
+        "remote_wire: a remote TASK tensor must carry no local backing"
     );
+    ensure(tensor.byte_offset == 0, "remote_wire: a remote TASK tensor must carry no byte_offset");
+    ensure(
+        tensor.ndims > 0 && tensor.ndims <= static_cast<uint32_t>(MAX_TENSOR_DIMS),
+        "remote_wire: tensor ndims out of range"
+    );
+    ensure(desc.body_len <= DESC_MAX_BYTES, "remote_wire: buffer descriptor body exceeds maximum");
     std::vector<uint8_t> out;
-    put_u64(out, tensor.buffer.addr);
-    for (uint32_t shape : tensor.shapes)
-        put_u32(out, shape);
+    put_bytes(out, desc.identity.owner_instance_id, OWNER_INSTANCE_ID_BYTES);
+    put_u64(out, desc.identity.buffer_id);
+    put_u32(out, desc.identity.generation);
+    put_u8(out, desc.address_space);
+    put_u8(out, desc.access);
+    put_u8(out, desc.backend_kind);
+    put_u64(out, desc.nbytes);
+    put_u32(out, desc.owner_worker_path_id);
+    put_u32(out, desc.body_len);
+    put_bytes(out, reinterpret_cast<const uint8_t *>(desc.body), desc.body_len);
+    put_u64(out, tensor.byte_offset);
     put_u32(out, tensor.ndims);
+    for (uint32_t i = 0; i < tensor.ndims; ++i)
+        put_u32(out, tensor.shapes[i]);
+    for (uint32_t i = 0; i < tensor.ndims; ++i)
+        put_u32(out, tensor.strides[i]);
     put_u32(out, static_cast<uint32_t>(tensor.dtype));
-    put_u8(out, static_cast<uint8_t>(tensor.address_space));
-    for (int i = 0; i < 7; ++i)
-        put_u8(out, 0);
     return out;
 }
 
-ChipTensor decode_tensor(const uint8_t *data, size_t size, size_t &offset, bool remote_task) {
-    uint64_t addr = get_u64(data, size, offset);
-    if (remote_task) ensure(addr == 0, "remote_wire: remote TASK tensor data must be zero");
-    uint32_t shapes[MAX_TENSOR_DIMS];
-    for (uint32_t &shape : shapes)
-        shape = get_u32(data, size, offset);
+Tensor decode_tensor(const uint8_t *data, size_t size, size_t &offset) {
+    Tensor tensor{};
+    BufferDescriptor &desc = tensor.buffer;
+    desc.magic = BUFFER_DESCRIPTOR_MAGIC;
+    ensure_available(size, offset, OWNER_INSTANCE_ID_BYTES, "buffer identity nonce");
+    std::memcpy(desc.identity.owner_instance_id, data + offset, OWNER_INSTANCE_ID_BYTES);
+    offset += OWNER_INSTANCE_ID_BYTES;
+    desc.identity.buffer_id = get_u64(data, size, offset);
+    desc.identity.generation = get_u32(data, size, offset);
+    desc.address_space = get_u8(data, size, offset);
+    desc.access = get_u8(data, size, offset);
+    desc.backend_kind = get_u8(data, size, offset);
+    ensure(
+        desc.backend_kind == static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR),
+        "remote_wire: a remote TASK tensor must carry no local backing"
+    );
+    desc.nbytes = get_u64(data, size, offset);
+    desc.owner_worker_path_id = get_u32(data, size, offset);
+    uint32_t body_len = get_u32(data, size, offset);
+    ensure(body_len <= DESC_MAX_BYTES, "remote_wire: buffer descriptor body exceeds maximum");
+    ensure_available(size, offset, body_len, "buffer descriptor body");
+    std::memcpy(desc.body, data + offset, body_len);
+    offset += body_len;
+    desc.body_len = static_cast<uint16_t>(body_len);
+
+    tensor.byte_offset = get_u64(data, size, offset);
+    ensure(tensor.byte_offset == 0, "remote_wire: a remote TASK tensor must carry no byte_offset");
     uint32_t ndims = get_u32(data, size, offset);
-    ensure(ndims > 0 && ndims <= MAX_TENSOR_DIMS, "remote_wire: tensor ndims out of range");
+    ensure(ndims > 0 && ndims <= static_cast<uint32_t>(MAX_TENSOR_DIMS), "remote_wire: tensor ndims out of range");
+    tensor.ndims = ndims;
+    for (uint32_t i = 0; i < ndims; ++i)
+        tensor.shapes[i] = get_u32(data, size, offset);
+    for (uint32_t i = 0; i < ndims; ++i)
+        tensor.strides[i] = get_u32(data, size, offset);
     uint32_t dtype = get_u32(data, size, offset);
     ensure(valid_dtype(dtype), "remote_wire: unknown tensor dtype");
-    uint8_t address_space = get_u8(data, size, offset);
-    ensure(address_space == 0 || address_space == 1, "remote_wire: tensor address_space must be 0 or 1");
-    for (int i = 0; i < 7; ++i) {
-        ensure(get_u8(data, size, offset) == 0, "remote_wire: ChipTensor reserved bytes must be zero");
+    tensor.dtype = static_cast<DataType>(dtype);
+
+    // validate_tensor is the single gate every Tensor trust boundary runs; it throws
+    // std::invalid_argument, which this codec re-raises as its own std::runtime_error.
+    try {
+        validate_tensor(tensor);
+    } catch (const std::invalid_argument &e) {
+        throw std::runtime_error(std::string("remote_wire: ") + e.what());
     }
-    // Reconstruct a contiguous external ChipTensor (owner=invalid, row-major strides).
-    return make_tensor_external(
-        reinterpret_cast<void *>(addr), shapes, ndims, static_cast<DataType>(dtype), /*manual_dep=*/false,
-        /*version=*/0, static_cast<AddressSpace>(address_space)
-    );
+    return tensor;
 }
 
 std::vector<uint8_t> encode_remote_tensor_desc(const RemoteTensorDesc &desc) {
@@ -416,22 +461,21 @@ RemoteTensorDesc decode_remote_tensor_desc(const uint8_t *data, size_t size, siz
 }
 
 std::vector<uint8_t> encode_remote_task_args(const RemoteTaskArgsWire &args) {
-    ensure(args.tensor_metadata.size() <= MAX_TENSORS, "remote_wire: tensor count exceeds maximum");
+    ensure(args.tensors.size() <= MAX_TENSORS, "remote_wire: tensor count exceeds maximum");
     ensure(args.scalars.size() <= MAX_SCALARS, "remote_wire: scalar count exceeds maximum");
     ensure(args.inline_payload.size() <= MAX_INLINE_PAYLOAD_BYTES, "remote_wire: inline payload exceeds maximum");
     ensure(
-        args.remote_desc.empty() || args.remote_desc.size() == args.tensor_metadata.size(),
+        args.remote_desc.empty() || args.remote_desc.size() == args.tensors.size(),
         "remote_wire: remote descriptor count must match tensor count"
     );
     std::vector<uint8_t> out;
-    put_u32(out, static_cast<uint32_t>(args.tensor_metadata.size()));
+    put_u32(out, static_cast<uint32_t>(args.tensors.size()));
     put_u32(out, static_cast<uint32_t>(args.scalars.size()));
-    for (const auto &tensor : args.tensor_metadata) {
-        ensure(tensor.buffer.addr == 0, "remote_wire: remote TASK tensor data must be zero");
+    for (const auto &tensor : args.tensors) {
         auto encoded = encode_tensor(tensor);
         put_bytes(out, encoded.data(), encoded.size());
     }
-    for (size_t i = 0; i < args.tensor_metadata.size(); ++i) {
+    for (size_t i = 0; i < args.tensors.size(); ++i) {
         RemoteTensorSidecar sidecar{};
         if (!args.remote_desc.empty()) sidecar = args.remote_desc[i];
         put_u8(out, sidecar.present ? 1 : 0);
@@ -456,9 +500,9 @@ RemoteTaskArgsWire decode_remote_task_args(const uint8_t *data, size_t size) {
     ensure(scalar_count <= MAX_SCALARS, "remote_wire: scalar count exceeds maximum");
 
     RemoteTaskArgsWire args;
-    args.tensor_metadata.reserve(tensor_count);
+    args.tensors.reserve(tensor_count);
     for (uint32_t i = 0; i < tensor_count; ++i)
-        args.tensor_metadata.push_back(decode_tensor(data, size, offset, true));
+        args.tensors.push_back(decode_tensor(data, size, offset));
 
     args.remote_desc.reserve(tensor_count);
     for (uint32_t i = 0; i < tensor_count; ++i) {

--- a/src/common/hierarchical/remote_wire.h
+++ b/src/common/hierarchical/remote_wire.h
@@ -17,15 +17,16 @@
 #include <string>
 #include <vector>
 
+#include "../task_interface/buffer.h"
 #include "../task_interface/call_config.h"
-#include "../task_interface/tensor.h"
 #include "types.h"
 
 namespace remote_l3 {
 
-// 2: CallConfig lost its block_dim field — a run always takes the whole
-// device, so the payload is one int32 shorter than v1's.
-static constexpr uint32_t PROTOCOL_VERSION = 2;
+// 3: a TASK's per-argument record is the self-describing wire `Tensor` — the embedded
+// BufferDescriptor plus the strided view. Both ends of a run come from one `pip install`,
+// so this constant is a mismatch alarm at the frame header, not a dual-decode selector.
+static constexpr uint32_t PROTOCOL_VERSION = 3;
 inline constexpr size_t FRAME_HEADER_BYTES = 40;
 static constexpr uint32_t MAX_FRAME_PAYLOAD_BYTES = 16U * 1024U * 1024U;
 static constexpr uint32_t MAX_STRING_BYTES = 1024U;
@@ -103,7 +104,7 @@ struct HelloPayload {
 };
 
 struct RemoteTaskArgsWire {
-    std::vector<ChipTensor> tensor_metadata;
+    std::vector<Tensor> tensors;
     std::vector<RemoteTensorSidecar> remote_desc;
     std::vector<uint64_t> scalars;
     std::vector<uint8_t> inline_payload;
@@ -170,8 +171,8 @@ HelloPayload decode_hello(const uint8_t *data, size_t size);
 std::vector<uint8_t> encode_call_config(const CallConfig &config);
 CallConfig decode_call_config(const uint8_t *data, size_t size, size_t &offset);
 
-std::vector<uint8_t> encode_tensor(const ChipTensor &tensor);
-ChipTensor decode_tensor(const uint8_t *data, size_t size, size_t &offset, bool remote_task);
+std::vector<uint8_t> encode_tensor(const Tensor &tensor);
+Tensor decode_tensor(const uint8_t *data, size_t size, size_t &offset);
 
 std::vector<uint8_t> encode_remote_tensor_desc(const RemoteTensorDesc &desc);
 RemoteTensorDesc decode_remote_tensor_desc(const uint8_t *data, size_t size, size_t &offset);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -214,9 +214,8 @@ add_library(hierarchical_objs OBJECT
     ${HIERARCHICAL_SRC_DIR}/worker.cpp
     ${WORKER_SRC_DIR}/chip_run_lane.cpp
     ${WORKER_SRC_DIR}/chip_worker.cpp
-    # Host-side assert_impl / get_stacktrace for the unified Tensor's
-    # always_assert (init_external, reached via make_tensor_external in
-    # remote_wire.cpp / orchestrator.cpp). Mirrors the binding's CMake.
+    # Host-side assert_impl / get_stacktrace for the unified ChipTensor's
+    # always_assert (init_external and the view ops). Mirrors the binding's CMake.
     # ODR invariant: assert_impl / get_stacktrace are ALSO defined in the runtime
     # orchestration/common.cpp. No target may link both that and this file, or
     # the linker sees duplicate symbols. This target links neither runtime

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -416,6 +416,24 @@ TaskArgs bare_pointer_args() {
     return args;
 }
 
+TaskArgs sidecar_free_placeholder_args() {
+    TaskArgs args;
+    Tensor ref{};
+    ref.buffer.magic = BUFFER_DESCRIPTOR_MAGIC;
+    ref.buffer.address_space = static_cast<uint8_t>(AddressSpace::HOST);
+    ref.buffer.access = static_cast<uint8_t>(AccessMode::READWRITE);
+    ref.buffer.backend_kind = static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR);
+    ref.buffer.identity.buffer_id = 0x1234;
+    ref.buffer.identity.generation = 1;
+    ref.buffer.nbytes = 1;
+    ref.ndims = 1;
+    ref.shapes[0] = 1;
+    ref.strides[0] = 1;
+    ref.dtype = DataType::UINT8;
+    args.add_tensor(ref, TensorArgType::INPUT);
+    return args;
+}
+
 }  // namespace
 
 TEST(RemoteEndpoint, TaskDispatchUsesProgressSubmissionAndPolling) {
@@ -807,6 +825,29 @@ TEST(RemoteEndpoint, BareHostPointerWithoutSidecarIsRejectedAtSubmission) {
         ADD_FAILURE() << "expected the local backing to be rejected";
     } catch (const std::runtime_error &e) {
         EXPECT_NE(std::string(e.what()).find("local backing"), std::string::npos) << e.what();
+    }
+    EXPECT_TRUE(transport->last_frame.empty());
+    ring.shutdown();
+}
+
+TEST(RemoteEndpoint, SidecarFreePlaceholderIsRejectedAtSubmission) {
+    Ring ring;
+    ring.init(1ULL << 20);
+    TaskSlot slot = make_slot(ring, sidecar_free_placeholder_args());
+
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+
+    WorkerDispatch dispatch;
+    dispatch.task_slot = slot;
+    // A REMOTE_SIDECAR placeholder names its backing only through its sidecar, so one submitted
+    // without a sidecar names nothing the runner could resolve. Match the message: submit_progress
+    // has several other runtime_error paths.
+    try {
+        endpoint.submit_progress(&ring, dispatch);
+        ADD_FAILURE() << "expected the sidecar-free placeholder to be rejected";
+    } catch (const std::runtime_error &e) {
+        EXPECT_NE(std::string(e.what()).find("without remote sidecar"), std::string::npos) << e.what();
     }
     EXPECT_TRUE(transport->last_frame.empty());
     ring.shutdown();

--- a/tests/ut/cpp/hierarchical/test_remote_wire.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_wire.cpp
@@ -21,13 +21,24 @@
 
 namespace {
 
-ChipTensor metadata_tensor() {
-    // Build through the canonical factory so the tensor is a valid contiguous
-    // descriptor (is_contiguous = true, start_offset = 0, row-major strides) —
-    // encode_tensor enforces contiguity on the wire. addr = 0 keeps it a
-    // metadata-only remote tensor.
-    const uint32_t shapes[1] = {4};
-    return make_tensor_external(nullptr, shapes, 1, DataType::UINT8);
+// A task arg bound for a remote worker: a REMOTE_SIDECAR placeholder naming remote buffer 9 on
+// worker 3, with no local backing of its own. That is the only backend this wire accepts.
+Tensor remote_arg_tensor() {
+    Tensor tensor{};
+    tensor.buffer.magic = BUFFER_DESCRIPTOR_MAGIC;
+    tensor.buffer.address_space = static_cast<uint8_t>(AddressSpace::HOST);
+    tensor.buffer.access = static_cast<uint8_t>(AccessMode::READWRITE);
+    tensor.buffer.backend_kind = static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR);
+    tensor.buffer.identity.owner_instance_id[0] = 3;
+    tensor.buffer.identity.buffer_id = 9;
+    tensor.buffer.identity.generation = 1;
+    tensor.buffer.nbytes = 4;
+    tensor.ndims = 1;
+    tensor.shapes[0] = 4;
+    tensor.strides[0] = 1;
+    tensor.dtype = DataType::UINT8;
+    validate_tensor(tensor);
+    return tensor;
 }
 
 }  // namespace
@@ -75,20 +86,74 @@ TEST(RemoteWire, FrameRejectsBadVersionFlagsAndUnknownType) {
     EXPECT_THROW((void)remote_l3::decode_frame(bad_flags), std::runtime_error);
 }
 
-TEST(RemoteWire, TaskPayloadRejectsNonZeroTensorData) {
+TEST(RemoteWire, TaskPayloadRoundTripsTheArgTensorVerbatim) {
     remote_l3::TaskPayloadWire payload;
     payload.callable_digest.fill(0xAB);
-    payload.args.tensor_metadata.push_back(metadata_tensor());
+    Tensor arg = remote_arg_tensor();
+    // A strided view: strides are carried explicitly, so the wire does not flatten one.
+    arg.buffer.nbytes = 16;
+    arg.ndims = 2;
+    arg.shapes[0] = 2;
+    arg.shapes[1] = 2;
+    arg.strides[0] = 8;
+    arg.strides[1] = 1;
+    validate_tensor(arg);
+    payload.args.tensors.push_back(arg);
     payload.args.scalars.push_back(0xCAFE);
 
     auto encoded = remote_l3::encode_task_payload(payload);
     auto decoded = remote_l3::decode_task_payload(encoded.data(), encoded.size());
-    ASSERT_EQ(decoded.args.tensor_metadata.size(), 1u);
+    ASSERT_EQ(decoded.args.tensors.size(), 1u);
     EXPECT_EQ(decoded.callable_digest[0], 0xAB);
     EXPECT_EQ(decoded.args.scalars[0], 0xCAFEu);
 
-    payload.args.tensor_metadata[0].buffer.addr = 0x1234;
+    const Tensor &back = decoded.args.tensors[0];
+    EXPECT_TRUE(back.buffer == arg.buffer);
+    EXPECT_EQ(back.byte_offset, arg.byte_offset);
+    EXPECT_EQ(back.ndims, 2u);
+    EXPECT_EQ(back.shapes[0], 2u);
+    EXPECT_EQ(back.shapes[1], 2u);
+    EXPECT_EQ(back.strides[0], 8u);
+    EXPECT_EQ(back.strides[1], 1u);
+    EXPECT_EQ(back.dtype, DataType::UINT8);
+    // Slots past ndims never cross, so a decoded record compares clean against a fresh one.
+    EXPECT_EQ(back.shapes[2], 0u);
+    EXPECT_EQ(back.strides[2], 0u);
+}
+
+TEST(RemoteWire, TaskPayloadRejectsAnArgWithALocalBacking) {
+    remote_l3::TaskPayloadWire payload;
+    payload.callable_digest.fill(0xAB);
+    Tensor arg = remote_arg_tensor();
+    // A backing this endpoint could materialize locally is a second source of truth for a backing
+    // the sidecar already names, so it never crosses this wire.
+    arg.buffer.backend_kind = static_cast<uint8_t>(BackendKind::DEVICE_MALLOC);
+    payload.args.tensors.push_back(arg);
+
     EXPECT_THROW((void)remote_l3::encode_task_payload(payload), std::runtime_error);
+}
+
+TEST(RemoteWire, TensorRecordRejectsAByteOffsetOnEncodeAndOnDecode) {
+    Tensor arg = remote_arg_tensor();
+    arg.buffer.nbytes = 8;
+    arg.byte_offset = 4;
+    arg.shapes[0] = 4;
+    validate_tensor(arg);
+    // The sidecar carries where the view sits in the backing, so a record naming its own origin
+    // fails at the sender rather than after transport.
+    EXPECT_THROW((void)remote_l3::encode_tensor(arg), std::runtime_error);
+
+    arg.byte_offset = 0;
+    auto encoded = remote_l3::encode_tensor(arg);
+    // byte_offset follows the 39-byte descriptor head of a record whose backend body is empty:
+    // identity nonce(8) + buffer_id(8) + generation(4) + address_space/access/backend(3) +
+    // nbytes(8) + owner_worker_path_id(4) + body_len(4).
+    constexpr size_t kByteOffsetPos = 39;
+    ASSERT_GT(encoded.size(), kByteOffsetPos + sizeof(uint64_t));
+    encoded[kByteOffsetPos] = 4;
+
+    size_t offset = 0;
+    EXPECT_THROW((void)remote_l3::decode_tensor(encoded.data(), encoded.size(), offset), std::runtime_error);
 }
 
 TEST(RemoteWire, TaskPayloadPreservesScopeStatsCallConfig) {
@@ -98,7 +163,7 @@ TEST(RemoteWire, TaskPayloadPreservesScopeStatsCallConfig) {
     payload.config.enable_scope_stats = 1;
     const char *prefix = "/tmp/remote-scope";
     std::memcpy(payload.config.output_prefix, prefix, std::strlen(prefix));
-    payload.args.tensor_metadata.push_back(metadata_tensor());
+    payload.args.tensors.push_back(remote_arg_tensor());
 
     auto encoded = remote_l3::encode_task_payload(payload);
     auto decoded = remote_l3::decode_task_payload(encoded.data(), encoded.size());
@@ -115,7 +180,7 @@ TEST(RemoteWire, TruncatedControlPayloadIsRejected) {
 
 TEST(RemoteWire, HostInlineDescriptorBoundsAreChecked) {
     remote_l3::RemoteTaskArgsWire args;
-    args.tensor_metadata.push_back(metadata_tensor());
+    args.tensors.push_back(remote_arg_tensor());
     args.inline_payload = {1, 2, 3, 4};
 
     RemoteTensorSidecar sidecar;
@@ -142,7 +207,7 @@ TEST(RemoteWire, HostInlineDescriptorBoundsAreChecked) {
 
 TEST(RemoteWire, NonHostInlineDescriptorRejectsInlinePayloadFields) {
     remote_l3::RemoteTaskArgsWire args;
-    args.tensor_metadata.push_back(metadata_tensor());
+    args.tensors.push_back(remote_arg_tensor());
 
     RemoteTensorSidecar sidecar;
     sidecar.present = true;
@@ -159,7 +224,7 @@ TEST(RemoteWire, NonHostInlineDescriptorRejectsInlinePayloadFields) {
 
 TEST(RemoteWire, NonHostInlineDescriptorRejectsMissingBufferIdentity) {
     remote_l3::RemoteTaskArgsWire args;
-    args.tensor_metadata.push_back(metadata_tensor());
+    args.tensors.push_back(remote_arg_tensor());
 
     RemoteTensorSidecar sidecar;
     sidecar.present = true;

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -35,10 +35,12 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
 )
 from simpler.buffer import (
     AccessMode,
+    AddressSpace,
     BackendKind,
     Tensor,
     create_host_shared_buffer,
     mint_owner_instance_id,
+    remote_sidecar_tensor,
     wrap_device_malloc,
     wrap_fork_inherited,
 )
@@ -70,6 +72,19 @@ def _dev_ref(addr, shapes, dtype, tag=None):
 def _ref_addr(ref: Tensor) -> int:
     """The device pointer carried in a DEVICE_MALLOC ref's backend body."""
     return int.from_bytes(bytes(ref.buffer.body)[:8], "little")
+
+
+def _remote_arg_tensor(shapes, nbytes, owner_worker_id=2, buffer_id=9, generation=1):
+    """The per-argument record a remote L3 TASK carries: the submitter's REMOTE_SIDECAR placeholder."""
+    return remote_sidecar_tensor(
+        shapes=tuple(shapes),
+        dtype=int(DataType.UINT8.value),
+        nbytes=int(nbytes),
+        owner_worker_id=owner_worker_id,
+        buffer_id=buffer_id,
+        generation=generation,
+        address_space=AddressSpace.HOST,
+    )
 
 
 def _session_buffer_minter():
@@ -767,7 +782,7 @@ class TestRemoteL3SessionTaskArgsMaterialization:
         )
         from simpler.remote_l3_session import _materialize_task_args
 
-        tensor = ChipTensor.make(0, (4,), DataType.UINT8)
+        tensor = _remote_arg_tensor((4,), nbytes=4)
         desc = RemoteTensorDesc(
             address_space=WireRemoteAddressSpace.HOST_INLINE,
             owner_worker_id=0,
@@ -806,7 +821,7 @@ class TestRemoteL3SessionTaskArgsMaterialization:
         )
         from simpler.remote_l3_session import _materialize_task_args
 
-        tensor = ChipTensor.make(0, (4,), DataType.UINT8)
+        tensor = _remote_arg_tensor((4,), nbytes=4)
         desc = RemoteTensorDesc(
             address_space=WireRemoteAddressSpace.HOST_INLINE,
             owner_worker_id=0,
@@ -852,7 +867,7 @@ class TestRemoteL3SessionTaskArgsMaterialization:
         try:
             ctypes.memmove(backing.base, b"01234567", 8)
             entry = _RemoteBufferEntry(backing, 8, 1, WireRemoteAddressSpace.REMOTE_DEVICE)
-            tensor = ChipTensor.make(0, (4,), DataType.UINT8)
+            tensor = _remote_arg_tensor((4,), nbytes=4)
             desc = RemoteTensorDesc(
                 address_space=WireRemoteAddressSpace.REMOTE_DEVICE,
                 owner_worker_id=2,
@@ -913,7 +928,7 @@ class TestRemoteL3SessionTaskArgsMaterialization:
                     flags=0,
                 )
 
-            tensor = ChipTensor.make(0, (4,), DataType.UINT8)
+            tensor = _remote_arg_tensor((4,), nbytes=4)
             wire = RemoteTaskArgsWire(
                 (tensor, tensor),
                 (RemoteTensorSidecar(True, sub_range(0)), RemoteTensorSidecar(True, sub_range(4))),
@@ -959,7 +974,7 @@ class TestRemoteL3SessionTaskArgsMaterialization:
                 flags=0,
             )
             wire = RemoteTaskArgsWire(
-                (ChipTensor.make(0, (4,), DataType.UINT8),), (RemoteTensorSidecar(True, desc),), (), b""
+                (_remote_arg_tensor((4,), nbytes=4),), (RemoteTensorSidecar(True, desc),), (), b""
             )
 
             args, _inline_backings = _materialize_task_args(


### PR DESCRIPTION
## The remote wire stops repacking what it already has

A remote L3 TASK frame carried a **null-address `ChipTensor`** per argument. The sender pulled
shape and dtype out of the `Tensor` it was already holding and repacked them; the session runner
rebuilt a `ChipTensor` from those bytes and immediately read the same two fields back out.
`ChipTensor` exists to carry a GM address (rule 13), and on this wire it never carried one — the
authoritative backing has always been the per-argument `RemoteTensorDesc` sidecar.

The record is now the wire `Tensor` itself, pushed verbatim:

```cpp
// before — build_task_payload
ChipTensor meta{};                       // address deliberately null
meta.shape = ...; meta.dtype = ...;      // re-derived from ref
payload.args.tensor_metadata.push_back(meta);

// after
payload.args.tensors.push_back(ref);     // the Tensor the caller submitted
```

An argument bound for a remote worker is *already* the `REMOTE_SIDECAR` placeholder
`TaskArgs.add_tensor` builds, whose canonical identity names the remote backing. So nothing is
re-derived on either side, and **the view's strides now cross** where previously only shapes did.

`PROTOCOL_VERSION` 2 -> 3. Both ends of a run come from one `pip install`, so the constant is a
mismatch alarm at the frame header, not a dual-decode selector.

### The wire only accepts a backing-free argument

`encode_tensor` / `decode_tensor` both reject `backend_kind != REMOTE_SIDECAR`, and
`build_task_payload` carries the encoder's own guard. `Orchestrator::validate_remote_sidecars`
already rejected a local backing alongside a sidecar at submit; these make it unrepresentable on
the wire as well.

Shapes and strides travel as `ndims`-many entries, so the slots past `ndims` that `validate_tensor`
requires be zero are never on the wire and cannot arrive dirty. `decode_tensor` runs
`validate_tensor` on every element and re-raises its `invalid_argument` as the codec's own error.

A 1-D record goes 44 -> 63 bytes; the general form is `55 + body_len + 8 * ndims`. The growth is
the embedded `BufferDescriptor` (identity + backing properties) that makes the record
self-describing, plus the strides that were previously dropped.

### Receiving side

`_materialize_task_args` takes the view from the wire `Tensor` verbatim and the backing from the
sidecar, then rebuilds a `Tensor` over a backing this runner holds. Two invariants it now checks,
both expressing that the sidecar is the sole authority for where the view sits:

- `desc.nbytes` must equal the tensor's `buffer.nbytes`
- the tensor's own `byte_offset` must be zero

## Verification

- [x] Build green — four arch x runtime trees plus the nanobind extension
- [x] `pyut` — 1304 passed, 6 skipped, identical to the base commit's own run
- [x] `cpput` — 91/91
- [x] `a2a3sim` / `a5sim` full scene suites — rc=0, 0 failures on both
- [x] `examples/workers/l4/vector_add_mixed_l3` on **real a2a3 silicon**, both halves:
      `local max_diff=0.000e+00`, `remote max_diff=0.000e+00`. This is the `_st-pod.yml` payload;
      a loopback daemon stood in for the second machine
- [x] pre-commit green

The sim, cpput and silicon runs above were taken on the immediately preceding base
(`1f0f0060`); `pyut` and pre-commit were re-run on this one. The rebase onto `3c69de1a` was
conflict-free and `git range-diff` reports the patch byte-identical, so nothing in the delta
touches this path.

## Context

Follows #1729, which flipped `TaskArgs` to carry the wire `Tensor` between local processes but
left the remote hop on the old per-argument record. Strides being flattened across a remote hop
predates both and is not addressed here.
