### PR TITLE
Fix: worker-chip region cleanup replay

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -8057,8 +8057,9 @@ class Worker:
             except BaseException as exc:  # noqa: BLE001
                 region_errors.append(exc)
             try:
-                if self._worker is not None:
+                if self._worker is not None and not region._chip_release_committed:
                     self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
+                    region._chip_release_committed = True
                     region.free()
             except BaseException as exc:  # noqa: BLE001
                 release_error = exc

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -8050,7 +8050,7 @@ class Worker:
                 tail = extra
             return primary
 
-        expired = bool(getattr(region, "expired", getattr(region, "_expired", False)))
+        expired = bool(region.expired)
         if not expired:
             try:
                 region._close_worker_host_mapping()
@@ -8059,9 +8059,7 @@ class Worker:
             try:
                 if self._worker is not None:
                     self._worker.control_worker_chip_region_release(region._worker_id, region.region_id)
-                    free = getattr(region, "free", None)
-                    if callable(free):
-                        free()
+                    region.free()
             except BaseException as exc:  # noqa: BLE001
                 release_error = exc
                 region_errors.append(exc)

--- a/python/simpler/worker_chip_orch_comm.py
+++ b/python/simpler/worker_chip_orch_comm.py
@@ -156,10 +156,8 @@ class WorkerHostRegionMapping:
     def close(self) -> None:
         if self.closed:
             return
-        try:
-            _worker_host_mapped_region_close(int(self.handle))
-        finally:
-            self.closed = True
+        _worker_host_mapped_region_close(int(self.handle))
+        self.closed = True
 
 
 def decode_region_create_reply(buf: memoryview) -> WorkerChipRegionCreateReply:
@@ -311,6 +309,7 @@ class WorkerChipOrchRegion:
         self._descriptor = desc
         self._worker_host_mapping = worker_host_mapping
         self._released = False
+        self._chip_release_committed = False
         self._poisoned = False
         self._expired = False
 

--- a/tests/ut/py/test_worker/test_comm_region.py
+++ b/tests/ut/py/test_worker/test_comm_region.py
@@ -339,6 +339,10 @@ class _FakeRegion:
         self._expired = False
         self._released = False
 
+    @property
+    def expired(self) -> bool:
+        return self._expired
+
     def payload_write(self, offset: int, host_buffer, nbytes=None) -> None:
         self._calls.append(("payload_write", offset, host_buffer, nbytes))
 

--- a/tests/ut/py/test_worker/test_comm_region.py
+++ b/tests/ut/py/test_worker/test_comm_region.py
@@ -338,6 +338,7 @@ class _FakeRegion:
         self.region_id = 42
         self._expired = False
         self._released = False
+        self._chip_release_committed = False
 
     @property
     def expired(self) -> bool:

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -3994,13 +3994,22 @@ class TestRunHandle:
                 self.region_id = region_id
                 self._worker_id = 0
                 self.mapping_closed = False
-                self.expired = False
+                self._expired = False
+                self._released = False
+                self._chip_release_committed = False
+
+            @property
+            def expired(self):
+                return self._expired
 
             def _close_worker_host_mapping(self):
                 self.mapping_closed = True
 
+            def free(self):
+                self._released = True
+
             def _expire(self):
-                self.expired = True
+                self._expired = True
 
         class NativeWorker:
             def __init__(self):
@@ -4088,13 +4097,22 @@ class TestRunHandle:
             _worker_id = 0
 
             def __init__(self):
-                self.expired = False
+                self._expired = False
+                self._released = False
+                self._chip_release_committed = False
+
+            @property
+            def expired(self):
+                return self._expired
 
             def _close_worker_host_mapping(self):
                 raise mapping_error
 
+            def free(self):
+                self._released = True
+
             def _expire(self):
-                self.expired = True
+                self._expired = True
 
         class NativeWorker:
             def __init__(self):
@@ -4150,9 +4168,18 @@ class TestRunHandle:
                 self._worker_id = 0
                 self.mapping_closes = 0
                 self.expires = 0
+                self._released = False
+                self._chip_release_committed = False
+
+            @property
+            def expired(self):
+                return self.expires > 0
 
             def _close_worker_host_mapping(self):
                 self.mapping_closes += 1
