### PR TITLE
Add: test alternating matmul-add on host build graph

### DIFF
--- a/tests/st/a2a3/host_build_graph/alternating_matmul_add/test_alternating_matmul_add.py
+++ b/tests/st/a2a3/host_build_graph/alternating_matmul_add/test_alternating_matmul_add.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Alternating matmul + add on host_build_graph.
+
+Tests interleaved AIC matmul and AIV add execution with scalar parameters and
+batched task submission.
+"""
+
+import ctypes
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+TMR_CASE = "../../tensormap_and_ringbuffer/alternating_matmul_add"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestAlternatingMatmulAddHostBuildGraph(SceneTestCase):
+    """Alternating matmul + add with scalar parameters."""
+
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/alternating_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{TMR_CASE}/kernels/aic/kernel_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{TMR_CASE}/kernels/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a2a3"],
+            "params": {"batch": 1, "M": 1, "N": 1, "matmul_batch": 1, "add_batch": 1},
+        },
+        {
+            "name": "Case1",
+            "platforms": ["a2a3"],
+            "params": {"batch": 500, "M": 4, "N": 4, "matmul_batch": 4, "add_batch": 4},
+            "manual": True,
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a2a3"],
+            "params": {"batch": 512, "M": 2, "N": 5, "matmul_batch": 4, "add_batch": 5},
+            "manual": True,
+        },
+    ]
+
+    def generate_args(self, params):
+        batch = params["batch"]
+        M = params["M"]
+        N = params["N"]
+        matmul_batch = params.get("matmul_batch", 1)
+        add_batch = params.get("add_batch", 1)
+        matmul_size = 128
+        add_rows = 128
+        add_cols = 128
+
+        torch.manual_seed(42)
+        A = torch.randn(batch, M, matmul_size, matmul_size, dtype=torch.float32) * 0.01
+        B = torch.randn(batch, M, matmul_size, matmul_size, dtype=torch.float32) * 0.01
+        C = torch.zeros(batch, M, matmul_size, matmul_size, dtype=torch.float32)
+        X = torch.randn(batch, N, add_rows, add_cols, dtype=torch.float32) * 0.01
+        Y = torch.randn(batch, N, add_rows, add_cols, dtype=torch.float32) * 0.01
+        Z = torch.zeros(batch, N, add_rows, add_cols, dtype=torch.float32)
+
+        return TaskArgsBuilder(
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            TensorArg("X", X.flatten()),
+            TensorArg("Y", Y.flatten()),
+            TensorArg("Z", Z.flatten()),
+            Scalar("batch", ctypes.c_int64(batch)),
+            Scalar("M_val", ctypes.c_int64(M)),
+            Scalar("N_val", ctypes.c_int64(N)),
+            Scalar("matmul_batch", ctypes.c_int64(matmul_batch)),
+            Scalar("add_batch", ctypes.c_int64(add_batch)),
+        )
+
+    def compute_golden(self, args, params):
+        batch = params["batch"]
+        M = params["M"]
+        N = params["N"]
+        matmul_size = 128
+        add_rows = 128
+        add_cols = 128
+
+        A = args.A.reshape(batch, M, matmul_size, matmul_size)
+        B = args.B.reshape(batch, M, matmul_size, matmul_size)
+        C = args.C.reshape(batch, M, matmul_size, matmul_size)
+        X = args.X.reshape(batch, N, add_rows, add_cols)
+        Y = args.Y.reshape(batch, N, add_rows, add_cols)
+        Z = args.Z.reshape(batch, N, add_rows, add_cols)
+
+        for b in range(batch):
+            for m in range(M):
+                C[b, m] = torch.matmul(A[b, m], B[b, m])
+        for b in range(batch):
+            for n in range(N):
+                Z[b, n] = X[b, n] + Y[b, n]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Alternating Matmul-Add Orchestration Function (tensormap_and_ringbuffer Runtime)
+ * Alternating Matmul-Add Orchestration Function
  *
  * Submits independent matmul and add tasks per batch.
  *


### PR DESCRIPTION
## Summary

- Add the `host_build_graph` counterpart of all three `alternating_matmul_add` cases.
- Keep the TMR parameters, callable signatures, tolerances, argument generation, and golden unchanged.
- Reuse the existing TMR orchestration and incore kernel sources directly so both runtimes execute the same graph.
- Remove the runtime-specific wording from the shared orchestration header.

This is one workload-sized part of #1727.

## Performance

Measured on one locked a2a3 NPU through `task-submit`: eight adjacent TMR/HBG pairs, alternating order, ten rounds per process and case, with each case's first round excluded (72 steady samples per runtime/case).

| Case | Host total: TMR -> HBG | Change | Device wall: TMR -> HBG | Change |
| --- | ---: | ---: | ---: | ---: |
| default | 1.248 -> 2.876 ms | +130.46% | 0.052 -> 0.108 ms | +106.17% |
| Case1 | 32.937 -> 42.572 ms | +29.25% | 0.988 -> 0.927 ms | **-6.13%** |
| Case2 | 29.494 -> 38.885 ms | +31.84% | 0.820 -> 0.784 ms | **-4.36%** |

The production-sized cases improve on device. The one-matmul/one-add `default` case is too small to amortize HBG's fixed graph-build cost and regresses as expected. Case1's paired device change is `-6.07%` (95% CI `-9.61%` to `-2.39%`); Case2 is `-4.25%` (`-10.19%` to `+2.09%`).

These measurements used simpler base `7b3a9754` and PTO-ISA pin `0cefc9a5a1c24c62655cc345d408559595a8af32`. Main later merged #1763, which removes redundant HBG arena initialization and explicitly leaves device time unchanged; the device comparison remains representative, while the host/bind values above are conservative pre-#1763 measurements.

Performance job: `task_20260811_004737_99227219015` (NPU 3, exit 0).

## Testing

- [x] HBG default, Case1, and Case2 onboard golden: `task_20260811_004643_94395715733`
- [x] Eight-pair onboard performance comparison
- [x] All pre-commit hooks for the changed files
