### PR TITLE
Fix A2A3 repeated-run AICore stream regression

### DIFF
--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -290,14 +290,16 @@ that window needs the admission layer to gate dispatch on `pool.owns(lease)`
 before handing work down, which is whole-run admission's job, not this
 layer's.
 
-AICore streams are outside that lease. The instruction cache belongs to the
-cores, every slot publishes its image to the same GM code address, and the
-platform offers no cache invalidation for code replaced there. Creating a
-stream is the only operation known to leave a core free of the previous image's
-instructions; selecting an already-existing one is not. So each run creates its
-own AICore stream and retires it on every exit path, and no record of which
-image a stream last ran is load-bearing. The AICPU stream carries no such state
-and stays with its slot.
+AICore streams are outside that lease. Registered callables keep content-hash
+deduplicated GM allocations: simultaneously resident code images occupy
+different allocations, while unregister frees an allocation that a later
+registration may reuse. A dedup miss is the only path that publishes new
+AICore instruction bytes. After that H2D copy succeeds, every retained slot
+stream is marked stale; its next acquire destroys and recreates the AICore
+stream before launch. Without a new publication, completed slot streams remain
+reusable even when two resident callables alternate. Unproven completion still
+destroys the stream conservatively. The AICPU stream carries no instruction
+cache state and stays with its slot.
 
 #### Whole-run FIFO admission
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2305,9 +2305,9 @@ NB_MODULE(_task_interface, m) {
         .def_prop_ro(
             "run_stream_set_create_count", &ChipWorker::run_stream_set_create_count,
             "Number of AICore run streams the bound runner has created. The AICPU "
-            "stream belongs to a pipeline slot for the worker's lifetime, while each "
-            "run creates and retires its own AICore stream, so this advances once per "
-            "run; platforms whose runs use the persistent bootstrap pair report 0."
+            "stream belongs to a pipeline slot for the worker's lifetime. A completed "
+            "AICore stream is reused until a new code upload makes it stale. Platforms "
+            "using the persistent bootstrap pair report 0."
         )
         .def_prop_ro(
             "committed_device_memory", &ChipWorker::committed_device_memory,

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -11221,10 +11221,10 @@ class Worker:
     def run_stream_set_create_count(self) -> int:
         """L2 only: number of AICore run streams the runner has created.
 
-        AICPU streams belong to pipeline slots for the worker's lifetime, while
-        each run creates and retires its own AICore stream, so this advances
-        once per run. Returns 0 on non-L2 workers and on platforms whose runs
-        use the persistent bootstrap stream pair (simulation, a5).
+        AICPU streams belong to pipeline slots for the worker's lifetime. A
+        completed AICore stream is reused until a new code upload makes it
+        stale. Returns 0 on non-L2 workers and on platforms whose runs use the
+        persistent bootstrap stream pair (simulation, a5).
         """
         if self.level != 2 or self._chip_worker is None:
             return 0

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -464,10 +464,9 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         return rc;
     }
 
-    // On a successful device drain, failure to retire this run's AICore stream
-    // is the run's error. Mark the attempt first so cleanup does not immediately
-    // retry a failed destroy; the retained handle keeps the slot unusable and
-    // lets finalize retry it later.
+    // A proven-complete stream is reusable until a code publication marks it
+    // stale. Publish retirement so cleanup does not replace it with an
+    // unproven state after the device result has already been established.
     prepared.aicore_retirement_attempted = true;
     rc = retire_run_aicore_stream(pipeline_slot, RunStreamSlots::CompletionStatus::Complete);
     if (rc != 0) return rc;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -105,6 +105,7 @@ public:
     bool can_accept_run() const override { return !device_unusable_.load(std::memory_order_acquire); }
     int provision_native_run_resources(uint32_t pipeline_slot) override;
     int abandon_native_run_resources(uint32_t pipeline_slot) override;
+    void mark_run_streams_stale() override { run_stream_slots_.mark_all_stale(); }
 
     // Map/unmap a device buffer into host address space via
     // halHostRegister(DEV_SVM_MAP_HOST) / halHostUnregister. The returned host
@@ -225,14 +226,10 @@ private:
     // One slot per in-flight run the pipeline contract can declare.
     static constexpr unsigned kRunStreamSetCount = PTO_PIPELINE_MAX_DEPTH;
 
-    // AICPU streams belong to slots for the worker's lifetime. AICore streams
-    // belong to a single run: the platform offers no instruction-cache
-    // invalidation for code replaced at a reused GM address, and creating the
-    // stream is the only operation known to leave a core free of the previous
-    // image's instructions. Selecting an existing stream is not.
-    // Stream lifetimes live in RunStreamSlots so the slot state machine —
-    // fresh AICore stream per run, handle kept when a destroy fails — is
-    // testable without a device.
+    // AICPU streams belong to slots for the worker's lifetime. A completed
+    // AICore stream remains reusable until a new code upload marks every slot
+    // stale. Stream lifetimes live in RunStreamSlots so publication and
+    // failed-destroy states are testable without a device.
     RunStreamSlots run_stream_slots_{
         [this](void **out) {
             return create_run_stream(out);

--- a/src/common/platform/include/host/run_stream_slots.h
+++ b/src/common/platform/include/host/run_stream_slots.h
@@ -24,11 +24,9 @@
  * Per-slot ownership of the two streams a run submits on.
  *
  * The AICPU stream carries no instruction-cache state, so it belongs to its
- * slot for the runner's lifetime. The AICore stream belongs to a single run:
- * the platform offers no instruction-cache invalidation for code replaced at a
- * reused GM address, and creating the stream is the only operation known to
- * leave a core free of the previous image's instructions — selecting an
- * existing one is not.
+ * slot for the runner's lifetime. A completed AICore stream remains reusable
+ * until new AICore code is published. Publication marks every slot stale; its
+ * next acquire destroys the old AICore stream before creating a replacement.
  *
  * A destroy that fails keeps its handle. Such a stream may still hold the
  * previous image's instructions, so the slot must refuse the next run rather
@@ -54,11 +52,7 @@ public:
         create_(std::move(create)),
         destroy_(std::move(destroy)) {}
 
-    /**
-     * Ready `slot` for a run: its AICPU stream on first use, and always a fresh
-     * AICore stream. Fails when the slot still holds an AICore stream a prior
-     * run could not retire.
-     */
+    /** Ready `slot` for a run, reusing its AICore stream unless stale. */
     int acquire(unsigned slot) {
         if (slot >= slots_.size()) return -1;
         Slot &s = slots_[slot];
@@ -70,16 +64,35 @@ public:
                 return rc;
             }
         }
-        if (s.aicore != nullptr) return -1;
+        if (s.aicore != nullptr) {
+            if (s.submitted || !s.complete) return -1;
+            if (!s.stale) {
+                s.submitted = false;
+                s.complete = false;
+                return 0;
+            }
+            int rc = destroy_(s.aicore);
+            if (rc != 0) return rc;
+            s.aicore = nullptr;
+        }
         int rc = create_(&s.aicore);
         if (rc != 0) {
             s.aicore = nullptr;
             return rc;
         }
         created_count_.fetch_add(1, std::memory_order_relaxed);
+        s.stale = false;
         s.submitted = false;
         s.complete = false;
         return 0;
+    }
+
+    /** Mark every retained AICore stream stale after code publication. */
+    void mark_all_stale() {
+        for (Slot &s : slots_) {
+            std::lock_guard<std::mutex> lock(s.mutex);
+            s.stale = true;
+        }
     }
 
     /** Make the prepared stream pair visible to non-blocking poll. */
@@ -116,9 +129,7 @@ public:
     }
 
     /**
-     * Retire `slot`'s AICore stream. The handle survives a failed destroy.
-     * Only a successful device query or stream synchronization may pass
-     * Complete; launch rollback and abandoned preparation pass Unproven.
+     * Complete retains the stream for reuse. Unproven destroys it.
      */
     int retire_aicore(unsigned slot, CompletionStatus completion_status) {
         if (slot >= slots_.size()) return -1;
@@ -130,6 +141,7 @@ public:
         // later failing sync, so the sync error remains authoritative.
         s.submitted = false;
         s.complete = completion_status == CompletionStatus::Complete;
+        if (completion_status == CompletionStatus::Complete) return 0;
         if (s.aicore == nullptr) return 0;
         int rc = destroy_(s.aicore);
         if (rc != 0) return rc;
@@ -144,6 +156,7 @@ public:
             std::lock_guard<std::mutex> lock(s.mutex);
             s.submitted = false;
             s.complete = false;
+            s.stale = false;
             for (void **stream : {&s.aicpu, &s.aicore}) {
                 if (*stream == nullptr) continue;
                 int rc = destroy_(*stream);
@@ -162,6 +175,9 @@ public:
         for (Slot &s : slots_) {
             s.aicpu = nullptr;
             s.aicore = nullptr;
+            s.stale = false;
+            s.submitted = false;
+            s.complete = false;
         }
     }
 
@@ -176,6 +192,7 @@ private:
         mutable std::mutex mutex;
         void *aicpu{nullptr};
         void *aicore{nullptr};
+        bool stale{false};
         bool submitted{false};
         bool complete{false};
     };

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -696,6 +696,7 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
         mem_alloc_.free(gm_addr);
         return 0;
     }
