### PR TITLE
Add: materialize planned comm endpoint regions

### DIFF
--- a/python/simpler/comm_endpoints.py
+++ b/python/simpler/comm_endpoints.py
@@ -339,6 +339,9 @@ class EndpointRegistry:
     ) -> bool:
         return self._record_for(a).node_scope_id == self._record_for(b).node_scope_id
 
+    def record_for(self, endpoint: EndpointRecord | EndpointIdentity | EndpointId) -> EndpointRecord:
+        return self._record_for(endpoint)
+
     def owner_endpoint(self, owner_instance_id: bytes) -> EndpointRecord:
         """The endpoint that minted buffers carrying `owner_instance_id`.
 

--- a/python/simpler/comm_endpoints.py
+++ b/python/simpler/comm_endpoints.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Endpoint selectors, registry resolution, and W2 backend planning."""
+"""Endpoint selectors, registry resolution, and backend planning."""
 
 from __future__ import annotations
 
@@ -324,7 +324,7 @@ class EndpointRegistry:
     def resolve_region_spec(self, members: Sequence[EndpointSelector], topology: SingleOwner) -> ResolvedRegionSpec:
         resolved_members = self.resolve_members(members)
         if not isinstance(topology, SingleOwner):
-            raise TypeError("W2 region planning supports SingleOwner topology only")
+            raise TypeError("Region planning supports SingleOwner topology only")
         provider_endpoint = None
         if topology.provider is not None:
             provider_records = self._resolve_provider(topology.provider)

--- a/python/simpler/comm_endpoints.py
+++ b/python/simpler/comm_endpoints.py
@@ -340,6 +340,7 @@ class EndpointRegistry:
         return self._record_for(a).node_scope_id == self._record_for(b).node_scope_id
 
     def record_for(self, endpoint: EndpointRecord | EndpointIdentity | EndpointId) -> EndpointRecord:
+        """Return this registry's canonical record for a record, identity, or endpoint id."""
         return self._record_for(endpoint)
 
     def owner_endpoint(self, owner_instance_id: bytes) -> EndpointRecord:

--- a/python/simpler/comm_region.py
+++ b/python/simpler/comm_region.py
@@ -50,6 +50,14 @@ class RegionInstanceState(str, Enum):
     CLOSE_FAILED = "CLOSE_FAILED"
 
 
+_TERMINAL_FAILURE_STATES = frozenset(
+    (
+        RegionInstanceState.ROLLBACK_FAILED,
+        RegionInstanceState.CLOSE_FAILED,
+    )
+)
+
+
 class RefusalReason(str, Enum):
     UNSUPPORTED_PLAN = "UNSUPPORTED_PLAN"
     NEEDS_DELEGATION = "NEEDS_DELEGATION"
@@ -139,7 +147,7 @@ class RegionInstance:
     def close(self) -> None:
         if self._state is RegionInstanceState.CLOSED:
             return
-        if self._state is RegionInstanceState.CLOSE_FAILED and self._cleanup_error is not None:
+        if self._state in _TERMINAL_FAILURE_STATES and self._cleanup_error is not None:
             raise self._cleanup_error
         if self._state in (RegionInstanceState.PLANNED, RegionInstanceState.ROLLED_BACK):
             self._state = RegionInstanceState.CLOSED
@@ -160,7 +168,7 @@ class RegionInstance:
     def rollback(self) -> None:
         if self._state in (RegionInstanceState.CLOSED, RegionInstanceState.ROLLED_BACK):
             return
-        if self._state is RegionInstanceState.ROLLBACK_FAILED and self._cleanup_error is not None:
+        if self._state in _TERMINAL_FAILURE_STATES and self._cleanup_error is not None:
             raise self._cleanup_error
         if self._region is None:
             self._state = RegionInstanceState.ROLLED_BACK
@@ -235,6 +243,11 @@ def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwn
             RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
             "Ordered members must contain the provider and consumer endpoints",
         )
+    if not ctx.registry.same_node(provider, consumer):
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
+            "Worker-chip region materialization only supports local endpoints",
+        )
     _validate_part(plan.payload, provider, consumer)
     _validate_part(plan.counter, provider, consumer)
     return SingleOwnerRegionShape(provider=provider, consumer=consumer, worker_id=worker_id)
@@ -282,7 +295,7 @@ def _validate_part(part: RegionPartPlan, provider: EndpointRecord, consumer: End
             "Only VMM_WINDOW-backed worker-chip region parts are supported",
         )
     attachments = {attachment.member: attachment for attachment in part.attachments}
-    if set(attachments) != {provider.identity, consumer.identity}:
+    if len(attachments) != len(part.attachments) or set(attachments) != {provider.identity, consumer.identity}:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_ATTACHMENT,
             "Part attachments must match exactly the provider and host consumer",

--- a/python/simpler/comm_region.py
+++ b/python/simpler/comm_region.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import itertools
-import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -31,10 +30,10 @@ from .comm_endpoints import (
     RegionPartPlan,
     SingleOwnerPlan,
     UnsupportedRegionPlan,
+    parse_endpoint_path,
 )
 
 _GENERATION_COUNTER = itertools.count(1)
-_LOCAL_L2_PATH_RE = re.compile(r"^L3/L2\[(?P<worker_id>[0-9]+)\]$")
 
 
 class RegionInstanceState(str, Enum):
@@ -108,6 +107,7 @@ class RegionInstance:
             f"payload={int(self.layout.payload_bytes)} counter={int(self.layout.counter_bytes)}"
         )
         self._worker = ctx.worker
+        self._cleanup_resources = getattr(ctx.worker, "_building_run_resources", None)
         self._region = None
         self._state = RegionInstanceState.PLANNED
         self._cleanup_error: BaseException | None = None
@@ -149,7 +149,9 @@ class RegionInstance:
             return
         if self._state in _TERMINAL_FAILURE_STATES and self._cleanup_error is not None:
             raise self._cleanup_error
-        if self._state in (RegionInstanceState.PLANNED, RegionInstanceState.ROLLED_BACK):
+        if self._state is RegionInstanceState.ROLLED_BACK:
+            return
+        if self._state is RegionInstanceState.PLANNED:
             self._state = RegionInstanceState.CLOSED
             return
         if self._region is None:
@@ -158,7 +160,11 @@ class RegionInstance:
         self._worker._require_region_control_context("region_instance.close")
         self._state = RegionInstanceState.CLOSING
         try:
-            self._worker._close_worker_chip_region(self._region, poison_on_error=True)
+            self._worker._close_worker_chip_region(
+                self._region,
+                self._cleanup_resources,
+                poison_on_error=True,
+            )
         except BaseException as exc:
             self._cleanup_error = exc
             self._state = RegionInstanceState.CLOSE_FAILED
@@ -176,7 +182,11 @@ class RegionInstance:
         self._worker._require_region_control_context("region_instance.rollback")
         self._state = RegionInstanceState.ROLLING_BACK
         try:
-            self._worker._close_worker_chip_region(self._region, poison_on_error=True)
+            self._worker._close_worker_chip_region(
+                self._region,
+                self._cleanup_resources,
+                poison_on_error=True,
+            )
         except BaseException as exc:
             self._cleanup_error = exc
             self._state = RegionInstanceState.ROLLBACK_FAILED
@@ -188,9 +198,9 @@ class RegionInstance:
 
     def _ensure_live(self) -> None:
         if self._state is not RegionInstanceState.LIVE:
-            raise RuntimeError(f"region instance is not live: {self._state.value}")
+            raise MaterializationError(f"region instance is not live: {self._state.value}")
         if self._region is None:
-            raise RuntimeError("region instance has no adopted worker-chip region")
+            raise MaterializationError("region instance has no adopted worker-chip region")
 
 
 def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwnerRegionShape:  # noqa: PLR0912
@@ -215,16 +225,23 @@ def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwn
             RefusalReason.UNSUPPORTED_PROVIDER_DEPLOYMENT,
             "Only DEVICE_AICPU providers are supported for worker-chip regions",
         )
-    match = _LOCAL_L2_PATH_RE.match(provider.path)
-    if match is None:
+    try:
+        provider_path = parse_endpoint_path(provider.path, root_level=ctx.registry.root_level)
+    except ValueError as exc:
+        raise MaterializationRefusal(RefusalReason.NEEDS_DELEGATION, "provider is not a local L3/L2 endpoint") from exc
+    if len(provider_path.segments) != 2:
         raise MaterializationRefusal(RefusalReason.NEEDS_DELEGATION, "provider is not a local L3/L2 endpoint")
-    worker_id = int(match.group("worker_id"))
-    device_ids = tuple(getattr(ctx.worker, "_config", {}).get("device_ids", ()))
-    if worker_id < 0 or worker_id >= len(device_ids):
+    root, child = provider_path.segments
+    if root.level != 3 or root.index is not None or child.level != 2 or child.index is None:
+        raise MaterializationRefusal(RefusalReason.NEEDS_DELEGATION, "provider is not a local L3/L2 endpoint")
+    worker_id = int(child.index)
+    try:
+        ctx.worker._validate_worker_chip_id(worker_id)
+    except ValueError as exc:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
             f"provider worker_id {worker_id} is outside the current L3 device list",
