### PR TITLE
Update: enable concurrent A5 prepared runs

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -84,6 +84,8 @@ extern "C" const PipelineContract *get_pipeline_contract(void) {
     return &contract;
 }
 
+extern "C" int concurrent_native_prepare_supported_impl(void) { return 1; }
+
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
     struct timeval tv;
@@ -497,6 +499,33 @@ static PrebuiltRuntimeArenaCacheProbe make_prebuilt_runtime_arena_cache_probe(co
     }
     probe.hash = hash;
     return probe;
+}
+
+static bool resolve_arena_sizing(
+    const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool, ArenaSizingConfig *out
+);
+
+extern "C" int prepared_run_config_compatible_impl(
+    const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+) {
+    if (api == nullptr) return -1;
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) return -1;
+
+    PrebuiltRuntimeArenaCacheProbe probe = make_prebuilt_runtime_arena_cache_probe(sizing);
+    void *gm_heap = nullptr;
+    void *gm_sm = nullptr;
+    void *runtime_arena = nullptr;
+    size_t runtime_offset = 0;
+    const void *image = nullptr;
+    size_t image_size = 0;
+    return api->lookup_prebuilt_runtime_arena_cache(
+               probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), &gm_heap, &gm_sm, &runtime_arena,
+               &runtime_offset, &image, &image_size
+           ) ?
+               1 :
+               0;
 }
 
 // per-(cid,config): resolve the cache-key sizing knobs. Pure host parsing over

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -572,6 +572,34 @@ target_link_libraries(test_trb_runtime_temp_buffer PRIVATE
 add_test(NAME test_trb_runtime_temp_buffer COMMAND test_trb_runtime_temp_buffer)
 set_tests_properties(test_trb_runtime_temp_buffer PROPERTIES LABELS "no_hardware")
 
+add_executable(test_a5_trb_runtime_temp_buffer
+    common/test_trb_runtime_temp_buffer.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/platform_compile_info.cpp
+)
+target_compile_definitions(test_a5_trb_runtime_temp_buffer PRIVATE SIMPLER_PLATFORM_NAME="a5sim")
+target_include_directories(test_a5_trb_runtime_temp_buffer PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/host
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/orchestration
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/runtime
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/common
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_a5_trb_runtime_temp_buffer PRIVATE
+    a5_rt_objs
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_a5_trb_runtime_temp_buffer COMMAND test_a5_trb_runtime_temp_buffer)
+set_tests_properties(test_a5_trb_runtime_temp_buffer PROPERTIES LABELS "no_hardware")
+
 add_executable(test_worker_chip_message_queue
     common/test_worker_chip_message_queue.cpp
     stubs/test_stubs.cpp


### PR DESCRIPTION
## Summary

- Enable concurrent native preparation for the A5 TMR runtime.
- Probe the prebuilt runtime arena cache using resolved task-window, heap, and dependency-pool sizing.
- Permit prepared-run overlap on compatible cache hits while retaining the fenced fallback for misses and errors.
- Build the retained temporary-buffer contract suite against A5.

Relates to #1582