+    mark_run_streams_stale();
 
     chip_callable_buffers_.emplace(layout.content_hash, ChipCallableBuffer{chip_dev, layout.total_size, 1});
     LOG_DEBUG(

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -516,6 +516,9 @@ public:
      */
     virtual bool can_accept_run() const = 0;
 
+    /** Invalidate retained run streams after new AICore code is published. */
+    virtual void mark_run_streams_stale() {}
+
     /** Provision/abandon platform resources owned by one prepared native run. */
     virtual int provision_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }
     virtual int abandon_native_run_resources(uint32_t /*pipeline_slot*/) { return 0; }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -162,9 +162,9 @@ public:
     size_t host_dlopen_count() const;
 
     /// Number of AICore run streams the bound runner has created. AICPU streams
-    /// belong to slots for the worker's lifetime; each run gets a freshly
-    /// created AICore stream, so this advances once per run. Platforms using
-    /// the persistent bootstrap pair report 0.
+    /// belong to slots for the worker's lifetime. Completed AICore streams are
+    /// reused until a new code upload makes them stale. Platforms using the
+    /// persistent bootstrap pair report 0.
     size_t run_stream_set_create_count() const;
 
     uint64_t malloc(size_t size);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -448,8 +448,8 @@ size_t get_host_dlopen_count(DeviceContextHandle ctx);
 
 /**
  * Number of AICore run streams the runner bound to `ctx` has created. AICPU
- * streams belong to pipeline slots for the worker's lifetime; each run gets a
- * freshly created AICore stream, so this advances once per run. Returns 0 on
+ * streams belong to pipeline slots for the worker's lifetime. A completed
+ * AICore stream is reused until a new code upload makes it stale. Returns 0 on
  * platforms whose runs use the persistent bootstrap pair.
  */
 size_t get_run_stream_set_create_count(DeviceContextHandle ctx);

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -227,9 +227,9 @@ class TestNativeRunLifecycle(SceneTestCase):
                     self.compute_golden(run_golden, case["params"])
                     return run_args, run_chip_args, run_output_names, run_golden
 
