### PR TITLE
[Performance] host_build_graph: shrink ready-queue capacity 65536 -> 8192

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -94,8 +94,13 @@
 // buffer (which would be UB on the arena's malloc'd backing).
 #define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
 
-// Ready queue
-#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
+// Per-shape ready-queue capacity (power of two). This is a ring buffer that
+// bounds peak CONCURRENT occupancy (enqueue_pos - dequeue_pos), not total task
+// count: slots recycle, so capacity need only exceed the most tasks ever
+// simultaneously ready in any one queue. Overflow on the ready/sync/dummy queues
+// latches PTO2_ERROR_READY_QUEUE_OVERFLOW (safe-fail), so it must exceed the
+// worst-case ready burst with margin.
+#define PTO2_READY_QUEUE_SIZE 8192
 
 // Cross-thread early-dispatch work queue (power of two)
 #define PTO2_EARLY_DISPATCH_QUEUE_SIZE 64

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -489,26 +489,27 @@ struct PTO2SchedulerState {
     // the per-shape ready_sync_queues[] (drained as Tier-0); everything else to
     // ready_queues[].
     void push_ready_routed(PTO2TaskSlotState *slot_state) {
-        if (slot_state->task_kind == TaskKind::GRAPH) {
-            graph_ready_queue.push(slot_state);
-            return;
-        }
-        PTO2ResourceShape shape = slot_state->active_mask.to_shape();
         bool pushed;
-        if (shape == PTO2ResourceShape::DUMMY ||
-            (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
-            pushed = dummy_ready_queue.push(slot_state);
-        } else if (slot_state->task_attrs.requires_sync_start()) {
-            pushed = ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
+        if (slot_state->task_kind == TaskKind::GRAPH) {
+            pushed = graph_ready_queue.push(slot_state);
         } else {
-            pushed = ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+            PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+            if (shape == PTO2ResourceShape::DUMMY ||
+                (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
+                pushed = dummy_ready_queue.push(slot_state);
+            } else if (slot_state->task_attrs.requires_sync_start()) {
+                pushed = ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
+            } else {
+                pushed = ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+            }
         }
-        // A queue is sized for the whole task window and each task is routed to one
-        // queue exactly once, so push cannot legitimately fail. A false return means
-        // the target slot fell outside the shipped prefix, or the window genuinely
-        // exceeds queue capacity — either way the task is dropped and the run would
-        // otherwise stall. Latch a named error so it surfaces as READY_QUEUE_OVERFLOW
-        // rather than an anonymous forward-progress timeout.
+        // Every ready / sync / dummy / graph task routes to exactly one queue. A
+        // false push means that queue's peak concurrent occupancy exceeded
+        // PTO2_READY_QUEUE_SIZE — a capacity mis-sizing, not a normal condition.
+        // Silently dropping the task would stall the run, so latch a named error
+        // (surfaces as READY_QUEUE_OVERFLOW rather than an anonymous
+        // forward-progress timeout). The graph_ready push is checked identically
+        // so a graph task cannot be dropped either.
         if (!pushed) {
             int32_t expected = PTO2_ERROR_NONE;
             sm_header->sched_error_code.compare_exchange_strong(


### PR DESCRIPTION
# Human Summary

The 65k ready queue capacity is excessive; it is filled with the initial set of ready tasks and then during runtime as scheduler threads detect ready-to-go tasks, and; emptied, as tasks are ultimately scheduled for execution. The capacity of this queue then obeys to a runtime amplitude between how fast schedulers can add them and how AI cores can execute them. 

The queue use amplitude never seems to get anywhere near the maximum here, which seems to be a couple orders of magnitude larger than it needs to be, at least. This PR safely reduces the size of the queue, reducing its memory footprint, but also the computational need to move this array from host to device before kernel execution.

# AI Summary

## PR notes — `host_build_graph`: shrink ready-queue capacity 65536 → 8192

- **Branch:** `hbg-ready-queue-8192` (commit `29e4738c`, off `upstream/main` `cf0fbc06`)
- **Diff:** 2 files, +25 / −19 — the capacity constant plus a graph-queue overflow guardrail
- **Arch/runtime:** a2a3 `host_build_graph` only

## TL;DR

The per-shape ready queue is a Vyukov ring buffer whose capacity bounds **peak
concurrent occupancy**, not total task count. At 65536 the nine ready queues
occupy ~13.5 MB of the per-run runtime arena, which is rebuilt and uploaded H2D
on **every** bind. Measured peak occupancy across the whole HBG onboard suite is
**≤ 106** (paged_attention = 1, bgemm = 64), so 65536 was ~600–65000× oversized.
Dropping to 8192 keeps 77–128× headroom and cuts **host bind wall by −41.6%** on
paged_attention (8627 → 5037 µs), golden-clean, with device time unchanged.

## Why the constant was oversized

`PTO2ReadyQueue` is a Vyukov MPMC ring (`slots[capacity]`, `enqueue_pos`,
`dequeue_pos`, `mask = capacity − 1`). Two facts:

1. **Capacity bounds concurrency, not throughput.** The ring recycles slots, so
   a queue of capacity *C* processes unlimited tasks as long as no more than *C*
   are ever *simultaneously* enqueued-but-unconsumed (`enqueue_pos − dequeue_pos`).
   65536 is therefore a worst-case *peak-occupancy* bound, not one-slot-per-task.
2. **The queues dominate the per-run arena.** `PTO2SchedulerState::reserve_layout`
   allocates **9** full-size queues — 3 ready + 3 ready-sync + dummy + graph_ready
   + graph_prepare — each `capacity × sizeof(PTO2ReadyQueueSlot)` (24 B). At 65536
   that is `9 × 65536 × 24 B ≈ 13.5 MB`. This region is re-seeded (`arena_build`,
   the `sequence = i` loop over every slot) and copied H2D (`arena_upload`) on
   every `bind`. After PR #1659 skipped the ~8.5 MB orchestrator block from the
   upload, these queues are the single largest remaining bind cost.

So the queues were being rebuilt and re-shipped at 65536-slot size every run to
hold, in practice, ≤ 106 live entries.

## The change

```c
// Per-shape ready-queue capacity (power of two). This is a ring buffer that
// bounds peak CONCURRENT occupancy (enqueue_pos - dequeue_pos), not total task
// count: slots recycle, so capacity need only exceed the most tasks ever
// simultaneously ready in any one queue. Overflow on the ready/sync/dummy queues
// latches PTO2_ERROR_READY_QUEUE_OVERFLOW (safe-fail), so it must exceed the
// worst-case ready burst with margin.
#define PTO2_READY_QUEUE_SIZE 8192   // was 65536
```

`8192` is a power of two (required — index is `pos & mask`) and gives **77×**
headroom over the observed suite max (106) and **128×** over the steady per-run
max (bgemm 64).

### Graph-queue guardrail (second half of the diff)

All nine queues share `PTO2_READY_QUEUE_SIZE`, so the shared cut also has to make
the **graph_ready** path safe-fail. `push_ready_routed` previously ignored the
return of `graph_ready_queue.push()`, so a full graph_ready_queue would silently
drop the task and stall the run — unlike ready/sync/dummy, which latch
`PTO2_ERROR_READY_QUEUE_OVERFLOW`. The graph task is now routed through the same
checked path, so every queue that shares the constant reports overflow as a
named error rather than an anonymous forward-progress timeout.

`graph_prepare_queue` pushes (scheduler_cold_path.cpp, scheduler_dispatch.cpp)
are already `while (!push_tagged(...))` spin-retries that wait for space instead
of dropping, so they are left unchanged.

## Measurements

All on a2a3 onboard, `paged_attention`, median of 50 rounds, from the
`[STRACE]` bind span tree. The three capacities were measured **back-to-back on
one locked device** to control for contention.

### Bind-phase breakdown (µs)

| Phase | 65536 | 8192 | 2048 |
| --- | --: | --: | --: |
| arena_upload | 2667.1 | 360.4 | 221.5 |
| arena_build | 2622.7 | 1490.3 | 1337.9 |
| orch_reinit | 1246.2 | 1290.9 | 1241.3 |
| host_orch (rest) | 363.0 | 336.8 | 352.0 |
| **bind subtotal** | **7126.0** | **3695.5** | **3365.8** |
| runner_run (host) | 637.3 | 572.7 | 568.5 |
| validate | 106.3 | 109.0 | 96.3 |

### Delta subtotals — Host / Device / Total

| Subtotal | 65536 | 8192 (Δ) | 2048 (Δ) |
| --- | --: | --: | --: |
| **Host** (total − device) | 8556.1 | 4960.7 (−42.0%) | 4620.1 (−46.0%) |
| **Device** (device_wall) | 71.1 | 75.8 (flat) | 70.5 (flat) |
| **Total** (host wall) | 8627.2 | 5036.5 (−41.6%) | 4690.6 (−45.6%) |

**Why 8192 and not lower:** 65536 → 8192 captures 91% of the achievable win
(−3591 µs); 8192 → 2048 adds only −346 µs (−6.9%, within host-wall noise) while
cutting overflow headroom 4×. The queue is no longer the bottleneck at 8192 —
`arena_upload` is already down to 360 µs. Device wall is flat throughout (no
on-NPU regression).

## Correctness & peak-occupancy evidence

Peak occupancy is measured with a high-water mark on `enqueue_pos − dequeue_pos`
sampled at each push (a near-upper-bound: occupancy only rises at an enqueue, so
its max is always caught at a push instant). Suite results:

| Workload | peak occupancy | golden @ 8192 |
| --- | --: | --- |
| qwen3 3-layer graph | **106** | (measured 65536) |
| bgemm | 64 | ✓ pass |
| graph_execution (2 cases) | 4 | ✓ pass |
| matmul / vector / predicated | ≤ 2 | — |
| paged_attention | 1 | ✓ pass |
| graph_mix_spmd (wide-SPMD + graph) | 0–1 | ✓ pass |

At both 8192 and 2048: golden clean on paged_attention / bgemm / graph_execution
/ graph_mix_spmd, no `READY_QUEUE_OVERFLOW`, no 507018.

## Risk analysis

**What happens if the cap is ever too low** (documented for reviewers):

- **ready / ready_sync / dummy queues — safe-fail.** `push_tagged` returns
  `false` on a full ring (never overwrites an occupied slot → no corruption);
  `push_ready_routed` latches `PTO2_ERROR_READY_QUEUE_OVERFLOW`; the scheduler's
  idle/exit check sees it and `emergency_shutdown`s → the run aborts **promptly
  with a named error**, not a hang, not a wrong answer.
- **graph_ready — now guardrailed by this PR.** `graph_ready_queue.push()` used
  to ignore its return (silent drop → stall); it now routes through the same
  checked path and latches `PTO2_ERROR_READY_QUEUE_OVERFLOW`. So all queues that
  share the constant are uniformly safe-fail.
- **graph_prepare — already safe.** Its pushes are `while (!push_tagged(...))`
  spin-retries that wait for space rather than dropping.

## Scope

- **a2a3 `host_build_graph` only.** a5 HBG carries the same 65536 constant but is
  **left unchanged** pending an a5 peak-occupancy measurement — a5 has different
  core counts, hence a different boot ready-burst.
- **`tensormap_and_ringbuffer` is out of scope** — a separate runtime that uses
  the queue differently; not analyzed here.

## Follow-ups (not in this PR)

1. **`wide_dispatch` coverage** — the sim-only SPMD-spill stress
   (`tests/st/host_build_graph_wide_dispatch/`) is the designated wide-SPMD
   worst case; its kernels don't compile in our container (`_Float16` on host
   gcc). If CI's sim lane exercises it, that closes the last worst-case gap.
2. **a5 HBG** — repeat the occupancy measurement and apply the matching cut.
3. **`orch_reinit` (~1.25 ms)** — now the biggest single bind sub-phase and
   queue-independent (the orchestrator is initialized twice per bind: device-SM
   in `arena_build`, then re-initialized against host-SM in
   `run_host_orchestration`). The next lever after this PR.

## Reproduce

```bash
# A/B one workload (baseline vs this branch) — needs a2a3 silicon + a device lock:
python tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py \
    -p a2a3 -d <dev> --rounds 50 --skip-golden
# Read the bind span tree (Host wall + bind sub-phases):
python -m simpler_setup.tools.strace_timing <captured-stderr> --tree

# Rebuild the HBG libs after the constant change:
cmake --build build/cache/a2a3/onboard/host_build_graph/host  -j"$(nproc)"
cmake --build build/cache/a2a3/onboard/host_build_graph/aicpu -j"$(nproc)"
```
