### PR TITLE
Fix: report staged blocks for sync-start drain

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -674,10 +674,13 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
 //      (running_slot_count) for a gated drain, and reopens the gate
 //      (a release-store the followers acquire, so the seed is visible before any
 //      completion promotes a pending block). Followers spin until the gate reopens.
-void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] uint64_t *out_stage_wall_cycles) {
+void SchedulerContext::handle_drain_mode(
+    int32_t thread_idx, [[maybe_unused]] uint64_t *out_stage_wall_cycles, [[maybe_unused]] int32_t *out_staged_blocks
+) {
 #if SIMPLER_DFX
     bool drain_prof = (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES && out_stage_wall_cycles != nullptr);
     uint64_t drain_acked_ts = 0;  // set immediately before staging; used to measure the stage wall
+    if (out_staged_blocks != nullptr) *out_staged_blocks = 0;
 #endif
     // Every spin in this function honors is_completed(): once the run latches
     // completed_ (all tasks done, or a fatal error raised elsewhere), peers leave
@@ -763,6 +766,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // out param carries the PURE stage_sync_start_cores wall (build_payload + MMIO publish of
     // this thread's cores), isolating it from availability + stage_go handshake.
     if (drain_prof && drain_acked_ts != 0) *out_stage_wall_cycles = get_sys_cnt_aicpu() - drain_acked_ts;
+    if (out_staged_blocks != nullptr) *out_staged_blocks = staged.staged_blocks;
 #endif
     drain_state_.drain_running_staged.fetch_add(staged.running_cores, std::memory_order_acq_rel);
     drain_state_.drain_stage_done_mask.fetch_or(1u << thread_idx, std::memory_order_release);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -467,7 +467,9 @@ private:
     // out_stage_wall_cycles (profiling only): cycles this thread spent in stage_sync_start_cores
     // (prepare + publish), set ONLY on threads that actually staged. Lets the caller isolate
     // the pure stage wall from the ack-barrier + finalize spans in the Drain bar.
-    void handle_drain_mode(int32_t thread_idx, uint64_t *out_stage_wall_cycles = nullptr);
+    void handle_drain_mode(
+        int32_t thread_idx, uint64_t *out_stage_wall_cycles = nullptr, int32_t *out_staged_blocks = nullptr
+    );
 
     // =========================================================================
     // Cold path: exit checks, stall diagnostics, profiling (scheduler_cold_path.cpp)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1160,7 +1160,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             // iteration that enters the drain; retries appear as multiple bars).
             uint64_t drain_t0 = (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
             uint64_t drain_stage_wall = 0;  // set by handle_drain_mode ONLY if this thread staged
-            handle_drain_mode(thread_idx, &drain_stage_wall);
+            int32_t drain_staged_blocks = 0;
+            handle_drain_mode(thread_idx, &drain_stage_wall, &drain_staged_blocks);
             // Record a Drain bar only when this thread actually did drain work (reached
             // stage_sync_start_cores). The many no-op entries — ack + availability-insufficient
             // reset or follower bail before stage_go — never stage, so they
@@ -1168,7 +1169,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES && drain_stage_wall != 0) {
                 chip_swimlane_aicpu_record_sched_phase(
                     thread_idx, ChipSwimlaneSchedPhaseKind::Drain, drain_t0, get_sys_cnt_aicpu(),
-                    chip_swimlane.sched_loop_count, static_cast<uint32_t>(drain_stage_wall)
+                    chip_swimlane.sched_loop_count, static_cast<uint32_t>(drain_staged_blocks)
                 );
             }
 #else

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_drain_phases.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_sync_start_drain_phases.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Positive coverage for A2/A3 global sync-start drain phase records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.tools.swimlane_converter import read_perf_data
+
+FLOATS_PER_CACHE_LINE = 16
+NUM_TASKS = 4
+MAX_AIV = 48
+MAX_TOTAL_CL = MAX_AIV // 12 + MAX_AIV // 3 + MAX_AIV // 12 + MAX_AIV // 2
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestSyncStartDrainPhases(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "../../spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SPMD_WRITE_AIV",
+                "source": "../../spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [{"name": "global_aiv", "platforms": ["a2a3sim", "a2a3"], "params": {}}]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(2 * NUM_TASKS, dtype=torch.int32)),
+        )
+
+    def compute_golden(self, args, params):
+        pass
+
+    def _build_config(self, config_dict, *args, **kwargs):
+        config = super()._build_config(config_dict, *args, **kwargs)
+        self._trace_perf_level = int(kwargs.get("enable_chip_swimlane", args[0] if args else 0))
+        output_prefix = kwargs.get("output_prefix", "")
+        self._trace_perf_path = Path(output_prefix) / "chip_swimlane_records.json" if output_prefix else None
+        return config
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        layout = [int(value) for value in test_args.layout]
+        expected = torch.zeros(MAX_TOTAL_CL, dtype=torch.float32)
+        for task_idx in range(NUM_TASKS):
+            block_num, base_cl = layout[2 * task_idx], layout[2 * task_idx + 1]
+            assert block_num >= 1, f"task {task_idx} reported block_num {block_num}"
+            for block_idx in range(block_num):
+                expected[base_cl + block_idx] = float(block_idx)
+        actual = test_args.output.reshape(MAX_TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        assert torch.equal(actual, expected), f"output disagrees with reported layout {layout}"
+
+        if getattr(self, "_trace_perf_level", 0) < 3:
+            return
+        perf_path = self._trace_perf_path
+        assert perf_path is not None and perf_path.exists(), "chip swimlane scheduler capture is missing"
+        perf = read_perf_data(perf_path)
+        phase_records = [record for thread in perf.get("aicpu_scheduler_phases", []) for record in thread]
+        sync_start_blocks = layout[0] + layout[2] + layout[2 * (NUM_TASKS - 1)]
+        phase_work = {}
+        for phase in ("drain", "drain_prepare", "drain_publish"):
+            records = [record for record in phase_records if record.get("phase") == phase]
+            phase_work[phase] = sum(int(record.get("tasks_processed", 0)) for record in records)
+            assert 0 < phase_work[phase] <= sync_start_blocks, (
+                f"{phase} reported {phase_work[phase]} blocks/subtasks for {sync_start_blocks} sync-start blocks; "
+                f"artifact={perf_path}"
+            )
+        assert len(set(phase_work.values())) == 1, f"drain phase workloads disagree: {phase_work}; artifact={perf_path}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

- Return the actual staged-block count from the A2/A3 global sync-start drain path.
- Record staged blocks as Drain phase work instead of casting wall-clock cycles to tasks_processed.
- Add a scene test that checks Drain, DrainPrepare, and DrainPublish report consistent work counts.

## Behavior

This changes chip-swimlane telemetry only. Sync-start scheduling and dispatch order are unchanged.

## Testing

- Repository commit hooks passed.
- The same code and scene test were covered by the original #1774 CI run; tests were not rerun after the mechanical extraction.

Relates to #1582