### PR TITLE
Add: benchmark host_build_graph runtime

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -11,7 +11,7 @@ Benchmark runtime performance on Ascend hardware. Automatically detects whether 
 
 | Condition | Mode | What happens |
 | --------- | ---- | ------------ |
-| 0 commits ahead AND no uncommitted changes | **Single** | Benchmark current state, report Elapsed + Orch times |
+| 0 commits ahead AND no uncommitted changes | **Single** | Benchmark current state and report its runtime-specific timing columns |
 | >= 1 commits ahead OR uncommitted changes | **Compare** | Benchmark merge-base (worktree) AND current workspace, show comparison table |
 
 ## Input
@@ -34,11 +34,15 @@ The `-d` flag specifies NPU device IDs.
 
 **Hard rule: one benchmark process per device at any time.** Never run two benchmark processes on the same `-d` device concurrently — not two runtimes, not baseline + current, nothing. This prevents resource contention and ensures stable measurements.
 
+On a shared hardware host, the complete single or compare run must execute
+inside one `task-submit` allocation. Let that allocation own every device for
+the full sequence; do not submit one job per example or run the script bare.
+
 | `-d` count | Compare mode behavior |
 | ---------- | --------------------- |
 | One device (`-d 4`) | **Sequential**: baseline first, then current, both on the same device. Multiple runtimes also run serially on that device. |
 | Two devices (`-d 4 -d 6`) | **Parallel per-runtime**: for each runtime, baseline on first device and current on second device can run in parallel (different devices). Multiple runtimes still run serially — finish one runtime on both devices before starting the next. |
-| Zero (not specified) | Auto-detect idle devices (see Step 2) |
+| Zero (not specified) | Let `task-submit --device auto` allocate one device (see Step 2) |
 
 **Defaults** (when not specified): use `benchmark_rounds.sh` defaults (device 0, 100 rounds, a2a3, tensormap_and_ringbuffer).
 
@@ -47,8 +51,12 @@ The `-d` flag specifies NPU device IDs.
 `tools/benchmark_rounds.sh` supports `-r <runtime>`:
 
 - `tensormap_and_ringbuffer` (default)
+- `host_build_graph`
 
-The example list is defined at the top of the script (`TMR_EXAMPLE_CASES`).
+Each architecture/runtime quadrant has its own list at the top of the script.
+TMR reports Host / Device / Effective / Orch / Sched. HBG reports Host / Device
+because its orchestration runs on the host and has no device-side Orch/Sched
+windows. `--serial-orch-sched` is TMR-only and must be rejected for HBG.
 
 ## Step 1: Detect Mode
 
@@ -65,17 +73,35 @@ else
 fi
 ```
 
-## Step 2: Device Detection
+## Step 2: Device Isolation
 
-If `-d` was provided in args, skip detection and use the user-specified device(s).
+When `task-submit` is available, allocate the requested device IDs or use
+`--device auto`; run the architecture gate as the first command inside that
+allocation, then pass `$TASK_DEVICE` to every benchmark command. Some shared
+hosts expose DCMI only inside `task-submit`, so a lock-external precheck cannot
+detect their silicon. Hold one allocation for the whole baseline/current
+sequence. When `task-submit` is unavailable, follow
+`.claude/lib/onboard-detection.md` and clearly report that the fallback run is
+unlocked.
 
-Otherwise, detect idle NPU devices (HBM-Usage = 0):
+Before submitting, inspect the queue:
 
 ```bash
-npu-smi info
+task-submit --list
 ```
 
-Pick devices with **HBM-Usage = 0**. Find the longest consecutive sub-range (at most 4). If no idle device is found, prompt user to specify a device ID.
+Remove each `-d` option from the forwarded `BENCH_ARGS` after collecting its
+value in `REQUESTED_DEVICES`. Build the allocation arguments once and reuse
+them for the single `task-submit` call:
+
+```bash
+case "${#REQUESTED_DEVICES[@]}" in
+  0) TASK_SUBMIT_DEVICE_ARGS=(--device auto --device-num 1) ;;
+  1) TASK_SUBMIT_DEVICE_ARGS=(--device "${REQUESTED_DEVICES[0]}") ;;
+  2) TASK_SUBMIT_DEVICE_ARGS=(--device "${REQUESTED_DEVICES[0]},${REQUESTED_DEVICES[1]}") ;;
+  *) echo "ERROR: benchmark accepts at most two -d devices"; exit 1 ;;
+esac
+```
 
 ## Step 3: Confirm PTO-ISA Pin
 
@@ -95,6 +121,7 @@ The Bash tool resets its working directory to the project root on every call. Re
 PROJECT_ROOT="$(pwd)"                    # e.g. /home/user/simpler
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 WORKTREE_ABS="${PROJECT_ROOT}/tmp/worktree_baseline_${TIMESTAMP}"
+PAYLOAD_SCRIPT="${PROJECT_ROOT}/tmp/benchmark_payload_${TIMESTAMP}.sh"
 mkdir -p "${PROJECT_ROOT}/tmp"
 ```
 
@@ -113,7 +140,12 @@ WORKTREE_ABS="/home/user/simpler/tmp/worktree_baseline_20260331_102302"
 ### Single Mode
 
 ```bash
-./tools/benchmark_rounds.sh $BENCH_ARGS -r "$RUNTIME" 2>&1 | tee "tmp/benchmark_${TIMESTAMP}.txt"
+task-submit --timeout 7200 --max-time 7200 "${TASK_SUBMIT_DEVICE_ARGS[@]}" \
+  --run "set -o pipefail && \
+    .claude/skills/onboard-arch-precheck/check.sh '$PLATFORM' && \
+    BENCH_DEVICE=\${TASK_DEVICE%%,*} && \
+    ./tools/benchmark_rounds.sh $BENCH_ARGS -d \$BENCH_DEVICE -r '$RUNTIME' \
+      2>&1 | tee 'tmp/benchmark_${TIMESTAMP}.txt'"
 ```
 
 Use `--serial-orch-sched` to run each case once in the default overlapped mode
@@ -123,6 +155,35 @@ Delta/Change tables.
 ### Compare Mode
 
 Use a **git worktree** for the baseline so the current workspace is never disturbed.
+Prepare the worktree and venv before taking an NPU lock. Steps 5b and 5c below
+are the inner payload of one self-contained shell script; never execute either
+onboard command outside that script's single `task-submit` allocation. Embed
+the computed paths and selected platform/runtime as literal assignments at the
+top of the payload, then map the allocated devices and run the architecture
+check:
+
+```bash
+set -euo pipefail
+
+PROJECT_ROOT="/absolute/path/to/current"
+WORKTREE_ABS="/absolute/path/to/baseline"
+PLATFORM="a2a3"
+RUNTIME="tensormap_and_ringbuffer"
+TIMESTAMP="YYYYmmdd_HHMMSS"
+BENCH_ARGS=("-n" "100")  # all forwarded args except -d/--device and -r/--runtime
+IFS=',' read -r -a LOCKED_DEVICES <<< "$TASK_DEVICE"
+BASELINE_DEVICE="${LOCKED_DEVICES[0]}"
+CURRENT_DEVICE="${LOCKED_DEVICES[1]:-${LOCKED_DEVICES[0]}}"
+"$PROJECT_ROOT/.claude/skills/onboard-arch-precheck/check.sh" "$PLATFORM"
+```
+
+After composing the payload from the sequential or parallel block below,
+submit that script exactly once:
+
+```bash
+task-submit --timeout 7200 --max-time 7200 "${TASK_SUBMIT_DEVICE_ARGS[@]}" \
+  --run "bash '$PAYLOAD_SCRIPT'"
+```
 
 #### CRITICAL: Worktree needs its own build environment
 
@@ -158,20 +219,22 @@ Activate the venv so `benchmark_rounds.sh` (which calls `python3`) picks up the 
 
 ```bash
 # WORKTREE_ABS must be the literal absolute path.
-cd "$WORKTREE_ABS" && \
-  source .venv/bin/activate && \
-  pwd && \
-  ./tools/benchmark_rounds.sh -d "$BASELINE_DEVICE" -r "$RUNTIME" \
-  2>&1 | tee "${PROJECT_ROOT}/tmp/benchmark_baseline_${TIMESTAMP}_${RUNTIME}.txt"
+(
+  cd "$WORKTREE_ABS"
+  source .venv/bin/activate
+  pwd
+  ./tools/benchmark_rounds.sh "${BENCH_ARGS[@]}" -d "$BASELINE_DEVICE" -r "$RUNTIME" \
+    2>&1 | tee "${PROJECT_ROOT}/tmp/benchmark_baseline_${TIMESTAMP}_${RUNTIME}.txt"
+)
 ```
 
