### PR TITLE
Fix: unify host trace clocks and STRACE formatting

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -22,6 +22,25 @@ children share.
 
 ## Marker grammar
 
+Every host log record starts with a `CLOCK_MONOTONIC` nanosecond timestamp:
+
+```text
+[mono_ns=<ns>][T0x<thread>][<level>] <func>: ...
+```
+
+Each process emits one TIMING-level mapping from that clock to wall time when
+its logger starts:
+
+```text
+[CLOCK_ANCHOR] v=1 pid=<pid> mono_ns=<ns> wall_ns=<ns>
+```
+
+For host-clock records, consumers recover an approximate absolute timestamp
+with `wall_ns + record_mono_ns - mono_ns`. Their event ordering and duration
+calculations remain entirely on the monotonic clock and are unaffected by
+wall-clock corrections. Records tagged `clk=dev` use the separate device-clock
+domain described below and do not use this anchor.
+
 One line per span, emitted on scope exit
 (`src/common/log/include/common/strace.h`):
 
@@ -33,7 +52,7 @@ One line per span, emitted on scope exit
 | ----- | ------- |
 | `v` | format version; the parser branches on it. Lets device-side markers align later by reusing the prefix + adding fields. |
 | `pid` `tid` | process / thread id — L3 parent and each L2 child are distinct pids, so they land on separate lanes. |