-        )
+        ) from exc
     member_records = tuple(_record_for(ctx, member) for member in plan.ordered_members)
     if len(member_records) != 2:
         raise MaterializationRefusal(

--- a/python/simpler/comm_region.py
+++ b/python/simpler/comm_region.py
@@ -1,0 +1,286 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Private W3.5 region materialization helpers."""
+
+from __future__ import annotations
+
+import itertools
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from .comm_endpoints import (
+    DEVICE_AICPU,
+    HOST_CPU,
+    AdapterKind,
+    AdapterProfile,
+    AttachmentRole,
+    BackendKind,
+    BackendPlan,
+    EndpointRecord,
+    EndpointRegistry,
+    MemberAttachmentPlan,
+    RegionLayoutSpec,
+    RegionPartPlan,
+    SingleOwnerPlan,
+    UnsupportedRegionPlan,
+)
+
+_GENERATION_COUNTER = itertools.count(1)
+_LOCAL_L2_PATH_RE = re.compile(r"^L3/L2\[(?P<worker_id>[0-9]+)\]$")
+
+
+class RegionInstanceState(str, Enum):
+    PLANNED = "PLANNED"
+    OWNER_CREATED = "OWNER_CREATED"
+    CONSUMER_ATTACHED = "CONSUMER_ATTACHED"
+    LIVE = "LIVE"
+    ROLLING_BACK = "ROLLING_BACK"
+    ROLLED_BACK = "ROLLED_BACK"
+    ROLLBACK_FAILED = "ROLLBACK_FAILED"
+    CLOSING = "CLOSING"
+    CLOSED = "CLOSED"
+    CLOSE_FAILED = "CLOSE_FAILED"
+
+
+class RefusalReason(str, Enum):
+    UNSUPPORTED_PLAN = "UNSUPPORTED_PLAN"
+    NEEDS_DELEGATION = "NEEDS_DELEGATION"
+    UNSUPPORTED_MEMBER_SHAPE = "UNSUPPORTED_MEMBER_SHAPE"
+    UNSUPPORTED_PROVIDER_DEPLOYMENT = "UNSUPPORTED_PROVIDER_DEPLOYMENT"
+    UNSUPPORTED_BACKEND_KIND = "UNSUPPORTED_BACKEND_KIND"
+    UNSUPPORTED_ATTACHMENT = "UNSUPPORTED_ATTACHMENT"
+    REGISTRY_MISMATCH = "REGISTRY_MISMATCH"
+
+
+class MaterializationError(RuntimeError):
+    pass
+
+
+class MaterializationRefusal(MaterializationError):
+    def __init__(self, reason: RefusalReason, message: str) -> None:
+        self.reason = reason
+        self.message = message
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class MaterializationContext:
+    worker: Any
+    registry: EndpointRegistry
+    plan: BackendPlan | UnsupportedRegionPlan
+    layout: RegionLayoutSpec
+
+
+@dataclass(frozen=True)
+class SingleOwnerRegionShape:
+    provider: EndpointRecord
+    consumer: EndpointRecord
+    worker_id: int
+
+
+class RegionInstance:
+    def __init__(self, ctx: MaterializationContext, shape: SingleOwnerRegionShape) -> None:
+        self.plan = ctx.plan
+        self.layout = ctx.layout
+        self.provider = shape.provider
+        self.consumer = shape.consumer
+        self.worker_id = int(shape.worker_id)
+        self.generation = next(_GENERATION_COUNTER)
+        self.diagnostic_label = (
+            f"{self.consumer.path} {self.consumer.deployment.value} -> "
+            f"{self.provider.path} {self.provider.deployment.value} "
+            f"payload={int(self.layout.payload_bytes)} counter={int(self.layout.counter_bytes)}"
+        )
+        self._worker = ctx.worker
+        self._region = None
+        self._state = RegionInstanceState.PLANNED
+
+    @property
+    def state(self) -> RegionInstanceState:
+        return self._state
+
+    @classmethod
+    def planned(cls, ctx: MaterializationContext, shape: SingleOwnerRegionShape) -> RegionInstance:
+        return cls(ctx, shape)
+
+    def _adopt_worker_chip_region(self, region: Any) -> None:
+        self._region = region
+
+    def payload_write(self, offset: int, host_buffer: Any, nbytes: int | None = None) -> None:
+        self._ensure_live()
+        self._region.payload_write(offset, host_buffer, nbytes)
+
+    def payload_read(self, offset: int, host_buffer: Any, nbytes: int | None = None) -> None:
+        self._ensure_live()
+        self._region.payload_read(offset, host_buffer, nbytes)
+
+    def counter(self, offset: int):
+        self._ensure_live()
+        return self._region.counter(offset)
+
+    def close(self) -> None:
+        if self._state is RegionInstanceState.CLOSED:
+            return
+        if self._state in (RegionInstanceState.PLANNED, RegionInstanceState.ROLLED_BACK):
+            self._state = RegionInstanceState.CLOSED
+            return
+        if self._region is None:
+            self._state = RegionInstanceState.CLOSED
+            return
+        self._state = RegionInstanceState.CLOSING
+        try:
+            self._worker._close_worker_chip_region(self._region)
+        except BaseException:
+            self._state = RegionInstanceState.CLOSE_FAILED
+            raise
+        self._state = RegionInstanceState.CLOSED
+
+    def rollback(self) -> None:
+        if self._state in (RegionInstanceState.CLOSED, RegionInstanceState.ROLLED_BACK):
+            return
+        if self._region is None:
+            self._state = RegionInstanceState.ROLLED_BACK
+            return
+        self._state = RegionInstanceState.ROLLING_BACK
+        try:
+            self._worker._close_worker_chip_region(self._region)
+        except BaseException:
+            self._state = RegionInstanceState.ROLLBACK_FAILED
+            raise
+        self._state = RegionInstanceState.ROLLED_BACK
+
+    def _rollback_after_failed_materialization(self) -> None:
+        self.rollback()
+
+    def _ensure_live(self) -> None:
+        if self._state is not RegionInstanceState.LIVE:
+            raise RuntimeError(f"region instance is not live: {self._state.value}")
+        if self._region is None:
+            raise RuntimeError("region instance has no adopted worker-chip region")
+
+
+def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwnerRegionShape:  # noqa: PLR0912
+    plan = ctx.plan
+    if isinstance(plan, UnsupportedRegionPlan):
+        raise MaterializationRefusal(RefusalReason.UNSUPPORTED_PLAN, plan.message)
+    if not isinstance(plan, BackendPlan):
+        raise MaterializationRefusal(RefusalReason.UNSUPPORTED_PLAN, "materializer expects a BackendPlan")
+    if int(getattr(ctx.worker, "level", -1)) != 3:
+        raise MaterializationRefusal(
+            RefusalReason.NEEDS_DELEGATION,
+            "W3.5 can materialize only an L3-local worker-chip region; higher roots need W5 delegation",
+        )
+    if not isinstance(plan.topology_plan, SingleOwnerPlan):
+        raise MaterializationRefusal(RefusalReason.UNSUPPORTED_PLAN, "W3.5 supports SingleOwner plans only")
+    provider = _record_for(ctx, plan.topology_plan.provider_endpoint)
+    if not provider.path.startswith("L3/"):
+        raise MaterializationRefusal(RefusalReason.NEEDS_DELEGATION, "provider path requires delegated materialization")
+    if provider.deployment is not DEVICE_AICPU:
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_PROVIDER_DEPLOYMENT,
+            "W3.5 supports only DEVICE_AICPU providers for worker-chip regions",
+        )
+    match = _LOCAL_L2_PATH_RE.match(provider.path)
+    if match is None:
+        raise MaterializationRefusal(RefusalReason.NEEDS_DELEGATION, "provider is not a local L3/L2 endpoint")
+    worker_id = int(match.group("worker_id"))
+    device_ids = tuple(getattr(ctx.worker, "_config", {}).get("device_ids", ()))
+    if worker_id < 0 or worker_id >= len(device_ids):
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
+            f"provider worker_id {worker_id} is outside the current L3 device list",
+        )
+    member_records = tuple(_record_for(ctx, member) for member in plan.ordered_members)
+    if len(member_records) != 2:
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
+            "W3.5 supports exactly one host consumer and one device provider",
+        )
+    host_consumers = [member for member in member_records if member.deployment is HOST_CPU]
+    if len(host_consumers) != 1 or host_consumers[0].path != "L3":
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
+            "W3.5 requires the current L3 HOST_CPU endpoint as the only consumer",
+        )
+    consumer = host_consumers[0]
+    if provider.identity not in plan.ordered_members or consumer.identity not in plan.ordered_members:
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
+            "W3.5 ordered members must contain the provider and consumer endpoints",
+        )
+    _validate_part(plan.payload, provider, consumer)
+    _validate_part(plan.counter, provider, consumer)
+    return SingleOwnerRegionShape(provider=provider, consumer=consumer, worker_id=worker_id)
+
+
+def materialize_region_instance(ctx: MaterializationContext) -> RegionInstance:
+    shape = validate_single_owner_region_shape(ctx)
+    instance = RegionInstance.planned(ctx, shape)
+    try:
+        instance._state = RegionInstanceState.OWNER_CREATED
+        region = ctx.worker._create_worker_chip_region(
+            shape.worker_id,
+            int(ctx.layout.payload_bytes),
+            int(ctx.layout.counter_bytes),
+        )
+        instance._adopt_worker_chip_region(region)
+        instance._state = RegionInstanceState.LIVE
+        return instance
+    except BaseException:
+        instance._rollback_after_failed_materialization()
+        raise
+
+
+def _record_for(ctx: MaterializationContext, endpoint: Any) -> EndpointRecord:
+    try:
+        return ctx.registry.record_for(endpoint)
+    except ValueError as exc:
+        raise MaterializationRefusal(RefusalReason.REGISTRY_MISMATCH, str(exc)) from exc
+
+
+def _validate_part(part: RegionPartPlan, provider: EndpointRecord, consumer: EndpointRecord) -> None:
+    if part.backend_kind is not BackendKind.VMM_WINDOW:
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_BACKEND_KIND,
+            "W3.5 supports only VMM_WINDOW-backed worker-chip region parts",
+        )
+    attachments = {attachment.member: attachment for attachment in part.attachments}
+    if set(attachments) != {provider.identity, consumer.identity}:
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_ATTACHMENT,
+            "W3.5 part attachments must match exactly the provider and host consumer",
+        )
+    _validate_provider_attachment(attachments[provider.identity])
+    _validate_consumer_attachment(attachments[consumer.identity])
+
+
+def _validate_provider_attachment(attachment: MemberAttachmentPlan) -> None:
+    if (
+        attachment.role is not AttachmentRole.PROVIDER
+        or attachment.adapter_kind is not None
+        or attachment.adapter_profile is not None
+    ):
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_ATTACHMENT,
+            "W3.5 provider attachment must be a bare PROVIDER attachment",
+        )
+
+
+def _validate_consumer_attachment(attachment: MemberAttachmentPlan) -> None:
+    if (
+        attachment.role is not AttachmentRole.CONSUMER
+        or attachment.adapter_kind is not AdapterKind.OWNER_DELEGATED_COPY
+        or attachment.adapter_profile is not AdapterProfile.HOST_VMM_COPY
+    ):
+        raise MaterializationRefusal(
+            RefusalReason.UNSUPPORTED_ATTACHMENT,
+            "W3.5 host consumer attachment must use OWNER_DELEGATED_COPY/HOST_VMM_COPY",
+        )

--- a/python/simpler/comm_region.py
+++ b/python/simpler/comm_region.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Private W3.5 region materialization helpers."""
+"""Private region materialization helpers."""
 
 from __future__ import annotations
 
@@ -102,6 +102,7 @@ class RegionInstance:
         self._worker = ctx.worker
         self._region = None
         self._state = RegionInstanceState.PLANNED
+        self._cleanup_error: BaseException | None = None
 
     @property
     def state(self) -> RegionInstanceState:
@@ -116,29 +117,42 @@ class RegionInstance:
 
     def payload_write(self, offset: int, host_buffer: Any, nbytes: int | None = None) -> None:
         self._ensure_live()
-        self._region.payload_write(offset, host_buffer, nbytes)
+        self._worker._require_region_control_context("region_instance.payload_write")
+        region = self._region
+        assert region is not None
+        region.payload_write(offset, host_buffer, nbytes)
 
     def payload_read(self, offset: int, host_buffer: Any, nbytes: int | None = None) -> None:
         self._ensure_live()
-        self._region.payload_read(offset, host_buffer, nbytes)
+        self._worker._require_region_control_context("region_instance.payload_read")
+        region = self._region
+        assert region is not None
+        region.payload_read(offset, host_buffer, nbytes)
 
     def counter(self, offset: int):
         self._ensure_live()
-        return self._region.counter(offset)
+        self._worker._require_region_control_context("region_instance.counter")
+        region = self._region
+        assert region is not None
+        return region.counter(offset)
 
     def close(self) -> None:
         if self._state is RegionInstanceState.CLOSED:
             return
+        if self._state is RegionInstanceState.CLOSE_FAILED and self._cleanup_error is not None:
+            raise self._cleanup_error
         if self._state in (RegionInstanceState.PLANNED, RegionInstanceState.ROLLED_BACK):
             self._state = RegionInstanceState.CLOSED
             return
         if self._region is None:
             self._state = RegionInstanceState.CLOSED
             return
+        self._worker._require_region_control_context("region_instance.close")
         self._state = RegionInstanceState.CLOSING
         try:
-            self._worker._close_worker_chip_region(self._region)
-        except BaseException:
+            self._worker._close_worker_chip_region(self._region, poison_on_error=True)
+        except BaseException as exc:
+            self._cleanup_error = exc
             self._state = RegionInstanceState.CLOSE_FAILED
             raise
         self._state = RegionInstanceState.CLOSED
@@ -146,13 +160,17 @@ class RegionInstance:
     def rollback(self) -> None:
         if self._state in (RegionInstanceState.CLOSED, RegionInstanceState.ROLLED_BACK):
             return
+        if self._state is RegionInstanceState.ROLLBACK_FAILED and self._cleanup_error is not None:
+            raise self._cleanup_error
         if self._region is None:
             self._state = RegionInstanceState.ROLLED_BACK
             return
+        self._worker._require_region_control_context("region_instance.rollback")
         self._state = RegionInstanceState.ROLLING_BACK
         try:
-            self._worker._close_worker_chip_region(self._region)
-        except BaseException:
+            self._worker._close_worker_chip_region(self._region, poison_on_error=True)
+        except BaseException as exc:
+            self._cleanup_error = exc
             self._state = RegionInstanceState.ROLLBACK_FAILED
             raise
         self._state = RegionInstanceState.ROLLED_BACK
@@ -168,6 +186,7 @@ class RegionInstance:
 
 
 def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwnerRegionShape:  # noqa: PLR0912
+    _validate_registry_matches_worker(ctx)
     plan = ctx.plan
     if isinstance(plan, UnsupportedRegionPlan):
         raise MaterializationRefusal(RefusalReason.UNSUPPORTED_PLAN, plan.message)
@@ -176,17 +195,17 @@ def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwn
     if int(getattr(ctx.worker, "level", -1)) != 3:
         raise MaterializationRefusal(
             RefusalReason.NEEDS_DELEGATION,
-            "W3.5 can materialize only an L3-local worker-chip region; higher roots need W5 delegation",
+            "Only L3-local worker-chip regions can be materialized directly; higher-level roots require delegation",
         )
     if not isinstance(plan.topology_plan, SingleOwnerPlan):
-        raise MaterializationRefusal(RefusalReason.UNSUPPORTED_PLAN, "W3.5 supports SingleOwner plans only")
+        raise MaterializationRefusal(RefusalReason.UNSUPPORTED_PLAN, "Only SingleOwner region plans are supported")
     provider = _record_for(ctx, plan.topology_plan.provider_endpoint)
     if not provider.path.startswith("L3/"):
         raise MaterializationRefusal(RefusalReason.NEEDS_DELEGATION, "provider path requires delegated materialization")
     if provider.deployment is not DEVICE_AICPU:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_PROVIDER_DEPLOYMENT,
-            "W3.5 supports only DEVICE_AICPU providers for worker-chip regions",
+            "Only DEVICE_AICPU providers are supported for worker-chip regions",
         )
     match = _LOCAL_L2_PATH_RE.match(provider.path)
     if match is None:
