### PR TITLE
Fix: count a pending accept only for a slot that reaches an endpoint

### DIFF
--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -459,11 +459,6 @@ void Orchestrator::decrement_run_tasks(RunId run_id) {
     if (remaining <= 0) finish_run_if_ready(run);
 }
 
-void Orchestrator::increment_run_accepts(RunId run_id, int32_t count) {
-    if (count <= 0) throw std::logic_error("Orchestrator: run acceptance count must be positive");
-    get_run(run_id)->pending_accepts.fetch_add(count, std::memory_order_relaxed);
-}
-
 void Orchestrator::decrement_run_accepts(RunId run_id) {
     auto run = find_run(run_id);
     if (run == nullptr) return;
@@ -830,8 +825,6 @@ SubmitResult Orchestrator::submit_impl(
         }
     }
 
-    increment_run_accepts(run->id, s.group_size());
-
     // --- Step 6: Publication — the one point where the slot leaves BUILDING.
     //
     // fanin_count and the transition out of BUILDING are published together,
@@ -851,6 +844,23 @@ SubmitResult Orchestrator::submit_impl(
                 expected, published, std::memory_order_acq_rel, std::memory_order_acquire
             )) {
             ready_now = satisfied;
+            // Counted here, under the same lock and in the same step that
+            // publishes the slot, because this branch is the only moment at
+            // which the slot is certain to reach an endpoint. mark_task_accepted
+            // is the sole matching decrement, and a slot that fails instead
+            // never reaches one, so counting a failed slot would leave
+            // pending_accepts permanently above zero: the run would still
+            // finish, since acceptance_ready() also accepts a terminal phase,
+            // but the fence would open at completion rather than at acceptance
+            // and serialise the next submission behind the whole run. Counting
+            // after the lock is released would be equally wrong in the other
+            // direction — a published slot is visible to Scheduler::poison_task,
+            // which can claim and fail it before the count lands.
+            //
+            // pending_accepts is incremented directly here; the run pointer is
+            // already resolved, so this avoids taking runs_mu_ while holding
+            // fanout_mu.
+            run->pending_accepts.fetch_add(s.group_size(), std::memory_order_relaxed);
         } else {
             // Only a failure claim moves a BUILDING slot, and it stops there
             // precisely so this thread — the one that knows the wiring is

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -251,7 +251,6 @@ private:
     void clear_run_ready_queues(RunId run_id);
     void compact_if_quiescent();
     void decrement_run_tasks(RunId run_id);
-    void increment_run_accepts(RunId run_id, int32_t count);
     void decrement_run_accepts(RunId run_id);
     static void record_run_error(const std::shared_ptr<RunState> &run, std::exception_ptr error);
     void record_run_error(RunId run_id, std::exception_ptr error);

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -217,6 +217,49 @@ TEST_F(OrchestratorFixture, SubmitAfterFailedProducerPoisonsConsumer) {
     EXPECT_EQ(S(b.task_slot).state.load(), TaskState::CONSUMED);
 }
 
+// A poisoned slot never reaches an endpoint, so nothing ever calls
+// mark_task_accepted for it. Counting it as a pending accept would leave the
+// count permanently above zero and push the acceptance fence out to run
+// completion — the run still finishes, because acceptance_ready() also accepts
+// a terminal phase, so the symptom is a lost overlap rather than a hang. The
+// live sibling here is what makes that observable: its own accept is the only
+// one owing, so the fence must open when it lands, while the run is still live.
+TEST_F(OrchestratorFixture, PoisonedConsumerIsNotCountedAsAPendingAccept) {
+    orch.scope_begin();
+
+    auto args_a = single_tensor_args(0xD00D, TensorArgType::OUTPUT);
+    auto a = orch.submit_next_level(C(42), args_a, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+    ASSERT_EQ(ready, a.task_slot);
+
+    // Submitted before the poison: once a run records an error, submit_next_level
+    // rethrows it rather than admitting anything more, so the live sibling has to
+    // exist first. It owes the only accept the run can still receive.
+    auto live = orch.submit_next_level(C(44), single_tensor_args(0xFEED, TensorArgType::OUTPUT), cfg, 0);
+    TaskSlot live_ready;
+    ASSERT_TRUE(rq.try_pop(live_ready));
+    ASSERT_EQ(live_ready, live.task_slot);
+
+    TaskSlotState &producer = S(a.task_slot);
+    producer.failure_message = "producer failed";
+    producer.state.store(TaskState::FAILED, std::memory_order_release);
+    producer.fanout_released.store(1, std::memory_order_release);
+
+    auto args_b = single_tensor_args(0xD00D, TensorArgType::INPUT);
+    auto poisoned = orch.submit_next_level(C(43), args_b, cfg, 0);
+    ASSERT_EQ(S(poisoned.task_slot).state.load(), TaskState::FAILED);
+
+    orch.close_run_submission(run_id);
+    EXPECT_FALSE(orch.run_accepted(run_id)) << "the live task has not been accepted yet";
+
+    orch.mark_task_accepted(a.task_slot);
+    orch.mark_task_accepted(live.task_slot);
+    EXPECT_TRUE(orch.run_accepted(run_id)) << "the poisoned slot is still owing an accept it can never receive";
+
+    orch.scope_end();
+}
+
 TEST_F(OrchestratorFixture, TensorMapTracksProducer) {
     auto args_a = single_tensor_args(0x1234, TensorArgType::OUTPUT);
     auto a = orch.submit_next_level(C(42), args_a, cfg, 0);


### PR DESCRIPTION
## Summary

`Orchestrator::submit_task` raised the run's accept count **before** deciding whether the slot was poisoned by a failed producer. A poisoned slot is marked failed and consumed without ever being dispatched, so `mark_task_accepted` — the sole matching decrement (`orchestrator.cpp:517`) — is never called for it. `pending_accepts` then stays above zero for the rest of the run.

**The run still finishes.** `acceptance_ready()` is `submission_closed && (pending == 0 || is_terminal(phase))`, so the terminal disjunct eventually satisfies it. What is lost is *when* the fence opens.

**Why that matters more now than when #1556 was filed.** The fence opens at completion instead of at acceptance, and `Worker.submit()` waits on the prior handle's acceptance before building the next graph. So one poisoned producer silently serialises the next submission behind the entire run — removing exactly the overlap the acceptance fence exists to provide. #1556 was filed on 2026-07-29, before W1b/W1c; the direct-chip pipeline that landed since is built on that same overlap, so the cost is now higher than the issue describes.

Fixes #1556.

## The change

Move the increment past the poisoned branch, so only a slot certain to reach an endpoint owes an accept. Nothing else moves.

Two things I checked before trusting that:

- **No other exit sits between the old and new positions.** The only `return` in between is the poisoned one — the path that must skip the count. (The `catch` at `:820` is upstream of both.)
- **The increment does not need `run->completion_mu`,** unlike `decrement_run_accepts`, which takes it specifically so a decrement cannot land between a waiter's predicate check and its block. `acceptance_ready()` requires `submission_closed`, which cannot be true while `submit_task` is still admitting into that run — so there is no waiter to race.

## Testing

The regression test asserts the fence opens **while the run is still live**, with a healthy sibling owing the only accept that can still arrive.

**Verified it fails against the previous ordering**, not just that it passes now — I reverted the fix, rebuilt, and got exactly the assertion this bug predicts:

```
test_orchestrator.cpp:258: Failure
Value of: orch.run_accepted(run_id)
  Actual: false
Expected: true
the poisoned slot is still owing an accept it can never receive
```

One non-obvious constraint the test had to respect: the sibling must be submitted **before** the producer is failed, because a run that has recorded an error rethrows it from the next `submit_next_level` (`orchestrator.cpp:706`) rather than admitting anything more. My first draft submitted it after and died with `C++ exception with description "producer failed"`.

| Suite | Result |
|---|---|
| C++ UT (`ctest -LE requires_hardware`) | **92/92** |
| Python UT | **1311 passed** / 13 skipped |
| a2a3 onboard sweep (`task-submit`, device lock held) | **56 passed** + 24 passed / 2 skipped, **0 failures** |

The onboard sweep is included because this changes the orchestrator's admission path, which every dispatched task crosses.
