### PR TITLE
[Performance] host_build_graph: activate graph nodes incrementally as they materialize

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/graph_execution.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/graph_execution.h
@@ -342,6 +342,13 @@ struct GraphExecution {
     std::atomic<uint8_t> materialize_busy{0};
     std::atomic<int32_t> remaining_nodes{0};
     std::atomic<int32_t> retired_nodes{0};
+    // Incremental activation: nodes in [0, published_nodes) are fully
+    // materialized and registered, so a route pass may consider them. route_cursor
+    // is the next such node index a route pass will claim; roots below it have
+    // been pushed to the ready queue exactly once. Both advance monotonically and
+    // reset per (re)submission.
+    std::atomic<int32_t> published_nodes{0};
+    std::atomic<int32_t> route_cursor{0};
     int32_t node_count{0};
     int32_t node_capacity{0};
     int32_t materialized_nodes{0};

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
@@ -52,6 +52,8 @@ void reset_execution(
     execution->materialize_busy.store(0, std::memory_order_relaxed);
     execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
     execution->retired_nodes.store(0, std::memory_order_relaxed);
+    execution->published_nodes.store(0, std::memory_order_relaxed);
+    execution->route_cursor.store(0, std::memory_order_relaxed);
     execution->node_count = node_count;
     execution->materialized_nodes = 0;
     execution->materialized_tensor_patches = 0;
@@ -253,25 +255,6 @@ bool graph_definition_hash_matches(const GraphDefinition &definition) {
     return hash == definition.content_hash;
 }
 
-bool register_initial_graph_waiter(GraphExecution &execution, int32_t consumer_index) {
-    const uint32_t begin = execution.fanin_offsets[consumer_index];
-    const uint32_t end = execution.fanin_offsets[consumer_index + 1];
-    if (begin == end) return true;
-
-    const uint16_t producer_index = execution.fanin_indices[begin];
-    PTO2TaskSlotState &producer = execution.node_storage[producer_index].slot;
-    PTO2TaskSlotState &consumer = execution.node_storage[consumer_index].slot;
-
-    // Orch has already wired the dependency as a producer index in fanin CSR.
-    // This only creates the execution-local polling subscription. Activation
-    // is gated on PREPARED, so no producer can close its list concurrently.
-    PTO2TaskSlotState *head = producer.wake_list_head.load(std::memory_order_relaxed);
-    if (head == WAKE_LIST_SENTINEL) return false;
-    consumer.next_in_wake_list = head;
-    producer.wake_list_head.store(&consumer, std::memory_order_relaxed);
-    return true;
-}
-
 }  // namespace
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
@@ -374,6 +357,12 @@ GraphMaterializeResult graph_execution_materialize_slice(
             execution.materialize_busy.store(0, std::memory_order_release);
             return GraphMaterializeResult::BUSY;
         }
+        // Incremental activation reads producer slots through execution.nodes
+        // while the graph is still materializing, so publish the storage base
+        // once, before the first range. Topological node order guarantees every
+        // producer index a materialized node references is already constructed,
+        // and materialize_busy serializes this with any concurrent slice.
+        execution.nodes = execution.node_storage;
     } else if (state != GraphExecutionState::MATERIALIZING) {
         execution.materialize_busy.store(0, std::memory_order_release);
         return GraphMaterializeResult::INVALID;
@@ -592,10 +581,6 @@ GraphMaterializeResult graph_execution_materialize_slice(
             }
         }
         reset_graph_payload(payload);
-        if (!register_initial_graph_waiter(execution, i)) {
-            execution.materialize_busy.store(0, std::memory_order_release);
-            return GraphMaterializeResult::INVALID;
-        }
     }
     execution.materialized_nodes = last;
     if (nodes_materialized != nullptr) *nodes_materialized = last - first;
@@ -616,9 +601,6 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::INVALID;
     }
 
-    // nodes is published before PREPARED. An activator that acquires the state
-    // may therefore route saved roots without observing partially built nodes.
-    execution.nodes = execution.node_storage;
     execution.materialized_graph_key = execution.graph_key;
     execution.materialized_definition_hash = execution.definition_hash;
     execution.materialized_node_count = execution.node_count;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -923,6 +923,59 @@ struct PTO2SchedulerState {
         return consumers_rescanned;
     }
 
