### PR TITLE
CI: move redundant scene tests to daily sweep

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -27,6 +27,7 @@ and will report failures that CI never sees:
 
 | Marker | Tests | CI behavior |
 | ------ | ----- | ----------- |
+| `@pytest.mark.manual` / `CASES[*]["manual"]` | Standalone pytest tests / individual scene-test cases; optionally scoped to a platform list | Per-PR: excluded by default on the selected platforms; `daily.yml`: full sweep with `--manual include` |
 | `@pytest.mark.sdma` | a2a3: `sdma_async_completion_demo`, `prefetch_async_demo`; a5: `sdma_async_completion_demo` | a2a3: the dedicated SDMA step; a5: included in the non-pod sweep |
 
 The a2a3 SDMA demos provision 48 device-only STARS streams, which makes an

--- a/.github/workflows/_profiling-flags-smoke.yml
+++ b/.github/workflows/_profiling-flags-smoke.yml
@@ -86,7 +86,7 @@ jobs:
               if ! .venv/bin/python -m pytest \
                    "examples/${ARCH_DIR}/tensormap_and_ringbuffer/vector_example/test_vector_example.py" \
                    --platform "$ARCH" --device 0-1 -p no:xdist \
-                   --pto-session-timeout 600; then
+                   --pto-session-timeout 600 --manual include; then
                 echo "::error::Smoke failed: $ARCH / $NAME"
                 FAIL+=("$ARCH/$NAME (pytest)")
               fi

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -24,6 +24,11 @@ on:
         required: false
         default: marker
         type: string
+      manual_mode:
+        description: exclude for Per-PR, include for the Daily full sweep.
+        required: false
+        default: exclude
+        type: string
 
 jobs:
   run:
@@ -31,6 +36,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 60
     env:
+      MANUAL_MODE: ${{ inputs.manual_mode }}
       SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
       SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
       SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
@@ -41,6 +47,16 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
+
+      - name: Validate manual mode
+        run: |
+          case "$MANUAL_MODE" in
+            exclude|include|only) ;;
+            *)
+              echo "::error::manual_mode must be exclude, include, or only"
+              exit 2
+              ;;
+          esac
 
       - name: Restore scene-test kernel cache (a2a3)
         uses: actions/cache@v5
@@ -70,21 +86,22 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           .venv/bin/python -m simpler_setup.tools.scene_test_compile examples tests/st \
-            --platform a2a3 --exclude-level 4 --require-pto-isa --compile-workers 8 -q
+            --platform a2a3 --exclude-level 4 --require-pto-isa --compile-workers 8 -q \
+            --manual "$MANUAL_MODE"
 
       - name: Run pytest scene tests (a2a3)
         if: inputs.a2a3_sdma_mode == 'marker'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200
+            .venv/bin/python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200 --manual "$MANUAL_MODE"
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"
+              --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
           fi
 
       - name: Run pytest scene tests (a2a3 legacy SDMA paths)
-        if: inputs.a2a3_sdma_mode == 'legacy-paths'
+        if: inputs.a2a3_sdma_mode == 'legacy-paths' && inputs.manual_mode != 'only'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           SDMA_IGNORE="--ignore=examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo --ignore=examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo"
@@ -96,7 +113,7 @@ jobs:
           fi
 
       - name: SDMA pytest (a2a3)
-        if: inputs.a2a3_sdma_mode == 'marker'
+        if: inputs.a2a3_sdma_mode == 'marker' && inputs.manual_mode != 'only'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           SDMA_TESTS="examples tests/st -m sdma"
@@ -108,7 +125,7 @@ jobs:
           fi
 
       - name: SDMA pytest (a2a3 legacy paths)
-        if: inputs.a2a3_sdma_mode == 'legacy-paths'
+        if: inputs.a2a3_sdma_mode == 'legacy-paths' && inputs.manual_mode != 'only'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           SDMA_TESTS="examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo"

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: false
         type: boolean
+      manual_mode:
+        description: exclude for Per-PR, include for the Daily full sweep.
+        required: false
+        default: exclude
+        type: string
 
 jobs:
   run:
@@ -26,6 +31,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 60
     env:
+      MANUAL_MODE: ${{ inputs.manual_mode }}
       SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
       SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
       SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
@@ -36,6 +42,16 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
+
+      - name: Validate manual mode
+        run: |
+          case "$MANUAL_MODE" in
+            exclude|include|only) ;;
+            *)
+              echo "::error::manual_mode must be exclude, include, or only"
+              exit 2
+              ;;
+          esac
 
       - name: Restore scene-test kernel cache (a5)
         uses: actions/cache@v5
@@ -57,13 +73,14 @@ jobs:
       - name: Compile scene-test kernels (a5)
         run: |
           .venv/bin/python -m simpler_setup.tools.scene_test_compile examples tests/st \
-            --platform a5 --exclude-level 4 --require-pto-isa --compile-workers 8 -q
+            --platform a5 --exclude-level 4 --require-pto-isa --compile-workers 8 -q \
+            --manual "$MANUAL_MODE"
 
       - name: Run pytest scene tests (a5)
         run: |
           DEVICE_LIST=$(.venv/bin/python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" \
-            --run ".venv/bin/python -m pytest examples tests/st --platform a5 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200"
+            --run ".venv/bin/python -m pytest examples tests/st --platform a5 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
 
       - name: DFX smokes (a5)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      manual_mode:
+        description: exclude for Per-PR, include for the Daily full sweep.
+        required: false
+        default: exclude
+        type: string
       python_version:
         required: false
         default: "3.10"
@@ -34,6 +39,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 30
     env:
+      MANUAL_MODE: ${{ inputs.manual_mode }}
       SIMPLER_SCHEDULER_TIMEOUT_MS: "5000"
     steps:
       - name: Checkout target
@@ -42,6 +48,16 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
+
+      - name: Validate manual mode
+        run: |
+          case "$MANUAL_MODE" in
+            exclude|include|only) ;;
+            *)
+              echo "::error::manual_mode must be exclude, include, or only"
+              exit 2
+              ;;
+          esac
 
       - name: Set up C++ compiler
         if: inputs.setup_variant == 'github'
@@ -89,7 +105,8 @@ jobs:
       - name: Run pytest scene tests
         run: |
           .venv/bin/python -m pytest examples tests/st --platform a2a3sim --device 0-15 -v \
-            --pto-session-timeout 600 --require-pto-isa
+            --pto-session-timeout 600 --require-pto-isa \
+            --manual "$MANUAL_MODE"
 
       - name: dep_gen smoke (a2a3)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      manual_mode:
+        description: exclude for Per-PR, include for the Daily full sweep.
+        required: false
+        default: exclude
+        type: string
       python_version:
         required: false
         default: "3.10"
@@ -34,6 +39,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 30
     env:
