### PR TITLE
Fix: give L2 the same in-flight protection release_buffer() gives L3+

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -4177,6 +4177,10 @@ class Worker:
         # handle back to its run so waiting and finalization can find it.
         self._chip_runs: dict[int, Any] = {}
         self._chip_run_seq: int = 0
+        # Mirrors _chip_runs' own lifecycle (added/removed at the same two points) so
+        # release_buffer() can see an L2 run in flight: L2 dispatch never touches
+        # _accepted_run_handles/_submit_mu, so it is otherwise invisible to that check.
+        self._chip_run_touched_identities: dict[int, set[CanonicalIdentity]] = {}
 
         # Level-3+ internals
         self._worker: _Worker | None = None
@@ -9234,6 +9238,11 @@ class Worker:
                 out.append((int.from_bytes(desc.body[:8], "little"), i))
         return out
 
+    @staticmethod
+    def _identities_in_args(args: Any) -> set[CanonicalIdentity]:
+        """Every tensor arg's identity in ``args``."""
+        return {args.tensor(i).buffer.identity for i in range(args.tensor_count())}
+
     def _record_touched_identities(self, args: Any) -> None:
         """Add every tensor arg's identity in ``args`` to the current run's touched set.
 
@@ -9245,8 +9254,7 @@ class Worker:
         resources = self._building_run_resources
         if resources is None:
             return
-        for i in range(args.tensor_count()):
-            resources.touched_identities.add(args.tensor(i).buffer.identity)
+        resources.touched_identities.update(self._identities_in_args(args))
 
     def _child_prov_check_dispatch(self, child_ptrs: list[tuple[int, int]], target_worker_id: int, *, api: str) -> None:
         """Validate every child_memory pointer against its exact target worker."""
@@ -9646,23 +9654,33 @@ class Worker:
     def release_buffer(self, buffer: Buffer) -> None:
         """Close + unlink one owner Buffer and drop its registry entry.
 
-        Rejects outright if any currently in-flight run (not yet past ``_cleanup_published``) sent
-        this identity as a NEXT_LEVEL Tensor arg — a Buffer never goes away while a dispatched task
-        still names it. Takes ``_submit_mu`` first: a handle is visible in ``_accepted_run_handles``
-        before its orchestration callback (where ``touched_identities`` gets populated) has run, and
-        that callback is what ``_submit_mu`` already serializes graph construction against, so taking
-        it here means the check only ever runs between callbacks, never mid-callback with a
-        not-yet-complete touched set. Not checked once ``buffer`` is already closed, matching
-        ``Buffer.close()``'s own idempotency. The entry survives a failed close, so
-        ``_release_all_buffers`` still reports the leak at close() rather than losing it here. The
-        slot is dropped only when it still holds *this* buffer: a buffer_id minted elsewhere can
-        collide with a registry key, and evicting the live entry it names would strand that
-        backing."""
+        Rejects outright if any currently in-flight L3+ run (not yet past ``_cleanup_published``)
+        sent this identity as a NEXT_LEVEL Tensor arg, or any in-flight L2 direct-chip run sent it —
+        a Buffer never goes away while a dispatched task still names it. The L3+ check takes
+        ``_submit_mu`` first: a handle is visible in ``_accepted_run_handles`` before its
+        orchestration callback (where ``touched_identities`` gets populated) has run, and that
+        callback is what ``_submit_mu`` already serializes graph construction against, so taking it
+        here means the check only ever runs between callbacks, never mid-callback with a
+        not-yet-complete touched set. The L2 check is independent (a separate run-id namespace with
+        no callback to serialize against — ``_chip_run_touched_identities`` is written atomically
+        alongside ``_chip_runs`` under ``_registry_lock`` instead, see ``_submit_l2_locked``), so the
+        two checks run sequentially rather than under one shared lock. Neither is checked once
+        ``buffer`` is already closed, matching ``Buffer.close()``'s own idempotency. The entry
+        survives a failed close, so ``_release_all_buffers`` still reports the leak at close() rather
+        than losing it here. The slot is dropped only when it still holds *this* buffer: a buffer_id
+        minted elsewhere can collide with a registry key, and evicting the live entry it names would
+        strand that backing."""
         if not buffer.closed:
             with self._submit_mu, self._hierarchical_start_cv:
                 for handle in self._accepted_run_handles:
                     if not handle._cleanup_published and buffer.identity in handle._resources.touched_identities:
                         raise RuntimeError(f"release_buffer: {buffer.identity} is still referenced by an in-flight run")
