### PR TITLE
Add: benchmark paged attention unroll on host build graph

### DIFF
--- a/tests/st/a2a3/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Paged attention unroll benchmark for the host-build-graph runtime."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
+from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
+
+TMR_CASE = "../../tensormap_and_ringbuffer/paged_attention_unroll"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/paged_attention_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "QK",
+                "source": f"{TMR_CASE}/kernels/aic/aic_qk_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SF",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_softmax_prepare.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT, D.OUT, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "name": "PV",
+                "source": f"{TMR_CASE}/kernels/aic/aic_pv_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 3,
+                "name": "UP",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_online_update.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.INOUT, D.INOUT],
+            },
+        ],
+    }
+
+    # The shared head_dim=256 kernels fail golden on both runtimes, so Case3
+    # is not a valid cross-runtime benchmark.
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a2a3"],
+            "params": {
+                "batch": 256,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+    ]
+
+    def generate_args(self, params):
+        result = _pa_generate_inputs(params)
+        specs = []
+        for name, value in result:
+            if isinstance(value, torch.Tensor):
+                specs.append(TensorArg(name, value))
+            else:
+                specs.append(Scalar(name, value))
+        return TaskArgsBuilder(*specs)
+
+    def compute_golden(self, args, params):
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
+        _pa_compute_golden(tensors, params)
+        for s in args.specs:
+            if isinstance(s, TensorArg) and s.name in tensors:
+                getattr(args, s.name)[:] = tensors[s.name]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

- Add the `host_build_graph` counterpart of `paged_attention_unroll` Case1 and Case2.
- Keep the TMR parameters, callable signatures, tolerances, argument generation, and golden unchanged.
- Reuse the existing TMR orchestration and incore kernel sources directly so both runtimes execute the same graph.
- Leave Case3 out because its shared `head_dim=256` kernels fail golden on both runtimes.

This is one workload-sized part of #1727.

## Performance

Measured on one locked a2a3 NPU through `task-submit`: eight adjacent TMR/HBG pairs, alternating order, ten rounds per process and case, with each case's first round excluded (72 steady samples per runtime/case).

| Case | Host total: TMR -> HBG | Change | Device wall: TMR -> HBG | Change |
| --- | ---: | ---: | ---: | ---: |
| Case1 | 54.237 -> 73.281 ms | +35.11% | 1.386 -> 1.268 ms | **-8.54%** |
| Case2 | 18.206 -> 32.775 ms | +80.03% | 0.766 -> 0.670 ms | **-12.62%** |

Paired device-wall changes (95% CI): Case1 `-8.53%` (`-10.50%` to `-6.51%`); Case2 `-12.55%` (`-16.01%` to `-8.96%`). HBG is consistently faster on device; the measured host increase is in bind and validation.

These measurements used simpler base `7a1b9b11` and PTO-ISA pin `0cefc9a5a1c24c62655cc345d408559595a8af32`. Main later merged #1763, which removes redundant HBG arena initialization and explicitly leaves device time unchanged; the device comparison remains representative, while the host/bind values above are conservative pre-#1763 measurements.

Performance job: `task_20260811_003357_606081246` (NPU 3, exit 0).

## Testing

- [x] HBG Case1 and Case2 onboard golden: `task_20260811_003020_385776328006`
- [x] Eight-pair onboard performance comparison
- [x] All pre-commit hooks for the changed file