+    // Push every materialized-and-published root that has not been routed yet,
+    // once the outer Graph task's external dependency gate (0x2) has opened.
+    // route_cursor makes this idempotent, so it composes across the per-slice
+    // calls during materialization and the final call at the activation meet;
+    // each root reaches the ready queue exactly once. Non-roots are never pushed
+    // here — they reach the ready queue through their producers' wake list.
+    int32_t graph_route_ready_roots(GraphExecution &execution) {
+        if (execution.outer_slot == nullptr) return 0;
+        GraphSubmission *submission = graph_submission_from_slot(*execution.outer_slot);
+        if (submission == nullptr || (__atomic_load_n(&submission->activation_gate, __ATOMIC_ACQUIRE) & 0x2u) == 0) {
+            return 0;
+        }
+        const int32_t published = execution.published_nodes.load(std::memory_order_acquire);
+        int32_t routed = 0;
+        while (true) {
+            int32_t i = execution.route_cursor.load(std::memory_order_relaxed);
+            if (i >= published) break;
+            if (!execution.route_cursor.compare_exchange_weak(
+                    i, i + 1, std::memory_order_acq_rel, std::memory_order_relaxed
+                )) {
+                continue;
+            }
+            if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) {
+                push_ready_routed(&execution.node_storage[i].slot);
+                routed++;
+            }
+        }
+        return routed;
+    }
+
+    // Register each newly materialized node [first, last) on its first unmet
+    // producer (or route it immediately when every producer already completed),
+    // publish the range for routing, and route any roots the external gate now
+    // admits. Runs single-owner per graph via the prepare-queue slot, so the
+    // range never overlaps another thread's. register_graph_wake and
+    // graph_first_unmet_producer are safe against a producer completing
+    // concurrently, which is what lets a node dispatch before the whole graph is
+    // materialized.
+    void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
+        for (int32_t i = first; i < last; ++i) {
+            if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
+            PTO2TaskSlotState &node = execution.node_storage[i].slot;
+            const int32_t unmet = graph_first_unmet_producer(execution, node);
+            if (unmet < 0) {
+                push_ready_routed(&node);
+            } else {
+                register_graph_wake(execution, &execution.nodes[unmet].slot, &node);
+            }
+        }
+        execution.published_nodes.store(last, std::memory_order_release);
+        graph_route_ready_roots(execution);
+    }
+
     int32_t activate_prepared_graph(GraphExecution &execution) {
         GraphExecutionState expected = GraphExecutionState::PREPARED;
         if (!execution.state.compare_exchange_strong(
@@ -930,20 +983,7 @@ struct PTO2SchedulerState {
             )) {
             return 0;
         }
-        const GraphDefinition &definition = *execution.definition;
-        const uint16_t *roots =
-            graph_definition_array<uint16_t>(definition, definition.off_root_indices, definition.root_count);
-        if (roots == nullptr) return 0;
-        int32_t routed = 0;
-        for (uint32_t i = 0; i < definition.root_count; ++i) {
-            const uint16_t node_index = roots[i];
-            if (node_index >= static_cast<uint32_t>(execution.node_count)) continue;
-            // Roots have zero internal fanin and are routed only here. Every
-            // non-root is registered on one saved producer at a time.
-            push_ready_routed(&execution.nodes[node_index].slot);
-            routed++;
-        }
-        return routed;
+        return graph_route_ready_roots(execution);
     }
 
     GraphMaterializeResult prepare_graph_task(
@@ -957,8 +997,12 @@ struct PTO2SchedulerState {
             return graph_submission_execution_initializing(*submission) ? GraphMaterializeResult::BUSY :
                                                                           GraphMaterializeResult::INVALID;
         }
+        const int32_t before = execution->materialized_nodes;
         const GraphMaterializeResult result =
             graph_execution_materialize_slice(outer_slot, *execution, max_nodes, nodes_materialized);
+        if (result == GraphMaterializeResult::PENDING || result == GraphMaterializeResult::PREPARED) {
+            graph_incremental_publish(*execution, before, execution->materialized_nodes);
+        }
         if (result == GraphMaterializeResult::PREPARED && graph_submission_signal(*submission, 0x1)) {
             activate_prepared_graph(*execution);
         }
@@ -998,8 +1042,16 @@ struct PTO2SchedulerState {
         }
 
         GraphExecution *execution = graph_execution_from_slot(slot_state);
-        if (execution == nullptr || execution->definition == nullptr || execution->nodes == nullptr ||
-            execution->state.load(std::memory_order_acquire) != GraphExecutionState::ACTIVE) {
+        if (execution == nullptr || execution->definition == nullptr || execution->nodes == nullptr) {
+            outcome.error_code = PTO2_ERROR_INVALID_ARGS;
+            return outcome;
+        }
+        // Incremental activation routes a node before the graph reaches ACTIVE, so a
+        // node can legitimately complete while the graph is still MATERIALIZING or
+        // PREPARED. Only SUBMITTED (execution not yet localized) and COMPLETED
+        // (execution already retired) are invalid states for a node completion.
+        const GraphExecutionState graph_state = execution->state.load(std::memory_order_acquire);
+        if (graph_state < GraphExecutionState::MATERIALIZING || graph_state > GraphExecutionState::ACTIVE) {
             outcome.error_code = PTO2_ERROR_INVALID_ARGS;
             return outcome;
         }

--- a/src/a5/runtime/host_build_graph/runtime/graph_execution.h
+++ b/src/a5/runtime/host_build_graph/runtime/graph_execution.h
@@ -342,6 +342,13 @@ struct GraphExecution {
     std::atomic<uint8_t> materialize_busy{0};
     std::atomic<int32_t> remaining_nodes{0};
     std::atomic<int32_t> retired_nodes{0};
+    // Incremental activation: nodes in [0, published_nodes) are fully
+    // materialized and registered, so a route pass may consider them. route_cursor
+    // is the next such node index a route pass will claim; roots below it have
+    // been pushed to the ready queue exactly once. Both advance monotonically and
+    // reset per (re)submission.
+    std::atomic<int32_t> published_nodes{0};
+    std::atomic<int32_t> route_cursor{0};
     int32_t node_count{0};
     int32_t node_capacity{0};
     int32_t materialized_nodes{0};

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
@@ -52,6 +52,8 @@ void reset_execution(
     execution->materialize_busy.store(0, std::memory_order_relaxed);
     execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
     execution->retired_nodes.store(0, std::memory_order_relaxed);
+    execution->published_nodes.store(0, std::memory_order_relaxed);
+    execution->route_cursor.store(0, std::memory_order_relaxed);
     execution->node_count = node_count;
     execution->materialized_nodes = 0;
     execution->materialized_tensor_patches = 0;
@@ -253,25 +255,6 @@ bool graph_definition_hash_matches(const GraphDefinition &definition) {
     return hash == definition.content_hash;
 }
 
-bool register_initial_graph_waiter(GraphExecution &execution, int32_t consumer_index) {
-    const uint32_t begin = execution.fanin_offsets[consumer_index];
-    const uint32_t end = execution.fanin_offsets[consumer_index + 1];
-    if (begin == end) return true;
-
-    const uint16_t producer_index = execution.fanin_indices[begin];
-    PTO2TaskSlotState &producer = execution.node_storage[producer_index].slot;
-    PTO2TaskSlotState &consumer = execution.node_storage[consumer_index].slot;
-
-    // Orch has already wired the dependency as a producer index in fanin CSR.
-    // This only creates the execution-local polling subscription. Activation
-    // is gated on PREPARED, so no producer can close its list concurrently.
-    PTO2TaskSlotState *head = producer.wake_list_head.load(std::memory_order_relaxed);
-    if (head == WAKE_LIST_SENTINEL) return false;
-    consumer.next_in_wake_list = head;
-    producer.wake_list_head.store(&consumer, std::memory_order_relaxed);
-    return true;
-}
-
 }  // namespace
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
@@ -374,6 +357,12 @@ GraphMaterializeResult graph_execution_materialize_slice(
             execution.materialize_busy.store(0, std::memory_order_release);
             return GraphMaterializeResult::BUSY;
         }
+        // Incremental activation reads producer slots through execution.nodes
+        // while the graph is still materializing, so publish the storage base
+        // once, before the first range. Topological node order guarantees every
+        // producer index a materialized node references is already constructed,
+        // and materialize_busy serializes this with any concurrent slice.
+        execution.nodes = execution.node_storage;
     } else if (state != GraphExecutionState::MATERIALIZING) {
         execution.materialize_busy.store(0, std::memory_order_release);
         return GraphMaterializeResult::INVALID;
@@ -592,10 +581,6 @@ GraphMaterializeResult graph_execution_materialize_slice(
             }
         }
         reset_graph_payload(payload);
-        if (!register_initial_graph_waiter(execution, i)) {
-            execution.materialize_busy.store(0, std::memory_order_release);
-            return GraphMaterializeResult::INVALID;
-        }
     }
     execution.materialized_nodes = last;
     if (nodes_materialized != nullptr) *nodes_materialized = last - first;
@@ -616,9 +601,6 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::INVALID;
     }
 
-    // nodes is published before PREPARED. An activator that acquires the state
-    // may therefore route saved roots without observing partially built nodes.
-    execution.nodes = execution.node_storage;
     execution.materialized_graph_key = execution.graph_key;
     execution.materialized_definition_hash = execution.definition_hash;
     execution.materialized_node_count = execution.node_count;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -923,6 +923,59 @@ struct PTO2SchedulerState {
         return consumers_rescanned;
     }
 
+    // Push every materialized-and-published root that has not been routed yet,
+    // once the outer Graph task's external dependency gate (0x2) has opened.
+    // route_cursor makes this idempotent, so it composes across the per-slice
+    // calls during materialization and the final call at the activation meet;
+    // each root reaches the ready queue exactly once. Non-roots are never pushed
+    // here — they reach the ready queue through their producers' wake list.
+    int32_t graph_route_ready_roots(GraphExecution &execution) {
+        if (execution.outer_slot == nullptr) return 0;
+        GraphSubmission *submission = graph_submission_from_slot(*execution.outer_slot);
+        if (submission == nullptr || (__atomic_load_n(&submission->activation_gate, __ATOMIC_ACQUIRE) & 0x2u) == 0) {
+            return 0;
+        }
+        const int32_t published = execution.published_nodes.load(std::memory_order_acquire);
+        int32_t routed = 0;
+        while (true) {
+            int32_t i = execution.route_cursor.load(std::memory_order_relaxed);
+            if (i >= published) break;
+            if (!execution.route_cursor.compare_exchange_weak(
+                    i, i + 1, std::memory_order_acq_rel, std::memory_order_relaxed
+                )) {
+                continue;
+            }
+            if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) {
+                push_ready_routed(&execution.node_storage[i].slot);
+                routed++;
+            }
+        }
+        return routed;
+    }
+
+    // Register each newly materialized node [first, last) on its first unmet
+    // producer (or route it immediately when every producer already completed),
+    // publish the range for routing, and route any roots the external gate now
+    // admits. Runs single-owner per graph via the prepare-queue slot, so the
+    // range never overlaps another thread's. register_graph_wake and
+    // graph_first_unmet_producer are safe against a producer completing
+    // concurrently, which is what lets a node dispatch before the whole graph is
+    // materialized.
+    void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
+        for (int32_t i = first; i < last; ++i) {
+            if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
+            PTO2TaskSlotState &node = execution.node_storage[i].slot;
+            const int32_t unmet = graph_first_unmet_producer(execution, node);
+            if (unmet < 0) {
+                push_ready_routed(&node);
+            } else {
+                register_graph_wake(execution, &execution.nodes[unmet].slot, &node);
+            }
+        }
+        execution.published_nodes.store(last, std::memory_order_release);
+        graph_route_ready_roots(execution);
+    }
+
     int32_t activate_prepared_graph(GraphExecution &execution) {
         GraphExecutionState expected = GraphExecutionState::PREPARED;
         if (!execution.state.compare_exchange_strong(
@@ -930,20 +983,7 @@ struct PTO2SchedulerState {
             )) {
             return 0;
         }
-        const GraphDefinition &definition = *execution.definition;
-        const uint16_t *roots =
-            graph_definition_array<uint16_t>(definition, definition.off_root_indices, definition.root_count);
-        if (roots == nullptr) return 0;
-        int32_t routed = 0;
-        for (uint32_t i = 0; i < definition.root_count; ++i) {
-            const uint16_t node_index = roots[i];
-            if (node_index >= static_cast<uint32_t>(execution.node_count)) continue;
-            // Roots have zero internal fanin and are routed only here. Every
-            // non-root is registered on one saved producer at a time.
-            push_ready_routed(&execution.nodes[node_index].slot);
-            routed++;
-        }
-        return routed;
+        return graph_route_ready_roots(execution);
     }
 
     GraphMaterializeResult prepare_graph_task(
@@ -957,8 +997,12 @@ struct PTO2SchedulerState {
             return graph_submission_execution_initializing(*submission) ? GraphMaterializeResult::BUSY :
                                                                           GraphMaterializeResult::INVALID;
         }
+        const int32_t before = execution->materialized_nodes;
         const GraphMaterializeResult result =
             graph_execution_materialize_slice(outer_slot, *execution, max_nodes, nodes_materialized);
+        if (result == GraphMaterializeResult::PENDING || result == GraphMaterializeResult::PREPARED) {
+            graph_incremental_publish(*execution, before, execution->materialized_nodes);
+        }
         if (result == GraphMaterializeResult::PREPARED && graph_submission_signal(*submission, 0x1)) {
             activate_prepared_graph(*execution);
         }
@@ -998,8 +1042,16 @@ struct PTO2SchedulerState {
         }
 
         GraphExecution *execution = graph_execution_from_slot(slot_state);
-        if (execution == nullptr || execution->definition == nullptr || execution->nodes == nullptr ||
-            execution->state.load(std::memory_order_acquire) != GraphExecutionState::ACTIVE) {
+        if (execution == nullptr || execution->definition == nullptr || execution->nodes == nullptr) {
+            outcome.error_code = PTO2_ERROR_INVALID_ARGS;
+            return outcome;
+        }
+        // Incremental activation routes a node before the graph reaches ACTIVE, so a
+        // node can legitimately complete while the graph is still MATERIALIZING or
+        // PREPARED. Only SUBMITTED (execution not yet localized) and COMPLETED
+        // (execution already retired) are invalid states for a node completion.
+        const GraphExecutionState graph_state = execution->state.load(std::memory_order_acquire);
+        if (graph_state < GraphExecutionState::MATERIALIZING || graph_state > GraphExecutionState::ACTIVE) {
             outcome.error_code = PTO2_ERROR_INVALID_ARGS;
             return outcome;
         }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -856,6 +856,22 @@ add_a5_hbg_runtime_test(test_a5_graph_cache a5/test_graph_cache.cpp)
 target_sources(test_a5_graph_cache PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
 )
+# Incremental-activation tests init a real PTO2SchedulerState (ready queues), so
+# they link the scheduler + shared runtime out-of-line members.
+add_a2a3_hbg_runtime_test(test_graph_activation a2a3/test_graph_activation.cpp)
+target_sources(test_graph_activation PRIVATE
+    ${HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp
+)
+add_a5_hbg_runtime_test(test_a5_graph_activation a5/test_graph_activation.cpp)
+target_sources(test_a5_graph_activation PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+)
 # PTO2TensorMap's out-of-line members (reserve_layout / init / valid_count) live
 # in this .cpp; no other add_a2a3_hbg_runtime_test target needs them.
 target_sources(test_hbg_tensormap PRIVATE

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Deterministic tests for incremental graph activation.
+ *
+ * Under incremental activation a graph node may reach the ready queue before the
+ * whole GRAPH task is materialized, so a producer can complete while a later
+ * consumer is still being registered. Scene tests hit that interleaving only
+ * probabilistically; these host-side tests force it, exercising the exact path
+ * (graph_first_unmet_producer re-reading task_state) that keeps the consumer from
+ * being lost on a producer's already-drained wake list.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "utils/device_arena.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+
+class GraphActivationTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2SchedulerState sched{};
+    PTO2SchedulerLayout sched_layout{};
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+    }
+
+    void TearDown() override {
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // One GraphExecution node whose slot is a routable single-block KERNEL/AIC
+    // task in the given completion state, with its payload wired the way
+    // materialization leaves it for the wake/route path.
+    static void init_graph_node(GraphNodeStorage &node, int32_t node_index, PTO2TaskState state) {
+        memset(&node, 0, sizeof(GraphNodeStorage));
+        node.slot.task_state.store(state);
+        node.slot.graph_node_index = node_index;
+        node.slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
+        node.slot.task_kind = TaskKind::KERNEL;
+        node.slot.total_required_subtasks = 1;
+        node.slot.logical_block_num = 1;
+        node.slot.payload = &node.payload;
+    }
+};
+
+// A consumer registered after its only producer has completed and drained (head
+// == SENTINEL) reaches graph_first_unmet_producer, which reads task_state and
+// routes it — it is never lost on the closed wake list.
+TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegister) {
+    auto nodes = std::make_unique<GraphNodeStorage[]>(2);
+    init_graph_node(nodes[0], 0, PTO2_TASK_COMPLETED);       // producer, already completed
+    init_graph_node(nodes[1], 1, PTO2_TASK_PENDING);         // consumer of node 0
+    nodes[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
+
+    std::vector<uint32_t> fanin_offsets{0, 0, 1};  // node 0 is a root; node 1 <- {0}
+    std::vector<uint16_t> fanin_indices{0};
+    GraphExecution exec{};
+    exec.nodes = exec.node_storage = nodes.get();
+    exec.fanin_offsets = fanin_offsets.data();
+    exec.fanin_indices = fanin_indices.data();
+
+    sched.register_graph_wake(exec, &nodes[0].slot, &nodes[1].slot);
+
+    PTO2TaskSlotState *out[2];
+    ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 2), 1)
+        << "consumer must route to ready, not hang on the SENTINEL wake list";
+    EXPECT_EQ(out[0], &nodes[1].slot);
+}
+
+// graph_incremental_publish routes a node whose producers are all COMPLETED at
+// publish time, and wake-chains a node with a still-pending producer so it
+// routes exactly once that producer completes and drains its wake list.
+TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPending) {
+    auto nodes = std::make_unique<GraphNodeStorage[]>(4);
+    init_graph_node(nodes[0], 0, PTO2_TASK_COMPLETED);  // root, completed
+    init_graph_node(nodes[1], 1, PTO2_TASK_PENDING);    // root, pending
+    init_graph_node(nodes[2], 2, PTO2_TASK_PENDING);    // consumer of node 0 (completed)
+    init_graph_node(nodes[3], 3, PTO2_TASK_PENDING);    // consumer of node 1 (pending)
+
+    std::vector<uint32_t> fanin_offsets{0, 0, 0, 1, 2};  // node 2 <- {0}, node 3 <- {1}
+    std::vector<uint16_t> fanin_indices{0, 1};
+    GraphExecution exec{};
+    exec.nodes = exec.node_storage = nodes.get();
+    exec.fanin_offsets = fanin_offsets.data();
+    exec.fanin_indices = fanin_indices.data();
+
+    sched.graph_incremental_publish(exec, 0, 4);
+    EXPECT_EQ(exec.published_nodes.load(), 4);
+
+    PTO2TaskSlotState *out[4];
+    ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4), 1)
+        << "only the consumer whose producers are all COMPLETED routes at publish time";
+    EXPECT_EQ(out[0], &nodes[2].slot);
+
+    nodes[1].slot.task_state.store(PTO2_TASK_COMPLETED);
+    sched.drain_graph_wake_list(exec, nodes[1].slot);
+    ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4), 1)
+        << "the wake-chained consumer must route once its pending producer completes";
+    EXPECT_EQ(out[0], &nodes[3].slot);
+}
+
+// Incremental activation dispatches a node before the graph reaches ACTIVE, so
+// complete_task must accept a node completion while the graph is MATERIALIZING or
+// PREPARED, and reject it only for SUBMITTED (not yet localized) or COMPLETED
+// (already retired).
+TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
+    GraphDefinition definition{};
+    auto complete_in_state = [&](GraphExecutionState state) {
+        auto node = std::make_unique<GraphNodeStorage[]>(1);
+        memset(node.get(), 0, sizeof(GraphNodeStorage));
+        node[0].slot.task_kind = TaskKind::GRAPH_NODE;
+        node[0].slot.graph_node_index = 0;
+        node[0].slot.total_required_subtasks = 1;
+        node[0].slot.payload = &node[0].payload;
+
+        GraphExecution exec{};
+        exec.definition = &definition;
+        exec.nodes = exec.node_storage = node.get();
+        exec.node_count = 1;
+        exec.remaining_nodes.store(1);
+        exec.outer_slot = nullptr;
+        exec.state.store(state);
+        node[0].slot.graph_context = &exec;
+#if SIMPLER_SCHED_PROFILING
+        return sched.complete_task(node[0].slot, 0).error_code;
+#else
+        return sched.complete_task(node[0].slot).error_code;
+#endif
+    };
+
+    EXPECT_EQ(complete_in_state(GraphExecutionState::MATERIALIZING), PTO2_ERROR_NONE);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::PREPARED), PTO2_ERROR_NONE);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::ACTIVE), PTO2_ERROR_NONE);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::SUBMITTED), PTO2_ERROR_INVALID_ARGS);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::COMPLETED), PTO2_ERROR_INVALID_ARGS);
+}

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Deterministic tests for incremental graph activation.
+ *
+ * Under incremental activation a graph node may reach the ready queue before the
+ * whole GRAPH task is materialized, so a producer can complete while a later
+ * consumer is still being registered. Scene tests hit that interleaving only
+ * probabilistically; these host-side tests force it, exercising the exact path
+ * (graph_first_unmet_producer re-reading task_state) that keeps the consumer from
+ * being lost on a producer's already-drained wake list.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "utils/device_arena.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+
+class GraphActivationTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2SchedulerState sched{};
+    PTO2SchedulerLayout sched_layout{};
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+    }
+
+    void TearDown() override {
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // One GraphExecution node whose slot is a routable single-block KERNEL/AIC
+    // task in the given completion state, with its payload wired the way
+    // materialization leaves it for the wake/route path.
+    static void init_graph_node(GraphNodeStorage &node, int32_t node_index, PTO2TaskState state) {
+        memset(&node, 0, sizeof(GraphNodeStorage));
+        node.slot.task_state.store(state);
+        node.slot.graph_node_index = node_index;
+        node.slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
+        node.slot.task_kind = TaskKind::KERNEL;
+        node.slot.total_required_subtasks = 1;
+        node.slot.logical_block_num = 1;
+        node.slot.payload = &node.payload;
+    }
+};
+
+// A consumer registered after its only producer has completed and drained (head
+// == SENTINEL) reaches graph_first_unmet_producer, which reads task_state and
+// routes it — it is never lost on the closed wake list.
+TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegister) {
+    auto nodes = std::make_unique<GraphNodeStorage[]>(2);
+    init_graph_node(nodes[0], 0, PTO2_TASK_COMPLETED);       // producer, already completed
+    init_graph_node(nodes[1], 1, PTO2_TASK_PENDING);         // consumer of node 0
+    nodes[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
+
+    std::vector<uint32_t> fanin_offsets{0, 0, 1};  // node 0 is a root; node 1 <- {0}
+    std::vector<uint16_t> fanin_indices{0};
+    GraphExecution exec{};
+    exec.nodes = exec.node_storage = nodes.get();
+    exec.fanin_offsets = fanin_offsets.data();
+    exec.fanin_indices = fanin_indices.data();
+
+    sched.register_graph_wake(exec, &nodes[0].slot, &nodes[1].slot);
+
+    PTO2TaskSlotState *out[2];
+    ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 2), 1)
+        << "consumer must route to ready, not hang on the SENTINEL wake list";
+    EXPECT_EQ(out[0], &nodes[1].slot);
+}
+
+// graph_incremental_publish routes a node whose producers are all COMPLETED at
+// publish time, and wake-chains a node with a still-pending producer so it
+// routes exactly once that producer completes and drains its wake list.
+TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPending) {
+    auto nodes = std::make_unique<GraphNodeStorage[]>(4);
+    init_graph_node(nodes[0], 0, PTO2_TASK_COMPLETED);  // root, completed
+    init_graph_node(nodes[1], 1, PTO2_TASK_PENDING);    // root, pending
+    init_graph_node(nodes[2], 2, PTO2_TASK_PENDING);    // consumer of node 0 (completed)
+    init_graph_node(nodes[3], 3, PTO2_TASK_PENDING);    // consumer of node 1 (pending)
+
+    std::vector<uint32_t> fanin_offsets{0, 0, 0, 1, 2};  // node 2 <- {0}, node 3 <- {1}
+    std::vector<uint16_t> fanin_indices{0, 1};
+    GraphExecution exec{};
+    exec.nodes = exec.node_storage = nodes.get();
+    exec.fanin_offsets = fanin_offsets.data();
+    exec.fanin_indices = fanin_indices.data();
+
+    sched.graph_incremental_publish(exec, 0, 4);
+    EXPECT_EQ(exec.published_nodes.load(), 4);
+
+    PTO2TaskSlotState *out[4];
+    ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4), 1)
+        << "only the consumer whose producers are all COMPLETED routes at publish time";
+    EXPECT_EQ(out[0], &nodes[2].slot);
+
+    nodes[1].slot.task_state.store(PTO2_TASK_COMPLETED);
+    sched.drain_graph_wake_list(exec, nodes[1].slot);
+    ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4), 1)
+        << "the wake-chained consumer must route once its pending producer completes";
+    EXPECT_EQ(out[0], &nodes[3].slot);
+}
+
+// Incremental activation dispatches a node before the graph reaches ACTIVE, so
+// complete_task must accept a node completion while the graph is MATERIALIZING or
+// PREPARED, and reject it only for SUBMITTED (not yet localized) or COMPLETED
+// (already retired).
+TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
+    GraphDefinition definition{};
+    auto complete_in_state = [&](GraphExecutionState state) {
+        auto node = std::make_unique<GraphNodeStorage[]>(1);
+        memset(node.get(), 0, sizeof(GraphNodeStorage));
+        node[0].slot.task_kind = TaskKind::GRAPH_NODE;
+        node[0].slot.graph_node_index = 0;
+        node[0].slot.total_required_subtasks = 1;
+        node[0].slot.payload = &node[0].payload;
+
+        GraphExecution exec{};
+        exec.definition = &definition;
+        exec.nodes = exec.node_storage = node.get();
+        exec.node_count = 1;
+        exec.remaining_nodes.store(1);
+        exec.outer_slot = nullptr;
+        exec.state.store(state);
+        node[0].slot.graph_context = &exec;
+#if SIMPLER_SCHED_PROFILING
+        return sched.complete_task(node[0].slot, 0).error_code;
+#else
+        return sched.complete_task(node[0].slot).error_code;
+#endif
+    };
+
+    EXPECT_EQ(complete_in_state(GraphExecutionState::MATERIALIZING), PTO2_ERROR_NONE);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::PREPARED), PTO2_ERROR_NONE);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::ACTIVE), PTO2_ERROR_NONE);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::SUBMITTED), PTO2_ERROR_INVALID_ARGS);
+    EXPECT_EQ(complete_in_state(GraphExecutionState::COMPLETED), PTO2_ERROR_INVALID_ARGS);
+}


