### PR TITLE
CI: select minimal pre-commit build target

### DIFF
--- a/.github/workflows/_pre-commit.yml
+++ b/.github/workflows/_pre-commit.yml
@@ -49,55 +49,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install build and lint tools
-        if: inputs.setup_variant == 'github'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build g++ clang-tidy
-
-      - name: Verify provisioned toolchain
-        if: inputs.setup_variant == 'self-cpu'
-        run: |
-          command -v cmake
-          command -v ninja
-          command -v g++
-          command -v clang-tidy
-          if ! command -v g++-15 >/dev/null 2>&1; then
-            mkdir -p "$RUNNER_TEMP/bin"
-            ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
-            echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-          fi
-          if command -v clang-tidy-18 >/dev/null 2>&1; then
-            mkdir -p "$RUNNER_TEMP/bin"
-            ln -sf "$(command -v clang-tidy-18)" "$RUNNER_TEMP/bin/clang-tidy"
-            echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-          fi
-          PATH="$RUNNER_TEMP/bin:$PATH" command -v clang-tidy
-          PATH="$RUNNER_TEMP/bin:$PATH" clang-tidy --version
-
       - name: Set up Python 3.10
         if: inputs.setup_variant == 'github'
         uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-
-      - name: Cache pip packages
-        if: inputs.setup_variant == 'self-cpu'
-        uses: ./.github/actions/cache-pip
-
-      - name: Install Python dependencies
-        if: inputs.setup_variant == 'github'
-        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Install package (for pyright C extension symbol resolution)
-        if: inputs.setup_variant == 'github'
-        run: pip install --config-settings=build.targets=build_package_sim .
-
-      - name: venv + deps
-        if: inputs.setup_variant == 'self-cpu'
-        uses: ./.github/actions/setup-venv
-        with:
-          packages: "--config-settings=build.targets=build_package_sim ."
 
       - name: Resolve base SHA
         id: base
@@ -107,6 +63,97 @@ jobs:
         run: |
           git fetch --no-tags "https://github.com/${BASE_REPOSITORY}.git" main
           echo "base_sha=$(git merge-base FETCH_HEAD HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Select lint build target