-                # The successor owns a distinct bank and fresh stream while A
-                # still owns the execution claim. A failed early launch must
-                # leave B prepared so the same token can launch after A's
+                # The successor owns a distinct bank and slot stream while A
+                # still owns the execution claim. A failed early launch
+                # must leave B prepared so the same token can launch after A's
                 # complete fence and finalization.
                 active_args, active_chip_args, active_outputs, active_golden = build_run_args()
                 successor_args, successor_chip_args, successor_outputs, successor_golden = build_run_args()
@@ -237,12 +237,12 @@ class TestNativeRunLifecycle(SceneTestCase):
                 native_run = chip_worker._prepare_native_run_with_pipeline_lease(
                     _SLOT, active_chip_args, 0, _GENERATION + 1, config=config
                 )
-                assert chip_worker.run_stream_set_create_count == stream_count + 1
+                assert chip_worker.run_stream_set_create_count == stream_count
                 chip_worker._launch_native_run(native_run)
                 successor_run = chip_worker._prepare_native_run_with_pipeline_lease(
                     _SLOT, successor_chip_args, 1, _GENERATION, config=config
                 )
-                assert chip_worker.run_stream_set_create_count == stream_count + 2
+                assert chip_worker.run_stream_set_create_count == stream_count + 1
                 bank0 = chip_worker.arena_bank_gm_heap_base(0)
                 bank1 = chip_worker.arena_bank_gm_heap_base(1)
                 assert bank0 != 0

--- a/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
+++ b/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
@@ -7,19 +7,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""A2A3 gives every run a freshly created AICore stream.
+"""A2A3 reuses completed AICore streams between code publications.
 
 A2A3 submits each run's AICore and AICPU kernels on the stream set of the
 selected pipeline slot rather than on the persistent bootstrap pair. The AICPU
 stream carries no instruction-cache state and belongs to the slot for the
-worker's lifetime. The AICore stream belongs to one run: the platform offers no
-instruction-cache invalidation for code replaced at a reused GM address, and
-creating the stream is the only operation known to leave a core free of the
-previous image's instructions — selecting an already-existing stream is not, so
-reuse cannot be made safe by tracking which image a stream last ran.
+worker's lifetime. A completed AICore stream remains reusable until a new
+AICore code buffer is uploaded, which marks every retained slot stream stale.
 
-`Worker.run_stream_set_create_count` counts those creations, so it advances once
-per run.
+`Worker.run_stream_set_create_count` counts AICore stream creations, so runs
+plateau after each slot is warm until another code publication.
 """
 
 import itertools