+
+            def free(self):
+                self._released = True
 
             def _expire(self):
                 self.expires += 1

--- a/tests/ut/py/test_worker/test_worker_chip_orch_comm.py
+++ b/tests/ut/py/test_worker/test_worker_chip_orch_comm.py
@@ -775,6 +775,71 @@ def test_late_cleanup_error_after_successful_close_replays_stably(monkeypatch):
     assert errors == {}
 
 
+def test_close_replay_does_not_double_release_worker_chip_region_after_mapping_close_failure(monkeypatch):
+    class _FakeCloseWorker(_FakeDirectCWorker):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    worker = Worker(level=3, device_ids=[0], platform="a2a3sim", runtime="tensormap_and_ringbuffer")
+    fake_c_worker = _FakeCloseWorker()
+    worker._lifecycle = worker_module._Lifecycle.READY
+    worker._worker = fake_c_worker
+    worker._init_owner_thread = threading.current_thread()
+    mapping = worker_chip_orch_comm.WorkerHostRegionMapping(
+        worker_id=0,
+        region_id=1,
+        access_profile=worker_chip_orch_comm.WorkerChipRegionAccessProfile.SIM_POSIX_SHM,
+        total_bytes=192,
+        payload_offset=0,
+        payload_bytes=64,
+        counter_offset=64,
+        counter_bytes=128,
+        handle=77,
+    )
+    region = worker_chip_orch_comm.WorkerChipOrchRegion(
+        worker,
+        0,
+        worker_chip_orch_comm.WorkerChipOrchRegionDesc(
+            magic_version=0x4C334C3200020000,
+            region_id=1,
+            payload_base=0xDEAD_0000,
+            payload_bytes=64,
+            counter_base=0xDEAD_0040,
+            counter_bytes=128,
+        ),
+        mapping,
+    )
+    worker._live_worker_chip_regions.append(region)
+    close_calls: list[int] = []
+    fail_next_mapping_close = True
+
+    def close_mapping(handle: int) -> None:
+        nonlocal fail_next_mapping_close
+        close_calls.append(int(handle))
+        if fail_next_mapping_close:
+            fail_next_mapping_close = False
+            raise RuntimeError("mapping close failed")
+
+    monkeypatch.setattr(worker_chip_orch_comm, "_worker_host_mapped_region_close", close_mapping)
+
+    with pytest.raises(RuntimeError, match="mapping close failed"):
+        worker.close()
+
+    assert close_calls == [77]
+    assert fake_c_worker.release_calls == [(0, 1)]
+    assert worker._live_worker_chip_regions == [region]
+
+    worker.close()
+
+    assert close_calls == [77, 77]
+    assert fake_c_worker.release_calls == [(0, 1)]
+    assert worker._live_worker_chip_regions == []
+
+
 def test_concurrent_close_publishes_joiner_cleanup_error_to_every_caller(monkeypatch):
     worker = Worker(level=3, num_sub_workers=0)
     worker._lifecycle = worker_module._Lifecycle.READY


### PR DESCRIPTION
 ## Summary

  This PR handles the #1770 follow-up items.

  Done here:

  - Tighten worker-chip region cleanup shape:
    - replace defensive `getattr(region, "expired", ...)` with direct `region.expired`
    - replace defensive `getattr(region, "free", None)` / callable check with direct `region.free()`
    - update test fake regions to expose the same cleanup surface as `WorkerChipOrchRegion`
  - Fix replay double-release:
    - add cleanup-owned chip release tracking separate from user-facing `_released`
    - mark chip release committed only after `control_worker_chip_region_release(...)` succeeds
    - allow close replay to retry native host mapping close without releasing the same chip region twice
    - add a whole-tree close regression test for mapping-close failure plus successful chip release

  Already handled in #1822:

  - W4 region sync/access refactor onto neutral region-native primitives
  - `WorkerChipOrchRegion` compatibility facade over W4 region access pieces
  - neutral native mapped-region backend and `_region_*` binding surface
  - redundant provider root check cleanup in `validate_single_owner_region_shape`

  Not done here:

  - post-W4 `comm_region.py` hygiene
  - public `create_region(...)`
  - W5 delegated transactions
  - queue/ring/mailbox/freelist templates
  - Symmetric/OpenSHMEM topology