-**Always include `pwd &&` after `cd` to verify you are in the correct directory.** If `pwd` does not print the worktree path, something went wrong — do not proceed.
+**Always print `pwd` after `cd` to verify you are in the correct directory.** If it does not print the worktree path, something went wrong — do not proceed.
 
 #### 5c. Run current
 
 ```bash
-# Runs from the main workspace (Bash tool default cwd)
-./tools/benchmark_rounds.sh -d $CURRENT_DEVICE -r "$RUNTIME" \
+cd "$PROJECT_ROOT"
+./tools/benchmark_rounds.sh "${BENCH_ARGS[@]}" -d "$CURRENT_DEVICE" -r "$RUNTIME" \
   2>&1 | tee "tmp/benchmark_current_${TIMESTAMP}_${RUNTIME}.txt"
 ```
 
@@ -195,9 +258,16 @@ When two devices are available, run baseline and current **for the same runtime*
 # For each runtime (serially):
 for RUNTIME in "${RUNTIMES_TO_BENCH[@]}"; do
   # Baseline on device A (from worktree with venv), current on device B (from main) — parallel
-  (cd "$WORKTREE_ABS" && source .venv/bin/activate && pwd && ./tools/benchmark_rounds.sh -d $DEVICE_BASELINE -r "$RUNTIME" ...) &
-  ./tools/benchmark_rounds.sh -d $DEVICE_CURRENT -r "$RUNTIME" ... &
-  wait  # Both finish before starting next runtime
+  (cd "$WORKTREE_ABS" && source .venv/bin/activate && pwd && ./tools/benchmark_rounds.sh "${BENCH_ARGS[@]}" -d "$BASELINE_DEVICE" -r "$RUNTIME") &
+  BASELINE_PID=$!
+  (cd "$PROJECT_ROOT" && ./tools/benchmark_rounds.sh "${BENCH_ARGS[@]}" -d "$CURRENT_DEVICE" -r "$RUNTIME") &
+  CURRENT_PID=$!
+  PARALLEL_RC=0
+  wait "$BASELINE_PID" || PARALLEL_RC=$?
+  wait "$CURRENT_PID" || PARALLEL_RC=$?
+  if [[ $PARALLEL_RC -ne 0 ]]; then
+    exit "$PARALLEL_RC"
+  fi
 done
 ```
 
@@ -209,15 +279,18 @@ done
 # 1. Worktree + venv already created in step 5a
 
 # 2. For each runtime (serially — one device, one process at a time):
-#    Baseline first (from worktree with venv activated)
-cd "$WORKTREE_ABS" && \
-  source .venv/bin/activate && \
-  pwd && \
-  ./tools/benchmark_rounds.sh -d "$DEVICE" -r "$RUNTIME" \
-  2>&1 | tee "${PROJECT_ROOT}/tmp/benchmark_baseline_${TIMESTAMP}_${RUNTIME}.txt"
+#    Baseline first (from worktree with venv activated in a subshell)
+(
+  cd "$WORKTREE_ABS"
+  source .venv/bin/activate
+  pwd
+  ./tools/benchmark_rounds.sh "${BENCH_ARGS[@]}" -d "$BASELINE_DEVICE" -r "$RUNTIME" \
+    2>&1 | tee "${PROJECT_ROOT}/tmp/benchmark_baseline_${TIMESTAMP}_${RUNTIME}.txt"
+)
 
-#    Then current (from main workspace — default cwd, no venv)
-./tools/benchmark_rounds.sh -d $DEVICE -r "$RUNTIME" \
+#    Then current (from main workspace, no baseline venv)
+cd "$PROJECT_ROOT"
+./tools/benchmark_rounds.sh "${BENCH_ARGS[@]}" -d "$CURRENT_DEVICE" -r "$RUNTIME" \
   2>&1 | tee "tmp/benchmark_current_${TIMESTAMP}_${RUNTIME}.txt"
 
 # 3. Cleanup
@@ -226,23 +299,28 @@ git -C "$PROJECT_ROOT" worktree remove "$WORKTREE_ABS" --force
 
 ## Step 6: Report Results
 
-Parse all five `Avg <Metric>:` lines per example (`Host`, `Device`, `Effective`, `Orch`, `Sched`) from benchmark output.
+Parse every `Avg <Metric>:` field present in the runtime's output. Missing
+runtime-inapplicable columns are not zero measurements and must not be printed.
 
 | Metric | Source | What it captures |
 | ------ | ------ | ---------------- |
 | Host | `[STRACE]` `run_prepared` span | steady_clock around dispatch (Python overhead included); rendered from markers by `strace_timing --rounds-table` |
-| Device | `[STRACE]` `run_prepared.runner_run.device_wall` span | full on-NPU AICPU run wall (`AicpuPhase::RunWall`, `max(end) − min(start)` across threads) — the whole run + teardown, strictly larger than the windows below |
-| Effective | orch/sched markers' device-domain `ts`+`dur` | `max(orch_end,sched_end) − min(orch_start,sched_start)` — the orch∪sched merged window (the old device-log "Total"), now pure-marker |
-| Orch | `[STRACE]` `…device_wall.orch` span (`--rounds-table`) | orchestrator (graph-build) window |
-| Sched | `[STRACE]` `…device_wall.sched` span (`--rounds-table`) | scheduler dispatch/execution window |
+| Device | `[STRACE]` `run_prepared.runner_run.device_wall` span | full on-NPU AICPU run wall (`AicpuPhase::RunWall`, `max(end) − min(start)` across threads); on TMR this whole run + teardown is strictly larger than the windows below |
+| Effective | TMR orch/sched markers' device-domain `ts`+`dur` | TMR only: `max(orch_end,sched_end) − min(orch_start,sched_start)` — the orch∪sched merged window |
+| Orch | `[STRACE]` `…device_wall.orch` span (`--rounds-table`) | TMR only: device orchestrator (graph-build) window |
+| Sched | `[STRACE]` `…device_wall.sched` span (`--rounds-table`) | TMR only: scheduler dispatch/execution window |
 
 The scene test only *emits* `[STRACE]` markers to stderr; `benchmark_rounds.sh`
 tees the run and renders the Host/Device/Effective/Orch/Sched table with
 `python -m simpler_setup.tools.strace_timing <log> --rounds-table`. All columns
 come from the markers (onboard and sim) — no CANN device log is read.
 
+Use Effective as the TMR headline metric. HBG has no equivalent phase window:
+report Host and Device independently and do not synthesize an overall score
+from one of them.
+
 For a per-stage breakdown of `Host`/`Device` (host `bind`/`runner_run`/`validate`
-plus the AICPU `preamble`/`so_load`/`graph_build`
+plus TMR's AICPU `preamble`/`so_load`/`graph_build`
 (`config_validate`/`arena_wire`/`sm_reset` prep sub-phases)/`post_orch`
 subdivision), parse the `[STRACE]` markers with
 `simpler_setup/tools/strace_timing.py` (add `--tree` for the nested view) — see
@@ -251,6 +329,9 @@ gate, no extra flag (set `SIMPLER_DEVICE_STRACE_ENABLE=0` to drop only the devic
 `clk=dev` markers).
 
 ### Single Mode
+
+Use the runtime's actual column set; the five-column example below is TMR. An
+HBG table contains only Host and Device.
 
 ```text
 Benchmark at: <short SHA>
@@ -265,7 +346,10 @@ benchmark_bgemm                  370000.0        7100.0          892.1          
 
 ### Compare Mode
 