-| `inv` | process-wide `simpler_run` invocation id (allocated from an atomic, so `(pid, inv)` is unique even across concurrent calls) — **a grouping key only** (gathers one call's spans), NOT a token index. Set once per call. |
+| `inv` | 64-bit process-wide `simpler_run` invocation id (allocated from an atomic, so `(pid, inv)` is unique even across concurrent calls) — **a grouping key only** (gathers one call's spans), NOT a token index. Set once per call. |
 | `hid` | callable content hash (ELF Build-ID 64), stable across slot reuse / processes / runs. The parser buckets by `hid`; the most-frequent bucket is decode (one invocation per token), a once-seen bucket is prefill. |
 | `depth` | thread-local nesting depth (`++` on enter, `--` on exit). The parser rebuilds the call tree from `depth` — **not** from timestamp containment. |
 | `name` | dotted span name (self-locating even without the tree). |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -17,7 +17,7 @@ Python: logging.getLogger("simpler").setLevel(N)
        ChipWorker.init(device_id, bins, level)             ◀── Python wrapper
                   │
        1. ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)  ◀── one HostLogger per process
-       2. simpler_log_init(level)    ──→ HostLogger.set_level
+       2. simpler_log_init(level)    ──→ HostLogger.set_level + clock anchor
                                      (seeds HostLogger BEFORE any host_runtime /
                                       sim_context / aicore SO is dlopen'd, so
                                       any LOG_* macro firing during dlopen-time
@@ -200,11 +200,11 @@ are allowed by default. CMake blocks live in:
 diagnostic on first call. With `--log-level info`:
 
 ```text
-[2026-05-06 ...][T0x...][INFO] pto_cpu_sim_acquire_device: cpu_sim_context.cpp:167] cpu_sim_context: acquired device 0
-[2026-05-06 ...][T0x...][INFO] init_runtime_impl:           runtime_maker.cpp:119] Registering 3 kernel(s) ...
+[mono_ns=...][T0x...][INFO] pto_cpu_sim_acquire_device: cpu_sim_context.cpp:167] cpu_sim_context: acquired device 0
+[mono_ns=...][T0x...][INFO] init_runtime_impl:           runtime_maker.cpp:119] Registering 3 kernel(s) ...
 ```
 
-Both lines carry the same `HostLogger`-formatted prefix (timestamp, thread
+Both lines carry the same `HostLogger`-formatted prefix (monotonic timestamp, thread
 id, level tag), proving that `cpu_sim_context.so` and `host_runtime.so`
 resolve to the same `HostLogger` instance. If singleton sharing were
 broken, `cpu_sim_context.so` would have its own `HostLogger` defaulting to
@@ -215,13 +215,24 @@ TIMING and the INFO diagnostic would be silenced entirely.
 ### Host (`HostLogger::emit`)
 
 ```text
-[YYYY-MM-DD HH:MM:SS.uuuuuu][T0xTID][LEVEL] func: [file.cpp:line] message
+[mono_ns=MONOTONIC_NS][T0xTID][LEVEL] func: [file.cpp:line] message
 ```
 
-Timestamp is local time with microsecond precision; `T0x...` is
-`pthread_self()`. Both prefixes are added before the level/func segments so
-parallel-test stderr from `pytest-xdist` is recoverable via `sort -k1`
-(timestamp) and `grep T0x...` (per-thread).
+The timestamp is `CLOCK_MONOTONIC` (`steady_clock`) in nanoseconds, so it is
+comparable with host `[STRACE]` timestamps and does not jump when wall time is
+corrected. `T0x...` is `pthread_self()`.
+
+The first TIMING-enabled logger initialization in each process emits one
+mapping to wall time:
+
+```text
+[mono_ns=...][T0x...][TIMING] clock_anchor: [CLOCK_ANCHOR] v=1 pid=<pid> mono_ns=<ns> wall_ns=<ns>
+```
+
+For a record at monotonic time `record_ns`, its approximate absolute time is
+`wall_ns + record_ns - mono_ns`. The anchor is a TIMING record so the default
+TIMING threshold keeps it whenever host trace spans are visible. A process
+created by `fork()` emits its own anchor because ownership is keyed by PID.
 
 ### AICPU sim
 

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -50,14 +50,12 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 
-# The host-log record prefix `HostLogger::emit` writes ahead of every message.
-# Its func segment excludes ':' because `LOG_TIMING` passes `__FUNCTION__`, an
-# unqualified name; a qualified name containing '::' would stop this alternative
-# from matching, leaving the `[STRACE]` alternative to bound the record instead.
-_HOST_LOG_PREFIX = (
-    r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\]"
-    r"\[T0x[0-9a-fA-F]+\]\[[A-Z]+\]\s+[^:\r\n]+:\s+"
-)
+# The monotonic prefix is current; the wall-clock form keeps archived logs
+# parseable. The func segment excludes ':' because `LOG_TIMING` passes
+# `__FUNCTION__`, an unqualified name. A qualified name containing '::' stops
+# this alternative from matching, leaving `[STRACE]` to bound the record.
+_HOST_LOG_TIME = r"(?:\[mono_ns=\d+\]|\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\])"
+_HOST_LOG_PREFIX = _HOST_LOG_TIME + r"\[T0x[0-9a-fA-F]+\]\[[A-Z]+\]\s+[^:\r\n]+:\s+"
 # MULTILINE anchors the `$` alternative at every line end, so a caller passing a
 # multi-line blob rather than one line per item keeps every record but the last.
 _STRACE_RE = re.compile(
@@ -70,6 +68,12 @@ _STRACE_RE = re.compile(
 # A record start, matched independently of whether the rest of that record
 # survived the write that emitted it.
 _STRACE_HEAD_RE = re.compile(r"\[STRACE\]\s+v=\d+")
+_CLOCK_ANCHOR_RE = re.compile(
+    r"\[mono_ns=\d+\]\[T0x[0-9a-fA-F]+\]\[TIMING\]\s+clock_anchor:\s+"
+    r"\[CLOCK_ANCHOR\]\s+v=(?P<v>\d+)\s+pid=(?P<pid>\d+)\s+"
+    r"mono_ns=(?P<mono_ns>\d+)\s+wall_ns=(?P<wall_ns>\d+)[ \t]*\r?$",
+    re.MULTILINE,
+)
 # The emitter percent-encodes any byte that would otherwise be record grammar —
 # see `encode_host_span_field` in src/common/log/host_log.cpp.
 _PERCENT_ESCAPE_RE = re.compile(r"%([0-9A-Fa-f]{2})")
@@ -82,6 +86,16 @@ def decode_field(text):
     marker that the value is incomplete, not an encoded byte.
     """
     return _PERCENT_ESCAPE_RE.sub(lambda m: chr(int(m.group(1), 16)), text)
+
+
+@dataclass
+class ClockAnchor:
+    pid: int
+    mono_ns: int
+    wall_ns: int
+
+    def to_wall_ns(self, monotonic_ns):
+        return self.wall_ns + monotonic_ns - self.mono_ns
 
 
 @dataclass
@@ -134,6 +148,19 @@ def count_record_heads(lines):
     without it a torn record is indistinguishable from a real measurement.
     """
     return sum(len(_STRACE_HEAD_RE.findall(line)) for line in lines)
+
+
+def parse_clock_anchors(lines):
+    """Yield the per-process monotonic-to-wall mappings in a log."""
+    for line in lines:
+        for match in _CLOCK_ANCHOR_RE.finditer(line):
+            if int(match["v"]) != 1:
+                continue
+            yield ClockAnchor(
+                pid=int(match["pid"]),
+                mono_ns=int(match["mono_ns"]),
+                wall_ns=int(match["wall_ns"]),
+            )
 
 
 def parse_spans(lines):

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -17,10 +17,10 @@
 
 #include <cerrno>
 #include <chrono>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <ctime>
 #include <limits.h>
 #include <pthread.h>
 #include <string>
@@ -33,6 +33,7 @@
 #endif
 
 #include "common/host_span.h"
+#include "common/log_clock.h"
 
 using simpler::log::LogLevel;
 
@@ -91,7 +92,7 @@ std::string encode_host_span_field(const char *value, size_t capacity, bool attr
 // record. A return value of `capacity` or more means `buffer` holds only a
 // truncated prefix and the caller must re-render into that many bytes.
 size_t format_record(
-    char *buffer, size_t capacity, const char *ts, unsigned long tid, const char *level_tag, const char *func,
+    char *buffer, size_t capacity, int64_t monotonic_ns, unsigned long tid, const char *level_tag, const char *func,
     const char *fmt, va_list args, bool append_newline
 ) {
     size_t length = 0;
@@ -102,7 +103,10 @@ size_t format_record(
         return length < capacity ? capacity - length : 0;
     };
 
-    const int prefix = snprintf(tail(), remaining(), "[%s][T0x%lx][%s] %s: ", ts, tid, level_tag, func);
+    const int prefix = snprintf(
+        tail(), remaining(), "[mono_ns=%lld][T0x%lx][%s] %s: ", static_cast<long long>(monotonic_ns), tid, level_tag,
+        func
+    );
     if (prefix < 0) {
         return 0;
     }
@@ -159,8 +163,11 @@ HostLogger::HostLogger() :
     current_level_(LogLevel::TIMING) {}
 
 void HostLogger::set_level(LogLevel level) {
-    std::scoped_lock lock(mutex_);
-    current_level_ = level;
+    {
+        std::scoped_lock lock(mutex_);
+        current_level_ = level;
+    }
+    emit_clock_anchor_if_needed();
 }
 
 int HostLogger::level() const { return static_cast<int>(current_level_); }
@@ -197,16 +204,7 @@ const char *HostLogger::level_name(LogLevel level) const {
 }
 
 void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args) {
-    using namespace std::chrono;
-    auto now = system_clock::now();
-    auto t = system_clock::to_time_t(now);
-    auto us = duration_cast<microseconds>(now.time_since_epoch()) % 1'000'000;
-    struct tm tm_buf;
-    localtime_r(&t, &tm_buf);
-    char ts[40];
-    size_t n = strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm_buf);
-    snprintf(ts + n, sizeof(ts) - n, ".%06lld", static_cast<long long>(us.count()));
-
+    const int64_t monotonic_ns = simpler::log::monotonic_now_ns();
     auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
 
     const bool append_newline = fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n';
@@ -217,8 +215,9 @@ void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, 
     // budgeted to the portable _POSIX_PIPE_BUF floor (512 bytes); longer human
     // log records use this same best-effort write path without that promise.
     char stack_buffer[kRecordStackCapacity];
-    const size_t length =
-        format_record(stack_buffer, sizeof(stack_buffer), ts, tid, level_tag, func, fmt, args, append_newline);
+    const size_t length = format_record(
+        stack_buffer, sizeof(stack_buffer), monotonic_ns, tid, level_tag, func, fmt, args, append_newline
+    );
     if (length < sizeof(stack_buffer)) {
         std::scoped_lock lock(mutex_);
         write_stderr(stack_buffer, length);
@@ -226,16 +225,45 @@ void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, 
     }
 
     std::vector<char> heap_buffer(length + 1);
-    const size_t heap_length =
-        format_record(heap_buffer.data(), heap_buffer.size(), ts, tid, level_tag, func, fmt, args, append_newline);
+    const size_t heap_length = format_record(
+        heap_buffer.data(), heap_buffer.size(), monotonic_ns, tid, level_tag, func, fmt, args, append_newline
+    );
     std::scoped_lock lock(mutex_);
     write_stderr(heap_buffer.data(), heap_length < heap_buffer.size() ? heap_length : length);
+}
+
+void HostLogger::emit_ungated(const char *level_tag, const char *func, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    emit(level_tag, func, fmt, args);
+    va_end(args);
+}
+
+void HostLogger::emit_clock_anchor_if_needed() {
+    if (!is_enabled(LogLevel::TIMING)) return;
+
+    const pid_t pid = getpid();
+    if (clock_anchor_pid_.load(std::memory_order_acquire) == pid) return;
+
+    std::scoped_lock lock(clock_anchor_mutex_);
+    if (clock_anchor_pid_.load(std::memory_order_relaxed) == pid) return;
+
+    const int64_t monotonic_ns = simpler::log::monotonic_now_ns();
+    const int64_t wall_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    emit_ungated(
+        level_name(LogLevel::TIMING), "clock_anchor", "[CLOCK_ANCHOR] v=1 pid=%d mono_ns=%lld wall_ns=%lld",
+        static_cast<int>(pid), static_cast<long long>(monotonic_ns), static_cast<long long>(wall_ns)
+    );
+    clock_anchor_pid_.store(pid, std::memory_order_release);
 }
 
 void HostLogger::vlog(LogLevel level, const char *func, const char *fmt, va_list args) {
     if (!is_enabled(level)) {
         return;
     }
+    emit_clock_anchor_if_needed();
     emit(level_name(level), func, fmt, args);
 }
 
@@ -277,9 +305,9 @@ extern "C" void simpler_log_emit_host_span(const SimplerHostSpan *span) {
         encode_host_span_field(span->attributes == nullptr ? "" : span->attributes, kHostSpanAttributesCapacity, true);
     HostLogger::get_instance().log(
         LogLevel::TIMING, "emit_host_span",
-        "[STRACE] v=1 pid=%d tid=%ld inv=%llu hid=%llx depth=%d name=%s ts=%lld dur=%lld %s",
-        static_cast<int>(getpid()), host_trace_tid(), static_cast<unsigned long long>(span->invocation_id),
-        static_cast<unsigned long long>(span->callable_hash), span->depth, name.c_str(),
-        static_cast<long long>(span->timestamp_ns), static_cast<long long>(span->duration_ns), attributes.c_str()
+        "[STRACE] v=1 pid=%d tid=%ld inv=%" PRIu64 " hid=%" PRIx64 " depth=%d name=%s ts=%" PRId64 " dur=%" PRId64
+        " %s",
+        static_cast<int>(getpid()), host_trace_tid(), span->invocation_id, span->callable_hash, span->depth,
+        name.c_str(), span->timestamp_ns, span->duration_ns, attributes.c_str()
     );
 }

--- a/src/common/log/include/common/host_span.h
+++ b/src/common/log/include/common/host_span.h
@@ -34,7 +34,10 @@ typedef struct SimplerHostSpan {
 
 typedef void (*SimplerLogEmitHostSpanFn)(const SimplerHostSpan *span);
 
-/* The logger owns this C ABI. Consumers call it through a bound
+/* Link-time adapter used by native Host consumers. */
+void unified_log_host_span(const SimplerHostSpan *span);
+
+/* The logger owns this C ABI. Extension consumers call it through a bound
  * SimplerLogEmitHostSpanFn so an absent logger remains a supported state. */
 void simpler_log_emit_host_span(const SimplerHostSpan *span);
 

--- a/src/common/log/include/common/host_span_scope.h
+++ b/src/common/log/include/common/host_span_scope.h
@@ -21,11 +21,11 @@
 #pragma once
 
 #include "common/host_span.h"
+#include "common/log_clock.h"
 #include "profiling_config.h"
 
 #if SIMPLER_HOST_STRACE
 
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -44,10 +44,7 @@ inline void bind_sink(SimplerLogEmitHostSpanFn sink) noexcept { sink_slot() = si
 /** False when this module has not been bound to libsimpler_log.so. */
 inline bool sink_available() noexcept { return sink_slot() != nullptr; }
 
-inline int64_t now_ns() noexcept {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
-        .count();
-}
+inline int64_t now_ns() noexcept { return simpler::log::monotonic_now_ns(); }
 
 inline void emit(
     const char *name, uint64_t invocation_id, uint64_t callable_hash, int32_t depth, int64_t timestamp_ns,

--- a/src/common/log/include/common/log_clock.h
+++ b/src/common/log/include/common/log_clock.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace simpler::log {
+
+inline int64_t monotonic_now_ns() noexcept {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+}  // namespace simpler::log

--- a/src/common/log/include/common/strace.h
+++ b/src/common/log/include/common/strace.h
@@ -28,7 +28,7 @@
  *          align later by reusing the same prefix + adding fields)
  *   pid    process id  (L3 parent vs each L2 child are distinct pids)
  *   tid    thread id   (multi-threaded orch stays attributable)
- *   inv    process-wide simpler_run() invocation id (atomic-allocated, so
+ *   inv    64-bit process-wide simpler_run() invocation id (atomic-allocated, so
  *          (pid, inv) is unique even across concurrent calls) — grouping key
  *          ONLY (gathers one call's spans together); not a token index. A
  *          lexical call sets it via StraceScope::next_inv(); a phased call
@@ -41,15 +41,17 @@
  *   name   dotted span name (self-locating even without the tree).
  *   ts,dur start + duration in ns on CLOCK_MONOTONIC (steady_clock). ts+dur
  *          maps 1:1 onto a Chrome-trace "X" event; same-host cross-process
- *          comparable. STRACE_A appends caller-supplied "k=v" attrs verbatim.
+ *          comparable. STRACE_A passes caller-supplied "k=v" attrs to the
+ *          logger for delimiter encoding and bounded rendering.
  *
  * Gated on SIMPLER_HOST_STRACE (default on, see profiling_config.h — no env var)
  * and emitted at LOG_TIMING (the default-visible timing tier). In a
  * non-profiling build the macros compile to nothing.
  */
 
-#ifndef PLATFORM_STRACE_H_
-#define PLATFORM_STRACE_H_
+#pragma once
+
+#include <cstdint>
 
 #include "profiling_config.h"
 
@@ -58,17 +60,10 @@
 #include <pthread.h>
 
 #include <atomic>
-#include <chrono>
-#include <cstdint>
 #include <cstdlib>
 
-#include <unistd.h>
-
-#if defined(__linux__)
-#include <sys/syscall.h>
-#endif
-
-#include "common/unified_log.h"
+#include "common/host_span.h"
+#include "common/log_clock.h"
 
 namespace simpler::strace {
 
@@ -77,7 +72,7 @@ namespace simpler::strace {
 // thread_local in SOs (ELF TLSDESC issues across dlopen — see
 // docs/dynamic-linking.md), so all per-thread state uses POSIX TLS.
 struct ThreadState {
-    unsigned inv = 0;
+    uint64_t inv = 0;
     int depth = 0;
     uint64_t hid = 0;
 };
@@ -102,14 +97,23 @@ inline ThreadState *strace_state() {
     return st;
 }
 
-inline long strace_tid() {
-#if defined(__linux__) && defined(SYS_gettid)
-    return static_cast<long>(syscall(SYS_gettid));
-#else
-    // macOS and any platform without SYS_gettid: process id is a sufficient
-    // lane key for the trace (per-process invocation grouping still holds).
-    return static_cast<long>(getpid());
-#endif
+inline void emit_record(
+    const char *name, uint64_t invocation_id, uint64_t callable_hash, int32_t depth, int64_t timestamp_ns,
+    int64_t duration_ns, const char *attributes
+) {
+    const SimplerHostSpan span{
+        SIMPLER_HOST_SPAN_ABI_VERSION,
+        sizeof(SimplerHostSpan),
+        invocation_id,
+        callable_hash,
+        depth,
+        0,
+        timestamp_ns,
+        duration_ns,
+        name,
+        attributes
+    };
+    unified_log_host_span(&span);
 }
 
 class StraceScope {
@@ -117,25 +121,16 @@ public:
     explicit StraceScope(const char *name, const char *attrs = "") :
         name_(name),
         attrs_(attrs),
-        t0_(std::chrono::steady_clock::now()) {
+        t0_ns_(simpler::log::monotonic_now_ns()) {
         ++depth();
     }
 
     ~StraceScope() {
-        const auto t1 = std::chrono::steady_clock::now();
-        const long long ts = static_cast<long long>(
-            std::chrono::duration_cast<std::chrono::nanoseconds>(t0_.time_since_epoch()).count()
-        );
-        const long long dur =
-            static_cast<long long>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0_).count());
+        const int64_t t1_ns = simpler::log::monotonic_now_ns();
         // depth printed is the scope's own level (post-decrement so the
         // outermost scope prints depth=0).
         const int d = --depth();
-        LOG_TIMING(
-            "[STRACE] v=1 pid=%d tid=%ld inv=%u hid=%llx depth=%d name=%s ts=%lld dur=%lld %s",
-            static_cast<int>(getpid()), strace_tid(), inv(), static_cast<unsigned long long>(hid()), d, name_, ts, dur,
-            attrs_
-        );
+        emit_record(name_, inv(), hid(), d, t0_ns_, t1_ns - t0_ns_, attrs_);
     }
 
     StraceScope(const StraceScope &) = delete;
@@ -150,29 +145,29 @@ public:
      *  would start at 1 and the parser would merge their spans. The resolved id
      *  is stored in the per-thread slot (`inv()`) so nested scopes / emit_span_at
      *  on this thread read the right value. */
-    static unsigned allocate_inv() {
-        static std::atomic<unsigned> global_inv{0};
+    static uint64_t allocate_inv() {
+        static std::atomic<uint64_t> global_inv{0};
         return global_inv.fetch_add(1, std::memory_order_acq_rel) + 1;
     }
-    static unsigned next_inv() {
-        const unsigned id = allocate_inv();
+    static uint64_t next_inv() {
+        const uint64_t id = allocate_inv();
         inv() = id;
         return id;
     }
     /** Set the callable hash for spans emitted on this thread. */
     static void set_hid(uint64_t h) { hid() = h; }
     /** Current invocation id / callable hash for this thread (for emit_span_at). */
-    static unsigned current_inv() { return inv(); }
+    static uint64_t current_inv() { return inv(); }
     static uint64_t current_hid() { return hid(); }
 
 private:
-    static unsigned &inv() { return strace_state()->inv; }
+    static uint64_t &inv() { return strace_state()->inv; }
     static int &depth() { return strace_state()->depth; }
     static uint64_t &hid() { return strace_state()->hid; }
 
     const char *name_;
     const char *attrs_;
-    std::chrono::steady_clock::time_point t0_;
+    int64_t t0_ns_;
 };
 
 /**
@@ -182,7 +177,7 @@ private:
  */
 class StraceContextScope {
 public:
-    StraceContextScope(unsigned inv, uint64_t hid, int base_depth) :
+    StraceContextScope(uint64_t inv, uint64_t hid, int base_depth) :
         state_(strace_state()),
         saved_(*state_) {
         state_->inv = inv;
@@ -201,12 +196,7 @@ private:
 };
 
 /** Current steady-clock timestamp in the marker grammar's nanosecond unit. */
-inline long long strace_now_ns() {
-    return static_cast<long long>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
-            .count()
-    );
-}
+inline long long strace_now_ns() { return static_cast<long long>(simpler::log::monotonic_now_ns()); }
 
 /**
  * Emit a marker for a span whose duration was measured elsewhere (e.g. a device
@@ -220,11 +210,7 @@ inline long long strace_now_ns() {
  */
 inline void
 emit_span_at(const char *name, long long ts_ns, long long dur_ns, int depth, const char *attrs = "clk=dev") {
-    LOG_TIMING(
-        "[STRACE] v=1 pid=%d tid=%ld inv=%u hid=%llx depth=%d name=%s ts=%lld dur=%lld %s", static_cast<int>(getpid()),
-        strace_tid(), StraceScope::current_inv(), static_cast<unsigned long long>(StraceScope::current_hid()), depth,
-        name, ts_ns, dur_ns, attrs
-    );
+    emit_record(name, StraceScope::current_inv(), StraceScope::current_hid(), depth, ts_ns, dur_ns, attrs);
 }
 
 /** Emit an explicitly timed host-domain span in the active invocation. */
@@ -267,8 +253,8 @@ inline void emit_host_span_at(const char *name, long long ts_ns, long long dur_n
 
 #define STRACE(name) ((void)0)
 #define STRACE_A(name, attrs) ((void)0)
-#define STRACE_NEW_INV() ((void)0)
-#define STRACE_ALLOC_INV() 0U
+#define STRACE_NEW_INV() UINT64_C(0)
+#define STRACE_ALLOC_INV() UINT64_C(0)
 #define STRACE_SET_HID(h) ((void)0)
 #define STRACE_CONTEXT(inv, hid, depth) ((void)0)
 #define STRACE_NOW_NS() 0LL
@@ -277,5 +263,3 @@ inline void emit_host_span_at(const char *name, long long ts_ns, long long dur_n
 #define STRACE_DEV_SPAN_AT(name, ts_ns, dur_ns, depth) ((void)0)
 
 #endif  // SIMPLER_HOST_STRACE
-
-#endif  // PLATFORM_STRACE_H_

--- a/src/common/log/include/host_log.h
+++ b/src/common/log/include/host_log.h
@@ -19,9 +19,12 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdarg>
 #include <cstdio>
 #include <mutex>
+
+#include <sys/types.h>
 
 #include "common/log_level.h"
 
@@ -60,7 +63,11 @@ private:
 
     const char *level_name(simpler::log::LogLevel level) const;
     void emit(const char *level_tag, const char *func, const char *fmt, va_list args);
+    void emit_ungated(const char *level_tag, const char *func, const char *fmt, ...);
+    void emit_clock_anchor_if_needed();
 
     simpler::log::LogLevel current_level_;
     std::mutex mutex_;
+    std::atomic<pid_t> clock_anchor_pid_{-1};
+    std::mutex clock_anchor_mutex_;
 };

--- a/src/common/log/unified_log_host.cpp
+++ b/src/common/log/unified_log_host.cpp
@@ -22,7 +22,11 @@
 
 #include <cstdarg>
 
+#include "common/host_span.h"
+
 using simpler::log::LogLevel;
+
+void unified_log_host_span(const SimplerHostSpan *span) { simpler_log_emit_host_span(span); }
 
 void unified_log_error(const char *func, const char *fmt, ...) {
     va_list args;

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -587,7 +587,7 @@ native_run_context(DeviceContextHandle ctx, RuntimeHandle runtime, const char *o
 }
 
 static void
-emit_native_run_host_wall(unsigned trace_inv, uint64_t trace_hid, long long trace_start_ns, const char *trace_attrs) {
+emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns, const char *trace_attrs) {
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(trace_inv, trace_hid, 0);
     STRACE_HOST_SPAN_AT_A("simpler_run", trace_start_ns, end_ns - trace_start_ns, 0, trace_attrs);
@@ -608,7 +608,7 @@ int supports_concurrent_native_prepare_ctx(DeviceContextHandle ctx) {
 }
 
 static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_rc, bool clear_gm_sm) {
-    const unsigned trace_inv = state->trace_inv;
+    const uint64_t trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     char trace_attrs[sizeof(state->trace_attrs)];
@@ -690,7 +690,7 @@ int simpler_prepare_run(
 
     OnboardNativeRunContext *state = nullptr;
     const uint64_t trace_hid = runner->callable_hash(callable_id);
-    const unsigned trace_inv = STRACE_ALLOC_INV();
+    const uint64_t trace_inv = STRACE_ALLOC_INV();
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
         state = new (runtime) OnboardNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
@@ -883,7 +883,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_finalize_run");
     if (state == nullptr) return -1;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
-    const unsigned trace_inv = state->trace_inv;
+    const uint64_t trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     char trace_attrs[sizeof(state->trace_attrs)];

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -553,7 +553,7 @@ static SimNativeRunContext *native_run_context(DeviceContextHandle ctx, RuntimeH
     return state;
 }
 
-static void emit_native_run_host_wall(unsigned trace_inv, uint64_t trace_hid, long long trace_start_ns) {
+static void emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns) {
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(trace_inv, trace_hid, 0);
     STRACE_HOST_SPAN_AT("simpler_run", trace_start_ns, end_ns - trace_start_ns, 0);
@@ -570,7 +570,7 @@ static void emit_native_run_runner_wall(SimNativeRunContext *state) {
 }
 
 static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, bool clear_gm_sm) {
-    const unsigned trace_inv = state->trace_inv;
+    const uint64_t trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
@@ -630,7 +630,7 @@ int simpler_prepare_run(
 
     SimNativeRunContext *state = nullptr;
     const uint64_t trace_hid = static_cast<uint64_t>(callable_id);
-    const unsigned trace_inv = STRACE_ALLOC_INV();
+    const uint64_t trace_inv = STRACE_ALLOC_INV();
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
         state = new (runtime) SimNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
@@ -752,7 +752,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_finalize_run");
     if (state == nullptr) return -1;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
-    const unsigned trace_inv = state->trace_inv;
+    const uint64_t trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
 

--- a/src/common/worker/native_run_context.h
+++ b/src/common/worker/native_run_context.h
@@ -75,7 +75,7 @@ struct NativeRunContext {
     HostApi host_api;
     Runtime runtime{};
     uint64_t trace_hid{0};
-    unsigned trace_inv{0};
+    uint64_t trace_inv{0};
     long long trace_start_ns{0};
     long long runner_trace_start_ns{0};
     int completion_rc{-1};

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -909,9 +909,11 @@ set(SIMPLER_LOG_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/log)
 add_executable(test_host_log_off
     a5/test_host_log_off.cpp
     ${SIMPLER_LOG_DIR}/host_log.cpp
+    ${SIMPLER_LOG_DIR}/unified_log_host.cpp
 )
 target_include_directories(test_host_log_off PRIVATE
     ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
     ${SIMPLER_LOG_DIR}
     ${SIMPLER_LOG_DIR}/include
 )

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <sstream>
+#include <set>
 #include <string>
 #include <thread>
 #include <vector>
@@ -28,6 +29,7 @@
 #include <gtest/gtest.h>
 
 #include "common/host_span.h"
+#include "common/strace.h"
 #include "host_log.h"
 
 using simpler::log::LogLevel;
@@ -169,27 +171,92 @@ TEST(HostLogTest, CannConfigurationUsesGlobalModuleAndRespectsExternalOverride) 
     }
 }
 
-TEST(HostLogTest, EmitPrefixHasTimestampAndTid) {
+TEST(HostLogTest, EmitPrefixHasMonotonicNanosecondsAndTid) {
     auto captured = run_with_config(LogLevel::INFO, [] {
         HostLogger::get_instance().log(LogLevel::ERROR, "fn", "marker");
     });
-    // Expected shape: "[YYYY-MM-DD HH:MM:SS.uuuuuu][T0x...][ERROR] fn: marker\n"
-    ASSERT_FALSE(captured.err.empty());
-    EXPECT_EQ(captured.err[0], '[');
-    // Year must be 4 ASCII digits.
-    for (int i = 1; i <= 4; ++i) {
-        EXPECT_GE(captured.err[i], '0');
-        EXPECT_LE(captured.err[i], '9');
-    }
-    EXPECT_EQ(captured.err[5], '-');
+    const size_t line_start = captured.err.rfind('\n', captured.err.find("marker"));
+    const size_t prefix_start = line_start == std::string::npos ? 0 : line_start + 1;
+    ASSERT_EQ(captured.err.compare(prefix_start, 9, "[mono_ns="), 0);
+    const size_t prefix_end = captured.err.find(']', prefix_start);
+    ASSERT_NE(prefix_end, std::string::npos);
+    ASSERT_GT(prefix_end, prefix_start + 9);
+    EXPECT_TRUE(
+        std::all_of(
+            captured.err.begin() + static_cast<std::ptrdiff_t>(prefix_start + 9),
+            captured.err.begin() + static_cast<std::ptrdiff_t>(prefix_end), [](char c) {
+                return c >= '0' && c <= '9';
+            }
+        )
+    );
     // Thread-id segment "[T0x" must appear before the level tag.
-    auto tid_pos = captured.err.find("][T0x");
-    auto level_pos = captured.err.find("][ERROR]");
+    auto tid_pos = captured.err.find("][T0x", prefix_end);
+    auto level_pos = captured.err.find("][ERROR]", tid_pos);
     ASSERT_NE(tid_pos, std::string::npos);
     ASSERT_NE(level_pos, std::string::npos);
     EXPECT_LT(tid_pos, level_pos);
     // Body still present.
     EXPECT_NE(captured.err.find("marker"), std::string::npos);
+}
+
+TEST(HostLogTest, TimingStartupEmitsOneClockAnchorPerProcess) {
+    int log_pipe[2];
+    ASSERT_EQ(pipe(log_pipe), 0);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(log_pipe[0]);
+        if (dup2(log_pipe[1], STDERR_FILENO) < 0) _exit(2);
+        close(log_pipe[1]);
+
+        HostLogger::get_instance().set_level(LogLevel::TIMING);
+        HostLogger::get_instance().log(LogLevel::TIMING, "child", "first-record");
+        HostLogger::get_instance().log(LogLevel::TIMING, "child", "second-record");
+        _exit(0);
+    }
+
+    close(log_pipe[1]);
+    std::string captured;
+    char buffer[1024];
+    ssize_t count = 0;
+    while ((count = read(log_pipe[0], buffer, sizeof(buffer))) > 0) {
+        captured.append(buffer, static_cast<size_t>(count));
+    }
+    close(log_pipe[0]);
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+
+    const size_t anchor_pos = captured.find("[CLOCK_ANCHOR]");
+    ASSERT_NE(anchor_pos, std::string::npos);
+    EXPECT_EQ(captured.find("[CLOCK_ANCHOR]", anchor_pos + 1), std::string::npos);
+    const size_t anchor_line_start = captured.rfind('\n', anchor_pos);
+    const size_t anchor_level =
+        captured.find("][TIMING]", anchor_line_start == std::string::npos ? 0 : anchor_line_start);
+    ASSERT_NE(anchor_level, std::string::npos);
+    EXPECT_LT(anchor_level, anchor_pos);
+    const size_t first_record_pos = captured.find("first-record");
+    const size_t second_record_pos = captured.find("second-record");
+    ASSERT_NE(first_record_pos, std::string::npos);
+    ASSERT_NE(second_record_pos, std::string::npos);
+    EXPECT_LT(anchor_pos, first_record_pos);
+
+    int anchor_pid = -1;
+    long long mono_ns = 0;
+    long long wall_ns = 0;
+    ASSERT_EQ(
+        sscanf(
+            captured.c_str() + anchor_pos, "[CLOCK_ANCHOR] v=1 pid=%d mono_ns=%lld wall_ns=%lld", &anchor_pid, &mono_ns,
+            &wall_ns
+        ),
+        3
+    );
+    EXPECT_EQ(anchor_pid, child);
+    EXPECT_GT(mono_ns, 0);
+    EXPECT_GT(wall_ns, 0);
 }
 
 TEST(HostLogTest, AllOutputGoesToStderr) {
@@ -231,10 +298,43 @@ TEST(HostLogTest, HostSpanEscapesDelimitersAndFitsAtomicPipeRecord) {
     EXPECT_EQ(captured.err.find("[STRACE]", marker + 1), std::string::npos);
     EXPECT_NE(captured.err.find("name=bad%20name%0A%5BSTRACE%5D%3Dx"), std::string::npos);
     EXPECT_NE(captured.err.find("run_id=7 role=worker%0A%5BSTRACE%5D injected=1"), std::string::npos);
-    EXPECT_EQ(std::count(captured.err.begin(), captured.err.end(), '\n'), 1);
-    EXPECT_LE(captured.err.size(), static_cast<size_t>(_POSIX_PIPE_BUF));
-    ASSERT_GE(captured.err.size(), 2u);
-    EXPECT_EQ(captured.err[captured.err.size() - 2], '~');
+    const std::string record = captured.err.substr(marker);
+    EXPECT_EQ(std::count(record.begin(), record.end(), '\n'), 1);
+    EXPECT_LE(record.size(), static_cast<size_t>(_POSIX_PIPE_BUF));
+    ASSERT_GE(record.size(), 2u);
+    EXPECT_EQ(record[record.size() - 2], '~');
+}
+
+TEST(HostLogTest, AllHostSpanEmitPathsPreserve64BitInvocationIds) {
+    constexpr uint64_t invocation_id = (UINT64_C(1) << 32) + 7;
+    constexpr uint64_t callable_hash = UINT64_C(0x1234);
+
+    auto captured = run_with_config(LogLevel::TIMING, [] {
+        simpler::strace::StraceContextScope context(invocation_id, callable_hash, 0);
+        { simpler::strace::StraceScope scope("scope_path"); }
+        simpler::strace::emit_host_span_at("explicit_path", 100, 25, 0);
+
+        const SimplerHostSpan span{SIMPLER_HOST_SPAN_ABI_VERSION,
+                                   sizeof(SimplerHostSpan),
+                                   invocation_id,
+                                   callable_hash,
+                                   0,
+                                   0,
+                                   200,
+                                   30,
+                                   "c_abi_path",
+                                   ""};
+        simpler_log_emit_host_span(&span);
+    });
+
+    const std::string expected_inv = "inv=" + std::to_string(invocation_id);
+    for (const char *name : {"scope_path", "explicit_path", "c_abi_path"}) {
+        const size_t name_pos = captured.err.find(std::string("name=") + name);
+        ASSERT_NE(name_pos, std::string::npos) << name;
+        const size_t record_pos = captured.err.rfind("[STRACE]", name_pos);
+        ASSERT_NE(record_pos, std::string::npos) << name;
+        EXPECT_NE(captured.err.substr(record_pos, name_pos - record_pos).find(expected_inv), std::string::npos) << name;
+    }
 }
 
 // A `%XX` escape is three bytes that only mean anything together, so a field
@@ -342,11 +442,19 @@ TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
     reader.join();
 
     std::vector<std::vector<bool>> seen(child_count, std::vector<bool>(records_per_child, false));
+    std::set<int> anchor_pids;
     std::istringstream lines(captured);
     std::string line;
     int line_count = 0;
     constexpr char payload_marker[] = " payload=";
     while (std::getline(lines, line)) {
+        const size_t anchor_pos = line.find("[CLOCK_ANCHOR]");
+        if (anchor_pos != std::string::npos) {
+            int anchor_pid = -1;
+            ASSERT_EQ(sscanf(line.c_str() + anchor_pos, "[CLOCK_ANCHOR] v=1 pid=%d", &anchor_pid), 1);
+            EXPECT_TRUE(anchor_pids.insert(anchor_pid).second);
+            continue;
+        }
         const size_t record_pos = line.find("child=");
         const size_t payload_pos = line.find(payload_marker);
         ASSERT_NE(record_pos, std::string::npos);
@@ -371,4 +479,5 @@ TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
         ++line_count;
     }
     EXPECT_EQ(line_count, child_count * records_per_child);
+    EXPECT_EQ(anchor_pids.size(), static_cast<size_t>(child_count));
 }

--- a/tests/ut/cpp/stubs/test_stubs.cpp
+++ b/tests/ut/cpp/stubs/test_stubs.cpp
@@ -34,6 +34,8 @@
 
 extern "C" {
 
+void unified_log_host_span(const struct SimplerHostSpan *) {}
+
 void unified_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -16,6 +16,7 @@ from simpler_setup.tools.strace_timing import (
     group_invocations,
     legacy_spans,
     main,
+    parse_clock_anchors,
     parse_spans,
     to_chrome_trace,
     to_host_swimlane,
@@ -23,11 +24,14 @@ from simpler_setup.tools.strace_timing import (
 
 
 def _record(pid, inv, name, attrs=""):
-    """One host-log record in the shape `HostLogger::emit` writes it.
+    """One current host-log record in the shape `HostLogger::emit` writes it."""
+    return (
+        f"[mono_ns={1_000_000 + pid}][T0x{pid}][TIMING] emit_host_span: "
+        f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
+    )
 
-    `LOG_TIMING` prepends `[<file>:<line>] ` to the caller's format string, so
-    the marker never sits flush against the `<func>: ` separator on stderr.
-    """
+
+def _legacy_record(pid, inv, name, attrs=""):
     return (
         f"[2026-08-04 10:00:00.00000{pid}][T0x{pid}][TIMING] emit_span: [strace.h:132] "
         f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
@@ -52,7 +56,7 @@ def test_parse_spans_finds_adjacent_records_on_one_physical_line():
 
 
 def test_parse_spans_keeps_every_record_of_a_multi_line_blob():
-    blob = _record(1, 1, "simpler_run", "rank=0") + "\n" + _record(2, 2, "simpler_run.bind", "rank=1") + "\n"
+    blob = _legacy_record(1, 1, "simpler_run", "rank=0") + "\n" + _record(2, 2, "simpler_run.bind", "rank=1") + "\n"
 
     spans = list(parse_spans([blob]))
 
@@ -62,6 +66,41 @@ def test_parse_spans_keeps_every_record_of_a_multi_line_blob():
     ]
     assert spans[0].attrs == "rank=0"
     assert spans[1].attrs == "rank=1"
+
+
+def test_parse_spans_preserves_64_bit_invocation_id():
+    invocation_id = 2**32 + 7
+
+    spans = list(parse_spans([_record(41, invocation_id, "simpler_run")]))
+
+    assert len(spans) == 1
+    assert spans[0].inv == invocation_id
+
+
+def test_parse_clock_anchor_maps_monotonic_to_wall_time():
+    lines = [
+        "worker-3: [mono_ns=1005][T0x1][TIMING] clock_anchor: "
+        "[CLOCK_ANCHOR] v=1 pid=41 mono_ns=1000 wall_ns=1700000000000000000\n"
+    ]
+
+    anchors = list(parse_clock_anchors(lines))
+
+    assert len(anchors) == 1
+    assert anchors[0].pid == 41
+    assert anchors[0].mono_ns == 1000
+    assert anchors[0].wall_ns == 1_700_000_000_000_000_000
+    assert anchors[0].to_wall_ns(1250) == 1_700_000_000_000_000_250
+
+
+def test_parse_clock_anchor_rejects_payloads_outside_complete_anchor_records():
+    payload = "[CLOCK_ANCHOR] v=1 pid=41 mono_ns=1000 wall_ns=1700000000000000000"
+    lines = [
+        payload + "\n",
+        f"[mono_ns=1005][T0x1][INFO] message: copied {payload}\n",
+        f"[mono_ns=1005][T0x1][TIMING] clock_anchor: {payload} trailing\n",
+    ]
+
+    assert list(parse_clock_anchors(lines)) == []
 
 
 def test_count_record_heads_sees_a_torn_record_that_parse_spans_drops():


### PR DESCRIPTION
- Timestamp host logs with the monotonic span clock and emit one wall-clock anchor per process
- Parse only complete logger-owned clock anchors while tolerating collector prefixes
- Route structured spans through HostLogger as the sole STRACE grammar owner
- Preserve 64-bit invocation IDs and legacy trace parser compatibility

Addresses items 1 and 2 of [#1792](https://github.com/hw-native-sys/simpler/issues/1792).