+            with self._registry_lock:
+                for touched in self._chip_run_touched_identities.values():
+                    if buffer.identity in touched:
+                        raise RuntimeError(
+                            f"release_buffer: {buffer.identity} is still referenced by an in-flight L2 run"
+                        )
         buffer.close()
         with self._registry_lock:
             buffer_id = int(buffer.identity.buffer_id)
@@ -9945,11 +9963,24 @@ class Worker:
         completion fence through :meth:`RunHandle.wait`.
         """
         assert self._chip_worker is not None
+        touched = self._identities_in_args(args) if args is not None else set()
         chip_args = self._materialize_l2_args(args)
-        chip_run = self._chip_worker._impl._submit_chip_run_direct(callable_id, chip_args, cfg)
-        self._chip_run_seq += 1
-        run_id = self._chip_run_seq
-        self._chip_runs[run_id] = chip_run
+        # Publish touched_identities BEFORE dispatch, not after: release_buffer() reads this
+        # dict to decide whether a Buffer is still in flight, so if it were only written after
+        # _submit_chip_run_direct() returns, a release racing the window between dispatch and
+        # publication would see no entry for a run that is already running on the chip.
+        with self._registry_lock:
+            self._chip_run_seq += 1
+            run_id = self._chip_run_seq
+            self._chip_run_touched_identities[run_id] = touched
+        try:
+            chip_run = self._chip_worker._impl._submit_chip_run_direct(callable_id, chip_args, cfg)
+        except BaseException:
+            with self._registry_lock:
+                self._chip_run_touched_identities.pop(run_id, None)
+            raise
+        with self._registry_lock:
+            self._chip_runs[run_id] = chip_run
         # chip_args is kept alive by the handle: the lane copies the args into
         # its own storage, but the keepalive also pins the buffers the resolved
         # descriptors point at for as long as the run can still read them.
@@ -10037,7 +10068,7 @@ class Worker:
         assert self._orch is not None
         self._orch._wait_run_accepted(run_id)
 
-    def _finalize_run_handle(
+    def _finalize_run_handle(  # noqa: PLR0912 -- one extra branch for the L2 pop-under-lock guard
         self,
         handle: RunHandle,
         run_id: int,
@@ -10051,9 +10082,14 @@ class Worker:
         # domains, remote slots or chip regions for it. Retiring the lane entry
         # is the whole of its cleanup, so it never enters the cursor below —
         # driving those steps here would report a cleanup failure for state that
-        # was never created.
-        if run_id in self._chip_runs:
-            del self._chip_runs[run_id]
+        # was never created. The membership check and both removals share one lock
+        # acquisition (pop(..., None), not del) so a concurrent Worker.close() clearing
+        # these same dicts can never make this raise KeyError or read a half-updated pair.
+        with self._registry_lock:
+            was_l2_run = self._chip_runs.pop(run_id, None) is not None
+            if was_l2_run:
+                self._chip_run_touched_identities.pop(run_id, None)
+        if was_l2_run:
             return native_error
 
         # Two different failures, deliberately not merged. A task that failed is
@@ -10793,7 +10829,9 @@ class Worker:
                         except Exception:
                             if undelivered:
                                 raise
-                    self._chip_runs.clear()
+                    with self._registry_lock:
+                        self._chip_runs.clear()
+                        self._chip_run_touched_identities.clear()
                     self._chip_worker.finalize()
                     self._chip_worker = None
 

--- a/tests/ut/py/test_remote_l3_lifecycle.py
+++ b/tests/ut/py/test_remote_l3_lifecycle.py
@@ -958,6 +958,7 @@ def _bare_l3_worker():
     w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
     w._accepted_run_handles = set()
     w._submit_mu = threading.Lock()
+    w._chip_run_touched_identities = {}
     return w
 
 

--- a/tests/ut/py/test_worker/test_create_buffer.py
+++ b/tests/ut/py/test_worker/test_create_buffer.py
@@ -38,6 +38,7 @@ def _bare_worker(level: int, *, chip: int = 0, sub: int = 0, next_level: int = 0
     w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
     w._accepted_run_handles = set()
     w._submit_mu = threading.Lock()
+    w._chip_run_touched_identities = {}
     return w
 
 

--- a/tests/ut/py/test_worker/test_release_buffer.py
+++ b/tests/ut/py/test_worker/test_release_buffer.py
@@ -9,22 +9,26 @@
 """``Worker.release_buffer()``: rejects release while an in-flight run still references the
 buffer's identity, and how that identity gets tracked in the first place.
 
