### PR TITLE
CI: streamline unit test jobs

### DIFF
--- a/.github/workflows/_ut-no-hardware.yml
+++ b/.github/workflows/_ut-no-hardware.yml
@@ -89,4 +89,4 @@ jobs:
           fi
           cmake -B tests/ut/cpp/build -S tests/ut/cpp
           cmake --build tests/ut/cpp/build
-          ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure
+          ctest --test-dir tests/ut/cpp/build -LE requires_hardware -j4 --output-on-failure

--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -50,19 +50,18 @@ jobs:
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
+            python -m pytest tests/ut -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest tests -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v"
+              --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v"
           fi
 
       - name: Build and run C++ hardware unit tests (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          python -c "from simpler_setup.runtime_builder import RuntimeBuilder; RuntimeBuilder('a2a3').get_binaries('tensormap_and_ringbuffer', build=True)"
           cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
-          cmake --build tests/ut/cpp/build
+          cmake --build tests/ut/cpp/build --target test_comm_lifecycle
           if [ "$(uname -m)" = "x86_64" ]; then
             python3 -c "
           import json, os

--- a/.github/workflows/_ut-npu-a5.yml
+++ b/.github/workflows/_ut-npu-a5.yml
@@ -49,22 +49,7 @@ jobs:
         run: |
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v"
-
-      - name: Build and run C++ hardware unit tests (a5)
-        run: |
-          source .venv/bin/activate
-          cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
-          cmake --build tests/ut/cpp/build
-          python3 -c "
-          import json, os
-          p = os.environ['DEVICE_RANGE'].split('-'); s, e = p[0], p[-1]
-          npus = [{'id': str(i), 'slots': 1} for i in range(int(s), int(e)+1)]
-          json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
-                    open('tests/ut/cpp/build/resources.json', 'w'))
-          "
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a5)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests/ut -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v"
 
       - name: Build cann-examples/query
         if: inputs.include_cann_examples

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,7 +6,7 @@ The CI pipeline maps test categories (st, ut-py, ut-cpp) × hardware tiers to Gi
 
 Design principles:
 
-1. **Merge by runner, not by language** — Python and C++ unit tests share setup cost and run as steps within a single job per runner tier (`ut`, `ut-a2a3`, `ut-a5`).
+1. **Merge by runner, not by language** — Python and applicable C++ unit tests share setup cost and run as steps within a single job per runner tier. A runner with no platform-specific C++ tests does not carry an empty CTest step; currently `ut-a5` is Python-only.
 2. **Runner matches hardware tier** — no-hardware tests run on `ubuntu-latest`; platform-specific tests run on self-hosted runners with the matching label (`a2a3`, `a5`).
 3. **`--platform` is the only filter** — pytest uses `--platform` + the `requires_hardware` marker; ctest uses label `-LE` exclusion. No `-m st`, no `-m "not requires_hardware"`.
 4. **sim = no hardware** — `a2a3sim`/`a5sim` jobs run on github-hosted runners alongside unit tests.
@@ -19,7 +19,7 @@ The complete test-type × hardware-tier matrix. Empty cells have no tests yet; o
 
 | Category | github-hosted (no hardware) | a2a3 runner | a5 runner |
 | -------- | --------------------------- | ----------- | --------- |
-| **ut** (py + cpp) | `ut` | `ut-a2a3` | `ut-a5` |
+| **ut** | `ut` (py + cpp) | `ut-a2a3` (py + cpp) | `ut-a5` (py) |
 | **st** | `st-sim-a2a3`, `st-sim-a5` | `st-onboard-a2a3`, `st-pod-onboard-a2a3` | `st-onboard-a5` |
 
 ## GitHub Actions Jobs
@@ -48,7 +48,7 @@ PullRequest
   ├── ut-a2a3                (a2a3 self-hosted)      — Python + C++ UT, a2a3 hardware [needs ut_affected]
   ├── st-onboard-a2a3        (a2a3 self-hosted)      — a2a3_changed && st_affected
   ├── st-pod-onboard-a2a3    (a2a3pod pair)          — a2a3_changed && st_affected
-  ├── ut-a5                  (a5 self-hosted)        — Python + C++ UT, a5 hardware [needs ut_affected]
+  ├── ut-a5                  (a5 self-hosted)        — Python UT, a5 hardware [needs ut_affected]
   └── st-onboard-a5          (a5 self-hosted)        — a5_changed && st_affected
 ```
 
@@ -59,7 +59,7 @@ PullRequest
 | `st-sim-a5` | `ubuntu-latest`, `macos-latest` | `pytest examples tests/st --platform a5sim` |
 | `ut-a2a3` | a2a3 self-hosted | `pytest tests/ut --platform a2a3` + `ctest -L "^requires_hardware(_a2a3)?$" --resource-spec-file ...` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (host + cross-compiled device SO, link smoke only) |
 | `st-onboard-a2a3` | a2a3 self-hosted | `pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ...`, then a separate `-m sdma` step, then adaptive-parallel DFX feature smokes |
-| `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + `ctest -L "^requires_hardware(_a5)?$"` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (link smoke only) |
+| `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (link smoke only) |
 | `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st --platform a5 --exclude-level 4 --device ...`, including SDMA tests, then adaptive-parallel DFX feature smokes |
 | `st-pod-onboard-a2a3` | a pair of `a2a3pod` machines | `pytest examples tests/st --level 4 --platform a2a3 --device ... --max-parallel 1`, one L3 daemon on the peer |
 


### PR DESCRIPTION
## Summary

- Limit onboard pytest collection to `tests/ut` instead of traversing the full test tree.
- Reuse the installed A2/A3 runtime and build only the C++ hardware target that actually runs.
- Remove the empty A5 C++ hardware step because A5 currently has Python hardware UTs only.
- Run no-hardware CTest with four workers and update the CI documentation.

## Testing

- All pre-commit hooks passed.
- Workflow YAML parsing and `git diff --check` passed after rebasing onto latest `main`.
- A2/A3 Python hardware UT via `task-submit`: 6 passed.
- A2/A3 C++ hardware CTest via `task-submit`: 1 passed (`test_comm_lifecycle`).
- No-hardware C++ CTest with `-j4`: 93 passed.
- Full local Python no-hardware run: 1304 passed, 13 skipped, with one reproducible host-specific failure in `test_session_timeout_surfaces_forked_child_traceback`; the test and its timeout implementation are untouched by this PR.
- A5 hardware was not run locally because the available host is A2/A3.

Related to #1772.
