### PR TITLE
Support: trace native decode overlap

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -105,7 +105,7 @@ including time the caller spends polling or doing other host work; blocking
 | Depth | Span names |
 | ----- | ---------- |
 | 0 | `simpler_run` |
-| 1 | `simpler_run.bind`, `simpler_run.runner_run`, `simpler_run.validate` |
+| 1 | `simpler_run.bind`, `simpler_run.runner_run`, `simpler_run.claim_release`, `simpler_run.validate` |
 | 2 | `simpler_run.bind.args`, `simpler_run.bind.prebuilt`, `simpler_run.runner_run.device_wall` |
 | 3 | TMR phase spans `simpler_run.runner_run.device_wall.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}` and optional `task_slot_*` spans |
 
@@ -123,9 +123,11 @@ an L4 pod alike, since the orchestrator and scheduler code they run is the same:
 | `l3.frame_submit` | local child mailbox-frame publication |
 | `l3.activate` | prepared-frame activation |
 | `l3.complete` | terminal child progress handling |
+| `l3.post_fence_retirement` | run erase + quiescent compaction, after the completion fence |
 
 Their attributes carry the available `run_id`, `task_slot`, `group_index`,
-`worker_id`, `dispatch_id`, and endpoint kind.
+`worker_id`, `dispatch_id`, endpoint kind, and the dispatch's pipeline lease
+(`slot_id` / `generation`).
 
 Because the names do not encode which level emitted them, a pod run puts the L4
 process and each of its L3 processes on lanes that differ only by pid. The
