### PR TITLE
Add: benchmark batch paged attention on host build graph

### DIFF
--- a/tests/st/a2a3/host_build_graph/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/batch_paged_attention/test_batch_paged_attention.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Batch paged attention benchmark for the host-build-graph runtime."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
+from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
+
+TMR_CASE = "../../tensormap_and_ringbuffer/batch_paged_attention"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestBatchPagedAttentionHostBuildGraph(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/paged_attention_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "QK",
+                "source": f"{TMR_CASE}/kernels/aic/aic_qk_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SF",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_softmax_prepare.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT, D.OUT, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "name": "PV",
+                "source": f"{TMR_CASE}/kernels/aic/aic_pv_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 3,
+                "name": "UP",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_online_update.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.INOUT, D.INOUT],
+            },
+        ],
+    }
+
+    # The shared head_dim=256 kernels fail golden on both runtimes, so Case3
+    # is not a valid cross-runtime benchmark.
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a2a3"],
+            # The complete graph's task outputs exceed the default 256 MiB heap.
+            "config": {"runtime_env": {"ring_heap": 512 * 1024 * 1024}},
+            "params": {
+                "batch": 256,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "config": {"runtime_env": {"ring_heap": 512 * 1024 * 1024}},
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "CaseSmall1",
+            "platforms": ["a2a3sim", "a2a3"],
+            "params": {
+                "batch": 1,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 16,
+                "block_size": 16,
+                "context_len": 33,
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "CaseSmall2",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 1,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 16,
+                "block_size": 16,
+                "context_len": 31,
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "CaseSmall3",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 1,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 16,
+                "block_size": 16,
+                "context_len": 128,
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "CaseVarSeq2",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 2,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 16,
+                "block_size": 16,
+                "context_len": 33,
+                "context_lens_list": [33, 17],
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "CaseVarSeq4",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 4,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 16,
+                "block_size": 16,
+                "context_len": 128,
+                "context_lens_list": [33, 64, 128, 15],
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        },
+    ]
+
+    def generate_args(self, params):
+        result = _pa_generate_inputs(params)
+        specs = []
+        for name, value in result:
+            if isinstance(value, torch.Tensor):
+                specs.append(TensorArg(name, value))
+            else:
+                specs.append(Scalar(name, value))
+        return TaskArgsBuilder(*specs)
+
+    def compute_golden(self, args, params):
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
+        _pa_compute_golden(tensors, params)
+        for s in args.specs:
+            if isinstance(s, TensorArg) and s.name in tensors:
+                getattr(args, s.name)[:] = tensors[s.name]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

- Add the `host_build_graph` counterpart of the seven golden-valid `batch_paged_attention` cases.
- Keep the TMR parameters, callable signatures, tolerances, argument generation, and shared golden unchanged.
- Reuse the existing TMR orchestration and incore kernel sources directly so both runtimes execute the same graph.
- Give the production-scale Case1 and Case2 graphs a 512 MiB HBG heap.
- Leave Case3 out because its shared `head_dim=256` kernels fail golden on both runtimes.

This is one workload-sized part of #1727.

## Performance

Measured on one locked a2a3 NPU through `task-submit`: eight adjacent TMR/HBG pairs, alternating order, ten rounds per process and case, with each case's first round excluded (72 steady samples per runtime/case).

| Case | Host total: TMR -> HBG | Change | Device wall: TMR -> HBG | Change |
| --- | ---: | ---: | ---: | ---: |
| Case1 | 32.728 -> 48.890 ms | +49.38% | 4.272 -> 3.518 ms | **-17.64%** |
| Case2 | 17.214 -> 21.865 ms | +27.02% | 7.262 -> 5.222 ms | **-28.09%** |

Paired device-wall changes (95% CI): Case1 `-17.56%` (`-21.68%` to `-13.45%`); Case2 `-28.09%` (`-29.09%` to `-27.09%`). HBG device wall and runner time are consistently faster; the host increase comes from bind and validation.

These measurements used simpler base `7b3a9754` and PTO-ISA pin `0cefc9a5a1c24c62655cc345d408559595a8af32`. Main later merged #1763, which removes redundant HBG arena initialization and explicitly leaves device time unchanged; the device comparison remains representative, while the host/bind values above are conservative pre-#1763 measurements.

Performance job: `task_20260811_005329_223032522760` (NPU 5, exit 0).

## Testing

- [x] Five applicable simulation cases, including manual cases
- [x] Seven HBG onboard golden cases: `task_20260811_005217_201289318187`
- [x] TMR Case3 diagnosis: `task_20260811_005052_157499517775` (reproduces the existing golden failure)
- [x] Eight-pair onboard performance comparison
- [x] All pre-commit hooks for the changed file
