### PR TITLE
Fix: preserve args dump selection in host-built graphs

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -78,12 +78,13 @@ Scalar values already live inline in the manifest and never need payload copy.
 With no `dump(...)` markers, the AICPU skips all arena payload copies, the
 manifest's `bin_file` is `null`, and every `bin_size` is `0`.
 
-Level 3 deliberately inherits Level 1's existing mask-propagation scope; it
-does not add a second selector path. Both runtime variants on `a2a3` and `a5`
-already propagate the `CoreTaskArgs::dump(...)` mask. Level 3 consumes that same
-mask without changing Level 1 behavior. On `a5`, however, the resulting tensor
-bytes remain untrusted under #1560, so payload restoration stays outside this
-change until that issue is fixed.
+Level 3 deliberately inherits Level 1's selector semantics; it does not add a
+second mask. `tensormap_and_ringbuffer` registers selection metadata in its
+AICPU per-task table. `host_build_graph` embeds the same mask, ambiguity flags,
+and scalar dtypes in each H2D task image, including cached Graph node
+definitions. The device collector consumes either source identically. On `a5`,
+however, the resulting tensor bytes remain untrusted under #1560, so payload
+restoration stays outside this change until that issue is fixed.
 
 ```bash
 # Standalone runner
@@ -110,7 +111,9 @@ via `set_platform_dump_base()`, the enable bit via
 `set_dump_args_enabled(SIMPLER_GET_DFX_FLAG(...))`, and latches the mode
 from the header level before task dispatch (`PARTIAL` → selective,
 `HYBRID` → all metadata, payload copy controlled by the
-same per-task mask as `PARTIAL`). Because the
+same per-task mask as `PARTIAL`). The runtime resolves the mask before each
+record reaches the platform writer, so the writer does not depend on a second
+task-id lookup. Because the
 level is decided host-side **before any task is
 dispatched**, it is latched up front — there is no dependence on task
 submission order. AICore executors read the same `SIMPLER_DFX_FLAG_DUMP_ARGS`

--- a/src/a2a3/runtime/host_build_graph/host/host_orch_compat_stubs.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_orch_compat_stubs.cpp
@@ -9,15 +9,15 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Host-side weak stubs for AICPU-only profiling / dump-args symbols.
+ * Host-side weak stubs for AICPU-only scope-stats symbols.
  *
  * host_build_graph runs the orchestrator on the host (host-orch-first), so the
  * orchestrator core (pto_orchestrator.cpp / pto_runtime2.cpp) is compiled into
  * libhost_runtime.so, which is dlopen'd RTLD_LOCAL and must therefore resolve
- * all of its symbols. The scope-stats and dump-args collectors are AICPU-only
- * (defined in common/platform/.../aicpu) and are NOT linked into the host
- * library. They record on-device diagnostics; the host orchestrator only builds
- * the task graph, so no-op definitions are correct here.
+ * all of its symbols. The scope-stats collector is AICPU-only (defined in
+ * common/platform/.../aicpu) and is NOT linked into the host library. It records
+ * on-device diagnostics; the host orchestrator only builds the task graph, so
+ * no-op definitions are correct here.
  *
  * Marked weak + hidden so they never leak into the global dynamic symbol table
  * (RTLD_LOCAL keeps them library-local anyway) and never shadow the AICPU
@@ -26,14 +26,6 @@
  */
 
 #include "aicpu/scope_stats_collector_aicpu.h"
-#include "aicpu/args_dump_aicpu.h"
-
-__attribute__((weak, visibility("hidden"))) bool is_dump_args_enabled() { return false; }
-
-__attribute__((weak, visibility("hidden"))) void set_dump_args_task_mask(uint64_t, ArgsDumpArgMask, ArgsDumpArgMask) {}
-
-__attribute__((weak, visibility("hidden"))) void set_dump_args_task_scalar_dtypes(uint64_t, uint32_t, const uint8_t *) {
-}
 
 __attribute__((weak, visibility("hidden"))) void
 scope_stats_begin(int, int32_t, int32_t, uint64_t, uint64_t, int32_t, int32_t, int32_t) {}

--- a/src/a2a3/runtime/host_build_graph/runtime/graph_execution.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/graph_execution.h
@@ -85,6 +85,7 @@ struct GraphNodeDefinition {
     int32_t total_output_size;
     uint32_t tensor_offset;
     uint32_t scalar_offset;
+    ArgsDumpTaskMetadata dump_metadata;
 };
 
 struct GraphBoundarySignature {

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -302,6 +302,7 @@ struct GraphRecordedNode {
     std::vector<uint64_t> scalars;
     std::vector<GraphRecordedScalarSourceRef> scalar_sources;
     std::vector<size_t> internal_fanins;
+    ArgsDumpTaskMetadata dump_metadata;
 };
 
 struct GraphRecording {
@@ -560,6 +561,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.total_output_size = static_cast<int32_t>(source.total_output_size);
         node.tensor_offset = static_cast<uint32_t>(tensors.size());
         node.scalar_offset = static_cast<uint32_t>(scalars.size());
+        node.dump_metadata = source.dump_metadata;
         for (const ChipTensor &tensor : source.tensors)
             tensors.push_back(graph_tensor_pack(tensor));
         for (const GraphRecordedTensorSourceRef &tensor_source : source.tensor_sources) {
@@ -1280,22 +1282,6 @@ static TaskOutputTensors submit_task_common(
             payload.predicate.op = PredicateOp::NONE;
         }
     }
-#if SIMPLER_DFX
-    if (is_dump_args_enabled()) {
-        if (args.scalar_count() > 0) {
-            set_dump_args_task_scalar_dtypes(
-                task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
-            );
-        }
-        // Preserve the existing Level-1 task/arg mask whenever dump is enabled.
-        // Level 1 uses it to select records; hybrid Level 3 reuses the same mask only
-        // to decide which tensors contribute payload alongside full metadata.
-        if (args.dump_arg_mask() != 0) {
-            set_dump_args_task_mask(task_id.raw, args.dump_arg_mask(), args.dump_arg_index_ambiguous_mask());
-        }
-    }
-#endif
-
     CYCLE_COUNT_LAP(g_orch_args_cycle);
 
     // === STEP 6: publish the inline fanin count (device boot classifies) ===
@@ -1607,6 +1593,11 @@ TaskOutputTensors graph_record_submit_node(
         if (args.tag(i) == TensorArgType::OUTPUT) result.materialize_output(node.tensors[static_cast<size_t>(i)]);
     }
     node.scalars.assign(args.scalars(), args.scalars() + args.scalar_count());
+#if SIMPLER_DFX
+    node.dump_metadata.dump_arg_mask = args.dump_arg_mask();
+    node.dump_metadata.dump_arg_flags = args.dump_arg_index_ambiguous_mask();
+    memcpy(node.dump_metadata.scalar_dtypes, args.scalar_dtypes(), args.scalar_count() * sizeof(uint8_t));
+#endif
 
     // Classify each scalar's source: a plain literal is static Definition data,
     // while a value copied from a boundary scalar is refreshed on replay. A

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -43,6 +43,7 @@
 // pto_runtime2_types.h never references PTO2DispatchPayload itself; consumers that
 // need it include it via runtime.h directly.
 #include "aicore_completion_mailbox.h"
+#include "common/args_dump.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
@@ -333,6 +334,7 @@ struct PTO2TaskPayload {
     // / scalars offsets only. Resolved at submit; evaluated by the scheduler at
     // dispatch.
     alignas(64) DispatchPredicate predicate;
+    ArgsDumpTaskMetadata dump_metadata;
     // === Cache lines 10-73 (4096B) — tensors (alignas(64) forces alignment) ===
     ChipTensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 74-75 (128B) — scalars ===
@@ -397,6 +399,13 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
+        dump_metadata = {};
+#if SIMPLER_DFX
+        dump_metadata.dump_arg_mask = args.dump_arg_mask();
+        dump_metadata.dump_arg_flags = args.dump_arg_index_ambiguous_mask();
+        memcpy(dump_metadata.scalar_dtypes, args.scalar_dtypes(), args.scalar_count() * sizeof(uint8_t));
+#endif
+
         // Early-dispatch metadata — the single init point for these
         // fields. reset_for_reuse MUST NOT touch the payload (it runs at slot
         // init and would pull this cold cache line across structures);
@@ -427,6 +436,10 @@ static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id
 static_assert(
     offsetof(PTO2TaskPayload, predicate) == 576,
     "dispatch predicate occupies cache line 9 at fixed byte 576 (before tensors, never moves)"
+);
+static_assert(
+    offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
+    "dump metadata must fit in the AICPU-only cache line before tensors"
 );
 static_assert(
     offsetof(PTO2TaskPayload, tensors) == 640, "tensors must start at byte 640 (cache line 10, after predicate)"

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -43,7 +43,7 @@
 // pto_runtime2_types.h never references PTO2DispatchPayload itself; consumers that
 // need it include it via runtime.h directly.
 #include "aicore_completion_mailbox.h"
-#include "common/args_dump.h"
+#include "common/args_dump_task_metadata.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
@@ -463,6 +463,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
             slot.graph_context = &execution;
             payload.tensor_count = source.tensor_count;
             payload.scalar_count = source.scalar_count;
+            payload.dump_metadata = source.dump_metadata;
             if (source.tensor_count < 0 || source.tensor_count > MAX_TENSOR_ARGS || source.scalar_count < 0 ||
                 source.scalar_count > MAX_SCALAR_ARGS ||
                 static_cast<uint32_t>(source.tensor_count) > definition.tensor_arg_count ||

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -397,6 +397,9 @@ int32_t SchedulerContext::handle_timeout_exit(
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
+                },
+                [](const PTO2TaskSlotState &slot_state) {
+                    return &slot_state.payload->dump_metadata;
                 }
             );
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -181,7 +181,8 @@ void SchedulerContext::complete_slot_task(
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
-                }
+                },
+                &slot_state.payload->dump_metadata
             );
         }
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -247,7 +247,8 @@ int SchedulerContext::prepare_block_for_dispatch(
             },
             [this](int32_t func_id) {
                 return get_function_bin_addr(func_id);
-            }
+            },
+            &slot_state.payload->dump_metadata
         );
     }
 #endif

--- a/src/a5/runtime/host_build_graph/host/host_orch_compat_stubs.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_orch_compat_stubs.cpp
@@ -9,15 +9,15 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Host-side weak stubs for AICPU-only profiling / dump-args symbols.
+ * Host-side weak stubs for AICPU-only scope-stats symbols.
  *
  * host_build_graph runs the orchestrator on the host (host-orch-first), so the
  * orchestrator core (pto_orchestrator.cpp / pto_runtime2.cpp) is compiled into
  * libhost_runtime.so, which is dlopen'd RTLD_LOCAL and must therefore resolve
- * all of its symbols. The scope-stats and dump-args collectors are AICPU-only
- * (defined in common/platform/.../aicpu) and are NOT linked into the host
- * library. They record on-device diagnostics; the host orchestrator only builds
- * the task graph, so no-op definitions are correct here.
+ * all of its symbols. The scope-stats collector is AICPU-only (defined in
+ * common/platform/.../aicpu) and is NOT linked into the host library. It records
+ * on-device diagnostics; the host orchestrator only builds the task graph, so
+ * no-op definitions are correct here.
  *
  * Marked weak + hidden so they never leak into the global dynamic symbol table
  * (RTLD_LOCAL keeps them library-local anyway) and never shadow the AICPU
@@ -26,14 +26,6 @@
  */
 
 #include "aicpu/scope_stats_collector_aicpu.h"
-#include "aicpu/args_dump_aicpu.h"
-
-__attribute__((weak, visibility("hidden"))) bool is_dump_args_enabled() { return false; }
-
-__attribute__((weak, visibility("hidden"))) void set_dump_args_task_mask(uint64_t, ArgsDumpArgMask, ArgsDumpArgMask) {}
-
-__attribute__((weak, visibility("hidden"))) void set_dump_args_task_scalar_dtypes(uint64_t, uint32_t, const uint8_t *) {
-}
 
 __attribute__((weak, visibility("hidden"))) void
 scope_stats_begin(int, int32_t, int32_t, uint64_t, uint64_t, int32_t, int32_t, int32_t) {}

--- a/src/a5/runtime/host_build_graph/runtime/graph_execution.h
+++ b/src/a5/runtime/host_build_graph/runtime/graph_execution.h
@@ -85,6 +85,7 @@ struct GraphNodeDefinition {
     int32_t total_output_size;
     uint32_t tensor_offset;
     uint32_t scalar_offset;
+    ArgsDumpTaskMetadata dump_metadata;
 };
 
 struct GraphBoundarySignature {

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -302,6 +302,7 @@ struct GraphRecordedNode {
     std::vector<uint64_t> scalars;
     std::vector<GraphRecordedScalarSourceRef> scalar_sources;
     std::vector<size_t> internal_fanins;
+    ArgsDumpTaskMetadata dump_metadata;
 };
 
 struct GraphRecording {
@@ -560,6 +561,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.total_output_size = static_cast<int32_t>(source.total_output_size);
         node.tensor_offset = static_cast<uint32_t>(tensors.size());
         node.scalar_offset = static_cast<uint32_t>(scalars.size());
+        node.dump_metadata = source.dump_metadata;
         for (const ChipTensor &tensor : source.tensors)
             tensors.push_back(graph_tensor_pack(tensor));
         for (const GraphRecordedTensorSourceRef &tensor_source : source.tensor_sources) {
@@ -1280,22 +1282,6 @@ static TaskOutputTensors submit_task_common(
             payload.predicate.op = PredicateOp::NONE;
         }
     }
-#if SIMPLER_DFX
-    if (is_dump_args_enabled()) {
-        if (args.scalar_count() > 0) {
-            set_dump_args_task_scalar_dtypes(
-                task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
-            );
-        }
-        // Preserve the existing Level-1 task/arg mask whenever dump is enabled.
-        // Level 1 uses it to select records; hybrid Level 3 reuses the same mask only
-        // to decide which tensors contribute payload alongside full metadata.
-        if (args.dump_arg_mask() != 0) {
-            set_dump_args_task_mask(task_id.raw, args.dump_arg_mask(), args.dump_arg_index_ambiguous_mask());
-        }
-    }
-#endif
-
     CYCLE_COUNT_LAP(g_orch_args_cycle);
 
     // === STEP 6: publish the inline fanin count (device boot classifies) ===
@@ -1607,6 +1593,11 @@ TaskOutputTensors graph_record_submit_node(
         if (args.tag(i) == TensorArgType::OUTPUT) result.materialize_output(node.tensors[static_cast<size_t>(i)]);
     }
     node.scalars.assign(args.scalars(), args.scalars() + args.scalar_count());
+#if SIMPLER_DFX
+    node.dump_metadata.dump_arg_mask = args.dump_arg_mask();
+    node.dump_metadata.dump_arg_flags = args.dump_arg_index_ambiguous_mask();
+    memcpy(node.dump_metadata.scalar_dtypes, args.scalar_dtypes(), args.scalar_count() * sizeof(uint8_t));
+#endif
 
     // Classify each scalar's source: a plain literal is static Definition data,
     // while a value copied from a boundary scalar is refreshed on replay. A

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -42,7 +42,7 @@
 // pto_runtime2_types.h never references PTO2DispatchPayload itself; consumers that
 // need it include it via runtime.h directly.
 #include "aicore_completion_mailbox.h"
-#include "common/args_dump.h"
+#include "common/args_dump_task_metadata.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -42,6 +42,7 @@
 // pto_runtime2_types.h never references PTO2DispatchPayload itself; consumers that
 // need it include it via runtime.h directly.
 #include "aicore_completion_mailbox.h"
+#include "common/args_dump.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
@@ -332,6 +333,7 @@ struct PTO2TaskPayload {
     // / scalars offsets only. Resolved at submit; evaluated by the scheduler at
     // dispatch.
     alignas(64) DispatchPredicate predicate;
+    ArgsDumpTaskMetadata dump_metadata;
     // === Cache lines 10-73 (4096B) — tensors (alignas(64) forces alignment) ===
     ChipTensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 74-75 (128B) — scalars ===
@@ -396,6 +398,13 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
+        dump_metadata = {};
+#if SIMPLER_DFX
+        dump_metadata.dump_arg_mask = args.dump_arg_mask();
+        dump_metadata.dump_arg_flags = args.dump_arg_index_ambiguous_mask();
+        memcpy(dump_metadata.scalar_dtypes, args.scalar_dtypes(), args.scalar_count() * sizeof(uint8_t));
+#endif
+
         // Early-dispatch metadata — the single init point for these
         // fields. reset_for_reuse MUST NOT touch the payload (it runs at slot
         // init and would pull this cold cache line across structures);
@@ -426,6 +435,10 @@ static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id
 static_assert(
     offsetof(PTO2TaskPayload, predicate) == 576,
     "dispatch predicate occupies cache line 9 at fixed byte 576 (before tensors, never moves)"
+);
+static_assert(
+    offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
+    "dump metadata must fit in the AICPU-only cache line before tensors"
 );
 static_assert(
     offsetof(PTO2TaskPayload, tensors) == 640, "tensors must start at byte 640 (cache line 10, after predicate)"

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/graph_execution.cpp
@@ -463,6 +463,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
             slot.graph_context = &execution;
             payload.tensor_count = source.tensor_count;
             payload.scalar_count = source.scalar_count;
+            payload.dump_metadata = source.dump_metadata;
             if (source.tensor_count < 0 || source.tensor_count > MAX_TENSOR_ARGS || source.scalar_count < 0 ||
                 source.scalar_count > MAX_SCALAR_ARGS ||
                 static_cast<uint32_t>(source.tensor_count) > definition.tensor_arg_count ||

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -397,6 +397,9 @@ int32_t SchedulerContext::handle_timeout_exit(
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
+                },
+                [](const PTO2TaskSlotState &slot_state) {
+                    return &slot_state.payload->dump_metadata;
                 }
             );
         }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -181,7 +181,8 @@ void SchedulerContext::complete_slot_task(
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
-                }
+                },
+                &slot_state.payload->dump_metadata
             );
         }
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -247,7 +247,8 @@ int SchedulerContext::prepare_block_for_dispatch(
             },
             [this](int32_t func_id) {
                 return get_function_bin_addr(func_id);
-            }
+            },
+            &slot_state.payload->dump_metadata
         );
     }
 #endif

--- a/src/common/platform/include/aicpu/args_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/args_dump_aicpu.h
@@ -96,7 +96,7 @@ int dump_arg_record(int thread_idx, const ArgsDumpInfo &info);
 template <int MaxSubtaskSlots, typename SlotStateT, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
 inline void dump_args_for_task(
     int32_t thread_idx, const SlotStateT &slot_state, ArgsDumpStage stage, IsSubtaskActiveFn is_subtask_active,
-    GetFunctionBinAddrFn get_function_bin_addr
+    GetFunctionBinAddrFn get_function_bin_addr, const ArgsDumpTaskMetadata *task_metadata = nullptr
 ) {
     // The record's func_ids[] must hold every active subtask's id. MaxSubtaskSlots
     // is PTO2_SUBTASK_SLOT_COUNT at every call site, so this ties the record array
@@ -105,7 +105,10 @@ inline void dump_args_for_task(
     const auto &pl = *slot_state.payload;
     ArgsDumpArgMask dump_arg_mask = ARGS_DUMP_ARG_MASK_NONE;
     ArgsDumpArgMask dump_arg_flags = ARGS_DUMP_ARG_MASK_NONE;
-    if (should_load_dump_args_task_masks()) {
+    if (task_metadata != nullptr) {
+        dump_arg_mask = task_metadata->dump_arg_mask;
+        dump_arg_flags = task_metadata->dump_arg_flags;
+    } else if (should_load_dump_args_task_masks()) {
         get_dump_args_task_masks(slot_state.task->task_id.raw, &dump_arg_mask, &dump_arg_flags);
     }
     if (!should_dump_task(dump_arg_mask)) {
@@ -190,6 +193,7 @@ inline void dump_args_for_task(
         info.role = role;
         info.stage = stage;
         info.kind = static_cast<uint8_t>(ArgsDumpKind::TENSOR);
+        info.capture_payload = has_dump_arg_flag(dump_arg_mask, static_cast<int32_t>(slot));
         info.func_count = active_count;
         for (int32_t i = 0; i < active_count; i++) {
             info.func_ids[i] = active_fids[i];
@@ -213,8 +217,15 @@ inline void dump_args_for_task(
     if (stage == ArgsDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
         uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS] = {};
         uint32_t dtype_scalar_count = 0;
-        bool has_scalar_dtypes =
-            get_dump_args_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
+        bool has_scalar_dtypes = false;
+        if (task_metadata != nullptr) {
+            dtype_scalar_count = static_cast<uint32_t>(pl.scalar_count);
+            memcpy(scalar_dtypes, task_metadata->scalar_dtypes, dtype_scalar_count * sizeof(uint8_t));
+            has_scalar_dtypes = true;
+        } else {
+            has_scalar_dtypes =
+                get_dump_args_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
+        }
         for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
             int32_t scalar_arg_index = pl.tensor_count + scalar_index;
             if (!should_dump_arg(dump_arg_mask, scalar_arg_index)) {
@@ -261,10 +272,12 @@ inline void dump_args_for_task(
 //                              emit each running task exactly once.
 //   is_subtask_active / get_function_bin_addr — same callbacks as
 //   dump_args_for_task.
-template <int MaxSubtaskSlots, typename GetRunningSlotFn, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
+template <
+    int MaxSubtaskSlots, typename GetRunningSlotFn, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn,
+    typename GetTaskMetadataFn>
 inline void dump_running_task_outputs(
     int32_t thread_idx, int32_t cores_total_num, GetRunningSlotFn get_running_slot, IsSubtaskActiveFn is_subtask_active,
-    GetFunctionBinAddrFn get_function_bin_addr
+    GetFunctionBinAddrFn get_function_bin_addr, GetTaskMetadataFn get_task_metadata
 ) {
     for (int32_t cid = 0; cid < cores_total_num; cid++) {
         auto *running = get_running_slot(cid);
@@ -283,9 +296,23 @@ inline void dump_running_task_outputs(
             continue;
         }
         dump_args_for_task<MaxSubtaskSlots>(
-            thread_idx, *running, ArgsDumpStage::AFTER_COMPLETION, is_subtask_active, get_function_bin_addr
+            thread_idx, *running, ArgsDumpStage::AFTER_COMPLETION, is_subtask_active, get_function_bin_addr,
+            get_task_metadata(*running)
         );
     }
+}
+
+template <int MaxSubtaskSlots, typename GetRunningSlotFn, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
+inline void dump_running_task_outputs(
+    int32_t thread_idx, int32_t cores_total_num, GetRunningSlotFn get_running_slot, IsSubtaskActiveFn is_subtask_active,
+    GetFunctionBinAddrFn get_function_bin_addr
+) {
+    dump_running_task_outputs<MaxSubtaskSlots>(
+        thread_idx, cores_total_num, get_running_slot, is_subtask_active, get_function_bin_addr,
+        [](const auto &) -> const ArgsDumpTaskMetadata * {
+            return nullptr;
+        }
+    );
 }
 
 template <typename TensorInfoT>
@@ -338,6 +365,10 @@ inline void dump_args_for_task(
 
     rmb();
 
+    ArgsDumpArgMask dump_arg_mask = ARGS_DUMP_ARG_MASK_NONE;
+    if (should_load_dump_args_task_masks()) {
+        get_dump_args_task_masks(task_id, &dump_arg_mask, nullptr);
+    }
     int32_t tensor_arg_index = 0;
     for (int32_t sig_idx = 0; sig_idx < sig_count; sig_idx++) {
         ArgDirection dir = callable.sig(sig_idx);
@@ -362,6 +393,7 @@ inline void dump_args_for_task(
         info.ndims = t.ndims;
         info.arg_index = static_cast<uint32_t>(sig_idx);
         info.buffer_addr = buffer_addrs[tensor_arg_index];
+        info.capture_payload = has_dump_arg_flag(dump_arg_mask, sig_idx);
         // TensorInfo (host_build_graph) still carries (raw_shapes, offsets)
         // implicitly describing a row-major-aligned sub-region. Translate to
         // (start_offset, strides[]) on the fly:

--- a/src/common/platform/include/common/args_dump.h
+++ b/src/common/platform/include/common/args_dump.h
@@ -37,12 +37,13 @@
  * specific host/device copy mechanics live outside these shared structures.
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_COMMON_ARGS_DUMP_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_COMMON_ARGS_DUMP_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
+#include "arg_direction.h"
 #include "common/dfx_backpressure_device.h"
 #include "common/platform_config.h"
 
@@ -85,6 +86,16 @@ using ArgsDumpArgMask = uint64_t;
 constexpr ArgsDumpArgMask ARGS_DUMP_ARG_MASK_NONE = 0;
 constexpr uint32_t ARGS_DUMP_ARG_MASK_BITS = 64;
 constexpr uint8_t ARGS_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
+
+struct ArgsDumpTaskMetadata {
+    ArgsDumpArgMask dump_arg_mask{ARGS_DUMP_ARG_MASK_NONE};
+    ArgsDumpArgMask dump_arg_flags{ARGS_DUMP_ARG_MASK_NONE};
+    uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS]{};
+};
+
+static_assert(std::is_trivially_copyable_v<ArgsDumpTaskMetadata>);
+static_assert(std::is_standard_layout_v<ArgsDumpTaskMetadata>);
+static_assert(sizeof(ArgsDumpTaskMetadata) == 32);
 
 // Max kernel ids a record carries: one per active subtask of a task (its mix
 // membership). Must equal the runtime's PTO2_SUBTASK_SLOT_COUNT (1C2V => 3);
@@ -288,7 +299,8 @@ struct ArgsDumpInfo {
     int32_t func_count;
     uint8_t kind;
     uint8_t flags;
-    uint8_t pad[6];
+    uint8_t capture_payload;
+    uint8_t pad[5];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
@@ -354,5 +366,3 @@ inline DumpBufferState *get_dump_buffer_state(void *base_ptr, int thread_idx) {
 #ifdef __cplusplus
 }
 #endif
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_COMMON_ARGS_DUMP_H_

--- a/src/common/platform/include/common/args_dump.h
+++ b/src/common/platform/include/common/args_dump.h
@@ -41,9 +41,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <type_traits>
 
-#include "arg_direction.h"
+#include "common/args_dump_task_metadata.h"
 #include "common/dfx_backpressure_device.h"
 #include "common/platform_config.h"
 
@@ -76,26 +75,6 @@ enum class ArgsDumpKind : uint8_t {
     TENSOR = 0,
     SCALAR = 1,
 };
-
-using ArgsDumpArgMask = uint64_t;
-
-// Bitmask stored in the platform-owned mask pool when orchestration selects
-// specific task tensor/scalar arguments for dump. Bit N corresponds to the
-// payload arg index: tensors first, then scalars.
-// Zero preserves legacy "dump all tasks" behavior unless selective mode is enabled.
-constexpr ArgsDumpArgMask ARGS_DUMP_ARG_MASK_NONE = 0;
-constexpr uint32_t ARGS_DUMP_ARG_MASK_BITS = 64;
-constexpr uint8_t ARGS_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
-
-struct ArgsDumpTaskMetadata {
-    ArgsDumpArgMask dump_arg_mask{ARGS_DUMP_ARG_MASK_NONE};
-    ArgsDumpArgMask dump_arg_flags{ARGS_DUMP_ARG_MASK_NONE};
-    uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS]{};
-};
-
-static_assert(std::is_trivially_copyable_v<ArgsDumpTaskMetadata>);
-static_assert(std::is_standard_layout_v<ArgsDumpTaskMetadata>);
-static_assert(sizeof(ArgsDumpTaskMetadata) == 32);
 
 // Max kernel ids a record carries: one per active subtask of a task (its mix
 // membership). Must equal the runtime's PTO2_SUBTASK_SLOT_COUNT (1C2V => 3);

--- a/src/common/platform/include/common/args_dump_task_metadata.h
+++ b/src/common/platform/include/common/args_dump_task_metadata.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "arg_direction.h"
+
+using ArgsDumpArgMask = uint64_t;
+
+// Bitmask stored with each task when orchestration selects specific
+// tensor/scalar arguments for dump. Bit N corresponds to the payload argument
+// index: tensors first, then scalars.
+constexpr ArgsDumpArgMask ARGS_DUMP_ARG_MASK_NONE = 0;
+constexpr uint32_t ARGS_DUMP_ARG_MASK_BITS = 64;
+constexpr uint8_t ARGS_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
+
+struct ArgsDumpTaskMetadata {
+    ArgsDumpArgMask dump_arg_mask{ARGS_DUMP_ARG_MASK_NONE};
+    ArgsDumpArgMask dump_arg_flags{ARGS_DUMP_ARG_MASK_NONE};
+    uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS]{};
+};
+
+static_assert(std::is_trivially_copyable_v<ArgsDumpTaskMetadata>);
+static_assert(std::is_standard_layout_v<ArgsDumpTaskMetadata>);
+static_assert(sizeof(ArgsDumpTaskMetadata) == 32);

--- a/src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/args_dump_aicpu.cpp
@@ -680,11 +680,7 @@ int dump_arg_record(int thread_idx, const ArgsDumpInfo &info) {
     bool truncated = false;
     bool is_contiguous = dump_arg_is_contiguous(info);
     bool is_scalar = kind == ArgsDumpKind::SCALAR;
-    ArgsDumpArgMask task_dump_arg_mask = ARGS_DUMP_ARG_MASK_NONE;
-    if (g_dump_args_level == DumpArgsLevel::HYBRID) {
-        get_dump_args_task_masks(info.task_id, &task_dump_arg_mask, nullptr);
-    }
-    bool capture_payload = has_dump_arg_flag(task_dump_arg_mask, static_cast<int32_t>(info.arg_index));
+    bool capture_payload = info.capture_payload != 0;
 
     if (is_scalar || (g_dump_args_level == DumpArgsLevel::HYBRID && !capture_payload)) {
         copy_bytes = 0;

--- a/tests/st/a2a3/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
@@ -52,14 +52,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     rt_submit_aiv_task(FUNC_ADD, p0);
 
     // t1: f = f + 1 (in place); INOUT establishes the dependency on t0 via f
-    union {
-        float f32;
-        uint64_t u64;
-    } sconv;
-    sconv.f32 = 1.0f;
+    float scale = 1.0F;
     CoreTaskArgs p1;
     p1.add_inout(f);
-    p1.add_scalar(sconv.u64);
+    p1.add_scalar(scale);
+    p1.dump(f, scale);
     rt_submit_aiv_task(FUNC_ADD_SCALAR_INPLACE, p1);
 
     LOG_INFO("[dump_args_orch] Submitted f = (a + b) + 1");

--- a/tests/st/a2a3/host_build_graph/dump_args/test_dump_args_example.py
+++ b/tests/st/a2a3/host_build_graph/dump_args/test_dump_args_example.py
@@ -49,7 +49,7 @@ class TestDumpArgsExample(SceneTestCase):
     CASES = [
         {
             "name": "default",
-            "platforms": ["a2a3"],
+            "platforms": ["a2a3sim", "a2a3"],
             "params": {},
         },
     ]

--- a/tests/st/a5/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
+++ b/tests/st/a5/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
@@ -52,14 +52,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     rt_submit_aiv_task(FUNC_ADD, p0);
 
     // t1: f = f + 1 (in place); INOUT establishes the dependency on t0 via f
-    union {
-        float f32;
-        uint64_t u64;
-    } sconv;
-    sconv.f32 = 1.0f;
+    float scale = 1.0F;
     CoreTaskArgs p1;
     p1.add_inout(f);
-    p1.add_scalar(sconv.u64);
+    p1.add_scalar(scale);
+    p1.dump(f, scale);
     rt_submit_aiv_task(FUNC_ADD_SCALAR_INPLACE, p1);
 
     LOG_INFO("[dump_args_orch] Submitted f = (a + b) + 1");

--- a/tests/st/a5/host_build_graph/dump_args/test_dump_args_example.py
+++ b/tests/st/a5/host_build_graph/dump_args/test_dump_args_example.py
@@ -49,7 +49,7 @@ class TestDumpArgsExampleA5(SceneTestCase):
     CASES = [
         {
             "name": "default",
-            "platforms": ["a5"],
+            "platforms": ["a5sim", "a5"],
             "params": {},
         },
     ]

--- a/tests/ut/cpp/a2a3/test_args_dump.cpp
+++ b/tests/ut/cpp/a2a3/test_args_dump.cpp
@@ -285,13 +285,8 @@ TEST_F(ArgsDumpTest, Level3UsesTaskMaskForTensorPayload) {
     set_platform_dump_base(reinterpret_cast<uint64_t>(dump_mem));
     set_dump_args_enabled(true);
     constexpr uint64_t kTaskId = 0;
-    set_dump_args_task_mask(kTaskId, uint64_t{1} << 6, ARGS_DUMP_ARG_MASK_NONE);
 
     dump_args_init(1);
-
-    ArgsDumpArgMask mask = ARGS_DUMP_ARG_MASK_NONE;
-    get_dump_args_task_masks(kTaskId, &mask, nullptr);
-    EXPECT_EQ(mask, uint64_t{1} << 6);
 
     ArgsDumpInfo info = {};
     info.task_id = kTaskId;
@@ -308,11 +303,13 @@ TEST_F(ArgsDumpTest, Level3UsesTaskMaskForTensorPayload) {
     info.func_ids[0] = 0;
     info.func_ids[1] = 1;
     info.func_ids[2] = 1;
+    info.capture_payload = true;
 
     ASSERT_EQ(dump_arg_record(0, info), 0);
     EXPECT_EQ(meta_buf.records[0].payload_size, sizeof(src_data));
 
     info.arg_index = 7;
+    info.capture_payload = false;
     ASSERT_EQ(dump_arg_record(0, info), 0);
     EXPECT_EQ(meta_buf.records[1].payload_size, 0u);
 

--- a/tests/ut/cpp/a2a3/test_graph_cache.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_cache.cpp
@@ -69,6 +69,10 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
         node.scalar_count = 1;
         node.total_output_size = 64;
     }
+    nodes[0].dump_metadata.dump_arg_mask = uint64_t{1} << 0;
+    nodes[0].dump_metadata.scalar_dtypes[0] = static_cast<uint8_t>(DataType::FLOAT32);
+    nodes[1].dump_metadata.dump_arg_mask = uint64_t{1} << 1;
+    nodes[1].dump_metadata.scalar_dtypes[0] = static_cast<uint8_t>(DataType::INT32);
     nodes[1].tensor_offset = 1;
     nodes[1].scalar_offset = 1;
     std::vector<GraphTensor> tensors{make_test_tensor(boundary_address), make_test_tensor(boundary_address)};
@@ -283,6 +287,10 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     ASSERT_EQ(node.payload.tensor_count, 1);
     EXPECT_EQ(node.payload.scalars[0], 17U);
     EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
+    EXPECT_EQ(node.payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
+    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
+    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::INT32));
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
@@ -324,6 +332,7 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     );
     EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -101,7 +101,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     CoreTaskArgs root_args;
     create_infos.emplace_back(shape, 1, DataType::FLOAT32);
     root_args.add_output(create_infos.back());
-    root_args.add_scalar(static_cast<uint64_t>(42));
+    float scale = 42.0F;
+    root_args.add_scalar(scale);
+    root_args.dump(create_infos.back(), scale);
     MixedKernels root_mixed{};
     root_mixed.aiv0_kernel_id = 0;
     TaskOutputTensors root = orch.submit_task(root_mixed, root_args);
@@ -169,6 +171,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
+    EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
+    EXPECT_EQ(root_pl.dump_metadata.dump_arg_flags, ARGS_DUMP_ARG_MASK_NONE);
+    EXPECT_EQ(root_pl.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
     EXPECT_NE(root_desc.packed_buffer_base, POISON_PTR);
     EXPECT_NE(root_desc.packed_buffer_base, nullptr);
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);

--- a/tests/ut/cpp/a5/test_graph_cache.cpp
+++ b/tests/ut/cpp/a5/test_graph_cache.cpp
@@ -69,6 +69,10 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
         node.scalar_count = 1;
         node.total_output_size = 64;
     }
+    nodes[0].dump_metadata.dump_arg_mask = uint64_t{1} << 0;
+    nodes[0].dump_metadata.scalar_dtypes[0] = static_cast<uint8_t>(DataType::FLOAT32);
+    nodes[1].dump_metadata.dump_arg_mask = uint64_t{1} << 1;
+    nodes[1].dump_metadata.scalar_dtypes[0] = static_cast<uint8_t>(DataType::INT32);
     nodes[1].tensor_offset = 1;
     nodes[1].scalar_offset = 1;
     std::vector<GraphTensor> tensors{make_test_tensor(boundary_address), make_test_tensor(boundary_address)};
@@ -283,6 +287,10 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     ASSERT_EQ(node.payload.tensor_count, 1);
     EXPECT_EQ(node.payload.scalars[0], 17U);
     EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
+    EXPECT_EQ(node.payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
+    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
+    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::INT32));
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
@@ -324,6 +332,7 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     );
     EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -101,7 +101,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     CoreTaskArgs root_args;
     create_infos.emplace_back(shape, 1, DataType::FLOAT32);
     root_args.add_output(create_infos.back());
-    root_args.add_scalar(static_cast<uint64_t>(42));
+    float scale = 42.0F;
+    root_args.add_scalar(scale);
+    root_args.dump(create_infos.back(), scale);
     MixedKernels root_mixed{};
     root_mixed.aiv0_kernel_id = 0;
     TaskOutputTensors root = orch.submit_task(root_mixed, root_args);
@@ -169,6 +171,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
+    EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
+    EXPECT_EQ(root_pl.dump_metadata.dump_arg_flags, ARGS_DUMP_ARG_MASK_NONE);
+    EXPECT_EQ(root_pl.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
     EXPECT_NE(root_desc.packed_buffer_base, POISON_PTR);
     EXPECT_NE(root_desc.packed_buffer_base, nullptr);
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);


### PR DESCRIPTION
Host-built graph orchestration runs outside AICPU, so its dump-mask and scalar-dtype table updates resolved to host-side no-op stubs. Partial dumps consequently selected no tasks, while hybrid dumps emitted metadata without marked tensor payloads.

Embed the selection mask, ambiguity flags, and scalar dtypes in each HBG task payload and cached Graph definition. Consume that metadata in dispatch, completion, and timeout dump paths while retaining the existing AICPU side table for tensormap-and-ringbuffer.

Cover direct submission and Graph replay on both architectures, and exercise partial and hybrid manifests on a2a3 onboard plus a2a3sim/a5sim.

Fixes #1800