@@ -202,19 +221,19 @@ def validate_single_owner_region_shape(ctx: MaterializationContext) -> SingleOwn
     if len(member_records) != 2:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
-            "W3.5 supports exactly one host consumer and one device provider",
+            "Only one host consumer and one device provider are supported",
         )
     host_consumers = [member for member in member_records if member.deployment is HOST_CPU]
     if len(host_consumers) != 1 or host_consumers[0].path != "L3":
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
-            "W3.5 requires the current L3 HOST_CPU endpoint as the only consumer",
+            "The current L3 HOST_CPU endpoint must be the only consumer",
         )
     consumer = host_consumers[0]
     if provider.identity not in plan.ordered_members or consumer.identity not in plan.ordered_members:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
-            "W3.5 ordered members must contain the provider and consumer endpoints",
+            "Ordered members must contain the provider and consumer endpoints",
         )
     _validate_part(plan.payload, provider, consumer)
     _validate_part(plan.counter, provider, consumer)
@@ -246,17 +265,27 @@ def _record_for(ctx: MaterializationContext, endpoint: Any) -> EndpointRecord:
         raise MaterializationRefusal(RefusalReason.REGISTRY_MISMATCH, str(exc)) from exc
 
 
+def _validate_registry_matches_worker(ctx: MaterializationContext) -> None:
+    worker_instance_id = getattr(ctx.worker, "_owner_instance_id", None)
+    worker_epoch = getattr(ctx.worker, "_endpoint_registry_epoch", None)
+    if worker_instance_id != ctx.registry.session_instance_id or worker_epoch != ctx.registry.registry_epoch:
+        raise MaterializationRefusal(
+            RefusalReason.REGISTRY_MISMATCH,
+            "Region materialization requires a registry from the current worker endpoint epoch",
+        )
+
+
 def _validate_part(part: RegionPartPlan, provider: EndpointRecord, consumer: EndpointRecord) -> None:
     if part.backend_kind is not BackendKind.VMM_WINDOW:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_BACKEND_KIND,
-            "W3.5 supports only VMM_WINDOW-backed worker-chip region parts",
+            "Only VMM_WINDOW-backed worker-chip region parts are supported",
         )
     attachments = {attachment.member: attachment for attachment in part.attachments}
     if set(attachments) != {provider.identity, consumer.identity}:
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_ATTACHMENT,
-            "W3.5 part attachments must match exactly the provider and host consumer",
+            "Part attachments must match exactly the provider and host consumer",
         )
     _validate_provider_attachment(attachments[provider.identity])
     _validate_consumer_attachment(attachments[consumer.identity])
@@ -270,7 +299,7 @@ def _validate_provider_attachment(attachment: MemberAttachmentPlan) -> None:
     ):
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_ATTACHMENT,
-            "W3.5 provider attachment must be a bare PROVIDER attachment",
+            "Provider attachment must be a bare PROVIDER attachment",
         )
 
 
@@ -282,5 +311,5 @@ def _validate_consumer_attachment(attachment: MemberAttachmentPlan) -> None:
     ):
         raise MaterializationRefusal(
             RefusalReason.UNSUPPORTED_ATTACHMENT,
-            "W3.5 host consumer attachment must use OWNER_DELEGATED_COPY/HOST_VMM_COPY",
+            "Host consumer attachment must use OWNER_DELEGATED_COPY/HOST_VMM_COPY",
         )

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -195,7 +195,7 @@ from .global_comm_domain import (
     resolve_global_comm_capability,
     validate_descriptor_table,
 )
-from .orchestrator import Orchestrator, _callback_run, direct_control
+from .orchestrator import Orchestrator, _callback_frame_for, _callback_run, direct_control
 from .remote_l3_protocol import HOST_TCP_TRANSPORT_PROFILE
 from .task_interface import (
     MAILBOX_ERROR_MSG_SIZE,
@@ -5791,7 +5791,10 @@ class Worker:
         self, members, topology: SingleOwner, layout_summary: RegionLayoutSpec
     ) -> RegionInstance:
         self._require_ready_for_region_planning("_materialize_region_instance")
-        with self._operation_lease("_materialize_region_instance"):
+        with (
+            self._operation_lease("_materialize_region_instance"),
+            self._control_admission("materialize_region_instance"),
+        ):
             registry = self._get_endpoint_registry()
             resolved = registry.resolve_region_spec(members, topology)
             resolver = BackendResolver(registry, self._get_region_access_service())
@@ -7799,8 +7802,15 @@ class Worker:
                 except (BufferError, FileNotFoundError, OSError):
                     pass
 
-    def _close_worker_chip_region(self, region, resources: _RunResources | None = None) -> None:
+    def _close_worker_chip_region(
+        self,
+        region,
+        resources: _RunResources | None = None,
+        *,
+        poison_on_error: bool = False,
+    ) -> None:
         region_errors: list[BaseException] = []
+        release_error: BaseException | None = None
         try:
             region._close_worker_host_mapping()
         except BaseException as exc:  # noqa: BLE001
@@ -7809,11 +7819,19 @@ class Worker:
             if self._worker is not None:
                 self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
         except BaseException as exc:  # noqa: BLE001
+            release_error = exc
             region_errors.append(exc)
         # End-of-run cleanup is poisoned and terminal for that run, so it still
         # expires both sides after attempting both debts. Whole-tree close
         # instead retains the region for journal replay.
-        if region_errors and resources is None:
+        if region_errors and resources is None and not poison_on_error:
+            raise region_errors[0]
+        if poison_on_error and region_errors and release_error is not None:
+            self._record_unreclaimable(
+                f"close_worker_chip_region: region {region.region_id} on worker {region._worker_id} could not be "
+                "fully reclaimed; no further work is admitted",
+                region_errors[0],
+            )
             raise region_errors[0]
         try:
             region._expire()
@@ -7824,6 +7842,12 @@ class Worker:
         except BaseException as exc:  # noqa: BLE001
             region_errors.append(exc)
         if region_errors:
+            if poison_on_error:
+                self._record_unreclaimable(
+                    f"close_worker_chip_region: region {region.region_id} on worker {region._worker_id} could not be "
+                    "fully reclaimed; no further work is admitted",
+                    region_errors[0],
+                )
             raise region_errors[0]
 
     def _retire_worker_chip_region_tracking(self, region, resources: _RunResources | None = None) -> None:
@@ -9904,6 +9928,20 @@ class Worker:
                     f"Worker.{api}: a prior run's ordered cleanup failed, so this worker's device state is "
                     "unreclaimed and no further work is admitted; close() it"
                 ) from self._ordered_cleanup_error
