### PR TITLE
Add: run Qwen3-14B decode with host graph execution

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,8 +48,10 @@ examples/
 ├── workers/                      # raw Worker API, organized by level
 │   ├── l2/                       #   one chip
 │   └── l3/                       #   one host, several chips (+ SubWorkers)
-├── a2a3/tensormap_and_ringbuffer/   # @scene_test kernels, a2a3
-└── a5/tensormap_and_ringbuffer/     # @scene_test kernels, a5
+├── a2a3/
+│   ├── host_build_graph/            # @scene_test host-built graphs, a2a3
+│   └── tensormap_and_ringbuffer/    # @scene_test device orchestration, a2a3
+└── a5/tensormap_and_ringbuffer/     # @scene_test device orchestration, a5
 ```
 
 An example directory holds its test file, a `kernels/` tree (`aic/`, `aiv/`,

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/README.md
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/README.md
@@ -1,0 +1,46 @@
+# Qwen3-14B 40-layer decode with Graph Execution
+
+This scene runs the complete Qwen3-14B decoder stack with the
+`host_build_graph` runtime. It reuses the kernels, fixture, and golden from the
+[`tensormap_and_ringbuffer` case](../../tensormap_and_ringbuffer/qwen3_14b_decode/README.md),
+but records one decoder layer as a Graph and replays it for the remaining 39.
+
+## Graph shape
+
+The invocation contains a short ordinary prefix, 40 Graph submissions, and a
+short ordinary suffix:
+
+```text
+paged-attention tiling + input preparation
+  -> layer 0: record decoder DAG off the ring, submit one GRAPH task
+  -> layers 1..39: reuse the cached Definition, submit one GRAPH task each
+  -> copy final hidden state to output
+```
+
+Every replay updates the current layer's weights, KV cache, hidden state, and
+scratch addresses while preserving the recorded boundary contract. See the
+[`Graph Execution` documentation](../../../../src/a2a3/runtime/host_build_graph/docs/GRAPH_EXECUTION.md)
+for that contract.
+
+## Temporary storage
+
+The orchestration allocates Graph boundary storage before recording:
+
+- two hidden-state and normalized-state slots are used as a ping-pong pair;
+- one BF16 and one FP32 scratch arena are shared by every layer;
+- the decoder dependency chain and shared inout workspace serialize Graph
+  execution, so a later layer cannot overwrite storage still used by an
+  earlier layer.
+
+This keeps the temporary live set flat in layer count and fits the default ring
+configuration.
+
+## Run
+
+```bash
+.claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
+task-submit --device auto --device-num 1 --run \
+  ".venv/bin/python -m pytest \
+  examples/a2a3/host_build_graph/qwen3_14b_decode \
+  --platform a2a3 --device \$TASK_DEVICE"
+```

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -109,8 +109,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const ChipTensor &pa_workspace = alloc_0.get_ref(1);
         const ChipTensor &cur = alloc_0.get_ref(2);
         const ChipTensor &normed = alloc_0.get_ref(3);
-        int64_t pa_num_layers = 3;
-        int64_t pa_num_pages = (KV_CACHE_ROWS_DYN / (pa_num_layers * 1024));
+        constexpr uint32_t num_layers = 40;
+        int64_t pa_num_pages = (KV_CACHE_ROWS_DYN / (num_layers * 1024));
         int64_t pa_max_blocks = (BLOCK_TABLE_FLAT_DYN / 16);
         int32_t pa_num_pages_i32 = static_cast<int32_t>(pa_num_pages);
         int32_t pa_max_blocks_i32 = static_cast<int32_t>(pa_max_blocks);
@@ -183,28 +183,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         uint32_t next_normed_ci_shapes[2] = {16, 5120};
         TensorCreateInfo next_normed_ci(next_normed_ci_shapes, 2, DataType::BFLOAT16);
 
-        // Allocate all per-layer boundary and scratch storage before recording.
-        // This keeps replay iterations to one Graph submit each.
+        // The decoder dependency chain serializes Graphs, so every layer shares
+        // scratch storage and ping-pongs between two hidden-state slots.
         TaskOutputTensors layer_storage = alloc_tensors(
-            next_hidden_ci, next_normed_ci, bf16_scratch_ci, fp32_scratch_ci, next_hidden_ci, next_normed_ci,
-            bf16_scratch_ci, fp32_scratch_ci, next_hidden_ci, next_normed_ci, bf16_scratch_ci, fp32_scratch_ci
+            next_hidden_ci, next_normed_ci, next_hidden_ci, next_normed_ci, bf16_scratch_ci, fp32_scratch_ci
         );
-        for (int64_t i = 0; i < 3; i += 1) {
+        for (uint32_t layer = 0; layer < num_layers; layer += 1) {
             PTO2_SCOPE() {
-                const uint32_t layer = static_cast<uint32_t>(i);
-                const uint32_t storage_base = layer * 4;
+                const uint32_t storage_base = (layer % 2) * 2;
                 const ChipTensor &next_hidden = layer_storage.get_ref(storage_base);
                 const ChipTensor &next_normed = layer_storage.get_ref(storage_base + 1);
-                const ChipTensor &bf16_scratch = layer_storage.get_ref(storage_base + 2);
-                const ChipTensor &fp32_scratch = layer_storage.get_ref(storage_base + 3);
+                const ChipTensor &bf16_scratch = layer_storage.get_ref(4);
+                const ChipTensor &fp32_scratch = layer_storage.get_ref(5);
                 auto layer_view = [](const ChipTensor &tensor, uint32_t layer_index, uint32_t rows) {
                     uint32_t offsets[2] = {layer_index * rows, 0};
                     uint32_t shapes[2] = {rows, tensor.shapes[1]};
                     return tensor.view(shapes, offsets);
                 };
-                const uint32_t cache_rows = ext_k_cache.shapes[0] / 3;
+                const uint32_t cache_rows = ext_k_cache.shapes[0] / num_layers;
                 ChipTensor next_input_rms_weight =
-                    layer_view(ext_input_rms_weight, std::min<uint32_t>(layer + 1, 2), 1);
+                    layer_view(ext_input_rms_weight, std::min<uint32_t>(layer + 1, num_layers - 1), 1);
                 ChipTensor wq = layer_view(ext_wq, layer, 5120);
                 ChipTensor wk = layer_view(ext_wk, layer, 5120);
                 ChipTensor wv = layer_view(ext_wv, layer, 5120);
@@ -2066,7 +2064,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t34.set_dependencies(params_t34_deps, params_t34_deps_count);
                     rt_submit_aiv_task(35, params_t34);
                 };
-                rt_submit_graph(GRAPH_KEY("qwen3_14b_decoder_layer_v1"), +layer_definition, graph_args);
+                rt_submit_graph(+layer_definition, graph_args);
                 ChipTensor cur__ssa_v8 = next_hidden;
                 ChipTensor normed__ssa_v6 = next_normed;
                 cur__rv_v7 = cur__ssa_v8;

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -7,14 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Qwen3-14B three-layer decode coverage for host-built Graph Execution.
-
-Layer 0 records and executes the decoder-layer task graph. Layers 1 and 2 submit
-one Graph task each; the scheduler expands the saved topology and applies the
-new layer's boundary tensors.
-"""
-
-from __future__ import annotations
+"""Qwen3-14B 40-layer decode using one recorded host-built Graph per layer."""
 
 import copy
 import importlib.util
@@ -25,15 +18,14 @@ from simpler_setup import SceneTestCase, scene_test
 from simpler_setup.goldens.qwen3_14b_decode import compute_golden as _decode_golden
 from simpler_setup.goldens.qwen3_14b_decode import generate_inputs as _decode_generate_inputs
 
-N_LAYERS = 3
+N_LAYERS = 40
 HERE = Path(__file__).resolve().parent
-REPO_ROOT = HERE.parents[4]
-QWEN_DIR = REPO_ROOT / "examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode"
+QWEN_CASE_DIR = HERE.parents[1] / "tensormap_and_ringbuffer/qwen3_14b_decode"
 
 
 def _load_qwen_case():
-    module_name = "_qwen3_14b_graph_execution_base"
-    spec = importlib.util.spec_from_file_location(module_name, QWEN_DIR / "test_qwen3_14b_decode.py")
+    module_name = "_qwen3_14b_host_build_graph_base"
+    spec = importlib.util.spec_from_file_location(module_name, QWEN_CASE_DIR / "test_qwen3_14b_decode.py")
     if spec is None or spec.loader is None:
         raise RuntimeError("cannot load the Qwen3-14B decode case")
     module = importlib.util.module_from_spec(spec)
@@ -44,14 +36,14 @@ def _load_qwen_case():
 
 def _callable():
     callable_cfg = copy.deepcopy(_load_qwen_case().CALLABLE)
-    callable_cfg["orchestration"]["source"] = str(HERE / "kernels/orchestration/qwen3_14b_3layer_graph_execution.cpp")
+    callable_cfg["orchestration"]["source"] = str(HERE / "kernels/orchestration/decode_fwd_layers.cpp")
     for incore in callable_cfg["incores"]:
-        incore["source"] = str(QWEN_DIR / incore["source"])
+        incore["source"] = str(QWEN_CASE_DIR / incore["source"])
     return callable_cfg
 
 
 @scene_test(level=2, runtime="host_build_graph")
-class TestQwen314B3LayerGraphExecution(SceneTestCase):
+class TestQwen314BDecodeHostBuildGraph(SceneTestCase):
     RTOL = 5e-2
     ATOL = 1e-1
     CALLABLE = _callable()
@@ -61,9 +53,6 @@ class TestQwen314B3LayerGraphExecution(SceneTestCase):
             "name": "GraphExecutionBatch16Seq3500",
             "platforms": ["a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 0},
-            # The three-layer fixture is about 3 GiB and compiles the complete
-            # Qwen decoder kernel set, so keep it out of routine CI.
-            "manual": True,
             "params": {"seed": 1234, "seq_len": 3500},
         },
     ]

--- a/src/a2a3/runtime/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/a2a3/runtime/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -380,6 +380,8 @@ With L2 swimlane level 4:
 
 The scene coverage under `tests/st/a2a3/host_build_graph/graph_execution`
 includes an AIV fanin/fanout DAG, a Qwen-style AIV/AIC decoder-layer DAG, a
-three-slot multi-block MIX/SPMD Graph, and a manual Qwen3-14B three-layer
-decode. Every scene invokes the same fixed Graph three times: one recording
-execution followed by two outer-Graph submissions.
+three-slot multi-block MIX/SPMD Graph. Every scene invokes the same fixed Graph
+three times: one recording execution followed by two outer-Graph submissions.
+The full-model example at `examples/a2a3/host_build_graph/qwen3_14b_decode`
+records one Qwen3-14B decoder layer and replays its Definition for the
+remaining 39 layers.


### PR DESCRIPTION
## Summary

- Promote the A3 host-build-graph Qwen scene to the complete 40-layer decode case.
- Record one decoder layer and replay it with per-layer tensor bindings.
- Reuse the existing A3 kernels, fixture, and golden with flat scratch storage; no A5 changes are included.

## Testing

- [x] Pre-commit hooks pass.
- [x] A3 hardware: `task-submit` + architecture precheck, `1 passed in 101.82s`.