+      MANUAL_MODE: ${{ inputs.manual_mode }}
       SIMPLER_SCHEDULER_TIMEOUT_MS: "5000"
     steps:
       - name: Checkout target
@@ -42,6 +48,16 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
+
+      - name: Validate manual mode
+        run: |
+          case "$MANUAL_MODE" in
+            exclude|include|only) ;;
+            *)
+              echo "::error::manual_mode must be exclude, include, or only"
+              exit 2
+              ;;
+          esac
 
       - name: Set up C++ compiler
         if: inputs.setup_variant == 'github'
@@ -89,7 +105,8 @@ jobs:
       - name: Run pytest scene tests
         run: |
           .venv/bin/python -m pytest examples tests/st --platform a5sim --device 0-15 -v \
-            --pto-session-timeout 600 --require-pto-isa
+            --pto-session-timeout 600 --require-pto-isa \
+            --manual "$MANUAL_MODE"
 
       - name: dep_gen smoke (a5)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_ut-no-hardware.yml
+++ b/.github/workflows/_ut-no-hardware.yml
@@ -88,5 +88,5 @@ jobs:
             source .venv/bin/activate
           fi
           cmake -B tests/ut/cpp/build -S tests/ut/cpp
-          cmake --build tests/ut/cpp/build
+          cmake --build tests/ut/cpp/build --parallel 4
           ctest --test-dir tests/ut/cpp/build -LE requires_hardware -j4 --output-on-failure

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,59 @@
+name: Daily Full Scene Tests
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "0 16 * * *"  # 00:00 Beijing
+  workflow_dispatch:
+
+concurrency:
+  group: daily-full-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  st-sim-a2a3:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    uses: ./.github/workflows/_st-sim-a2a3.yml
+    with:
+      runs_on: ${{ toJSON(matrix.os) }}
+      setup_variant: github
+      include_dfx_smokes: true
+      manual_mode: include
+
+  st-sim-a5:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    uses: ./.github/workflows/_st-sim-a5.yml
+    with:
+      runs_on: ${{ toJSON(matrix.os) }}
+      setup_variant: github
+      include_dfx_smokes: true
+      manual_mode: include
+
+  st-onboard-a2a3:
+    uses: ./.github/workflows/_st-npu-a2a3.yml
+    with:
+      runs_on: '["self-hosted","a2a3"]'
+      include_dfx_smokes: true
+      a2a3_sdma_mode: marker
+      manual_mode: include
+
+  st-onboard-a5:
+    uses: ./.github/workflows/_st-npu-a5.yml
+    with:
+      runs_on: '["self-hosted","a5"]'
+      include_dfx_smokes: true
+      manual_mode: include
+
+  st-pod-onboard-a2a3:
+    uses: ./.github/workflows/_st-pod.yml
+    with:
+      platform: a2a3
+      runs_on: '["self-hosted","Linux","ARM64","a2a3pod"]'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd simpler
 pip install --no-build-isolation -e '.[test]'
 
 # Run the vector example (simulation, no hardware required)