@@ -69,7 +66,7 @@ class _SubtractCallable(SceneTestCase):
 
 @scene_test(level=2, runtime="host_build_graph")
 class TestRunStreamReuseHbg(SceneTestCase):
-    """Each run gets its own AICore stream; its pipeline slot owns the rest."""
+    """Each pipeline slot retains a completed AICore stream until publication."""
 
     RTOL = 1e-5
     ATOL = 1e-5
@@ -119,25 +116,58 @@ class TestRunStreamReuseHbg(SceneTestCase):
             TensorArg("f", torch.zeros(size, dtype=torch.float32)),
         )
 
-    def compute_golden(self, args, params):
+    def compute_golden(self, args, params, *, subtract=False):
         a, b = args.a, args.b
-        args.f[:] = (a + b + 1) * (a + b + 2)
+        base = a - b if subtract else a + b
+        args.f[:] = (base + 1) * (base + 2)
 
-    def test_every_run_creates_its_own_aicore_stream(self, st_platform, st_worker):
-        """N runs create N AICore streams, and every result is right."""
+    def test_repeated_runs_without_publication_reuse_aicore_stream(self, st_platform, st_worker):
+        """Repeated runs preserve a warm stream while no code is published."""
         if st_platform != "a2a3":
             pytest.skip("run stream sets are an a2a3 onboard resource")
 
-        callable_obj = self.build_callable(st_platform)
-        self._run_and_validate_l2(st_worker, callable_obj, self.CASES[0], rounds=1)
-        after_first = st_worker.run_stream_set_create_count
-        rounds = _REPEATED_RUNS - 1
-        self._run_and_validate_l2(st_worker, callable_obj, self.CASES[0], rounds=rounds)
+        handle = st_worker.register(self.build_callable(st_platform))
+        try:
+            self._run_registered(st_worker, handle, subtract=False)
+            after_first = st_worker.run_stream_set_create_count
+            for _ in range(_REPEATED_RUNS - 1):
+                self._run_registered(st_worker, handle, subtract=False)
+            assert st_worker.run_stream_set_create_count == after_first, (
+                f"runs without code publication recreated their AICore stream: "
+                f"{after_first} -> {st_worker.run_stream_set_create_count}"
+            )
+        finally:
+            st_worker.unregister(handle)
 
