### PR TITLE
Give ImportContext's capability rejections the domain-scoped vocabulary

### DIFF
--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -42,6 +42,8 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     read_args_from_blob,
 )
 
+from .comm_endpoints import RegionAccessReasonCode
+
 __all__ = [
     "AccessMode",
     "AddressSpace",
@@ -545,6 +547,17 @@ class ImportContext:
     the endpoint x address_space matrix is enforced at submit time by the
     ``(target_worker_id, ptr)`` check in ``orchestrator.py``; this is a backstop for a path that
     reaches ``materialize`` without going through it, not a replacement for that check.
+
+    ``materialize()``'s DEVICE-backing rejections are tagged with
+    ``RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION`` (``comm_endpoints.py``) — the same
+    reason code the domain-scoped ``EndpointRegistry``/``RegionAccessService`` capability engine
+    reports for the same question at region-planning time. The two mechanisms share only this
+    rejection vocabulary, not a live registry object: this context is built inside forked child
+    processes (and at L2's same-process lazy-materialize point), both of which run before
+    ``EndpointRegistry.from_snapshot()``'s ``_require_ready_for_region_planning()`` precondition
+    can be assumed to hold. ``EndpointRegistry``'s topology snapshot also carries no per-chip
+    identity (only per-Worker), so it could not close this class's own Worker-grained-not-chip-
+    grained limit even where it is reachable.
     """
 
     is_host_endpoint: bool
@@ -605,11 +618,13 @@ class ImportRegistry:
         if desc.address_space == AddressSpace.DEVICE:
             if self._context is None or self._context.is_host_endpoint:
                 raise ValueError(
-                    f"ImportRegistry: refusing to materialize a DEVICE backing ({desc.identity}) on a host endpoint"
+                    f"ImportRegistry: [{RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION.value}] "
+                    f"refusing to materialize a DEVICE backing ({desc.identity}) on a host endpoint"
                 )
             if bytes(desc.identity.owner_instance_id) != self._context.owning_chip_instance_id:
                 raise ValueError(
-                    f"ImportRegistry: refusing to materialize a DEVICE backing ({desc.identity}) "
+                    f"ImportRegistry: [{RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION.value}] "
+                    f"refusing to materialize a DEVICE backing ({desc.identity}) "
                     f"minted for a different chip's owner"
                 )
         if desc.backend_kind in (

--- a/tests/ut/py/test_worker/test_endpoint_capability.py
+++ b/tests/ut/py/test_worker/test_endpoint_capability.py
@@ -14,6 +14,7 @@ the argument; the materialization check behind it covers any future submit path 
 """
 
 import ctypes
+import re
 
 import pytest
 from simpler.buffer import (
@@ -24,6 +25,7 @@ from simpler.buffer import (
     mint_owner_instance_id,
     wrap_device_malloc,
 )
+from simpler.comm_endpoints import RegionAccessReasonCode
 from simpler.task_interface import DataType, TaskArgs, TensorArgType
 from simpler.worker import Worker
 
@@ -116,3 +118,20 @@ def test_chip_materialization_refuses_a_foreign_chips_device_tensor():
     reg = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=foreign_chip_owner))
     with pytest.raises(ValueError, match="different chip's owner"):
         reg.materialize(dev.to_descriptor())
+
+
+def test_device_backing_rejections_carry_the_endpoint_relation_reason_code():
+    # Both materialize() rejections above are instances of the same capability-judgment question
+    # the domain-scoped EndpointRegistry/RegionAccessService engine answers with
+    # RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION -- pinned here so the two mechanisms'
+    # rejection vocabulary stays in sync rather than drifting back into two freeform strings.
+    dev = _device_handle()
+
+    host_reg = ImportRegistry(ImportContext(is_host_endpoint=True))
+    with pytest.raises(ValueError, match=re.escape(RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION.value)):
+        host_reg.materialize(dev.to_descriptor())
+
+    foreign_chip_owner = mint_owner_instance_id()
+    chip_reg = ImportRegistry(ImportContext(is_host_endpoint=False, owning_chip_instance_id=foreign_chip_owner))
+    with pytest.raises(ValueError, match=re.escape(RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION.value)):
+        chip_reg.materialize(dev.to_descriptor())


### PR DESCRIPTION
## Summary

- `ImportContext`/`ImportRegistry.materialize()` (P1-B's worker-tree capability check) and `EndpointRegistry`/`RegionAccessService` (#1696's domain-scoped capability engine) are two independent implementations of "can this endpoint reach this backing" — flagged repeatedly in `.docs` as a naming gap, most recently in the P1-B closure audit (2026-08-11).
- Investigated two ways to actually unify them and ruled both out (recorded on `ImportContext` itself so they don't get re-proposed):
  - Routing `ImportContext`'s construction through the live `EndpointRegistry` object doesn't work across the fork boundary — `ImportContext` is built inside forked child processes or at L2's same-process point, both of which predate `EndpointRegistry`'s `_require_ready_for_region_planning()` precondition.
  - Swapping `is_host_endpoint: bool` for the domain-scoped `EndpointDeployment` enum (HOST_CPU/DEVICE_AICORE/DEVICE_AICPU) doesn't map onto the chip-fork model — one forked chip process covers both AICore and AICPU roles, and the topology snapshot doesn't track per-chip identity anyway, so the enum wouldn't even close `ImportContext`'s known Worker-grained-not-chip-grained limit.
- What both mechanisms *can* share safely: the vocabulary for *why* a capability check failed. `comm_endpoints.py`'s `RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION` already names this question. Both of `materialize()`'s DEVICE-backing rejections now carry it, prose unchanged so existing `match=` patterns keep matching.
- No behavior change: same accept/reject logic, only the error-message text (built only on the already-failing path) changed.

## Testing

- New test pins the reason code in both rejection messages — verified against the pre-fix code first (reverted, confirmed it fails on the plain message, restored, confirmed it passes).
- Two pre-existing tests pass unmodified, confirming the change is additive.
- pyut: 1319 passed / 13 skipped / 0 failed
- ruff check/format, pyright: clean
- Checked `buffer.py` → `comm_endpoints.py` for import cycles: none (`comm_endpoints.py` only imports from `_task_interface`)