-Show comparison table per metric (one row per metric per example), **grouped by runtime**. `Effective` is the headline metric used in the overall summary; the other four are sub-rows for context:
+Show a comparison table per metric (one row per metric per example), **grouped
+by runtime**. For TMR, `Effective` is the headline metric used in the overall
+summary and the other four are context. HBG has no combined headline metric:
+show Host and Device as independent rows and summarize regressions separately.
 
 ```text
 Merge-base: <short SHA>  →  HEAD: <short SHA> (+ uncommitted)
@@ -309,7 +393,7 @@ If any example shows > 5% regression, highlight it explicitly.
 
 | Error | Action |
 | ----- | ------ |
-| No idle device and no `-d` specified | Prompt user to specify device ID |
+| `task-submit` cannot allocate the requested device count | Report the queue/allocation error; do not run outside the lock |
 | Benchmark script fails | Report which examples failed; continue with remaining |
 | No timing data | Warn: "No timing markers — ensure `SIMPLER_HOST_STRACE` is enabled" |
 | All examples fail | Check: did you run `pip install -e .` in the worktree venv? |
@@ -320,13 +404,13 @@ If any example shows > 5% regression, highlight it explicitly.
 ## Checklist
 
 - [ ] Mode detected (single vs compare)
-- [ ] Idle device found or user-specified
+- [ ] Architecture precheck passed and one `task-submit` allocation owns the run
 - [ ] PTO-ISA pinned to CI commit
 - [ ] `PROJECT_ROOT` and `WORKTREE_ABS` absolute paths computed
 - [ ] (Compare mode) Worktree created, venv built with `pip install -e .`
 - [ ] (Compare mode) Baseline completed — venv activated, `pwd` confirmed worktree path before running
 - [ ] Current completed in main workspace
 - [ ] Worktree cleaned up (compare mode)
-- [ ] Results table presented with Host / Device / Effective / Orch / Sched times
+- [ ] Results table uses TMR's five columns or HBG's Host / Device columns
 - [ ] (Compare mode) Device difference noted if applicable
 - [ ] (Compare mode) Regressions > 2% flagged

--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -45,8 +45,9 @@ styles**. They measure different things; don't confuse them:
   .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
   task-submit --device auto --device-num 1 --run "\
     python -m pytest examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode \
-      --platform a2a3 --device \$TASK_DEVICE"
-  # standalone: python .../qwen3_14b_decode/test_qwen3_14b_decode.py -p a2a3 -d \$TASK_DEVICE
+      --platform a2a3 --device \$TASK_DEVICE --manual include"
+  # standalone: python .../qwen3_14b_decode/test_qwen3_14b_decode.py \
+  #   -p a2a3 -d \$TASK_DEVICE --manual include
   ```
 
   This is **not** a cross-repo path, so the rest of this skill (§1 setup,

--- a/.claude/skills/perf-example-device/SKILL.md
+++ b/.claude/skills/perf-example-device/SKILL.md
@@ -23,3 +23,6 @@ same logic for a single example. Detection / isolation procedures live in
    pattern as `run_bench()` in `tools/benchmark_rounds.sh`: snapshot logs, run
    `python $ARGUMENTS/test_<name>.py -p <platform> -d $TASK_DEVICE --rounds 10 --skip-golden`,
    find the new log, parse timing, report results.
+6. Report only metrics present in the parsed markers. TMR normally supplies
+   Host / Device / Effective / Orch / Sched; HBG supplies Host / Device. A
+   missing HBG phase is not a zero-duration measurement.

--- a/.claude/skills/perf-runtime-device/SKILL.md
+++ b/.claude/skills/perf-runtime-device/SKILL.md
@@ -26,5 +26,6 @@ format). Detection / isolation procedures live in
    `run_bench()` pattern from `tools/benchmark_rounds.sh`: snapshot logs, run
    `python <example>/test_<name>.py -p <platform> -d $TASK_DEVICE --rounds 10 --skip-golden`,
    find the new log, parse timing, report results.
-7. Print a final summary table with example name, average latency, trimmed
-   average, and pass/fail.
+7. Print only metrics backed by captured markers: TMR normally has Host /
+   Device / Effective / Orch / Sched; HBG has Host / Device. Never render a
+   missing HBG phase as zero. Include average, trimmed average, and pass/fail.

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -2,9 +2,9 @@
 
 `simpler_run()` spans several host-side stages (`bind`, `runner_run`,
 `validate`) plus, inside `runner_run`'s enqueue-through-drain lifetime, an
-on-NPU AICPU window that itself subdivides into preamble / SO-load /
-graph-build / post-orch. The
-two headline walls (`host_wall` / `device_wall`, see
+on-NPU AICPU window. TMR subdivides that window into preamble / SO-load /
+graph-build / post-orch; HBG emits the whole device wall without those
+device-orchestrator phases. The two headline walls (`host_wall` / `device_wall`, see
 [l2-timing.md](l2-timing.md)) cannot show *where* the time goes.
 
 `[STRACE]` markers are simpler's answer — host-side trace spans emitted to the
@@ -75,13 +75,15 @@ simpler_run                                   (= host_wall)
 ├─ simpler_run.runner_run          (device enqueue + completion drain)
 │  └─ simpler_run.runner_run.device_wall      (whole on-NPU AICPU wall)
 │     └─ .{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}
-│           device-domain (clk=dev): AICPU subdivision of the on-NPU wall
+│           TMR device-domain (clk=dev): AICPU subdivision of the on-NPU wall
 └─ simpler_run.validate
 ```
 
-The `device_wall` + its `.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}`
-spans are **device-domain**, tagged `clk=dev`. They are not host `steady_clock`
-spans: the AICPU stamps raw sys-counter cycles into a host-allocated buffer
+The `device_wall` span exists for both runtimes. Its
+`.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}`
+children are TMR-only; HBG orchestration runs on the host and stamps none of
+those phases. All emitted device spans are tagged `clk=dev`. They are not host
+`steady_clock` spans: the AICPU stamps raw sys-counter cycles into a host-allocated buffer
 (whose address rides on `KernelArgs::device_wall_data_base`), the host reads it
 back after stream-sync, converts cycles → ns, and emits the marker. `orch`/
 `sched` are the orchestrator/scheduler windows that formerly only appeared as
@@ -105,7 +107,7 @@ including time the caller spends polling or doing other host work; blocking
 | 0 | `simpler_run` |
 | 1 | `simpler_run.bind`, `simpler_run.runner_run`, `simpler_run.validate` |
 | 2 | `simpler_run.bind.args`, `simpler_run.bind.prebuilt`, `simpler_run.runner_run.device_wall` |
-| 3 | `simpler_run.runner_run.device_wall.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched,task_slot_*}` |
+| 3 | TMR phase spans `simpler_run.runner_run.device_wall.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}` and optional `task_slot_*` spans |
 
 ## L3/L4 host scheduler spans
 

--- a/docs/dfx/l2-timing.md
+++ b/docs/dfx/l2-timing.md
@@ -28,17 +28,22 @@ Both are emitted whenever the runtime was built with `SIMPLER_HOST_STRACE` (the
 default) — **independent of `--enable-chip-swimlane`**. The `device_wall` marker is
 absent only on a `SIMPLER_HOST_STRACE`-off build.
 
-Nested under `device_wall` are the AICPU orchestrator / scheduler sub-spans
-(`clk=dev`; captured on both onboard and sim):
+For `tensormap_and_ringbuffer`, nested under `device_wall` are the AICPU
+orchestrator / scheduler sub-spans (`clk=dev`; captured on both onboard and
+sim):
 
 | Span | Window |
 | ---- | ------ |
 | **`…device_wall.orch`** (Orch) | orchestrator run window — graph construction on the AICPU. |
 | **`…device_wall.sched`** (Sched) | scheduler dispatch/execution window. |
 
-**`device_wall` is the full kernel wall, NOT the orchestration span** — it is
-strictly larger than Orch/Sched/Effective below, because it also covers AICPU
-init and exec teardown around the orchestrate+schedule work.
+`host_build_graph` also emits `device_wall`, but its orchestration runs on the
+host and it stamps no device-side Orch/Sched phases. Its rounds table therefore
+contains Host / Device only.
+
+**`device_wall` is the full kernel wall, NOT the orchestration span** — on TMR
+it is strictly larger than Orch/Sched/Effective below, because it also covers
+AICPU init and exec teardown around the orchestrate+schedule work.
 
 For a finer per-stage breakdown of `device_wall` (preamble / SO-load /
 graph-build / post-orch) and of the host side (`bind` / `runner_run` /
@@ -65,11 +70,11 @@ python -m simpler_setup.tools.strace_timing run.log --rounds-table
 ```
 
 One column per `[STRACE]` wall found — **Host** always, plus **Device** /