+        id: lint-build
+        env:
+          BASE_SHA: ${{ inputs.setup_variant == 'self-cpu' && steps.base.outputs.base_sha || inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.setup_variant == 'self-cpu' && (inputs.ref || github.sha) || inputs.head_sha }}
+        run: |
+          needs_package=false
+          needs_cpp=false
+          target=_task_interface
+
+          while IFS= read -r path; do
+            case "$path" in
+              3rdparty/*|vendor/*)
+                ;;
+              *.c|*.cc|*.cpp|*.cxx|*.h|*.hh|*.hpp|*.hxx)
+                needs_package=true
+                needs_cpp=true
+                target=build_package_sim
+                ;;
+              *.py|*.pyi)
+                needs_package=true
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          echo "needs_package=$needs_package" >> "$GITHUB_OUTPUT"
+          echo "needs_cpp=$needs_cpp" >> "$GITHUB_OUTPUT"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+
+      - name: Install build and lint tools
+        if: inputs.setup_variant == 'github' && steps.lint-build.outputs.needs_package == 'true'
+        env:
+          NEEDS_CPP: ${{ steps.lint-build.outputs.needs_cpp }}
+        run: |
+          missing_packages=()
+          command -v cmake >/dev/null 2>&1 || missing_packages+=(cmake)
+          command -v ninja >/dev/null 2>&1 || missing_packages+=(ninja-build)
+          command -v g++ >/dev/null 2>&1 || missing_packages+=(g++)
+          if [[ "$NEEDS_CPP" == "true" ]] && ! command -v clang-tidy >/dev/null 2>&1; then
+            missing_packages+=(clang-tidy)
+          fi
+          if (( ${#missing_packages[@]} )); then
+            sudo apt-get update
+            sudo apt-get install -y "${missing_packages[@]}"
+          fi
+
+      - name: Verify provisioned toolchain
+        if: inputs.setup_variant == 'self-cpu' && steps.lint-build.outputs.needs_package == 'true'
+        env:
+          NEEDS_CPP: ${{ steps.lint-build.outputs.needs_cpp }}
+        run: |
+          command -v cmake
+          command -v ninja
+          command -v g++
+          if [[ "$NEEDS_CPP" == "true" ]]; then
+            command -v clang-tidy
+            if ! command -v g++-15 >/dev/null 2>&1; then
+              mkdir -p "$RUNNER_TEMP/bin"
+              ln -sf "$(command -v g++)" "$RUNNER_TEMP/bin/g++-15"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+            fi
+            if command -v clang-tidy-18 >/dev/null 2>&1; then
+              mkdir -p "$RUNNER_TEMP/bin"
+              ln -sf "$(command -v clang-tidy-18)" "$RUNNER_TEMP/bin/clang-tidy"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+            fi
+            PATH="$RUNNER_TEMP/bin:$PATH" command -v clang-tidy
+            PATH="$RUNNER_TEMP/bin:$PATH" clang-tidy --version
+          fi
+
+      - name: Cache pip packages
+        if: steps.lint-build.outputs.needs_package == 'true'
+        uses: ./.github/actions/cache-pip
+
+      - name: Install Python dependencies
+        if: inputs.setup_variant == 'github' && steps.lint-build.outputs.needs_package == 'true'
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package (for lint extension symbol resolution)
+        if: inputs.setup_variant == 'github' && steps.lint-build.outputs.needs_package == 'true'
+        env:
+          BUILD_TARGET: ${{ steps.lint-build.outputs.target }}
+        run: pip install --config-settings="build.targets=$BUILD_TARGET" .
+
+      - name: venv + deps
+        if: inputs.setup_variant == 'self-cpu' && steps.lint-build.outputs.needs_package == 'true'
+        uses: ./.github/actions/setup-venv
+        with:
+          packages: >-
+            --config-settings=build.targets=${{ steps.lint-build.outputs.target }} .
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0

--- a/tests/ut/py/test_pre_commit_build_selection.py
+++ b/tests/ut/py/test_pre_commit_build_selection.py
@@ -1,0 +1,80 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[3]
+WORKFLOW = REPO_ROOT / ".github/workflows/_pre-commit.yml"
+
+
+def _selection_script() -> str:
+    workflow = WORKFLOW.read_text()
+    start = "      - name: Select lint build target\n"
+    end = "\n      - name: Install build and lint tools\n"
+    assert workflow.count(start) == 1
+    block = workflow.split(start, 1)[1].split(end, 1)[0]
+    run = block.split("        run: |\n", 1)[1]
+    return textwrap.dedent(run)
+
+
+def _commit(repo: Path, relative_path: str, contents: str) -> str:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    subprocess.run(["git", "add", relative_path], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=CI", "-c", "user.email=ci@example.com", "commit", "-m", relative_path],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+
+
+@pytest.mark.parametrize(
+    ("changed_files", "expected"),
+    [
+        (["docs/readme.md"], {"needs_package": "false", "needs_cpp": "false", "target": "_task_interface"}),
+        (["python/simpler/api.py"], {"needs_package": "true", "needs_cpp": "false", "target": "_task_interface"}),
+        (["src/common/api.cpp"], {"needs_package": "true", "needs_cpp": "true", "target": "build_package_sim"}),
+        (["vendor/dependency.cpp"], {"needs_package": "false", "needs_cpp": "false", "target": "_task_interface"}),
+        (
+            ["python/simpler/api.py", "include/simpler/api.h"],
+            {"needs_package": "true", "needs_cpp": "true", "target": "build_package_sim"},
+        ),
+    ],
+)
+def test_select_lint_build_target(tmp_path: Path, changed_files: list[str], expected: dict[str, str]) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    base = _commit(repo, "README.md", "base\n")
+    for index, changed_file in enumerate(changed_files):
+        head = _commit(repo, changed_file, f"change {index}\n")
+
+    output = tmp_path / "github-output"
+    env = os.environ.copy()
+    env.update({"BASE_SHA": base, "HEAD_SHA": head, "GITHUB_OUTPUT": str(output)})
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _selection_script()],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    actual = dict(line.split("=", 1) for line in output.read_text().splitlines())
+    assert actual == expected


### PR DESCRIPTION
## Summary

- Classify the PR diff before installing the project in the pre-commit job.
- Skip package/toolchain setup for documentation and configuration-only changes whose selected hooks do not import the project.
- Build only `_task_interface` for Python-only changes, giving pyright the nanobind symbols it needs without compiling both simulator runtime stacks.
- Preserve `build_package_sim` for C/C++ changes so clang-tidy still receives the A2/A3 and A5 simulator compile databases.
- Restore the pip cache on GitHub-hosted pre-commit jobs and install only missing system packages; install clang-tidy only when C/C++ changed.
- Apply the same target selection to the self-hosted CPU workflow.

## Why `_task_interface`

`_task_interface` is the nanobind extension that exposes the project's C++ task/runtime types to Python, including `Worker`, `CallConfig`, `ChipCallable`, tensor/buffer types, and orchestration bindings. Pyright needs those extension symbols, but it does not need the A2/A3 and A5 simulator runtime shared libraries for a Python-only diff.

| Target | Builds |
| --- | --- |
| `_task_interface` | Python-to-C++ nanobind extension |
| `build_package_sim` | `_task_interface` plus all A2/A3 Sim and A5 Sim runtime binaries |

## Selection policy

| Changed files | Package build | System tools | Coverage |
| --- | --- | --- | --- |
| Documentation/configuration only | None | None | File-specific pre-commit hooks still run |
| Python/Python stub | `_task_interface` | Missing CMake/Ninja/G++ only | Pyright retains extension symbol resolution |
| C/C++ source or header | `build_package_sim` | Missing CMake/Ninja/G++/clang-tidy | Existing runtime compilation and clang-tidy compile databases are retained |
| `3rdparty/` or `vendor/` C/C++ only | None | None | Matches existing hook exclusions |
| Mixed Python and C/C++ | `build_package_sim` | Full C++ lint tool set | Uses the strongest required path |

## Observed timing

The first CI run exercised the Python-only path because this PR changes the workflow plus a Python test. It passed.

| Step | Previous run 31692720382 | This PR run 31693911353 | Reduction |
| --- | ---: | ---: | ---: |
| Build/lint tool setup | 17s | <1s | about 17s |
| Torch install | 23s | 21s | 2s |
| Project package build | 1m58s (`build_package_sim`) | 24s (`_task_interface`) | 1m34s |
| Pre-commit hooks | 42s | 34s | 8s, diff-dependent |
| Whole job | 3m32s | 1m30s | 2m02s |

Across the 12 successful jobs sampled before this change, the whole pre-commit job was typically about 2m26s-3m49s and the package build had a median near 1m56s. This run reduced the stable package-build cost by 80% and completed the gate in 1m30s.

[Measured run 31693911353](https://github.com/hw-native-sys/simpler/actions/runs/31693911353)

## Validation

- Build-selection tests cover documentation-only, Python-only, C++, excluded vendor C++, and mixed Python/C++ diffs: 5 passed.
- Related workflow-script tests: 9 passed total.
- YAML validation passed.
- Pre-commit checks for the workflow and new test passed locally and in CI.
- `git diff --check upstream/main...HEAD`: passed.