### PR DESCRIPTION
# Human Summary

In HBG the task graph is sent to the device and fully expanded before computation starts. This PR pipelines the expansion and the computation so that AI cores can start doing useful work as soon as the first task is processed. This saves a bunch of initialization time.

# AI Summary

The on-device Graph scheduler expanded a `GRAPH` task into **all** its nodes before dispatching **any** of them — `graph_execution_materialize_slice` reached `PREPARED` only after the last node, and `activate_prepared_graph` routed the roots only at that point. For a large graph the AICores idle through the entire expansion. On the qwen3-14B 3-layer decode this front-loaded ramp is **~530 µs per layer** with every core waiting.

This routes roots (and any node whose producers have all completed) **as soon as they materialize**, once the outer `GRAPH` task's external-dependency gate has opened, so compute overlaps the remaining expansion.

## How it's made safe — and what makes it possible

Dispatching a node before the whole graph is materialized means a producer can complete while a later consumer is still being registered — the exact hazard the `PREPARED` gate existed to prevent. This change is only possible because of the **polling-completion scheduler**: the per-slot `completion_flags` byte + `task_state` completion mirror introduced for `tensormap_and_ringbuffer` in **#1137** and adapted to `host_build_graph` in **#1435**. That model lets a consumer answer "has this producer finished?" by reading a flag, so a producer completing mid-expansion is *discovered*, not missed. Under the older pure wake-list model this would have been unsafe — which is precisely why the whole-graph `PREPARED` gate existed. Three things close the hazard:

