### PR TITLE
Add: A5 benchmark cases across graph runtimes

### DIFF
--- a/examples/a5/host_build_graph/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a5/host_build_graph/benchmark_bgemm/test_benchmark_bgemm.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Benchmark BGEMM on A5 with the host-build-graph runtime."""
+
+import ctypes
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+KERNEL_CASE = "../../tensormap_and_ringbuffer/benchmark_bgemm"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestBenchmarkBgemmHostBuildGraph(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNEL_CASE}/kernels/orchestration/bgemm_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "GEMM",
+                "source": f"{KERNEL_CASE}/kernels/aic/kernel_gemm_tile.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "ADD",
+                "source": f"{KERNEL_CASE}/kernels/aiv/kernel_tile_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT, D.IN],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case0",
+            "platforms": ["a5"],
+            "params": {"matmul_add_task_num": 500, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
+        },
+    ]
+
+    def generate_args(self, params):
+        tile_size = params["incore_data_size"]
+        incore_loop = params["incore_loop"]
+        grid_k = params["grid_k"]
+        num_groups = params["matmul_add_task_num"] // grid_k
+        A = torch.randn(num_groups, grid_k, incore_loop, tile_size, tile_size, dtype=torch.float32) * 0.01
+        B = torch.randn(num_groups, grid_k, incore_loop, tile_size, tile_size, dtype=torch.float32) * 0.01
+        C = torch.zeros(incore_loop * num_groups, tile_size, tile_size, dtype=torch.float32)
+        return TaskArgsBuilder(
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            Scalar("tile_size", ctypes.c_int64(tile_size)),
+            Scalar("grid_k", ctypes.c_int64(grid_k)),
+            Scalar("num_groups", ctypes.c_int64(num_groups)),
+            Scalar("incore_loop", ctypes.c_int64(incore_loop)),
+        )
+
+    def compute_golden(self, args, params):
+        tile_size = params["incore_data_size"]
+        incore_loop = params["incore_loop"]
+        grid_k = params["grid_k"]
+        num_groups = params["matmul_add_task_num"] // grid_k
+        A = args.A.reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+        B = args.B.reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+        C = args.C.reshape(incore_loop * num_groups, tile_size, tile_size)
+        C[:] = 0.0
+        for group in range(num_groups):
+            for k_idx in range(grid_k):
+                for i in range(incore_loop):
+                    C[group * incore_loop + i] += torch.matmul(A[group, k_idx, i], B[group, k_idx, i])
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/examples/a5/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a5/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Paged attention manual-scope benchmark for the host-build-graph runtime."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
+from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
+
+TMR_CASE = "../../tensormap_and_ringbuffer/paged_attention_unroll_manual_scope"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestPagedAttentionUnrollManualScopeHostBuildGraph(SceneTestCase):
+    """Paged attention unroll manual-scope variant on A5."""
+
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/paged_attention_orch.cpp",
+            "function_name": "build_paged_attention_graph",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "QK",
+                "source": f"{TMR_CASE}/kernels/aic/aic_qk_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "name": "PV",
+                "source": f"{TMR_CASE}/kernels/aic/aic_pv_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SF",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_softmax_prepare.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT, D.OUT, D.OUT],
+            },
+            {
+                "func_id": 3,
+                "name": "UP",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_online_update.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.INOUT, D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a5"],
+            "params": {
+                "batch": 256,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a5"],
+            "manual": True,
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+    ]
+
+    def generate_args(self, params):
+        inputs = _pa_generate_inputs(params)
+        specs = []
+        for name, val in inputs:
+            if isinstance(val, torch.Tensor):
+                specs.append(TensorArg(name, val))
+            else:
+                specs.append(Scalar(name, val))
+        return TaskArgsBuilder(*specs)
+
+    def compute_golden(self, args, params):
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
+        _pa_compute_golden(tensors, params)
+        for s in args.specs:
+            if isinstance(s, TensorArg) and s.name in tensors:
+                getattr(args, s.name)[:] = tensors[s.name]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Tile-based Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: output = input_a @ input_b (tile_size x tile_size tile matmul)
+ *
+ * Args (ChipTensor*):
+ *   args[0] = input_a (INPUT)
+ *   args[1] = input_b (INPUT)
+ *   args[2] = output  (OUTPUT)
+ *
+ * The A5 Case0 kernel uses 128 x 128 tiles and derives the tile count from the
+ * ChipTensor view created by orchestration.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+#include "pipe_sync.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+static __aicore__ inline int get_num_tiles(__gm__ ChipTensor *tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
+template <int TILE>
+static __aicore__ void gemm_tile_impl(__gm__ float *input_a, __gm__ float *input_b, __gm__ float *output) {
+    constexpr int blockAlign = pto::C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = pto::GlobalTensor<
+        float, pto::Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = pto::GlobalTensor<
+        float, pto::Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = pto::GlobalTensor<
+        float, pto::Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA =
+        pto::Tile<pto::TileType::Mat, float, M, K, pto::BLayout::ColMajor, TILE, TILE, pto::SLayout::RowMajor, 512>;
+    using TileMatB =
+        pto::Tile<pto::TileType::Mat, float, K, N, pto::BLayout::ColMajor, TILE, TILE, pto::SLayout::RowMajor, 512>;
+    using LeftTile = pto::TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = pto::TileRight<float, K, N, TILE, TILE>;
+    using AccTile = pto::TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+
+    pipe_sync();
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *input_a = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *input_b = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+    __gm__ ChipTensor *output = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
+    constexpr uint64_t TILE_ELEMS = 128 * 128;
+    int num_tiles = get_num_tiles(input_a, TILE_ELEMS);
+
+    __gm__ float *base_a = reinterpret_cast<__gm__ float *>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float *base_b = reinterpret_cast<__gm__ float *>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(output->buffer.addr) + output->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float *a_ptr = base_a + (tile_idx * TILE_ELEMS);
+        __gm__ float *b_ptr = base_b + (tile_idx * TILE_ELEMS);
+        __gm__ float *c_ptr = base_c + (tile_idx * TILE_ELEMS);
+
+        gemm_tile_impl<128>(a_ptr, b_ptr, c_ptr);
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
+ *
+ * Computes: C_tile = C_tile + P (tile_size x tile_size tile accumulation)
+ *
+ * Args (ChipTensor*):
+ *   args[0] = C_tile (INOUT: read + write accumulator)
+ *   args[1] = P      (INPUT: matmul result to accumulate)
+ *
+ * The A5 Case0 kernel uses 128 x 128 tiles and derives the tile count from the
+ * ChipTensor view created by orchestration.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+#include "tensor.h"
+
+#include "pipe_sync.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static __aicore__ inline int get_num_tiles(__gm__ ChipTensor *tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
+template <int TILE>
+static __aicore__ void tile_add_impl(__gm__ float *c_ptr, __gm__ float *p_ptr) {
+    using DynShapeDim5 = pto::Shape<1, 1, 1, TILE, TILE>;
+    using DynStridDim5 = pto::Stride<1, 1, 1, TILE, 1>;
+    using GlobalData = pto::GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = pto::Tile<pto::TileType::Vec, float, TILE, TILE, pto::BLayout::RowMajor, -1, -1>;
+
+    TileData cTile(TILE, TILE);
+    TileData pTile(TILE, TILE);
+    TileData outTile(TILE, TILE);
+    TASSIGN(cTile, 0x0);
+    TASSIGN(pTile, 0x10000);
+    TASSIGN(outTile, 0x20000);
+
+    GlobalData cGlobal(c_ptr);
+    GlobalData pGlobal(p_ptr);
+    GlobalData outGlobal(c_ptr);
+
+    TLOAD(cTile, cGlobal);
+    TLOAD(pTile, pGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(outTile, cTile, pTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outGlobal, outTile);
+    pipe_sync();
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *c_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *p_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+    constexpr uint64_t TILE_ELEMS = 128 * 128;
+    int num_tiles = get_num_tiles(c_tensor, TILE_ELEMS);
+
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float *base_p = reinterpret_cast<__gm__ float *>(p_tensor->buffer.addr) + p_tensor->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float *c_ptr = base_c + (tile_idx * TILE_ELEMS);
+        __gm__ float *p_ptr = base_p + (tile_idx * TILE_ELEMS);
+
+        tile_add_impl<128>(c_ptr, p_ptr);
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * A5 benchmark BGEMM orchestration.
+ *
+ * The topology parameters are scalar orchestration arguments. The fixed-size
+ * A5 incore kernels derive incore_loop from their tensor views.
+ *
+ * Arg layout: [A, B, C, tile_size, grid_k, num_groups, incore_loop]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_GEMM_TILE 0
+#define FUNC_TILE_ADD 1
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    const ChipTensor &ext_A = orch_args.tensor(0).ref();
+    const ChipTensor &ext_B = orch_args.tensor(1).ref();
+    const ChipTensor &ext_C = orch_args.tensor(2).ref();
+
+    int tile_size = static_cast<int>(orch_args.scalar(0));
+    int grid_k = static_cast<int>(orch_args.scalar(1));
+    int num_groups = static_cast<int>(orch_args.scalar(2));
+    int incore_loop = static_cast<int>(orch_args.scalar(3));
+    uint64_t tile_elems = static_cast<uint64_t>(tile_size) * tile_size;
+
+    LOG_INFO(
+        "[bgemm_orch] tile_size: %d, grid_k: %d, num_groups: %d, incore_loop: %d", tile_size, grid_k, num_groups,
+        incore_loop
+    );
+
+    uint64_t group_tile_elems = static_cast<uint64_t>(incore_loop) * tile_elems;
+    uint32_t group_shapes[1] = {static_cast<uint32_t>(group_tile_elems)};
+    TensorCreateInfo group_ci(group_shapes, 1, DataType::FLOAT32);
+
+    int total_gemm = 0;
+    int total_add = 0;
+
+    for (int group_idx = 0; group_idx < num_groups; group_idx++) {
+        PTO2_SCOPE_GUARD();
+
+        uint32_t c_elem_offset = static_cast<uint32_t>(static_cast<uint64_t>(group_idx) * group_tile_elems);
+        uint32_t c_view_offsets[1] = {c_elem_offset};
+        ChipTensor C_view = ext_C.view(group_shapes, c_view_offsets);
+
+        for (int k_idx = 0; k_idx < grid_k; k_idx++) {
+            uint64_t ab_offset =
+                (static_cast<uint64_t>(group_idx) * grid_k + static_cast<uint64_t>(k_idx)) * group_tile_elems;
+
+            uint32_t a_view_offsets[1] = {static_cast<uint32_t>(ab_offset)};
+            ChipTensor A_view = ext_A.view(group_shapes, a_view_offsets);
+            uint32_t b_view_offsets[1] = {static_cast<uint32_t>(ab_offset)};
+            ChipTensor B_view = ext_B.view(group_shapes, b_view_offsets);
+
+            CoreTaskArgs params_gemm;
+            params_gemm.add_input(A_view);
+            params_gemm.add_input(B_view);
+            params_gemm.add_output(group_ci);
+            TaskOutputTensors gemm_outs = rt_submit_aic_task(FUNC_GEMM_TILE, params_gemm);
+            total_gemm++;
+
+            CoreTaskArgs params_add;
+            params_add.add_inout(C_view);
+            params_add.add_input(gemm_outs.get_ref(0));
+            rt_submit_aiv_task(FUNC_TILE_ADD, params_add);
+            total_add++;
+        }
+    }
+
+    LOG_INFO(
+        "[bgemm_orch] Submitted %d gemm tasks and %d add tasks (%d total)", total_gemm, total_add,
+        total_gemm + total_add
+    );
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Benchmark BGEMM on A5 with the tensormap-and-ringbuffer runtime."""
+
+import ctypes
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestBenchmarkBgemm(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/bgemm_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "GEMM",
+                "source": "kernels/aic/kernel_gemm_tile.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "ADD",
+                "source": "kernels/aiv/kernel_tile_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT, D.IN],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case0",
+            "platforms": ["a5"],
+            "params": {"matmul_add_task_num": 500, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
+        }
+    ]
+
+    def generate_args(self, params):
+        tile_size = params["incore_data_size"]
+        incore_loop = params["incore_loop"]
+        grid_k = params["grid_k"]
+        num_groups = params["matmul_add_task_num"] // grid_k
+        A = torch.randn(num_groups, grid_k, incore_loop, tile_size, tile_size, dtype=torch.float32) * 0.01
+        B = torch.randn(num_groups, grid_k, incore_loop, tile_size, tile_size, dtype=torch.float32) * 0.01
+        C = torch.zeros(incore_loop * num_groups, tile_size, tile_size, dtype=torch.float32)
+        return TaskArgsBuilder(
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            Scalar("tile_size", ctypes.c_int64(tile_size)),
+            Scalar("grid_k", ctypes.c_int64(grid_k)),
+            Scalar("num_groups", ctypes.c_int64(num_groups)),
+            Scalar("incore_loop", ctypes.c_int64(incore_loop)),
+        )
+
+    def compute_golden(self, args, params):
+        tile_size = params["incore_data_size"]
+        incore_loop = params["incore_loop"]
+        grid_k = params["grid_k"]
+        num_groups = params["matmul_add_task_num"] // grid_k
+        A = args.A.reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+        B = args.B.reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+        C = args.C.reshape(incore_loop * num_groups, tile_size, tile_size)
+        C[:] = 0.0
+        for group in range(num_groups):
+            for k_idx in range(grid_k):
+                for i in range(incore_loop):
+                    C[group * incore_loop + i] += torch.matmul(A[group, k_idx, i], B[group, k_idx, i])
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/alternating_matmul_add/test_alternating_matmul_add.py
+++ b/tests/st/a5/host_build_graph/alternating_matmul_add/test_alternating_matmul_add.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Alternating matmul + add benchmark for the host-build-graph runtime."""
+
+import ctypes
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+TMR_CASE = "../../tensormap_and_ringbuffer/alternating_matmul_add"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestAlternatingMatmulAddHostBuildGraph(SceneTestCase):
+    """Alternating matmul + add with scalar parameters."""
+
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/alternating_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{TMR_CASE}/kernels/aic/kernel_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{TMR_CASE}/kernels/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a5sim", "a5"],
+            "params": {"batch": 1, "M": 1, "N": 1, "matmul_batch": 1, "add_batch": 1},
+        },
+        {
+            "name": "Case1",
+            "platforms": ["a5"],
+            "params": {"batch": 500, "M": 4, "N": 4, "matmul_batch": 4, "add_batch": 4},
+            "manual": True,
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a5"],
+            "params": {"batch": 512, "M": 2, "N": 5, "matmul_batch": 4, "add_batch": 5},
+            "manual": True,
+        },
+    ]
+
+    def generate_args(self, params):
+        batch = params["batch"]
+        M = params["M"]
+        N = params["N"]
+        matmul_batch = params.get("matmul_batch", 1)
+        add_batch = params.get("add_batch", 1)
+        matmul_size = 128
+        add_rows = 128
+        add_cols = 128
+
+        torch.manual_seed(42)
+        A = torch.randn(batch, M, matmul_size, matmul_size, dtype=torch.float32) * 0.01
+        B = torch.randn(batch, M, matmul_size, matmul_size, dtype=torch.float32) * 0.01
+        C = torch.zeros(batch, M, matmul_size, matmul_size, dtype=torch.float32)
+        X = torch.randn(batch, N, add_rows, add_cols, dtype=torch.float32) * 0.01
+        Y = torch.randn(batch, N, add_rows, add_cols, dtype=torch.float32) * 0.01
+        Z = torch.zeros(batch, N, add_rows, add_cols, dtype=torch.float32)
+
+        return TaskArgsBuilder(
+            TensorArg("A", A.flatten()),
+            TensorArg("B", B.flatten()),
+            TensorArg("C", C.flatten()),
+            TensorArg("X", X.flatten()),
+            TensorArg("Y", Y.flatten()),
+            TensorArg("Z", Z.flatten()),
+            Scalar("batch", ctypes.c_int64(batch)),
+            Scalar("M_val", ctypes.c_int64(M)),
+            Scalar("N_val", ctypes.c_int64(N)),
+            Scalar("matmul_batch", ctypes.c_int64(matmul_batch)),
+            Scalar("add_batch", ctypes.c_int64(add_batch)),
+        )
+
+    def compute_golden(self, args, params):
+        batch = params["batch"]
+        M = params["M"]
+        N = params["N"]
+        matmul_size = 128
+        add_rows = 128
+        add_cols = 128
+
+        A = args.A.reshape(batch, M, matmul_size, matmul_size)
+        B = args.B.reshape(batch, M, matmul_size, matmul_size)
+        C = args.C.reshape(batch, M, matmul_size, matmul_size)
+        X = args.X.reshape(batch, N, add_rows, add_cols)
+        Y = args.Y.reshape(batch, N, add_rows, add_cols)
+        Z = args.Z.reshape(batch, N, add_rows, add_cols)
+
+        for b in range(batch):
+            for m in range(M):
+                C[b, m] = torch.matmul(A[b, m], B[b, m])
+        for b in range(batch):
+            for n in range(N):
+                Z[b, n] = X[b, n] + Y[b, n]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a5/host_build_graph/batch_paged_attention/test_batch_paged_attention.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Batch paged attention benchmark for the host-build-graph runtime."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
+from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
+
+TMR_CASE = "../../tensormap_and_ringbuffer/batch_paged_attention"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestBatchPagedAttentionHostBuildGraph(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/paged_attention_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "QK",
+                "source": f"{TMR_CASE}/kernels/aic/aic_qk_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SF",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_softmax_prepare.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT, D.OUT, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "name": "PV",
+                "source": f"{TMR_CASE}/kernels/aic/aic_pv_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 3,
+                "name": "UP",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_online_update.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.INOUT, D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a5"],
+            "config": {"runtime_env": {"ring_heap": 512 * 1024 * 1024}},
+            "params": {
+                "batch": 256,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a5"],
+            "manual": True,
+            "config": {"runtime_env": {"ring_heap": 512 * 1024 * 1024}},
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+    ]
+
+    def generate_args(self, params):
+        result = _pa_generate_inputs(params)
+        specs = []
+        for name, value in result:
+            if isinstance(value, torch.Tensor):
+                specs.append(TensorArg(name, value))
+            else:
+                specs.append(Scalar(name, value))
+        return TaskArgsBuilder(*specs)
+
+    def compute_golden(self, args, params):
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
+        _pa_compute_golden(tensors, params)
+        for s in args.specs:
+            if isinstance(s, TensorArg) and s.name in tensors:
+                getattr(args, s.name)[:] = tensors[s.name]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Paged attention unroll benchmark for the host-build-graph runtime."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
+from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
+
+TMR_CASE = "../../tensormap_and_ringbuffer/paged_attention_unroll"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{TMR_CASE}/kernels/orchestration/paged_attention_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "QK",
+                "source": f"{TMR_CASE}/kernels/aic/aic_qk_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SF",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_softmax_prepare.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT, D.OUT, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "name": "PV",
+                "source": f"{TMR_CASE}/kernels/aic/aic_pv_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 3,
+                "name": "UP",
+                "source": f"{TMR_CASE}/kernels/aiv/aiv_online_update.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.INOUT, D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a5"],
+            "params": {
+                "batch": 256,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case2",
+            "platforms": ["a5"],
+            "manual": True,
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+    ]
+
+    def generate_args(self, params):
+        result = _pa_generate_inputs(params)
+        specs = []
+        for name, value in result:
+            if isinstance(value, torch.Tensor):
+                specs.append(TensorArg(name, value))
+            else:
+                specs.append(Scalar(name, value))
+        return TaskArgsBuilder(*specs)
+
+    def compute_golden(self, args, params):
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
+        _pa_compute_golden(tensors, params)
+        for s in args.specs:
+            if isinstance(s, TensorArg) and s.name in tensors:
+                getattr(args, s.name)[:] = tensors[s.name]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

- Add A5 host-build-graph scene cases for the non-Qwen benchmark workloads.
- Add the actual `benchmark_bgemm/Case0` workload to A5 TMR and HBG, using A5-specific fixed-128-tile kernels and scalar topology arguments.
- Reuse each existing A5 TMR orchestration and incore source for the other HBG counterparts.
- Keep the change limited to case migration: no runtime, harness, skill, metric, or A2/A3 changes.

Related to #1727.

## Coverage matrix

| Benchmark workload | A3 TMR | A3 HBG | A5 TMR | A5 HBG |
| --- | --- | --- | --- | --- |
| `alternating_matmul_add` | `Case1` | `Case1` | `Case1` | `Case1` (new) |
| `benchmark_bgemm` | `Case0` | `Case0` | `Case0` (new) | `Case0` (new) |
| `paged_attention_unroll` | `Case1`, `Case2` | `Case1`, `Case2` | `Case1`, `Case2` | `Case1`, `Case2` (new) |
| `paged_attention_unroll_manual_scope` | `Case1`, `Case2` | `Case1`, `Case2` | `Case1`, `Case2` | `Case1`, `Case2` (new) |
| `batch_paged_attention` | `Case1` | `Case1` | `Case1` | `Case1` (new) |
| `qwen3_14b_decode` | `StressBatch16Seq3500` | × | × | × |
| `spmd_paged_attention` | `Case1`, `Case2` | × | × | × |

The five included workloads have full A3/A5 × TMR/HBG case coverage. `×` marks a counterpart that is not present in the current tree or this PR:

- `qwen3_14b_decode`: excluded by request.
- `spmd_paged_attention`: excluded from this PR and left for follow-up.

## A5 BGEMM details

- Preserves the A3 `benchmark_bgemm/Case0` shape: 500 matmul tasks, 500 add tasks, tile size 128, `incore_loop=4`, and `grid_k=2`.
- Uses A5-specific AIC/AIV kernels because the A2/A3 kernels are not directly reusable on A5.
- Supplies graph-topology values as scalar orchestration arguments. A5 HBG builds the graph on the host, so it must not directly dereference a config tensor's device address.
- The A5 HBG test references the A5 TMR kernel and orchestration sources.

## Validation

- A5 hardware (`a5new`), all NPU access through `task-submit --device auto`:
  - `benchmark_bgemm/Case0` TMR + golden: passed (`task_20260813_113257_36868417320`)
  - `benchmark_bgemm/Case0` HBG + golden: passed (`task_20260813_113313_3713652657`)
  - Remaining four workloads: default HBG/TMR sweep 4/4 + 4/4; selected manual benchmark cases 3/3 + 3/3.
- A5 lock-free scene compilation: 6/6 classes passed on the rebased tree.
- `pre-commit` passed: headers, platform literals, clang-format, cpplint, ruff, pyright, and whitespace checks.
- `git diff --check` passed.
