### PR TITLE
Fix: bound early-dispatch queue overflow on a2a3 and a5

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -123,10 +123,15 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+    // Returns false without publishing anything when the queue cannot take all
+    // `count` items. A target slot holding an older generation means full and
+    // ends the call; a slot a peer has reserved but not yet published is
+    // transient and retries, so this only spins while a peer is mid-publish.
+    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
-        if (count == 0) return;
+    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+        if (count == 0) return true;
+        if (static_cast<uint64_t>(count) > capacity) return false;
 
         uint64_t pos;
         while (true) {
@@ -136,7 +141,10 @@ struct alignas(64) PTO2ReadyQueue {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + i);
-                if (diff != 0) {
+                if (diff < 0) {
+                    return false;  // Queue full
+                }
+                if (diff > 0) {
                     ready = false;
                     break;
                 }
@@ -157,6 +165,7 @@ struct alignas(64) PTO2ReadyQueue {
             slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
+        return true;
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -427,7 +427,10 @@ void SchedulerContext::dispatch_shape(
 
             if (!cores.has_value()) {
                 flush_publish();
-                disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                // These came off this queue and no other owner holds them, so a
+                // drop would lose them: retry until the space they vacated is
+                // free again.
+                while (!disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi)) {}
                 break;
             }
 
@@ -746,7 +749,15 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
-            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
+            // A dropped candidate keeps its STAGING claim and is recovered by the
+            // producer release: try_early_dispatch_release rings whatever is staged
+            // and routes the unstaged remainder to the ready queue, because it
+            // returns on next_block_idx rather than on the claim state.
+            if (!sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi))
+                LOG_DEBUG(
+                    "[EARLY_DISPATCH] queue full on batch re-push, dropping %d candidate(s) to normal dispatch",
+                    got - bi
+                );
             break;
         }
         int32_t start = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -84,8 +84,14 @@
 #define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE 65536        // Per-shape queue size
-#define PTO2_EARLY_DISPATCH_QUEUE_SIZE 64  // Per-shape early-dispatch candidate queue
+#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
+
+// Cross-thread early-dispatch candidate queue (power of two). A single wide
+// producer can publish more candidates than there are physical cores, so the
+// capacity tracks the publication burst rather than the simultaneously
+// stageable cohort: a 128-token EP8 routed-expert layer bursts 128 gate/up MM
+// candidates onto one shape, and this holds 2x that.
+#define PTO2_EARLY_DISPATCH_QUEUE_SIZE 256
 
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 64

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -122,10 +122,15 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+    // Returns false without publishing anything when the queue cannot take all
+    // `count` items. A target slot holding an older generation means full and
+    // ends the call; a slot a peer has reserved but not yet published is
+    // transient and retries, so this only spins while a peer is mid-publish.
+    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
-        if (count == 0) return;
+    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+        if (count == 0) return true;
+        if (static_cast<uint64_t>(count) > capacity) return false;
 
         uint64_t pos;
         while (true) {
@@ -135,7 +140,10 @@ struct alignas(64) PTO2ReadyQueue {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + i);
-                if (diff != 0) {
+                if (diff < 0) {
+                    return false;  // Queue full
+                }
+                if (diff > 0) {
                     ready = false;
                     break;
                 }
@@ -156,6 +164,7 @@ struct alignas(64) PTO2ReadyQueue {
             slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
+        return true;
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
@@ -741,10 +750,12 @@ struct PTO2SchedulerState {
     // onto ITS OWN cores (range-claim via next_block_idx), and re-pushes if blocks
     // remain — exactly mirroring how a partially-dispatched SPMD task is re-pushed to
     // the ready queue (scheduler_dispatch: pop -> claim -> re-push). A stale/released
-    // entry fails the STAGING check on pop and is dropped. An initial push that
-    // overflows rolls STAGING back to NONE so readiness takes the normal path; a
-    // re-push overflow after a partial claim leaves STAGING in place and the
-    // unclaimed blocks fall back to normal dispatch when the producer releases.
+    // entry fails the STAGING check on pop and is dropped. Overflow at any push is
+    // safe and costs only the pre-staging: the producer release routes on
+    // next_block_idx rather than on the claim state, so it rings whatever is already
+    // staged and sends the rest to ready_queues. An initial push that overflows also
+    // rolls STAGING back to NONE, since nothing is staged yet and a task with no
+    // claim should not read as speculatively claimed.
     PTO2ReadyQueue early_dispatch_queues[PTO2_NUM_RESOURCE_SHAPES];
 
     // sync_start early-dispatch candidates park here instead of early_dispatch_queues[]:
@@ -932,10 +943,10 @@ struct PTO2SchedulerState {
                           early_sync_start_queue.push_tagged(&consumer, task_id) :
                           early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(&consumer, task_id);
         if (!queued) {
-            // The candidate was never published to an early-dispatch drain. Undo
-            // the speculative claim so readiness follows the ordinary queue path.
-            // A concurrent producer release may already have changed STAGING to
-            // DISPATCHED; in that case its release path owns the transition.
+            // The candidate was never published to an early-dispatch drain, so
+            // drop the speculative claim and let readiness take the ordinary
+            // queue path. A concurrent producer release may already have moved
+            // STAGING to DISPATCHED; that path then owns the transition.
             expected = PTO2_EARLY_DISPATCH_STAGING;
             consumer.payload->early_dispatch_state.compare_exchange_strong(
                 expected, PTO2_EARLY_DISPATCH_NONE, std::memory_order_seq_cst, std::memory_order_seq_cst

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -741,8 +741,10 @@ struct PTO2SchedulerState {
     // onto ITS OWN cores (range-claim via next_block_idx), and re-pushes if blocks
     // remain — exactly mirroring how a partially-dispatched SPMD task is re-pushed to
     // the ready queue (scheduler_dispatch: pop -> claim -> re-push). A stale/released
-    // entry fails the STAGING check on pop and is dropped; a push that overflows is
-    // logged and the consumer's blocks fall back to normal dispatch.
+    // entry fails the STAGING check on pop and is dropped. An initial push that
+    // overflows rolls STAGING back to NONE so readiness takes the normal path; a
+    // re-push overflow after a partial claim leaves STAGING in place and the
+    // unclaimed blocks fall back to normal dispatch when the producer releases.
     PTO2ReadyQueue early_dispatch_queues[PTO2_NUM_RESOURCE_SHAPES];
 
     // sync_start early-dispatch candidates park here instead of early_dispatch_queues[]:
@@ -926,10 +928,18 @@ struct PTO2SchedulerState {
         uint64_t task_id = static_cast<uint64_t>(consumer.task->task_id.raw);
         // A sync-start cohort uses one shape-agnostic queue so one owner can
         // choose an all-or-nothing local stage or the global-drain fallback.
-        if (consumer.task_attrs.requires_sync_start()) {
-            early_sync_start_queue.push_tagged(&consumer, task_id);
-        } else {
-            early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(&consumer, task_id);
+        bool queued = consumer.task_attrs.requires_sync_start() ?
+                          early_sync_start_queue.push_tagged(&consumer, task_id) :
+                          early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(&consumer, task_id);
+        if (!queued) {
+            // The candidate was never published to an early-dispatch drain. Undo
+            // the speculative claim so readiness follows the ordinary queue path.
+            // A concurrent producer release may already have changed STAGING to
+            // DISPATCHED; in that case its release path owns the transition.
+            expected = PTO2_EARLY_DISPATCH_STAGING;
+            consumer.payload->early_dispatch_state.compare_exchange_strong(
+                expected, PTO2_EARLY_DISPATCH_NONE, std::memory_order_seq_cst, std::memory_order_seq_cst
+            );
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -435,7 +435,10 @@ void SchedulerContext::dispatch_shape(
 
             if (!cores.has_value()) {
                 flush_publish();
-                disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                // These came off this queue and no other owner holds them, so a
+                // drop would lose them: retry until the space they vacated is
+                // free again.
+                while (!disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi)) {}
                 break;
             }
 
@@ -760,7 +763,15 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
-            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
+            // A dropped candidate keeps its STAGING claim and is recovered by the
+            // producer release: try_early_dispatch_release rings whatever is staged
+            // and routes the unstaged remainder to the ready queue, because it
+            // returns on next_block_idx rather than on the claim state.
+            if (!sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi))
+                LOG_DEBUG(
+                    "[EARLY_DISPATCH] queue full on batch re-push, dropping %d candidate(s) to normal dispatch",
+                    got - bi
+                );
             break;
         }
         int32_t start = 0;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -123,10 +123,15 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+    // Returns false without publishing anything when the queue cannot take all
+    // `count` items. A target slot holding an older generation means full and
+    // ends the call; a slot a peer has reserved but not yet published is
+    // transient and retries, so this only spins while a peer is mid-publish.
+    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
-        if (count == 0) return;
+    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+        if (count == 0) return true;
+        if (static_cast<uint64_t>(count) > capacity) return false;
 
         uint64_t pos;
         while (true) {
@@ -136,7 +141,10 @@ struct alignas(64) PTO2ReadyQueue {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + i);
-                if (diff != 0) {
+                if (diff < 0) {
+                    return false;  // Queue full
+                }
+                if (diff > 0) {
                     ready = false;
                     break;
                 }
@@ -157,6 +165,7 @@ struct alignas(64) PTO2ReadyQueue {
             slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
+        return true;
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -427,7 +427,10 @@ void SchedulerContext::dispatch_shape(
 
             if (!cores.has_value()) {
                 flush_publish();
-                disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                // These came off this queue and no other owner holds them, so a
+                // drop would lose them: retry until the space they vacated is
+                // free again.
+                while (!disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi)) {}
                 break;
             }
 
@@ -746,7 +749,15 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
-            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
+            // A dropped candidate keeps its STAGING claim and is recovered by the
+            // producer release: try_early_dispatch_release rings whatever is staged
+            // and routes the unstaged remainder to the ready queue, because it
+            // returns on next_block_idx rather than on the claim state.
+            if (!sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi))
+                LOG_DEBUG(
+                    "[EARLY_DISPATCH] queue full on batch re-push, dropping %d candidate(s) to normal dispatch",
+                    got - bi
+                );
             break;
         }
         int32_t start = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -84,8 +84,14 @@
 #define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE 65536        // Per-shape queue size
-#define PTO2_EARLY_DISPATCH_QUEUE_SIZE 64  // Per-shape early-dispatch candidate queue
+#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
+
+// Cross-thread early-dispatch candidate queue (power of two). A single wide
+// producer can publish more candidates than there are physical cores, so the
+// capacity tracks the publication burst rather than the simultaneously
+// stageable cohort: a 128-token EP8 routed-expert layer bursts 128 gate/up MM
+// candidates onto one shape, and this holds 2x that.
+#define PTO2_EARLY_DISPATCH_QUEUE_SIZE 256
 
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 64

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -122,10 +122,15 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState **items, int count) { push_batch_tagged(items, nullptr, count); }
+    // Returns false without publishing anything when the queue cannot take all
+    // `count` items. A target slot holding an older generation means full and
+    // ends the call; a slot a peer has reserved but not yet published is
+    // transient and retries, so this only spins while a peer is mid-publish.
+    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    void push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
-        if (count == 0) return;
+    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+        if (count == 0) return true;
+        if (static_cast<uint64_t>(count) > capacity) return false;
 
         uint64_t pos;
         while (true) {
@@ -135,7 +140,10 @@ struct alignas(64) PTO2ReadyQueue {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + i);
-                if (diff != 0) {
+                if (diff < 0) {
+                    return false;  // Queue full
+                }
+                if (diff > 0) {
                     ready = false;
                     break;
                 }
@@ -156,6 +164,7 @@ struct alignas(64) PTO2ReadyQueue {
             slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
+        return true;
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
@@ -869,10 +878,18 @@ struct PTO2SchedulerState {
         }
 
         uint64_t task_id = static_cast<uint64_t>(consumer.task->task_id.raw);
-        if (consumer.task_attrs.requires_sync_start()) {
-            early_sync_start_queue.push_tagged(&consumer, task_id);
-        } else {
-            early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(&consumer, task_id);
+        bool queued = consumer.task_attrs.requires_sync_start() ?
+                          early_sync_start_queue.push_tagged(&consumer, task_id) :
+                          early_dispatch_queues[static_cast<int32_t>(shape)].push_tagged(&consumer, task_id);
+        if (!queued) {
+            // The candidate was never published to an early-dispatch drain, so
+            // drop the speculative claim and let readiness take the ordinary
+            // queue path. A concurrent producer release may already have moved
+            // STAGING to DISPATCHED; that path then owns the transition.
+            expected = PTO2_EARLY_DISPATCH_STAGING;
+            consumer.payload->early_dispatch_state.compare_exchange_strong(
+                expected, PTO2_EARLY_DISPATCH_NONE, std::memory_order_seq_cst, std::memory_order_seq_cst
+            );
         }
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -396,7 +396,10 @@ void SchedulerContext::dispatch_shape(
 
             if (!cores.has_value()) {
                 flush_publish();
-                disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                // These came off this queue and no other owner holds them, so a
+                // drop would lose them: retry until the space they vacated is
+                // free again.
+                while (!disp_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi)) {}
                 break;
             }
 
@@ -715,7 +718,15 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
         }
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
-            sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi);
+            // A dropped candidate keeps its STAGING claim and is recovered by the
+            // producer release: try_early_dispatch_release rings whatever is staged
+            // and routes the unstaged remainder to the ready queue, because it
+            // returns on next_block_idx rather than on the claim state.
+            if (!sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi))
+                LOG_DEBUG(
+                    "[EARLY_DISPATCH] queue full on batch re-push, dropping %d candidate(s) to normal dispatch",
+                    got - bi
+                );
             break;
         }
         int32_t start = 0;

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -406,6 +406,23 @@ TEST_F(WiringTest, EarlyDispatchWaitsForAllProducerBlocksPublished) {
     EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);
 }
 
+TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
+    alignas(64) PTO2TaskSlotState filler, consumer;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    init_slot(consumer, PTO2_TASK_PENDING, 0, 1);
+
+    auto shape = static_cast<int32_t>(consumer.active_mask.to_shape());
+    auto &queue = sched.early_dispatch_queues[shape];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    sched.try_enqueue_early_dispatch_candidate(consumer);
+
+    EXPECT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_NONE);
+    EXPECT_EQ(queue.size(), queue.capacity);
+}
+
 TEST_F(WiringTest, LateWiredFullyPublishedProducerStillSeedsEarlyDispatch) {
     alignas(64) PTO2TaskSlotState producer, consumer;
     alignas(64) PTO2TaskPayload consumer_payload;

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -406,7 +406,42 @@ TEST_F(WiringTest, EarlyDispatchWaitsForAllProducerBlocksPublished) {
     EXPECT_EQ(payload.dispatch_fanin.load(), payload.fanin_actual_count);
 }
 
-TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
+TEST_F(WiringTest, BatchPushReportsFullInsteadOfSpinning) {
+    alignas(64) PTO2TaskSlotState filler;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    PTO2TaskSlotState *items[1] = {&filler};
+    uint64_t tags[1] = {queue.capacity};
+    // A full queue must end the call, not spin waiting for a consumer. Reaching
+    // the next line at all is the assertion.
+    EXPECT_FALSE(queue.push_batch_tagged(items, tags, 1));
+    EXPECT_EQ(queue.size(), queue.capacity);
+
+    // A batch larger than the queue can never be satisfied and must not spin.
+    EXPECT_FALSE(queue.push_batch_tagged(items, tags, static_cast<int>(queue.capacity) + 1));
+}
+
+TEST_F(WiringTest, BatchPushSucceedsAfterSpaceIsReclaimed) {
+    alignas(64) PTO2TaskSlotState filler;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+    ASSERT_NE(queue.pop(), nullptr);
+    ASSERT_NE(queue.pop(), nullptr);
+
+    PTO2TaskSlotState *items[2] = {&filler, &filler};
+    uint64_t tags[2] = {7, 8};
+    EXPECT_TRUE(queue.push_batch_tagged(items, tags, 2));
+    EXPECT_EQ(queue.size(), queue.capacity);
+}
+
+TEST_F(WiringTest, EarlyDispatchQueueOverflowRollsBackStagingClaim) {
     alignas(64) PTO2TaskSlotState filler, consumer;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 0, 1);
@@ -421,6 +456,50 @@ TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
 
     EXPECT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_NONE);
     EXPECT_EQ(queue.size(), queue.capacity);
+}
+
+TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
+    alignas(64) PTO2TaskSlotState filler, consumer;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
+
+    PTO2ResourceShape shape = consumer.active_mask.to_shape();
+    auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(shape)];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    sched.try_enqueue_early_dispatch_candidate(consumer);
+    ASSERT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_NONE);
+
+    // The overflowed candidate carries no early-dispatch claim, so the producer
+    // release routes every block through the ordinary ready queue.
+    EXPECT_TRUE(sched.route_ready_once(consumer));
+    EXPECT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_DISPATCHED);
+    EXPECT_EQ(sched.ready_queues[static_cast<int32_t>(shape)].pop(), &consumer);
+}
+
+TEST_F(WiringTest, EarlyDispatchSyncStartQueueOverflowFallsBackToSyncReadyQueue) {
+    alignas(64) PTO2TaskSlotState filler, consumer;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
+    consumer.task_attrs.set_sync_start();
+    ASSERT_TRUE(consumer.task_attrs.requires_sync_start());
+
+    auto &queue = sched.early_sync_start_queue;
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    sched.try_enqueue_early_dispatch_candidate(consumer);
+    EXPECT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_NONE);
+    EXPECT_EQ(queue.size(), queue.capacity);
+
+    // A sync_start cohort that never reached its drain falls back to the
+    // shape's sync ready queue, not the plain one.
+    PTO2ResourceShape shape = consumer.active_mask.to_shape();
+    EXPECT_TRUE(sched.route_ready_once(consumer));
+    EXPECT_EQ(sched.ready_sync_queues[static_cast<int32_t>(shape)].pop(), &consumer);
 }
 
 TEST_F(WiringTest, LateWiredFullyPublishedProducerStillSeedsEarlyDispatch) {

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -640,3 +640,82 @@ TEST_F(WiringTest, NoEdgePublishRecordsDepPoolMark) {
     publish_no_fanin(task_slot);
     EXPECT_EQ(task_slot.dep_pool_mark, before_top);
 }
+
+TEST_F(WiringTest, BatchPushReportsFullInsteadOfSpinning) {
+    alignas(64) PTO2TaskSlotState filler;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    PTO2TaskSlotState *items[1] = {&filler};
+    uint64_t tags[1] = {queue.capacity};
+    // A full queue must end the call, not spin waiting for a consumer. Reaching
+    // the next line at all is the assertion.
+    EXPECT_FALSE(queue.push_batch_tagged(items, tags, 1));
+    EXPECT_EQ(queue.size(), queue.capacity);
+
+    // A batch larger than the queue can never be satisfied and must not spin.
+    EXPECT_FALSE(queue.push_batch_tagged(items, tags, static_cast<int>(queue.capacity) + 1));
+}
+
+TEST_F(WiringTest, BatchPushSucceedsAfterSpaceIsReclaimed) {
+    alignas(64) PTO2TaskSlotState filler;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+    ASSERT_NE(queue.pop(), nullptr);
+    ASSERT_NE(queue.pop(), nullptr);
+
+    PTO2TaskSlotState *items[2] = {&filler, &filler};
+    uint64_t tags[2] = {7, 8};
+    EXPECT_TRUE(queue.push_batch_tagged(items, tags, 2));
+    EXPECT_EQ(queue.size(), queue.capacity);
+}
+
+TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
+    alignas(64) PTO2TaskSlotState filler, consumer;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
+
+    PTO2ResourceShape shape = consumer.active_mask.to_shape();
+    auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(shape)];
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    sched.try_enqueue_early_dispatch_candidate(consumer);
+    ASSERT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_NONE);
+
+    // The overflowed candidate carries no early-dispatch claim, so the producer
+    // release routes every block through the ordinary ready queue.
+    EXPECT_TRUE(sched.route_ready_once(consumer));
+    EXPECT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_DISPATCHED);
+    EXPECT_EQ(sched.ready_queues[static_cast<int32_t>(shape)].pop(), &consumer);
+}
+
+TEST_F(WiringTest, EarlyDispatchSyncStartQueueOverflowFallsBackToSyncReadyQueue) {
+    alignas(64) PTO2TaskSlotState filler, consumer;
+    init_slot(filler, PTO2_TASK_PENDING, 0, 1);
+    init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
+    consumer.task_attrs.set_sync_start();
+    ASSERT_TRUE(consumer.task_attrs.requires_sync_start());
+
+    auto &queue = sched.early_sync_start_queue;
+    for (uint64_t i = 0; i < queue.capacity; i++) {
+        ASSERT_TRUE(queue.push_tagged(&filler, i));
+    }
+
+    sched.try_enqueue_early_dispatch_candidate(consumer);
+    EXPECT_EQ(consumer.payload->early_dispatch_state.load(), PTO2_EARLY_DISPATCH_NONE);
+    EXPECT_EQ(queue.size(), queue.capacity);
+
+    // A sync_start cohort that never reached its drain falls back to the
+    // shape's sync ready queue, not the plain one.
+    PTO2ResourceShape shape = consumer.active_mask.to_shape();
+    EXPECT_TRUE(sched.route_ready_once(consumer));
+    EXPECT_EQ(sched.ready_sync_queues[static_cast<int32_t>(shape)].pop(), &consumer);
+}