+
+    def _require_region_control_context(self, api: str) -> None:
+        frame = _callback_frame_for(self)
+        if frame is not None:
+            if frame.has_submitted_task:
+                raise RuntimeError(
+                    f"Worker.{api}: RegionInstance access cannot follow a task submission in the same run"
+                )
+            self._require_no_ordered_cleanup_failure(api)
+            return
+        if id(self) in _held_control_reservations():
+            self._require_no_ordered_cleanup_failure(api)
+            return
+        raise RuntimeError(f"Worker.{api}: RegionInstance access requires an active orchestration/control context")
 
     def _control_admission(self, api: str):
         """The direct-control ordering policy for a Worker-level command.

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -7825,20 +7825,20 @@ class Worker:
             return primary
 
         expired = bool(getattr(region, "expired", getattr(region, "_expired", False)))
-        release_pending = not expired and not bool(getattr(region, "_released", False))
         if not expired:
             try:
                 region._close_worker_host_mapping()
             except BaseException as exc:  # noqa: BLE001
                 region_errors.append(exc)
-            if release_pending:
-                try:
-                    if self._worker is not None:
-                        self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
-                        region.free()
-                except BaseException as exc:  # noqa: BLE001
-                    release_error = exc
-                    region_errors.append(exc)
+            try:
+                if self._worker is not None:
+                    self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
+                    free = getattr(region, "free", None)
+                    if callable(free):
+                        free()
+            except BaseException as exc:  # noqa: BLE001
+                release_error = exc
+                region_errors.append(exc)
         # A region remains tracked while chip ownership may still be live, so
         # whole-tree close can replay it and instance cleanup can poison future
         # admission. Once the chip release is committed or the native handle is

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -7824,19 +7824,25 @@ class Worker:
                 tail = extra
             return primary
 
-        try:
-            region._close_worker_host_mapping()
-        except BaseException as exc:  # noqa: BLE001
-            region_errors.append(exc)
-        try:
-            if self._worker is not None:
-                self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
-        except BaseException as exc:  # noqa: BLE001
-            release_error = exc
-            region_errors.append(exc)
-        # End-of-run cleanup is poisoned and terminal for that run, so it still
-        # expires both sides after attempting both debts. Whole-tree close
-        # instead retains the region for journal replay.
+        expired = bool(getattr(region, "expired", getattr(region, "_expired", False)))
+        release_pending = not expired and not bool(getattr(region, "_released", False))
+        if not expired:
+            try:
+                region._close_worker_host_mapping()
+            except BaseException as exc:  # noqa: BLE001
+                region_errors.append(exc)
+            if release_pending:
+                try:
+                    if self._worker is not None:
+                        self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
+                        region.free()
+                except BaseException as exc:  # noqa: BLE001
+                    release_error = exc
+                    region_errors.append(exc)
+        # A region remains tracked while chip ownership may still be live, so
+        # whole-tree close can replay it and instance cleanup can poison future
+        # admission. Once the chip release is committed or the native handle is
+        # already expired, cleanup may retire every tracking list that owns it.
         if region_errors and resources is None and not poison_on_error:
             raise primary_region_error()
         if poison_on_error and region_errors and release_error is not None:
@@ -7848,7 +7854,8 @@ class Worker:
             )
             raise primary
         try:
-            region._expire()
+            if not expired:
+                region._expire()
         except BaseException as exc:  # noqa: BLE001
             region_errors.append(exc)
         try:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -7811,6 +7811,19 @@ class Worker:
     ) -> None:
         region_errors: list[BaseException] = []
         release_error: BaseException | None = None
+
+        def primary_region_error() -> BaseException:
+            primary = region_errors[0]
+            tail = primary
+            seen = {id(tail)}
+            while tail.__cause__ is not None and id(tail.__cause__) not in seen:
+                tail = tail.__cause__
+                seen.add(id(tail))
+            for extra in region_errors[1:]:
+                tail.__cause__ = extra
+                tail = extra
+            return primary
+
         try:
             region._close_worker_host_mapping()
         except BaseException as exc:  # noqa: BLE001
@@ -7825,14 +7838,15 @@ class Worker:
         # expires both sides after attempting both debts. Whole-tree close
         # instead retains the region for journal replay.
         if region_errors and resources is None and not poison_on_error:
-            raise region_errors[0]
+            raise primary_region_error()
         if poison_on_error and region_errors and release_error is not None:
+            primary = primary_region_error()
             self._record_unreclaimable(
                 f"close_worker_chip_region: region {region.region_id} on worker {region._worker_id} could not be "
                 "fully reclaimed; no further work is admitted",
-                region_errors[0],
+                primary,
             )
-            raise region_errors[0]
+            raise primary
         try:
             region._expire()
         except BaseException as exc:  # noqa: BLE001
@@ -7842,37 +7856,26 @@ class Worker:
         except BaseException as exc:  # noqa: BLE001
             region_errors.append(exc)
         if region_errors:
+            primary = primary_region_error()
             if poison_on_error:
                 self._record_unreclaimable(
                     f"close_worker_chip_region: region {region.region_id} on worker {region._worker_id} could not be "
                     "fully reclaimed; no further work is admitted",
-                    region_errors[0],
+                    primary,
                 )
-            raise region_errors[0]
+            raise primary
 
     def _retire_worker_chip_region_tracking(self, region, resources: _RunResources | None = None) -> None:
         tracking_lists = [self._live_worker_chip_regions]
         if resources is not None and resources.worker_chip_regions is not self._live_worker_chip_regions:
             tracking_lists.insert(0, resources.worker_chip_regions)
         errors: list[BaseException] = []
-        next_tracking_list = 0
 
-        def retire_tracking() -> None:
-            nonlocal next_tracking_list
+        for owned_regions in tracking_lists:
             try:
-                while next_tracking_list < len(tracking_lists):
-                    owned_regions = tracking_lists[next_tracking_list]
-                    owned_regions[:] = [owned for owned in owned_regions if owned is not region]
-                    next_tracking_list += 1
-            except Exception as exc:  # noqa: BLE001
-                errors.append(exc)
-                next_tracking_list += 1
-                retire_tracking()
+                owned_regions[:] = [owned for owned in owned_regions if owned is not region]
             except BaseException as exc:  # noqa: BLE001
                 errors.append(exc)
-                retire_tracking()
-
-        retire_tracking()
         if errors:
             raise errors[0]
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -149,6 +149,7 @@ from .comm_endpoints import (
     _normalize_node_identity,
     parse_endpoint_path,
 )
+from .comm_region import MaterializationContext, RegionInstance, materialize_region_instance
 from .global_comm_domain import (
     CTRL_GLOBAL_DOMAIN_COPY_FROM,
     CTRL_GLOBAL_DOMAIN_COPY_TO,
@@ -5786,6 +5787,19 @@ class Worker:
             resolver = BackendResolver(registry, self._get_region_access_service())
             return resolver.plan(resolved, layout_summary)
 
+    def _materialize_region_instance(
+        self, members, topology: SingleOwner, layout_summary: RegionLayoutSpec
+    ) -> RegionInstance:
+        self._require_ready_for_region_planning("_materialize_region_instance")
+        with self._operation_lease("_materialize_region_instance"):
+            registry = self._get_endpoint_registry()
+            resolved = registry.resolve_region_spec(members, topology)
+            resolver = BackendResolver(registry, self._get_region_access_service())
+            plan = resolver.plan(resolved, layout_summary)
+            return materialize_region_instance(
+                MaterializationContext(worker=self, registry=registry, plan=plan, layout=layout_summary)
+            )
+
     def _register_into_snapshot_or_wait(self, reg: _CallableRegistration) -> CallableHandle | None:
         """Linearize a level>=3 register against the startup epoch.
 
@@ -7785,6 +7799,59 @@ class Worker:
                 except (BufferError, FileNotFoundError, OSError):
                     pass
 
+    def _close_worker_chip_region(self, region, resources: _RunResources | None = None) -> None:
+        region_errors: list[BaseException] = []
+        try:
+            region._close_worker_host_mapping()
+        except BaseException as exc:  # noqa: BLE001
+            region_errors.append(exc)
+        try:
+            if self._worker is not None:
+                self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
+        except BaseException as exc:  # noqa: BLE001
+            region_errors.append(exc)
+        # End-of-run cleanup is poisoned and terminal for that run, so it still
+        # expires both sides after attempting both debts. Whole-tree close
+        # instead retains the region for journal replay.
+        if region_errors and resources is None:
+            raise region_errors[0]
+        try:
+            region._expire()
+        except BaseException as exc:  # noqa: BLE001
+            region_errors.append(exc)
+        try:
+            self._retire_worker_chip_region_tracking(region, resources)
+        except BaseException as exc:  # noqa: BLE001
+            region_errors.append(exc)
+        if region_errors:
+            raise region_errors[0]
+
+    def _retire_worker_chip_region_tracking(self, region, resources: _RunResources | None = None) -> None:
+        tracking_lists = [self._live_worker_chip_regions]
+        if resources is not None and resources.worker_chip_regions is not self._live_worker_chip_regions:
+            tracking_lists.insert(0, resources.worker_chip_regions)
+        errors: list[BaseException] = []
+        next_tracking_list = 0
+
+        def retire_tracking() -> None:
+            nonlocal next_tracking_list
+            try:
+                while next_tracking_list < len(tracking_lists):
+                    owned_regions = tracking_lists[next_tracking_list]
+                    owned_regions[:] = [owned for owned in owned_regions if owned is not region]
+                    next_tracking_list += 1
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+                next_tracking_list += 1
+                retire_tracking()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+                retire_tracking()
+
+        retire_tracking()
+        if errors:
+            raise errors[0]
+
     def _cleanup_worker_chip_regions(self, resources: _RunResources | None = None) -> None:
         # A region stays tracked until both ownership debts commit. This makes a
         # failed close replayable by the cleanup journal instead of publishing a
@@ -7795,49 +7862,10 @@ class Worker:
         regions = list(tracked)
         errors: list[BaseException] = []
         for region in regions:
-            region_errors: list[BaseException] = []
             try:
-                region._close_worker_host_mapping()
-            except BaseException as exc:  # noqa: BLE001
-                region_errors.append(exc)
-            try:
-                if self._worker is not None:
-                    self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
-            except BaseException as exc:  # noqa: BLE001
-                region_errors.append(exc)
-            # End-of-run cleanup is poisoned and terminal for that run, so it
-            # still expires both sides after attempting both debts. Whole-tree
-            # close instead retains the region for journal replay.
-            if region_errors and resources is None:
-                errors.extend(region_errors)
-                continue
-            try:
-                region._expire()
+                self._close_worker_chip_region(region, resources)
             except BaseException as exc:  # noqa: BLE001
                 errors.append(exc)
-            errors.extend(region_errors)
-
-            tracking_lists = (
-                (tracked,) if tracked is self._live_worker_chip_regions else (tracked, self._live_worker_chip_regions)
-            )
-            next_tracking_list = 0
-
-            def retire_tracking() -> None:
-                nonlocal next_tracking_list
-                try:
-                    while next_tracking_list < len(tracking_lists):
-                        owned_regions = tracking_lists[next_tracking_list]
-                        owned_regions[:] = [owned for owned in owned_regions if owned is not region]
-                        next_tracking_list += 1
-                except Exception as exc:  # noqa: BLE001
-                    errors.append(exc)
-                    next_tracking_list += 1
-                    retire_tracking()
-                except BaseException as exc:  # noqa: BLE001
-                    errors.append(exc)
-                    retire_tracking()
-
-            retire_tracking()
         if errors:
             raise errors[0]
 