-L2 never needs this: a run completes synchronously inside ``submit()`` (``RunHandle._completed``),
-so there is never an in-flight window. Tracking hooks the two L3+ async dispatch entry points,
-``Orchestrator.submit_next_level`` / ``.submit_next_level_group``, device-free via the same
-fake-C++-orchestrator harness ``test_child_addr_guard.py`` already established.
+L3+ tracking hooks the two async dispatch entry points, ``Orchestrator.submit_next_level`` /
+``.submit_next_level_group``, device-free via the same fake-C++-orchestrator harness
+``test_child_addr_guard.py`` already established. L2's direct-chip dispatch
+(``_submit_l2_locked``) is a separate run-id namespace that never touches
+``_accepted_run_handles``/``_submit_mu`` at all, so it gets its own parallel tracking dict
+(``_chip_run_touched_identities``, mirroring ``_chip_runs``' own add/remove lifecycle) and its
+own independent check in ``release_buffer``.
 """
 
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from _task_interface import DataType, TensorArgType
 from simpler.buffer import create_host_shared_buffer, mint_owner_instance_id
 from simpler.orchestrator import Orchestrator
-from simpler.task_interface import TaskArgs
+from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import RunHandle, Worker, _RunResources
 
 _F32 = 0  # DataType.FLOAT32 value
@@ -192,3 +196,97 @@ class TestReleaseBuffer:
         releaser.join(timeout=5)
         assert release_returned.is_set()
         assert not buf.closed  # correctly rejected once it could finally check -- not released mid-race
+
+
+class _FakeChipImpl:
+    """Stands in for ChipWorker._impl: records the dispatch, hands back a run object whose only
+    used surface is .wait() (never exercised by these tests, kept for interface completeness)."""
+
+    def __init__(self):
+        self.calls: list[tuple[int, object, object]] = []
+
+    def _submit_chip_run_direct(self, callable_id, chip_args, cfg):
+        self.calls.append((callable_id, chip_args, cfg))
+        return SimpleNamespace(wait=lambda timeout: True)
+
+
+def _l2_with_registered_buffer(nbytes: int = 64):
+    """An L2 Worker (its own chip, no fork needed) plus one buffer already registered in
+    w._buffers, the way Worker.create_buffer() would leave it."""
+    w = Worker(level=2)
+    w._chip_worker = SimpleNamespace(_impl=_FakeChipImpl())
+    buf = w._create_buffer_locked(nbytes)
+    return w, buf
+
+
+class TestL2TouchedIdentityTracking:
+    def test_submit_l2_locked_records_touched_identity(self):
+        w, buf = _l2_with_registered_buffer()
+        handle = w._submit_l2_locked(3, _buffer_args(buf), CallConfig())
+        assert handle._run_id is not None
+        assert w._chip_run_touched_identities[handle._run_id] == {buf.identity}
+
+    def test_submit_l2_locked_with_no_args_is_empty(self):
+        w, _buf = _l2_with_registered_buffer()
+        handle = w._submit_l2_locked(3, None, CallConfig())
+        assert handle._run_id is not None
+        assert w._chip_run_touched_identities[handle._run_id] == set()
+
+    def test_finalize_run_handle_clears_l2_touched_identities(self):
+        w, buf = _l2_with_registered_buffer()
+        handle = w._submit_l2_locked(3, _buffer_args(buf), CallConfig())
+        run_id = handle._run_id
+        assert run_id in w._chip_runs
+        assert run_id in w._chip_run_touched_identities
+        w._finalize_run_handle(handle, run_id, None)
+        assert run_id not in w._chip_runs
+        assert run_id not in w._chip_run_touched_identities
+
+    def test_publishes_touched_identities_before_dispatch_not_after(self):
+        # _submit_l2_locked must publish _chip_run_touched_identities BEFORE calling
+        # _submit_chip_run_direct, not after -- otherwise a release_buffer() landing in the
+        # window between dispatch and publication would see no entry for a run already
+        # running on the chip. Block dispatch mid-call and confirm release_buffer already
+        # sees (and rejects on) the identity at that point, not only after dispatch returns.
+        w, buf = _l2_with_registered_buffer()
+        entered_dispatch = threading.Event()
+        proceed = threading.Event()
+
+        class _BlockingChipImpl(_FakeChipImpl):
+            def _submit_chip_run_direct(self, callable_id, chip_args, cfg):
+                entered_dispatch.set()
+                proceed.wait(timeout=5)
+                return super()._submit_chip_run_direct(callable_id, chip_args, cfg)
+
+        w._chip_worker = SimpleNamespace(_impl=_BlockingChipImpl())
+
+        submit_thread = threading.Thread(target=lambda: w._submit_l2_locked(3, _buffer_args(buf), CallConfig()))
+        submit_thread.start()
+        assert entered_dispatch.wait(timeout=5)
+
+        try:
+            with pytest.raises(RuntimeError, match="in-flight L2 run"):
+                w.release_buffer(buf)
+        finally:
+            proceed.set()
+            submit_thread.join(timeout=5)
+        assert not buf.closed
+
+
+class TestReleaseBufferL2InFlight:
+    def test_rejects_while_an_l2_run_is_in_flight(self):
+        w, buf = _l2_with_registered_buffer()
+        w._chip_run_touched_identities[1] = {buf.identity}
+        with pytest.raises(RuntimeError, match="in-flight L2 run"):
+            w.release_buffer(buf)
+        assert not buf.closed
+        buffer_id = int(buf.identity.buffer_id)
+        assert w._buffers.get(buffer_id) is buf  # rejection must not half-apply the registry drop
+
+    def test_succeeds_once_the_l2_run_is_gone(self):
+        w, buf = _l2_with_registered_buffer()
+        w._chip_run_touched_identities[1] = {buf.identity}
+        del w._chip_run_touched_identities[1]
+        w.release_buffer(buf)
+        assert buf.closed
+        assert int(buf.identity.buffer_id) not in w._buffers


### PR DESCRIPTION
## Summary

My own review comment on #1751 flagged a real gap: `release_buffer()`'s in-flight check only ever looks at `self._accepted_run_handles`, and `_submit_l2_locked` — the direct-chip dispatch path `submit()` uses at L2 — never adds its `RunHandle` there. `create_buffer()` only requires `level >= 2`, so an L2 Worker can hold a real, registered `Buffer` and dispatch chip runs against it with zero protection from `release_buffer()`.

Checked how exploitable this is today: zero production callers do `Worker(level=2).create_buffer()` then race `release_buffer()` against a concurrent `submit()` — this is a latent trap for future usage, not a firing bug. It doesn't explode today only because `ImportRegistry.materialize()` maps its own separate mmap for the identity, and POSIX `unlink()` only removes the shm's name — an already-open mapping keeps working. That's an undocumented, untested coincidence, not a guarantee.

Also corrected the assumption #1751 shipped — "L2 never needs this, a run completes synchronously inside `submit()`" — which is false: the direct-chip lane permits one active plus one prepared compatible run, so up to two L2 runs can be in flight at once (per the W1b/W1c async-pipeline work, #1748/#1750). The real reason `release_buffer()`'s existing check can't see L2 runs is narrower: L2 uses a separate run-id namespace (`self._chip_run_seq`, tracked in `self._chip_runs`) and never touches `_accepted_run_handles`/`_submit_mu` — `_submit_locked` returns from the L2 branch before reaching the `with self._submit_mu:` block.

Rather than fold L2 into `_accepted_run_handles` (whose other readers carry L3-specific assumptions built around `_orch`-issued run ids and orchestration callbacks), this mirrors `_chip_runs`' own lifecycle with a parallel dict, `_chip_run_touched_identities`, added/removed at the same points under the existing `_registry_lock`. `release_buffer()` now runs a second, independent check against it after the existing L3+ one.

## Test plan

- [x] New tests: `_submit_l2_locked` records the touched identity (and an empty set for `args=None`); `_finalize_run_handle` clears it; `release_buffer` rejects while an L2 run's identity is present (registry entry survives the rejection) and succeeds once it's gone
- [x] Fixed two existing bare-`Worker` test helpers that now also need the new dict
- [x] `pytest tests/ut` — 1302 passed / 13 skipped / 0 failed
- [x] `ruff check` / `ruff format --check` clean
- [x] Real onboard a2a3 run (`pipeline_slots/test_pipeline_slots.py`, an L2 direct-chip scene test) exercising the touched-identity walk on the real L2 dispatch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