-**Orch** / **Sched** / **Effective** whenever those markers were captured
-(onboard and sim both capture the device-domain subdivision). A column is hidden
-when every round read 0, and an individual phase whose duration rounds to 0 is
-not emitted. Because the offline tool groups markers by `(pid, inv)`, this works
-for **L3 multi-round too** (each chip-child's `simpler_run` is its own
+**Orch** / **Sched** / **Effective** whenever those markers were captured. TMR
+captures all five on onboard and sim; HBG captures Host / Device. A column is
+hidden when every round read 0, and an individual phase whose duration rounds
+to 0 is not emitted. Because the offline tool groups markers by `(pid, inv)`,
+this works for **L3 multi-round too** (each chip-child's `simpler_run` is its own
 invocation).
 
 ### Column meanings
@@ -78,9 +83,9 @@ invocation).
 | ------ | ---------- |
 | **Host** | `simpler_run` span — host wall incl. Python/dispatch overhead. |
 | **Device** | `device_wall` span — full on-NPU wall incl. init/teardown. |
-| **Effective** | `max(orch_end, sched_end) − min(orch_start, sched_start)` — the orch∪sched merged window (the effective on-device execution window). Computed from the orch/sched markers' **device-domain** `ts`+`dur` (the device spans carry a device-clock start offset, not the host emit time). This is the old device-log "Total", now derived purely from the markers — no device log needed. |
-| **Orch** | `…device_wall.orch` span — orchestrator (graph-build) window. |
-| **Sched** | `…device_wall.sched` span — scheduler dispatch/execution window. |
+| **Effective** | TMR only: `max(orch_end, sched_end) − min(orch_start, sched_start)` — the orch∪sched merged window (the effective on-device execution window). Computed from the orch/sched markers' **device-domain** `ts`+`dur` (the device spans carry a device-clock start offset, not the host emit time). This is the old device-log "Total", now derived purely from the markers — no device log needed. |
+| **Orch** | TMR only: `…device_wall.orch` span — device orchestrator (graph-build) window. |
+| **Sched** | TMR only: `…device_wall.sched` span — scheduler dispatch/execution window. |
 
 ```text
 device_wall  =  init  +  [ orchestrate + schedule/execute ≈ Effective ]  +  teardown
@@ -88,9 +93,9 @@ device_wall  =  init  +  [ orchestrate + schedule/execute ≈ Effective ]  +  te
                  only in device_wall, not in Effective/Orch/Sched
 ```
 
-Use Orch/Sched/Effective to see *where inside the run* time went (graph build vs
-scheduling); use `device_wall` for the end-to-end on-NPU cost including
-init/teardown.
+For TMR, use Orch/Sched/Effective to see *where inside the run* time went (graph
+build vs scheduling). For both runtimes, use `device_wall` for the end-to-end
+on-NPU cost including init/teardown.
 
 `tools/benchmark_rounds.sh` runs this tool for you across a set of examples (it
 tees each run and renders the table, then builds a cross-example summary).

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/README.md
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/README.md
@@ -42,5 +42,8 @@ configuration.
 task-submit --device auto --device-num 1 --run \
   ".venv/bin/python -m pytest \
   examples/a2a3/host_build_graph/qwen3_14b_decode \
-  --platform a2a3 --device \$TASK_DEVICE"
+  --platform a2a3 --device \$TASK_DEVICE --manual include"
 ```
+
+The case runs in the daily full scene-test sweep and is excluded from per-PR
+CI.

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -52,6 +52,7 @@ class TestQwen314BDecodeHostBuildGraph(SceneTestCase):
         {
             "name": "GraphExecutionBatch16Seq3500",
             "platforms": ["a2a3"],
+            "manual": True,
             "config": {"aicpu_thread_num": 4, "block_dim": 0},
             "params": {"seed": 1234, "seq_len": 3500},
         },

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/README.md
@@ -144,17 +144,18 @@ and the golden can verify all 40 layers' KV writes, not just the hidden output.
 ```bash
 # pytest (hardware; wrap in task-submit on shared boxes)
 pytest examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode \
-    --platform a2a3 --device ${DEVICE}
+    --platform a2a3 --device ${DEVICE} --manual include
 
 # standalone
-python examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py -p a2a3 -d ${DEVICE}
+python examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py \
+    -p a2a3 -d ${DEVICE} --manual include
 ```
 
 DFX is opt-in via the existing flags — no kernel changes needed:
 
 ```bash
 pytest .../qwen3_14b_decode --platform a2a3 --device ${DEVICE} \
-    --enable-chip-swimlane 1 --enable-dep-gen
+    --manual include --enable-chip-swimlane 1 --enable-dep-gen
 ```
 
 Note that `--enable-dep-gen` / `--enable-chip-swimlane` on the full 40-layer graph
@@ -169,7 +170,7 @@ reference at `RTOL=5e-2 / ATOL=1e-1`.
 
 ## Cost
 
-It runs in the general `st-onboard-a2a3` scene-test sweep like any other case.
+It runs in the daily full scene-test sweep and is excluded from per-PR CI.
 Measured on this repo's a2a3 box, one device:
 
 | Phase | Wall |

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -426,6 +426,7 @@ class TestQwen314BDecode(SceneTestCase):
         {
             "name": "StressBatch16Seq3500",
             "platforms": ["a2a3"],
+            "manual": True,
             # A run takes the whole device, matching the lib default.
             "params": {"seed": 1234, "seq_len": 3500},
         },

--- a/examples/a5/host_build_graph/qwen3_14b_decode/README.md
+++ b/examples/a5/host_build_graph/qwen3_14b_decode/README.md
@@ -21,5 +21,8 @@ Run on A5 hardware through the shared-device queue:
 task-submit --device auto --device-num 1 --run \
   ".venv/bin/python -m pytest \
   examples/a5/host_build_graph/qwen3_14b_decode \
-  --platform a5 --device \$TASK_DEVICE"
+  --platform a5 --device \$TASK_DEVICE --manual include"
 ```
+
+The case runs in the daily full scene-test sweep and is excluded from per-PR
+CI.

--- a/examples/a5/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a5/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -36,6 +36,7 @@ class TestQwen314BDecodeHostBuildGraph(SceneTestCase):
         {
             "name": "GraphExecutionBatch16Seq3500",
             "platforms": ["a5"],
+            "manual": True,
             "params": {"seed": 1234, "seq_len": 3500},
         },
     ]

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/README.md
@@ -167,17 +167,18 @@ and the golden can verify all 40 layers' KV writes, not just the hidden output.
 ```bash
 # pytest (hardware; wrap in task-submit on shared boxes)
 pytest examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode \
-    --platform a5 --device ${DEVICE}
+    --platform a5 --device ${DEVICE} --manual include
 
 # standalone
-python examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py -p a5 -d ${DEVICE}
+python examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py \
+    -p a5 -d ${DEVICE} --manual include
 ```
 
 DFX is opt-in via the existing flags — no kernel changes needed:
 
 ```bash
 pytest .../qwen3_14b_decode --platform a5 --device ${DEVICE} \
-    --enable-chip-swimlane 1 --enable-dep-gen
+    --manual include --enable-chip-swimlane 1 --enable-dep-gen
 ```
 
 Note that `--enable-dep-gen` / `--enable-chip-swimlane` on the full 40-layer graph