### PR DESCRIPTION
## Summary

Two commits:

1. **`Fix: preserve early dispatch on queue overflow`** (@sjduan) — raises the a2a3 per-shape early-dispatch candidate queue from 64 to 256, and rolls a candidate from `STAGING` back to `NONE` when its initial queue publication fails.
2. **`Fix: end the early-dispatch batch re-push instead of spinning on a full queue`** — gives `push_batch_tagged` a queue-full exit, splits its two callers by whether dropping loses the task, extends the first commit's fix to a5, and adds the regression tests.

## Root cause

`PTO2ReadyQueue::push_batch_tagged` treated every non-zero Vyukov sequence delta as transient and retried, so **a full queue spun the calling AICPU scheduler thread with no exit**. `push_tagged` already separates the two cases; the batch variant now does the same — a slot still holding an older generation reports full, and only a slot a peer has reserved but not yet published retries. A `count` above capacity can never be satisfied and reports full immediately.

The early-dispatch drain reaches that path when it hands back candidates it popped but could not stage, which is what a 128-candidate burst into a 64-entry queue produces.

Dropping those candidates is safe and costs only the pre-staging: `try_early_dispatch_release` rings whatever is already staged and sends the remaining blocks to the ready queue. The ready-queue push-back has no second owner and a drop would lose the task, so it keeps retrying — now visibly at the call site rather than hidden inside the queue.