--- a/tests/ut/py/test_worker/test_comm_region.py
+++ b/tests/ut/py/test_worker/test_comm_region.py
@@ -1,0 +1,341 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for the private W3.5 region materializer."""
+
+import dataclasses
+
+import pytest
+from simpler import comm_endpoints as ce
+from simpler.comm_region import (
+    MaterializationContext,
+    MaterializationRefusal,
+    RefusalReason,
+    RegionInstanceState,
+    validate_single_owner_region_shape,
+)
+from simpler.worker import Worker, _Lifecycle
+from simpler.worker_chip_orch_comm import NotifyOp, WaitCmp
+
+
+def _ready(worker: Worker) -> Worker:
+    worker._lifecycle = _Lifecycle.READY
+    return worker
+
+
+def _l3(device_ids=(0,)) -> Worker:
+    return _ready(Worker(level=3, device_ids=list(device_ids)))
+
+
+def _l4_with_local_l3(device_ids=(0,)) -> Worker:
+    child = Worker(level=3, device_ids=list(device_ids), num_sub_workers=0)
+    worker = Worker(level=4, num_sub_workers=0)
+    worker.add_worker(child)
+    return _ready(worker)
+
+
+def _context(worker: Worker, members, topology, layout=None) -> MaterializationContext:
+    registry = worker._get_endpoint_registry()
+    resolved = registry.resolve_region_spec(members, topology)
+    plan = ce.BackendResolver(registry, worker._get_region_access_service()).plan(
+        resolved,
+        layout or ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+    )
+    return MaterializationContext(
+        worker=worker,
+        registry=registry,
+        plan=plan,
+        layout=layout or ce.RegionLayoutSpec(64, 128),
+    )
+
+
+def _accepted_context(worker: Worker | None = None) -> MaterializationContext:
+    worker = worker or _l3(device_ids=[8, 9])
+    return _context(
+        worker,
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+    )
+
+
+def _assert_refusal(ctx: MaterializationContext, reason: RefusalReason) -> None:
+    with pytest.raises(MaterializationRefusal) as excinfo:
+        validate_single_owner_region_shape(ctx)
+    assert excinfo.value.reason is reason
+
+
+def _attachments(part: ce.RegionPartPlan) -> dict[ce.EndpointIdentity, ce.MemberAttachmentPlan]:
+    return {attachment.member: attachment for attachment in part.attachments}
+
+
+def test_shape_validation_accepts_l3_host_to_local_l2_aicpu_copy_plan():
+    ctx = _accepted_context()
+    shape = validate_single_owner_region_shape(ctx)
+
+    assert shape.consumer.path == "L3"
+    assert shape.consumer.deployment is ce.HOST_CPU
+    assert shape.provider.path == "L3/L2[1]"
+    assert shape.provider.deployment is ce.DEVICE_AICPU
+    assert shape.worker_id == 1
+
+
+def test_shape_validation_rejects_l4_plan_as_delegation_work():
+    worker = _l4_with_local_l3(device_ids=[4])
+    ctx = _context(
+        worker,
+        [ce.at("L4", ce.HOST_CPU), ce.at("L4/L3[0]/L2[0]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L4/L3[0]/L2[0]", ce.DEVICE_AICPU)),
+    )
+
+    _assert_refusal(ctx, RefusalReason.NEEDS_DELEGATION)
+
+
+def test_shape_validation_rejects_aicore_provider_until_it_has_a_materializer():
+    worker = _l3(device_ids=[0])
+    ctx = _context(
+        worker,
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[0]", ce.DEVICE_AICORE)],
+        ce.SingleOwner(provider=ce.at("L3/L2[0]", ce.DEVICE_AICORE)),
+    )
+
+    _assert_refusal(ctx, RefusalReason.UNSUPPORTED_PROVIDER_DEPLOYMENT)
+
+
+def test_shape_validation_rejects_unsupported_plan_and_non_vmm_backing():
+    unsupported = _context(
+        _l3(device_ids=[0]),
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[0]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3", ce.HOST_CPU)),
+    )
+    _assert_refusal(unsupported, RefusalReason.UNSUPPORTED_PLAN)
+
+    ctx = _accepted_context()
+    posix_payload = dataclasses.replace(ctx.plan.payload, backend_kind=ce.BackendKind.POSIX_SHM)
+    _assert_refusal(
+        dataclasses.replace(ctx, plan=dataclasses.replace(ctx.plan, payload=posix_payload)),
+        RefusalReason.UNSUPPORTED_BACKEND_KIND,
+    )
+
+
+def test_shape_validation_rejects_direct_map_and_extra_consumers():
+    ctx = _accepted_context()
+    host = validate_single_owner_region_shape(ctx).consumer.identity
+    payload_by_member = _attachments(ctx.plan.payload)
+    payload_by_member[host] = dataclasses.replace(
+        payload_by_member[host],
+        adapter_kind=ce.AdapterKind.DIRECT_MAP,
+        adapter_profile=ce.AdapterProfile.HOST_SVM_MAP,
+    )
+    direct_map_payload = dataclasses.replace(ctx.plan.payload, attachments=tuple(payload_by_member.values()))
+    _assert_refusal(
+        dataclasses.replace(ctx, plan=dataclasses.replace(ctx.plan, payload=direct_map_payload)),
+        RefusalReason.UNSUPPORTED_ATTACHMENT,
+    )
+
+    worker = _l3(device_ids=[0])
+    worker._region_access_service = ce.StaticRegionAccessService(
+        {
+            (
+                ce.BackendKind.VMM_WINDOW,
+                part,
+                ce.AdapterKind.OWNER_DELEGATED_COPY,
+                ce.AdapterProfile.HOST_VMM_COPY,
+            ): True
+            for part in (ce.RegionPartKind.PAYLOAD, ce.RegionPartKind.COUNTER)
+        }
+        | {
+            (
+                ce.BackendKind.VMM_WINDOW,
+                part,
+                ce.AdapterKind.DEVICE_PEER,
+                ce.AdapterProfile.DEVICE_VMM_PEER_IMPORT,
+            ): True
+            for part in (ce.RegionPartKind.PAYLOAD, ce.RegionPartKind.COUNTER)
+        }
+    )
+    extra = _context(
+        worker,
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[0]", ce.DEVICE_AICPU), ce.at("L3/L2[0]", ce.DEVICE_AICORE)],
+        ce.SingleOwner(provider=ce.at("L3/L2[0]", ce.DEVICE_AICPU)),
+    )
+    _assert_refusal(extra, RefusalReason.UNSUPPORTED_MEMBER_SHAPE)
+
+
+class _FakeCounter:
+    def __init__(self, calls: list[tuple]) -> None:
+        self._calls = calls
+
+    def notify(self, value: int, op=NotifyOp.Set) -> None:
+        self._calls.append(("notify", value, op))
+
+    def test(self, cmp_value: int, cmp: WaitCmp):
+        self._calls.append(("test", cmp_value, cmp))
+        return True
+
+    def wait(self, cmp_value: int, cmp: WaitCmp, timeout: int):
+        self._calls.append(("wait", cmp_value, cmp, timeout))
+        return None
+
+
+class _FakeRegion:
+    def __init__(self, calls: list[tuple], *, fail_mapping_close: bool = False) -> None:
+        self._calls = calls
+        self._fail_mapping_close = fail_mapping_close
+        self._worker_id = 1
+        self.region_id = 42
+
+    def payload_write(self, offset: int, host_buffer, nbytes=None) -> None:
+        self._calls.append(("payload_write", offset, host_buffer, nbytes))
+
+    def payload_read(self, offset: int, host_buffer, nbytes=None) -> None:
+        self._calls.append(("payload_read", offset, host_buffer, nbytes))
+
+    def counter(self, offset: int) -> _FakeCounter:
+        self._calls.append(("counter", offset))
+        return _FakeCounter(self._calls)
+
+    def _close_worker_host_mapping(self) -> None:
+        self._calls.append(("mapping_close",))
+        if self._fail_mapping_close:
+            raise RuntimeError("mapping close failed")
+
+    def _expire(self) -> None:
+        self._calls.append(("expire",))
+
+
+class _FakeNativeWorker:
+    def __init__(self, calls: list[tuple]) -> None:
+        self._calls = calls
+
+    def control_worker_chip_region_release(self, worker_id: int, region_id: int) -> None:
+        self._calls.append(("release", worker_id, region_id))
+
+
+def test_worker_materializes_region_instance_and_closes_single_region(monkeypatch):
+    worker = _l3(device_ids=[8, 9])
+    calls: list[tuple] = []
+    fake_region = _FakeRegion(calls)
+    worker._worker = _FakeNativeWorker(calls)
+
+    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
+        calls.append(("create", worker_id, payload_bytes, counter_bytes))
+        worker._live_worker_chip_regions.append(fake_region)
+        return fake_region
+
+    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+
+    instance = worker._materialize_region_instance(
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+    )
+
+    assert instance.state is RegionInstanceState.LIVE
+    assert instance.worker_id == 1
+    instance.payload_write(4, "src", nbytes=8)
+    instance.payload_read(12, "dst")
+    assert instance.counter(16).test(7, WaitCmp.EQ) is True
+
+    instance.close()
+    instance.close()
+    assert instance.state is RegionInstanceState.CLOSED
+    assert worker._live_worker_chip_regions == []
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("payload_write", 4, "src", 8),
+        ("payload_read", 12, "dst", None),
+        ("counter", 16),
+        ("test", 7, WaitCmp.EQ),
+        ("mapping_close",),
+        ("release", 1, 42),
+        ("expire",),
+    ]
+
+
+def test_live_region_instance_rollback_reuses_single_region_cleanup(monkeypatch):
+    worker = _l3(device_ids=[8, 9])
+    calls: list[tuple] = []
+    fake_region = _FakeRegion(calls)
+    worker._worker = _FakeNativeWorker(calls)
+
+    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
+        calls.append(("create", worker_id, payload_bytes, counter_bytes))
+        worker._live_worker_chip_regions.append(fake_region)
+        return fake_region
+
+    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+    instance = worker._materialize_region_instance(
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+    )
+
+    instance.rollback()
+    instance.rollback()
+
+    assert instance.state is RegionInstanceState.ROLLED_BACK
+    assert worker._live_worker_chip_regions == []
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("mapping_close",),
+        ("release", 1, 42),
+        ("expire",),
+    ]
+    with pytest.raises(RuntimeError, match="not live"):
+        instance.payload_write(0, "src")
+
+
+def test_region_instance_close_failure_marks_failed_and_keeps_tracking(monkeypatch):
+    worker = _l3(device_ids=[8, 9])
+    calls: list[tuple] = []
+    fake_region = _FakeRegion(calls, fail_mapping_close=True)
+    worker._worker = _FakeNativeWorker(calls)
+
+    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
+        calls.append(("create", worker_id, payload_bytes, counter_bytes))
+        worker._live_worker_chip_regions.append(fake_region)
+        return fake_region
+
+    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+    instance = worker._materialize_region_instance(
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+    )
+
+    with pytest.raises(RuntimeError, match="mapping close failed"):
+        instance.close()
+
+    assert instance.state is RegionInstanceState.CLOSE_FAILED
+    assert worker._live_worker_chip_regions == [fake_region]
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("mapping_close",),
+        ("release", 1, 42),
+    ]
+
+
+def test_materialize_create_failure_propagates_without_live_tracking(monkeypatch):
+    worker = _l3(device_ids=[8, 9])
+    calls: list[tuple] = []
+
+    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
+        calls.append(("create", worker_id, payload_bytes, counter_bytes))
+        raise RuntimeError("create failed")
+
+    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+
+    with pytest.raises(RuntimeError, match="create failed"):
+        worker._materialize_region_instance(
+            [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+            ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+            ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+        )
+
+    assert worker._live_worker_chip_regions == []
+    assert calls == [("create", 1, 64, 128)]

--- a/tests/ut/py/test_worker/test_comm_region.py
+++ b/tests/ut/py/test_worker/test_comm_region.py
@@ -41,17 +41,15 @@ def _l4_with_local_l3(device_ids=(0,)) -> Worker:
 
 
 def _context(worker: Worker, members, topology, layout=None) -> MaterializationContext:
+    layout = layout or ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128)
     registry = worker._get_endpoint_registry()
     resolved = registry.resolve_region_spec(members, topology)
-    plan = ce.BackendResolver(registry, worker._get_region_access_service()).plan(
-        resolved,
-        layout or ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
-    )
+    plan = ce.BackendResolver(registry, worker._get_region_access_service()).plan(resolved, layout)
     return MaterializationContext(
         worker=worker,
         registry=registry,
         plan=plan,
-        layout=layout or ce.RegionLayoutSpec(64, 128),
+        layout=layout,
     )
 
 
@@ -72,6 +70,57 @@ def _assert_refusal(ctx: MaterializationContext, reason: RefusalReason) -> None:
 
 def _attachments(part: ce.RegionPartPlan) -> dict[ce.EndpointIdentity, ce.MemberAttachmentPlan]:
     return {attachment.member: attachment for attachment in part.attachments}
+
+
+def _materialize_default_region(worker: Worker):
+    return worker._materialize_region_instance(
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+    )
+
+
+def _manual_two_member_context(
+    worker: Worker,
+    provider: ce.EndpointRecord,
+    consumer: ce.EndpointRecord,
+    layout: Optional[ce.RegionLayoutSpec] = None,
+) -> MaterializationContext:
+    layout = layout or ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128)
+    registry = ce.EndpointRegistry(
+        root_level=3,
+        session_instance_id=worker._owner_instance_id,
+        registry_epoch=worker._endpoint_registry_epoch,
+        records=(consumer, provider),
+    )
+    provider_attachment = ce.MemberAttachmentPlan(
+        member=provider.identity,
+        role=ce.AttachmentRole.PROVIDER,
+        adapter_kind=None,
+        adapter_profile=None,
+    )
+    consumer_attachment = ce.MemberAttachmentPlan(
+        member=consumer.identity,
+        role=ce.AttachmentRole.CONSUMER,
+        adapter_kind=ce.AdapterKind.OWNER_DELEGATED_COPY,
+        adapter_profile=ce.AdapterProfile.HOST_VMM_COPY,
+    )
+    part_attachments = (provider_attachment, consumer_attachment)
+    plan = ce.BackendPlan(
+        ordered_members=(consumer.identity, provider.identity),
+        payload=ce.RegionPartPlan(
+            part=ce.RegionPartKind.PAYLOAD,
+            backend_kind=ce.BackendKind.VMM_WINDOW,
+            attachments=part_attachments,
+        ),
+        counter=ce.RegionPartPlan(
+            part=ce.RegionPartKind.COUNTER,
+            backend_kind=ce.BackendKind.VMM_WINDOW,
+            attachments=part_attachments,
+        ),
+        topology_plan=ce.SingleOwnerPlan(provider_endpoint=provider.identity),
+    )
+    return MaterializationContext(worker=worker, registry=registry, plan=plan, layout=layout)
 
 
 def test_shape_validation_accepts_l3_host_to_local_l2_aicpu_copy_plan():
@@ -169,6 +218,59 @@ def test_shape_validation_rejects_direct_map_and_extra_consumers():
     _assert_refusal(extra, RefusalReason.UNSUPPORTED_MEMBER_SHAPE)
 
 
+def test_shape_validation_rejects_remote_endpoint_member():
+    worker = _l3(device_ids=[0])
+    session_id = worker._owner_instance_id
+    registry_epoch = worker._endpoint_registry_epoch
+    consumer = ce.EndpointRecord(
+        identity=ce.EndpointIdentity(session_id, registry_epoch, 0),
+        path="L3",
+        deployment=ce.HOST_CPU,
+        node_scope_id=0,
+    )
+    remote_provider = ce.EndpointRecord(
+        identity=ce.EndpointIdentity(session_id, registry_epoch, 1),
+        path="L3/L2[0]",
+        deployment=ce.DEVICE_AICPU,
+        node_scope_id=1,
+    )
+
+    _assert_refusal(
+        _manual_two_member_context(worker, remote_provider, consumer),
+        RefusalReason.UNSUPPORTED_MEMBER_SHAPE,
+    )
+
+
+def test_shape_validation_rejects_device_peer_consumer_attachment():
+    ctx = _accepted_context()
+    host = validate_single_owner_region_shape(ctx).consumer.identity
+    payload_by_member = _attachments(ctx.plan.payload)
+    payload_by_member[host] = dataclasses.replace(
+        payload_by_member[host],
+        adapter_kind=ce.AdapterKind.DEVICE_PEER,
+        adapter_profile=ce.AdapterProfile.DEVICE_VMM_PEER_IMPORT,
+    )
+    device_peer_payload = dataclasses.replace(ctx.plan.payload, attachments=tuple(payload_by_member.values()))
+
+    _assert_refusal(
+        dataclasses.replace(ctx, plan=dataclasses.replace(ctx.plan, payload=device_peer_payload)),
+        RefusalReason.UNSUPPORTED_ATTACHMENT,
+    )
+
+
+def test_shape_validation_rejects_duplicate_attachment_members():
+    ctx = _accepted_context()
+    duplicate_payload = dataclasses.replace(
+        ctx.plan.payload,
+        attachments=ctx.plan.payload.attachments + (ctx.plan.payload.attachments[-1],),
+    )
+
+    _assert_refusal(
+        dataclasses.replace(ctx, plan=dataclasses.replace(ctx.plan, payload=duplicate_payload)),
+        RefusalReason.UNSUPPORTED_ATTACHMENT,
+    )
+
+
 class _FakeCounter:
     def __init__(self, calls: list[tuple]) -> None:
         self._calls = calls
@@ -211,31 +313,38 @@ class _FakeRegion:
 
 
 class _FakeNativeWorker:
-    def __init__(self, calls: list[tuple]) -> None:
+    def __init__(self, calls: list[tuple], *, fail_release: bool = False) -> None:
         self._calls = calls
+        self._fail_release = fail_release
 
     def control_worker_chip_region_release(self, worker_id: int, region_id: int) -> None:
         self._calls.append(("release", worker_id, region_id))
+        if self._fail_release:
+            raise RuntimeError("release failed")
 
 
-def test_worker_materializes_region_instance_and_closes_single_region(monkeypatch):
-    worker = _l3(device_ids=[8, 9])
-    calls: list[tuple] = []
-    fake_region = _FakeRegion(calls)
-    worker._worker = _FakeNativeWorker(calls)
+@pytest.fixture
+def region_worker(monkeypatch):
+    def build(*, fail_mapping_close: bool = False, fail_release: bool = False, device_ids=(8, 9)):
+        worker = _l3(device_ids=device_ids)
+        calls: list[tuple] = []
+        fake_region = _FakeRegion(calls, fail_mapping_close=fail_mapping_close)
+        worker._worker = _FakeNativeWorker(calls, fail_release=fail_release)
 
-    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
-        calls.append(("create", worker_id, payload_bytes, counter_bytes))
-        worker._live_worker_chip_regions.append(fake_region)
-        return fake_region
+        def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
+            calls.append(("create", worker_id, payload_bytes, counter_bytes))
+            worker._live_worker_chip_regions.append(fake_region)
+            return fake_region
 
-    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+        monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+        return worker, calls, fake_region
 
-    instance = worker._materialize_region_instance(
-        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
-        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
-        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
-    )
+    return build
+
+
+def test_worker_materializes_region_instance_and_closes_single_region(region_worker):
+    worker, calls, _fake_region = region_worker()
+    instance = _materialize_default_region(worker)
 
     assert instance.state is RegionInstanceState.LIVE
     assert instance.worker_id == 1
@@ -266,23 +375,9 @@ def test_worker_materializes_region_instance_and_closes_single_region(monkeypatc
     ]
 
 
-def test_live_region_instance_rollback_reuses_single_region_cleanup(monkeypatch):
-    worker = _l3(device_ids=[8, 9])
-    calls: list[tuple] = []
-    fake_region = _FakeRegion(calls)
-    worker._worker = _FakeNativeWorker(calls)
-
-    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
-        calls.append(("create", worker_id, payload_bytes, counter_bytes))
-        worker._live_worker_chip_regions.append(fake_region)
-        return fake_region
-
-    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
-    instance = worker._materialize_region_instance(
-        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
-        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
-        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
-    )
+def test_live_region_instance_rollback_reuses_single_region_cleanup(region_worker):
+    worker, calls, _fake_region = region_worker()
+    instance = _materialize_default_region(worker)
 
     with worker._control_reservation("test_region_instance"):
         instance.rollback()
@@ -300,23 +395,9 @@ def test_live_region_instance_rollback_reuses_single_region_cleanup(monkeypatch)
         instance.payload_write(0, "src")
 
 
-def test_region_instance_close_failure_marks_failed_and_poisons_worker(monkeypatch):
-    worker = _l3(device_ids=[8, 9])
-    calls: list[tuple] = []
-    fake_region = _FakeRegion(calls, fail_mapping_close=True)
-    worker._worker = _FakeNativeWorker(calls)
-
-    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
-        calls.append(("create", worker_id, payload_bytes, counter_bytes))
-        worker._live_worker_chip_regions.append(fake_region)
-        return fake_region
-
-    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
-    instance = worker._materialize_region_instance(
-        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
-        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
-        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
-    )
+def test_region_instance_close_failure_marks_failed_and_poisons_worker(region_worker):
+    worker, calls, _fake_region = region_worker(fail_mapping_close=True)
+    instance = _materialize_default_region(worker)
 
     with worker._control_reservation("test_region_instance"):
         with pytest.raises(RuntimeError, match="mapping close failed"):
@@ -336,6 +417,60 @@ def test_region_instance_close_failure_marks_failed_and_poisons_worker(monkeypat
         ("release", 1, 42),
         ("expire",),
     ]
+
+
+def test_region_instance_rollback_failure_replays_cached_error_for_close(region_worker):
+    worker, calls, _fake_region = region_worker(fail_mapping_close=True)
+    instance = _materialize_default_region(worker)
+
+    with worker._control_reservation("test_region_instance"):
+        with pytest.raises(RuntimeError, match="mapping close failed") as first_excinfo:
+            instance.rollback()
+        with pytest.raises(RuntimeError, match="mapping close failed") as second_excinfo:
+            instance.rollback()
+        with pytest.raises(RuntimeError, match="mapping close failed") as close_excinfo:
+            instance.close()
+
+    assert instance.state is RegionInstanceState.ROLLBACK_FAILED
+    assert second_excinfo.value is first_excinfo.value
+    assert close_excinfo.value is first_excinfo.value
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("mapping_close",),
+        ("release", 1, 42),
+        ("expire",),
+    ]
+
+
+def test_close_worker_chip_region_preserves_release_error_cause(region_worker):
+    worker, _calls, fake_region = region_worker(fail_mapping_close=True, fail_release=True)
+
+    with pytest.raises(RuntimeError, match="mapping close failed") as excinfo:
+        worker._close_worker_chip_region(fake_region, poison_on_error=True)
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert str(excinfo.value.__cause__) == "release failed"
+
+
+def test_retire_worker_chip_region_tracking_does_not_retry_base_exception():
+    class FailingTrackingList(list):
+        def __init__(self, values):
+            super().__init__(values)
+            self.assignments = 0
+
+        def __setitem__(self, key, value):
+            self.assignments += 1
+            raise KeyboardInterrupt("tracking interrupted")
+
+    worker = _l3(device_ids=[8, 9])
+    region = object()
+    tracking = FailingTrackingList([region])
+    worker._live_worker_chip_regions = tracking
+
+    with pytest.raises(KeyboardInterrupt, match="tracking interrupted"):
+        worker._retire_worker_chip_region_tracking(region)
+
+    assert tracking.assignments == 1
 
 
 def test_materialize_create_failure_propagates_without_live_tracking(monkeypatch):
@@ -359,23 +494,9 @@ def test_materialize_create_failure_propagates_without_live_tracking(monkeypatch
     assert calls == [("create", 1, 64, 128)]
 
 
-def test_live_region_instance_access_requires_control_context(monkeypatch):
-    worker = _l3(device_ids=[8, 9])
-    calls: list[tuple] = []
-    fake_region = _FakeRegion(calls)
-    worker._worker = _FakeNativeWorker(calls)
-
-    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
-        calls.append(("create", worker_id, payload_bytes, counter_bytes))
-        worker._live_worker_chip_regions.append(fake_region)
-        return fake_region
-
-    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
-    instance = worker._materialize_region_instance(
-        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
-        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
-        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
-    )
+def test_live_region_instance_access_requires_control_context(region_worker):
+    worker, calls, _fake_region = region_worker()
+    instance = _materialize_default_region(worker)
 
     with pytest.raises(RuntimeError, match="active orchestration/control context"):
         instance.payload_write(0, "src")

--- a/tests/ut/py/test_worker/test_comm_region.py
+++ b/tests/ut/py/test_worker/test_comm_region.py
@@ -15,12 +15,14 @@ import pytest
 from simpler import comm_endpoints as ce
 from simpler.comm_region import (
     MaterializationContext,
+    MaterializationError,
     MaterializationRefusal,
     RefusalReason,
     RegionInstanceState,
     validate_single_owner_region_shape,
 )
-from simpler.worker import Worker, _Lifecycle
+from simpler.orchestrator import _callback_frame_for, _callback_run
+from simpler.worker import Worker, _Lifecycle, _RunResources
 from simpler.worker_chip_orch_comm import NotifyOp, WaitCmp
 
 
@@ -30,7 +32,9 @@ def _ready(worker: Worker) -> Worker:
 
 
 def _l3(device_ids=(0,)) -> Worker:
-    return _ready(Worker(level=3, device_ids=list(device_ids)))
+    worker = _ready(Worker(level=3, device_ids=list(device_ids)))
+    worker._worker = object()
+    return worker
 
 
 def _l4_with_local_l3(device_ids=(0,)) -> Worker:
@@ -154,6 +158,46 @@ def test_shape_validation_rejects_aicore_provider_until_it_has_a_materializer():
     )
 
     _assert_refusal(ctx, RefusalReason.UNSUPPORTED_PROVIDER_DEPLOYMENT)
+
+
+def test_shape_validation_rejects_non_l2_child_provider_path():
+    worker = _l3(device_ids=[0])
+    session_id = worker._owner_instance_id
+    registry_epoch = worker._endpoint_registry_epoch
+    consumer = ce.EndpointRecord(
+        identity=ce.EndpointIdentity(session_id, registry_epoch, 0),
+        path="L3",
+        deployment=ce.HOST_CPU,
+        node_scope_id=0,
+    )
+    provider = ce.EndpointRecord(
+        identity=ce.EndpointIdentity(session_id, registry_epoch, 1),
+        path="L3/L1[0]",
+        deployment=ce.DEVICE_AICPU,
+        node_scope_id=0,
+    )
+
+    _assert_refusal(_manual_two_member_context(worker, provider, consumer), RefusalReason.NEEDS_DELEGATION)
+
+
+def test_shape_validation_translates_worker_chip_id_value_error():
+    worker = _l3(device_ids=[0])
+    session_id = worker._owner_instance_id
+    registry_epoch = worker._endpoint_registry_epoch
+    consumer = ce.EndpointRecord(
+        identity=ce.EndpointIdentity(session_id, registry_epoch, 0),
+        path="L3",
+        deployment=ce.HOST_CPU,
+        node_scope_id=0,
+    )
+    provider = ce.EndpointRecord(
+        identity=ce.EndpointIdentity(session_id, registry_epoch, 1),
+        path="L3/L2[1]",
+        deployment=ce.DEVICE_AICPU,
+        node_scope_id=0,
+    )
+
+    _assert_refusal(_manual_two_member_context(worker, provider, consumer), RefusalReason.UNSUPPORTED_MEMBER_SHAPE)
 
 
 def test_shape_validation_rejects_unsupported_plan_and_non_vmm_backing():
@@ -292,6 +336,8 @@ class _FakeRegion:
         self._fail_mapping_close = fail_mapping_close
         self._worker_id = 1
         self.region_id = 42
+        self._expired = False
+        self._released = False
 
     def payload_write(self, offset: int, host_buffer, nbytes=None) -> None:
         self._calls.append(("payload_write", offset, host_buffer, nbytes))
@@ -304,12 +350,17 @@ class _FakeRegion:
         return _FakeCounter(self._calls)
 
     def _close_worker_host_mapping(self) -> None:
-        self._calls.append(("mapping_close",))
+        self._calls.append(("mapping_close", self._expired))
         if self._fail_mapping_close:
             raise RuntimeError("mapping close failed")
 
+    def free(self) -> None:
+        self._calls.append(("free",))
+        self._released = True
+
     def _expire(self) -> None:
         self._calls.append(("expire",))
+        self._expired = True
 
 
 class _FakeNativeWorker:
@@ -334,6 +385,10 @@ def region_worker(monkeypatch):
         def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
             calls.append(("create", worker_id, payload_bytes, counter_bytes))
             worker._live_worker_chip_regions.append(fake_region)
+            resources = worker._building_run_resources
+            if resources is not None:
+                resources.worker_chip_regions.append(fake_region)
+                resources.requires_ordered_cleanup = True
             return fake_region
 
         monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
@@ -369,8 +424,9 @@ def test_worker_materializes_region_instance_and_closes_single_region(region_wor
         ("wait", 3, WaitCmp.GE, 10),
         ("counter", 16),
         ("test", 7, WaitCmp.EQ),
-        ("mapping_close",),
+        ("mapping_close", False),
         ("release", 1, 42),
+        ("free",),
         ("expire",),
     ]
 
@@ -387,11 +443,15 @@ def test_live_region_instance_rollback_reuses_single_region_cleanup(region_worke
     assert worker._live_worker_chip_regions == []
     assert calls == [
         ("create", 1, 64, 128),
-        ("mapping_close",),
+        ("mapping_close", False),
         ("release", 1, 42),
+        ("free",),
         ("expire",),
     ]
-    with pytest.raises(RuntimeError, match="not live"):
+    with worker._control_reservation("test_region_instance"):
+        instance.close()
+    assert instance.state is RegionInstanceState.ROLLED_BACK
+    with pytest.raises(MaterializationError, match="not live"):
         instance.payload_write(0, "src")
 
 
@@ -413,8 +473,9 @@ def test_region_instance_close_failure_marks_failed_and_poisons_worker(region_wo
         instance.close()
     assert calls == [
         ("create", 1, 64, 128),
-        ("mapping_close",),
+        ("mapping_close", False),
         ("release", 1, 42),
+        ("free",),
         ("expire",),
     ]
 
@@ -436,8 +497,9 @@ def test_region_instance_rollback_failure_replays_cached_error_for_close(region_
     assert close_excinfo.value is first_excinfo.value
     assert calls == [
         ("create", 1, 64, 128),
-        ("mapping_close",),
+        ("mapping_close", False),
         ("release", 1, 42),
+        ("free",),
         ("expire",),
     ]
 
@@ -452,6 +514,65 @@ def test_close_worker_chip_region_preserves_release_error_cause(region_worker):
     assert str(excinfo.value.__cause__) == "release failed"
 
 
+def test_callback_region_close_before_submit_retired_from_run_cleanup(region_worker):
+    worker, calls, _fake_region = region_worker()
+    resources = _RunResources()
+    worker._building_run_resources = resources
+    try:
+        with _callback_run(17, worker):
+            instance = _materialize_default_region(worker)
+            instance.close()
+    finally:
+        worker._building_run_resources = None
+
+    assert instance.state is RegionInstanceState.CLOSED
+    assert worker._live_worker_chip_regions == []
+    assert resources.worker_chip_regions == []
+
+    worker._cleanup_worker_chip_regions(resources)
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("mapping_close", False),
+        ("release", 1, 42),
+        ("free",),
+        ("expire",),
+    ]
+
+
+def test_callback_region_run_cleanup_then_later_close_is_idempotent(region_worker):
+    worker, calls, _fake_region = region_worker()
+    resources = _RunResources()
+    worker._building_run_resources = resources
+    try:
+        with _callback_run(18, worker):
+            instance = _materialize_default_region(worker)
+            frame = _callback_frame_for(worker)
+            assert frame is not None
+            frame.has_submitted_task = True
+            with pytest.raises(RuntimeError, match="cannot follow a task submission"):
+                instance.close()
+    finally:
+        worker._building_run_resources = None
+
+    worker._cleanup_worker_chip_regions(resources)
+
+    assert instance.state is RegionInstanceState.LIVE
+    assert worker._live_worker_chip_regions == []
+    assert resources.worker_chip_regions == []
+
+    with worker._control_reservation("test_region_instance"):
+        instance.close()
+
+    assert instance.state is RegionInstanceState.CLOSED
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("mapping_close", False),
+        ("release", 1, 42),
+        ("free",),
+        ("expire",),
+    ]
+
+
 def test_retire_worker_chip_region_tracking_does_not_retry_base_exception():
     class FailingTrackingList(list):
         def __init__(self, values):
@@ -464,13 +585,16 @@ def test_retire_worker_chip_region_tracking_does_not_retry_base_exception():
 
     worker = _l3(device_ids=[8, 9])
     region = object()
-    tracking = FailingTrackingList([region])
-    worker._live_worker_chip_regions = tracking
+    failing_tracking = FailingTrackingList([region])
+    succeeding_tracking = [region]
+    resources = _RunResources(worker_chip_regions=failing_tracking)
+    worker._live_worker_chip_regions = succeeding_tracking
 
     with pytest.raises(KeyboardInterrupt, match="tracking interrupted"):
-        worker._retire_worker_chip_region_tracking(region)
+        worker._retire_worker_chip_region_tracking(region, resources)
 
-    assert tracking.assignments == 1
+    assert failing_tracking.assignments == 1
+    assert succeeding_tracking == []
 
 
 def test_materialize_create_failure_propagates_without_live_tracking(monkeypatch):
@@ -510,8 +634,9 @@ def test_live_region_instance_access_requires_control_context(region_worker):
 
     assert calls == [
         ("create", 1, 64, 128),
-        ("mapping_close",),
+        ("mapping_close", False),
         ("release", 1, 42),
+        ("free",),
         ("expire",),
     ]
 
@@ -524,6 +649,14 @@ def test_shape_validation_rejects_foreign_registry_context():
         validate_single_owner_region_shape(dataclasses.replace(owner, worker=foreign_worker))
 
     assert excinfo.value.reason is RefusalReason.REGISTRY_MISMATCH
+
+
+def test_shape_validation_does_not_translate_worker_readiness_errors():
+    ctx = _accepted_context()
+    ctx.worker._worker = None
+
+    with pytest.raises(RuntimeError, match="requires Worker.init"):
+        validate_single_owner_region_shape(ctx)
 
 
 def test_shape_validation_rejects_stale_registry_epoch():

--- a/tests/ut/py/test_worker/test_comm_region.py
+++ b/tests/ut/py/test_worker/test_comm_region.py
@@ -6,9 +6,10 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Unit tests for the private W3.5 region materializer."""
+"""Unit tests for the private region materializer."""
 
 import dataclasses
