### PR TITLE
Add: check the mailbox wire constants against the C++ enums at import

### DIFF
--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -839,6 +839,33 @@ inline void bind_worker(nb::module_ &m) {
     m.attr("MAILBOX_FRAME_SIZE") = static_cast<int>(MAILBOX_FRAME_SIZE);
     m.attr("MAILBOX_OFF_ERROR_MSG") = static_cast<int>(MAILBOX_OFF_ERROR_MSG);
     m.attr("MAILBOX_ERROR_MSG_SIZE") = static_cast<int>(MAILBOX_ERROR_MSG_SIZE);
+    // The MailboxState values as the C++ side defines them, keyed by
+    // enumerator name. They are a cross-process wire contract: the word at
+    // MAILBOX_OFF_STATE is written by a parent and read by its forked child,
+    // so a Python constant that disagrees with this table is a protocol
+    // mismatch between two live processes, not a compile error. simpler.worker
+    // declares its own constants for use in hot paths and checks them against
+    // this table at import.
+    nb::dict mailbox_states;
+    mailbox_states["IDLE"] = static_cast<int32_t>(MailboxState::IDLE);
+    mailbox_states["TASK_READY"] = static_cast<int32_t>(MailboxState::TASK_READY);
+    mailbox_states["TASK_DONE"] = static_cast<int32_t>(MailboxState::TASK_DONE);
+    mailbox_states["SHUTDOWN"] = static_cast<int32_t>(MailboxState::SHUTDOWN);
+    mailbox_states["CONTROL_REQUEST"] = static_cast<int32_t>(MailboxState::CONTROL_REQUEST);
+    mailbox_states["CONTROL_DONE"] = static_cast<int32_t>(MailboxState::CONTROL_DONE);
+    mailbox_states["INIT_READY"] = static_cast<int32_t>(MailboxState::INIT_READY);
+    mailbox_states["INIT_FAILED"] = static_cast<int32_t>(MailboxState::INIT_FAILED);
+    mailbox_states["FRAME_STAGED"] = static_cast<int32_t>(MailboxState::FRAME_STAGED);
+    mailbox_states["TASK_LAUNCHED"] = static_cast<int32_t>(MailboxState::TASK_LAUNCHED);
+    mailbox_states["TASK_FAILED"] = static_cast<int32_t>(MailboxState::TASK_FAILED);
+    mailbox_states["ACTIVATE"] = static_cast<int32_t>(MailboxState::ACTIVATE);
+    mailbox_states["PREPARE_READY"] = static_cast<int32_t>(MailboxState::PREPARE_READY);
+    m.attr("MAILBOX_STATE_VALUES") = mailbox_states;
+    nb::dict mailbox_dispositions;
+    mailbox_dispositions["NONE"] = static_cast<int32_t>(MailboxPreparationDisposition::NONE);
+    mailbox_dispositions["VALIDATED_ONLY"] = static_cast<int32_t>(MailboxPreparationDisposition::VALIDATED_ONLY);
+    mailbox_dispositions["NATIVE_PREPARED"] = static_cast<int32_t>(MailboxPreparationDisposition::NATIVE_PREPARED);
+    m.attr("MAILBOX_PREPARATION_DISPOSITION_VALUES") = mailbox_dispositions;
     m.attr("PTO_PIPELINE_MAX_DEPTH") = static_cast<uint32_t>(PTO_PIPELINE_MAX_DEPTH);
     m.attr("MAX_RING_DEPTH") = static_cast<int32_t>(MAX_RING_DEPTH);
     m.attr("MAX_SCOPE_DEPTH") = static_cast<int32_t>(MAX_SCOPE_DEPTH);

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -48,7 +48,9 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     MAILBOX_ERROR_MSG_SIZE,
     MAILBOX_FRAME_SIZE,
     MAILBOX_OFF_ERROR_MSG,
+    MAILBOX_PREPARATION_DISPOSITION_VALUES,
     MAILBOX_SIZE,
+    MAILBOX_STATE_VALUES,
     MAX_REGISTERED_CALLABLE_IDS,
     MAX_TENSOR_DIMS,
     ArgDirection,
@@ -170,6 +172,8 @@ __all__ = [
     "MAILBOX_FRAME_SIZE",
     "MAILBOX_OFF_ERROR_MSG",
     "MAILBOX_ERROR_MSG_SIZE",
+    "MAILBOX_STATE_VALUES",
+    "MAILBOX_PREPARATION_DISPOSITION_VALUES",
     "read_args_from_blob",
     # Dynamic CommDomain allocation (orch-only API)
     "CommBufferSpec",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -200,7 +200,9 @@ from .task_interface import (
     MAILBOX_ERROR_MSG_SIZE,
     MAILBOX_FRAME_SIZE,
     MAILBOX_OFF_ERROR_MSG,
+    MAILBOX_PREPARATION_DISPOSITION_VALUES,
     MAILBOX_SIZE,
+    MAILBOX_STATE_VALUES,
     CallConfig,
     ChipCallable,
     ChipDomainContext,
@@ -286,6 +288,10 @@ _OFF_TASK_ARGS_BLOB = _OFF_TASK_CALLABLE_HASH + CALLABLE_HASH_DIGEST_BYTES
 _OFF_ACCEPTED = MAILBOX_FRAME_SIZE - MAILBOX_ERROR_MSG_SIZE - 8
 _TASK_ACCEPTED = 1
 _OFF_PREPARATION_DISPOSITION = _OFF_ACCEPTED + 4
+# The parent resets the disposition word to NONE when it claims a frame, so a
+# child never publishes it: staging reports VALIDATED_ONLY or NATIVE_PREPARED
+# and nothing else. Declared so the wire check below covers the whole enum.
+_DISPOSITION_NONE = 0
 _VALIDATED_ONLY = 1
 _NATIVE_PREPARED = 2
 _OFF_FRAME_PROTOCOL = _OFF_ACCEPTED - 40
@@ -328,6 +334,68 @@ _TASK_FAILED = 10
 _ACTIVATE = 11
 _PREPARE_READY = 12
 _TASK_FRAME_COUNT = 2
+
+
+def _assert_mailbox_wire_constants() -> None:
+    """Fail import if these constants disagree with the C++ enums.
+
+    The state word and the disposition word are a cross-process contract: a
+    parent writes them and its forked child reads them, so a value that differs
+    from the C++ side is a protocol mismatch between two live processes. Nothing
+    else catches it — the two declarations are in different languages, so there
+    is no compile error, and a wrong value reads as a legal-but-different state
+    rather than as corruption. The constants stay literals because they are read
+    on the mailbox polling path; this checks them instead of replacing them.
+    """
+    declared = {
+        "IDLE": _IDLE,
+        "TASK_READY": _TASK_READY,
+        "TASK_DONE": _TASK_DONE,
+        "SHUTDOWN": _SHUTDOWN,
+        "CONTROL_REQUEST": _CONTROL_REQUEST,
+        "CONTROL_DONE": _CONTROL_DONE,
+        "INIT_READY": _INIT_READY,
+        "INIT_FAILED": _INIT_FAILED,
+        "FRAME_STAGED": _FRAME_STAGED,
+        "TASK_LAUNCHED": _TASK_LAUNCHED,
+        "TASK_FAILED": _TASK_FAILED,
+        "ACTIVATE": _ACTIVATE,
+        "PREPARE_READY": _PREPARE_READY,
+    }
+    dispositions = {
+        "NONE": _DISPOSITION_NONE,
+        "VALIDATED_ONLY": _VALIDATED_ONLY,
+        "NATIVE_PREPARED": _NATIVE_PREPARED,
+    }
+    for name, table, native in (
+        ("MailboxState", declared, MAILBOX_STATE_VALUES),
+        ("MailboxPreparationDisposition", dispositions, MAILBOX_PREPARATION_DISPOSITION_VALUES),
+    ):
+        # Report every disagreement at once: a renumbering usually moves several
+        # values, and fixing them one import at a time is needless.
+        mismatched = sorted(
+            f"{key}: python={value} c++={native[key]}"
+            for key, value in table.items()
+            if key not in native or native[key] != value
+        )
+        if mismatched:
+            raise RuntimeError(
+                f"{name} constants in simpler.worker disagree with the C++ enum: "
+                + "; ".join(mismatched)
+                + ". These cross a process boundary, so the mismatch would surface as a hung or "
+                "misrouted child rather than an error."
+            )
+        # A value the C++ side has and Python does not is a state a child can
+        # legitimately publish and this module would not recognise.
+        missing = sorted(set(native) - set(table))
+        if missing:
+            raise RuntimeError(
+                f"{name} has enumerators the Python side does not declare: {', '.join(missing)}. "
+                "A child can publish them and this module would not recognise the value."
+            )
+
+
+_assert_mailbox_wire_constants()
 
 
 def _local_task_frame_count(platform: str, _runtime: str, pipeline_depth: int) -> int:

--- a/tests/ut/py/test_worker/test_mailbox_atomics.py
+++ b/tests/ut/py/test_worker/test_mailbox_atomics.py
@@ -215,3 +215,73 @@ class TestWorkerSmoke:
         finally:
             counter_shm.close()
             counter_shm.unlink()
+
+
+class TestWireConstantAgreement:
+    """The mailbox state and disposition words are a cross-process contract.
+
+    A parent writes them and its forked child reads them, so a Python constant
+    that disagrees with the C++ enum is a protocol mismatch between two live
+    processes: the value is legal, just different, so it surfaces as a hung or
+    misrouted child rather than as an error. The two declarations are in
+    different languages, so no compiler catches it.
+    """
+
+    def test_every_declared_state_matches_the_native_enum(self):
+        from _task_interface import MAILBOX_STATE_VALUES  # noqa: PLC0415
+        from simpler import worker as worker_mod  # noqa: PLC0415
+
+        declared = {
+            "IDLE": worker_mod._IDLE,
+            "TASK_READY": worker_mod._TASK_READY,
+            "TASK_DONE": worker_mod._TASK_DONE,
+            "SHUTDOWN": worker_mod._SHUTDOWN,
+            "CONTROL_REQUEST": worker_mod._CONTROL_REQUEST,
+            "CONTROL_DONE": worker_mod._CONTROL_DONE,
+            "INIT_READY": worker_mod._INIT_READY,
+            "INIT_FAILED": worker_mod._INIT_FAILED,
+            "FRAME_STAGED": worker_mod._FRAME_STAGED,
+            "TASK_LAUNCHED": worker_mod._TASK_LAUNCHED,
+            "TASK_FAILED": worker_mod._TASK_FAILED,
+            "ACTIVATE": worker_mod._ACTIVATE,
+            "PREPARE_READY": worker_mod._PREPARE_READY,
+        }
+        assert declared == dict(MAILBOX_STATE_VALUES)
+
+    def test_every_declared_disposition_matches_the_native_enum(self):
+        from _task_interface import MAILBOX_PREPARATION_DISPOSITION_VALUES  # noqa: PLC0415
+        from simpler import worker as worker_mod  # noqa: PLC0415
+
+        declared = {
+            "NONE": worker_mod._DISPOSITION_NONE,
+            "VALIDATED_ONLY": worker_mod._VALIDATED_ONLY,
+            "NATIVE_PREPARED": worker_mod._NATIVE_PREPARED,
+        }
+        assert declared == dict(MAILBOX_PREPARATION_DISPOSITION_VALUES)
+
+    def test_the_guard_rejects_a_renumbered_constant(self):
+        """The import-time check fails on a divergence rather than passing it through."""
+        from simpler import worker as worker_mod  # noqa: PLC0415
+
+        original = worker_mod._TASK_LAUNCHED
+        worker_mod._TASK_LAUNCHED = original + 100
+        try:
+            with pytest.raises(RuntimeError, match="disagree with the C"):
+                worker_mod._assert_mailbox_wire_constants()
+        finally:
+            worker_mod._TASK_LAUNCHED = original
+        # Restoring is what lets the rest of the suite keep running.
+        worker_mod._assert_mailbox_wire_constants()
+
+    def test_the_guard_rejects_an_undeclared_enumerator(self):
+        """A state the child can publish but Python does not know is also a failure."""
+        from simpler import worker as worker_mod  # noqa: PLC0415
+
+        original = worker_mod.MAILBOX_STATE_VALUES
+        worker_mod.MAILBOX_STATE_VALUES = {**dict(original), "FUTURE_STATE": 13}
+        try:
+            with pytest.raises(RuntimeError, match="does not declare"):
+                worker_mod._assert_mailbox_wire_constants()
+        finally:
+            worker_mod.MAILBOX_STATE_VALUES = original
+        worker_mod._assert_mailbox_wire_constants()


### PR DESCRIPTION
## Summary

The mailbox **state word** and **preparation-disposition word** are a cross-process contract — a parent writes them, its forked child reads them through shared memory. Both sides declared the values independently, with nothing tying the two declarations together:

- C++ — `MailboxState` (13 values) and `MailboxPreparationDisposition` in `worker_manager.h`
- Python — the same values re-declared by hand in `simpler/worker.py`

**That combination has no failure signal.** The declarations are in different languages, so a divergence is not a compile error. The resulting value is a *legal* state, just a different one, so it is not corruption either. A parent storing `9` for `TASK_LAUNCHED` against a child reading `19` produces a child waiting on a state its parent never publishes — a hang or misrouted frame, far from the edit that caused it.

This is the drift-guard half of #1764. The `MailboxState` enum split stays open there.

## Approach

The binding now exports both enums as name→value tables, right next to the four mailbox constants `worker.py` **already** imports from it for exactly this reason (`worker_bind.h:838-841`). The pattern isn't new — it just didn't cover the enums.

`simpler.worker` keeps its literals — they're read on the mailbox polling path and an attribute lookup per poll isn't worth paying — and checks them against the native tables once at import. It reports **every** disagreement in one message rather than the first, since a renumbering usually moves several values at once, and separately rejects an enumerator the native side has that Python doesn't: that's a state a child can legitimately publish and this module wouldn't recognise.

**Nothing is renumbered.** The change is additive on the C++ side, and a check plus one new constant on the Python side.

## What writing the check immediately found

`MailboxPreparationDisposition::NONE` exists in C++ but was never declared in Python — the parent writes it when claiming a frame, and no child ever publishes it. Python is *right* to reject `NONE` as a **published** disposition (`worker.py:2848`), so I declared the constant with that distinction stated rather than loosening the check to ignore it.

## Testing

| Check | Result |
|---|---|
| Python UT | **1311 passed** / 13 skipped (up 4 from the new tests) |
| C++ UT (`ctest -LE requires_hardware`) | **92/92** |
| pyright, clang-format | clean |

**The guard was verified against a real divergence, not a simulated one.** I renumbered `TASK_LAUNCHED` from 9 to 19 in `worker_manager.h`, rebuilt, and confirmed `import simpler.worker` fails with both values named:

```
RuntimeError: MailboxState constants in simpler.worker disagree with the C++ enum:
TASK_LAUNCHED: python=9 c++=19. These cross a process boundary, so the mismatch
would surface as a hung or misrouted child rather than an error.
```

The enum was then restored and rebuilt. Tests pin both directions — that every declared value matches, and that the guard rejects a divergence rather than passing it through — with the perturbation cases restoring what they touch so the rest of the suite is unaffected.

Onboard sweeps were not run: no runtime behavior changes, and the added code executes once at import.