- **Flag-safe registration.** Materialization-time registration moves from `register_initial_graph_waiter` (a raw wake-list store that assumed no producer could complete during expansion) to `register_graph_wake`, which resolves a producer that completed mid-expansion through its `task_state` completion flag (the #1137/#1435 mechanism) instead of losing the wake. This machinery already existed on the live wake path; this change simply routes materialization through it.
- **Topological order.** The definition is validated to be topologically ordered (every producer index < consumer index), so every producer a materialized node references is already constructed. `execution.nodes` is published at `MATERIALIZING` (under `materialize_busy`) so the wake path can read producer slots during expansion.
- **Idempotent root routing.** Roots reach the ready queue through `route_cursor`, a monotonic per-execution cursor that makes routing idempotent across the per-slice calls and the final call at the activation meet — each root is pushed exactly once. Non-roots reach the queue only through their producers' wake list, unchanged.

## Testing

- **Correctness:** the three `graph_execution` scene tests (2D replay, AIC+AIV, MIX-SPMD) and the **qwen3-14B 3-layer graph-execution golden** pass, including a 3-round replay. A 45-run repeat of the three graph-exec tests passes 45/45 (initial rapid-repeat failures were host-side `halMemCtl` MMIO contention from process churn — a different binary, before the scheduler runs — and vanish once process starts are spaced).
- **Performance** (qwen3-14B 3-layer, a2a3 onboard, same-device A/B, 15 rounds):

  | | Avg device_wall |
  |---|--:|
  | baseline | 3397.8 µs |
  | incremental | 3247.1 µs |
  | **delta** | **−150.7 µs (−4.4%)** |

  The chip swimlane confirms compute begins overlapping graph expansion (cores busy at ~400 µs) instead of waiting for it (~600 µs baseline). The first-compute start is still bounded by the outer task's external-dependency latency, so the recovered time is the expansion **tail**, not an earlier start.

## Scope

- a2a3 + a5 `host_build_graph`, same commit (identical graph scheduler). a5 is **compile-verified only** — the dev box is a2a3 silicon.
- Only affects the graph-execution path; non-graph dispatch is untouched.