-        assert st_worker.run_stream_set_create_count == after_first + rounds, (
-            f"{rounds} runs did not each create an AICore stream: "
-            f"{after_first} -> {st_worker.run_stream_set_create_count}"
-        )
+    def test_deduplicated_registration_does_not_invalidate_stream(self, st_platform, st_worker):
+        """A content-hash dedup hit does not publish code or stale a stream."""
+        if st_platform != "a2a3":
+            pytest.skip("AICore code publication is an a2a3 onboard resource")
+
+        chip_callable = self.build_callable(st_platform)
+        first_handle = st_worker.register(chip_callable)
+        duplicate_handle = None
+        try:
+            self._run_registered_with_lease(
+                st_worker,
+                first_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+            warmed = st_worker.run_stream_set_create_count
+
+            duplicate_handle = st_worker.register(chip_callable)
+            self._run_registered_with_lease(
+                st_worker,
+                duplicate_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+            assert st_worker.run_stream_set_create_count == warmed
+        finally:
+            if duplicate_handle is not None:
+                st_worker.unregister(duplicate_handle)
+            st_worker.unregister(first_handle)
 
     def _run_registered(self, worker, handle, *, subtract):
         params = self.CASES[0]["params"]
@@ -146,9 +176,7 @@ class TestRunStreamReuseHbg(SceneTestCase):
         # the direct chip API's shape, used by the lease path below.
         args, output_names = _build_l2_ref_args(test_args, self.CALLABLE["orchestration"]["signature"], worker)
         golden_args = test_args.clone()
-        a, b = golden_args.a, golden_args.b
-        base = a - b if subtract else a + b
-        golden_args.f[:] = (base + 1) * (base + 2)
+        self.compute_golden(golden_args, params, subtract=subtract)
         worker.run(handle, args, config=self._build_config(self.CASES[0]["config"]))
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
@@ -161,11 +189,11 @@ class TestRunStreamReuseHbg(SceneTestCase):
     def _next_generation(cls):
         return next(cls._generation_counter)
 
-    def _run_registered_with_lease(self, worker, handle, *, slot_id, generation):
+    def _run_registered_with_lease(self, worker, handle, *, slot_id, generation, subtract=False):
         params = self.CASES[0]["params"]
         test_args = self.generate_args(params)
         golden_args = test_args.clone()
-        self.compute_golden(golden_args, params)
+        self.compute_golden(golden_args, params, subtract=subtract)
         chip_args, output_names = _build_chip_task_args(test_args, self.CALLABLE["orchestration"]["signature"])
         state = worker._resolve_handle(handle)
         worker._chip_worker._run_slot_with_pipeline_lease(
@@ -177,8 +205,8 @@ class TestRunStreamReuseHbg(SceneTestCase):
         )
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
-    def test_alternating_code_images_never_execute_stale_instructions(self, st_platform, st_worker):
-        """A→B→A→B at one reused GM code address always runs the selected image.
+    def test_resident_code_images_reuse_one_stream(self, st_platform, st_worker):
+        """A->B->A->B reuses one slot stream when no code is published.
 
         Each result is compared against the golden for the image that run asked
         for, so an AICore that executed the previous image's instructions shows
@@ -190,17 +218,124 @@ class TestRunStreamReuseHbg(SceneTestCase):
         add_handle = st_worker.register(self.build_callable(st_platform))
         sub_handle = st_worker.register(_SubtractCallable.compile_chip_callable(st_platform))
         try:
+            self._run_registered_with_lease(
+                st_worker,
+                add_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+            warmed = st_worker.run_stream_set_create_count
             for handle, subtract in (
-                (add_handle, False),
                 (sub_handle, True),
                 (add_handle, False),
                 (sub_handle, True),
             ):
-                before = st_worker.run_stream_set_create_count
-                self._run_registered(st_worker, handle, subtract=subtract)
-                assert st_worker.run_stream_set_create_count == before + 1
+                self._run_registered_with_lease(
+                    st_worker,
+                    handle,
+                    slot_id=0,
+                    generation=self._next_generation(),
+                    subtract=subtract,
+                )
+                assert st_worker.run_stream_set_create_count == warmed
         finally:
             st_worker.unregister(sub_handle)
+            st_worker.unregister(add_handle)
+
+    def test_depth_two_slots_reuse_across_resident_images(self, st_platform, st_worker):
+        """Both slots reuse their streams while resident images alternate."""
+        if st_platform != "a2a3":
+            pytest.skip("AICore code images are an a2a3 onboard resource")
+
+        add_handle = st_worker.register(self.build_callable(st_platform))
+        sub_handle = st_worker.register(_SubtractCallable.compile_chip_callable(st_platform))
+        try:
+            for slot_id, handle, subtract in (
+                (0, add_handle, False),
+                (1, sub_handle, True),
+            ):
+                self._run_registered_with_lease(
+                    st_worker,
+                    handle,
+                    slot_id=slot_id,
+                    generation=self._next_generation(),
+                    subtract=subtract,
+                )
+
+            warmed = st_worker.run_stream_set_create_count
+            for slot_id, handle, subtract in (
+                (0, sub_handle, True),
+                (1, add_handle, False),
+            ):
+                self._run_registered_with_lease(
+                    st_worker,
+                    handle,
+                    slot_id=slot_id,
+                    generation=self._next_generation(),
+                    subtract=subtract,
+                )
+                assert st_worker.run_stream_set_create_count == warmed
+
+            self._run_registered_with_lease(
+                st_worker,
+                sub_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+                subtract=True,
+            )
+            self._run_registered_with_lease(
+                st_worker,
+                add_handle,
+                slot_id=1,
+                generation=self._next_generation(),
+            )
+            assert st_worker.run_stream_set_create_count == warmed
+        finally:
+            st_worker.unregister(sub_handle)
+            st_worker.unregister(add_handle)
+
+    def test_code_publication_invalidates_both_slots_across_reregistration(self, st_platform, st_worker):
+        """A->B->A uploads invalidate streams retained by either slot."""
+        if st_platform != "a2a3":
+            pytest.skip("AICore code publication is an a2a3 onboard resource")
+
+        add_callable = self.build_callable(st_platform)
+        add_handle = st_worker.register(add_callable)
+        try:
+            self._run_registered_with_lease(
+                st_worker,
+                add_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+        finally:
+            st_worker.unregister(add_handle)
+
+        sub_handle = st_worker.register(_SubtractCallable.compile_chip_callable(st_platform))
+        try:
+            before_sub = st_worker.run_stream_set_create_count
+            self._run_registered_with_lease(
+                st_worker,
+                sub_handle,
+                slot_id=1,
+                generation=self._next_generation(),
+                subtract=True,
+            )
+            assert st_worker.run_stream_set_create_count == before_sub + 1
+        finally:
+            st_worker.unregister(sub_handle)
+
+        add_handle = st_worker.register(add_callable)
+        try:
+            before_add = st_worker.run_stream_set_create_count
+            self._run_registered_with_lease(
+                st_worker,
+                add_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+            assert st_worker.run_stream_set_create_count == before_add + 1
+        finally:
             st_worker.unregister(add_handle)
 
     def test_depth_two_slots_own_separate_resources(self, st_platform, st_worker):
@@ -225,8 +360,28 @@ class TestRunStreamReuseHbg(SceneTestCase):
 
         add_handle = st_worker.register(self.build_callable(st_platform))
         try:
-            self._run_registered(st_worker, add_handle, subtract=False)
+            stream_sets = st_worker.run_stream_set_create_count
+            self._run_registered_with_lease(
+                st_worker,
+                add_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+            after_slot0 = st_worker.run_stream_set_create_count
+            expected_increment = 1 if st_platform == "a2a3" else 0
+            assert after_slot0 == stream_sets + expected_increment
             self._run_registered_with_lease(st_worker, add_handle, slot_id=1, generation=self._next_generation())
+            after_slot1 = st_worker.run_stream_set_create_count
+            assert after_slot1 == after_slot0 + expected_increment
+
+            self._run_registered_with_lease(
+                st_worker,
+                add_handle,
+                slot_id=0,
+                generation=self._next_generation(),
+            )
+            self._run_registered_with_lease(st_worker, add_handle, slot_id=1, generation=self._next_generation())
+            assert st_worker.run_stream_set_create_count == after_slot1
 
             # hbg declares its GM heap HOST_PER_RUN, so a run on slot 1 must
             # commit a second device allocation rather than reuse slot 0's.
@@ -290,22 +445,26 @@ class TestRunStreamReuseHbg(SceneTestCase):
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
-class TestRunStreamFreshTmr(SceneTestCase):
-    """TMR preparation keeps the same fresh run-owned AICore stream rule."""
+class TestRunStreamReuseTmr(SceneTestCase):
+    """TMR preparation keeps the same publication-aware stream rule."""
 
     CALLABLE = TestRunStreamReuseHbg.CALLABLE
     CASES = TestRunStreamReuseHbg.CASES
 
     generate_args = TestRunStreamReuseHbg.generate_args
     compute_golden = TestRunStreamReuseHbg.compute_golden
+    _run_registered = TestRunStreamReuseHbg._run_registered
 
-    def test_every_run_creates_its_own_aicore_stream(self, st_platform, st_worker):
+    def test_repeated_runs_without_publication_reuse_aicore_stream(self, st_platform, st_worker):
         if st_platform != "a2a3":
             pytest.skip("run stream sets are an a2a3 onboard resource")
 
-        callable_obj = self.build_callable(st_platform)
-        self._run_and_validate_l2(st_worker, callable_obj, self.CASES[0], rounds=1)
-        after_first = st_worker.run_stream_set_create_count
-        rounds = _REPEATED_RUNS - 1
-        self._run_and_validate_l2(st_worker, callable_obj, self.CASES[0], rounds=rounds)
-        assert st_worker.run_stream_set_create_count == after_first + rounds
+        handle = st_worker.register(self.build_callable(st_platform))
+        try:
+            self._run_registered(st_worker, handle, subtract=False)
+            after_first = st_worker.run_stream_set_create_count
+            for _ in range(_REPEATED_RUNS - 1):
+                self._run_registered(st_worker, handle, subtract=False)
+            assert st_worker.run_stream_set_create_count == after_first
+        finally:
+            st_worker.unregister(handle)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -398,8 +398,8 @@ add_hierarchical_test(test_remote_wire hierarchical/test_remote_wire.cpp)
 add_hierarchical_test(test_remote_endpoint hierarchical/test_remote_endpoint.cpp)
 add_hierarchical_test(test_pipeline_contract hierarchical/test_pipeline_contract.cpp)
 
-# Run-stream slot state machine: fresh AICore stream per run, and the handle a
-# failed destroy must keep. Header-only with injected create/destroy, so it
+# Run-stream slot state machine: publication-aware AICore stream reuse and
+# failed-destroy ownership. Header-only with injected create/destroy, so it
 # needs no runtime objects and no device.
 add_executable(test_run_stream_slots hierarchical/test_run_stream_slots.cpp)
 target_include_directories(test_run_stream_slots PRIVATE

--- a/tests/ut/cpp/hierarchical/test_run_stream_slots.cpp
+++ b/tests/ut/cpp/hierarchical/test_run_stream_slots.cpp
@@ -74,9 +74,7 @@ RunStreamSlots make_slots(FakeStreams &fake) {
     );
 }
 
-// The AICPU stream is the slot's for the runner's lifetime; the AICore stream
-// belongs to one run, so the count advances once per acquire.
-TEST(RunStreamSlots, EveryAcquireCreatesAnAicoreStreamAndKeepsTheAicpuOne) {
+TEST(RunStreamSlots, RetiredStreamIsReusedWithoutCodePublication) {
     FakeStreams fake;
     RunStreamSlots slots = make_slots(fake);
 
@@ -87,17 +85,117 @@ TEST(RunStreamSlots, EveryAcquireCreatesAnAicoreStreamAndKeepsTheAicpuOne) {
     ASSERT_NE(first_aicore, nullptr);
     EXPECT_EQ(slots.created_count(), 1u);
 
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
+    EXPECT_EQ(slots.aicore(0), first_aicore);
+
+    ASSERT_EQ(slots.acquire(0), 0);
+    EXPECT_EQ(slots.aicpu(0), aicpu) << "the AICPU stream must not be recreated";
+    EXPECT_EQ(slots.aicore(0), first_aicore) << "a retired stream stays warm until code publication";
+    EXPECT_EQ(slots.created_count(), 1u);
+}
+
+TEST(RunStreamSlots, CodePublicationInvalidatesEveryRetiredSlot) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.acquire(1), 0);
+    void *slot0_aicore = slots.aicore(0);
+    void *slot1_aicore = slots.aicore(1);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+    ASSERT_EQ(slots.mark_submitted(1), 0);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
+    ASSERT_EQ(slots.retire_aicore(1, CompletionStatus::Complete), 0);
+
+    slots.mark_all_stale();
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.acquire(1), 0);
+    EXPECT_NE(slots.aicore(0), slot0_aicore);
+    EXPECT_NE(slots.aicore(1), slot1_aicore);
+    EXPECT_EQ(slots.created_count(), 4u);
+}
+
+TEST(RunStreamSlots, CodePublicationDuringARunRebuildsAfterRetirement) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+
+    ASSERT_EQ(slots.acquire(0), 0);
+    void *active_aicore = slots.aicore(0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+
+    slots.mark_all_stale();
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
+    ASSERT_EQ(slots.acquire(0), 0);
+    EXPECT_NE(slots.aicore(0), active_aicore);
+    EXPECT_EQ(slots.created_count(), 2u);
+}
+
+TEST(RunStreamSlots, CompleteRetirementWithoutAHandleIsBenign) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+
+    EXPECT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
+}
+
+TEST(RunStreamSlots, PollCompletionDoesNotPermitReuseBeforeRetirement) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+
+    ASSERT_EQ(slots.acquire(0), 0);
+    void *aicore = slots.aicore(0);
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+    ASSERT_EQ(
+        slots.poll(
+            0,
+            [](void *, void *) {
+                return SIMPLER_NATIVE_RUN_POLL_COMPLETE;
+            }
+        ),
+        SIMPLER_NATIVE_RUN_POLL_COMPLETE
+    );
+
+    EXPECT_NE(slots.acquire(0), 0);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
+    ASSERT_EQ(slots.acquire(0), 0);
+    EXPECT_EQ(slots.aicore(0), aicore);
+}
+
+TEST(RunStreamSlots, UnprovenRunDestroysTheAicoreStream) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+
+    ASSERT_EQ(slots.acquire(0), 0);
     ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Unproven), 0);
     EXPECT_EQ(slots.aicore(0), nullptr);
 
     ASSERT_EQ(slots.acquire(0), 0);
-    EXPECT_EQ(slots.aicpu(0), aicpu) << "the AICPU stream must not be recreated";
-    EXPECT_NE(slots.aicore(0), first_aicore) << "the AICore stream must be a new one";
     EXPECT_EQ(slots.created_count(), 2u);
 }
 
