### PR TITLE
[Performance] A2/A3/A5 host_build_graph: skip redundant orchestrator init in arena build

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -206,7 +206,10 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
  * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
- * AICPU at boot.
+ * AICPU at boot. Initializes the scheduler only: the orchestrator is left
+ * zeroed for the host-orch path (run_host_orchestration) to initialize
+ * against the host SM, since initializing it here would be overwritten and
+ * is never uploaded to the device.
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -358,6 +358,19 @@ PTO2Runtime *runtime_init_data_from_layout(
     return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
 }
 
+/**
+ * Populate the prebuilt runtime-arena image in place (host build path).
+ *
+ * Zeroes the PTO2Runtime header at layout.off_runtime, records the GM heap,
+ * and initializes the scheduler (ready / sync / dummy / graph queues) against
+ * the device SM. The orchestrator is deliberately left zeroed: the host-orch
+ * path (run_host_orchestration) initializes it against the host SM once that
+ * buffer exists, then relocates it for the device. Initializing it here would
+ * be dead work — overwritten by that re-init, and the orchestrator arena block
+ * is never uploaded to the device. Caller must follow up with
+ * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
+ * nullptr on failure.
+ */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
     uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
@@ -380,11 +393,13 @@ PTO2Runtime *runtime_init_data_from_layout(
     rt->total_cycles = 0;
     rt->active_callable_hash = 0;
 
-    if (!rt->orchestrator.init_data_from_layout(
-            layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_sizes[0], layout.task_window_sizes[0]
-        )) {
-        return nullptr;
-    }
+    // The orchestrator is initialized by the host-orch path
+    // (run_host_orchestration) against the host SM once it is allocated, then
+    // relocated for the device. Initializing it here would be dead work: its
+    // arena content (tensormap + seen_epoch memset) is immediately overwritten by
+    // that re-init, and the orchestrator arena block is not uploaded to the device
+    // (the scheduler boots without it). So only the scheduler is initialized here;
+    // rt->orchestrator stays zeroed (from the memset above) until run_host_orchestration.
     if (!rt->scheduler.init_data_from_layout(layout.sched, arena, sm_dev_base)) {
         return nullptr;
     }

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -200,7 +200,10 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
  * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
- * AICPU at boot.
+ * AICPU at boot. Initializes the scheduler only: the orchestrator is left
+ * zeroed for the host-orch path (run_host_orchestration) to initialize
+ * against the host SM, since initializing it here would be overwritten and
+ * is never uploaded to the device.
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -344,6 +344,19 @@ PTO2Runtime *runtime_init_data_from_layout(
     return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
 }
 
+/**
+ * Populate the prebuilt runtime-arena image in place (host build path).
+ *
+ * Zeroes the PTO2Runtime header at layout.off_runtime, records the GM heap,
+ * and initializes the scheduler (ready / sync / dummy / graph queues) against
+ * the device SM. The orchestrator is deliberately left zeroed: the host-orch
+ * path (run_host_orchestration) initializes it against the host SM once that
+ * buffer exists, then relocates it for the device. Initializing it here would
+ * be dead work — overwritten by that re-init, and the orchestrator arena block
+ * is never uploaded to the device. Caller must follow up with
+ * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
+ * nullptr on failure.
+ */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
     uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
@@ -365,11 +378,13 @@ PTO2Runtime *runtime_init_data_from_layout(
     rt->gm_heap_owned = false;
     rt->total_cycles = 0;
 
-    if (!rt->orchestrator.init_data_from_layout(
-            layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_sizes[0], layout.task_window_sizes[0]
-        )) {
-        return nullptr;
-    }
+    // The orchestrator is initialized by the host-orch path
+    // (run_host_orchestration) against the host SM once it is allocated, then
+    // relocated for the device. Initializing it here would be dead work: its
+    // arena content (tensormap + seen_epoch memset) is immediately overwritten by
+    // that re-init, and the orchestrator arena block is not uploaded to the device
+    // (the scheduler boots without it). So only the scheduler is initialized here;
+    // rt->orchestrator stays zeroed (from the memset above) until run_host_orchestration.
     if (!rt->scheduler.init_data_from_layout(layout.sched, arena, sm_dev_base)) {
         return nullptr;
     }

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/conftest.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/conftest.py
@@ -1,0 +1,55 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Isolated L2 worker for the concurrent-prepare white-box stress.
+
+The default ``st_worker`` (root conftest) is shared across L2 ST classes in a
+session-scoped pool — correct for ordinary business tests, but this stress
+drives the ChipWorker native-run lane directly (registering a callable slot and
+submitting overlapping runs), so it needs a fresh worker whose private slot
+table and native-run lane start empty and are not left with residue for other
+pooled tests.
+
+Override ``st_worker`` here as class-scope, building a fresh L2 worker that does
+**not** enter ``_l2_worker_pool``. Cost: one extra init/close per test class.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="class")
+def st_worker(request, st_platform, device_pool):
+    """Yield a fresh class-scope L2 worker that does not enter the shared pool."""
+    cls = request.node.cls
+    if cls is None or not hasattr(cls, "_st_runtime"):
+        pytest.skip("isolated st_worker requires a SceneTestCase subclass")
+
+    runtime = cls._st_runtime
+
+    ids = device_pool.allocate(1)
+    if not ids:
+        pytest.fail("no devices available for isolated L2 worker")
+    dev_id = ids[0]
+    try:
+        from simpler.worker import Worker  # noqa: PLC0415
+
+        w = Worker(
+            level=2,
+            device_id=dev_id,
+            platform=st_platform,
+            runtime=runtime,
+        )
+        w.init()
+        try:
+            yield w
+        finally:
+            w.close()
+    finally:
+        device_pool.release(ids)

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Concurrent-prepare overlap stress for host_build_graph.
+
+Drives a 2-deep native-run pipeline over the two arena banks: run i is
+*prepared* (which runs its full bind — arena build + host orchestration) while
+run i-1 is still launched-but-not-finalized. That is exactly the
+``overlaps_active_run`` path (a successor prepared into bank B while a
+predecessor executes in bank A), which the ordinary blocking run() never hits.
+
+Each iteration uses distinct input data, so any cross-run interference between
+the two banks' runtimes/orchestrators (e.g. a shared or under-initialized
+orchestrator) would corrupt a result and fail the golden check. The point is to
+exercise the concurrent-prepare bind path under many alternating-bank
+iterations, not to measure anything.
+"""
+
+import pytest
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
+
+_VECTOR_KERNELS = "../vector_example/kernels"
+_SIZE = 128 * 128
+_ITERS = 40  # 20 reuses per bank
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestConcurrentPrepareStressHbg(SceneTestCase):
+    """Prepare-while-active stress over the two pipeline banks (a2a3 onboard)."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{_VECTOR_KERNELS}/orchestration/example_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{_VECTOR_KERNELS}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{_VECTOR_KERNELS}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{_VECTOR_KERNELS}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    _PLATFORMS = ["a2a3"]
+
+    CASES = [
+        {
+            "name": "overlap_stress",
+            "platforms": _PLATFORMS,
+            # Consumed by the framework's default test_run (a plain blocking run);
+            # the overlap loop below builds its own per-iteration params.
+            "params": {"a": 2.0, "b": 3.0},
+        },
+    ]
+
+    def generate_args(self, params):
+        """Build the two constant input vectors and the zero output for ``params``."""
+        a, b = params["a"], params["b"]
+        return TaskArgsBuilder(
+            TensorArg("a", torch.full((_SIZE,), a, dtype=torch.float32)),
+            TensorArg("b", torch.full((_SIZE,), b, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(_SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        """Reference output: example_orch computes ``(a + b + 1) * (a + b + 2)``."""
+        a, b = args.a, args.b
+        args.f[:] = (a + b + 1) * (a + b + 2)
+
+    def _chip_worker(self, worker):
+        """Return the L2 ChipWorker backing ``worker`` (asserts it exists)."""
+        chip_worker = worker._chip_worker
+        assert chip_worker is not None
+        return chip_worker
+
+    def test_concurrent_prepare_overlap(self, st_platform, st_worker):
+        """Golden-check a 2-deep overlapping pipeline over both arena banks.
+
+        Each submission prepares (fully binds) its run against one bank while the
+        predecessor is still active in the other, exercising the
+        ``overlaps_active_run`` path many times with distinct data.
+        """
+        if st_platform != "a2a3":
+            pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
+
+        orch_sig = self.CALLABLE["orchestration"]["signature"]
+        callable_obj = self.build_callable(st_platform)
+        config = self._build_config({})
+        chip_worker = self._chip_worker(st_worker)
+
+        if int(chip_worker.pipeline_depth) < 2:
+            pytest.skip(f"need pipeline_depth >= 2 for overlap, have {chip_worker.pipeline_depth}")
+
+        callable_id = 0
+        chip_worker._register_callable_at_slot(callable_id, callable_obj)
+
+        # The direct-chip lane is the sole admission authority and follows the
+        # runtime PipelineContract: it admits one active plus one prepared
+        # compatible successor. Submitting run i while run i-1 is still in flight
+        # therefore prepares run i (its full bind — arena build + host
+        # orchestration) against the other bank while run i-1 is active, i.e. the
+        # overlaps_active_run path. Each in-flight entry keeps BOTH the encoded
+        # chip_args and the backing tensors (test_args) alive until the run
+        # reaches terminal (the lane copies inputs but the buffers back the
+        # resolved descriptors, and the output is copied back at finalize).
+        inflight = []  # (chip_run, test_args, golden_args, output_names, chip_args, iteration)
+
+        def _retire(entry):
+            """Block one run to terminal (lane finalizes + copies back) and golden-check it."""
+            chip_run, test_args, golden_args, output_names, _chip_args, _it = entry
+            # Block to the completion fence; the lane finalizes (validate +
+            # copy-back) as part of reaching terminal.
+            chip_run.wait(-1.0)
+            # Distinct per-iteration data → a corrupted/aliased bank fails this.
+            _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
+
+        try:
+            for i in range(_ITERS):
+                # Distinct inputs per iteration so golden catches cross-bank interference.
+                params = {"a": 1.0 + i, "b": 2.0 + 0.5 * i}
+                test_args = self.generate_args(params)
+                chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
+                golden_args = test_args.clone()
+                self.compute_golden(golden_args, params)
+
+                chip_run = chip_worker._impl._submit_chip_run_direct(callable_id, chip_args, config)
+                inflight.append((chip_run, test_args, golden_args, output_names, chip_args, i))
+
+                # Keep two runs in flight so each submission overlaps its predecessor.
+                if len(inflight) >= 2:
+                    _retire(inflight.pop(0))
+
+            while inflight:
+                _retire(inflight.pop(0))
+        finally:
+            chip_worker._unregister_slot(callable_id)


### PR DESCRIPTION
# Human Summary

The run_host_orchestration() function was being called twice. This PR removes the redundant call.

Applies to A2/A3/A5.

# AI Summary

## PR notes — `host_build_graph`: skip redundant orchestrator init in arena build

- **Branch:** `hbg-skip-redundant-orch-init` (commit `a2a42446`, off `upstream/main` `cf0fbc06`)
- **Diff:** 6 files, +264 / −12 — the one-function change + its doc comment
  mirrored across **a2a3 and a5**, plus a concurrent-prepare white-box stress test
  (`concurrent_prepare_stress/` + isolated-worker conftest).
- **Arch/runtime:** `host_build_graph` on **both a2a3 and a5** (see [a5 parity](#a5-parity))
- **Independent of** `hbg-ready-queue-8192` (different file; either merge order works).

## TL;DR

The host bind path initialized the orchestrator **twice** per run: once against
the device SM while building the prebuilt arena, then again against the host SM
in `run_host_orchestration`. The first init is dead work — its arena content is
overwritten by the second, and the orchestrator arena block is never uploaded to
the device. Skipping it cuts the `arena_build` phase of bind by ~46% (the
redundant tensormap memset), trimming host bind wall **−13.6%** on paged_attention
(8677 → 7494 µs), device time unchanged, golden-clean.

## The double-init

Two calls to `PTO2OrchestratorState::init_data_from_layout` happen per bind:

1. **arena_build** — `runtime_init_data_from_layout` (pto_runtime2_init.cpp) calls
   `rt->orchestrator.init_data_from_layout(..., sm_dev_base, ...)` against the
   **device SM** while assembling the prebuilt arena image.
2. **host_orch** — `run_host_orchestration` (runtime_maker.cpp) calls
   `rt->orchestrator.init_data_from_layout(..., host_sm, ...)` against the **host
   SM**, because the orchestrator's submit loop runs on the host and writes task
   descriptors into a host-side SM buffer that is allocated only at that point.
   After the submit loop the image is relocated (host→device pointers) and the
   live prefix is uploaded.

`init_data_from_layout` does two kinds of work: **arena work** (the
`fanin_seen_epoch` memset + `tensor_map.init_data_from_layout` — the expensive,
SM-independent part) and **SM-pointer setup** (`task_allocator.init`, `sm_header`
— cheap, SM-specific). Both inits memset the *same arena regions*; only the SM
pointers differ. So the first init's expensive arena work is entirely redone by
the second.

## Why the first init is safe to drop

- **Single caller.** The 8-arg `runtime_init_data_from_layout` is called from
  exactly one place — the host bind path (`runtime_maker.cpp`). The AICPU boots
  scheduler-only (per #1659) and never calls it, so no device path depends on it.
- **Always re-initialized.** That sole caller unconditionally calls
  `run_host_orchestration` right after, which re-inits the orchestrator against
  the host SM. The first init's result never survives.
- **Never uploaded.** #1659 already skips the orchestrator arena block from the
  H2D upload, so whatever the first init wrote there does not reach the device.
- **Nothing reads it in between.** The intervening `runtime_wire_arena_pointers`
  only *sets* pointers (it does not read orchestrator state), and
  `rt->orchestrator` is already zeroed by the `memset(rt, 0, ...)` at the top of
  `runtime_init_data_from_layout`. So leaving it zeroed until
  `run_host_orchestration` is well-defined.

The change initializes only the scheduler in `runtime_init_data_from_layout` and
lets `run_host_orchestration` own the single orchestrator init.

## a5 parity

The change is mirrored into the a5 `host_build_graph` sibling in the **same
commit** — a2a3 and a5 are near-duplicate trees with no architectural divergence
here. All four safety pillars above were re-verified on a5:

- **Single caller** — the 8-arg `runtime_init_data_from_layout` is called from
  exactly one place, the a5 host bind path (`src/a5/.../host/runtime_maker.cpp`);
  the AICPU never calls it.
- **Always re-initialized** — a5's `run_host_orchestration` re-inits the
  orchestrator against the host SM (`src/a5/.../host/runtime_maker.cpp`), same as
  a2a3.
- **Never uploaded** — a5 boots the scheduler without the orchestrator arena
  block.
- **Nothing reads it in between** — a5's `runtime_wire_arena_pointers` only sets
  pointers.

Files: `src/a5/.../runtime/shared/pto_runtime2_init.cpp` (the orchestrator init
removed from the 8-arg `runtime_init_data_from_layout`, replaced by the same
explanatory comment) and `src/a5/.../runtime/pto_runtime2.h` (matching doc
comment). **Verification:** a5 (and a2a3) host libs compile + link clean; all
pre-commit hooks pass on all six files. a5 is **compile-verified only** — not
perf-measured, as the dev box is a2a3 silicon (the numbers below are a2a3). The
`concurrent_prepare_stress` test lives under `tests/st/a2a3/` and exercises the
shared bind/prepare logic; it is not duplicated per-arch.

Going forward, HBG optimizations land in both arches in one commit unless there
is a genuine arch-level difference.

## Measurement

a2a3 onboard, paged_attention, median of 50 rounds, from the `[STRACE]` bind span
tree (default capacity 65536; this PR does not change the queue size).

| Phase | before | after | Δ |
| --- | --: | --: | --: |
| arena_build | 2564.8 | 1372.6 | **−1192 µs (−46.5%)** |
| host_orch (incl. orch_reinit) | ~1610 | ~1708 | unchanged (the *surviving* init) |
| arena_upload | 2676.1 | 2693.3 | unchanged |
| **host wall (simpler_run)** | **8677.1** | **7493.6** | **−1184 µs (−13.6%)** |
| device_wall | 69.8 | 71.1 | unchanged |

`orch_reinit` (the host-SM init the submit loop actually needs) is untouched, as
expected — this PR removes only the *duplicate*. Device time is flat.

> Stacked on `hbg-ready-queue-8192` the two levers compound: measured together on
> the 8192 build, arena_build fell to ~186 µs and host wall to ~3790 µs (−56% vs
> upstream). Standalone off `main` the effect is the −13.6% above.

## Correctness

Full `host_build_graph` golden suite (`pytest tests/st/a2a3/host_build_graph/`,
a2a3 onboard): **22 passed, 2 skipped, 2 failed**. Both failures are
**pre-existing and unrelated**, verified by rebuilding the runtime source at
`cf0fbc06` baseline (orch init present) with a matching binding — both reproduce
identically:

- `run_stream_reuse::test_depth_two_slots_own_separate_resources` — "a served
  bank is uncommitted: …, 0x0" (arena-bank-commit path; already tracked).
- `worker_async_fifo::TestWorkerAsyncWholeRunFifo::test_run` — `507901`
  finalize/hdc-disconnect (same native-run pipeline-slot / arena-bank family).

The diff touches neither path (`ChipWorker::arena_bank_gm_heap_base` / native-run
finalize are untouched), and the pass/fail set is identical with and without the
change.

### Concurrent-prepare stress (added by this PR)

Because the orchestrator init is per-run scratch, the one place worth exercising
is concurrent prepare — a successor prepared (bound) into bank B while a
predecessor is still executing in bank A (`overlaps_active_run`). Ordinary
blocking `run()` never hits it, and the two existing tests that do
(`run_stream_reuse`, `worker_async_fifo`) are the pre-existing-broken ones, so
they cannot confirm safety.

`concurrent_prepare_stress/` adds a white-box test that drives a 2-deep pipeline
over both banks through the canonical direct-chip lane
(`_submit_chip_run_direct`, the exact path production L2 `Worker.run` uses):
40 iterations, distinct per-iteration inputs, each result golden-checked, so any
cross-bank orchestrator interference would fail. It passes **identically on this
change and a baseline build** (orch init present) — confirming the test is sound
and the change is safe under concurrent prepare. This is safe by construction:
each run has its own arena bank → its own `PTO2Runtime`/orchestrator; the
orchestrator block is never uploaded to the device; and nothing reads it between
the (removed) init and the surviving host-SM init.

## Scope & follow-ups

- **a2a3 + a5 `host_build_graph`.** The same double-init existed in a5 HBG and is
  fixed in this same commit (see [a5 parity](#a5-parity)); a5 is compile-verified,
  perf-measured on a2a3.
- **Next lever:** `orch_reinit` (~1.3 ms) is now the largest single bind
  sub-phase — the *surviving* orchestrator init (tensormap memset against host
  SM). Reducing it (bounded tensormap, or a persistent-zeroed pool that the
  submit loop cleans up) is the logical successor, and harder.

## Reproduce

```bash
python tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py \
    -p a2a3 -d <dev> --rounds 50 --skip-golden
python -m simpler_setup.tools.strace_timing <captured-stderr> --tree   # Host wall + bind sub-phases

cmake --build build/cache/a2a3/onboard/host_build_graph/host  -j"$(nproc)"
cmake --build build/cache/a2a3/onboard/host_build_graph/aicpu -j"$(nproc)"

# a5 compile-verify (no a5 silicon on this box, so build-only):
cmake --build build/cache/a5/onboard/host_build_graph/host -j"$(nproc)"

# Concurrent-prepare overlap stress:
python -m pytest tests/st/a2a3/host_build_graph/concurrent_prepare_stress/ \
    --platform a2a3 --device <dev>
```