-python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim
+python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim --manual include
 ```
 
 PTO ISA headers are automatically cloned on first run. See [Getting Started](docs/getting-started.md) for manual setup and troubleshooting.

--- a/conftest.py
+++ b/conftest.py
@@ -53,7 +53,7 @@ import pytest  # noqa: E402
 from simpler_setup import parallel_scheduler as _ps  # noqa: E402
 from simpler_setup.log_config import DEFAULT_LOG_LEVEL, configure_logging  # noqa: E402
 from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: E402
-from simpler_setup.scene_test import SceneTestLevel, clear_compile_cache  # noqa: E402
+from simpler_setup.scene_test import SceneTestLevel, clear_compile_cache, is_manual_for_platform  # noqa: E402
 
 # Exit code used when the session watchdog fires. Matches the GNU `timeout`
 # convention so shell wrappers (e.g. CI) can distinguish timeout from other
@@ -137,7 +137,7 @@ def pytest_addoption(parser):
         action="store",
         choices=["exclude", "include", "only"],
         default="exclude",
-        help="Manual case handling: exclude (default), include, only",
+        help="Manual test handling: exclude (default), include, only",
     )
     parser.addoption("--runtime", action="store", default=None, help="Only run tests for this runtime")
     parser.addoption(
@@ -473,6 +473,9 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "requires_hardware: test needs Ascend toolchain and real device")
     config.addinivalue_line("markers", "device_count(n): number of NPU devices needed")
     config.addinivalue_line(
+        "markers", "manual(platforms=None): test runs only when --manual is include or only on selected platforms"
+    )
+    config.addinivalue_line(
         "markers",
         "pod_remote_device_count(n): number of remote NPU devices needed on the peer machine",
     )
@@ -561,6 +564,34 @@ def pytest_configure(config):
     # filenames or rename dance.
 
 
+def _manual_mode_matches(is_manual: bool, manual_mode: str) -> bool:
+    return manual_mode == "include" or is_manual == (manual_mode == "only")
+
+
+def _manual_marker_applies(marker, platform: str | None) -> bool:
+    if marker is None:
+        return False
+
+    unknown_kwargs = set(marker.kwargs) - {"platforms"}
+    if unknown_kwargs:
+        names = ", ".join(sorted(unknown_kwargs))
+        raise pytest.UsageError(f"@pytest.mark.manual got unsupported keyword argument(s): {names}")
+    if marker.args and "platforms" in marker.kwargs:
+        raise pytest.UsageError(
+            "@pytest.mark.manual platforms must be passed either positionally or by keyword, not both"
+        )
+
+    if "platforms" in marker.kwargs:
+        platforms = marker.kwargs["platforms"]
+    elif marker.args:
+        platforms = marker.args[0] if len(marker.args) == 1 else marker.args
+    else:
+        return True
+    if platforms is None or platform is None:
+        return True
+    return is_manual_for_platform(platforms, platform)
+
+
 def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
     """Filter ST tests by --platform / --runtime / level axes; order L3 before L2.
 
@@ -580,6 +611,7 @@ def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
     runtime_filter = config.getoption("--runtime")
     level_filter = _normalize_cli_scene_level(config.getoption("--level"))
     exclude_level_filter = _normalize_cli_scene_level(config.getoption("--exclude-level"))
+    manual_mode = config.getoption("--manual", default="exclude")
 
     keep: list = []
     deselected: list = []
@@ -602,7 +634,11 @@ def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
                 item.add_marker(pytest.mark.skip(reason="--platform required"))
                 keep.append(item)
                 continue
-            if not any(platform in c.get("platforms", []) for c in cls.CASES):
+            if not any(
+                platform in case.get("platforms", [])
+                and _manual_mode_matches(is_manual_for_platform(case.get("manual"), platform), manual_mode)
+                for case in cls.CASES
+            ):
                 deselected.append(item)
                 continue
             if runtime_filter and getattr(cls, "_st_runtime", None) != runtime_filter:
@@ -617,7 +653,12 @@ def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
             keep.append(item)
             continue
 
-        # Non-class pytest function (standalone resource tests and such).
+        # Standalone pytest test (resource functions and ordinary tests).
+        is_manual = _manual_marker_applies(item.get_closest_marker("manual"), platform)
+        if not _manual_mode_matches(is_manual, manual_mode):
+            deselected.append(item)
+            continue
+
         platforms_marker = item.get_closest_marker("platforms")
         if platforms_marker:
             if not platform:
@@ -724,14 +765,14 @@ def _collect_st_runtimes(items, level=None):
     return sorted(runtimes)
 
 
-def _collect_resource_jobs(items, platform):
+def _collect_resource_jobs(items, platform, manual_mode="exclude"):
     """Collect every item that needs a dedicated device-allocating subprocess.
 
     Two job kinds share one phase:
 
       - ``l3``:         one per L3 ``SceneTestCase`` class.
         ``device_count`` is the max across the class's platform-matching
-        non-manual cases.
+        cases selected by ``manual_mode``.
       - ``standalone``: one per non-class pytest function that declares its
         resource needs via ``@pytest.mark.device_count(n)`` +
         ``@pytest.mark.runtime("...")`` (and optional
@@ -759,7 +800,7 @@ def _collect_resource_jobs(items, platform):
         for case in getattr(cls, "CASES", []):
             if platform and platform not in case.get("platforms", []):
                 continue
-            if case.get("manual"):
+            if not _manual_mode_matches(is_manual_for_platform(case.get("manual"), platform), manual_mode):
                 continue
             saw_case = True
             max_dev = max(max_dev, int(case.get("config", {}).get("device_count", 1)))
@@ -813,6 +854,25 @@ def _strip_value_options(args, options):
             continue
         stripped.append(text)
     return stripped
+
+
+def _resource_child_command(spec, device_ids, platform, manual_mode):
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        spec.nodeid,
+        "--runtime",
+        spec.runtime,
+        "--device",
+        _ps.format_device_range(device_ids),
+    ]
+    if spec.kind == "l3":
+        command.extend(["--level", "3"])
+    if platform:
+        command.extend(["--platform", platform])
+    command.extend(["--manual", manual_mode])
+    return command
 
 
 def _base_pytest_argv(session, *, strip_options=()):
@@ -903,6 +963,7 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
     # pytest registers -x as an alias of --exitfirst; both resolve via this name.
     fail_fast = bool(cfg.getoption("--exitfirst", default=False))
     platform = cfg.getoption("--platform")
+    manual_mode = cfg.getoption("--manual", default="exclude")
     max_parallel = _resolve_max_parallel(cfg, platform or "", device_ids)
 
     base_args = _base_pytest_argv(session, strip_options=("--exclude-level",))
@@ -916,31 +977,14 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
         for spec in resource_specs:
             label = f"{spec.kind} {spec.label} (rt={spec.runtime}, dev={spec.device_count})"
 
-            def _build(ids, _nodeid=spec.nodeid, _rt=spec.runtime, _kind=spec.kind):
+            def _build(ids, _spec=spec):
                 # Narrow the child to the specific nodeid, not the inherited
                 # directory args (examples tests/st). Passing the directories
                 # would re-collect every SceneTestCase and run them alongside
                 # this job in the same subprocess, which has only this job's
                 # allocated devices — e.g. TestL3Group (needs 2) would fail
                 # inside TestL3ChildMemory's 1-device subprocess.
-                cmd = [
-                    sys.executable,
-                    "-m",
-                    "pytest",
-                    _nodeid,
-                    "--runtime",
-                    _rt,
-                    "--device",
-                    _ps.format_device_range(ids),
-                ]
-                if _kind == "l3":
-                    # L3 jobs run inside --level 3 child mode; standalone jobs
-                    # are non-SceneTestCase functions and do not participate
-                    # in level-based dispatch.
-                    cmd.extend(["--level", "3"])
-                if platform:
-                    cmd.extend(["--platform", platform])
-                return cmd
+                return _resource_child_command(_spec, ids, platform, manual_mode)
 
             jobs.append(
                 _ps.Job(
@@ -1112,8 +1156,9 @@ def pytest_runtestloop(session):
     # dispatcher to avoid walking ``session.items`` twice.
     level_filter_explicit = level_filter is not None
     platform = session.config.getoption("--platform")
+    manual_mode = session.config.getoption("--manual", default="exclude")
     runtimes_all = _collect_st_runtimes(session.items)
-    resource_specs = _collect_resource_jobs(session.items, platform)
+    resource_specs = _collect_resource_jobs(session.items, platform, manual_mode)
     if not resource_specs and len(runtimes_all) <= 1 and not level_filter_explicit:
         return
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -99,6 +99,27 @@ Writing an example — the files, the entry module, the `run(...)` entry point,
 the `test_*.py` pod wrapper, and the manual `run_parent.sh` — is covered in
 [`examples/workers/README.md`](../examples/workers/README.md).
 
+### Daily full scene-test sweep
+
+[`daily.yml`](../.github/workflows/daily.yml) runs the full regular + manual
+scene-test corpus with `--manual include` once per day and supports manual
+re-runs through `workflow_dispatch`. Simulation runs on Ubuntu and macOS for
+both architectures; onboard runs on the A2/A3 and A5 self-hosted pools. The
+same DFX smoke steps used by Per-PR run once in each Daily platform job, and
+the A2/A3 Pod corpus runs through the existing two-machine workflow. Per-PR
+scene-test jobs keep the default `--manual exclude`, so moving a case to Daily
+does not require a second workflow exclusion list.
+
+Use `"manual": True` on an individual `SceneTestCase.CASES` entry and
+`@pytest.mark.manual` on a standalone pytest test. The reusable scene-test
+workflows accept `manual_mode`; Per-PR callers use its `exclude` default and the
+Daily caller passes `include`.
+
+For platform-specific pruning, the same `manual` value accepts a platform list,
+for example `"manual": ["a2a3sim", "a5sim"]`; standalone tests use
+`@pytest.mark.manual(["a2a3sim", "a5sim"])`. This removes only the Sim execution
+from Per-PR while retaining onboard coverage.
+
 ### Nightly sanitizer sweep
 
 A **separate** workflow, [`sanitizers.yml`](../.github/workflows/sanitizers.yml),

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ pytest examples tests/st -m sdma --platform a2a3 --device 4-5
 pytest examples tests/st --platform a5 --exclude-level 4 --device 0-7
 
 # Single scene test (standalone)
-python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim
+python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim --manual include
 
 # Benchmark mode (100 rounds, skip golden comparison)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
@@ -157,7 +157,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--level {2,3,4}` | | (all) | Restrict to one scene-test level. Level 4 selects pod wrappers. |
 | `--exclude-level {2,3,4}` | | (none) | Exclude tests explicitly carrying that scene-test level. Ordinary onboard lanes use `--exclude-level 4`. |
 | `--case SEL` | | (all) | Case selector, repeatable: `Foo`, `ClassA::Foo`, `ClassA::` |