+from typing import Any, Optional, Union
 
 import pytest
 from simpler import comm_endpoints as ce
@@ -54,7 +55,7 @@ def _context(worker: Worker, members, topology, layout=None) -> MaterializationC
     )
 
 
-def _accepted_context(worker: Worker | None = None) -> MaterializationContext:
+def _accepted_context(worker: Optional[Worker] = None) -> MaterializationContext:
     worker = worker or _l3(device_ids=[8, 9])
     return _context(
         worker,
@@ -138,26 +139,28 @@ def test_shape_validation_rejects_direct_map_and_extra_consumers():
     )
 
     worker = _l3(device_ids=[0])
-    worker._region_access_service = ce.StaticRegionAccessService(
-        {
+    decisions: dict[
+        tuple[Any, ce.RegionPartKind, ce.AdapterKind, ce.AdapterProfile],
+        Union[ce.RegionAccessDecision, bool],
+    ] = {}
+    for part in (ce.RegionPartKind.PAYLOAD, ce.RegionPartKind.COUNTER):
+        decisions[
             (
                 ce.BackendKind.VMM_WINDOW,
                 part,
                 ce.AdapterKind.OWNER_DELEGATED_COPY,
                 ce.AdapterProfile.HOST_VMM_COPY,
-            ): True
-            for part in (ce.RegionPartKind.PAYLOAD, ce.RegionPartKind.COUNTER)
-        }
-        | {
+            )
+        ] = True
+        decisions[
             (
                 ce.BackendKind.VMM_WINDOW,
                 part,
                 ce.AdapterKind.DEVICE_PEER,
                 ce.AdapterProfile.DEVICE_VMM_PEER_IMPORT,
-            ): True
-            for part in (ce.RegionPartKind.PAYLOAD, ce.RegionPartKind.COUNTER)
-        }
-    )
+            )
+        ] = True
+    worker._region_access_service = ce.StaticRegionAccessService(decisions)
     extra = _context(
         worker,
         [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[0]", ce.DEVICE_AICPU), ce.at("L3/L2[0]", ce.DEVICE_AICORE)],
@@ -179,7 +182,6 @@ class _FakeCounter:
 
     def wait(self, cmp_value: int, cmp: WaitCmp, timeout: int):
         self._calls.append(("wait", cmp_value, cmp, timeout))
-        return None
 
 
 class _FakeRegion:
@@ -237,18 +239,25 @@ def test_worker_materializes_region_instance_and_closes_single_region(monkeypatc
 
     assert instance.state is RegionInstanceState.LIVE
     assert instance.worker_id == 1
-    instance.payload_write(4, "src", nbytes=8)
-    instance.payload_read(12, "dst")
-    assert instance.counter(16).test(7, WaitCmp.EQ) is True
+    with worker._control_reservation("test_region_instance"):
+        instance.payload_write(4, "src", nbytes=8)
+        instance.payload_read(12, "dst")
+        instance.counter(0).notify(3)
+        instance.counter(8).wait(3, WaitCmp.GE, timeout=10)
+        assert instance.counter(16).test(7, WaitCmp.EQ) is True
 
-    instance.close()
-    instance.close()
+        instance.close()
+        instance.close()
     assert instance.state is RegionInstanceState.CLOSED
     assert worker._live_worker_chip_regions == []
     assert calls == [
         ("create", 1, 64, 128),
         ("payload_write", 4, "src", 8),
         ("payload_read", 12, "dst", None),
+        ("counter", 0),
+        ("notify", 3, NotifyOp.Set),
+        ("counter", 8),
+        ("wait", 3, WaitCmp.GE, 10),
         ("counter", 16),
         ("test", 7, WaitCmp.EQ),
         ("mapping_close",),
@@ -275,8 +284,9 @@ def test_live_region_instance_rollback_reuses_single_region_cleanup(monkeypatch)
         ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
     )
 
-    instance.rollback()
-    instance.rollback()
+    with worker._control_reservation("test_region_instance"):
+        instance.rollback()
+        instance.rollback()
 
     assert instance.state is RegionInstanceState.ROLLED_BACK
     assert worker._live_worker_chip_regions == []
@@ -290,7 +300,7 @@ def test_live_region_instance_rollback_reuses_single_region_cleanup(monkeypatch)
         instance.payload_write(0, "src")
 
 
-def test_region_instance_close_failure_marks_failed_and_keeps_tracking(monkeypatch):
+def test_region_instance_close_failure_marks_failed_and_poisons_worker(monkeypatch):
     worker = _l3(device_ids=[8, 9])
     calls: list[tuple] = []
     fake_region = _FakeRegion(calls, fail_mapping_close=True)
@@ -308,15 +318,23 @@ def test_region_instance_close_failure_marks_failed_and_keeps_tracking(monkeypat
         ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
     )
 
-    with pytest.raises(RuntimeError, match="mapping close failed"):
-        instance.close()
+    with worker._control_reservation("test_region_instance"):
+        with pytest.raises(RuntimeError, match="mapping close failed"):
+            instance.close()
 
     assert instance.state is RegionInstanceState.CLOSE_FAILED
-    assert worker._live_worker_chip_regions == [fake_region]
+    assert worker._live_worker_chip_regions == []
+    with pytest.raises(RuntimeError, match="no further work is admitted"):
+        worker._require_no_ordered_cleanup_failure("test")
+    with pytest.raises(RuntimeError, match="not live"):
+        instance.payload_write(0, "src")
+    with pytest.raises(RuntimeError, match="mapping close failed"):
+        instance.close()
     assert calls == [
         ("create", 1, 64, 128),
         ("mapping_close",),
         ("release", 1, 42),
+        ("expire",),
     ]
 
 
@@ -339,3 +357,59 @@ def test_materialize_create_failure_propagates_without_live_tracking(monkeypatch
 
     assert worker._live_worker_chip_regions == []
     assert calls == [("create", 1, 64, 128)]
+
+
+def test_live_region_instance_access_requires_control_context(monkeypatch):
+    worker = _l3(device_ids=[8, 9])
+    calls: list[tuple] = []
+    fake_region = _FakeRegion(calls)
+    worker._worker = _FakeNativeWorker(calls)
+
+    def create_region(worker_id: int, payload_bytes: int, counter_bytes: int):
+        calls.append(("create", worker_id, payload_bytes, counter_bytes))
+        worker._live_worker_chip_regions.append(fake_region)
+        return fake_region
+
+    monkeypatch.setattr(worker, "_create_worker_chip_region", create_region)
+    instance = worker._materialize_region_instance(
+        [ce.at("L3", ce.HOST_CPU), ce.at("L3/L2[1]", ce.DEVICE_AICPU)],
+        ce.SingleOwner(provider=ce.at("L3/L2[1]", ce.DEVICE_AICPU)),
+        ce.RegionLayoutSpec(payload_bytes=64, counter_bytes=128),
+    )
+
+    with pytest.raises(RuntimeError, match="active orchestration/control context"):
+        instance.payload_write(0, "src")
+    with pytest.raises(RuntimeError, match="active orchestration/control context"):
+        instance.counter(0)
+    with pytest.raises(RuntimeError, match="active orchestration/control context"):
+        instance.close()
+
+    with worker._control_reservation("test_region_instance"):
+        instance.close()
+
+    assert calls == [
+        ("create", 1, 64, 128),
+        ("mapping_close",),
+        ("release", 1, 42),
+        ("expire",),
+    ]
+
+
+def test_shape_validation_rejects_foreign_registry_context():
+    owner = _accepted_context(_l3(device_ids=[0, 1]))
+    foreign_worker = _l3(device_ids=[0, 1])
+
+    with pytest.raises(MaterializationRefusal) as excinfo:
+        validate_single_owner_region_shape(dataclasses.replace(owner, worker=foreign_worker))
+
+    assert excinfo.value.reason is RefusalReason.REGISTRY_MISMATCH
+
+
+def test_shape_validation_rejects_stale_registry_epoch():
+    ctx = _accepted_context(_l3(device_ids=[0, 1]))
+    ctx.worker._invalidate_endpoint_registry()
+
+    with pytest.raises(MaterializationRefusal) as excinfo:
+        validate_single_owner_region_shape(ctx)
+
+    assert excinfo.value.reason is RefusalReason.REGISTRY_MISMATCH


### PR DESCRIPTION
## Summary

  This PR builds on #1696 by adding the private Python materialization layer for
  the first planned communication-region shape.

  #1696 introduced the endpoint model: endpoint selectors, endpoint registries,
  `SingleOwner` backend planning, typed `BackendPlan`s, and explicit unsupported
  plans. This PR takes one supported plan shape from that layer and turns it into
  a live internal `RegionInstance` backed by the existing worker-chip region
  native path.

  In the work breakdown, this corresponds to the internal region
  instance/materializer step. It is intentionally private: it gives later W4/W5
  work a real plan-to-resource object without exposing a public
  `create_region(...)` API yet.

 ## Why This PR Exists

   In the work breakdown, this PR is the internal region
  instance/materializer step. This PR sits between #1696's endpoint/backend planner
  and the later W4/W5 work.

  W4 is the sync-primitive normalization step. It promotes the current
  worker-chip counter operations (`notify`, `test`, `wait`) into region-level
  publish/observe APIs, with arch-specific cache-maintenance call sites hidden
  behind the region abstraction. W4 needs a real internal region object so those
  sync operations are no longer tied directly to the old worker-chip API shape.

  W5 is the delegated transaction step. It lets a higher-level worker declare a
  region over endpoint members, delegates execution to the owning L3/chip side,
  and gives the operation transaction semantics: partial-failure rollback,
  membership freeze, epoch/generation tracking, and an all-member READY barrier.
  W5 needs a rollback-capable internal region instance before it can safely build
  delegated create/commit/rollback orchestration.

  Before this PR, #1696 could describe a valid region plan, and the worker already
  had a native worker-chip region backend, but there was no internal layer that
  bound those two together. This PR adds that layer and its lifecycle/error
  behavior without exposing a public `create_region(...)` API yet.

  ## Supported Materialization Shape

  This PR supports exactly the current production shape:

  - current L3 `HOST_CPU` consumer
  - local `L3/L2[i] DEVICE_AICPU` provider
  - `SingleOwner` topology
  - `VMM_WINDOW` payload and counter backing
  - host consumer attachment through
    `OWNER_DELEGATED_COPY / HOST_VMM_COPY`

  This maps to the existing `Worker._create_worker_chip_region(...)` backend and
  does not add a new native backend, C++ binding, or wire ABI.

  ## Why The Scope Is Deliberately Narrow

  The current work-breakdown conclusion is that production region materialization
  must stay on `VMM_WINDOW + HOST_VMM_COPY` for now. Earlier direct host-map plans
  were rejected by W0/W1 validation: host CPU mappings alone do not prove that
  AICPU can observe host writes through the region device address. As a result,
  direct-map and host-mapped profiles remain planning vocabulary, not production
  materialization paths.

  This PR therefore refuses every shape that would require a materializer we do
  not yet have, including:

  - L4/delegated regions
  - remote endpoints
  - cross-node endpoint pairs
  - direct-map host attachments
  - device-peer consumer attachments
  - AICore providers
  - host providers
  - multi-consumer plans
  - malformed attachment sets, including duplicate attachment members

  Those refusals are intentional. They keep this PR as a stable base for W4/W5
  instead of smuggling W4 sync semantics or W5 delegated transactions into this
  PR.

  ## Region Lifecycle

  The private `RegionInstance` tracks planned, live, closed, rolled-back, and
  cleanup-failed states. Cleanup is routed through the worker's existing ordered
  cleanup/admission model:

  - materialization runs under direct-control admission
  - payload/counter access requires an active orchestration/control context
  - `close()` and `rollback()` share cached terminal cleanup errors
  - failed cleanup poisons further work rather than publishing a false success
  - worker-chip region tracking is retired only after cleanup debts are attempted

  This gives W5 a rollback-capable internal object and gives W4 a single place to
  hang future region-level publish/observe operations.

  ## Non-Goals

  This PR does not:

  - add public `Worker.create_region(...)` or `Orchestrator.create_region(...)`
  - implement delegated L4 region creation
  - implement W5 membership freeze, epoch, commit, or READY barrier semantics
  - implement W4 publish/observe sync APIs
  - add direct host-map materialization
  - add device-peer or remote endpoint materializers
  - change C++ bindings or native wire ABI
  - expose `RegionInstance` as public API

  ## Tests

  - accepted L3 host -> local L2 AICPU materialization
  - explicit refusals for unsupported plans and unsupported attachment shapes
  - remote endpoint and device-peer refusal paths
  - duplicate attachment member refusal
  - payload/counter access requiring a control context
  - close and rollback cleanup reuse
  - rollback failure cached-error replay
  - failed cleanup poisoning
  - cleanup secondary-error preservation
  - tracking retirement under `BaseException`
  - stale/foreign endpoint registry rejection