### PR TITLE
Update: align tensormap_and_ringbuffer across A2/A3 and A5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ changing simpler's own internals.
 | [Buffer Memory Model](buffer-abi.md) | How L3+ tasks name data: canonical identity, backend descriptor, strided view |
 | [Orchestrator](orchestrator.md) | DAG submission: TensorMap, Scope, Ring, task state machine |
 | [Scheduler](scheduler.md) | DAG dispatch: wiring / ready / completion queues, dispatch loop |
+| [`tensormap_and_ringbuffer`: A2/A3 vs A5](tensormap-and-ringbuffer-a2a3-vs-a5.md) | Per-file comparison split into hardware/PTO-ISA architecture differences and implementation differences |
 | [Worker Manager](worker-manager.md) | Worker pool, THREAD/PROCESS modes, fork + mailbox mechanics |
 | [hardware/](hardware/README.md) | Hardware substrate: chip architecture, cache coherency, MMIO performance, CANN source references |
 

--- a/docs/tensormap-and-ringbuffer-a2a3-vs-a5.md
+++ b/docs/tensormap-and-ringbuffer-a2a3-vs-a5.md
@@ -1,0 +1,259 @@
+# `tensormap_and_ringbuffer`: A2/A3 vs. A5
+
+This document describes the substantive differences in the current code under
+`src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/`.
+
+> **Maintenance baseline:** This document uses PR 1795 as its baseline. Update
+> this document whenever the files or constants it describes change.
+
+## Overview of Current Differences
+
+The current differences fall into two categories:
+
+- **Platform divergences that must be retained**: physical topology, cache
+  coherence, the PMU collection protocol, system counter and DMB register
+  layouts, the CANN launch ABI, A5 compiler-reserved symbols, and the optional
+  URMA completion path currently unique to A5.
+- **Software differences that can be converged or require further validation**:
+  include guards, `block_num()`/`core_num()` naming, A2/A3 next-block
+  prefetching, and the different fatal teardown strategies.
+
+| Difference | Root cause | Must remain platform-specific? | Current decision |
+| ---------- | ---------- | ------------------------------ | ---------------- |
+| Compute topology | Physical hardware | Yes | Retain each platform's capacity constants and derived layouts |
+| AICPU launch plan | Product thread limits, CANN launch ABI, and firmware topology | Yes | Retain the A5 dynamic topology query; do not equate thread limits with physical topology |
+| Cache coherence | Hardware coherence model | Yes | Retain the required invalidate/flush operations on A2/A3; do not copy unnecessary maintenance operations to A5 |
+| PMU collection | Hardware PMU and platform collection protocol | Yes | Retain the different counter counts, readers, and FIN submission paths |
+| System counter and DMB | Hardware timing and register layout | Yes | Use the constants for each platform |
+| `s_block_*` fields | Symbols reserved by the A5 CCEC compiler | Yes | Retain the platform-specific internal field names while preserving identical getter semantics |
+| URMA completion | A5-specific implementation and product capability gate | Yes, for now | Retain the A5 path; do not claim that URMA is available in the default build |
+| Include guards | Mechanical difference | No | Converge to `#pragma once` when the corresponding files are next modified |
+| `block_num()`/`core_num()` | Historical interface naming | No | Retain both interfaces for now and do not confuse them with physical core counts |
+| Next-block prefetch | A2/A3-only performance optimization | No | Retain on A2/A3; validate on A5 before considering a port |
+| Fatal teardown | Software reliability strategy | No | Retain the current implementations; decide whether to converge after measuring the worst-case A5 teardown time |
+
+Here, "platform divergences that must be retained" includes not only physical
+hardware differences, but also implementation differences required by the
+platform ABI, toolchain, and currently platform-specific backends. "Software
+differences" means that the hardware and ABI do not require different solutions
+on the two platforms; whether to converge immediately still depends on the
+benefit and validation cost.
+
+## Platform Divergences That Must Be Retained
+
+### Compute Topology and AICPU Launch Plan
+
+One A2/A3 runtime device corresponds to one die with 24 clusters, comprising
+24 AICs and 48 AIVs. An A3 chip exposes its two dies as two device IDs. One A5
+runtime device instead spans both dies of the chip and has 36 clusters,
+comprising 36 AICs and 72 AIVs. Because the physical core and cluster counts
+visible to one runtime device differ, `PLATFORM_MAX_CORES`,
+`RUNTIME_MAX_WORKER`, and the capacities of per-core diagnostic buffers must
+also differ.
+
+In the current product configuration, A2/A3 uses at most four active AICPU
+threads, while A5 uses at most five. `DeviceRuntimeLaunchDesc` retains
+`aicpu_launch_count` on both platforms. A5 uses
+`simpler_aicpu_query_topology` to determine the launch plan dynamically from
+OCCUPY/FG/PG/SMT, whereas A2/A3 does not currently use the same dynamic query
+path.
+
+Physical topology, product thread limits, and firmware launch topology are
+three related but distinct constraints. The physical core count determines the
+runtime capacity ceiling, while the AICPU thread limit and topology query
+determine how the current product launches and shards the scheduler. They are
+not interchangeable.
+
+| File | Role |
+| ---- | ---- |
+| `platform/include/common/platform_config.h` | Defines cluster/core counts, the product AICPU thread limit, and platform capacity constants |
+| `runtime/runtime.h` | Maps `RUNTIME_MAX_WORKER` to 72/108 platform cores and defines the shared launch descriptor |
+| `host/runtime_maker.cpp` | A5 registers and uses the dynamic topology query; A2/A3 does not use this path |
+
+### Cache Coherence
+
+On A2/A3, after Host DMA or SDMA writes to GM, the AICPU must invalidate its
+cache before reading the data. On A5, DMA/HBM is coherent with the AICPU, so
+these invalidations are unnecessary at the same points. The current SDMA
+completion protocol publishes a monotonic completed post ID: both platforms
+read it with acquire semantics and neither clears or retires the shared record.
+AICore results are still published by the AICore with `dcci`.
+
+This cache maintenance directly guarantees visibility. It cannot be
+mechanically removed from A2/A3, nor should it be copied to A5 as unnecessary
+overhead.
+
+| File | Current difference |
+| ---- | ------------------ |
+| `aicpu/aicpu_executor.cpp` | A2/A3 invalidates `runtime->dev`, which Host DMA writes, before teardown; A5 does not require the corresponding operation |
+| `runtime/backend/sdma/sdma_completion_scheduler.h` | A2/A3 invalidates the cache line before the acquire load of the completed post ID; A5 performs the acquire load directly; retirement is a no-op on both platforms |
+| `runtime/pto_async_wait.h` | A2/A3 provides a cache-line invalidation helper for async COUNTER polling; A5 does not require it |
+| `runtime/scheduler/pto_scheduler.h` | A2/A3 invalidates the cache line before async COUNTER polling; A5 polls directly |
+
+### PMU, System Counter, and DMB
+
+A2/A3 exposes eight PMU counters, which the AICPU reads from MMIO after FIN.
+A5 exposes ten counters, which the AICore reads with the PTO-ISA `ld_dev`
+operation and writes to a per-core staging slot before the AICPU submits the
+record after FIN. The counter counts, MMIO readers, and available instructions
+differ, so the record layout, FIN sequencing, and per-core ring must diverge.
+
+The A2/A3 system counter runs at 50 MHz and uses DMB MMIO offset `0xA0`; the A5
+values are 1 GHz and `0xD0`, respectively. These facts come from each
+platform's `platform/include/common/platform_config.h`.
+`docs/RUNTIME_LOGIC.md` only documents the corresponding mapping.
+
+| File | Current difference |
+| ---- | ------------------ |
+| `platform/include/common/platform_config.h` | Defines the system counter frequency and DMB offset for each platform |
+| `aicore/aicore_executor.cpp` | Both platforms bracket kernel execution with the PMU gate; A5 additionally writes the ten-counter staging record before FIN |
+| `runtime/scheduler/scheduler_completion.cpp` | After FIN, A2/A3 invokes the AICPU MMIO reader for eight counters; A5 commits the ten-counter slot written by the AICore |
+| `platform/shared/aicpu/pmu_collector_aicpu.cpp` | Implements the A2/A3 direct MMIO read and the A5 staging-slot consumption paths |
+
+### Symbols Reserved by the A5 Compiler
+
+The A5 CCEC compiler treats `block_idx` and `block_num` as built-in symbols, so
+using the original field names causes a compilation conflict. A5 therefore
+uses `s_block_idx` and `s_block_num` in `LocalContext` and the dispatch payload,
+while A2/A3 continues to use `block_idx` and `block_num`. The getters and logical
+semantics are identical on both platforms. This is a toolchain symbol
+constraint, not a change to the runtime data model.
+
+| File | Current difference |
+| ---- | ------------------ |
+| `common/intrinsic.h` | `LocalContext` uses the field names permitted by the corresponding platform |
+| `runtime/pto2_dispatch_payload.h` | The dispatch payload follows the platform-specific field layout |
+| `runtime/scheduler/scheduler_dispatch.cpp` | Writes the corresponding platform's payload fields |
+
+### Optional A5-Specific URMA Backend
+
+A5 contains the source path for issuing URMA completion requests, creating
+deferred entries, forwarding FIN, and polling/retiring CQ entries. A2/A3
+currently registers only the COUNTER and SDMA completion backends.
+
+The repository does not currently define `PTO_URMA_SUPPORTED`. A5 therefore
+compiles the shared ABI, mailbox, CQ polling/retirement, and related paths, but
+the kernel path that successfully issues URMA PTO instructions is unreachable.
+The current state is "implemented but disabled by default." It neither means
+that the default A5 build supports URMA nor proves that the A2/A3 hardware does
+not support URMA.
+
+Both platforms already share `CompletionToken::backend_cookie`,
+`ASYNC_ENGINE_URMA`, the 32-byte `DeferredCompletionEntry`, end-to-end cookie
+propagation from the AICore slab into the 64-byte mailbox message, and the
+generic completion-backend dispatch. The actual platform divergence is that
+A2/A3 lacks the URMA completion type, request-issue implementation, registered
+backend operations, and CQ polling/retirement path.
+
+| Path stage | File | Current difference |
+| ---------- | ---- | ------------------ |
+| Request issue | `runtime/backend/urma/urma_completion_kernel.h` | Present only on A5; it invokes `TGET_ASYNC`/`TPUT_ASYNC` only when `PTO_URMA_SUPPORTED` is defined |
+| Deferred entry | `runtime/aicore_completion_mailbox_types.h`, `runtime/pto_async_kernel_api.h` | Both platforms use the same 32-byte entry and propagate `backend_cookie`; A5 additionally defines the URMA completion type |
+| FIN forwarding | `runtime/scheduler/scheduler_completion.cpp`, `runtime/aicore_completion_mailbox.h` | Both platforms carry `backend_cookie` into the same 64-byte mailbox message; A5 can populate it with URMA workspace metadata |
+| CQ polling/retirement | `runtime/backend/urma/urma_completion_scheduler.h`, `runtime/pto_async_wait.h` | A5 registers URMA operations, polls CQE owner/status, advances the CQ/WQ tail, and updates the doorbell; the scheduler header itself is not guarded by the capability macro |
+
+## Software Implementation Differences
+
+### Include Guards
+
+Some equivalent headers use path-based include guards on one platform and
+`#pragma once` on the other. This does not change the ABI, concurrency
+protocol, or runtime behavior, and there is no reason to retain it as a
+long-term platform divergence. No standalone bulk cleanup is planned; each
+file should converge to `#pragma once` when it is next modified, following the
+repository convention.
+
+The affected files are:
+
+- `runtime/backend/sdma/sdma_completion_kernel.h`
+- `runtime/backend/sdma/sdma_completion_scheduler.h`
+- `runtime/pto_types.h`
+
+### `block_num()` and `core_num()`
+
+The A2/A3 launch accessor is named `block_num()`, while the A5 accessor is
+named `core_num()`. Both represent the number of logical SPMD blocks in a task,
+not the number of physical cores. This difference appears in
+`runtime/pto_orchestrator.cpp` and `runtime/pto_submit_types.h`.
+
+This is a historical interface naming difference, not a physical topology
+difference. It is also distinct from the `s_block_num` payload field required
+to avoid the A5 compiler-reserved symbol. Both existing interfaces are retained
+for now.
+
+### A2/A3 Next-Block Prefetch
+
+The A2/A3 completion path calls `prefetch_block_dst()` in
+`runtime/scheduler/scheduler_completion.cpp`; the corresponding helper is
+declared in `runtime/scheduler/scheduler_context.h`. This prefetch reduces the
+A2/A3 sync-start drain burst without changing the scheduling protocol.
+
+Prefetch effectiveness depends strongly on platform characteristics such as
+cache capacity. The repository does not contain an A5 measurement that
+establishes a benefit, so the optimization should not be ported mechanically.
+This is a platform-sensitive performance strategy, not a different scheduler
+architecture.
+
+### Fatal Teardown
+
+The A2/A3 scheduler uses a dedicated fatal latch to elect an owner, broadcasts
+EXIT to all AICores that completed the handshake, and then joins them in
+parallel against a single deadline. A5 uses `completed_` to elect the owner and
+deinitializes each core sequentially.
+
+The A2/A3 implementation mitigates failure scenarios involving 48 SDMA remote
+streams, but the hardware, PTO-ISA, and platform ABI do not mandate this
+algorithm. The current A5 sequential deinitialization does not omit the
+acknowledgement wait and is therefore not a known correctness defect. The risk
+is that each unresponsive core may consume a one-second timeout, so the
+aggregate teardown time can reach or exceed the AICPU operation-execution
+timeout.
+
+The current implementations are retained. The total teardown time for N
+unresponsive cores should first be measured on A5. If a port is needed, the A5
+handshake, EXIT MMIO, shared deadline, and core deinitialization semantics must
+then be validated. See
+[Issue #1710](https://github.com/hw-native-sys/simpler/issues/1710) for tracking.
+
+| File | Current difference |
+| ---- | ------------------ |
+| `runtime/scheduler/scheduler_cold_path.cpp` | A2/A3 uses a fatal latch, broadcasts EXIT, and uses a shared deadline; A5 uses a `completed_` owner and deinitializes each core sequentially |
+| `runtime/scheduler/scheduler_context.h` | A2/A3 declares fatal-owner election and broadcast/join helpers; A5 retains its existing emergency-shutdown interface |
+
+## Files and Comparison Boundaries
+
+### Byte-Identical Runtime Files
+
+The following files at matching paths are byte-identical in the current code:
+
+```text
+build_config.py
+docs/{MULTI_RING.md,SCALAR_DATA_ACCESS.md,SUBMIT_BY_CLUSTER.md,device_log_profiling.md,
+      profiling_levels.md}
+host/{dep_gen_replay.cpp,runtime_compile_info.cpp}
+orchestration/{common.cpp,pto_arg_with_deps.h,pto_orchestration_api.h}
+runtime/{common.h,pto_dep_compute.h,pto_orchestrator.h,pto_ring_buffer.cpp,
+         pto_ring_buffer.h,pto_runtime2.cpp,pto_runtime2.h,pto_shared_memory.h,
+         pto_tensormap.h,tensor_create_info.h}
+runtime/scheduler/{pto_scheduler.cpp,scheduler_types.h}
+runtime/shared/{pto_runtime2_init.cpp,pto_shared_memory.cpp,pto_tensormap.cpp,runtime.cpp}
+```
+
+This list only indicates that the file contents are identical. It does not
+mean that every unlisted file has a substantive platform difference. Textual
+differences not included in the evidence mapping above are primarily
+mechanical, such as helper placement, comment detail, include ordering, and
+blank lines.
+
+### Examples and Tests
+
+`examples/.../tensormap_and_ringbuffer` and
+`tests/st/.../tensormap_and_ringbuffer` are outside the runtime implementation
+comparison. Examples and tests unique to either platform primarily reflect
+chip-feature validation and test-porting progress; they cannot be used to
+infer whether the runtime supports a shared algorithm.
+
+For example, A5 has `urma_deferred_completion_demo`, but this does not mean
+that the current build defines `PTO_URMA_SUPPORTED`. Likewise, the absence of a
+workload on one platform does not automatically mean that the corresponding
+runtime capability is unavailable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Buffer Memory Model: buffer-abi.md
       - Orchestrator: orchestrator.md
       - Scheduler: scheduler.md
+      - TMR A2/A3 vs A5: tensormap-and-ringbuffer-a2a3-vs-a5.md
       - A5 AICPU core selection: design/a5-fg-pg-core-selection.en.md
       - Worker Manager: worker-manager.md
       - Hardware:

--- a/src/a2a3/platform/include/aicore/aicore_profiling_state.h
+++ b/src/a2a3/platform/include/aicore/aicore_profiling_state.h
@@ -35,16 +35,14 @@
  *      `set_chip_swimlane_aicore_head_slot()`, and calls `set_aicore_profiling_flag()`,
  *      before invoking `aicore_execute`.
  *   3. `get_chip_swimlane_aicore_head()` dereferences the slot on first use and
- *      caches the result. Callers must defer the first call until AFTER the
- *      Phase 1 handshake (`aicpu_ready == 1`): AICPU's `chip_swimlane_aicpu_init`
- *      runs before it sets `aicpu_ready = 1`, so Phase 1 exit is the
- *      slot-populated guarantee. The executor resolves the head right after
- *      handshake exit so the first-task dispatch→start path carries no
- *      resolve work.
+ *      caches the result. The first call is valid after AICore observes the
+ *      AICPU initialization publication point for the current launch. In the
+ *      current handshake this is Phase 2 exit (`DATA_MAIN_BASE != 0`) after
+ *      AICPU opens the register window. Executors may resolve the head there or
+ *      defer it until the first dispatch.
  */
 
-#ifndef PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
-#define PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
+#pragma once
 
 #include <cstdint>
 
@@ -71,11 +69,12 @@ __aicore__ uint32_t get_aicore_profiling_flag();
  *
  * `get_chip_swimlane_aicore_head()` dereferences the stashed slot on first use,
  * caches the result, and returns the cached pointer on subsequent calls.
- * Callers MUST defer the first call until after AICPU has set
- * `aicpu_ready = 1` (Phase 1 handshake exit), since AICPU's
- * `chip_swimlane_aicpu_init` populates the slot before that signal.
+ * Callers MUST defer the first call until AICore has observed the AICPU
+ * initialization publication point for the current launch. In the current
+ * handshake this is Phase 2 exit (`DATA_MAIN_BASE != 0`) after AICPU opens the
+ * register window. `chip_swimlane_aicpu_init` publishes the slot before any
+ * register window is opened, so resolving at handshake exit and lazy resolution
+ * on first dispatch are both valid.
  */
 __aicore__ void set_chip_swimlane_aicore_head_slot(__gm__ uint64_t *slot_ptr);
 __aicore__ __gm__ ChipSwimlaneActiveHead *get_chip_swimlane_aicore_head();
-
-#endif  // PLATFORM_AICORE_AICORE_PROFILING_STATE_H_

--- a/src/a2a3/platform/onboard/aicore/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicore/kernel.cpp
@@ -56,10 +56,8 @@ __attribute__((weak)) __aicore__ void set_chip_swimlane_aicore_head_slot(__gm__ 
     s_chip_swimlane_aicore_head = nullptr;  // force lazy resolution on next get
 }
 __attribute__((weak)) __aicore__ __gm__ ChipSwimlaneActiveHead *get_chip_swimlane_aicore_head() {
-    // Lazy first-call resolve: AICPU init populates `*s_chip_swimlane_aicore_head_slot`
-    // before dispatching the first task, so by the time the executor reaches
-    // for the head (inside the first-task branch of the dispatch poll) the
-    // slot holds a valid device address.
+    // Lazy first-call resolve. AICPU publishes the slot before opening any
+    // register window, so it is valid after AICore observes Phase 2 exit.
     if (s_chip_swimlane_aicore_head == nullptr && s_chip_swimlane_aicore_head_slot != nullptr) {
         s_chip_swimlane_aicore_head =
             reinterpret_cast<__gm__ ChipSwimlaneActiveHead *>(*s_chip_swimlane_aicore_head_slot);
@@ -73,11 +71,11 @@ extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, Co
  * Kernel entry point with control loop
  *
  * This function implements the AICore-side task execution protocol:
- * 1. Wait for AICPU ready signal (handshake initialization)
- * 2. Signal AICore is ready (aicore_done = core_id + 1)
+ * 1. Signal AICore is ready (aicore_done = block_idx + 1)
+ * 2. Wait for AICPU to open the register window (DATA_MAIN_BASE != 0)
  * 3. Enter polling loop:
- *    - Check control flag (1 = quit, 0 = continue)
- *    - If task pointer is non-zero, execute task and mark as complete
+ *    - Poll DATA_MAIN_BASE for a task or exit command
+ *    - Execute newly dispatched tasks and report completion via COND
  *    - Use DCCI to ensure cache coherency with AICPU
  *
  * Each core (AIC or AIV) gets its own handshake buffer indexed by block_idx.
@@ -121,9 +119,9 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ KernelA
         k_args->chip_swimlane_aicore_rotation_table != 0) {
         // Stash only the slot pointer. The slot CONTENTS are written by
         // AICPU's `chip_swimlane_aicpu_init`, which races with this entry but
-        // completes before AICPU sets `aicpu_ready = 1`. The executor
-        // dereferences via `get_chip_swimlane_aicore_head()` only after Phase 1
-        // handshake exit.
+        // publishes the slot before opening any register window. The executor
+        // dereferences via `get_chip_swimlane_aicore_head()` only after it
+        // observes Phase 2 exit.
         __gm__ uint64_t *head_table = reinterpret_cast<__gm__ uint64_t *>(k_args->chip_swimlane_aicore_rotation_table);
         set_chip_swimlane_aicore_head_slot(&head_table[block_idx]);
     } else {

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -121,8 +121,8 @@ extern "C" void aicore_execute_wrapper(
     set_aicore_profiling_flag(enable_profiling_flag);
     if (chip_swimlane_aicore_rotation_table != 0) {
         // Stash only the slot pointer; the executor dereferences it via
-        // get_chip_swimlane_aicore_head() after Phase 1 handshake exit. See
-        // aicore_profiling_state.h.
+        // get_chip_swimlane_aicore_head() after observing Phase 2 window-open.
+        // See aicore_profiling_state.h.
         uint64_t *head_table = reinterpret_cast<uint64_t *>(chip_swimlane_aicore_rotation_table);
         set_chip_swimlane_aicore_head_slot(reinterpret_cast<__gm__ uint64_t *>(&head_table[block_idx]));
     } else {

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -49,18 +49,18 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * Implements the AICPU-AICore register-based dispatch protocol:
  * 1. Report physical core ID and core type, signal aicore_done (no AICPU wait)
  * 2. Wait for the AICPU to open our register window (DATA_MAIN_BASE != 0)
- * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
+ * 3. Cache per-core PTO2DispatchPayload pointer from my_hank->task
  * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
  * AICore reports on launch; the AICPU writes &s_payload_per_core[i] to
- * hank->task and then opens the register window (DATA_MAIN_BASE = IDLE), which
+ * my_hank->task and then opens the register window (DATA_MAIN_BASE = IDLE), which
  * is itself the acknowledgement. AICore caches this pointer and reads
  * function_bin_addr + args pointer from it on each dispatch. reg_val is a
  * monotonically increasing task ID used only for dispatch signaling and
  * ACK/FIN protocol.
  *
  * Profiling state (enable flag, chip swimlane rotation channel) is published into the platform
- * via set_aicore_profiling_flag / set_aicore_chip_swimlane_ring at kernel entry —
+ * via set_aicore_profiling_flag / set_chip_swimlane_aicore_head_slot at kernel entry —
  * this routine reads it through the matching getters, so neither Handshake
  * nor this signature carry profiling fields.
  *

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -67,12 +67,13 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * AICPU and AICore during task execution.
  *
  * Protocol State Machine:
- * 1. Initialization: AICPU sets aicpu_ready=1
- * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
- * 4. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
- * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
- * 6. Shutdown: AICPU sets control=1, AICore exits
+ * 1. AICore publishes physical_core_id, core_type, and aicore_done on launch
+ * 2. AICPU publishes the task pointer and opens the register window with DATA_MAIN_BASE=IDLE
+ * 3. AICore observes window-open, reports initial idle state, and reads the task pointer
+ * 4. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
+ * 5. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
+ * 6. Task Completion: AICore writes FIN to COND; AICPU observes completion
+ * 7. Shutdown: AICPU writes the exit signal to DATA_MAIN_BASE; AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
  * task execution across multiple cores.
@@ -86,17 +87,17 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * between cores and optimize cache coherency operations.
  *
  * Field Access Patterns:
- * - aicpu_ready: Written by AICPU, read by AICore
+ * - aicpu_ready: Reserved legacy field; the current handshake does not use it
  * - aicore_done: Written by AICore, read by AICPU (final report; physical_core_id
  *   and core_type are published alongside it in the same write)
- * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
+ * - task: Written by AICPU before window-open, read by AICore after window-open
  * - core_type: Written by AICore (with aicore_done), read by AICPU (CoreType::AIC or CoreType::AIV)
  * - physical_core_id: Written by AICore (with aicore_done), read by AICPU
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;  // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicpu_ready;  // Legacy layout field; unused by the current handshake
     volatile uint32_t aicore_done;  // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;         // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile uint64_t task;         // PTO2DispatchPayload* published before register window-open
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV (reported by AICore with aicore_done)
     volatile uint32_t physical_core_id;  // Physical core ID (reported by AICore with aicore_done)
 } __attribute__((aligned(64)));

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -822,7 +822,7 @@ int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thr
     // prior enabled launch's level can't leak into the phase-record gates in
     // scheduler_dispatch. This runs on the leader before it publishes
     // hs_setup_done_, so it happens-before every thread's handshake_partition
-    // (and therefore before any aicpu_ready=1 write).
+    // and therefore before any register window is opened.
     if (is_chip_swimlane_enabled()) {
         chip_swimlane_aicpu_init(runtime->worker_count);
         chip_swimlane_level_ = get_chip_swimlane_level();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -47,18 +47,20 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * AICore main execution loop
  *
  * Implements the AICPU-AICore register-based dispatch protocol:
- * 1. Wait for AICPU ready signal via handshake buffer
- * 2. Report physical core ID and core type, signal AICore ready
- * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
+ * 1. Report physical core ID and core type, signal aicore_done (no AICPU wait)
+ * 2. Wait for the AICPU to open our register window (DATA_MAIN_BASE != 0)
+ * 3. Cache per-core PTO2DispatchPayload pointer from my_hank->task
  * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * AICPU writes &s_payload_per_core[i] to hank->task before setting
- * aicpu_ready=1. AICore caches this pointer and reads function_bin_addr +
- * args pointer from it on each dispatch. reg_val is a monotonically
- * increasing task ID used only for dispatch signaling and ACK/FIN protocol.
+ * AICore reports on launch; the AICPU writes &s_payload_per_core[i] to
+ * my_hank->task and then opens the register window (DATA_MAIN_BASE = IDLE), which
+ * is itself the acknowledgement. AICore caches this pointer and reads
+ * function_bin_addr + args pointer from it on each dispatch. reg_val is a
+ * monotonically increasing task ID used only for dispatch signaling and
+ * ACK/FIN protocol.
  *
  * Profiling state (enable flag, chip swimlane rotation channel) is published into the platform
- * via set_aicore_profiling_flag / set_aicore_chip_swimlane_ring at kernel entry —
+ * via set_aicore_profiling_flag / set_chip_swimlane_aicore_head_slot at kernel entry —
  * this routine reads it through the matching getters, so neither Handshake
  * nor this signature carry profiling fields.
  *
@@ -106,8 +108,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     bool dump_args_enabled = SIMPLER_GET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
     bool pmu_enabled = SIMPLER_GET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
 
-    // The per-core rotation channel is resolved on first dispatch. AICPU
-    // initializes the channel before publishing the first task.
+    // This executor chooses first-dispatch lazy resolution. The rotation
+    // channel has already been safe to resolve since Phase 2 exit above.
     __gm__ ChipSwimlaneActiveHead *chip_swimlane_head = nullptr;
     // cached_buf_seq must start != AICPU's initial head.current_buf_seq (0)
     // so the first reservation observes a mismatch and loads the buffer ptr.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -236,7 +236,7 @@ header just like on onboard.
 | ----- | -------- |
 | 0 | Nothing (disabled) |
 | 1 | AICore timing only (start/end/task_token_raw) — AICPU `complete_task` is bypassed |
-| 2 | + AICPU dispatch_time, finish_time |
+| 2 | + dispatch_time, finish_time |
 | 3 | + Scheduler phases (`SCHED_*`) |
 | 4 | + Orchestrator phases (full) |
 
@@ -271,6 +271,10 @@ Fanout edges are no longer carried on the device hot path — `swimlane_converte
 joins them from the sibling `deps.json` (produced by dep_gen) at post-process time.
 
 Bare `--enable-chip-swimlane` = level 4 (backward compatible).
+
+The Complete phase's `tasks_processed` value is the number of AICore FIN/retire
+events observed by the scheduler poll. For SPMD tasks this includes non-final
+sub-block retires; it is therefore not always the number of logical tasks.
 
 ### Level gating in AICPU code
 
@@ -427,9 +431,9 @@ definitions to runtime headers.
 ### Code Locations
 
 - Macro defaults and validation: `src/common/task_interface/profiling_config.h`
-- Scheduler profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp` and `scheduler_cold_path.cpp`
-- Orchestrator profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`
-- TensorMap profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
+- Scheduler profiling: `../runtime/scheduler/scheduler_dispatch.cpp` and `../runtime/scheduler/scheduler_cold_path.cpp`
+- Orchestrator profiling: `../aicpu/aicpu_executor.cpp`
+- TensorMap profiling: `../runtime/pto_tensormap.h`
 
 ---
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -21,9 +21,10 @@
  * initialized during scheduler cold start from core topology and the resident
  * per-device config, then remains stable for that scheduler instance.
  *
- * LocalContext (block_idx, block_num) and args[] are rebuilt by build_payload()
- * before each dispatch.  Both context struct pointers are written into the
- * args[] suffix on every dispatch (since args[] is rebuilt entirely each time).
+ * The scheduler prefills the AsyncCtx slab pointers and capacity, along with
+ * both context pointers in the args[] suffix, during cold initialization.
+ * build_payload() updates only the task-varying LocalContext fields and
+ * args[0..num_args) before each dispatch.
  *
  * AICore caches a pointer to its per-core slot at startup and reads from
  * it on each dispatch.  The struct is cache-line aligned to avoid false

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
@@ -40,8 +40,7 @@
  * std::function — it would break the inlining and add ~5 ns/call to the orch hot path.
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_
+#pragma once
 
 #include <cstdint>
 
@@ -175,5 +174,3 @@ inline int32_t count_registrable_outputs(const DepInputs &inputs, bool in_manual
     }
     return needed;
 }
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -552,7 +552,6 @@ static bool prepare_task(
     out->slot_state->bind_ring(ring_id);
     out->slot_state->reset_for_reuse();
     out->slot_state->fanin_count = 0;
-    out->slot_state->dep_pool_mark = 0;
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -10,9 +10,9 @@
  */
 
 /**
- * PTO Runtime2 - Core Type Definitions
+ * tensormap_and_ringbuffer Runtime - Core Type Definitions
  *
- * This header defines all fundamental types used by the PTO Runtime2 system:
+ * This header defines the fundamental tensormap_and_ringbuffer runtime types:
  * - Configuration constants
  * - Worker types and task states
  * - ChipTensor regions and task parameters
@@ -22,8 +22,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -61,7 +60,7 @@
 
 // Task management
 // NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
-// Actual window size is passed at runtime to runtime_create_from_sm().
+// Actual window size is passed at runtime to runtime_reserve_layout().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
 #define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
@@ -85,10 +84,8 @@
 #define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
-
-// Cross-thread early-dispatch work queue (power of two)
-#define PTO2_EARLY_DISPATCH_QUEUE_SIZE 64
+#define PTO2_READY_QUEUE_SIZE 65536        // Per-shape queue size
+#define PTO2_EARLY_DISPATCH_QUEUE_SIZE 64  // Per-shape early-dispatch candidate queue
 
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 64
@@ -213,13 +210,6 @@ static_assert(offsetof(PTO2TaskDescriptor, packed_buffer_base) == 24, "packed_bu
 // Per-Slot Scheduling State
 // =============================================================================
 
-/**
- * Task payload data (cold path - only accessed during orchestration and dispatch)
- *
- * Layout: metadata + inline fanin packed in the first 9 cache lines, followed
- * by bulk tensor and scalar data. Small fanins stay fully inline; larger
- * fanins spill into a per-ring ring buffer slice.
- */
 // Early-dispatch claim states for PTO2TaskPayload::early_dispatch_state.
 enum PTO2EarlyDispatchState : uint8_t {
     PTO2_EARLY_DISPATCH_NONE = 0,       // not pre-staged
@@ -251,6 +241,13 @@ enum PTO2EarlySyncDrainState : uint8_t {
 // consumer can pre-stage all its idle cores. 2 words = 128 bits >= 72.
 inline constexpr int PTO2_EARLY_DISPATCH_CORE_MASK_WORDS = 2;
 
+/**
+ * Task payload data (cold path - only accessed during orchestration and dispatch)
+ *
+ * Layout: metadata + inline fanin packed in the first 9 cache lines, followed
+ * by bulk tensor and scalar data. Small fanins stay fully inline; larger
+ * fanins spill into a per-ring ring buffer slice.
+ */
 struct PTO2TaskPayload {
     // === Cache lines 0-8 (576B) — metadata + inline fanin ===
     int32_t tensor_count{0};
@@ -260,55 +257,41 @@ struct PTO2TaskPayload {
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
     // Early-dispatch metadata (AICPU-side only). Ordered by descending
-    // alignment (8B mask, 4B fanin, then 2B/1B counters and flags) so the block packs with no
-    // internal padding. Kept here after the fanin array (not moved up front): on
-    // cache line 8 it shares only with the rarely-touched fanin tail, whereas in
-    // line 0 the early-dispatch atomics (written during staging) would false-share with
-    // tensor_count/scalar_count (read by build_payload at dispatch). Fits in the 40B
-    // between the fanin array (offset 536) and the 64B-aligned tensors[] (offset
-    // 576), so sizeof and tensors[] are unchanged.
+    // alignment so the block packs without internal padding. Cache line 8
+    // contains the rarely-touched fanin tail rather than the hot tensor/scalar
+    // counts, and the block fits between the fanin array and the 64B-aligned
+    // predicate without changing the payload layout.
     //
-    // Bitmask of global core_ids this consumer is pre-staged (gated) on. Concurrent
-    // stagers publish bits with atomic fetch_or. A regular consumer destructively
-    // splits them between release and late-stager owners; a sync_start cohort keeps
-    // the completed mask stable for its single launch owner, whether staging is local
-    // or uses the global drain fallback.
+    // Concurrent stagers publish global core-id bits with fetch_or. A regular
+    // consumer destructively splits those bits between release and late-stager
+    // owners; a sync_start cohort keeps the completed mask stable for one launch
+    // owner across both local staging and the global-drain fallback.
     std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
-    // Early-dispatch CANDIDATE detection (event-driven, dual of fanin_refcount):
-    // seeded at wiring with producers already complete, then a flagged producer
-    // bumps each consumer after all of its logical blocks are published.
-    // dispatch_fanin == fanin_actual_count  <=>  every producer is
-    // flagged-and-fully-published or was
-    // pre-completed  =>  this task is an early-dispatch candidate (push early_dispatch_queues[shape]).
+    // Candidate detection is the event-driven dual of fanin_refcount. Wiring
+    // seeds producers already complete, and flagged producers increment the
+    // count only after all logical blocks are launch-visible. Equality with
+    // fanin_actual_count makes the consumer eligible for early dispatch.
     std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: fully-published + pre-completed producers
-    // Number of logical blocks whose payloads and MMIO tokens are published.
-    // Claimed-but-unpublished blocks do not make a producer launch-visible. Its
-    // seq_cst updates pair with early_dispatch_state to avoid losing the final
-    // publish vs. release wakeup for a pre-staged producer.
+    // Claimed-but-unpublished blocks are not launch-visible. Seq_cst updates
+    // pair with early_dispatch_state so final publication cannot be lost when
+    // producer release races a stager.
     std::atomic<int16_t> published_block_count{0};
-    // Lock-free claim state shared by the stagers (Hook 1, possibly several AICPU
-    // threads concurrently) and the completion-path release: 0=NONE, 1=STAGING,
-    // 3=DISPATCHED (2=STAGED is unused now). STAGING is the STABLE gated state —
-    // many threads stage blocks concurrently while it holds, each claiming a block
-    // via the atomic next_block_idx and OR-ing its cores into staged_core_mask.
-    // Release does STAGING->DISPATCHED. For a regular consumer it claims the current
-    // mask and a late stager rings only its remaining bits. A sync_start consumer
-    // preserves the mask for rendezvous counting and its single launch pass.
+    // Shared stager/release claim state. STAGING remains stable while multiple
+    // AICPU threads claim blocks and publish mask bits; release changes it to
+    // DISPATCHED. Regular consumers split mask ownership, while sync_start
+    // consumers preserve the mask for rendezvous counting and one launch pass.
     std::atomic<uint8_t> early_dispatch_state{0};
-    // The launch owner publishes COMPLETE only after all owned doorbells are
-    // visible, keeping fanout private until every gated block has launched.
+    // COMPLETE is published only after every owned doorbell is visible, keeping
+    // fanout private until all gated blocks have launched.
     std::atomic<uint8_t> early_dispatch_launch_state{PTO2_EARLY_DISPATCH_LAUNCH_NONE};
-    // sync_start early-dispatch rendezvous: count of this task's gated CORES currently
-    // occupying a RUNNING slot (staged directly to an idle core, or promoted from a
-    // gated pending slot). Counted per-core (not per-block) so it is shape-agnostic: a
-    // MIX block spans a cluster whose cores promote independently. A sync_start task's
-    // doorbells are rung only once this reaches popcount(staged_core_mask) AND the
-    // producer released, so all cores launch atomically. Unused (0) for non-sync_start.
+    // Number of this sync_start task's gated cores occupying RUNNING slots.
+    // Counting cores is shape-agnostic for MIX, whose cluster cores promote
+    // independently. Doorbells launch only after this count matches the staged
+    // mask and producer release is visible. Unused for non-sync_start tasks.
     std::atomic<int16_t> running_slot_count{0};
-    // Ownership handshake between the early sync queue and final ready routing.
-    // A successful OWNER persists through ARMED and COMPLETE until payload
-    // reinitialization. READY records that producer release observed OWNER;
-    // only cancellation clears OWNER during the current task lifetime.
+    // OWNER persists through ARMED and COMPLETE for one task lifetime. READY
+    // records that producer release observed the owner; only cancellation clears
+    // ownership before payload reinitialization.
     std::atomic<uint8_t> early_sync_drain_state{PTO2_EARLY_SYNC_DRAIN_NONE};
     // === Cache line 9 (byte 576) — dispatch predicate (AICPU-only) ===
     // Offset is a fixed 576, independent of MAX_TENSOR_ARGS / MAX_SCALAR_ARGS.
@@ -326,11 +309,9 @@ struct PTO2TaskPayload {
     static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
 
     /**
-     * Prefetch (for write) the regions init() is about to fill so the stores land
-     * in warm cache. tensor_count/scalar_count come from the Arg — the payload's
-     * own counts are not set until init(). Warms the early-dispatch block at
-     * offset 536 (cache line 8) too. A member fn lowers to the same prefetch
-     * instructions as a free function (`this` is just a register), no cache impact.
+     * Prefetch for write the regions init() fills. tensor_count/scalar_count
+     * come from the argument because the payload counts are not initialized
+     * yet. The touched range also warms the early-dispatch metadata line.
      */
     void prefetch(int32_t tensor_count, int32_t scalar_count) const {
         for (int32_t i = 0; i < tensor_count; i++) {
@@ -380,19 +361,10 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
-        // Early-dispatch metadata — the single init point for these
-        // fields. reset_for_reuse MUST NOT touch the payload (it runs on the
-        // scheduler's advance-ring path and would pull this cold cache line across
-        // structures); prepare_task only allocates/binds. prefetch() warms this
-        // line (offset 512) so these writes land in warm cache.
-        //
-        // early_dispatch_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
-        // task whose own allow_early_resolve is false still has them touched when
-        // one of ITS producers is flagged (propagate_dispatch_fanin bumps
-        // dispatch_fanin and may CAS early_dispatch_state on any consumer, independent of the
-        // consumer's own hint). So they MUST be zeroed here unconditionally.
-        // Publication and launch fields share this same per-submit lifetime
-        // and are reset here too.
+        // reset_for_reuse deliberately skips this cold payload. These fields
+        // are consumer-side state and must be initialized on every submit even
+        // when the consumer itself does not allow early resolve, because one of
+        // its flagged producers may still update them.
         early_dispatch_state.store(PTO2_EARLY_DISPATCH_NONE, std::memory_order_relaxed);
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_core_mask[w].store(0, std::memory_order_relaxed);
@@ -457,6 +429,9 @@ enum PTO2TaskLifecycleFlag : uint8_t {
     PTO2_LIFECYCLE_FLAGS_NONE = 0,
     PTO2_READY_CLAIMED = 1U << 0,
     PTO2_COMPLETION_DONE = 1U << 1,
+    // Deferred-completion discriminator packed into lifecycle_flags so the
+    // slot remains 64B. Call sites use mark_any_subtask_deferred() and
+    // has_any_subtask_deferred().
     PTO2_SUBTASK_DEFERRED = 1U << 2,
     PTO2_DISPATCH_PROPAGATED = 1U << 3,
 };
@@ -547,14 +522,14 @@ struct alignas(64) PTO2TaskSlotState {
         task = t;
     }
 
-    // Lock-free callers use this only as a fast-path hint. A false result is
+    // Lock-free callers use this as a fast-path hint. A false result is
     // rechecked by try_mark_dispatch_propagated() while holding fanout_lock.
     bool has_dispatch_propagated() const {
         return (lifecycle_flags.load(std::memory_order_acquire) & PTO2_DISPATCH_PROPAGATED) != 0;
     }
 
-    // The propagation owner holds fanout_lock from this claim through its
-    // fanout snapshot so wiring can classify late edges exactly once.
+    // The propagation owner holds fanout_lock through its fanout snapshot, so
+    // wiring can classify late edges exactly once.
     bool try_mark_dispatch_propagated() {
         return (lifecycle_flags.fetch_or(PTO2_DISPATCH_PROPAGATED, std::memory_order_acq_rel) &
                 PTO2_DISPATCH_PROPAGATED) == 0;
@@ -572,9 +547,8 @@ struct alignas(64) PTO2TaskSlotState {
     // Set by any subtask FIN that pushed deferred-completion CONDITIONs to the
     // runtime mailbox; read by the last subtask FIN to decide whether the task
     // needs MPSC-deferred completion or can complete inline on this thread. The
-    // release write is sequenced before on_subtask_complete's acq_rel fetch_add
-    // and the acquire read after, so all earlier subtasks' writes are visible to
-    // the last subtask.
+    // release write is sequenced before on_subtask_complete's acq_rel fetch_add;
+    // the acquire read by the last subtask observes all earlier writes.
     void mark_any_subtask_deferred() { lifecycle_flags.fetch_or(PTO2_SUBTASK_DEFERRED, std::memory_order_release); }
 
     bool has_any_subtask_deferred() const {
@@ -603,10 +577,8 @@ struct alignas(64) PTO2TaskSlotState {
         lifecycle_flags.store(PTO2_LIFECYCLE_FLAGS_NONE, std::memory_order_relaxed);
         // Note: active_mask and task_attrs are per-submit-constant fields
         // rewritten in prepare_task on every reuse, so they are not reset here.
-        // Note: payload early-dispatch fields (state, masks, fanin, publication count)
-        // are NOT reset here — this method skips the payload by contract. They are
-        // (re)initialized in PTO2TaskPayload::init on every submit, before the slot
-        // becomes visible to the scheduler.
+        // Payload early-dispatch fields are initialized by PTO2TaskPayload::init
+        // on every submit before the slot becomes scheduler-visible.
     }
 
     // === Per-task fanout spinlock ===
@@ -659,5 +631,3 @@ struct alignas(64) PTO2TaskSlotState {
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -69,12 +69,13 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * AICPU and AICore during task execution.
  *
  * Protocol State Machine:
- * 1. Initialization: AICPU sets aicpu_ready=1
- * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
- * 4. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
- * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
- * 6. Shutdown: AICPU sets control=1, AICore exits
+ * 1. AICore publishes physical_core_id, core_type, and aicore_done on launch
+ * 2. AICPU publishes the task pointer and opens the register window with DATA_MAIN_BASE=IDLE
+ * 3. AICore observes window-open, reports initial idle state, and reads the task pointer
+ * 4. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
+ * 5. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
+ * 6. Task Completion: AICore writes FIN to COND; AICPU observes completion
+ * 7. Shutdown: AICPU writes the exit signal to DATA_MAIN_BASE; AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
  * task execution across multiple cores.
@@ -88,17 +89,17 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * between cores and optimize cache coherency operations.
  *
  * Field Access Patterns:
- * - aicpu_ready: Written by AICPU, read by AICore
+ * - aicpu_ready: Reserved legacy field; the current handshake does not use it
  * - aicore_done: Written by AICore, read by AICPU (final report; physical_core_id
  *   and core_type are published alongside it in the same write)
- * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
+ * - task: Written by AICPU before window-open, read by AICore after window-open
  * - core_type: Written by AICore (with aicore_done), read by AICPU (CoreType::AIC or CoreType::AIV)
  * - physical_core_id: Written by AICore (with aicore_done), read by AICPU
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;  // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicpu_ready;  // Legacy layout field; unused by the current handshake
     volatile uint32_t aicore_done;  // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;         // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile uint64_t task;         // PTO2DispatchPayload* published before register window-open
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV (reported by AICore with aicore_done)
     volatile uint32_t physical_core_id;  // Physical core ID (reported by AICore with aicore_done)
 } __attribute__((aligned(64)));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1117,7 +1117,7 @@ int32_t SchedulerContext::pre_handshake_init(
     // prior enabled launch's level can't leak into the phase-record gates in
     // scheduler_dispatch. This runs on the leader before it publishes
     // hs_setup_done_, so it happens-before every thread's handshake_partition
-    // (and therefore before any aicpu_ready=1 write).
+    // and therefore before any register window is opened.
     if (is_chip_swimlane_enabled()) {
         chip_swimlane_aicpu_init(runtime->dev.worker_count);
         chip_swimlane_level_ = get_chip_swimlane_level();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -8,8 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#ifndef SCHEDULER_TYPES_H
-#define SCHEDULER_TYPES_H
+#pragma once
 
 #include <atomic>
 #include <cstddef>
@@ -234,25 +233,6 @@ public:
 
     bool has_any_running_cores() const { return ((~core_states_) & (aic_mask_ | aiv_mask_)).has_value(); }
 
-    // True if any core on this thread still has a free slot to stage onto — an
-    // idle core (running slot) or a running core with a free pending slot. A
-    // core is unavailable only when running AND its pending slot is occupied;
-    // idle cores keep pending_occupied_ clear by invariant, so
-    // ~pending_occupied_ over all cores is exactly "has a free slot". Purely
-    // local (no shared/atomic access) — used to skip early dispatch, and its
-    // shared-queue pop, when this thread has no capacity at all.
-    // BitStates of every core on this thread with a free slot to stage onto: a
-    // core is unavailable only when running AND its pending slot is occupied.
-    // Idle cores keep pending_occupied_ clear by invariant, so ~pending_occupied_
-    // over aic|aiv is exactly "has a free slot". Spans AIC+AIV, so its .count() is
-    // an upper bound on the early-dispatch drain's per-shape pop (never exceeds the
-    // thread's total free cores), and .has_value() is the has_any_free_slot()
-    // predicate that gates the Phase-4b early-dispatch pass. Purely local (no
-    // shared/atomic access).
-    BitStates get_free_slot_states() const { return (~pending_occupied_) & (aic_mask_ | aiv_mask_); }
-
-    bool has_any_free_slot() const { return get_free_slot_states().has_value(); }
-
     template <CoreType CT>
     int32_t get_running_count() const {
         if constexpr (CT == CoreType::AIC) {
@@ -275,6 +255,12 @@ public:
 
     BitStates get_all_running_cores() const { return (~core_states_) & (aic_mask_ | aiv_mask_); }
     BitStates get_cluster_offset_states() const { return aic_mask_; }
+
+    // Every core whose pending slot is free has capacity for early-dispatch
+    // staging: an idle core uses its running slot, while a running core uses its
+    // pending slot. This is local tracker state with no shared-memory access.
+    BitStates get_free_slot_states() const { return (~pending_occupied_) & (aic_mask_ | aiv_mask_); }
+    bool has_any_free_slot() const { return get_free_slot_states().has_value(); }
 
     // --- Cluster matching ---
 
@@ -380,53 +366,6 @@ public:
         return MixPlacement::PENDING;
     }
 
-    // --- Gated MIX split placement ---
-    // A gated MIX block can place each of its cores INDEPENDENTLY (idle core -> gated
-    // running slot; busy core with a free pending slot -> gated pending slot), because
-    // every core waits on the doorbell and nothing executes until the rendezvous rings.
-    // This is unsafe for immediate (non-gated) dispatch — hence separate from
-    // classify_mix_cluster, which forces a single placement for the whole cluster.
-
-    // Cores of `cluster_offset` named by core_mask.
-    BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used;
-        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates::bit(cluster_offset);
-        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates::bit(cluster_offset + 1);
-        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates::bit(cluster_offset + 2);
-        return used;
-    }
-
-    // Every used core has SOME free slot: a core lacks one only when it is running AND
-    // its pending slot is occupied (both slots taken).
-    bool mix_cluster_all_slots(int32_t cluster_offset, uint8_t core_mask) const {
-        BitStates used = mix_used_cores(cluster_offset, core_mask);
-        if (!used.has_value()) return false;
-        BitStates no_slot = (~core_states_) & pending_occupied_;  // running AND pending taken
-        return !(used & no_slot).has_value();
-    }
-
-    // Used cores that are idle -> will take a running slot (rendezvous seed count).
-    int32_t mix_cluster_idle_core_count(int32_t cluster_offset, uint8_t core_mask) const {
-        return (mix_used_cores(cluster_offset, core_mask) & core_states_).count();
-    }
-
-    // Clusters where every used core has a free slot (gated MIX split gate/iteration).
-    BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
-        BitStates result;
-        BitStates candidates = get_cluster_offset_states();
-        while (candidates.has_value()) {
-            int32_t off = candidates.pop_first();
-            if (mix_cluster_all_slots(off, core_mask)) {
-                result |= BitStates::bit(off);
-            }
-        }
-        return result;
-    }
-
-    int32_t count_mix_split_clusters(uint8_t core_mask) const {
-        return get_mix_split_cluster_offset_states(core_mask).count();
-    }
-
     BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
         BitStates result;
         BitStates candidates = get_cluster_offset_states();
@@ -443,21 +382,51 @@ public:
         return get_mix_running_cluster_offset_states(core_mask).count();
     }
 
-    // Number of whole logical blocks this tracker can accept for sync_start
-    // staging. AIC/AIV count cores; MIX counts clusters because one logical MIX
-    // block may occupy multiple cores in the same cluster. Gated early staging
-    // includes pending slots, while ready staging is restricted to idle slots.
-    int32_t count_available_blocks(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending) const {
-        if (shape == PTO2ResourceShape::MIX) {
-            return include_pending ? count_mix_split_clusters(core_mask) : count_mix_running_clusters(core_mask);
-        }
-        if (shape == PTO2ResourceShape::DUMMY) return 0;
+    // --- Gated MIX split placement ---
+    // A gated MIX block can place each core independently: idle cores take
+    // running slots and busy cores with free capacity take pending slots. Every
+    // core waits on the doorbell, so nothing executes before the rendezvous.
+    // Immediate dispatch instead uses classify_mix_cluster to require one
+    // placement for the whole cluster.
 
-        int32_t available = get_idle_core_offset_states(shape).count();
-        if (include_pending) {
-            available += get_pending_core_offset_states(shape).count();
+    // Cores of `cluster_offset` named by core_mask.
+    BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
+        BitStates used;
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates::bit(cluster_offset);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) used |= BitStates::bit(cluster_offset + 1);
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) used |= BitStates::bit(cluster_offset + 2);
+        return used;
+    }
+
+    bool mix_cluster_all_slots(int32_t cluster_offset, uint8_t core_mask) const {
+        BitStates used = mix_used_cores(cluster_offset, core_mask);
+        if (!used.has_value()) return false;
+        // A used core has no capacity only while both running and pending slots
+        // are occupied.
+        BitStates no_slot = (~core_states_) & pending_occupied_;
+        return !(used & no_slot).has_value();
+    }
+
+    // Used idle cores take running slots and seed the rendezvous count.
+    int32_t mix_cluster_idle_core_count(int32_t cluster_offset, uint8_t core_mask) const {
+        return (mix_used_cores(cluster_offset, core_mask) & core_states_).count();
+    }
+
+    // Clusters where every used core has a free slot.
+    BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
+        BitStates result;
+        BitStates candidates = get_cluster_offset_states();
+        while (candidates.has_value()) {
+            int32_t off = candidates.pop_first();
+            if (mix_cluster_all_slots(off, core_mask)) {
+                result |= BitStates::bit(off);
+            }
         }
-        return available;
+        return result;
+    }
+
+    int32_t count_mix_split_clusters(uint8_t core_mask) const {
+        return get_mix_split_cluster_offset_states(core_mask).count();
     }
 
     BitStates get_pending_core_offset_states(PTO2ResourceShape shape) const {
@@ -480,6 +449,21 @@ public:
         }
         // AIV
         return (~core_states_) & aiv_mask_ & ~pending_occupied_;
+    }
+
+    // Number of logical sync_start blocks this tracker can place. AIC/AIV use
+    // one core per block; MIX uses one active-mask-compatible cluster per block.
+    // Gated early staging may use both idle running slots and free pending slots,
+    // while a ready cohort is restricted to idle running slots.
+    int32_t count_available_blocks(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending) const {
+        if (shape == PTO2ResourceShape::MIX) {
+            return include_pending ? count_mix_split_clusters(core_mask) : count_mix_running_clusters(core_mask);
+        }
+        if (shape != PTO2ResourceShape::AIC && shape != PTO2ResourceShape::AIV) return 0;
+
+        int32_t available = get_idle_core_offset_states(shape).count();
+        if (include_pending) available += get_pending_core_offset_states(shape).count();
+        return available;
     }
 
     // --- Two-phase dispatch unified query ---
@@ -534,11 +518,10 @@ struct alignas(64) SchedChipSwimlaneCounters {
     uint64_t sched_async_cycle{0};
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
-    // Sub-block retires that did NOT finish a slot (SPMD blocks of a multi-block
-    // task retiring one at a time). Counted separately so the Complete-phase
-    // emit can fire on poll iterations that only retired sub-blocks — otherwise
-    // the serial-harvest tail of an SPMD slot is invisible (no slot completes
-    // until the last block, leaving the scheduler lane blank for that window).
+    // Sub-block retires that did not finish a slot (SPMD blocks of a
+    // multi-block task retiring one at a time). Keep this separate from
+    // phase_complete_count so the Complete phase remains visible during the
+    // serial-harvest tail of an SPMD task.
     uint32_t phase_subretire_count{0};
     uint32_t phase_dispatch_count{0};
     // Per-emit delta is (current - *_at_last_emit). Accumulated only when
@@ -568,14 +551,13 @@ struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> sync_start_pending{0};              // 0=normal; -1=initializing; >0=active (value=block_num)
     std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
     std::atomic<uint64_t> drain_attempt{0};                  // incremented whenever an ack round is reset
-    // Parallel staging: after the coordinator confirms global availability it sets
-    // stage_go, releasing every thread to stage its OWN cores concurrently (vs the old
-    // single-thread serial fill). Each thread ORs its bit into stage_done_mask when it
-    // finishes and accumulates its running-slot cores into running_staged; the coordinator
-    // thread waits for all bits, seeds the rendezvous, and reopens the gate.
-    std::atomic<int32_t> drain_stage_go{0};          // 0=hold; 1=coordinator released parallel staging
-    std::atomic<uint32_t> drain_stage_done_mask{0};  // bit per thread; all-set = all threads done staging
-    std::atomic<int32_t> drain_running_staged{0};    // sum of running-slot cores staged (rendezvous seed)
+    // The coordinator publishes stage_go after global capacity is confirmed.
+    // Each scheduler stages its local cores, publishes its bit in
+    // stage_done_mask, and contributes running-slot cores to running_staged.
+    // The coordinator waits for all scheduler bits before seeding the rendezvous.
+    std::atomic<int32_t> drain_stage_go{0};          // 0=hold; 1=parallel staging enabled
+    std::atomic<uint32_t> drain_stage_done_mask{0};  // bit per scheduler thread
+    std::atomic<int32_t> drain_running_staged{0};    // total running-slot cores staged
     int32_t _pad[7];
 };
 static_assert(sizeof(SyncStartDrainState) == 64);
@@ -594,5 +576,3 @@ inline uint64_t sync_start_drain_next_attempt(uint64_t attempt) {
 inline uint64_t sync_start_drain_ack_subtree_token(uint64_t attempt) {
     return attempt | SYNC_START_DRAIN_ACK_SUBTREE_READY;
 }
-
-#endif  // SCHEDULER_TYPES_H

--- a/src/a5/platform/include/aicore/aicore_profiling_state.h
+++ b/src/a5/platform/include/aicore/aicore_profiling_state.h
@@ -37,19 +37,19 @@
  *      `set_chip_swimlane_aicore_head_slot()`, resolves its own PMU MMIO base
  *      from `regs[physical_core_id]`, and calls the PMU setters, before
  *      invoking `aicore_execute`.
- *   3. `get_chip_swimlane_aicore_head()` lazily dereferences the slot the
- *      first time it is called. Callers must defer the call until AFTER
- *      AICPU has dispatched the first task (so AICPU init has had a chance
- *      to populate the table). The executor handles this by calling it
- *      inside the main loop's first-task branch.
+ *   3. `get_chip_swimlane_aicore_head()` dereferences the slot on first use and
+ *      caches the result. The first call is valid after AICore observes the
+ *      AICPU initialization publication point for the current launch. In the
+ *      current handshake this is Phase 2 exit (`DATA_MAIN_BASE != 0`) after
+ *      AICPU opens the register window. Executors may resolve the head there or
+ *      defer it until the first dispatch.
  *
  * a5 specifics: PMU on a5 is AICore-side (AICore reads MMIO + writes the
  * staging slot), so a5 carries an extra `pmu_ring` + `pmu_reg_base` pair
  * that a2a3 does not have.
  */
 
-#ifndef PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
-#define PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
+#pragma once
 
 #include <cstdint>
 
@@ -75,13 +75,14 @@ __aicore__ uint32_t get_aicore_profiling_flag();
  * yet have populated the table (the host launches both kernels and AICPU's
  * init runs concurrently with AICore's entry).
  *
- * `get_chip_swimlane_aicore_head()` lazily dereferences the stashed slot on
- * first use, caches the result, and returns it on subsequent calls. Callers
- * MUST defer the first call until after AICPU has dispatched the first task —
- * by then AICPU's init has completed and the slot holds a valid device
- * address pointing at the AICore pool's `head` (an `ChipSwimlaneActiveHead`).
- * The executor's main loop honours this by reading the head only inside the
- * first-task branch of the dispatch poll.
+ * `get_chip_swimlane_aicore_head()` dereferences the stashed slot on first use,
+ * caches the result, and returns the cached pointer on subsequent calls.
+ * Callers MUST defer the first call until AICore has observed the AICPU
+ * initialization publication point for the current launch. In the current
+ * handshake this is Phase 2 exit (`DATA_MAIN_BASE != 0`) after AICPU opens the
+ * register window. `chip_swimlane_aicpu_init` publishes the slot before any
+ * register window is opened, so resolving at handshake exit and lazy resolution
+ * on first dispatch are both valid.
  */
 __aicore__ void set_chip_swimlane_aicore_head_slot(__gm__ uint64_t *slot_ptr);
 __aicore__ __gm__ ChipSwimlaneActiveHead *get_chip_swimlane_aicore_head();
@@ -102,5 +103,3 @@ __aicore__ __gm__ PmuAicoreRing *get_aicore_pmu_ring();
  */
 __aicore__ void set_aicore_pmu_reg_base(uint64_t reg_base);
 __aicore__ uint64_t get_aicore_pmu_reg_base();
-
-#endif  // PLATFORM_AICORE_AICORE_PROFILING_STATE_H_

--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -63,10 +63,8 @@ __attribute__((weak)) __aicore__ void set_chip_swimlane_aicore_head_slot(__gm__ 
     s_chip_swimlane_aicore_head = nullptr;  // force lazy resolution on next get
 }
 __attribute__((weak)) __aicore__ __gm__ ChipSwimlaneActiveHead *get_chip_swimlane_aicore_head() {
-    // Lazy first-call resolve: AICPU init populates `*s_chip_swimlane_aicore_head_slot`
-    // before dispatching the first task, so by the time the executor reaches
-    // for the head (inside the first-task branch of the dispatch poll) the
-    // slot holds a valid device address.
+    // Lazy first-call resolve. AICPU publishes the slot before opening any
+    // register window, so it is valid after AICore observes Phase 2 exit.
     if (s_chip_swimlane_aicore_head == nullptr && s_chip_swimlane_aicore_head_slot != nullptr) {
         s_chip_swimlane_aicore_head =
             reinterpret_cast<__gm__ ChipSwimlaneActiveHead *>(*s_chip_swimlane_aicore_head_slot);
@@ -86,11 +84,11 @@ extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, Co
  * Kernel entry point with control loop
  *
  * This function implements the AICore-side task execution protocol:
- * 1. Wait for AICPU ready signal (handshake initialization)
- * 2. Signal AICore is ready (aicore_done = core_id + 1)
+ * 1. Signal AICore is ready (aicore_done = block_idx + 1)
+ * 2. Wait for AICPU to open the register window (DATA_MAIN_BASE != 0)
  * 3. Enter polling loop:
- *    - Check control flag (1 = quit, 0 = continue)
- *    - If task pointer is non-zero, execute task and mark as complete
+ *    - Poll DATA_MAIN_BASE for a task or exit command
+ *    - Execute newly dispatched tasks and report completion via COND
  *    - Use DCCI to ensure cache coherency with AICPU
  *
  * Each core (AIC or AIV) gets its own handshake buffer indexed by block_idx.
@@ -128,11 +126,10 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ KernelA
     if (SIMPLER_GET_DFX_FLAG(k_args->enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE) &&
         k_args->chip_swimlane_aicore_rotation_table != 0) {
         // Stash only the slot pointer. The slot CONTENTS are written by
-        // AICPU's `chip_swimlane_aicpu_init` which runs concurrently with this
-        // entry; dereferencing here would race with AICPU's write. The
-        // executor defers the deref via `get_chip_swimlane_aicore_head()` until
-        // inside the first-task branch — by then AICPU has dispatched, so
-        // init is done and the slot is populated.
+        // AICPU's `chip_swimlane_aicpu_init`, which races with this entry but
+        // publishes the slot before opening any register window. The executor
+        // dereferences via `get_chip_swimlane_aicore_head()` only after it
+        // observes Phase 2 exit.
         __gm__ uint64_t *head_table = reinterpret_cast<__gm__ uint64_t *>(k_args->chip_swimlane_aicore_rotation_table);
         set_chip_swimlane_aicore_head_slot(&head_table[block_idx]);
     } else {

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -144,9 +144,9 @@ extern "C" void aicore_execute_wrapper(
     // Publish per-core profiling state before the executor runs.
     set_aicore_profiling_flag(enable_profiling_flag);
     if ((enable_profiling_flag & SIMPLER_DFX_FLAG_CHIP_SWIMLANE) && chip_swimlane_aicore_rotation_table != 0) {
-        // Stash only the slot pointer; deref happens lazily inside
-        // get_chip_swimlane_aicore_head() once AICPU has populated the table. See
-        // aicore_profiling_state.h.
+        // Stash only the slot pointer; the executor dereferences it via
+        // get_chip_swimlane_aicore_head() after observing Phase 2 window-open.
+        // See aicore_profiling_state.h.
         uint64_t *head_table = reinterpret_cast<uint64_t *>(chip_swimlane_aicore_rotation_table);
         set_chip_swimlane_aicore_head_slot(reinterpret_cast<__gm__ uint64_t *>(&head_table[block_idx]));
     } else {

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -49,18 +49,18 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * Implements the AICPU-AICore register-based dispatch protocol:
  * 1. Report physical core ID and core type, signal aicore_done (no AICPU wait)
  * 2. Wait for the AICPU to open our register window (DATA_MAIN_BASE != 0)
- * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
+ * 3. Cache per-core PTO2DispatchPayload pointer from my_hank->task
  * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
  * AICore reports on launch; the AICPU writes &s_payload_per_core[i] to
- * hank->task and then opens the register window (DATA_MAIN_BASE = IDLE), which
+ * my_hank->task and then opens the register window (DATA_MAIN_BASE = IDLE), which
  * is itself the acknowledgement. AICore caches this pointer and reads
  * function_bin_addr + args pointer from it on each dispatch. reg_val is a
  * monotonically increasing task ID used only for dispatch signaling and
  * ACK/FIN protocol.
  *
  * Profiling state (enable flag, chip swimlane rotation channel) is published into the platform
- * via set_aicore_profiling_flag / set_aicore_chip_swimlane_ring at kernel entry —
+ * via set_aicore_profiling_flag / set_chip_swimlane_aicore_head_slot at kernel entry —
  * this routine reads it through the matching getters, so neither Handshake
  * nor this signature carry profiling fields.
  *

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -66,12 +66,13 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * AICPU and AICore during task execution.
  *
  * Protocol State Machine:
- * 1. Initialization: AICPU sets aicpu_ready=1
- * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
- * 4. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
- * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
- * 6. Shutdown: AICPU sets control=1, AICore exits
+ * 1. AICore publishes physical_core_id, core_type, and aicore_done on launch
+ * 2. AICPU publishes the task pointer and opens the register window with DATA_MAIN_BASE=IDLE
+ * 3. AICore observes window-open, reports initial idle state, and reads the task pointer
+ * 4. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
+ * 5. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
+ * 6. Task Completion: AICore writes FIN to COND; AICPU observes completion
+ * 7. Shutdown: AICPU writes the exit signal to DATA_MAIN_BASE; AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
  * task execution across multiple cores.
@@ -85,17 +86,17 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * between cores and optimize cache coherency operations.
  *
  * Field Access Patterns:
- * - aicpu_ready: Written by AICPU, read by AICore
+ * - aicpu_ready: Reserved legacy field; the current handshake does not use it
  * - aicore_done: Written by AICore, read by AICPU (final report; physical_core_id
  *   and core_type are published alongside it in the same write)
- * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
+ * - task: Written by AICPU before window-open, read by AICore after window-open
  * - core_type: Written by AICore (with aicore_done), read by AICPU (CoreType::AIC or CoreType::AIV)
  * - physical_core_id: Written by AICore (with aicore_done), read by AICPU
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;  // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicpu_ready;  // Legacy layout field; unused by the current handshake
     volatile uint32_t aicore_done;  // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;         // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile uint64_t task;         // PTO2DispatchPayload* published before register window-open
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV (reported by AICore with aicore_done)
     volatile uint32_t physical_core_id;  // Physical core ID (reported by AICore with aicore_done)
 } __attribute__((aligned(64)));

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -822,7 +822,7 @@ int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thr
     // prior enabled launch's level can't leak into the phase-record gates in
     // scheduler_dispatch. This runs on the leader before it publishes
     // hs_setup_done_, so it happens-before every thread's handshake_partition
-    // (and therefore before any aicpu_ready=1 write).
+    // and therefore before any register window is opened.
     if (is_chip_swimlane_enabled()) {
         chip_swimlane_aicpu_init(runtime->worker_count);
         chip_swimlane_level_ = get_chip_swimlane_level();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -48,15 +48,17 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * AICore main execution loop
  *
  * Implements the AICPU-AICore register-based dispatch protocol:
- * 1. Wait for AICPU ready signal via handshake buffer
- * 2. Report physical core ID and core type, signal AICore ready
- * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
+ * 1. Report physical core ID and core type, signal aicore_done (no AICPU wait)
+ * 2. Wait for the AICPU to open our register window (DATA_MAIN_BASE != 0)
+ * 3. Cache per-core PTO2DispatchPayload pointer from my_hank->task
  * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * AICPU writes &s_payload_per_core[i] to hank->task before setting
- * aicpu_ready=1. AICore caches this pointer and reads function_bin_addr +
- * args pointer from it on each dispatch. reg_val is a monotonically
- * increasing task ID used only for dispatch signaling and ACK/FIN protocol.
+ * AICore reports on launch; the AICPU writes &s_payload_per_core[i] to
+ * my_hank->task and then opens the register window (DATA_MAIN_BASE = IDLE), which
+ * is itself the acknowledgement. AICore caches this pointer and reads
+ * function_bin_addr + args pointer from it on each dispatch. reg_val is a
+ * monotonically increasing task ID used only for dispatch signaling and
+ * ACK/FIN protocol.
  *
  * @param runtime Pointer to Runtime in global memory
  * @param s_block_idx Block index (core ID)
@@ -98,7 +100,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE);
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
-    // Cache profiling state once after Phase 3. The L2 / PMU rings and the
+    // Cache profiling state once after Phase 2. The L2 / PMU rings and the
     // PMU MMIO base are all stable for the entire run (host-resolved at
     // AICore kernel entry from KernelArgs::regs[physical_core_id]), so
     // they are safe to cache here.
@@ -106,10 +108,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     bool chip_swimlane_enabled = SIMPLER_GET_DFX_FLAG(profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
     bool dump_args_enabled = SIMPLER_GET_DFX_FLAG(profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
     bool pmu_enabled = SIMPLER_GET_DFX_FLAG(profiling_flag, SIMPLER_DFX_FLAG_PMU);
-    // Per-core ChipSwimlaneActiveHead channel — lazy-resolved on first task; the
-    // table slot AICPU populates inside `chip_swimlane_aicpu_init` runs
-    // concurrently with kernel entry, so we cannot deref at startup. The
-    // first dispatch is proof AICPU init is done.
+    // This executor chooses first-dispatch lazy resolution. The rotation
+    // channel has already been safe to resolve since Phase 2 exit above.
     __gm__ ChipSwimlaneActiveHead *chip_swimlane_head = nullptr;
     ChipSwimlaneAicoreLocalState chip_swimlane_local = {nullptr, UINT32_MAX, 0};
     __gm__ PmuAicoreRing *pmu_ring = pmu_enabled ? get_aicore_pmu_ring() : nullptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -25,7 +25,6 @@
 #include "aicpu/device_time.h"
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/orch_so_file.h"
-#include "aicpu/platform_aicpu_affinity.h"
 #include "callable_protocol.h"
 #include "common/kernel_args.h"
 #include "pto2_dispatch_payload.h"
@@ -38,15 +37,16 @@
 #include "pto_shared_memory.h"
 
 // Performance profiling headers
-#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/chip_swimlane_collector_aicpu.h"
 #include "aicpu/scope_stats_collector_aicpu.h"
 #include "aicpu/args_dump_aicpu.h"
+#include "aicpu/dep_gen_collector_aicpu.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/unified_log.h"
 
 // Register-based communication
 #include "aicpu/aicpu_device_config.h"
+#include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
 
@@ -674,12 +674,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             if (get_chip_swimlane_level() >= ChipSwimlaneLevel::ORCH_PHASES) {
                 chip_swimlane_aicpu_set_orch_thread_idx(thread_idx);
             }
-            // scope_stats streams scope_end records off the orchestrator thread:
-            // record the per-thread ready_queue index. No-op (writer shared
-            // state null) when scope_stats is disabled; the current buffer is
-            // popped lazily on the first scope_end append.
-            scope_stats_aicpu_set_orch_thread_idx(thread_idx);
+#endif
 
+#if SIMPLER_DFX
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
             // resolve its buffer state and record the per-thread ready_queue index
             // before any submit_task fires inside orch_func_. The init belongs to
@@ -697,6 +694,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 dep_gen_aicpu_init();
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
             }
+
+            // scope_stats streams scope_end records off the orchestrator thread:
+            // record the per-thread ready_queue index. No-op (writer shared
+            // state null) when scope_stats is disabled; the current buffer is
+            // popped lazily on the first scope_end append.
+            scope_stats_aicpu_set_orch_thread_idx(thread_idx);
 #endif
 
 #if SIMPLER_DFX

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -93,7 +93,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     uint64_t heap_size;
     uint64_t task_descriptors_offset;
 
-    // Per-ring data pointers (host-side, set by PTO2SharedMemoryHandle::setup_pointers)
+    // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -558,7 +558,9 @@ Each scheduler thread runs a tight loop with two main phases:
 
 **Phase 2 — Dispatch** (full model in §8.6):
 
-- For each idle core: drain the matching sync_start ready queue first, then the regular shape-based ready queue
+- Service each source (normal ready ▸ speculative early) in occupancy order — `sync_start`
+  Tier-0 ▸ MIX ▸ AIC/AIV, idle ▸ pending — popping from the matching shape-based ready queue
+  (lock-free MPMC Vyukov queue, one per resource shape)
 - Build `PTO2DispatchPayload` from `TaskDescriptor` with `task_id`, `subslot`, `kernel_id`, and `core_type`
 - Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE` (DMB offset `0xD0` on a5)
 - After normal ready queues are empty, Phase **4b** may stage speculative early-dispatch candidates onto spare slots (`early_dispatch_queues[]` / `early_sync_start_queue`)
@@ -569,13 +571,14 @@ After these phases, the scheduler updates profiling headers and checks for termi
 
 Ready queues use a lock-free bounded MPMC (Vyukov) design:
 
-- Two `PTO2ReadyQueue` lanes per resource shape: sync_start Tier-0 and regular work
-- **Push**: any thread (orchestrator via wiring, or scheduler on completion) pushes newly-ready tasks to the queue matching `task->active_mask.to_shape()`
+- One `PTO2ReadyQueue` per resource shape — 3 shapes (`PTO2_NUM_RESOURCE_SHAPES`): `MIX`
+  (AIC+AIV cluster), `AIC`, `AIV`. Alongside `ready_queues[]` there is a per-shape
+  `ready_sync_queues[]` (sync_start Tier-0) and the speculative `early_dispatch_queues[]` /
+  `early_sync_start_queue` — see §8.6 for the full source × tier model.
+- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `task->active_mask.to_shape()` (sync_start cohorts to the sync lane)
 - **Pop**: scheduler threads pop from the queue matching the idle core's resource shape
 - Per-slot sequence counters prevent ABA problems
 - `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing
-
-Ready `require_sync_start` cohorts use `ready_sync_queues[]` and take cores before regular ready work. Speculative sync_start early candidates use the separate `early_sync_start_queue` (see §8.6).
 
 ### 8.4 Watermark Advancement (last_task_alive)
 
@@ -623,27 +626,27 @@ Private internals are split across three .cpp files by responsibility:
 ### 8.6 Dispatch model — two sources, sync tiers, occupancy order
 
 `resolve_and_dispatch` places ready and speculative work onto AICore cores under one
-occupancy model (ported from a2a3 early-dispatch; a5 specifics called out below). Two
-orthogonal axes decide *what* runs and *where*:
+occupancy model. Two orthogonal axes decide *what* runs and *where*:
 
 - **Source** — `NORMAL` (all producers done; the task sits in a ready queue and launches on
   pickup) vs `EARLY` (a *speculative* pre-stage of a not-yet-released task; its dispatch
-  payload carries a non-zero `src_payload` gate and launches later by a high-32 doorbell on
-  `DATA_MAIN_BASE`). Normal strictly precedes early.
+  payload carries a non-zero `src_payload` gate and launches later by a doorbell). Normal
+  strictly precedes early.
 - **Cohort** — `SYNC_START` (an SPMD cohort that must launch atomically) vs `REGULAR` (each
   block launches independently). "is it ready" (source) and "does it need a rendezvous"
   (cohort) are orthogonal.
 
-Within each source the occupancy order is **`sync_start` ▸ MIX ▸ AIC/AIV`** (shape), and per
+Within each source the occupancy order is **`sync_start` ▸ MIX ▸ AIC/AIV** (shape), and per
 shape **idle ▸ pending** (an idle core takes its running slot; a busy core takes its gated
-pending slot, promoted on completion).`dispatch_ready_tasks` and
-`try_early_dispatch` share `run_staging_order` for this shape/placement order.
+pending slot, promoted on completion). This order lives in one shared skeleton,
+`run_staging_order`; the normal and early sources differ only in the per-shape stage callback
+(pickup vs gated).
 
 #### Queues
 
 | Source | Regular lanes | sync_start lane |
 | ------ | ------------- | --------------- |
-| NORMAL (ready) | `ready_queues[MIX\|AIC\|AIV]` | `ready_sync_queues[MIX\|AIC\|AIV]` |
+| NORMAL (ready) | `ready_queues[MIX\|AIC\|AIV]` | `ready_sync_queues[MIX\|AIC\|AIV]` (per-shape) |
 | EARLY (speculative) | `early_dispatch_queues[MIX\|AIC\|AIV]` | `early_sync_start_queue` (single) |
 
 A task routes to the early sync lane iff `task_attrs.requires_sync_start()`. Early
@@ -713,7 +716,8 @@ edge (#1405).
 
 #### MIX per-core placement
 
-A MIX task spans a cluster (1 AIC + 2 AIV). Gated MIX may place **per core**
+A MIX task spans a cluster (1 AIC + 2 AIV). `classify_mix_cluster` admits a cluster whenever
+every used core has a free slot; `prepare_block_for_dispatch` then places **per core**
 (`to_pending && !is_core_idle`): idle cores → running, busy cores → pending. Cross-core start
 skew within a block is tolerated by AICore incore synchronization.
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -431,9 +431,9 @@ definitions to runtime headers.
 ### Code Locations
 
 - Macro defaults and validation: `src/common/task_interface/profiling_config.h`
-- Scheduler profiling: `src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp` and `scheduler_cold_path.cpp`
-- Orchestrator profiling: `src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`
-- TensorMap profiling: `src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
+- Scheduler profiling: `../runtime/scheduler/scheduler_dispatch.cpp` and `../runtime/scheduler/scheduler_cold_path.cpp`
+- Orchestrator profiling: `../aicpu/aicpu_executor.cpp`
+- TensorMap profiling: `../runtime/pto_tensormap.h`
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
@@ -40,8 +40,7 @@
  * std::function — it would break the inlining and add ~5 ns/call to the orch hot path.
  */
 
-#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_
-#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_
+#pragma once
 
 #include <cstdint>
 
@@ -175,5 +174,3 @@ inline int32_t count_registrable_outputs(const DepInputs &inputs, bool in_manual
     }
     return needed;
 }
-
-#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -37,6 +37,7 @@
 #include "tensor.h"
 
 #if SIMPLER_DFX
+#include "aicpu/scope_stats_collector_aicpu.h"
 #include "aicpu/args_dump_aicpu.h"
 #endif
 
@@ -56,18 +57,15 @@ static_assert(
 // link these no-op stubs so the runtime translation unit is self-contained.
 // Visibility is hidden so the HOST .so doesn't export them into the global
 // dynamic symbol table where they'd shadow the AICPU .so's strong symbols
-// (same pattern as get_sys_cnt_aicpu / l2_perf_aicpu_record_orch_phase below).
+// (same pattern as get_sys_cnt_aicpu / chip_swimlane_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
     uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
 ) {}
 
-#if SIMPLER_DFX
-#include "aicpu/scope_stats_collector_aicpu.h"
-
 // Scope_stats enable gate, queried via the same predicate idiom as
-// is_dep_gen_enabled. The AICPU collector links the strong definition; host
-// builds fall back to this weak `false`. Gating here still skips the
+// is_dep_gen_enabled above. The AICPU collector links the strong definition;
+// host builds fall back to this weak `false`. Gating here still skips the
 // cross-agent occupancy reads that feed the sample when scope_stats is disabled.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
 
@@ -75,7 +73,6 @@ extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabl
 // wrap. Strong definition lives in the AICPU collector; host builds fall back to
 // this weak no-op so the runtime translation unit stays self-contained.
 extern "C" __attribute__((weak, visibility("hidden"))) void scope_stats_note_heap_wrap(int) {}
-#endif
 
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
@@ -181,10 +178,12 @@ static int32_t orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) 
 static void
 orch_report_fatal_v(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args) {
     int32_t latched_code = orch_mark_fatal(orch, error_code);
+
 #if SIMPLER_DFX
-    // Flush the active scope's peaks before the FATAL line so the diagnostic
-    // context lands adjacent in the log. Latched internally — safe to call
-    // from every cascaded report_fatal.
+    // Flush the current scope's peaks BEFORE the FATAL log line, so the
+    // diagnostic context (which pool/window filled up) appears right next to
+    // the failure reason. on_fatal is latched, so duplicate fatals from
+    // different layers don't print multiple stats lines.
     scope_stats_on_fatal();
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -27,8 +27,8 @@
 
 #pragma once
 
-#include "utils/device_arena.h"
 #include "common/chip_swimlane_profiling.h"
+#include "utils/device_arena.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_submit_types.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -96,8 +96,8 @@ struct PTO2RuntimeOps {
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
-    // collector. Always present to keep ops-table layout stable across
-    // SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
+    // collector. Always present in the struct to keep ops-table layout stable
+    // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -10,9 +10,9 @@
  */
 
 /**
- * PTO Runtime2 - Core Type Definitions
+ * tensormap_and_ringbuffer Runtime - Core Type Definitions
  *
- * This header defines all fundamental types used by the PTO Runtime2 system:
+ * This header defines the fundamental tensormap_and_ringbuffer runtime types:
  * - Configuration constants
  * - Worker types and task states
  * - ChipTensor regions and task parameters
@@ -256,14 +256,42 @@ struct PTO2TaskPayload {
     int32_t fanin_spill_start{0};   // Linear start index in fanin spill pool (0 = no spill)
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
-    // Early-dispatch metadata (AICPU-side only). Fits in the 40B between the fanin
-    // array (offset 536) and the 64B-aligned predicate (offset 576).
+    // Early-dispatch metadata (AICPU-side only). Ordered by descending
+    // alignment so the block packs without internal padding. Cache line 8
+    // contains the rarely-touched fanin tail rather than the hot tensor/scalar
+    // counts, and the block fits between the fanin array and the 64B-aligned
+    // predicate without changing the payload layout.
+    //
+    // Concurrent stagers publish global core-id bits with fetch_or. A regular
+    // consumer destructively splits those bits between release and late-stager
+    // owners; a sync_start cohort keeps the completed mask stable for one launch
+    // owner across both local staging and the global-drain fallback.
     std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
+    // Candidate detection is the event-driven dual of fanin_refcount. Wiring
+    // seeds producers already complete, and flagged producers increment the
+    // count only after all logical blocks are launch-visible. Equality with
+    // fanin_actual_count makes the consumer eligible for early dispatch.
     std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: fully-published + pre-completed producers
+    // Claimed-but-unpublished blocks are not launch-visible. Seq_cst updates
+    // pair with early_dispatch_state so final publication cannot be lost when
+    // producer release races a stager.
     std::atomic<int16_t> published_block_count{0};
+    // Shared stager/release claim state. STAGING remains stable while multiple
+    // AICPU threads claim blocks and publish mask bits; release changes it to
+    // DISPATCHED. Regular consumers split mask ownership, while sync_start
+    // consumers preserve the mask for rendezvous counting and one launch pass.
     std::atomic<uint8_t> early_dispatch_state{0};
+    // COMPLETE is published only after every owned doorbell is visible, keeping
+    // fanout private until all gated blocks have launched.
     std::atomic<uint8_t> early_dispatch_launch_state{PTO2_EARLY_DISPATCH_LAUNCH_NONE};
+    // Number of this sync_start task's gated cores occupying RUNNING slots.
+    // Counting cores is shape-agnostic for MIX, whose cluster cores promote
+    // independently. Doorbells launch only after this count matches the staged
+    // mask and producer release is visible. Unused for non-sync_start tasks.
     std::atomic<int16_t> running_slot_count{0};
+    // OWNER persists through ARMED and COMPLETE for one task lifetime. READY
+    // records that producer release observed the owner; only cancellation clears
+    // ownership before payload reinitialization.
     std::atomic<uint8_t> early_sync_drain_state{PTO2_EARLY_SYNC_DRAIN_NONE};
     // === Cache line 9 (byte 576) — dispatch predicate (AICPU-only) ===
     // Offset is a fixed 576, independent of MAX_TENSOR_ARGS / MAX_SCALAR_ARGS.
@@ -280,6 +308,11 @@ struct PTO2TaskPayload {
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
     static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
 
+    /**
+     * Prefetch for write the regions init() fills. tensor_count/scalar_count
+     * come from the argument because the payload counts are not initialized
+     * yet. The touched range also warms the early-dispatch metadata line.
+     */
     void prefetch(int32_t tensor_count, int32_t scalar_count) const {
         for (int32_t i = 0; i < tensor_count; i++) {
             __builtin_prefetch(&tensors[i], 1, 3);
@@ -328,7 +361,10 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
-        // Early-dispatch metadata — reset on every submit (reset_for_reuse skips payload).
+        // reset_for_reuse deliberately skips this cold payload. These fields
+        // are consumer-side state and must be initialized on every submit even
+        // when the consumer itself does not allow early resolve, because one of
+        // its flagged producers may still update them.
         early_dispatch_state.store(PTO2_EARLY_DISPATCH_NONE, std::memory_order_relaxed);
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_core_mask[w].store(0, std::memory_order_relaxed);
@@ -393,10 +429,9 @@ enum PTO2TaskLifecycleFlag : uint8_t {
     PTO2_LIFECYCLE_FLAGS_NONE = 0,
     PTO2_READY_CLAIMED = 1U << 0,
     PTO2_COMPLETION_DONE = 1U << 1,
-    // a5 deferred-completion discriminator (formerly std::atomic<bool>
-    // any_subtask_deferred). Packed into lifecycle_flags so sizeof stays 64
-    // while READY_CLAIMED / DISPATCH_PROPAGATED also fit. Call sites use
-    // mark_any_subtask_deferred() / has_any_subtask_deferred().
+    // Deferred-completion discriminator packed into lifecycle_flags so the
+    // slot remains 64B. Call sites use mark_any_subtask_deferred() and
+    // has_any_subtask_deferred().
     PTO2_SUBTASK_DEFERRED = 1U << 2,
     PTO2_DISPATCH_PROPAGATED = 1U << 3,
 };
@@ -439,6 +474,8 @@ struct alignas(64) PTO2TaskSlotState {
     // slot is scheduler-visible), so it MUST NOT share a byte with the atomically
     // mutated lifecycle_flags.
     TaskAttrs task_attrs{};
+    // Concurrent lifecycle updates preserve unrelated bits. Slot reuse clears
+    // the byte only after the previous task lifetime is quiescent.
     std::atomic<uint8_t> lifecycle_flags{PTO2_LIFECYCLE_FLAGS_NONE};
     int32_t dep_pool_mark{0};  // Dep pool top after Orch-side wiring
 
@@ -485,10 +522,14 @@ struct alignas(64) PTO2TaskSlotState {
         task = t;
     }
 
+    // Lock-free callers use this as a fast-path hint. A false result is
+    // rechecked by try_mark_dispatch_propagated() while holding fanout_lock.
     bool has_dispatch_propagated() const {
         return (lifecycle_flags.load(std::memory_order_acquire) & PTO2_DISPATCH_PROPAGATED) != 0;
     }
 
+    // The propagation owner holds fanout_lock through its fanout snapshot, so
+    // wiring can classify late edges exactly once.
     bool try_mark_dispatch_propagated() {
         return (lifecycle_flags.fetch_or(PTO2_DISPATCH_PROPAGATED, std::memory_order_acq_rel) &
                 PTO2_DISPATCH_PROPAGATED) == 0;
@@ -505,7 +546,9 @@ struct alignas(64) PTO2TaskSlotState {
 
     // Set by any subtask FIN that pushed deferred-completion CONDITIONs to the
     // runtime mailbox; read by the last subtask FIN to decide whether the task
-    // needs MPSC-deferred completion or can complete inline on this thread.
+    // needs MPSC-deferred completion or can complete inline on this thread. The
+    // release write is sequenced before on_subtask_complete's acq_rel fetch_add;
+    // the acquire read by the last subtask observes all earlier writes.
     void mark_any_subtask_deferred() { lifecycle_flags.fetch_or(PTO2_SUBTASK_DEFERRED, std::memory_order_release); }
 
     bool has_any_subtask_deferred() const {
@@ -534,6 +577,8 @@ struct alignas(64) PTO2TaskSlotState {
         lifecycle_flags.store(PTO2_LIFECYCLE_FLAGS_NONE, std::memory_order_relaxed);
         // Note: active_mask and task_attrs are per-submit-constant fields
         // rewritten in prepare_task on every reuse, so they are not reset here.
+        // Payload early-dispatch fields are initialized by PTO2TaskPayload::init
+        // on every submit before the slot becomes scheduler-visible.
     }
 
     // === Per-task fanout spinlock ===

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -68,12 +68,13 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * AICPU and AICore during task execution.
  *
  * Protocol State Machine:
- * 1. Initialization: AICPU sets aicpu_ready=1
- * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
- * 4. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
- * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
- * 6. Shutdown: AICPU sets control=1, AICore exits
+ * 1. AICore publishes physical_core_id, core_type, and aicore_done on launch
+ * 2. AICPU publishes the task pointer and opens the register window with DATA_MAIN_BASE=IDLE
+ * 3. AICore observes window-open, reports initial idle state, and reads the task pointer
+ * 4. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
+ * 5. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
+ * 6. Task Completion: AICore writes FIN to COND; AICPU observes completion
+ * 7. Shutdown: AICPU writes the exit signal to DATA_MAIN_BASE; AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
  * task execution across multiple cores.
@@ -94,17 +95,17 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * not require touching this struct anymore.
  *
  * Field Access Patterns:
- * - aicpu_ready: Written by AICPU, read by AICore
+ * - aicpu_ready: Reserved legacy field; the current handshake does not use it
  * - aicore_done: Written by AICore, read by AICPU (final report; physical_core_id
  *   and core_type are published alongside it in the same write)
- * - task: Written by AICPU, read by AICore (Init: PTO2DispatchPayload*; runtime: unused)
+ * - task: Written by AICPU before window-open, read by AICore after window-open
  * - core_type: Written by AICore (with aicore_done), read by AICPU
  * - physical_core_id: Written by AICore (with aicore_done), read by AICPU
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;  // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicpu_ready;  // Legacy layout field; unused by the current handshake
     volatile uint32_t aicore_done;  // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;         // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile uint64_t task;         // PTO2DispatchPayload* published before register window-open
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV (reported by AICore with aicore_done)
     volatile uint32_t physical_core_id;  // Physical core ID (reported by AICore with aicore_done)
 } __attribute__((aligned(64)));

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -584,6 +584,19 @@ struct PTO2SchedulerState {
         return advanced;
     }
 
+    bool try_claim_ready_once(PTO2TaskSlotState &slot_state) {
+        uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
+        for (;;) {
+            if ((flags & PTO2_READY_CLAIMED) != 0) return false;
+            uint8_t desired_flags = flags | PTO2_READY_CLAIMED;
+            if (slot_state.lifecycle_flags.compare_exchange_weak(
+                    flags, desired_flags, std::memory_order_acq_rel, std::memory_order_acquire
+                )) {
+                return true;
+            }
+        }
+    }
+
     void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
         // Read fanout_refcount/fanout_count and flip COMPLETED->CONSUMED under
         // fanout_lock. The orchestrator claims producers (fanout_count++) under the
@@ -943,19 +956,6 @@ struct PTO2SchedulerState {
         return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
     }
 
-    bool try_claim_ready_once(PTO2TaskSlotState &slot_state) {
-        uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
-        for (;;) {
-            if ((flags & PTO2_READY_CLAIMED) != 0) return false;
-            uint8_t desired_flags = flags | PTO2_READY_CLAIMED;
-            if (slot_state.lifecycle_flags.compare_exchange_weak(
-                    flags, desired_flags, std::memory_order_acq_rel, std::memory_order_acquire
-                )) {
-                return true;
-            }
-        }
-    }
-
     bool route_ready_once(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         if (!try_claim_ready_once(slot_state)) return false;
 
@@ -968,7 +968,16 @@ struct PTO2SchedulerState {
         } else if (early_handled) {
             return true;
         }
-        push_ready_routed(&slot_state);
+
+        PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+        if (shape == PTO2ResourceShape::DUMMY ||
+            (slot_state.task_attrs.has_predicate() && !slot_state.payload->predicate.pass())) {
+            dummy_ready_queue.push(&slot_state);
+        } else if (slot_state.task_attrs.requires_sync_start()) {
+            ready_sync_queues[static_cast<int32_t>(shape)].push(&slot_state);
+        } else {
+            ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
+        }
         return true;
     }
 
@@ -1121,7 +1130,7 @@ struct PTO2SchedulerState {
         slot_state.unlock_fanout();
 
 #if SIMPLER_SCHED_PROFILING
-        lock_atomics += 2;  // state.store + unlock.store
+        lock_atomics += 3;  // task_state.store + lifecycle_flags.fetch_or + unlock.store
         g_sched_lock_atomic_count[thread_idx] += lock_atomics;
         g_sched_lock_wait_cycle[thread_idx] += lock_wait;
         PTO2_SCHED_CYCLE_LAP(g_sched_lock_cycle[thread_idx]);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1097,7 +1097,7 @@ int32_t SchedulerContext::pre_handshake_init(
     // prior enabled launch's level can't leak into the phase-record gates in
     // scheduler_dispatch (`>= SCHED_PHASES`). This runs on the leader before it
     // publishes hs_setup_done_, so it happens-before every thread's
-    // handshake_partition (and therefore before any aicpu_ready=1 write).
+    // handshake_partition and therefore before any register window is opened.
     if (is_chip_swimlane_enabled()) {
         chip_swimlane_aicpu_init(runtime->dev.worker_count);
         chip_swimlane_level_ = get_chip_swimlane_level();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -514,15 +514,83 @@ void SchedulerContext::run_staging_order(
     }
 }
 
+void SchedulerContext::dispatch_ready_tasks(
+    int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
+) {
+    // Normal ready dispatch (is_ready): dispatch_shape places each block on pickup and
+    // signals a stop by setting entered_drain when it enters a sync_start drain.
+    bool entered_drain = false;
+
+    // Tier 0: ready sync_start cohorts take cores before any regular ready task
+    // (sync_start > MIX > C/V within the normal source). Same order and machinery,
+    // fed from ready_sync_queues; an oversized cohort arms the stop-the-world drain
+    // (entered_drain), which also short-circuits the regular tier below.
+    run_staging_order(
+        thread_idx, pmu_active,
+        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
+            dispatch_shape(
+                thread_idx, sched_->ready_sync_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
+            );
+            return entered_drain;
+        },
+        [&] {
+            return has_residual_sync_mix();
+        }
+    );
+    if (entered_drain) return;
+
+    // Tier 1: regular ready work.
+    run_staging_order(
+        thread_idx, pmu_active,
+        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
+            dispatch_shape(
+                thread_idx, sched_->ready_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
+            );
+            return entered_drain;
+        },
+        [&] {
+            return has_residual_mix();
+        }
+    );
+}
+
+// Stage the ALREADY-CLAIMED range [start, start+count) of consumer `c` onto
+// thread_idx's idle then pending cores. The caller has atomically advanced
+// next_block_idx by `count` AND re-pushed `c` for peers
+// BEFORE calling this — so this, the expensive prepare+publish, runs CONCURRENTLY
+// with peers staging other ranges of the same consumer. This mirrors the normal
+// SPMD dispatch path (claim range -> re-push -> dispatch).
+// `idle`/`pend` are this thread's free-core sets, sized so idle.count+pend.count >=
+// count (the caller clamped the claim to them), so all `count` blocks get a core.
+//
+// Rule 1: idle cores -> gated task in the RUNNING slot. Rule 2: PENDING slot of
+// cores running a real task -> promoted in when that task FINs (gated-pending Case
+// 3.3 in decide_slot_transition completes the running FIN + promotes instead of
+// waiting for an ack the gated task never sends). Each staged core stays
+// pending_occupied while gated, so no second gated block stacks on it.
+//
+// Doorbell ownership: release flips STAGING->DISPATCHED and exchanges the shared
+// mask to claim its bits. A late stager ORs its bits, then fetch-and-clears only
+// those release did not take and rings them from its immutable local handles.
+// The seq_cst order guarantees every gated core has exactly one writer.
 int32_t SchedulerContext::stage_consumer_blocks(
     int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
     CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
+    // Stamp the real pre-stage time (NOT 0) so the swimlane shows these blocks
+    // dispatched during the producer's run, not at trace start.
     uint64_t early_dispatch_ts = get_sys_cnt_aicpu();
-    uint64_t my_cores[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
+    uint64_t my_cores[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};  // cores gated by this staging pass
     int32_t staged = 0;
     int32_t block = start;
+    // Mirror the normal flush_publish (scheduler_dispatch.cpp wmb()+publish loop):
+    // prepare ALL claimed blocks' payloads (idle bucket -> running slot, pend bucket
+    // -> gated pending), then ONE wmb(), then publish. The wmb guarantees the
+    // src_payload gate + source args are globally visible before any DATA_MAIN_BASE token —
+    // without it a gated core can pick up the token and dcci a stale payload. The
+    // shared `count` budget bounds total blocks <= free clusters/cores, so both
+    // buckets fit one handles[] buffer.
     PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
     int n = 0;
     auto prepare_from = [&](CoreTracker::BitStates &avail, bool to_pending) {
@@ -548,11 +616,19 @@ int32_t SchedulerContext::stage_consumer_blocks(
             my_cores[cid >> 6] |= (1ULL << (cid & 63));
         }
     }
+    // Publish all this thread's gated cores into the shared mask in one OR per word
+    // (vs one per subtask) so release sees them; seq_cst keeps the self-ring order.
     for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++)
         if (my_cores[w] != 0) c->payload->staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
+    // Full publication and release are independent events. The seq_cst
+    // state/launch/count operations form a two-sided handshake. A released
+    // block must ring before contributing to the publication count.
     bool released = staged > 0 &&
                     c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == PTO2_EARLY_DISPATCH_DISPATCHED;
+
+    // Claim only bits the release path did not take. Local handles remain valid
+    // even if the shared per-core table is reused before this thread resumes.
     if (released) {
         uint64_t owned[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
@@ -570,10 +646,19 @@ int32_t SchedulerContext::stage_consumer_blocks(
         wmb();
     }
     sched_->record_published_blocks(*c, staged);
+    // Retry unconditionally after publication. The guards are cheap, and a
+    // pre-ring state read can become stale if release completes before this
+    // count update.
     sched_->propagate_dispatch_fanin(*c);
     return staged;
 }
 
+// Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
+// pre-stage claimed block ranges onto this thread's `shape` cores for `phase`. IDLE
+// stages onto idle cores (RUNNING slot, gated); PENDING stages onto a running core's
+// gated pending slot. Producer propagation and late wiring push candidates to the
+// shape's queue when dispatch_fanin becomes complete, so the shape is the queue
+// index (no per-consumer to_shape()). Returns the number of blocks staged.
 int32_t
 SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -581,6 +666,9 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     bool is_mix = (shape == PTO2ResourceShape::MIX);
     bool is_idle = (phase == CoreTracker::DispatchPhase::IDLE);
 
+    // Size the pop exactly as dispatch_shape does: MIX to the cluster count, else the
+    // phase's dispatchable-core count. Skip the queue entirely when no core is free
+    // for this shape+phase (avoids a pointless pop + immediate push-back).
     CoreTracker::BitStates cores =
         is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
     if (!cores.has_value()) return 0;
@@ -588,12 +676,29 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     int32_t total_staged = 0;
     PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
     uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
+    // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
+    // bounded by the shape's capacity so the stack buffer always holds it. Then for
+    // each consumer: CLAIM a range sized to THIS thread's free cores by advancing
+    // next_block_idx with a CAS (atomic — next_block_idx is shared with normal
+    // dispatch, which also claims it if release routes the consumer to the ready
+    // queue, so a plain store could double-dispatch), RE-PUSH it for peers, THEN do
+    // the expensive prepare+publish. Re-pushing before staging lets peers claim the
+    // next range and stage CONCURRENTLY — a wide consumer is filled by all idle
+    // threads in parallel. When cores run out mid-batch the unprocessed remainder
+    // is pushed back for peers (mirrors normal's push_batch of the unconsumed tail).
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
         PTO2TaskSlotState *c = batch[bi];
         if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
-        if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING) continue;
+        if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
+            continue;  // released
 
+        // The single free-core bucket for this phase. For MIX, an active-mask-aware
+        // whole-cluster scan keeps only the clusters whose placement matches the phase
+        // (RUNNING placement for IDLE, PENDING placement for PENDING), matching normal
+        // dispatch's classify_mix_cluster — unused cores in the cluster are ignored, so
+        // a MIX whose unused AIV is busy is not stranded. For AIC/AIV it is just the
+        // phase's dispatchable cores.
         CoreTracker::BitStates bucket;
         if (is_mix) {
             auto wanted = is_idle ? CoreTracker::MixPlacement::RUNNING : CoreTracker::MixPlacement::PENDING;
@@ -609,13 +714,14 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
             bucket = tracker.get_dispatchable_cores(shape, phase);
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
-        if (freecores == 0) {
+        if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
             sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
             break;
         }
         int32_t start = 0;
         int32_t claim = c->claim_block_range(c->logical_block_num, freecores, start);
-        if (claim == 0) continue;
+        if (claim == 0) continue;  // nothing left to claim -> drop (no re-push)
+        // Re-push for concurrent peers BEFORE the expensive staging.
         if (start + claim < c->logical_block_num) {
             if (!sched_->early_dispatch_queues[s].push_tagged(c, task_id_snapshots[bi]))
                 LOG_DEBUG(
@@ -623,6 +729,9 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
                     static_cast<int64_t>(c->task->task_id.raw)
                 );
         }
+        // stage_consumer_blocks fills the idle bucket (RUNNING slot) then the pend
+        // bucket (gated pending); pass this phase's bucket in the matching slot and an
+        // empty other so only the phase's cores are staged.
         CoreTracker::BitStates empty(0ULL);
         total_staged += is_idle ? stage_consumer_blocks(thread_idx, c, shape, start, claim, bucket, empty) :
                                   stage_consumer_blocks(thread_idx, c, shape, start, claim, empty, bucket);
@@ -630,14 +739,25 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     return total_staged;
 }
 
+// Early-dispatch drain (idle pass) — the EARLY source's analog of dispatch_ready_tasks.
+// Both sources share run_staging_order for the shape order (MIX strict priority, IDLE
+// before PENDING, cross-thread idle gating: MIX-IDLE ▶ c/v-IDLE ▶ MIX-PEND ▶ c/v-PEND).
+// Each handles its sync_start cohort FIRST as Tier 0: an exact local fit stages on
+// one owner, while a capacity-short cohort falls back to the global drain.
+// Returns the number of blocks staged this pass (for the EarlyDispatch swimlane bar).
 int32_t SchedulerContext::try_early_dispatch(
     int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
 ) {
-    // Gate (a2a3 #1288): owned here rather than by the caller.
-    //   - pmu_active: staging gated work perturbs single-issue PMU windows.
-    //   - has_any_free_slot: spare capacity (local read; fully-occupied bails
-    //     before touching shared queues) — not the old fully-idle pass.
-    //   - ready queues empty: normal dispatch strictly precedes early.
+    // Gate, owned here rather than by the caller (mirrors dispatch_ready_tasks
+    // withholding PENDING under PMU internally):
+    //   - pmu_active: staging gated work perturbs the single-issue PMU windows the
+    //     same way dual-issue PENDING dispatch does, so early dispatch is off.
+    //   - has_any_free_slot: this thread has no spare capacity to stage onto (a
+    //     purely local read; a fully-occupied thread bails before touching shared
+    //     queues).
+    //   - ready queues empty: normal dispatch (both the ready sync_start lane and the
+    //     regular ready_queues) strictly precedes early — there is no real ready task
+    //     to delay only when every normal queue is drained.
     if (pmu_active || !tracker.has_any_free_slot()) return 0;
     for (int s = 0; s < PTO2_NUM_RESOURCE_SHAPES; s++) {
         if (sched_->ready_sync_queues[s].size() > 0 || sched_->ready_queues[s].size() > 0) return 0;
@@ -702,46 +822,6 @@ int32_t SchedulerContext::try_early_dispatch(
         try_pushed = true;
     }
     return total_staged;
-}
-
-void SchedulerContext::dispatch_ready_tasks(
-    int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
-) {
-    // Normal ready dispatch (is_ready): dispatch_shape places each block on pickup and
-    // signals a stop by setting entered_drain when it enters a sync_start drain.
-    bool entered_drain = false;
-
-    // Tier 0: ready sync_start cohorts take cores before any regular ready task
-    // (sync_start > MIX > C/V within the normal source). Same order and machinery,
-    // fed from ready_sync_queues; an oversized cohort arms the stop-the-world drain
-    // (entered_drain), which also short-circuits the regular tier below.
-    run_staging_order(
-        thread_idx, pmu_active,
-        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
-            dispatch_shape(
-                thread_idx, sched_->ready_sync_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
-            );
-            return entered_drain;
-        },
-        [&] {
-            return has_residual_sync_mix();
-        }
-    );
-    if (entered_drain) return;
-
-    // Tier 1: regular ready work.
-    run_staging_order(
-        thread_idx, pmu_active,
-        [&](PTO2ResourceShape shape, CoreTracker::DispatchPhase phase) {
-            dispatch_shape(
-                thread_idx, sched_->ready_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
-            );
-            return entered_drain;
-        },
-        [&] {
-            return has_residual_mix();
-        }
-    );
 }
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -16,7 +16,6 @@
 
 #include "common/core_type.h"
 #include "common/platform_config.h"
-#include "pto2_dispatch_payload.h"
 #include "pto_runtime2_types.h"
 #include "spin_hint.h"
 
@@ -257,9 +256,9 @@ public:
     BitStates get_all_running_cores() const { return (~core_states_) & (aic_mask_ | aiv_mask_); }
     BitStates get_cluster_offset_states() const { return aic_mask_; }
 
-    // Free capacity for early-dispatch staging: any core whose pending slot is
-    // not occupied (idle RUNNING or dual-issue PENDING). Matches a2a3 #1288-ish
-    // spare-slot gate (not full-idle-only).
+    // Every core whose pending slot is free has capacity for early-dispatch
+    // staging: an idle core uses its running slot, while a running core uses its
+    // pending slot. This is local tracker state with no shared-memory access.
     BitStates get_free_slot_states() const { return (~pending_occupied_) & (aic_mask_ | aiv_mask_); }
     bool has_any_free_slot() const { return get_free_slot_states().has_value(); }
 
@@ -383,8 +382,14 @@ public:
         return get_mix_running_cluster_offset_states(core_mask).count();
     }
 
-    // Gated MIX split placement (#1304): each used core independently takes
-    // running-if-idle / pending-if-busy while every used core waits on the doorbell.
+    // --- Gated MIX split placement ---
+    // A gated MIX block can place each core independently: idle cores take
+    // running slots and busy cores with free capacity take pending slots. Every
+    // core waits on the doorbell, so nothing executes before the rendezvous.
+    // Immediate dispatch instead uses classify_mix_cluster to require one
+    // placement for the whole cluster.
+
+    // Cores of `cluster_offset` named by core_mask.
     BitStates mix_used_cores(int32_t cluster_offset, uint8_t core_mask) const {
         BitStates used;
         if (core_mask & PTO2_SUBTASK_MASK_AIC) used |= BitStates::bit(cluster_offset);
@@ -396,14 +401,18 @@ public:
     bool mix_cluster_all_slots(int32_t cluster_offset, uint8_t core_mask) const {
         BitStates used = mix_used_cores(cluster_offset, core_mask);
         if (!used.has_value()) return false;
+        // A used core has no capacity only while both running and pending slots
+        // are occupied.
         BitStates no_slot = (~core_states_) & pending_occupied_;
         return !(used & no_slot).has_value();
     }
 
+    // Used idle cores take running slots and seed the rendezvous count.
     int32_t mix_cluster_idle_core_count(int32_t cluster_offset, uint8_t core_mask) const {
         return (mix_used_cores(cluster_offset, core_mask) & core_states_).count();
     }
 
+    // Clusters where every used core has a free slot.
     BitStates get_mix_split_cluster_offset_states(uint8_t core_mask) const {
         BitStates result;
         BitStates candidates = get_cluster_offset_states();
@@ -542,9 +551,13 @@ struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> sync_start_pending{0};              // 0=normal; -1=initializing; >0=active (value=block_num)
     std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
     std::atomic<uint64_t> drain_attempt{0};                  // incremented whenever an ack round is reset
-    std::atomic<int32_t> drain_stage_go{0};
-    std::atomic<uint32_t> drain_stage_done_mask{0};
-    std::atomic<int32_t> drain_running_staged{0};
+    // The coordinator publishes stage_go after global capacity is confirmed.
+    // Each scheduler stages its local cores, publishes its bit in
+    // stage_done_mask, and contributes running-slot cores to running_staged.
+    // The coordinator waits for all scheduler bits before seeding the rendezvous.
+    std::atomic<int32_t> drain_stage_go{0};          // 0=hold; 1=parallel staging enabled
+    std::atomic<uint32_t> drain_stage_done_mask{0};  // bit per scheduler thread
+    std::atomic<int32_t> drain_running_staged{0};    // total running-slot cores staged
     int32_t _pad[7];
 };
 static_assert(sizeof(SyncStartDrainState) == 64);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -525,6 +525,7 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
     PTO2RuntimeArenaLayout layout{};
+
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         layout.sizing.task_window_sizes[r] = task_window_sizes[r];
         layout.sizing.heap_sizes[r] = heap_sizes[r];

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -8,7 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-// Host-side fake HostApi tests for a2a3 TRB bind/validate tensor leases.
+// Host-side fake HostApi tests for TRB bind/validate tensor leases.
 //
 // The retained temporary buffer's grow/pack/slice logic lives entirely in
 // runtime_maker.cpp (file-local RetainedTempBump). The platform side is just a


### PR DESCRIPTION
## Summary

- Replay the complete `tmr-a2a3-a5-alignment-backup` change onto the latest `main` while retaining fixes that already landed upstream.
- Converge shared TMR runtime structures, dependency handling, orchestrator behavior, scheduler state, and A5 runtime setup while preserving documented hardware and ABI differences.
- Add an A2/A3 versus A5 comparison document and link it from the documentation index.
- Align the AICore swimlane readiness contract at the Phase 2 window-open publication point and fold in the current review corrections.

## Validation

- `pip install --no-build-isolation -e .`
- `pre-commit run --hook-stage commit`
- C++ no-hardware suite: 97/97 passed
- A5 TMR hardware sweep via `task-submit`: 58 passed, 1 skipped; all 7 sweep-isolation failures passed in fresh isolated jobs (3 task-timing, 3 Worker L3, and the two-device SDMA case)
- A5 ChipSwimlane DFX smoke via `task-submit`: 4/4 passed

Follow-up to #1779.
Relates to #1582.