-// The three consequences a failed destroy must have.
-TEST(RunStreamSlots, AFailedDestroyReportsKeepsTheHandleAndLocksTheSlot) {
+TEST(RunStreamSlots, PipelineSlotsKeepIndependentWarmStreams) {
+    FakeStreams fake;
+    RunStreamSlots slots = make_slots(fake);
+
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.acquire(1), 0);
+    void *slot0_aicore = slots.aicore(0);
+    void *slot1_aicore = slots.aicore(1);
+    ASSERT_NE(slot0_aicore, slot1_aicore);
+
+    ASSERT_EQ(slots.mark_submitted(0), 0);
+    ASSERT_EQ(slots.mark_submitted(1), 0);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
+    ASSERT_EQ(slots.retire_aicore(1, CompletionStatus::Complete), 0);
+
+    ASSERT_EQ(slots.acquire(0), 0);
+    ASSERT_EQ(slots.acquire(1), 0);
+    EXPECT_EQ(slots.aicore(0), slot0_aicore);
+    EXPECT_EQ(slots.aicore(1), slot1_aicore);
+    EXPECT_EQ(slots.created_count(), 2u);
+}
+
+TEST(RunStreamSlots, AFailedStaleDestroyReportsAndKeepsTheHandle) {
     FakeStreams fake;
     RunStreamSlots slots = make_slots(fake);
 
@@ -105,11 +203,12 @@ TEST(RunStreamSlots, AFailedDestroyReportsKeepsTheHandleAndLocksTheSlot) {
     ASSERT_EQ(slots.mark_submitted(0), 0);
     void *stranded = slots.aicore(0);
 
-    // 1. the error reaches the caller
-    fake.fail_next_destroys(1);
-    EXPECT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), -13);
+    ASSERT_EQ(slots.retire_aicore(0, CompletionStatus::Complete), 0);
 
