### PR TITLE
Fix: Flaky C++ test causes intermittent CI fails -- this PR fixes it

### DIFF
--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -3117,6 +3117,17 @@ TEST_F(GroupSchedulerFixture, GroupPublishedBetweenGroupAndSinglePhasesStillOwns
     std::promise<void> publication_done;
     std::future<void> publication_future = publication_done.get_future();
     after_group_phase_hook = [&] {
+        // The scheduler runs a group phase every dispatch pass, including an
+        // empty one it may reach before this thread's first_group submission is
+        // visible. Publishing then would place second_group while cores 0/1 are
+        // still idle, so it would dispatch to them instead of blocking behind
+        // first_group. Fire only once first_group has claimed its targets — the
+        // scheduler occupies each worker's active lane synchronously during that
+        // dispatch, so idle() here reflects it on this same thread.
+        if (manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 0)->idle() ||
+            manager.get_worker_by_id(WorkerType::NEXT_LEVEL, 1)->idle()) {
+            return;
+        }
         if (published.exchange(true, std::memory_order_acq_rel)) return;
         second_group = orch.submit_next_level_group(
             C(91), {single_tensor_args(0x202, TensorArgType::OUTPUT), single_tensor_args(0x203, TensorArgType::OUTPUT)},


### PR DESCRIPTION
# Human Summary

There is a CI test that causes random fails with a pre-existing bug. This fixes it.

# AI Summary

Fixes a flaky C++ unit test, `GroupSchedulerFixture.GroupPublishedBetweenGroupAndSinglePhasesStillOwnsItsTargets` (`tests/ut/cpp/hierarchical/test_scheduler.cpp`), that intermittently reddens the `ut` job on unrelated PRs.

The test arms a one-shot `after_group_phase_hook` **before** submitting `first_group`, assuming the first group phase the hook observes is `first_group`'s. But the scheduler runs a group phase on **every** dispatch pass and can reach an empty one before this thread's `submit(first_group)` becomes visible. The hook then publishes `second_group{1,2}` while cores 0 and 1 are still idle, so `second_group` dispatches straight to them instead of blocking behind `first_group` — `worker_c` receives `second_group` (`dispatched_count() == 1`, expected 0) and `worker_a` is starved (expected 2, gets 0). A diagnostic on a failing run confirms it: `worker_c` and `worker_b` both receive callable 91 (`second_group`) and `worker_a` receives nothing.

The scheduler itself is correct — it dispatched ready work to idle workers. Only the test's timing assumption was unsound.

## Fix

Gate the hook so it fires only once `first_group` has claimed its targets (workers 0 and 1 both non-idle). The scheduler occupies each worker's active lane synchronously while dispatching, and the hook runs on that same scheduler thread, so `idle()` observed there reflects the dispatch without a cross-thread race.

## Testing

- Previously-flaky test: **0 failures across 1000 runs** under `--gtest_shuffle` + `MALLOC_PERTURB_=165` (was ~15% under shuffle, ~1% under perturb before the fix).
- Full C++ ut suite: **93/93 pass**, plain and under `MALLOC_PERTURB_=165`.

```bash
cmake -B tests/ut/cpp/build -S tests/ut/cpp && cmake --build tests/ut/cpp/build
MALLOC_PERTURB_=165 tests/ut/cpp/build/test_scheduler \
  --gtest_filter='GroupSchedulerFixture.GroupPublishedBetweenGroupAndSinglePhasesStillOwnsItsTargets' \
  --gtest_repeat=300 --gtest_shuffle
```