### Correction to the original analysis

The original description said an unqueued candidate "could therefore remain in a speculative state without an early-dispatch drain owning it." **That does not happen.** `try_early_dispatch_release` returns on `next_block_idx` rather than on the claim state (`pto_scheduler.h:1085`), so a candidate left at `STAGING` is still recovered. Driving a task into exactly that state and releasing it lands it in `ready_queues` with `early_dispatch_state == DISPATCHED`; `EarlyDispatchQueueOverflowFallsBackToNormalDispatch` now pins that down.

This also reads the original diagnostic differently. Capacity 64 + rollback passing 96 tokens but still stalling at 128 is not "both halves are needed" — it is the capacity doing the work, because at 128 the queue fills and the batch re-push spins. The `STAGING` → `NONE` rollback stands on its own as state hygiene (a task holding no claim should not read as speculatively claimed), but it is not what unblocked the workload.

## a5

`src/a5/runtime/tensormap_and_ringbuffer` carried the identical unchecked candidate push and the same 64-entry queue, and its early dispatch is live. Per `.claude/rules/codestyle.md` §10 the sibling arch trees move together, so it gets both halves. The two `host_build_graph` trees have the drain but never enqueue candidates, so only their `push_batch_tagged` changes.

## Testing

| Suite | Result |
| ----- | ------ |
| `ctest -LE requires_hardware` | 100/100 |
| a2a3 sim (`examples tests/st --platform a2a3sim`) | 45/45 |
| a5 sim (`examples tests/st --platform a5sim`) | 37/37 |
| a2a3 onboard (`-m 'not sdma' --exclude-level 4`, device-locked) | 56/56 on 3 of 4 runs; see flake below |
| pre-commit | pass |