-| `--manual` | | `exclude` | `exclude`/`include`/`only` for manual cases |
+| `--manual` | | `exclude` | `exclude`/`include`/`only` for manual scene-test cases and standalone pytest tests |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
 | `--enable-chip-swimlane [PERF_LEVEL]` | | `0` | Enable chip swimlane collection on first round only. The flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/chip-swimlane-profiling.md](dfx/chip-swimlane-profiling.md#31-enable-chip-swimlane) for the level table. Each test case gets its own `outputs/<case>_<ts>/` directory under which `chip_swimlane_records.json` lands; parallel runs never collide. |
 | `--dump-args` | | `0` | Dump tensors plus scalar args into unified runtime artifacts (bare flag = `1`; supports `0/1/2/3`) |
@@ -720,7 +720,27 @@ still gets checked, whereas a skipped case only proves the run didn't crash.
 | `--case ClassA::` | all cases in `ClassA` |
 | `--case A::x --case B::y` | multiple selectors (repeatable) |
 
-`--manual exclude` (default) skips `manual: True` cases; `--manual include` runs them alongside normal cases; `--manual only` runs only manual cases. These compose orthogonally with `--case`: explicit selectors still respect the manual filter — to run a manual case by name, pass `--manual include`.
+`--manual exclude` (default) skips `manual: True` cases and standalone tests
+marked `@pytest.mark.manual`; `--manual include` runs them alongside normal
+tests; `--manual only` runs only manual tests. The `only` filter applies to the
+entire pytest session, so it also deselects ordinary standalone tests without a
+`manual` marker. These compose orthogonally with `--case`: explicit selectors
+still respect the manual filter — to run a manual case by name, pass
+`--manual include`.
+
+The separate `daily.yml` workflow runs the full corpus with `--manual include`
+once per day on A2/A3 and A5, simulation and onboard. Mark a whole standalone
+pytest test with `@pytest.mark.manual`; mark only one case in a `SceneTestCase`
+by setting `"manual": True` on that `CASES` entry. Per-PR excludes those tests,
+while Daily runs them together with the regular corpus. The A2/A3 Pod cases run
+in the same Daily workflow through their existing two-machine job.
+
+To move only selected platforms, pass the platform list to the same marker:
+use `@pytest.mark.manual(["a2a3sim", "a5sim"])` (or the equivalent
+`@pytest.mark.manual(platforms=["a2a3sim", "a5sim"])`) for a standalone test,
+or `"manual": ["a2a3sim", "a5sim"]` for a scene-test case. Do not mix the two
+standalone marker forms. The onboard execution then remains in the default
+Per-PR sweep.
 
 ### Sharing an Example Between examples/ and tests/st/
 

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -20,11 +20,16 @@ python examples/my_example/test_my_example.py -p a2a3sim   # standalone, no pyte
 | `--level` | Restrict to one level, e.g. `--level 2`; pod wrappers use `--level 4` |
 | `--exclude-level` | Exclude tests explicitly carrying one level, e.g. ordinary onboard lanes use `--exclude-level 4` |
 | `--case` | Case selector, repeatable: `Foo`, `ClassA::Foo`, or `ClassA::` for a whole class |
-| `--manual` | Manual-case handling: `exclude` (default), `include`, `only` |
+| `--manual` | Manual-test handling for scene cases and standalone pytest tests: `exclude` (default), `include`, `only` |
 | `--rounds` | Run each case N times. Default `1`; use this so first-run effects do not dominate a measurement |
 | `--skip-golden` | Skip golden comparison — benchmark mode |
 | `--require-pto-isa` | Fail the session immediately if PTO-ISA cannot be resolved, instead of deferring to the per-test lazy path |
 | `--sanitizer` | Run against a sanitizer build; see [Compiler Sanitizers](../../sanitizers.md) |
+
+Standalone tests may use `@pytest.mark.manual` for every platform, or limit the
+marker with `@pytest.mark.manual(platforms=["a2a3sim", "a5sim"])`. Scene-test
+cases use `"manual": True` or a platform list such as
+`"manual": ["a2a3sim", "a5sim"]`.
 
 ### Diagnostics
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ pytest examples -m "not sdma" --platform a2a3 --exclude-level 4 --device 0-1    
 A single example:
 
 ```bash
-pytest examples/a2a3/tensormap_and_ringbuffer/vector_example --platform a2a3sim
+pytest examples/a2a3/tensormap_and_ringbuffer/vector_example --platform a2a3sim --manual include
 ```
 
 Most `workers/` examples are also plain scripts, which is the quickest way to

--- a/examples/a2a3/tensormap_and_ringbuffer/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/README.md
@@ -24,7 +24,7 @@ For the `Worker` API underneath the framework, see
 
 | Example | What it teaches |
 | ------- | --------------- |
-| [`benchmark_bgemm/`](benchmark_bgemm/) | Runtime-configurable tiled matmul `C = sum(k) A[k] @ B[k]`, laid out as single-axis moves over task count, tile size, work per task, and accumulation depth. Runs on sim. Four of its six cases are `"manual": True` and need `--manual include`. |
+| [`benchmark_bgemm/`](benchmark_bgemm/) | Runtime-configurable tiled matmul `C = sum(k) A[k] @ B[k]`, laid out as single-axis moves over task count, tile size, work per task, and accumulation depth. On Sim, five of six cases are manual and Per-PR keeps the 500-task `Case0`; Onboard still runs `Case0` and `Bgemm64` by default. |
 | [`paged_attention/`](paged_attention/) | Online softmax with AIC/AIV subgraph splitting, bfloat16. The baseline the three variants below are compared against. |
 | [`paged_attention_manual_scope/`](paged_attention_manual_scope/) | The same computation with explicit scope control — kernels byte-identical to the baseline's, only the orchestration differs. See [`docs/manual-scope.md`](../../../docs/manual-scope.md). |
 | [`paged_attention_unroll_manual_scope/`](paged_attention_unroll_manual_scope/) | A second implementation, not a patch on the baseline: KV blocks batched into groups of `N_UNROLL`, four tasks per group instead of per block, with the kernels rewritten to match. |

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/README.md
@@ -21,33 +21,36 @@ so you can move one axis at a time and watch what it costs.
 The cases are laid out as single-axis moves from `Case1`, which is what makes
 them comparable:
 
-| Case | Default run? | `task_num` | `data_size` | `loop` | `grid_k` | Reads as |
-| ---- | ------------ | ---------- | ----------- | ------ | -------- | -------- |
-| `Case1` | no | 64 | 128 | 4 | 2 | the reference point |
-| `Case2` | no | 256 | 128 | 4 | 2 | 4× the tasks |
-| `Case0` | **yes** | 500 | 128 | 4 | 2 | ~8× the tasks |
-| `Case3` | no | 64 | 128 | 16 | 2 | 4× the work per task, same task count |
-| `Case4` | no | 64 | 128 | 4 | 4 | twice the accumulation depth |
-| `Bgemm64` | **yes** | 32 | 64 | 1 | 4 | small tiles, minimal per-task work |
+| Case | Default Sim? | Default Onboard? | `task_num` | `data_size` | `loop` | `grid_k` | Reads as |
+| ---- | ------------ | ---------------- | ---------- | ----------- | ------ | -------- | -------- |
+| `Case1` | no | no | 64 | 128 | 4 | 2 | the reference point |
+| `Case2` | no | no | 256 | 128 | 4 | 2 | 4× the tasks |
+| `Case0` | **yes** | **yes** | 500 | 128 | 4 | 2 | ~8× the tasks |
+| `Case3` | no | no | 64 | 128 | 16 | 2 | 4× the work per task, same task count |
+| `Case4` | no | no | 64 | 128 | 4 | 4 | twice the accumulation depth |
+| `Bgemm64` | no | **yes** | 32 | 64 | 1 | 4 | small tiles, minimal per-task work |
 
 `Case2` against `Case3` is the interesting pair: both quadruple the total
 matmul work relative to `Case1`, one by adding tasks and one by making each
 task bigger.
 
-## Only two cases run by default
+## The default run differs by platform
 
-`Case1`–`Case4` are marked `"manual": True`, and `_select_cases` drops manual
-cases unless you ask for them (`simpler_setup/scene_test.py`). A plain run
-executes `Case0` and `Bgemm64` only:
+`Case1`–`Case4` are manual on both platforms. `Bgemm64` is manual only on
+`a2a3sim`, so the Sim Per-PR run keeps the larger `Case0`, while the Onboard
+Per-PR run continues to execute both `Case0` and `Bgemm64`:
 
 ```bash
-# default — 2 of 6 cases
+# Sim default — Case0 only, 1 of 6 cases
 pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3sim
 
-# all six
+# Onboard default — Case0 + Bgemm64, 2 of 6 cases
+pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3 --device 0
+
+# all six on either platform
 pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3sim --manual include
 
-# only the sweep
+# Sim Daily selection — Case1–Case4 + Bgemm64, 5 of 6 cases
 pytest examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm --platform a2a3sim --manual only
 ```
 

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
@@ -81,6 +81,7 @@ class TestBenchmarkBgemm(SceneTestCase):
         {
             "name": "Bgemm64",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": ["a2a3sim"],
             "params": {"matmul_add_task_num": 32, "incore_data_size": 64, "incore_loop": 1, "grid_k": 4},
         },
     ]

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py
@@ -51,6 +51,7 @@ class TestVectorExample(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": ["a2a3sim"],
             "params": {},
         },
     ]

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/test_vector_example.py
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/test_vector_example.py
@@ -51,6 +51,7 @@ class TestVectorExample(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
+            "manual": ["a5sim"],
             "params": {},
         },
     ]