@@ -194,8 +195,9 @@ match, with every element inside tolerance (worst element `out` 0.0625,
 
 ## Cost
 
-The a2a3 source runs in the general `st-onboard-a2a3` scene-test sweep like any
-other case. Measured on this repo's a2a3 box, one device:
+This A5 case runs in the daily full scene-test sweep and is excluded from
+per-PR CI. The measured breakdown below comes from the a2a3 source on one
+device:
 
 | Phase | Wall |
 | ----- | ---- |

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -426,6 +426,7 @@ class TestQwen314BDecode(SceneTestCase):
         {
             "name": "StressBatch16Seq3500",
             "platforms": ["a5"],
+            "manual": True,
             # A run takes the whole device, matching the lib default. The 40-layer
             # graph's peak in-flight dependency footprint (~32 k entries) overflows
             # the a5 ring's default dep pool (16 k); the a2a3 source's "default

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -346,8 +346,10 @@ qwen3 decode, where the pypto-serving profile warmup dispatches a tiny-KV step
 single-invocation tree would report the warmup value.
 
 `--rounds-table` renders one row per invocation of the busiest `hid` —
-**Host** always, plus **Device / Effective / Orch / Sched** when present, in the
-format `tools/benchmark_rounds.sh` parses. `Effective` is the orch∪sched merged
+**Host** always, plus every device column whose marker is present, in the format
+`tools/benchmark_rounds.sh` parses. TMR normally supplies Device / Effective /
+Orch / Sched. HBG supplies Device but no device-side orch/sched windows, so its
+table contains Host / Device only. `Effective` is the TMR orch∪sched merged
 window (`max(orch_end,sched_end) − min(orch_start,sched_start)`, the old
 device-log "Total"), recomputed from the orch/sched markers' `ts`+`dur` — no
 device log needed. The scene test only *emits* the markers to stderr; tee a run

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -16,6 +16,9 @@ compile-time ``SIMPLER_HOST_STRACE`` macro (on by default) and emitted at
 are emitted by the host after readback as ``clk=dev`` spans nested under
 ``simpler_run.runner_run.device_wall``.
 
+Runtimes emit only the device spans they implement. Both current runtimes emit
+``device_wall``; the finer orch/sched phase subdivision is TMR-specific.
+
 Marker grammar (matched anywhere on the line, so the CANN/host log prefix is
 ignored)::
 
@@ -319,8 +322,8 @@ def print_rounds_table(buckets, stream=sys.stdout):
     inline. The most-invoked hid bucket is treated as the rounds (one row per
     invocation, ordered by ``inv``); each row's metrics come from
     :func:`_round_metrics`. A column is hidden when every row read 0 (e.g.
-    device/orch/sched/effective are 0 on a SIMPLER_HOST_STRACE-off build or on sim,
-    where the device-domain subdivision is not captured).
+    device/orch/sched/effective are 0 when their marker is absent; for example,
+    HBG emits device wall but has no device-side orch/sched windows).
 
     The output format is consumed by ``tools/benchmark_rounds.sh``'s
     framework-table parser (header ``Round  Host (us) …``, ``Avg Host:``

--- a/tests/ut/py/test_benchmark_rounds.py
+++ b/tests/ut/py/test_benchmark_rounds.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import ast
+import os
+import shlex
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[3]
+HARNESS = REPO_ROOT / "tools/benchmark_rounds.sh"
+
+
+def _fake_python_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    invocations = tmp_path / "invocations"
+    python3 = bin_dir / "python3"
+    python3.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            if [[ "${1:-}" == "-m" ]]; then
+                cat <<'EOF'
+              Round      Host (us)   Device (us)
+              ----------------------------------
+              0              100.0          20.0
+              Avg Host: 100.0 us  |  Avg Device: 20.0 us [1/1]  (1 rounds)
+            EOF
+                exit 0
+            fi
+            printf '%s\\n' "$*" >> "$FAKE_BENCH_INVOCATIONS"
+            """
+        )
+    )
+    python3.chmod(0o755)
+
+    env = os.environ.copy()
+    env["FAKE_BENCH_INVOCATIONS"] = str(invocations)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    return env, invocations
+
+
+def _run_harness_from_root(
+    tmp_path: Path, repo_root: Path, *args: str
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    env, invocations = _fake_python_env(tmp_path)
+    result = subprocess.run(  # noqa: S603 -- fixed repository script
+        [str(repo_root / "tools/benchmark_rounds.sh"), *args],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, invocations
+
+
+def _run_harness(tmp_path: Path, *args: str) -> tuple[subprocess.CompletedProcess[str], Path]:
+    return _run_harness_from_root(tmp_path, REPO_ROOT, *args)
+
+
+def _invoked_cases(invocations: Path) -> list[tuple[str, str, str]]:
+    result = []
+    for line in invocations.read_text().splitlines():
+        args = shlex.split(line)
+        test_file = Path(args[0])
+        case_idx = args.index("--case")
+        result.append((test_file.parent.parent.name, test_file.parent.name, args[case_idx + 1]))
+        assert "--skip-golden" in args
+        assert args[case_idx + 2 : case_idx + 4] == ["--manual", "include"]
+    return result
+
+
+@pytest.mark.parametrize(
+    ("platform", "runtime", "expected"),
+    [
+        (
+            "a2a3",
+            "tensormap_and_ringbuffer",
+            [
+                ("tensormap_and_ringbuffer", "alternating_matmul_add", "Case1"),
+                ("tensormap_and_ringbuffer", "benchmark_bgemm", "Case0"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll", "Case1"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll", "Case2"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll_manual_scope", "Case1"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll_manual_scope", "Case2"),
+                ("tensormap_and_ringbuffer", "batch_paged_attention", "Case1"),
+                ("tensormap_and_ringbuffer", "qwen3_14b_decode", "StressBatch16Seq3500"),
+            ],
+        ),
+        (
+            "a2a3",
+            "host_build_graph",
+            [
+                ("host_build_graph", "alternating_matmul_add", "Case1"),
+                ("host_build_graph", "benchmark_bgemm", "Case0"),
+                ("host_build_graph", "paged_attention_unroll", "Case1"),
+                ("host_build_graph", "paged_attention_unroll", "Case2"),
+                ("host_build_graph", "paged_attention_unroll_manual_scope", "Case1"),
+                ("host_build_graph", "paged_attention_unroll_manual_scope", "Case2"),
+                ("host_build_graph", "batch_paged_attention", "Case1"),
+                ("host_build_graph", "qwen3_14b_decode", "GraphExecutionBatch16Seq3500"),
+            ],
+        ),
+        (
+            "a5",
+            "tensormap_and_ringbuffer",
+            [
+                ("tensormap_and_ringbuffer", "alternating_matmul_add", "Case1"),
+                ("tensormap_and_ringbuffer", "benchmark_bgemm", "Case0"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll", "Case1"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll", "Case2"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll_manual_scope", "Case1"),
+                ("tensormap_and_ringbuffer", "paged_attention_unroll_manual_scope", "Case2"),
+                ("tensormap_and_ringbuffer", "batch_paged_attention", "Case1"),
+                ("tensormap_and_ringbuffer", "qwen3_14b_decode", "StressBatch16Seq3500"),
+            ],
+        ),
+        (
+            "a5",
+            "host_build_graph",
+            [
+                ("host_build_graph", "alternating_matmul_add", "Case1"),
+                ("host_build_graph", "benchmark_bgemm", "Case0"),
+                ("host_build_graph", "paged_attention_unroll", "Case1"),
+                ("host_build_graph", "paged_attention_unroll", "Case2"),
+                ("host_build_graph", "paged_attention_unroll_manual_scope", "Case1"),
+                ("host_build_graph", "paged_attention_unroll_manual_scope", "Case2"),
+                ("host_build_graph", "batch_paged_attention", "Case1"),
+                ("host_build_graph", "qwen3_14b_decode", "GraphExecutionBatch16Seq3500"),
+            ],
+        ),
+    ],
+    ids=["a2a3-tmr", "a2a3-hbg", "a5-tmr", "a5-hbg"],
+)
+def test_arch_runtime_quadrants_route_to_independent_corpora(
+    tmp_path: Path, platform: str, runtime: str, expected: list[tuple[str, str, str]]
+) -> None:
+    result, invocations = _run_harness(
+        tmp_path,
+        "--runtime",
+        runtime,
+        "--platform",
+        platform,
+        "--device",
+        "7",
+        "--rounds",
+        "1",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    invoked_cases = _invoked_cases(invocations)
+    assert invoked_cases == expected
+    expected_qwen_cases = {
+        ("a2a3", "tensormap_and_ringbuffer"): ["StressBatch16Seq3500"],
+        ("a2a3", "host_build_graph"): ["GraphExecutionBatch16Seq3500"],
+        ("a5", "tensormap_and_ringbuffer"): ["StressBatch16Seq3500"],
+        ("a5", "host_build_graph"): ["GraphExecutionBatch16Seq3500"],
+    }
+    qwen_cases = [case for _, example, case in invoked_cases if example == "qwen3_14b_decode"]
+    assert qwen_cases == expected_qwen_cases[platform, runtime]
+    assert all(example != "spmd_paged_attention" for _, example, _ in expected)
+    assert f"Runtime: {runtime}" in result.stdout
+    expected_mode = "default" if runtime == "host_build_graph" else "parallel"
+    assert f"[{expected_mode}]" in result.stdout
+    assert f"Performance Summary ({runtime})" in result.stdout
+    assert "Host (us)" in result.stdout
+    assert "Device (us)" in result.stdout
+    if runtime == "host_build_graph":
+        assert "Effective (us)" not in result.stdout
+        assert "Orch (us)" not in result.stdout
+        assert "Sched (us)" not in result.stdout
+    assert f"Benchmark complete ({runtime}): {len(expected)} passed, 0 failed" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "case_name"),
+    [
+        (
+            "examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py",
+            "StressBatch16Seq3500",
+        ),
+        (
+            "examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py",
+            "GraphExecutionBatch16Seq3500",
+        ),
+        (
+            "examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/test_qwen3_14b_decode.py",
+            "StressBatch16Seq3500",
+        ),
+        (
+            "examples/a5/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py",
+            "GraphExecutionBatch16Seq3500",
+        ),
+    ],
+)
+def test_qwen_benchmark_cases_are_manual(relative_path: str, case_name: str) -> None:
+    tree = ast.parse((REPO_ROOT / relative_path).read_text())
+    cases = [
+        case
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "CASES" for target in node.targets)
+        for case in ast.literal_eval(node.value)
+    ]
+
+    selected = next(case for case in cases if case["name"] == case_name)
+    assert selected["manual"] is True
+
+
+def test_default_runtime_remains_tensormap_and_ringbuffer(tmp_path: Path) -> None:
+    result, invocations = _run_harness(tmp_path, "--platform", "a2a3", "--device", "7", "--rounds", "1")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    invoked_cases = _invoked_cases(invocations)
+    assert len(invoked_cases) == 8
+    assert all(runtime == "tensormap_and_ringbuffer" for runtime, _, _ in invoked_cases)
+    assert "Runtime: tensormap_and_ringbuffer" in result.stdout
+    assert "[parallel]" in result.stdout
+    assert "host_build_graph" not in invocations.read_text()
+
+
+def test_extra_arguments_are_forwarded_to_every_benchmark(tmp_path: Path) -> None:
+    result, invocations = _run_harness(
+        tmp_path,
+        "--runtime",
+        "host_build_graph",
+        "--rounds",
+        "1",
+        "--custom-flag",
+        "custom-value",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    for line in invocations.read_text().splitlines():
+        assert shlex.split(line)[-2:] == ["--custom-flag", "custom-value"]
+
+
+def test_host_build_graph_rejects_serial_orch_sched_before_running(tmp_path: Path) -> None:
+    result, invocations = _run_harness(
+        tmp_path,
+        "--runtime",
+        "host_build_graph",
+        "--serial-orch-sched",
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.strip() == "ERROR: --serial-orch-sched is only supported by tensormap_and_ringbuffer."
+    assert not invocations.exists()
+
+
+def test_missing_workload_is_an_error_not_a_skip(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    tools_dir = repo_root / "tools"
+    tools_dir.mkdir(parents=True)
+    harness = tools_dir / "benchmark_rounds.sh"
+    harness.write_text(HARNESS.read_text())
+    harness.chmod(0o755)
+
+    result, invocations = _run_harness_from_root(
+        tmp_path,
+        repo_root,
+        "--runtime",
+        "host_build_graph",
+        "--platform",
+        "a5",
+    )
+
+    assert result.returncode == 1
+    assert "ERROR: benchmark workload 'alternating_matmul_add' not found" in result.stdout
+    assert "SKIP" not in result.stdout
+    assert not invocations.exists()
+
+
+def test_help_lists_both_runtime_metric_shapes(tmp_path: Path) -> None:
+    result, invocations = _run_harness(tmp_path, "--help")
+
+    assert result.returncode == 0
+    assert "tensormap_and_ringbuffer (default)" in result.stdout
+    assert "host_build_graph" in result.stdout
+    assert "TMR: Host, Device, Effective, Orch, Sched." in result.stdout
+    assert "HBG: Host, Device." in result.stdout
+    assert not invocations.exists()

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -9,6 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 
 import json
+from io import StringIO
 
 from simpler_setup.tools.strace_timing import (
     bucket_by_hid,
@@ -18,16 +19,18 @@ from simpler_setup.tools.strace_timing import (
     main,
     parse_clock_anchors,
     parse_spans,
+    print_rounds_table,
     to_chrome_trace,
     to_host_swimlane,
 )
 
 
-def _record(pid, inv, name, attrs=""):
+def _record(pid, inv, name, attrs="", *, depth=0, ts=100, dur=20):
     """One current host-log record in the shape `HostLogger::emit` writes it."""
     return (
         f"[mono_ns={1_000_000 + pid}][T0x{pid}][TIMING] emit_host_span: "
-        f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
+        f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth={depth} "
+        f"name={name} ts={ts} dur={dur} {attrs}"
     )
 
 
@@ -429,3 +432,33 @@ def test_swimlane_cli_writes_trace(tmp_path):
 
     trace = json.loads(output_path.read_text(encoding="utf-8"))
     assert any(event.get("name") == "l3.graph_build" for event in trace["traceEvents"])
+
+
+def test_rounds_table_omits_tmr_only_columns_when_only_host_and_device_exist():
+    lines = []
+    for inv, host_dur, device_dur in ((1, 100_000, 20_000), (2, 120_000, 24_000)):
+        lines.append(
+            _record(1, inv, "simpler_run", dur=host_dur)
+            + _record(
+                1,
+                inv,
+                "simpler_run.runner_run.device_wall",
+                "clk=dev",
+                depth=2,
+                dur=device_dur,
+            )
+            + "\n"
+        )
+    buckets = bucket_by_hid(group_invocations(parse_spans(lines)))
+    output = StringIO()
+
+    print_rounds_table(buckets, stream=output)
+
+    rendered = output.getvalue()
+    assert "Host (us)" in rendered
+    assert "Device (us)" in rendered
+    assert "Effective (us)" not in rendered
+    assert "Orch (us)" not in rendered
+    assert "Sched (us)" not in rendered
+    assert "Avg Host: 110.0 us" in rendered
+    assert "Avg Device: 22.0 us [2/2]" in rendered

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,21 +9,28 @@ invoke them via `python -m simpler_setup.tools.<name>`.
 
 ## benchmark_rounds.sh
 
-Batch-run a predefined set of ST examples on hardware, parse `orch_start` /
-`orch_end` / `sched_end` timestamps from the device log, and report per-round
-elapsed time.
+Batch-run a predefined set of scene tests on hardware and report per-round
+latency from host-emitted `[STRACE]` markers. The script supports both runtimes;
+`tensormap_and_ringbuffer` remains the default.
 
 ```bash
-# Use defaults (device 0, 10 rounds)
+# Use defaults (device 0, 100 rounds, tensormap_and_ringbuffer)
 ./tools/benchmark_rounds.sh
 
-# Specify device / rounds / runtime
-./tools/benchmark_rounds.sh -p a2a3 -d 4 -n 20 -r tensormap_and_ringbuffer
+# On a shared hardware host, hold one task-submit lock for the whole HBG sweep
+task-submit --device auto --device-num 1 --timeout 3600 --max-time 3600 \
+  --run ".claude/skills/onboard-arch-precheck/check.sh a2a3 && \
+    ./tools/benchmark_rounds.sh -p a2a3 -d \$TASK_DEVICE -n 20 -r host_build_graph"
 ```
 
-Requires `SIMPLER_DFX=1` in the runtime; device log must include the
-`orch_*` / `sched_*` lines. The `TMR_EXAMPLE_CASES` map at the top of the
-script controls which examples/cases are run.
+`strace_timing --rounds-table` renders one column per captured marker. TMR
+reports Host / Device / Effective / Orch / Sched. HBG reports Host / Device;
+its orchestration runs on the host, so the TMR-only columns are omitted. The
+four architecture/runtime corpus lists at the top of the script independently
+control a2a3 + TMR, a2a3 + HBG, a5 + TMR, and a5 + HBG. Every corpus includes
+the workloads shared by both runtimes plus its matching Qwen case:
+`StressBatch16Seq3500` for TMR and `GraphExecutionBatch16Seq3500` for HBG. SPMD
+paged attention is not part of the benchmark sweep.
 
 ## verify_packaging.sh
 

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -12,15 +12,15 @@
 # by `strace_timing --rounds-table` (no CANN device log is read):
 #   - Host      run_prepared span (host wall, incl. Python)
 #   - Device    run_prepared.runner_run.device_wall span (full on-NPU AICPU wall)
-#   - Effective orch∪sched merged window, from the orch/sched markers'
+#   - Effective orch∪sched merged window, from the TMR orch/sched markers'
 #               device-domain ts+dur (the old device-log "Total", now pure-marker)
-#   - Orch      run_prepared.runner_run.device_wall.orch span
-#   - Sched     run_prepared.runner_run.device_wall.sched span
+#   - Orch      TMR run_prepared.runner_run.device_wall.orch span
+#   - Sched     TMR run_prepared.runner_run.device_wall.sched span
 #
 # Usage:
 #   ./tools/benchmark_rounds.sh [-p <platform>] [-d <device>] [-n <rounds>] [-r <runtime>] [--serial-orch-sched]
 #
-# Edit the EXAMPLE_CASES map below to control which examples and cases to run.
+# Edit the architecture/runtime EXAMPLE_CASES lists below to control which examples and cases to run.
 
 set -euo pipefail
 
@@ -28,31 +28,52 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ---------------------------------------------------------------------------
-# Examples to benchmark and their case lists, per runtime.
-# Key   = directory name under tests/st/<platform>/<runtime>/
-# Value = comma-separated case names to run (empty string = run DEFAULT_CASE)
+# Examples to benchmark and their case lists, per architecture and runtime.
+# Each entry is <directory-name>=<comma-separated-case-names>.
+# An empty case list runs DEFAULT_CASE.
 # ---------------------------------------------------------------------------
 
-# --- tensormap_and_ringbuffer ---
-declare -A TMR_EXAMPLE_CASES=(
-    [alternating_matmul_add]="Case1"
-    [benchmark_bgemm]="Case0"
-    [paged_attention_unroll]="Case1,Case2"
-    [paged_attention_unroll_manual_scope]="Case1,Case2"
-    [batch_paged_attention]="Case1"
+# --- a2a3 + tensormap_and_ringbuffer ---
+A2A3_TMR_EXAMPLE_CASES=(
+    "alternating_matmul_add=Case1"
+    "benchmark_bgemm=Case0"
+    "paged_attention_unroll=Case1,Case2"
+    "paged_attention_unroll_manual_scope=Case1,Case2"
+    "batch_paged_attention=Case1"
     # spmd_paged_attention temporarily disabled: pre-existing onboard stall
     # (507018 S1:running-stalled), reproduces on baseline — see KNOWN_ISSUES.md.
-    # [spmd_paged_attention]="Case1,Case2"
-    [qwen3_14b_decode]="StressBatch16Seq3500"
+    # "spmd_paged_attention=Case1,Case2"
+    "qwen3_14b_decode=StressBatch16Seq3500"
 )
-TMR_EXAMPLE_ORDER=(
-    alternating_matmul_add
-    benchmark_bgemm
-    paged_attention_unroll
-    paged_attention_unroll_manual_scope
-    batch_paged_attention
-    # spmd_paged_attention  # temporarily disabled — see KNOWN_ISSUES.md
-    qwen3_14b_decode
+
+# --- a2a3 + host_build_graph ---
+A2A3_HBG_EXAMPLE_CASES=(
+    "alternating_matmul_add=Case1"
+    "benchmark_bgemm=Case0"
+    "paged_attention_unroll=Case1,Case2"
+    "paged_attention_unroll_manual_scope=Case1,Case2"
+    "batch_paged_attention=Case1"
+    "qwen3_14b_decode=GraphExecutionBatch16Seq3500"
+)
+
+# --- a5 + tensormap_and_ringbuffer ---
+A5_TMR_EXAMPLE_CASES=(
+    "alternating_matmul_add=Case1"
+    "benchmark_bgemm=Case0"
+    "paged_attention_unroll=Case1,Case2"
+    "paged_attention_unroll_manual_scope=Case1,Case2"
+    "batch_paged_attention=Case1"
+    "qwen3_14b_decode=StressBatch16Seq3500"
+)
+
+# --- a5 + host_build_graph ---
+A5_HBG_EXAMPLE_CASES=(
+    "alternating_matmul_add=Case1"
+    "benchmark_bgemm=Case0"
+    "paged_attention_unroll=Case1,Case2"
+    "paged_attention_unroll_manual_scope=Case1,Case2"
+    "batch_paged_attention=Case1"
+    "qwen3_14b_decode=GraphExecutionBatch16Seq3500"
 )
 
 # ---------------------------------------------------------------------------
@@ -65,6 +86,7 @@ RUNTIME=tensormap_and_ringbuffer
 VERBOSE=0
 SERIAL_ORCH_SCHED=0
 EXTRA_ARGS=()
+EXTRA_ARGS_COUNT=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -103,27 +125,31 @@ Options:
   -p, --platform Platform to run on (default: a2a3)
   -d, --device   Device ID (default: 0)
   -n, --rounds   Override number of rounds for each example (default: 100)
-  -r, --runtime  Runtime to benchmark: tensormap_and_ringbuffer (default)
+  -r, --runtime  Runtime to benchmark: tensormap_and_ringbuffer (default),
+                 host_build_graph
   -v, --verbose  Save detailed test_*.py output to a timestamped log file
   --serial-orch-sched
-                 Run each case twice: default parallel mode, then serial
+                 Run each TMR case twice: default parallel mode, then serial
                  orch->sched mode with PTO2_SERIAL_ORCH_SCHED=1.
   -h, --help     Show this help
 
 All other options are passed through to the underlying `python test_*.py`
 invocation (e.g. --case).
 
-Edit the EXAMPLE_CASES map at the top of this script to control which
-examples and cases to benchmark.
+Edit the architecture/runtime EXAMPLE_CASES lists at the top of this script
+to control which examples and cases to benchmark.
 
 Output:
   Per-round and average latency (microseconds), all from the [STRACE] markers:
-  Host, Device, Effective, Orch, Sched (parsed by strace_timing --rounds-table).
+  TMR: Host, Device, Effective, Orch, Sched.
+  HBG: Host, Device. Columns without captured markers are omitted.
+  All metrics are parsed by strace_timing --rounds-table.
 USAGE
             exit 0
             ;;
         *)
             EXTRA_ARGS+=("$1")
+            EXTRA_ARGS_COUNT=$((EXTRA_ARGS_COUNT + 1))
             shift
             ;;
     esac
@@ -161,18 +187,34 @@ case "$PLATFORM" in
     *) echo "ERROR: unsupported platform '$PLATFORM'. Use a2a3 or a5."; exit 1 ;;
 esac
 
-# Select example cases and order based on runtime
-case "$RUNTIME" in
-    tensormap_and_ringbuffer)
-        declare -n EXAMPLE_CASES=TMR_EXAMPLE_CASES
-        EXAMPLE_ORDER=("${TMR_EXAMPLE_ORDER[@]}")
+# Select example cases and order based on architecture and runtime.
+case "$ARCH:$RUNTIME" in
+    a2a3:tensormap_and_ringbuffer)
+        EXAMPLE_CASES=("${A2A3_TMR_EXAMPLE_CASES[@]}")
+        DEFAULT_MODE=parallel
+        ;;
+    a2a3:host_build_graph)
+        EXAMPLE_CASES=("${A2A3_HBG_EXAMPLE_CASES[@]}")
+        DEFAULT_MODE=default
+        ;;
+    a5:tensormap_and_ringbuffer)
+        EXAMPLE_CASES=("${A5_TMR_EXAMPLE_CASES[@]}")
+        DEFAULT_MODE=parallel
+        ;;
+    a5:host_build_graph)
+        EXAMPLE_CASES=("${A5_HBG_EXAMPLE_CASES[@]}")
+        DEFAULT_MODE=default
         ;;
     *)
-        echo "ERROR: unknown runtime '$RUNTIME'. Use tensormap_and_ringbuffer."
+        echo "ERROR: unknown runtime '$RUNTIME'. Use tensormap_and_ringbuffer or host_build_graph."
         exit 1
         ;;
 esac
 
+if [[ $SERIAL_ORCH_SCHED -eq 1 && "$RUNTIME" == "host_build_graph" ]]; then
+    echo "ERROR: --serial-orch-sched is only supported by tensormap_and_ringbuffer."
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # parse_timing <fw_stdout_file>
@@ -184,7 +226,7 @@ esac
 #     - Effective (us) orch∪sched merged window, from orch/sched device-domain ts+dur
 #     - Orch (us)      [STRACE] device_wall.orch span
 #     - Sched (us)     [STRACE] device_wall.sched span
-#   Effective/Orch/Sched come from the AICPU phase subdivision (onboard and sim).
+#   Effective/Orch/Sched come from TMR's AICPU phase subdivision.
 #   No CANN device log is read.
 # ---------------------------------------------------------------------------
 parse_timing() {
@@ -194,7 +236,7 @@ parse_timing() {
     out=$(python3 -m simpler_setup.tools.strace_timing "$fw_file" --rounds-table 2>/dev/null || true)
 
     if [[ -z "$out" || "$out" == *"No [STRACE] markers found."* ]]; then
-        echo "  (no benchmark timing data — was SIMPLER_PROFILING enabled?)"
+        echo "  (no benchmark timing data — are SIMPLER_HOST_STRACE markers visible?)"
         return 1
     fi
     echo "$out"
@@ -239,7 +281,10 @@ run_bench() {
         run_cmd+=(--case "$case_name")
         [[ -n "$test_file" ]] && run_cmd+=(--manual include)
     fi
-    run_cmd+=("${EXTRA_ARGS[@]}")
+    # Bash 3.2 with `set -u` rejects expanding an empty indexed array.
+    if [[ $EXTRA_ARGS_COUNT -gt 0 ]]; then
+        run_cmd+=("${EXTRA_ARGS[@]}")
+    fi
 
     # Run example, capturing stdout+stderr — the [STRACE] markers are on stderr.
     vlog "Running: ${run_cmd[*]}"
@@ -316,52 +361,57 @@ SUMMARY_EFFECTIVE=()
 SUMMARY_SCHED=()
 SUMMARY_ORCH=()
 
-echo ""
-echo "Runtime: $RUNTIME"
-
-for example in "${EXAMPLE_ORDER[@]}"; do
-    case_list="${EXAMPLE_CASES[$example]:-}"
-
-    # Search for example: prefer test_*.py (new style), fall back to golden.py (legacy).
-    # tests/st/ is searched before examples/ since benchmarks use production-scale cases.
-    EXAMPLE_DIR=""
+find_example_dir() {
+    local example="$1" candidate dir
     for dir in "${EXAMPLES_DIRS[@]}"; do
         candidate="$dir/$example"
         if [[ -d "$candidate" ]] && ls "$candidate"/test_*.py 1>/dev/null 2>&1; then
-            EXAMPLE_DIR="$candidate"
-            break
+            echo "$candidate"
+            return 0
         fi
     done
-    if [[ -z "$EXAMPLE_DIR" ]]; then
-        for dir in "${EXAMPLES_DIRS[@]}"; do
-            candidate="$dir/$example"
-            if [[ -f "$candidate/golden.py" && -d "$candidate/kernels" ]]; then
-                EXAMPLE_DIR="$candidate"
-                break
-            fi
-        done
+    for dir in "${EXAMPLES_DIRS[@]}"; do
+        candidate="$dir/$example"
+        if [[ -f "$candidate/golden.py" && -d "$candidate/kernels" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+for example_case in "${EXAMPLE_CASES[@]}"; do
+    example="${example_case%%=*}"
+    if ! find_example_dir "$example" >/dev/null; then
+        echo "ERROR: benchmark workload '$example' not found for $ARCH + $RUNTIME."
+        exit 1
     fi
+done
+
+echo ""
+echo "Runtime: $RUNTIME"
+
+for example_case in "${EXAMPLE_CASES[@]}"; do
+    example="${example_case%%=*}"
+    case_list="${example_case#*=}"
+
+    # tests/st/ is searched before examples/ since benchmarks use production-scale cases.
+    EXAMPLE_DIR=$(find_example_dir "$example")
 
     echo ""
     echo "================================================================"
     echo "  $example"
     echo "================================================================"
 
-    if [[ -z "$EXAMPLE_DIR" ]]; then
-        echo "  SKIP: not found in any search directory"
-        ((FAIL++)) || true
-        continue
-    fi
-
     if [[ -z "${case_list:-}" ]]; then
-        run_bench "$example" "$EXAMPLE_DIR" "" "parallel"
+        run_bench "$example" "$EXAMPLE_DIR" "" "$DEFAULT_MODE"
         if [[ $SERIAL_ORCH_SCHED -eq 1 ]]; then
             run_bench "$example" "$EXAMPLE_DIR" "" "serial"
         fi
     else
         IFS=',' read -ra cases <<< "$case_list"
         for c in "${cases[@]}"; do
-            run_bench "$example" "$EXAMPLE_DIR" "$c" "parallel"
+            run_bench "$example" "$EXAMPLE_DIR" "$c" "$DEFAULT_MODE"
             if [[ $SERIAL_ORCH_SCHED -eq 1 ]]; then
                 run_bench "$example" "$EXAMPLE_DIR" "$c" "serial"
             fi


### PR DESCRIPTION
# Summary

- Add `host_build_graph` support to `tools/benchmark_rounds.sh` while keeping
  `tensormap_and_ringbuffer` as the default runtime.
- Define independent benchmark corpora for all four
  `{a2a3, a5} × {tensormap_and_ringbuffer, host_build_graph}` quadrants.
- Include each runtime-specific Qwen case on both architectures and mark all
  four Qwen cases as manual, keeping them in daily rather than per-PR CI.
- Report only metrics backed by each runtime trace: TMR reports Host / Device /
  Effective / Orch / Sched, while HBG reports Host / Device.
- Skip golden validation during benchmark rounds, fail fast when a configured
  workload is missing, and propagate failures through `task-submit`, `tee`, and
  parallel baseline/current comparisons.

## Benchmark matrix

| Architecture | TMR | HBG |
| --- | ---: | ---: |
| A2/A3 | 8 invocations, including Qwen | 8 invocations, including Qwen |
| A5 | 8 invocations, including Qwen | 8 invocations, including Qwen |

The Qwen entries use `StressBatch16Seq3500` for TMR and
`GraphExecutionBatch16Seq3500` for HBG. Tests assert those runtime-specific
case names in all four quadrants and verify every Qwen benchmark case is
manual.

The shared corpus covers `alternating_matmul_add`, `benchmark_bgemm`,
`paged_attention_unroll`, `paged_attention_unroll_manual_scope`, and
`batch_paged_attention`. `spmd_paged_attention` remains outside the benchmark
corpus because of a pre-existing onboard stall reproduced on the baseline.

## Timing scope

This PR provides the HBG regression surface supported by markers available
today. A follow-up performance change can add HBG-specific record-vs-replay
reporting and finer host stages such as graph build, relocation, H2D upload,
and dispatch without coupling that instrumentation design to the harness.

## Testing

- Targeted benchmark/manual/timing unit tests: 56 passed.
- A5 Qwen collection: both cases deselected with the per-PR default and both
  collected with the daily `--manual include` mode.
- Pre-commit hooks passed for every file changed from the latest `main`,
  including markdownlint, Ruff, formatting, and pyright.
- Routing tests cover the exact corpus for all four architecture/runtime
  quadrants, runtime-specific Qwen selection, `--skip-golden`, manual-case
  inclusion, missing-workload failure, and Bash 3.2 compatibility.

Part of #1727.
