### PR TITLE
Add: benchmark BGEMM on host build graph

### DIFF
--- a/examples/a2a3/host_build_graph/benchmark_bgemm/README.md
+++ b/examples/a2a3/host_build_graph/benchmark_bgemm/README.md
@@ -1,0 +1,21 @@
+# benchmark_bgemm — host_build_graph
+
+This is the `host_build_graph` counterpart of the
+[`tensormap_and_ringbuffer` benchmark](../../tensormap_and_ringbuffer/benchmark_bgemm/README.md).
+It ports only `Case0`, keeping its parameters, callable signatures, and golden
+unchanged. The orchestration and incore sources remain in the
+`tensormap_and_ringbuffer` example and are referenced here rather than copied,
+so both runtimes exercise the same compute graph.
+
+Run `Case0` in simulation:
+
+```bash
+pytest examples/a2a3/host_build_graph/benchmark_bgemm --platform a2a3sim
+```
+
+Run `Case0` on hardware:
+
+```bash
+pytest examples/a2a3/host_build_graph/benchmark_bgemm \
+  --platform a2a3 --device 0
+```

--- a/examples/a2a3/host_build_graph/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a2a3/host_build_graph/benchmark_bgemm/test_benchmark_bgemm.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Benchmark BGEMM on host_build_graph."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+TMR_EXAMPLE = "../../tensormap_and_ringbuffer/benchmark_bgemm"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestBenchmarkBgemmHostBuildGraph(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_EXAMPLE}/kernels/orchestration/bgemm_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            # C is a zero-initialized accumulator: the AIV add kernel reads C
+            # from GM, adds the matmul result, and stores it back across grid_k
+            # iterations. Its host-provided zeros must be staged H2D, so C is
+            # INOUT (read-before-write), not a pure OUT.
+            "signature": [D.IN, D.IN, D.INOUT, D.IN],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "GEMM",
+                "source": f"{TMR_EXAMPLE}/kernels/aic/kernel_gemm_tile.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "ADD",
+                "source": f"{TMR_EXAMPLE}/kernels/aiv/kernel_tile_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT, D.IN],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case0",
+            "platforms": ["a2a3sim", "a2a3"],
+            "params": {"matmul_add_task_num": 500, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
+        },
+    ]
+
+    def generate_args(self, params):
+        tile_size = params["incore_data_size"]
+        incore_loop = params["incore_loop"]
+        grid_k = params["grid_k"]
+        num_groups = params["matmul_add_task_num"] // grid_k
+        A = torch.randn(num_groups, grid_k, incore_loop, tile_size, tile_size, dtype=torch.float32) * 0.01
+        B = torch.randn(num_groups, grid_k, incore_loop, tile_size, tile_size, dtype=torch.float32) * 0.01
+        C = torch.zeros(incore_loop * num_groups, tile_size, tile_size, dtype=torch.float32)
+        config = torch.tensor([tile_size, grid_k, num_groups, incore_loop], dtype=torch.int64)
+        return TaskArgsBuilder(
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            TensorArg("config", config),
+        )
+
+    def compute_golden(self, args, params):
+        tile_size = params["incore_data_size"]
+        incore_loop = params["incore_loop"]
+        grid_k = params["grid_k"]
+        num_groups = params["matmul_add_task_num"] // grid_k
+        A = args.A.reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+        B = args.B.reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+        C = args.C.reshape(incore_loop * num_groups, tile_size, tile_size)
+        C[:] = 0.0
+        for group in range(num_groups):
+            for k_idx in range(grid_k):
+                for i in range(incore_loop):
+                    C[group * incore_loop + i] += torch.matmul(A[group, k_idx, i], B[group, k_idx, i])
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * BGEMM Orchestration Function (tensormap_and_ringbuffer Runtime)
+ * BGEMM Orchestration Function
  *
  * Builds the task graph for tiled matrix multiplication: C = A @ B
  *


### PR DESCRIPTION
## Summary

- Add the `host_build_graph` counterpart of `benchmark_bgemm::Case0`.
- Keep the original parameters, callable signatures, tolerances, and golden
  implementation unchanged.
- Reference the existing TMR orchestration and incore kernel sources directly,
  so both runtimes exercise the same 500-GEMM + 500-ADD compute graph without
  duplicating kernel code.
- Keep `C` as `INOUT` because it is a zero-initialized read-before-write
  accumulator across `grid_k` iterations.

This is one workload-sized part of #1727. The remaining workloads and the
benchmark tooling/skill changes are intentionally left for separate PRs.

## Performance methodology

Measured on a2a3 hardware through `task-submit`, using one locked NPU 7 at
simpler base revision `0fc77f21`:

- 8 adjacent TMR/HBG batch pairs
- alternating order (`TMR -> HBG`, then `HBG -> TMR`)
- 10 rounds per process
- first round of each process excluded
- 72 steady-state samples per runtime

| Metric | TMR mean / P50 / P95 | HBG mean / P50 / P95 | Mean change |
| --- | ---: | ---: | ---: |
| Host total | 15.007 / 14.537 / 18.618 ms | 24.553 / 23.085 / 33.972 ms | +63.61% |
| Bind | 9.528 / 9.100 / 13.085 ms | 17.115 / 15.601 / 25.857 ms | +79.63% |
| Runner | 1.718 / 1.724 / 1.950 ms | 1.531 / 1.516 / 1.743 ms | -10.90% |
| Validate | 2.944 / 2.945 / 3.051 ms | 5.079 / 4.957 / 5.987 ms | +72.53% |
| Device wall | 1.022 / 0.983 / 1.291 ms | 0.813 / 0.811 / 0.935 ms | -20.44% |

Paired-batch geometric changes (95% confidence interval):

- Device wall: **-20.37%** (`-23.53%` to `-17.07%`). All 8 pairs were
  faster with HBG; individual improvements were 12.43%-24.53%.
- Host total: **+62.36%** (`+42.28%` to `+85.26%`). All 8 pairs were
  slower with HBG; the median paired increase was 58.84%.
- Runner: **-10.96%** (`-14.87%` to `-6.88%`).
- Validate: **+72.19%** (`+61.84%` to `+83.20%`).

The mean host-total delta is +9.545 ms. Its phase attribution is:

- bind: +7.587 ms
- validate: +2.135 ms
- runner: -0.187 ms
- unclassified remainder: approximately +0.011 ms

An HBG info-level attribution run (kept separate because logging perturbs the
benchmark) measured `args_malloc_copy` at 8.8 ms and
`prebuilt_runtime_arena` at 6.3 ms, with `total_init_runtime_impl` at 15.2 ms.
For comparison, steady TMR `bind.prebuilt` was about 0.005 ms. The HBG
prebuilt-runtime arena explains most of the bind increase.

Therefore this migration shows no device-side regression: HBG device wall is
consistently about 20% faster for Case0. Steady host latency is higher, mainly
from bind/runtime-arena preparation and validation. The workload keeps the
same graph instead of masking that runtime cost; future #1727 benchmark tooling
should report host total and device wall as separate guard metrics.

Performance job: `task_20260810_192420_238922620377` (NPU 7, exit 0).

## Testing

- [x] Simulation:
  `python test_benchmark_bgemm.py -p a2a3sim`
- [x] Onboard golden validation through `task-submit` on NPU 4:
  `task_20260810_191738_183514219385` (exit 0)
- [x] Hardware performance comparison through `task-submit` on NPU 7:
  `task_20260810_192420_238922620377` (exit 0)
- [x] All pre-commit hooks for the changed files