--- a/examples/workers/l2/hello_worker/test_hello_worker.py
+++ b/examples/workers/l2/hello_worker/test_hello_worker.py
@@ -16,6 +16,7 @@ from .main import run
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual
 def test_hello_worker(st_platform, st_device_ids):
     rc = run(st_platform, int(st_device_ids[0]))
     assert rc == 0

--- a/examples/workers/l2/vector_add/test_run_timing.py
+++ b/examples/workers/l2/vector_add/test_run_timing.py
@@ -102,6 +102,7 @@ def _drive_one_run(platform: str, device_id: int, *, enable_chip_swimlane: bool 
 @pytest.mark.platforms(["a2a3sim", "a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim"])
 def test_simpler_run_emits_strace_markers(st_platform, st_device_ids, capfd):
     _drive_one_run(st_platform, int(st_device_ids[0]))
     err = capfd.readouterr().err
@@ -127,6 +128,7 @@ def test_simpler_run_emits_strace_markers(st_platform, st_device_ids, capfd):
 @pytest.mark.platforms(["a2a3sim", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_sim_forwards_info_level_to_aicpu(st_platform, st_device_ids, capfd):
     previous_level = get_current_config()
     configure_logging("info")

--- a/examples/workers/l2/vector_add/test_vector_add.py
+++ b/examples/workers/l2/vector_add/test_vector_add.py
@@ -16,6 +16,7 @@ from .main import run
 @pytest.mark.platforms(["a2a3sim", "a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual
 def test_vector_add(st_platform, st_device_ids):
     rc = run(st_platform, int(st_device_ids[0]))
     assert rc == 0

--- a/examples/workers/l3/dual_domain_overlap/README.md
+++ b/examples/workers/l3/dual_domain_overlap/README.md
@@ -69,7 +69,7 @@ path calls `run()` directly, so it is not limited by `main()`'s `--platform`
 choices):
 
 ```bash
-pytest examples/workers/l3/dual_domain_overlap --platform a2a3sim
+pytest examples/workers/l3/dual_domain_overlap --platform a2a3sim --manual include
 ```
 
 Exactly three devices are required.

--- a/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
+++ b/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
@@ -16,6 +16,7 @@ from .main import run
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(3)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_dual_domain_overlap(st_platform, st_device_ids):
     rc = run(st_platform, [int(d) for d in st_device_ids])
     assert rc == 0

--- a/examples/workers/l3/ffn_tp_parallel/README.md
+++ b/examples/workers/l3/ffn_tp_parallel/README.md
@@ -39,7 +39,7 @@ python examples/workers/l3/ffn_tp_parallel/main.py -p a2a3 -d 0-1
 Or as a scene test — `a2a3sim`, `a2a3`, and `a5sim` are marked:
 
 ```bash
-pytest examples/workers/l3/ffn_tp_parallel --platform a2a3sim
+pytest examples/workers/l3/ffn_tp_parallel --platform a2a3sim --manual include
 ```
 
 Exactly two devices are required — `parse_device_range` rejects any other

--- a/examples/workers/l3/ffn_tp_parallel/test_ffn_tp_parallel.py
+++ b/examples/workers/l3/ffn_tp_parallel/test_ffn_tp_parallel.py
@@ -20,6 +20,7 @@ run = _main.run
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_ffn_tp_parallel(st_device_ids, st_platform):
     rc = run([int(d) for d in st_device_ids], platform=st_platform)
     assert rc == 0

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -824,6 +824,20 @@ def _match_selectors(cls_name: str, case_name: str, selectors: list[tuple]) -> b
     return False
 
 
+def is_manual_for_platform(manual, platform: str | None) -> bool:
+    """Whether a case's manual value applies to the selected platform.
+
+    ``True`` keeps the original all-platform behavior. A platform name or a
+    collection of platform names moves only those executions to the manual
+    sweep while leaving the same case in Per-PR coverage elsewhere.
+    """
+    if isinstance(manual, str):
+        return manual == platform
+    if isinstance(manual, (list, tuple, set, frozenset)):
+        return platform in manual
+    return bool(manual)
+
+
 def _select_cases(test_classes, platform: str, selectors: list[tuple], manual_mode: str):
     """Resolve (class, case) pairs to run. Validates selectors strictly.
 
@@ -850,7 +864,7 @@ def _select_cases(test_classes, platform: str, selectors: list[tuple], manual_mo
                 continue
             if not _match_selectors(cls.__name__, case["name"], selectors):
                 continue
-            is_manual = bool(case.get("manual"))
+            is_manual = is_manual_for_platform(case.get("manual"), platform)
             if manual_mode == "exclude" and is_manual:
                 continue
             if manual_mode == "only" and not is_manual:
@@ -1686,7 +1700,7 @@ class SceneTestCase:
                 continue
             if not _match_selectors(cls_name, case["name"], selectors):
                 continue
-            is_manual = bool(case.get("manual"))
+            is_manual = is_manual_for_platform(case.get("manual"), st_platform)
             if manual_mode == "exclude" and is_manual:
                 continue
             if manual_mode == "only" and not is_manual:

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
@@ -52,6 +52,7 @@ class TestGraphExecutionHostBuildGraph(SceneTestCase):
         {
             "name": "record_then_replay_1d",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": ["a2a3sim"],
             "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {"shape": (128 * 128,)},
         },

--- a/tests/st/a2a3/host_build_graph/matmul/test_matmul.py
+++ b/tests/st/a2a3/host_build_graph/matmul/test_matmul.py
@@ -58,6 +58,7 @@ class TestMatmulHostBuildGraph(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py
+++ b/tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py
@@ -58,6 +58,7 @@ class TestVectorExampleHostBuildGraph(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": ["a2a3sim"],
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -85,6 +85,7 @@ class TestDummyTask(SceneTestCase):
         {
             "name": "LongDummyChain",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
             "config": {"aicpu_thread_num": 2},
             "params": {"case": 2},
         },

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -49,11 +49,13 @@ class TestFaninLookupPerf(SceneTestCase):
         {
             "name": "LookupOnlyProducers64Consumers64",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
             "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 0},
         },
         {
             "name": "SwimlaneProducers64Consumers64",
             "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
             "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 1},
         },
     ]

--- a/tests/st/a5/host_build_graph/vector_example/test_vector_example.py
+++ b/tests/st/a5/host_build_graph/vector_example/test_vector_example.py
@@ -58,6 +58,7 @@ class TestVectorExampleHostBuildGraphA5(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a5sim", "a5"],
+            "manual": ["a5sim"],
             "params": {},
         },
     ]

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -81,6 +81,7 @@ class TestDummyTask(SceneTestCase):
         {
             "name": "LongDummyChain",
             "platforms": ["a5sim", "a5"],
+            "manual": True,
             "config": {"aicpu_thread_num": 2},
             "params": {"case": 2},
         },

--- a/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -49,11 +49,13 @@ class TestFaninLookupPerf(SceneTestCase):
         {
             "name": "LookupOnlyProducers64Consumers64",
             "platforms": ["a5sim", "a5"],
+            "manual": True,
             "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 0},
         },
         {
             "name": "SwimlaneProducers64Consumers64",
             "platforms": ["a5sim", "a5"],
+            "manual": True,
             "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 1},
         },
     ]

--- a/tests/st/task_timing/task_timing_slots/test_task_timing_e2e.py
+++ b/tests/st/task_timing/task_timing_slots/test_task_timing_e2e.py
@@ -159,6 +159,7 @@ def _drive(
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_distinct_slots_emit_markers(st_platform, st_device_ids, capfd):
     # Two-task chain: t0 -> slot 0, t1 -> slot 1. out = a + 2b.
     _drive(st_platform, int(st_device_ids[0]), "task_timing_orchestration", 2)
@@ -179,6 +180,7 @@ def test_distinct_slots_emit_markers(st_platform, st_device_ids, capfd):
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_duplicate_slot_merges_window(st_platform, st_device_ids, capfd):
     dev = int(st_device_ids[0])
 
@@ -211,6 +213,7 @@ def test_duplicate_slot_merges_window(st_platform, st_device_ids, capfd):
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("host_build_graph")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_hbg_distinct_slots_emit_markers(st_platform, st_device_ids, capfd):
     # Same two-task chain as test_distinct_slots_emit_markers, on the hbg path.
     _drive(st_platform, int(st_device_ids[0]), "task_timing_orchestration", 2, runtime="host_build_graph")
@@ -231,6 +234,7 @@ def test_hbg_distinct_slots_emit_markers(st_platform, st_device_ids, capfd):
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("host_build_graph")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_hbg_duplicate_slot_merges_window(st_platform, st_device_ids, capfd):
     # Same 3-task same-slot merge as test_duplicate_slot_merges_window, on the hbg
     # path: min(dispatch)/max(finish) must fold into a single slot-0 window.
@@ -293,6 +297,7 @@ def _build_mix_chip_callable(platform: str) -> ChipCallable:
 @pytest.mark.platforms(["a2a3sim", "a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim"])
 def test_mix_task_aggregates_across_subtasks(st_platform, st_device_ids, capfd):
     # One MIX task (AIC matmul + AIV0 add + AIV1 mul) tagged slot 0. All three
     # subtasks fold their dispatch/finish into slot 0 -> one complete window.
@@ -360,6 +365,7 @@ def test_mix_task_aggregates_across_subtasks(st_platform, st_device_ids, capfd):
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
+@pytest.mark.manual(["a2a3sim", "a5sim"])
 def test_spmd_task_aggregates_across_threads(st_platform, st_device_ids, capfd):
     # One SPMD task (block_num=8) tagged slot 0; blocks dispatch across multiple
     # scheduler threads and must reduce to one complete slot. out = a + b.

--- a/tests/st/worker/collectives/all_to_all/test_all_to_all.py
+++ b/tests/st/worker/collectives/all_to_all/test_all_to_all.py
@@ -113,6 +113,7 @@ class TestAllToAllP4(SceneTestCase):
         {
             "name": "p4",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4},
         }

--- a/tests/st/worker/collectives/allgather/test_allgather.py
+++ b/tests/st/worker/collectives/allgather/test_allgather.py
@@ -111,6 +111,7 @@ class TestAllgatherP4(SceneTestCase):
         {
             "name": "p4",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4},
         }

--- a/tests/st/worker/collectives/allreduce/test_allreduce.py
+++ b/tests/st/worker/collectives/allreduce/test_allreduce.py
@@ -117,6 +117,7 @@ class TestAllreduceTwophaseP2(SceneTestCase):
         {
             "name": "twophase",
             "platforms": ["a2a3sim", "a2a3", "a5sim", "a5"],
+            "manual": ["a2a3sim", "a5sim"],
             "config": {"device_count": 2},
             "params": {"nranks": 2, "mode_id": 1},
         }
@@ -163,6 +164,7 @@ class TestAllreduceBidirectionalRingP2(SceneTestCase):
         {
             "name": "bidirectional_ring",
             "platforms": ["a2a3sim", "a2a3", "a5sim", "a5"],
+            "manual": ["a2a3sim", "a5sim"],
             "config": {"device_count": 2},
             "params": {"nranks": 2, "mode_id": 3},
         }
@@ -186,6 +188,7 @@ class TestAllreduceIbingP2(SceneTestCase):
         {
             "name": "ibing",
             "platforms": ["a2a3sim", "a2a3", "a5sim", "a5"],
+            "manual": ["a2a3sim", "a5sim"],
             "config": {"device_count": 2},
             "params": {"nranks": 2, "mode_id": 4},
         }
@@ -209,6 +212,7 @@ class TestAllreduceOnephaseP4(SceneTestCase):
         {
             "name": "onephase",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4, "mode_id": 0},
         }
@@ -232,6 +236,7 @@ class TestAllreduceTwophaseP4(SceneTestCase):
         {
             "name": "twophase",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4, "mode_id": 1},
         }
@@ -255,6 +260,7 @@ class TestAllreduceRingP4(SceneTestCase):
         {
             "name": "ring",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4, "mode_id": 2},
         }
@@ -278,6 +284,7 @@ class TestAllreduceBidirectionalRingP4(SceneTestCase):
         {
             "name": "bidirectional_ring",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4, "mode_id": 3},
         }
@@ -301,6 +308,7 @@ class TestAllreduceIbingNranksError(SceneTestCase):
         {
             "name": "ibing_nranks_4",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4, "mode_id": 4},
         }

--- a/tests/st/worker/collectives/broadcast/test_broadcast.py
+++ b/tests/st/worker/collectives/broadcast/test_broadcast.py
@@ -117,6 +117,7 @@ class TestBroadcastP4(SceneTestCase):
         {
             "name": "p4",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4},
         }

--- a/tests/st/worker/collectives/reduce_scatter/test_reduce_scatter.py
+++ b/tests/st/worker/collectives/reduce_scatter/test_reduce_scatter.py
@@ -111,6 +111,7 @@ class TestReduceScatterP4(SceneTestCase):
         {
             "name": "p4",
             "platforms": ["a2a3sim", "a2a3", "a5sim"],
+            "manual": True,
             "config": {"device_count": 4},
             "params": {"nranks": 4},
         }

--- a/tests/ut/py/test_manual_selection.py
+++ b/tests/ut/py/test_manual_selection.py
@@ -1,0 +1,158 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from simpler_setup.scene_test import is_manual_for_platform
+
+_ROOT = Path(__file__).resolve().parents[3]
+_SPEC = importlib.util.spec_from_file_location("_root_conftest_for_manual_selection_tests", _ROOT / "conftest.py")
+assert _SPEC is not None and _SPEC.loader is not None
+root_conftest = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(root_conftest)
+
+
+class _FakeMarker:
+    def __init__(self, name, *args, **kwargs):
+        self.name = name
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _FakeItem:
+    def __init__(self, nodeid, *, markers=()):
+        self.nodeid = nodeid
+        self.cls = None
+        self.function = None
+        self._markers = list(markers)
+
+    def iter_markers(self, name=None):
+        return (marker for marker in self._markers if name is None or marker.name == name)
+
+    def get_closest_marker(self, name):
+        for marker in self._markers:
+            if marker.name == name:
+                return marker
+        return None
+
+    def add_marker(self, marker):
+        self._markers.append(marker)
+
+
+class _FakeHook:
+    def __init__(self):
+        self.deselected = []
+
+    def pytest_deselected(self, items):
+        self.deselected.extend(items)
+
+
+class _FakeConfig:
+    def __init__(self, **options):
+        self.options = options
+        self.hook = _FakeHook()
+
+    def getoption(self, name, default=None):
+        return self.options.get(name, self.options.get(name.lstrip("-"), default))
+
+
+@pytest.mark.parametrize(
+    ("manual", "platform", "expected"),
+    [
+        (True, "a2a3sim", True),
+        (False, "a2a3sim", False),
+        (None, "a2a3sim", False),
+        ("a2a3sim", "a2a3sim", True),
+        ("a5sim", "a2a3sim", False),
+        (["a2a3sim", "a5sim"], "a5sim", True),
+        (("a2a3sim", "a5sim"), "a2a3", False),
+        ({"a2a3sim", "a5sim"}, "a2a3sim", True),
+    ],
+)
+def test_is_manual_for_platform(manual, platform, expected):
+    assert is_manual_for_platform(manual, platform) is expected
+
+
+@pytest.mark.parametrize(
+    ("is_manual", "manual_mode", "expected"),
+    [
+        (False, "exclude", True),
+        (True, "exclude", False),
+        (False, "include", True),
+        (True, "include", True),
+        (False, "only", False),
+        (True, "only", True),
+    ],
+)
+def test_manual_mode_matches(is_manual, manual_mode, expected):
+    assert root_conftest._manual_mode_matches(is_manual, manual_mode) is expected
+
+
+@pytest.mark.parametrize(
+    ("marker", "platform", "expected"),
+    [
+        (None, "a2a3sim", False),
+        (_FakeMarker("manual"), "a2a3sim", True),
+        (_FakeMarker("manual", ["a2a3sim", "a5sim"]), "a5sim", True),
+        (_FakeMarker("manual", ["a2a3sim", "a5sim"]), "a2a3", False),
+        (_FakeMarker("manual", platforms=["a2a3sim", "a5sim"]), "a2a3sim", True),
+        (_FakeMarker("manual", platforms=["a2a3sim", "a5sim"]), "a5", False),
+    ],
+)
+def test_manual_marker_applies(marker, platform, expected):
+    assert root_conftest._manual_marker_applies(marker, platform) is expected
+
+
+def test_manual_marker_rejects_positional_and_keyword_platforms():
+    marker = _FakeMarker("manual", ["a2a3sim"], platforms=["a5sim"])
+
+    with pytest.raises(pytest.UsageError, match="either positionally or by keyword"):
+        root_conftest._manual_marker_applies(marker, "a2a3sim")
+
+
+def test_manual_marker_rejects_unknown_keyword_arguments():
+    marker = _FakeMarker("manual", platforms=["a2a3sim"], reason="slow")
+
+    with pytest.raises(pytest.UsageError, match=r"unsupported keyword argument\(s\): reason"):
+        root_conftest._manual_marker_applies(marker, "a2a3sim")
+
+
+@pytest.mark.parametrize(
+    ("platform", "manual_mode", "expected"),
+    [
+        ("a2a3sim", "exclude", ["tests::ordinary"]),
+        ("a2a3sim", "include", ["tests::global_manual", "tests::ordinary", "tests::sim_manual"]),
+        ("a2a3sim", "only", ["tests::global_manual", "tests::sim_manual"]),
+        ("a2a3", "exclude", ["tests::ordinary", "tests::sim_manual"]),
+        ("a2a3", "include", ["tests::global_manual", "tests::ordinary", "tests::sim_manual"]),
+        ("a2a3", "only", ["tests::global_manual"]),
+    ],
+)
+def test_collection_filters_platform_scoped_manual_tests(platform, manual_mode, expected):
+    items = [
+        _FakeItem("tests::ordinary"),
+        _FakeItem("tests::global_manual", markers=[_FakeMarker("manual")]),
+        _FakeItem("tests::sim_manual", markers=[_FakeMarker("manual", platforms=["a2a3sim"])]),
+    ]
+    config = _FakeConfig(
+        platform=platform,
+        manual=manual_mode,
+        runtime=None,
+        level=None,
+        **{"exclude-level": None, "enable-chip-swimlane": 0},
+    )
+
+    root_conftest.pytest_collection_modifyitems(None, config, items)
+
+    assert [item.nodeid for item in items] == expected


### PR DESCRIPTION
## Summary

- Reduce Per-PR scene-test cost by moving redundant smoke, scale-only,
  timing/DFX-observation, P4 collective, and selected duplicate Sim cases
  behind the existing manual selection.
- Keep `--manual exclude` as the reusable workflow default for PR CI; the
  separate Daily workflow uses `--manual include` to retain the full corpus.
- Extend manual selection to standalone pytest tests and platform-scoped
  markers, and pass the same mode to pre-compilation so only selected test
  classes are compiled.
- Validate `manual_mode` as `exclude`, `include`, or `only` before using it in
  shell commands.
- Keep case parameters, kernels, golden checks, tolerances, runtime settings,
  and workflow timeout thresholds unchanged.

## Per-PR coverage policy

Cases are moved out of Per-PR when their value is primarily shallow smoke,
rank/shape scale expansion, performance/marker observation, or a duplicate
execution path with a stronger representative still running. Per-PR retains
production-model paths, fault/recovery/stress coverage, large pressure cases,
and representative algorithm coverage on each supported platform.

Paged-attention shapes are unchanged, and A2/A3 Sim still retains the
500-task BGEMM pressure case.

## Cases removed from Per-PR

### Single-card and observability cases

| Test | Per-PR platforms removed | Coverage retained in Per-PR |
| --- | --- | --- |
| `test_hello_worker` | A2/A3 Sim, A3 Onboard, A5 Sim, A5 Onboard | Worker allocation/copy/free and close paths |
| `test_vector_add` | A2/A3 Sim, A3 Onboard | Other runtime vector computation paths |
| `TestMatmulHostBuildGraph::default` | A2/A3 Sim, A3 Onboard | Graph record/replay path exercising the same incore kernels |
| `TestFaninLookupPerf` 64x64 cases | A2/A3 Sim, A3 Onboard, A5 Sim, A5 Onboard | Dependency-generation boundary and representative fanout/fanin cases |
| `TestDummyTask::LongDummyChain` | A2/A3 Sim, A3 Onboard, A5 Sim, A5 Onboard | Smaller dependency-chain and dense fanout/fanin cases |
| TMR/HBG vector examples | A2/A3 Sim, A5 Sim | Same cases remain Onboard; stronger computation paths remain on Sim |
| Graph execution 1D | A2/A3 Sim | Graph execution 2D remains on Sim; 1D remains Onboard |
| BGEMM 64 | A2/A3 Sim | 500-task `Case0` remains on Sim; BGEMM 64 remains Onboard |
| Run-timing and task-timing marker tests | Supported Sim platforms | Onboard marker coverage and Per-PR vector correctness remain |
| `ffn_tp_parallel` | A2/A3 Sim, A5 Sim | Same two-card matmul + allreduce path remains A3 Onboard |
| `dual_domain_overlap` | A2/A3 Sim, A5 Sim | `domain_rank_map` remains on both Sim lanes; the full overlap computation remains A3 Onboard |

### Collective cases

| Tests | Per-PR platforms removed | Coverage retained in Per-PR |
| --- | --- | --- |
| Allgather, AllToAll, Broadcast, and ReduceScatter P4 | A2/A3 Sim, A3 Onboard, A5 Sim | The corresponding P2 collective remains on both Sim lanes and A3 Onboard |
| Allreduce One-phase, Two-phase, Ring, and Bidirectional Ring P4; Ibing four-rank error | A2/A3 Sim, A3 Onboard, A5 Sim | One-phase and Ring P2 remain on both Sim lanes; all five P2 algorithms remain on A3 and A5 Onboard |
| Allreduce Two-phase, Bidirectional Ring, and Ibing P2 | A2/A3 Sim, A5 Sim | One-phase and Ring P2 remain on both Sim lanes; all five P2 algorithms remain on A3 and A5 Onboard |

A5 Onboard is unchanged by the P4 migration because the P4 classes are not
defined for that platform. Daily continues to run every migrated P2 and P4
case on its supported platforms.

## CI compatibility fixes

- The profiling-flags smoke targets a vector example that is now manual on Sim,
  so it explicitly passes `--manual include`; otherwise pytest deselects the
  only target and exits non-zero.
- All four reusable Sim/Onboard workflows validate `manual_mode` through an
  environment variable before shell parsing, then reuse only the validated
  value in pytest, pre-compile, and `task-submit --run` commands.
- No-hardware C++ UT builds use four-way CMake build parallelism to avoid the
  macOS serial-build tail that previously exhausted the 20-minute job timeout.

## Validation

- Targeted profiling smoke target passed on A2/A3 Sim and A5 Sim.
- Collective selection checks verify every P4 class is manual, while the three
  additional P2 cases are manual only on the two Sim platforms.
- `python -m pytest tests/ut/py/test_scene_level_selection.py -q`: 8 passed.
- Targeted pre-commit checks passed for the changed Python, YAML, Markdown, and
  repository policy files.
- `git diff --check upstream/main...HEAD`: passed.