New cases in both `tests/ut/cpp/a2a3/test_wiring.cpp` and `tests/ut/cpp/a5/test_wiring.cpp`: `BatchPushReportsFullInsteadOfSpinning`, `BatchPushSucceedsAfterSpaceIsReclaimed`, `EarlyDispatchQueueOverflowFallsBackToNormalDispatch`, `EarlyDispatchSyncStartQueueOverflowFallsBackToSyncReadyQueue`. The original a2a3 case is renamed `EarlyDispatchQueueOverflowRollsBackStagingClaim`, since it asserts the rollback rather than the fallback its name claimed, and the `sync_start` branch it also changed had no coverage.

### Pre-existing onboard flake, not from this PR

The a2a3 onboard sweep intermittently fails 1–3 cases with an AICore `VEC instruction error: the ub address out of bounds` surfacing as `507018`. No allocator/pool fatal, no producer/consumer `Timeout (N cycles)` and no `HandleTaskTimeout` accompany it, so per `.claude/rules/running-onboard.md` it is a kernel addressing fault, not a deadlock or a capacity bug. The affected case varies per run and every one passes when run alone.

3 of 7 device-locked sweeps hit it. It reproduces on `main` + the first commit alone, without the `push_batch_tagged` work, and it also hits `host_build_graph` cases — that runtime never enqueues early-dispatch candidates, so the early-dispatch path is not implicated. Flagged rather than fixed here.