-    // 2. the handle survives, so teardown still has something to reclaim
+    slots.mark_all_stale();
+    fake.fail_next_destroys(1);
+    EXPECT_EQ(slots.acquire(0), -13);
+
     EXPECT_EQ(slots.aicore(0), stranded);
 
     // Device execution was already drained before retirement. The retained
@@ -124,12 +223,9 @@ TEST(RunStreamSlots, AFailedDestroyReportsKeepsTheHandleAndLocksTheSlot) {
         SIMPLER_NATIVE_RUN_POLL_COMPLETE
     );
 
-    // 3. the next run is refused rather than handed a second live stream
-    EXPECT_NE(slots.acquire(0), 0);
-    EXPECT_EQ(slots.aicore(0), stranded);
-    EXPECT_EQ(slots.created_count(), 1u) << "a refused acquire must not create anything";
-
-    // and teardown retries it
+    ASSERT_EQ(slots.acquire(0), 0);
+    EXPECT_NE(slots.aicore(0), stranded);
+    EXPECT_EQ(slots.created_count(), 2u);
     EXPECT_EQ(slots.destroy_all(), 0);
     EXPECT_EQ(slots.aicore(0), nullptr);
     EXPECT_EQ(fake.live_count(), 0u);
@@ -163,7 +259,7 @@ TEST(RunStreamSlots, SuccessorProvisionAndAbandonDoNotTouchTheActiveSlot) {
     EXPECT_NE(slots.aicore(1), active_aicore);
     EXPECT_EQ(slots.created_count(), 2u);
 
-    // Abandoning the unpublished successor retires only its fresh AICore
+    // Abandoning the unpublished successor retires only its AICore
     // stream. Its slot-persistent AICPU stream remains reusable.
     ASSERT_EQ(slots.retire_aicore(1, CompletionStatus::Unproven), 0);
     EXPECT_TRUE(slots.ready(0));
@@ -325,7 +421,7 @@ TEST(RunStreamSlots, PollDoesNotWaitBehindRetirement) {
     ASSERT_EQ(slots.mark_submitted(0), 0);
 
     auto retire = std::async(std::launch::async, [&]() {
-        return slots.retire_aicore(0, CompletionStatus::Complete);
+        return slots.retire_aicore(0, CompletionStatus::Unproven);
     });
     destroy_entered.get_future().wait();
 


### PR DESCRIPTION
## Summary

- retain proven-complete per-slot A2A3 AICore streams while no new AICore code has been published
- mark every retained slot stream stale only after a successful AICore H2D upload; content-hash dedup hits do not invalidate streams
- recreate stale streams on the next acquire, while preserving conservative destruction for unproven runs and failed-destroy retry ownership
- cover repeated reuse, deduplicated registration, concurrently resident callables, cross-slot `A -> B -> A` address-recycle publication, retirement gating, and exact stream-creation counts
- update `docs/task-flow.md` with the actual content-hash allocation and publication invariant

Fixes #1791

## Validation

- changed-file pre-commit: all hooks passed (`clang-format`, `clang-tidy`, `cpplint`, `ruff`, `pyright`, `markdownlint`)
- `RunStreamSlots` C++ unit tests: 19/19 passed with GCC 15 on LCW
- A2A3 architecture probe: passed on `task-submit` (`task_20260814_024716_37579914368`)
- GitHub CI on `a9ec96bb2`: 18/18 checks completed with no failures (17 success, expected `deploy` skip), including `ut-a2a3`, `ut-a5`, `st-onboard-a2a3`, `st-onboard-a5`, `st-pod-onboard-a2a3`, both A2A3/A5 simulation matrices, packaging, profiling, and pre-commit

An additional LCW mixed-venv targeted run (`task_20260814_025329_67147427068`) reached its 600-second pytest session timeout in `native_run_lifecycle::test_run` before any assertion result. It is not treated as product evidence; the clean GitHub `st-onboard-a2a3` run above passed the full suite on this exact head.

The stream-creation assertions validate the mechanism. The issue-specific HCA/SWA latency benchmark pins older PyPTO/PTO-ISA revisions, so no mixed-revision latency number is reported as comparable performance evidence.