@@ -170,14 +172,71 @@ per-invocation lane, so each call renders as an isolated nested tree in
 [Perfetto](https://ui.perfetto.dev) / `chrome://tracing`.
 
 `--swimlane` is a separate view. Host slices keep their real OS pid/tid, and
-task submission-to-dispatch handoffs render as flow arrows. Chrome Trace JSON
-has only one visible timestamp axis, so putting the raw per-invocation device
-clock beside `CLOCK_MONOTONIC` would create a multi-day empty interval. The
-converter therefore keeps `clk=dev` records, with their original ns timestamps,
-in the top-level `unalignedDeviceSpans` array instead of `traceEvents`; it does
-not guess a clock offset. Perfetto opens directly on the host activity, while
-the existing tables, tree, and `--trace-out` still provide the device-phase
-timing views.
+task submission-to-dispatch handoffs render as flow arrows.
+
+**One exception, because a K-deep pipeline is not K threads.** The direct-chip
+lane drives prepare(N+1) and finalize(N) from the *same* OS thread, so a 40-run
+K=2 stress produces 40 overlapping run lifetimes on one tid. Perfetto nests
+slices by timestamp containment within a track, so flattening them there puts
+run N+1's spans *inside* run N's root — false nesting that hides the very
+overlap the view exists to show. A thread whose depth-0 spans overlap is
+therefore split into one lane per pipeline slot (`pipeline slot 0 (tid …)`),
+which reads as a plain sequence because a run holds its slot exclusively. The
+overlap then shows where it belongs: across lanes. Each slice keeps `os_tid` in
+its args, and a thread that ran sequentially — the L3 scheduler, which carries a
+slot but never interleaves — keeps its real tid.
+
+Chrome Trace JSON has only one visible timestamp axis, so putting the raw
+per-invocation device clock beside `CLOCK_MONOTONIC` would create a multi-day
+empty interval. The converter therefore keeps `clk=dev` records, with their
+original ns timestamps, in the top-level `unalignedDeviceSpans` array instead of
+`traceEvents`; it does not guess a clock offset. Perfetto opens directly on the
+host activity, while the existing tables, tree, and `--trace-out` still provide
+the device-phase timing views.
+
+## Async pipeline proof
+
+The phased native lane claims that run N+1's preparation runs *concurrently*
+with run N's device execution. That claim is checkable from a captured log
+without any new marker family: the windows are already in the `simpler_run`
+tree, and the root span already carries the identity that tells two runs apart.
+
+| Property | Read from |
+| -------- | --------- |
+| successor's preparation | `simpler_run.bind` — its arena build + host orchestration |
+| predecessor's device work | `simpler_run.runner_run` |
+| when a successor may launch | `simpler_run.claim_release` |
+| which run each belongs to | root `simpler_run` attrs, joined by `(pid, inv)` |
+
+Only `claim_release` was added for this: it wraps `release_native_run` inside
+finalize, the point a successor's launch becomes admissible, and no other span
+marks that boundary. `l3.post_fence_retirement` covers the L3 orchestrator's
+`release_run` tail for the same reason.
+
+The identity is `run_id / dispatch_id / run_epoch / slot_id / generation`. Each
+field means one thing: `run_id` and `dispatch_id` are zero on the direct-chip
+lane, which allocates neither, and `run_epoch` is a per-process monotonic counter
+that is always set — so it is what orders runs when the other two are absent.
+`NativeDispatchIdentity.sequence` makes that choice in the parser, where it is
+visible, rather than in the record.
+
+```bash
+python -m simpler_setup.tools.strace_timing path/to/log --assert-native-overlap
+```
+
+Per adjacent run on one child process, the command requires `bind(N+1)` to
+**overlap** `runner_run(N)` — the intervals intersect — and `runner_run(N+1)` not
+to start before `claim_release(N)`. It exits nonzero on a missing identity, a
+missing span, or an ordering violation.
+
+Reading `bind` rather than the whole prepare is deliberate: `bind` sits inside
+prepare, so an overlap it reports is one the prepare certainly had.
+
+`--require-hidden-prepare` adds the stronger claim that the preparation also
+*finishes* inside the predecessor's device window — fully hidden rather than
+merely concurrent. That is a statement about pipeline depth and it is sensitive
+to host scheduling, so it is opt-in and the scene test asserts only the overlap
+property.
 
 ## Why markers, not a return value
 

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -40,8 +40,10 @@ Outputs:
     * optionally a Chrome-trace / Perfetto JSON (``--trace-out``): one ``ph:"X"``
       event per span on a synthetic per-invocation lane, so each host call tree
       renders as nested slices, or
-    * a host scheduler swimlane (``--swimlane``) whose host lanes retain the
-      real OS pid/tid and whose cross-thread handoffs are Chrome flow events.
+    * a host scheduler swimlane (``--swimlane``) whose lanes are the real OS
+      pid/tid, except that a thread which interleaved runs is split into one lane
+      per pipeline slot so each lane reads as a sequence; cross-thread handoffs
+      are Chrome flow events.
 """
 
 from __future__ import annotations
@@ -118,6 +120,37 @@ class Span:
         return "clk=dev" in self.attrs
 
 
+class NativeOverlapError(ValueError):
+    """Raised when pipeline markers do not prove native preparation overlap."""
+
+
+@dataclass(frozen=True)
+class NativeDispatchIdentity:
+    pid: int
+    run_id: int
+    dispatch_id: int
+    run_epoch: int
+    slot_id: int
+    generation: int
+
+    @property
+    def sequence(self):
+        """Submission order within a process.
+
+        ``dispatch_id`` is the scheduler's, and is zero on the direct-chip lane,
+        which allocates none; ``run_epoch`` is a per-process monotonic counter
+        that is always set. Neither field stands in for the other in the record —
+        the choice is made here, where it is visible.
+        """
+        return self.dispatch_id or self.run_epoch
+
+
+@dataclass(frozen=True)
+class NativeOverlapCheck:
+    predecessor: NativeDispatchIdentity
+    successor: NativeDispatchIdentity
+
+
 @dataclass
 class Invocation:
     """All spans emitted by one simpler_run call (one (pid, inv) group)."""
@@ -186,11 +219,13 @@ def parse_spans(lines):
 def legacy_spans(spans):
     """Return spans belonging to the established ``simpler_run`` views.
 
-    L3/L4 host-scheduler markers share the STRACE grammar but answer a
-    different question. Keeping them out of invocation grouping preserves the
-    TPOT, rounds, tree, and ``--trace-out`` contracts when a log contains both
-    marker families. Filter only the newly introduced namespace so existing
-    marker families such as ``simpler_prewarm`` retain their old behavior.
+    Other marker families share the STRACE grammar but answer a different
+    question, and the invocation views are keyed on ``(pid, inv)`` — a family
+    that carries no invocation id would group into one bogus lane. Keeping them
+    out here preserves the TPOT, rounds, tree, and ``--trace-out`` contracts for
+    every consumer at once; filtering downstream covers only the view that
+    filters. Existing families such as ``simpler_prewarm`` keep their old
+    behavior.
     """
     return [span for span in spans if not span.name.startswith("l3.")]
 
@@ -217,6 +252,119 @@ def bucket_by_hid(invocations):
     for bucket in buckets.values():
         bucket.sort(key=lambda i: i.inv)
     return buckets
+
+
+# The spans one native run contributes to the overlap proof. All three already
+# exist in the `simpler_run` tree; only `claim_release` was added for it.
+_PREPARE_SPAN = "simpler_run.bind"
+_DEVICE_SPAN = "simpler_run.runner_run"
+_RELEASE_SPAN = "simpler_run.claim_release"
+_NATIVE_REQUIRED_SPANS = (_PREPARE_SPAN, _DEVICE_SPAN, _RELEASE_SPAN)
+_PIPELINE_IDENTITY_FIELDS = ("run_id", "dispatch_id", "run_epoch", "slot_id", "generation")
+
+
+def _native_dispatches(invocations):
+    """Map each native run's identity to its ``{span name: span}``.
+
+    The identity rides on the root ``simpler_run`` span, and every sub-span of
+    that run shares its ``(pid, inv)`` — so grouping by invocation is what joins
+    the windows to the identity. An invocation whose root carries no identity is
+    not a phased native run and is skipped.
+    """
+    dispatches = {}
+    for invocation in invocations:
+        root = invocation.root()
+        if root is None:
+            continue
+        attrs = _parsed_attrs(root)
+        if not any(field in attrs for field in _PIPELINE_IDENTITY_FIELDS):
+            continue
+        missing = [field for field in _PIPELINE_IDENTITY_FIELDS if field not in attrs]
+        if missing:
+            raise NativeOverlapError(
+                f"{root.name} (pid={root.pid} inv={root.inv}) is missing identity field(s): {', '.join(missing)}"
+            )
+        try:
+            identity = NativeDispatchIdentity(
+                pid=root.pid,
+                run_id=int(attrs["run_id"]),
+                dispatch_id=int(attrs["dispatch_id"]),
+                run_epoch=int(attrs["run_epoch"]),
+                slot_id=int(attrs["slot_id"]),
+                generation=int(attrs["generation"]),
+            )
+        except (TypeError, ValueError) as exc:
+            raise NativeOverlapError(f"{root.name} has a non-integer identity") from exc
+        if identity.sequence == 0:
+            continue
+        if identity in dispatches:
+            raise NativeOverlapError(f"duplicate identity for pid={identity.pid} sequence={identity.sequence}")
+        dispatches[identity] = invocation.by_name()
+    return dispatches
+
+
+def assert_native_overlap(spans, *, require_hidden=False):
+    """Prove native prepare overlap and FIFO launch ordering for adjacent runs.
+
+    Two properties per adjacent pair on one process lane:
+
+    * ``bind(N+1)`` overlaps ``runner_run(N)`` — the intervals intersect, which
+      is what makes the successor's preparation concurrent with the
+      predecessor's device work.
+    * ``runner_run(N+1)`` does not start before ``claim_release(N)``.
+
+    ``bind`` is the successor's own arena build and host orchestration and sits
+    inside its prepare, so reading it is conservative: an overlap it reports is
+    one the prepare certainly had.
+
+    ``require_hidden`` additionally demands that the preparation *finish* inside
+    the predecessor's device window — fully hidden rather than merely
+    overlapping. That is a claim about pipeline depth and is sensitive to host
+    scheduling, so it is opt-in: a bind that runs long on a contended machine
+    still overlaps.
+    """
+    dispatches = _native_dispatches(group_invocations(legacy_spans(spans)))
+    by_pid = defaultdict(list)
+    for identity, by_name in dispatches.items():
+        missing = [name for name in _NATIVE_REQUIRED_SPANS if name not in by_name]
+        if missing:
+            raise NativeOverlapError(f"sequence={identity.sequence} is missing span(s): {', '.join(missing)}")
+        by_pid[identity.pid].append((identity, by_name))
+
+    checks = []
+    for lane in by_pid.values():
+        lane.sort(key=lambda item: item[1][_DEVICE_SPAN].ts)
+        for (predecessor, pred_spans), (successor, succ_spans) in zip(lane, lane[1:]):
+            if successor.sequence <= predecessor.sequence:
+                raise NativeOverlapError(
+                    f"launch order is not monotonic: predecessor={predecessor.sequence} successor={successor.sequence}"
+                )
+            pred_device = pred_spans[_DEVICE_SPAN]
+            pred_release = pred_spans[_RELEASE_SPAN]
+            succ_prepare = succ_spans[_PREPARE_SPAN]
+            succ_device = succ_spans[_DEVICE_SPAN]
+            pred_device_end = pred_device.ts + pred_device.dur
+            succ_prepare_end = succ_prepare.ts + succ_prepare.dur
+            if succ_prepare.ts >= pred_device_end or succ_prepare_end <= pred_device.ts:
+                raise NativeOverlapError(
+                    f"preparation did not overlap: sequence={successor.sequence} prepare="
+                    f"[{succ_prepare.ts},{succ_prepare_end}] predecessor_device="
+                    f"[{pred_device.ts},{pred_device_end}]"
+                )
+            if require_hidden and succ_prepare_end > pred_device_end:
+                raise NativeOverlapError(
+                    f"preparation was not fully hidden: sequence={successor.sequence} prepare_end="
+                    f"{succ_prepare_end} predecessor_device_end={pred_device_end}"
+                )
+            if succ_device.ts < pred_release.ts:
+                raise NativeOverlapError(
+                    f"device execution reordered before the claim release: sequence={successor.sequence} "
+                    f"device_start={succ_device.ts} predecessor_release={pred_release.ts}"
+                )
+            checks.append(NativeOverlapCheck(predecessor=predecessor, successor=successor))
+    if not checks:
+        raise NativeOverlapError("need at least two complete native runs on one process lane")
+    return checks
 
 
 def _fmt_us(ns: int) -> str:
@@ -475,6 +623,54 @@ def _parsed_attrs(span):
 _HOST_THREAD_ROLES = ("facade", "scheduler", "worker")
 
 
+def _roots_overlap(entries):
+    """Whether two runs were in flight at once on this thread.
+
+    A depth-0 span is one run's whole lifetime, so two of them overlapping means
+    the thread interleaved runs. Nesting *within* a run is wanted; nesting one
+    run's spans inside another's is an artifact of flattening them onto one lane.
+    """
+    roots = sorted((span.ts, span.ts + span.dur) for span, _ in entries if span.depth == 0)
+    return any(a[1] > b[0] for a, b in zip(roots, roots[1:]))
+
+
+def _slot_by_invocation(entries):
+    """Map ``(pid, inv)`` to the pipeline slot that run held.
+
+    Only the root span carries the identity; its children carry no attributes at
+    all. They share the root's ``(pid, inv)``, so that is the join — the same one
+    :func:`assert_native_overlap` uses.
+    """
+    slots = {}
+    for span, attrs in entries:
+        if "slot_id" in attrs:
+            slots[(span.pid, span.inv)] = attrs["slot_id"]
+    return slots
+
+
+def _slot_lanes(entries, slot_by_invocation):
+    """Split one thread's spans by pipeline slot, or None to leave it on its tid.
+
+    The pipeline slot is what a run holds exclusively, so runs sharing a slot
+    cannot overlap — which is what makes a per-slot lane render as a plain
+    sequence instead of false containment. Returning None keeps the real-tid
+    lane: splitting a thread whose runs never overlapped would only fragment it,
+    and the L3 scheduler thread carries a slot while running strictly
+    sequentially.
+    """
+    if not _roots_overlap(entries):
+        return None
+    by_slot = defaultdict(list)
+    for span, attrs in entries:
+        slot_id = slot_by_invocation.get((span.pid, span.inv))
+        if slot_id is None:
+            return None
+        by_slot[slot_id].append((span, attrs))
+    if len(by_slot) < 2 or any(_roots_overlap(group) for group in by_slot.values()):
+        return None
+    return dict(sorted(by_slot.items()))
+
+
 def _host_thread_name(entries):
     """Name one OS thread's lane from every span it emitted.
 
@@ -516,6 +712,35 @@ def _flow_key(span, attrs):
     return span.pid, run_id, task_slot
 
 
+def _assign_lanes(host_entries, host_threads):
+    """Choose a lane per span, and a name per lane.
+
+    A thread that interleaved runs is split by pipeline slot (see
+    :func:`_slot_lanes`); every other thread keeps its real tid. Synthetic lane
+    ids start past the observed tid space so a split lane cannot collide with a
+    real thread's.
+    """
+    lane_of = {}
+    lane_names = {}
+    next_synthetic_tid = max(tid for _, tid in host_threads) + 1
+    slot_by_invocation = _slot_by_invocation(host_entries)
+    for pid, tid in host_threads:
+        on_thread = [entry for entry in host_entries if entry[0].pid == pid and entry[0].tid == tid]
+        slot_lanes = _slot_lanes(on_thread, slot_by_invocation)
+        if slot_lanes is None:
+            lane_names[(pid, tid)] = _host_thread_name(on_thread)
+            for span, _ in on_thread:
+                lane_of[id(span)] = tid
+            continue
+        for slot_id, group in slot_lanes.items():
+            lane_tid = next_synthetic_tid
+            next_synthetic_tid += 1
+            lane_names[(pid, lane_tid)] = f"pipeline slot {slot_id} (tid {tid})"
+            for span, _ in group:
+                lane_of[id(span)] = lane_tid
+    return lane_of, lane_names
+
+
 def to_host_swimlane(spans):
     """Build a real-pid/tid host scheduling timeline for Perfetto.
 
@@ -536,6 +761,8 @@ def to_host_swimlane(spans):
     host_pids = sorted({span.pid for span, _ in host_entries})
     host_threads = sorted({(span.pid, span.tid) for span, _ in host_entries})
 
+    lane_of, lane_names = _assign_lanes(host_entries, host_threads)
+
     for pid in host_pids:
         process_spans = [span for span, _ in host_entries if span.pid == pid]
         role = "host" if any(span.name.startswith("l3.") for span in process_spans) else "chip child"
@@ -548,19 +775,25 @@ def to_host_swimlane(spans):
                 "args": {"name": f"simpler {role} (pid={pid})"},
             }
         )
-    for pid, tid in host_threads:
-        on_thread = [entry for entry in host_entries if entry[0].pid == pid and entry[0].tid == tid]
+    for (pid, lane_tid), name in sorted(lane_names.items()):
         events.append(
             {
                 "ph": "M",
                 "name": "thread_name",
                 "pid": pid,
-                "tid": tid,
-                "args": {"name": _host_thread_name(on_thread)},
+                "tid": lane_tid,
+                "args": {"name": name},
             }
         )
     for span, parsed in sorted(host_entries, key=lambda item: (item[0].ts, item[0].pid, item[0].tid, item[0].name)):
-        event_args = {"inv": span.inv, "hid": span.hid, "depth": span.depth, "attrs": span.attrs, **parsed}
+        event_args = {
+            "inv": span.inv,
+            "hid": span.hid,
+            "depth": span.depth,
+            "attrs": span.attrs,
+            "os_tid": span.tid,
+            **parsed,
+        }
         events.append(
             {
                 "name": span.name,
@@ -568,7 +801,7 @@ def to_host_swimlane(spans):
                 "ts": span.ts / 1000.0,
                 "dur": span.dur / 1000.0,
                 "pid": span.pid,
-                "tid": span.tid,
+                "tid": lane_of[id(span)],
                 "args": event_args,
             }
         )
@@ -612,7 +845,7 @@ def to_host_swimlane(spans):
                 "id": flow_id,
                 "ts": min(source.ts + source.dur, destination.ts) / 1000.0,
                 "pid": source.pid,
-                "tid": source.tid,
+                "tid": lane_of[id(source)],
                 "args": flow_args,
             }
         )
@@ -624,7 +857,7 @@ def to_host_swimlane(spans):
                 "id": flow_id,
                 "ts": destination.ts / 1000.0,
                 "pid": destination.pid,
-                "tid": destination.tid,
+                "tid": lane_of[id(destination)],
                 "args": flow_args,
             }
         )
@@ -769,6 +1002,17 @@ def main(argv=None):
         help="print an indented nested span tree per callable (device_wall → sub-phases), "
         "instead of the per-callable TPOT table",
     )
+    ap.add_argument(
+        "--assert-native-overlap",
+        action="store_true",
+        help="fail unless adjacent dispatches prove prepare(N+1) overlaps device(N) and preserve ordered launch",
+    )
+    ap.add_argument(
+        "--require-hidden-prepare",
+        action="store_true",
+        help="with --assert-native-overlap, also require prepare(N+1) to finish inside device(N) "
+        "(fully hidden, not merely overlapping — sensitive to host scheduling)",
+    )
     args = ap.parse_args(argv)
 
     if args.log == "-":
@@ -789,7 +1033,14 @@ def main(argv=None):
     invocations = group_invocations(legacy)
     buckets = bucket_by_hid(invocations)
 
-    if args.rounds_table:
+    if args.assert_native_overlap:
+        try:
+            checks = assert_native_overlap(spans, require_hidden=args.require_hidden_prepare)
+        except NativeOverlapError as exc:
+            print(f"native overlap assertion failed: {exc}", file=sys.stderr)
+            return 2
+        print(f"Native overlap verified for {len(checks)} adjacent dispatch pair(s).")
+    elif args.rounds_table:
         print_rounds_table(buckets)
     elif args.tree:
         print_tree(buckets)

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -135,6 +135,7 @@ void Orchestrator::finish_run_if_ready(const std::shared_ptr<RunState> &run) {
             return;
         }
         bool failed = run->submission_failed || static_cast<bool>(run->first_error);
+        run->trace_terminal_ns = simpler::host_trace::now_ns();
         run->phase.store(failed ? RunPhase::FAILED : RunPhase::COMPLETED, std::memory_order_release);
         notify = true;
     }
@@ -356,6 +357,8 @@ void Orchestrator::compact_if_quiescent() {
 }
 
 void Orchestrator::release_run(RunId run_id) {
+    int64_t terminal_ns = 0;
+    PipelineSlotLease lease{};
     {
         std::lock_guard<std::mutex> lk(runs_mu_);
         auto it = runs_.find(run_id);
@@ -363,10 +366,21 @@ void Orchestrator::release_run(RunId run_id) {
         if (!is_terminal(it->second->phase.load(std::memory_order_acquire))) {
             throw std::logic_error("Orchestrator::release_run: run is not terminal");
         }
+        terminal_ns = it->second->trace_terminal_ns;
+        lease = it->second->lease;
         runs_.erase(it);
     }
 
     compact_if_quiescent();
+#if SIMPLER_HOST_STRACE
+    std::ostringstream retire_attrs;
+    retire_attrs << "run_id=" << run_id << " slot_id=" << lease.slot_id << " generation=" << lease.generation
+                 << " role=facade";
+    simpler::host_trace::emit(
+        "l3.post_fence_retirement", run_id, 0, 0, terminal_ns, simpler::host_trace::now_ns() - terminal_ns,
+        retire_attrs.str().c_str()
+    );
+#endif
 }
 
 void Orchestrator::register_run_slot(const std::shared_ptr<RunState> &run, TaskSlot slot) {

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -157,6 +157,10 @@ struct RunState {
     bool submission_closed{false};
     bool submission_failed{false};
     bool lease_released{false};
+    // When this run reached a terminal phase. `l3.post_fence_retirement`
+    // measures from here to the end of release_run, which is the only host cost
+    // that falls outside every other span.
+    int64_t trace_terminal_ns{0};
 };
 
 // =============================================================================

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -92,6 +92,17 @@ trace_dispatch_attrs(RunId run_id, const WorkerDispatch &dispatch, const WorkerE
           << " prepare_only=" << static_cast<int>(dispatch.prepare_only) << " role=" << role;
     return attrs.str();
 }
+
+// The lease the dispatch's slot holds, read from the ring. Callers read this
+// before publishing the frame: past that point the endpoint may retire the slot.
+std::string trace_lease_attrs(Ring *ring, TaskSlot task_slot) {
+    if (ring == nullptr) return "";
+    const TaskSlotState *state = ring->slot_state(task_slot);
+    if (state == nullptr) return "";
+    std::ostringstream attrs;
+    attrs << " slot_id=" << state->pipeline_lease.slot_id << " generation=" << state->pipeline_lease.generation;
+    return attrs.str();
+}
 #endif
 
 // Wall-clock period between child liveness samples. Every mailbox wait spins,
@@ -454,6 +465,7 @@ WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expect
 #if SIMPLER_HOST_STRACE
     const RunId trace_run = trace_run_id(ring_, d.task_slot);
     const uint64_t trace_hash = trace_callable_hash(ring_, d.task_slot);
+    const std::string trace_lease = trace_lease_attrs(ring_, d.task_slot);
 #endif
     try {
         endpoint_->submit_progress(ring_, d);
@@ -465,7 +477,7 @@ WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expect
     admission_lk.unlock();
 #if SIMPLER_HOST_STRACE
     const int64_t trace_end_ns = simpler::host_trace::now_ns();
-    const std::string trace_attrs = trace_dispatch_attrs(trace_run, d, endpoint_->caps(), "scheduler");
+    const std::string trace_attrs = trace_dispatch_attrs(trace_run, d, endpoint_->caps(), "scheduler") + trace_lease;
     simpler::host_trace::emit(
         "l3.dispatch", trace_run, trace_hash, 0, trace_start_ns, trace_end_ns - trace_start_ns, trace_attrs.c_str()
     );

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -696,10 +696,10 @@ int simpler_prepare_run(
         state = new (runtime) OnboardNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
         std::snprintf(
             state->trace_attrs, sizeof(state->trace_attrs),
-            "run_id=%llu slot=%u generation=%llu dispatch_id=%llu run_epoch=%llu",
-            static_cast<unsigned long long>(state->descriptor.run_id), state->descriptor.pipeline_slot,
+            "run_id=%llu dispatch_id=%llu slot_id=%u generation=%llu run_epoch=%llu",
+            static_cast<unsigned long long>(state->descriptor.run_id),
+            static_cast<unsigned long long>(state->descriptor.dispatch_id), state->descriptor.pipeline_slot,
             static_cast<unsigned long long>(state->descriptor.generation),
-            static_cast<unsigned long long>(state->descriptor.dispatch_id),
             static_cast<unsigned long long>(state->descriptor.run_epoch)
         );
         const bool allow_prepared_successor =
@@ -962,6 +962,10 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     }
 
     if (state->runner_claimed) {
+        // The point a successor's launch becomes admissible. Ordering a
+        // successor's device work against this boundary is what separates a
+        // pipelined launch from a reordered one, and no other span marks it.
+        STRACE("simpler_run.claim_release");
         state->runner->release_native_run(state);
         state->runner_claimed = false;
     }

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
@@ -28,6 +28,7 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
+from simpler_setup.tools.strace_timing import assert_native_overlap, parse_spans
 
 _VECTOR_KERNELS = "../vector_example/kernels"
 _SIZE = 128 * 128
@@ -98,7 +99,7 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         assert chip_worker is not None
         return chip_worker
 
-    def test_concurrent_prepare_overlap(self, st_platform, st_worker):
+    def test_concurrent_prepare_overlap(self, st_platform, st_worker, capfd):
         """Golden-check a 2-deep overlapping pipeline over both arena banks.
 
         Each submission prepares (fully binds) its run against one bank while the
@@ -159,3 +160,10 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
                 _retire(inflight.pop(0))
         finally:
             chip_worker._unregister_slot(callable_id)
+
+        # Each pair must prove prepare(N+1) ran concurrently with device(N) — the
+        # property this pipeline exists for. Not that prepare *finished* inside
+        # that window (`require_hidden=True`): that additionally depends on how
+        # much host CPU this shared machine gives the preparing thread.
+        checks = assert_native_overlap(parse_spans(capfd.readouterr().err.splitlines()))
+        assert len(checks) == _ITERS - 1

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -112,9 +112,9 @@ class TestNativeRunLifecycle(SceneTestCase):
             assert all(
                 key in attrs
                 for attrs in root_attrs
-                for key in ("run_id=", "slot=", "generation=", "dispatch_id=", "run_epoch=")
+                for key in ("run_id=", "slot_id=", "generation=", "dispatch_id=", "run_epoch=")
             )
-            assert any("slot=1" in attrs and "generation=1" in attrs for attrs in root_attrs)
+            assert any("slot_id=1" in attrs and "generation=1" in attrs for attrs in root_attrs)
 
     def _run_and_validate_l2(  # noqa: PLR0913, PLR0915 -- lifecycle contract is intentionally sequential
         self,

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -9,9 +9,14 @@
 # -----------------------------------------------------------------------------------------------------------
 
 import json
+from collections import defaultdict
 from io import StringIO
 
+import pytest
+
 from simpler_setup.tools.strace_timing import (
+    NativeOverlapError,
+    assert_native_overlap,
     bucket_by_hid,
     count_record_heads,
     group_invocations,
@@ -462,3 +467,177 @@ def test_rounds_table_omits_tmr_only_columns_when_only_host_and_device_exist():
     assert "Sched (us)" not in rendered
     assert "Avg Host: 110.0 us" in rendered
     assert "Avg Device: 22.0 us [2/2]" in rendered
+
+
+def _run_records(*, run_epoch, prepare, device, release, run_id=0, dispatch_id=0, slot_id=0, pid=7, inv=None):
+    """One phased native run's spans, as the `simpler_run` tree carries them.
+
+    `prepare` and `device` are (ts, dur). The root span carries the identity and
+    spans the whole lifetime, so it must enclose the children.
+    """
+    invocation = run_epoch if inv is None else inv
+    identity = f"run_id={run_id} dispatch_id={dispatch_id} slot_id={slot_id} generation=1 run_epoch={run_epoch}"
+    root_end = release + 10
+    return [
+        _record(pid, invocation, "simpler_run.bind", depth=1, ts=prepare[0], dur=prepare[1]),
+        _record(pid, invocation, "simpler_run.runner_run", depth=1, ts=device[0], dur=device[1]),
+        _record(pid, invocation, "simpler_run.claim_release", depth=1, ts=release, dur=5),
+        _record(pid, invocation, "simpler_run", identity, depth=0, ts=prepare[0], dur=root_end - prepare[0]),
+    ]
+
+
+def test_native_overlap_reads_identity_from_the_invocation_root():
+    """The identity is on the root; the windows are on its children.
+
+    `(pid, inv)` is what joins them — the same grouping the TPOT views use.
+    """
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, prepare=(150, 30), device=(240, 100), release=340)
+
+    checks = assert_native_overlap(parse_spans(lines))
+
+    assert len(checks) == 1
+    assert (checks[0].predecessor.sequence, checks[0].successor.sequence) == (1, 2)
+
+
+def test_native_overlap_accepts_a_prepare_that_outlasts_the_device_window():
+    """Overlap means the intervals intersect, not that prepare is contained.
+
+    A prepare that starts inside the predecessor's device window and finishes
+    after it still ran concurrently with device work, which is the property being
+    proved. Demanding containment turns a slow host into a failure whose message
+    blames the wrong thing.
+    """
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, prepare=(190, 40), device=(240, 100), release=340)
+
+    assert len(assert_native_overlap(parse_spans(lines))) == 1
+
+    with pytest.raises(NativeOverlapError, match="not fully hidden"):
+        assert_native_overlap(parse_spans(lines), require_hidden=True)
+
+
+def test_native_overlap_rejects_a_prepare_after_the_device_window():
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, prepare=(210, 20), device=(240, 100), release=340)
+
+    with pytest.raises(NativeOverlapError, match="did not overlap"):
+        assert_native_overlap(parse_spans(lines))
+
+
+def test_native_overlap_rejects_device_work_before_the_predecessor_release():
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=250)
+    lines += _run_records(run_epoch=2, prepare=(150, 30), device=(240, 100), release=400)
+
+    with pytest.raises(NativeOverlapError, match="reordered before the claim release"):
+        assert_native_overlap(parse_spans(lines))
+
+
+def test_native_overlap_orders_by_run_epoch_when_dispatch_id_is_absent():
+    """`_submit_chip_run_direct` defaults run_id and dispatch_id to 0.
+
+    `run_epoch` is the only identity those runs carry, so it is what orders them.
+    """
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, prepare=(150, 30), device=(240, 100), release=340)
+
+    identities = [check.predecessor for check in assert_native_overlap(parse_spans(lines))]
+
+    assert identities[0].dispatch_id == 0
+    assert identities[0].run_epoch == 1
+    assert identities[0].sequence == 1
+
+
+def test_native_overlap_orders_by_dispatch_id_when_the_scheduler_allocates_one():
+    lines = _run_records(run_epoch=1, dispatch_id=10, run_id=5, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, dispatch_id=11, run_id=6, prepare=(150, 30), device=(240, 100), release=340)
+
+    checks = assert_native_overlap(parse_spans(lines))
+
+    assert (checks[0].predecessor.sequence, checks[0].successor.sequence) == (10, 11)
+
+
+def test_native_overlap_skips_an_invocation_that_is_not_a_phased_run():
+    """A lexical `simpler_run` carries no identity attrs, so it orders nothing."""
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, prepare=(150, 30), device=(240, 100), release=340)
+    lines += [_record(7, 99, "simpler_run", "", depth=0, ts=10, dur=5)]
+
+    assert len(assert_native_overlap(parse_spans(lines))) == 1
+
+
+def test_native_overlap_needs_two_runs_on_one_lane():
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+
+    with pytest.raises(NativeOverlapError, match="at least two complete native runs"):
+        assert_native_overlap(parse_spans(lines))
+
+
+def test_claim_release_span_stays_inside_the_invocation_tree():
+    """It is a `simpler_run` child, so the existing views absorb it.
+
+    A separate family would have to be filtered out of every view; a depth-1
+    child of the root is what the tree already knows how to render — and it
+    cannot displace the root the way a second depth-0 span would.
+    """
+    lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
+
+    invocation = group_invocations(legacy_spans(list(parse_spans(lines))))[0]
+
+    assert invocation.root().name == "simpler_run"
+    assert invocation.by_name()["simpler_run.claim_release"].depth == 1
+    # The root still reports the whole lifetime, not a sub-stage's duration.
+    assert invocation.root().dur == 210 - 50
+
+
+def test_swimlane_splits_an_interleaved_thread_into_one_lane_per_pipeline_slot():
+    """A K-deep pipeline runs on one OS thread, so tid is not the unit of concurrency.
+
+    Flattening overlapping runs onto one lane makes Perfetto nest run N+1's spans
+    inside run N's root by timestamp containment — false nesting that hides the
+    very overlap the lane is meant to show. The pipeline slot is what a run holds
+    exclusively, so runs sharing one cannot overlap.
+    """
+    lines = _run_records(run_epoch=1, slot_id=0, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, slot_id=1, prepare=(150, 30), device=(240, 100), release=340)
+    lines += _run_records(run_epoch=3, slot_id=0, prepare=(300, 30), device=(380, 100), release=480)
+
+    trace = to_host_swimlane(list(parse_spans(lines)))
+    lanes = {
+        event["tid"]: event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "thread_name"
+    }
+
+    assert sorted(lanes.values()) == ["pipeline slot 0 (tid 7)", "pipeline slot 1 (tid 7)"]
+    # Two runs shared slot 0, so that lane holds both — and neither overlaps.
+    roots = defaultdict(list)
+    for event in trace["traceEvents"]:
+        if event["ph"] == "X" and event["args"]["depth"] == 0:
+            roots[event["tid"]].append((event["ts"], event["ts"] + event["dur"]))
+    assert sorted(len(windows) for windows in roots.values()) == [1, 2]
+    for windows in roots.values():
+        windows.sort()
+        assert all(a[1] <= b[0] for a, b in zip(windows, windows[1:]))
+    # The real thread stays recoverable from the slice.
+    slices = [event for event in trace["traceEvents"] if event["ph"] == "X"]
+    assert {event["args"]["os_tid"] for event in slices} == {7}
+
+
+def test_swimlane_keeps_a_sequential_thread_on_its_own_tid():
+    """Splitting a thread whose runs never overlapped would only fragment it.
+
+    The L3 scheduler thread carries a pipeline slot but runs strictly
+    sequentially, so it must keep its real tid.
+    """
+    lines = _run_records(run_epoch=1, slot_id=0, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, slot_id=1, prepare=(300, 20), device=(350, 100), release=460)
+
+    trace = to_host_swimlane(list(parse_spans(lines)))
+    lanes = {
+        event["tid"]: event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "thread_name"
+    }
+
+    assert list(lanes) == [7]


### PR DESCRIPTION
## Summary
- emit correlated host-clock spans for graph build, frame staging, native prepare, launch acceptance, device execution, ordered release, and post-fence retirement
- carry `run_id / dispatch_id / slot_id / generation` through the trace and add `--assert-native-overlap` for machine-verifiable ordering
- make the existing A2/A3 concurrent-prepare stress test prove 39 adjacent overlap pairs without changing scheduling behavior

## Testing
- `pre-commit run --files ...`
- `pytest -q tests/ut/py/test_strace_timing.py` (18 passed)
- `_task_interface` build
- `test_orchestrator` (54 passed)
- `test_scheduler` (66 passed)
- `test_chip_run_lane` (17 passed)
- A2/A3 architecture precheck via `task-submit`
- `build_package_a2a3` with PTO-ISA pin `0cefc9a5a1c24c62655cc345d408559595a8af32`
- A2/A3 onboard `test_concurrent_prepare_overlap` via `task-submit` (1 passed, 40 runs / 39 adjacent pairs)
- sim tests not run (not required for this A2/A3 trace PR)