### PR TITLE
Add: benchmark manual-scope paged attention on host build graph

### DIFF
--- a/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Paged attention unroll manual-scope wrapper for A2A3 tensormap_and_ringbuffer."""
+"""Paged attention unroll manual-scope benchmark for host_build_graph."""
 
 import torch
 from simpler.task_interface import ArgDirection as D
@@ -16,15 +16,17 @@ from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, sce
 from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
 from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
 
+TMR_CASE = "../../tensormap_and_ringbuffer/paged_attention_unroll_manual_scope"
 
-@scene_test(level=2, runtime="tensormap_and_ringbuffer")
-class TestPagedAttentionUnrollManualScope(SceneTestCase):
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestPagedAttentionUnrollManualScopeHostBuildGraph(SceneTestCase):
     RTOL = 1e-3
     ATOL = 1e-3
 
     CALLABLE = {
         "orchestration": {
-            "source": "kernels/orchestration/paged_attention_orch.cpp",
+            "source": f"{TMR_CASE}/kernels/orchestration/paged_attention_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
             "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
         },
@@ -32,34 +34,36 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
             {
                 "func_id": 0,
                 "name": "QK",
-                "source": "kernels/aic/aic_qk_matmul.cpp",
+                "source": f"{TMR_CASE}/kernels/aic/aic_qk_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 1,
                 "name": "SF",
-                "source": "kernels/aiv/aiv_softmax_prepare.cpp",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_softmax_prepare.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 2,
                 "name": "PV",
-                "source": "kernels/aic/aic_pv_matmul.cpp",
+                "source": f"{TMR_CASE}/kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 3,
                 "name": "UP",
-                "source": "kernels/aiv/aiv_online_update.cpp",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_online_update.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.INOUT, D.INOUT],
             },
         ],
     }
 
+    # The shared head_dim=256 kernels fail golden on both runtimes, so Case3
+    # is not a valid cross-runtime benchmark.
     CASES = [
         {
             "name": "Case1",
@@ -90,31 +94,16 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
                 "dtype": "bfloat16",
             },
         },
-        {
-            "name": "Case3",
-            "platforms": ["a2a3"],
-            "manual": True,
-            "params": {
-                "batch": 64,
-                "num_heads": 64,
-                "kv_head_num": 1,
-                "head_dim": 256,
-                "block_size": 64,
-                "context_len": 8192,
-                "max_model_len": 32768,
-                "dtype": "bfloat16",
-            },
-        },
     ]
 
     def generate_args(self, params):
-        inputs = _pa_generate_inputs(params)
+        result = _pa_generate_inputs(params)
         specs = []
-        for name, val in inputs:
-            if isinstance(val, torch.Tensor):
-                specs.append(TensorArg(name, val))
+        for name, value in result:
+            if isinstance(value, torch.Tensor):
+                specs.append(TensorArg(name, value))
             else:
-                specs.append(Scalar(name, val))
+                specs.append(Scalar(name, value))
         return TaskArgsBuilder(*specs)
 
     def compute_golden(self, args, params):


### PR DESCRIPTION
## Summary

- Add the `host_build_graph` counterpart of `paged_attention_unroll_manual_scope` Case1 and Case2.
- Keep the TMR parameters, tolerances, argument generation, golden, and compute graph unchanged while reusing its orchestration and incore sources.
- Complete the QK and PV callable signatures in both wrappers with the `block_table` input they actually consume.
- Leave Case3 out because its shared `head_dim=256` kernels fail golden on both runtimes.

This is one workload-sized part of #1727.

## Performance

Measured on one locked a2a3 NPU through `task-submit`: eight adjacent TMR/HBG pairs, alternating order, ten rounds per process and case, with each case's first round excluded (72 steady samples per runtime/case).

| Case | Host total: TMR -> HBG | Change | Device wall: TMR -> HBG | Change |
| --- | ---: | ---: | ---: | ---: |
| Case1 | 28.921 -> 44.572 ms | +54.11% | 1.334 -> 1.266 ms | **-5.11%** |
| Case2 | 10.645 -> 16.529 ms | +55.27% | 0.716 -> 0.666 ms | **-6.95%** |

Paired device-wall changes (95% CI): Case1 `-5.08%` (`-7.71%` to `-2.39%`); Case2 `-6.94%` (`-8.96%` to `-4.88%`). HBG is consistently faster on device; the measured host increase is in bind and validation, while runner time is unchanged within noise.

These measurements used simpler base `7b3a9754` and PTO-ISA pin `0cefc9a5a1c24c62655cc345d408559595a8af32`. Main later merged #1763, which removes redundant HBG arena initialization and explicitly leaves device time unchanged; the device comparison remains representative, while the host/bind values above are conservative pre-#1763 measurements.

Performance job: `task_20260811_005307_2205262883` (NPU 3, exit 0).

## Testing

- [x] HBG and TMR Case1/Case2 onboard golden: `task_20260811_004958_11579646241`
- [x] Case3 diagnosis on both runtimes: `task_20260811_005131_18023031684` (both reproduce the existing golden failure)
- [x] Eight-pair onboard performance comparison
- [x] All pre-commit hooks for the changed files
