### PR TITLE
Fix: align host and device L4 swimlane clocks

### DIFF
--- a/simpler_setup/tools/clock_correlation.py
+++ b/simpler_setup/tools/clock_correlation.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from dataclasses import dataclass
+from typing import Optional
+
+_A0_POSITION = "pre_host_orchestration"
+_A2_POSITION = "post_device_execution"
+_METHOD = "nominal_frequency_offset_interp_v1"
+
+
+@dataclass(frozen=True)
+class ClockAnchor:
+    position: str
+    sample_idx: int
+    host_mid_ns: int
+    device_cycles: int
+    rtt_ns: int
+    uncertainty_ns: int
+
+
+@dataclass(frozen=True)
+class ClockAlignment:
+    status: str
+    reason: Optional[str]
+    frequency_hz: int
+    host_timestamp_quantization_ns: int = 0
+    start: Optional[ClockAnchor] = None
+    end: Optional[ClockAnchor] = None
+
+    @property
+    def anchor_uncertainty_ns(self):
+        if self.start is None or self.end is None:
+            return None
+        return max(self.start.uncertainty_ns, self.end.uncertainty_ns)
+
+    @property
+    def max_uncertainty_ns(self):
+        if self.anchor_uncertainty_ns is None:
+            return None
+        return self.anchor_uncertainty_ns + self.host_timestamp_quantization_ns
+
+    def metadata(self):
+        out = {
+            "status": self.status,
+            "method": _METHOD,
+            "anchor_uncertainty_ns": self.anchor_uncertainty_ns,
+            "host_timestamp_quantization_ns": self.host_timestamp_quantization_ns,
+            "max_uncertainty_ns": self.max_uncertainty_ns,
+        }
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.start is not None and self.end is not None:
+            out["selected_sample_idx"] = {
+                self.start.position: self.start.sample_idx,
+                self.end.position: self.end.sample_idx,
+            }
+        return out
+
+    def contains(self, device_cycles):
+        return (
+            self.status == "calibrated"
+            and self.start is not None
+            and self.end is not None
+            and self.start.device_cycles <= device_cycles <= self.end.device_cycles
+        )
+
+    def map_cycles_to_host_ns(self, device_cycles):
+        if self.start is None or self.end is None or not self.contains(device_cycles):
+            raise ValueError(f"device timestamp {device_cycles} is outside calibrated anchor coverage")
+
+        start = self.start
+        end = self.end
+        delta_cycles = device_cycles - start.device_cycles
+        span_cycles = end.device_cycles - start.device_cycles
+        nominal_delta_ns = _mul_div_toward_zero(delta_cycles, 1_000_000_000, self.frequency_hz)
+        nominal_end_ns = start.host_mid_ns + _mul_div_toward_zero(span_cycles, 1_000_000_000, self.frequency_hz)
+        end_correction_ns = end.host_mid_ns - nominal_end_ns
+        correction_ns = _mul_div_toward_zero(end_correction_ns, delta_cycles, span_cycles)
+        return start.host_mid_ns + nominal_delta_ns + correction_ns
+
+
+def _mul_div_toward_zero(value, multiplier, divisor):
+    if divisor <= 0:
+        raise ValueError("divisor must be positive")
+    product = value * multiplier
+    if product >= 0:
+        return product // divisor
+    return -((-product) // divisor)
+
+
+def _unaligned(frequency_hz, reason, host_timestamp_quantization_ns=0):
+    return ClockAlignment(
+        status="unaligned",
+        reason=reason,
+        frequency_hz=frequency_hz,
+        host_timestamp_quantization_ns=host_timestamp_quantization_ns,
+    )
+
+
+def _parse_anchor(sample, position, device_quantization_ns):
+    error = sample.get("error")
+    if error not in (None, 0, ""):
+        return None
+    try:
+        host_before_ns = int(sample["host_before_ns"])
+        device_cycles = int(sample["device_cycles"])
+        host_after_ns = int(sample["host_after_ns"])
+        sample_idx = int(sample["sample_idx"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if host_before_ns <= 0 or device_cycles <= 0 or host_after_ns < host_before_ns or sample_idx < 0:
+        return None
+    rtt_ns = host_after_ns - host_before_ns
+    return ClockAnchor(
+        position=position,
+        sample_idx=sample_idx,
+        host_mid_ns=host_before_ns + rtt_ns // 2,
+        device_cycles=device_cycles,
+        rtt_ns=rtt_ns,
+        uncertainty_ns=(rtt_ns + 1) // 2 + device_quantization_ns,
+    )
+
+
+def build_clock_alignment(  # noqa: PLR0912
+    clock_anchors, frequency_hz, device_timestamps=(), host_timestamp_quantization_ns=0
+):
+    host_timestamp_quantization_ns = int(host_timestamp_quantization_ns)
+    if host_timestamp_quantization_ns < 0:
+        return _unaligned(frequency_hz, "invalid_host_timestamp_quantization")
+    if frequency_hz <= 0:
+        return _unaligned(frequency_hz, "invalid_device_frequency", host_timestamp_quantization_ns)
+    if not isinstance(clock_anchors, dict):
+        return _unaligned(frequency_hz, "missing_clock_anchors", host_timestamp_quantization_ns)
+    samples = clock_anchors.get("samples")
+    if not isinstance(samples, list):
+        return _unaligned(frequency_hz, "missing_clock_anchor_samples", host_timestamp_quantization_ns)
+    if clock_anchors.get("device_timestamp_unit") != "syscnt_cycles":
+        return _unaligned(frequency_hz, "unsupported_device_timestamp_unit", host_timestamp_quantization_ns)
+    raw_unit = clock_anchors.get("raw_device_timestamp_unit", "syscnt_cycles")
+    if raw_unit == "device_uptime_us":
+        # aclrtEventGetTimestamp has microsecond resolution. Normalizing it to
+        # cycles does not recover the discarded sub-microsecond portion.
+        device_quantization_ns = 1_000
+    elif raw_unit == "syscnt_cycles":
+        device_quantization_ns = 0
+    else:
+        return _unaligned(frequency_hz, "unsupported_raw_device_timestamp_unit", host_timestamp_quantization_ns)
+
+    valid_by_position = {_A0_POSITION: [], _A2_POSITION: []}
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        position = sample.get("position")
+        if position not in valid_by_position:
+            continue
+        anchor = _parse_anchor(sample, position, device_quantization_ns)
+        if anchor is not None:
+            valid_by_position[position].append(anchor)
+
+    if not valid_by_position[_A0_POSITION]:
+        return _unaligned(frequency_hz, "no_valid_pre_host_orchestration_anchor", host_timestamp_quantization_ns)
+    if not valid_by_position[_A2_POSITION]:
+        return _unaligned(frequency_hz, "no_valid_post_device_execution_anchor", host_timestamp_quantization_ns)
+
+    start = min(valid_by_position[_A0_POSITION], key=lambda anchor: (anchor.rtt_ns, anchor.sample_idx))
+    end = min(valid_by_position[_A2_POSITION], key=lambda anchor: (anchor.rtt_ns, anchor.sample_idx))
+    if end.host_mid_ns <= start.host_mid_ns:
+        return _unaligned(frequency_hz, "host_anchor_order_invalid", host_timestamp_quantization_ns)
+    if end.device_cycles <= start.device_cycles:
+        return _unaligned(frequency_hz, "device_anchor_order_invalid", host_timestamp_quantization_ns)
+
+    alignment = ClockAlignment(
+        status="calibrated",
+        reason=None,
+        frequency_hz=frequency_hz,
+        host_timestamp_quantization_ns=host_timestamp_quantization_ns,
+        start=start,
+        end=end,
+    )
+    for timestamp in device_timestamps:
+        timestamp = int(timestamp)
+        if timestamp > 0 and not alignment.contains(timestamp):
+            return _unaligned(
+                frequency_hz,
+                "device_timestamps_outside_anchor_coverage",
+                host_timestamp_quantization_ns,
+            )
+    return alignment

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -35,6 +35,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from simpler_setup.tools.clock_correlation import build_clock_alignment
+
 
 def _func_id_to_letter(func_id):
     """Map a non-negative integer func_id to a numeric+letter label.
@@ -230,7 +232,8 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
                             end_cycles, receive_to_start_cycles], ...],
           "aicpu_tasks":  [[core_id, reg_task_id, dispatch_cycles, finish_cycles], ...],
           "aicpu_scheduler_phases":     [ [ {kind, start_cycles, end_cycles, ...}, ... ], ... ],
-          "aicpu_orchestrator_phases":  [ [ {submit_idx, task_id, start_cycles, end_cycles}, ... ], ... ]
+          "aicpu_orchestrator_phases":  [ [ {submit_idx, task_id, start_cycles, end_cycles}, ... ], ... ],
+          "host_orchestrator_phases":   [ [ {submit_idx, task_id, start_host_ns, end_host_ns}, ... ], ... ]
         }
 
     aicore_tasks columns (v3 schema): the trailing receive_to_start_cycles
@@ -284,6 +287,67 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
     aicpu_rows = data.get("aicpu_tasks") or []
     sched_phases_raw = data.get("aicpu_scheduler_phases") or []
     orch_phases_raw = data.get("aicpu_orchestrator_phases") or []
+    host_orch_phases_raw = data.get("host_orchestrator_phases") or []
+    raw_host_capture = metadata.get("host_capture")
+    host_mode = (
+        metadata.get("orchestrator_source") == "host"
+        or bool(host_orch_phases_raw)
+        or isinstance(raw_host_capture, dict)
+    )
+    if orch_phases_raw and host_mode:
+        raise ValueError("both AICPU and host orchestrator phases are present; clock-domain source is ambiguous")
+
+    actual_host_record_count = sum(len(records) for records in host_orch_phases_raw)
+    if isinstance(raw_host_capture, dict):
+        host_capture = dict(raw_host_capture)
+        capture_status = str(host_capture.get("status") or "unknown")
+        raw_dropped_records = host_capture.get("dropped_records")
+        dropped_records = int(raw_dropped_records) if raw_dropped_records is not None else None
+        reported_records = host_capture.get("recorded_records")
+        count_matches = reported_records is None or int(reported_records) == actual_host_record_count
+        capture_finished = host_capture.get("finished") is True
+        expected_records = host_capture.get("expected_records")
+        expected_count_matches = expected_records is not None and int(expected_records) == actual_host_record_count
+        host_capture_complete = (
+            capture_status == "complete"
+            and dropped_records == 0
+            and count_matches
+            and capture_finished
+            and expected_count_matches
+        )
+        validation_errors = []
+        if not count_matches:
+            validation_errors.append("recorded_record_count_mismatch")
+        if not capture_finished:
+            validation_errors.append("capture_not_finished")
+        if expected_records is None:
+            validation_errors.append("expected_record_count_missing")
+        elif not expected_count_matches:
+            validation_errors.append("expected_record_count_mismatch")
+        if validation_errors:
+            host_capture["converter_validation_errors"] = validation_errors
+    elif host_mode:
+        host_capture = {
+            "status": "unknown",
+            "recorded_records": actual_host_record_count,
+            "dropped_records": None,
+            "error": "legacy_capture_status_missing",
+        }
+        host_capture_complete = False
+    else:
+        host_capture = None
+        host_capture_complete = False
+
+    host_timestamps = [
+        int(pr[field])
+        for thread_records in host_orch_phases_raw
+        for pr in thread_records
+        for field in ("start_host_ns", "end_host_ns")
+    ]
+    host_origin_ns = int(metadata.get("host_orchestration_origin_ns") or 0)
+    if host_timestamps and host_origin_ns == 0:
+        host_origin_ns = min(host_timestamps)
+    host_composite_end_us = (max(host_timestamps) - host_origin_ns) / 1000.0 if host_timestamps else 0.0
 
     # AICore lookup keyed by (core_id, reg_task_id). Two dispatches of the
     # same PTO2 task_token_raw to the same core (SPMD over-subscription, MIX
@@ -339,12 +403,43 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
     if base_time_cycles is None:
         base_time_cycles = 0
 
+    device_timestamps = []
+    for row in aicore_rows:
+        start_cycles = int(row[3])
+        receive_to_start_cycles = int(row[5]) if len(row) > 5 else 0
+        device_timestamps.extend((start_cycles - receive_to_start_cycles, start_cycles, int(row[4])))
+    for _, _, dispatch_cycles, finish_cycles in aicpu_rows:
+        device_timestamps.extend((int(dispatch_cycles), int(finish_cycles)))
+    for phase_threads in (sched_phases_raw, orch_phases_raw):
+        for thread_records in phase_threads:
+            for phase in thread_records:
+                device_timestamps.extend((int(phase.get("start_cycles", 0)), int(phase.get("end_cycles", 0))))
+
+    clock_alignment = None
+    if host_mode:
+        clock_alignment = build_clock_alignment(
+            metadata.get("clock_anchors"),
+            clock_freq_hz,
+            device_timestamps,
+            metadata.get("host_timestamp_quantization_ns", 0),
+        )
+        if host_origin_ns == 0 and clock_alignment.start is not None:
+            host_origin_ns = clock_alignment.start.host_mid_ns
+
     cycles_to_us_factor = 1_000_000.0 / float(clock_freq_hz)
 
     def _to_us(cycles):
         if cycles <= 0:
             return 0.0
-        return (cycles - base_time_cycles) * cycles_to_us_factor
+        if clock_alignment is not None and clock_alignment.status == "calibrated":
+            return (clock_alignment.map_cycles_to_host_ns(cycles) - host_origin_ns) / 1000.0
+        relative_device_us = (cycles - base_time_cycles) * cycles_to_us_factor
+        if host_mode:
+            # Fail-soft diagnostic layout: preserve both clock domains and only
+            # encode the known happens-before relation. The physical gap at
+            # this seam is unknown and must never feed cross-domain latency.
+            return host_composite_end_us + relative_device_us
+        return relative_device_us
 
     def _core_type(core_id):
         if 0 <= core_id < len(core_types):
@@ -367,11 +462,8 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
             start_us = _to_us(start_cycles)
             end_us = _to_us(end_cycles)
             dispatch_us = _to_us(int(dispatch_cycles))
-            # receive_to_start delta is in cycles; convert via the same
-            # cycles_to_us_factor that drives the absolute timestamps. No
-            # base_time subtraction — this is a delta.
-            local_setup_us = r2s_cycles * cycles_to_us_factor
-            receive_us = start_us - local_setup_us
+            receive_us = _to_us(start_cycles - r2s_cycles)
+            local_setup_us = start_us - receive_us
             tasks.append(
                 {
                     "task_id": task_token_raw,
@@ -399,7 +491,8 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
             task_token_raw = int(task_token_raw)
             start_us = _to_us(int(start_cycles))
             end_us = _to_us(int(end_cycles))
-            local_setup_us = r2s_cycles * cycles_to_us_factor
+            receive_us = _to_us(int(start_cycles) - r2s_cycles)
+            local_setup_us = start_us - receive_us
             tasks.append(
                 {
                     "task_id": task_token_raw,
@@ -412,7 +505,7 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
                     "duration_us": end_us - start_us,
                     "dispatch_time_us": 0.0,
                     "finish_time_us": 0.0,
-                    "receive_time_us": start_us - local_setup_us,
+                    "receive_time_us": receive_us,
                     "local_setup_us": local_setup_us,
                     # propagation_us requires AICPU dispatch_ts; absent at level 1.
                 }
@@ -463,6 +556,26 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
             converted.append(out)
         aicpu_orchestrator_phases.append(converted)
 
+    host_orchestrator_phases = []
+    for thread_records in host_orch_phases_raw:
+        converted = []
+        for pr in thread_records:
+            start_ns = int(pr.get("start_host_ns", 0))
+            end_ns = int(pr.get("end_host_ns", 0))
+            if start_ns < host_origin_ns or end_ns < start_ns:
+                raise ValueError(
+                    f"invalid host orchestrator phase: origin={host_origin_ns}, start={start_ns}, end={end_ns}"
+                )
+            out = dict(pr)
+            out["start_time_us"] = (start_ns - host_origin_ns) / 1000.0
+            out["end_time_us"] = (end_ns - host_origin_ns) / 1000.0
+            out["phase"] = "orch_submit"
+            out.pop("start_host_ns", None)
+            out.pop("end_host_ns", None)
+            converted.append(out)
+        if converted:
+            host_orchestrator_phases.append(converted)
+
     out = {
         "chip_swimlane_level": level,
         "tasks": tasks,
@@ -471,6 +584,33 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
         out["aicpu_scheduler_phases"] = aicpu_scheduler_phases
     if aicpu_orchestrator_phases:
         out["aicpu_orchestrator_phases"] = aicpu_orchestrator_phases
+        out["orchestrator_source"] = "aicpu"
+    if host_mode:
+        if clock_alignment is None:
+            raise RuntimeError("host timeline is missing its clock-alignment result")
+        out["orchestrator_source"] = "host"
+        calibrated = clock_alignment.status == "calibrated"
+        trace_status = "complete" if host_capture_complete else "partial"
+        out["timeline_metadata"] = {
+            "layout": "clock_aligned" if calibrated else "causal_composite",
+            "trace_status": trace_status,
+            "relation": metadata.get("timeline_relation", "host_orchestration_precedes_device"),
+            "clock_alignment": clock_alignment.metadata(),
+            "host_capture": host_capture,
+            "host_records_complete": host_capture_complete,
+            "cross_domain_latency_available": calibrated and host_capture_complete,
+        }
+        if not calibrated:
+            out["timeline_metadata"].update(
+                {
+                    "cross_domain_gap_unknown": True,
+                    "logical_seam_us": host_composite_end_us,
+                }
+            )
+        if host_orchestrator_phases:
+            out["aicpu_orchestrator_phases"] = host_orchestrator_phases
+        else:
+            out["timeline_metadata"]["host_records_missing"] = True
     if core_to_thread:
         out["core_to_thread"] = core_to_thread
     return out
@@ -1185,6 +1325,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     orchestrator_phases=None,
     core_to_thread=None,
     orchestrator_name=None,
+    orchestrator_source=None,
+    timeline_metadata=None,
     deps_edges=None,
     deps_kernel_map=None,
     deps_block_map=None,
@@ -1207,7 +1349,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
 
     Generates processes in the trace:
         - pid=5 "Graph Execution": one end-to-end envelope per Graph task
-        - pid=1 "AICPU Orchestrator": orchestrator phase bars (chip_swimlane_level >= 4)
+        - pid=1 "Host/AICPU Orchestrator": orchestrator phase bars (chip_swimlane_level >= 4)
         - pid=2 "AICPU Scheduler": scheduler phase bars (chip_swimlane_level >= 3)
         - pid=3 "Scheduler View": dispatch_time_us to finish_time_us (AICPU perspective)
         - pid=4 "Worker View": per-subtask kernel execution on physical cores
@@ -1865,7 +2007,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # line covers the run-window envelope for debugging without swimlane.
     if orchestrator_phases:
         # Process metadata
-        orch_process_label = f"AICPU {orchestrator_name}" if orchestrator_name else "AICPU Orchestrator"
+        if orchestrator_source == "host":
+            orch_process_label = "Host Orchestrator"
+        else:
+            orch_process_label = f"AICPU {orchestrator_name}" if orchestrator_name else "AICPU Orchestrator"
         events.append(
             {"args": {"name": orch_process_label}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 1}
         )
@@ -1876,7 +2021,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         # Thread name metadata for each orchestrator thread
         for orch_idx in range(len(orchestrator_phases)):
             tid = 4000 + orch_idx
-            name = f"Orch_{orch_idx}"
+            name = f"Host_{orch_idx}" if orchestrator_source == "host" else f"Orch_{orch_idx}"
             events.append(
                 {"args": {"name": name}, "cat": "__metadata", "name": "thread_name", "ph": "M", "pid": 1, "tid": tid}
             )
@@ -2503,7 +2648,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # Anchor each task's dispatch arrow on the end of its orch_submit record
     # (covers the entire submit_task() span). Legacy captures with the older
     # per-sub-step phases (orch_fanin / orch_params) are accepted as fallbacks.
-    if orchestrator_phases and scheduler_phases:
+    cross_domain_aligned = not (
+        orchestrator_source == "host"
+        and timeline_metadata
+        and not timeline_metadata.get("cross_domain_latency_available", False)
+    )
+    if orchestrator_phases and scheduler_phases and cross_domain_aligned:
         orch_anchor_by_task = {}
         for orch_idx, thread_records in enumerate(orchestrator_phases):
             for record in thread_records:
@@ -2588,8 +2738,11 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         if verbose:
             print(f"  Overhead Analysis: {sum(1 for e in oh if e.get('ph') == 'C')} counter points (8 tracks)")
 
+    trace = {"traceEvents": events}
+    if timeline_metadata:
+        trace["metadata"] = timeline_metadata
     with open(output_path, "w") as f:
-        json.dump({"traceEvents": events}, f, indent=2)
+        json.dump(trace, f, indent=2)
 
     if verbose:
         print(f"JSON written to: {output_path}")
@@ -2809,6 +2962,8 @@ def main():
             orchestrator_name=orchestrator_name,
             scheduler_phases=data.get("aicpu_scheduler_phases"),
             orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+            orchestrator_source=data.get("orchestrator_source"),
+            timeline_metadata=data.get("timeline_metadata"),
             core_to_thread=data.get("core_to_thread"),
             deps_edges=deps_edges,
             deps_kernel_map=deps_kernel_map,

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -190,6 +190,12 @@ constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
  */
 constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 50000000;  // 50 MHz
 
+// aclrtEventGetTimestamp capability, verified on a2a3 silicon: the raw value
+// is device-uptime microseconds and covers the same epoch as profiling syscnt
+// after frequency normalization.
+constexpr uint64_t PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ = 1000000;
+constexpr const char *PLATFORM_ACL_EVENT_TIMESTAMP_UNIT = "device_uptime_us";
+
 /**
  * Unified spin-wait timeout for DFX subsystem backpressure gates (system-counter
  * cycles). Every DFX collector's park loop aborts after this budget on host

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
@@ -74,6 +75,7 @@ list(APPEND HOST_RUNTIME_SOURCES
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/c_api_shared.cpp"
 )

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -707,7 +707,7 @@ int DeviceRunner::reap_run(unsigned slot) {
         // JSON manifest, i.e. unusable for triage. reconcile/export are not
         // idempotent, so this runs only on the error return; the success path
         // still exports exactly once below.
-        teardown_shared_collectors_after_run();
+        teardown_shared_collectors_after_run(false);
         return rc;
     }
 
@@ -715,7 +715,7 @@ int DeviceRunner::reap_run(unsigned slot) {
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    teardown_shared_collectors_after_run();
+    teardown_shared_collectors_after_run(true);
 
     // a2a3-only dep_gen teardown: host-orch emits the graph its orchestration
     // built on this same thread; device-orch stops the collector, reconciles the

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"
@@ -57,6 +58,7 @@ list(APPEND HOST_RUNTIME_SOURCES
 # linked once per arch's libhost_runtime.so. Mirrors the onboard split.
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/device_runner_base.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/c_api_shared.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/memory_allocator.cpp"
 )

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -648,11 +648,13 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
+        finish_clock_correlation_session(false);
         return runtime_rc;
     }
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
+    finish_clock_correlation_session(true);
     if (enable_chip_swimlane_) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -109,6 +109,56 @@ static int64_t _now_ms() {
     return static_cast<int64_t>(tv.tv_sec) * 1000 + tv.tv_usec / 1000;
 }
 
+namespace {
+
+thread_local const HostApi *g_host_orch_profile_api = nullptr;
+thread_local uint32_t g_host_orch_submit_idx = 0;
+
+uint64_t host_fallback_cycles_to_ns(uint64_t cycles) {
+    constexpr uint64_t kNsPerSecond = 1000000000ull;
+    return (cycles / PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond +
+           (cycles % PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond / PLATFORM_PROF_SYS_CNT_FREQ;
+}
+
+class HostOrchestratorProfileBinding {
+public:
+    HostOrchestratorProfileBinding(const HostApi *api, uint64_t task_window_size) :
+        previous_(g_host_orch_profile_api),
+        previous_submit_idx_(g_host_orch_submit_idx) {
+        if (api != nullptr && api->chip_swimlane_level() == static_cast<uint32_t>(ChipSwimlaneLevel::ORCH_PHASES)) {
+            api->begin_host_orchestrator_capture(task_window_size);
+            g_host_orch_profile_api = api;
+            g_host_orch_submit_idx = 0;
+        }
+    }
+
+    ~HostOrchestratorProfileBinding() {
+        g_host_orch_profile_api = previous_;
+        g_host_orch_submit_idx = previous_submit_idx_;
+    }
+
+private:
+    const HostApi *previous_;
+    uint32_t previous_submit_idx_;
+};
+
+}  // namespace
+
+// Strong host-side override for the weak fallback in pto_orchestrator.cpp.
+// Its inputs are the host fallback's frequency-scaled CLOCK_MONOTONIC values;
+// convert them back to ns and route the typed record through this run's
+// HostApi binding. The AICPU build does not link runtime_maker.cpp and keeps
+// using the device collector's implementation.
+__attribute__((visibility("hidden"))) void
+chip_swimlane_aicpu_record_orch_phase(uint64_t start_time, uint64_t end_time, uint64_t task_id, uint32_t) {
+    if (g_host_orch_profile_api == nullptr) return;
+    ChipSwimlaneHostOrchPhaseRecord record{
+        host_fallback_cycles_to_ns(start_time), host_fallback_cycles_to_ns(end_time), task_id, g_host_orch_submit_idx++,
+        0
+    };
+    g_host_orch_profile_api->record_host_orchestrator_phase(record);
+}
+
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
 template <typename T>
@@ -496,6 +546,9 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
         return -1;
     }
+#if SIMPLER_DFX
+    rt->orchestrator.chip_swimlane_level = static_cast<ChipSwimlaneLevel>(api->chip_swimlane_level());
+#endif
     rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, &rt->scheduler);
 
     PTO2SharedMemoryHandle host_sm_handle;
@@ -535,6 +588,7 @@ int32_t run_host_orchestration(
     // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
+    HostOrchestratorProfileBinding profile_binding(api, eff_task_window_sizes[0]);
     rt_scope_begin(rt);
     entry_points->entry(orch_l2);
     rt_scope_end(rt);
@@ -549,6 +603,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
         return -1;
     }
+    api->finish_host_orchestrator_capture(static_cast<uint64_t>(total_tasks));
 
     // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
     // on the host, before the SM and arena leave for the device. Pointers into

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -170,6 +170,7 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)                                                         \
     do {                                                                                            \
         if (_prof_active) {                                                                         \
+            _t1 = get_sys_cnt_aicpu();                                                              \
             chip_swimlane_aicpu_record_orch_phase(_submit_start_ts, _t1, (tid), g_orch_submit_idx); \
         }                                                                                           \
     } while (0)
@@ -1432,6 +1433,7 @@ bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
     const CoreTaskArgs &args, PTO2TaskId *submitted_id
 ) {
+    CYCLE_COUNT_START();
     const GraphDefinition *definition = graph_definition(definition_image);
     if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
         definition->required_heap > static_cast<uint64_t>(INT32_MAX)) {
@@ -1497,6 +1499,7 @@ bool graph_submit_definition(
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(std::move(pending));
     if (submitted_id != nullptr) *submitted_id = task_id;
+    CYCLE_COUNT_ORCH_SUBMIT_RECORD(task_id.raw);
 #if SIMPLER_DFX
     orch->tasks_submitted++;
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -837,9 +837,10 @@ int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thr
             // would prime zero sched pools and all sched_phase emits would silently
             // drop.
             const int sched_phase_threads = aicpu_thread_num_;
-            // Orchestration is always single-threaded, so orch-phase is one pool
-            // (ordinal 0) — see record_orch_phase.
-            const int orch_phase_threads = 1;
+            // HBG orchestration already completed on the host. Its level-4
+            // records use the host callback path, so the device initializes no
+            // dead AICPU orchestrator pool.
+            const int orch_phase_threads = 0;
             chip_swimlane_aicpu_init_phase(runtime->worker_count, sched_phase_threads, orch_phase_threads);
         }
     } else {
@@ -1055,15 +1056,6 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
 void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
 ) {
-#if SIMPLER_DFX
-    if (chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES) {
-        // Flush the orchestrator's orch-phase buffer (single instance, pool 0).
-        // The orchestrator has no scheduler-phase pool of its own — those belong
-        // to the scheduler threads and are flushed in scheduler_dispatch.
-        chip_swimlane_aicpu_flush_orch_phase_buffer(thread_idx);
-    }
-#endif
-
     total_tasks_ = total_tasks;
 
     // Allocate the per-S CompletedTaskQueues here on the boot leader, before it

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -216,6 +216,12 @@ constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
  */
 constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 1000000000;  // 1000 MHz
 
+// aclrtEventGetTimestamp capability, verified on a5 silicon: the raw value
+// is device-uptime microseconds and covers the same epoch as profiling syscnt
+// after frequency normalization.
+constexpr uint64_t PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ = 1000000;
+constexpr const char *PLATFORM_ACL_EVENT_TIMESTAMP_UNIT = "device_uptime_us";
+
 /**
  * Unified spin-wait timeout for DFX subsystem backpressure gates (system-counter
  * cycles). Every DFX collector's park loop aborts after this budget on host

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -65,6 +65,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/scope_stats_collector.cpp"
@@ -79,6 +80,7 @@ list(APPEND HOST_RUNTIME_SOURCES
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/c_api_shared.cpp"
 )

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -585,12 +585,12 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         recover_device_or_mark_unusable(rc);
         // Emergency shutdown may already have flushed diagnostics. Export the
         // manifest on the error path exactly once.
-        teardown_shared_collectors_after_run();
+        teardown_shared_collectors_after_run(false);
         return rc;
     }
 
     read_device_wall_ns();
-    teardown_shared_collectors_after_run();
+    teardown_shared_collectors_after_run(true);
 
     // a5-specific dep_gen teardown: stop + reconcile + replay emit.
     if (enable_dep_gen_) {

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/scope_stats_collector.cpp"
@@ -58,6 +59,7 @@ list(APPEND HOST_RUNTIME_SOURCES
 # linked once per arch's libhost_runtime.so. Mirrors the onboard split.
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/device_runner_base.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/c_api_shared.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/host/memory_allocator.cpp"
 )

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -594,11 +594,13 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
+        finish_clock_correlation_session(false);
         return runtime_rc;
     }
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
+    finish_clock_correlation_session(true);
     if (enable_chip_swimlane_) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -109,6 +109,56 @@ static int64_t _now_ms() {
     return static_cast<int64_t>(tv.tv_sec) * 1000 + tv.tv_usec / 1000;
 }
 
+namespace {
+
+thread_local const HostApi *g_host_orch_profile_api = nullptr;
+thread_local uint32_t g_host_orch_submit_idx = 0;
+
+uint64_t host_fallback_cycles_to_ns(uint64_t cycles) {
+    constexpr uint64_t kNsPerSecond = 1000000000ull;
+    return (cycles / PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond +
+           (cycles % PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond / PLATFORM_PROF_SYS_CNT_FREQ;
+}
+
+class HostOrchestratorProfileBinding {
+public:
+    HostOrchestratorProfileBinding(const HostApi *api, uint64_t task_window_size) :
+        previous_(g_host_orch_profile_api),
+        previous_submit_idx_(g_host_orch_submit_idx) {
+        if (api != nullptr && api->chip_swimlane_level() == static_cast<uint32_t>(ChipSwimlaneLevel::ORCH_PHASES)) {
+            api->begin_host_orchestrator_capture(task_window_size);
+            g_host_orch_profile_api = api;
+            g_host_orch_submit_idx = 0;
+        }
+    }
+
+    ~HostOrchestratorProfileBinding() {
+        g_host_orch_profile_api = previous_;
+        g_host_orch_submit_idx = previous_submit_idx_;
+    }
+
+private:
+    const HostApi *previous_;
+    uint32_t previous_submit_idx_;
+};
+
+}  // namespace
+
+// Strong host-side override for the weak fallback in pto_orchestrator.cpp.
+// Its inputs are the host fallback's frequency-scaled CLOCK_MONOTONIC values;
+// convert them back to ns and route the typed record through this run's
+// HostApi binding. The AICPU build does not link runtime_maker.cpp and keeps
+// using the device collector's implementation.
+__attribute__((visibility("hidden"))) void
+chip_swimlane_aicpu_record_orch_phase(uint64_t start_time, uint64_t end_time, uint64_t task_id, uint32_t) {
+    if (g_host_orch_profile_api == nullptr) return;
+    ChipSwimlaneHostOrchPhaseRecord record{
+        host_fallback_cycles_to_ns(start_time), host_fallback_cycles_to_ns(end_time), task_id, g_host_orch_submit_idx++,
+        0
+    };
+    g_host_orch_profile_api->record_host_orchestrator_phase(record);
+}
+
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
 template <typename T>
@@ -542,6 +592,9 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
         return -1;
     }
+#if SIMPLER_DFX
+    rt->orchestrator.chip_swimlane_level = static_cast<ChipSwimlaneLevel>(api->chip_swimlane_level());
+#endif
     rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, &rt->scheduler);
 
     // Initialize the host SM header (ring flow control) so submit_task can run.
@@ -591,6 +644,7 @@ int32_t run_host_orchestration(
     // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
+    HostOrchestratorProfileBinding profile_binding(api, eff_task_window_sizes[0]);
     rt_scope_begin(rt);
     entry_points->entry(orch_l2);
     rt_scope_end(rt);
@@ -605,6 +659,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
         return -1;
     }
+    api->finish_host_orchestrator_capture(static_cast<uint64_t>(total_tasks));
 
     // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
     // on the host, before the SM and arena leave for the device. Pointers into

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -170,6 +170,7 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)                                                         \
     do {                                                                                            \
         if (_prof_active) {                                                                         \
+            _t1 = get_sys_cnt_aicpu();                                                              \
             chip_swimlane_aicpu_record_orch_phase(_submit_start_ts, _t1, (tid), g_orch_submit_idx); \
         }                                                                                           \
     } while (0)
@@ -1432,6 +1433,7 @@ bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
     const CoreTaskArgs &args, PTO2TaskId *submitted_id
 ) {
+    CYCLE_COUNT_START();
     const GraphDefinition *definition = graph_definition(definition_image);
     if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
         definition->required_heap > static_cast<uint64_t>(INT32_MAX)) {
@@ -1497,6 +1499,7 @@ bool graph_submit_definition(
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(std::move(pending));
     if (submitted_id != nullptr) *submitted_id = task_id;
+    CYCLE_COUNT_ORCH_SUBMIT_RECORD(task_id.raw);
 #if SIMPLER_DFX
     orch->tasks_submitted++;
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -837,9 +837,10 @@ int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thr
             // would prime zero sched pools and all sched_phase emits would silently
             // drop.
             const int sched_phase_threads = aicpu_thread_num_;
-            // Orchestration is always single-threaded, so orch-phase is one pool
-            // (ordinal 0) — see record_orch_phase.
-            const int orch_phase_threads = 1;
+            // HBG orchestration already completed on the host. Its level-4
+            // records use the host callback path, so the device initializes no
+            // dead AICPU orchestrator pool.
+            const int orch_phase_threads = 0;
             chip_swimlane_aicpu_init_phase(runtime->worker_count, sched_phase_threads, orch_phase_threads);
         }
     } else {
@@ -1055,15 +1056,6 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
 void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
 ) {
-#if SIMPLER_DFX
-    if (chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES) {
-        // Flush the orchestrator's orch-phase buffer (single instance, pool 0).
-        // The orchestrator has no scheduler-phase pool of its own — those belong
-        // to the scheduler threads and are flushed in scheduler_dispatch.
-        chip_swimlane_aicpu_flush_orch_phase_buffer(thread_idx);
-    }
-#endif
-
     total_tasks_ = total_tasks;
 
     // Allocate the per-S CompletedTaskQueues here on the boot leader, before it

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -613,6 +613,24 @@ struct ChipSwimlaneAicpuOrchPhaseRecord {
 };
 static_assert(sizeof(ChipSwimlaneAicpuOrchPhaseRecord) == 32, "ChipSwimlaneAicpuOrchPhaseRecord layout drift");
 
+/**
+ * Host orchestrator phase record.
+ *
+ * host_build_graph constructs the complete runtime graph on the host before
+ * device execution starts. Keep these timestamps in the host monotonic-ns
+ * clock domain. The converter uses platform anchors for a physical alignment;
+ * if that fails, it emits an explicitly marked causal composite and forbids
+ * cross-domain latency calculations.
+ */
+struct ChipSwimlaneHostOrchPhaseRecord {
+    uint64_t start_time_ns;
+    uint64_t end_time_ns;
+    uint64_t task_id;
+    uint32_t submit_idx;
+    uint32_t _pad;
+};
+static_assert(sizeof(ChipSwimlaneHostOrchPhaseRecord) == 32, "ChipSwimlaneHostOrchPhaseRecord layout drift");
+
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per sched thread, ~512KB per orch thread
 
 // Fixed-size phase record buffers. Same TypedBuffer template as the task

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -13,6 +13,8 @@
 #include <cstddef>
 #include <cstdint>
 
+struct ChipSwimlaneHostOrchPhaseRecord;
+
 /**
  * Host API function pointers for device memory operations.
  * Allows a runtime to use pluggable device-memory backends.
@@ -110,6 +112,13 @@ struct HostApiOps {
     // DeviceRunner::bind_callable_to_runtime replays onto the runtime's
     // func_id_to_addr_ before each run.
     uint64_t (*upload_chip_callable_buffer)(void *runner_ctx, const void *callable);
+    // Host-build-graph level-4 profiling. Capture begins during bind, before
+    // the device collector is initialized; the runner therefore owns the
+    // pending host vector and merges it into the eventual JSON export.
+    uint32_t (*get_chip_swimlane_level)(void *runner_ctx);
+    void (*begin_host_orchestrator_capture)(void *runner_ctx, uint64_t reserve_capacity);
+    void (*record_host_orchestrator_phase)(void *runner_ctx, const ChipSwimlaneHostOrchPhaseRecord *record);
+    void (*finish_host_orchestrator_capture)(void *runner_ctx, uint64_t expected_records);
 };
 
 /**
@@ -182,6 +191,24 @@ public:
     }
     uint64_t upload_chip_callable_buffer(const void *callable) const {
         return ops_->upload_chip_callable_buffer(runner_ctx_, callable);
+    }
+    uint32_t chip_swimlane_level() const {
+        return ops_->get_chip_swimlane_level != nullptr ? ops_->get_chip_swimlane_level(runner_ctx_) : 0;
+    }
+    void begin_host_orchestrator_capture(uint64_t reserve_capacity) const noexcept {
+        if (ops_->begin_host_orchestrator_capture != nullptr) {
+            ops_->begin_host_orchestrator_capture(runner_ctx_, reserve_capacity);
+        }
+    }
+    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) const noexcept {
+        if (ops_->record_host_orchestrator_phase != nullptr) {
+            ops_->record_host_orchestrator_phase(runner_ctx_, &record);
+        }
+    }
+    void finish_host_orchestrator_capture(uint64_t expected_records) const noexcept {
+        if (ops_->finish_host_orchestrator_capture != nullptr) {
+            ops_->finish_host_orchestrator_capture(runner_ctx_, expected_records);
+        }
     }
 
 private:

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "common/chip_swimlane_profiling.h"
+#include "host/clock_correlation.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -407,6 +408,17 @@ public:
      */
     void set_core_types(const CoreType *types, int n);
 
+    /** Reset and append host-build-graph level-4 submit records. These calls
+     * happen during bind, before initialize(), because HBG finishes host graph
+     * construction before the device collector is provisioned. */
+    void begin_host_orchestrator_capture(size_t reserve_capacity) noexcept;
+    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept;
+    void finish_host_orchestrator_capture(uint64_t expected_records) noexcept;
+    void begin_clock_correlation_session(const char *provider_name, const char *raw_device_timestamp_unit);
+    void record_clock_anchor_samples(std::vector<simpler::dfx::ClockAnchorSample> samples);
+    void finish_clock_correlation_session();
+    bool clock_correlation_active() const { return clock_correlation_session_.active(); }
+
     /**
      * Export collected records as a Chrome Trace Event JSON (swimlane view).
      * Writes <output_prefix>/chip_swimlane_records.json — directory is captured at
@@ -528,6 +540,8 @@ private:
     // orch records (kind-tagged at routing time; no parse-time discrimination).
     std::vector<std::vector<ChipSwimlaneAicpuSchedPhaseRecord>> collected_sched_phase_records_;
     std::vector<std::vector<ChipSwimlaneAicpuOrchPhaseRecord>> collected_orch_phase_records_;
+    std::vector<ChipSwimlaneHostOrchPhaseRecord> collected_host_orch_phase_records_;
+    simpler::dfx::ClockCorrelationSession clock_correlation_session_;
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
@@ -544,6 +558,14 @@ private:
     uint64_t total_orch_phase_collected_{0};
     bool has_phase_data_{false};
     bool collector_shards_merged_{false};
+    bool host_orchestrator_capture_started_{false};
+    bool host_orchestrator_capture_enabled_{false};
+    enum class HostCaptureError : uint8_t { None = 0, ReserveFailed, RecordAllocationFailed };
+    HostCaptureError host_capture_error_{HostCaptureError::None};
+    uint64_t host_capture_reserve_requested_{0};
+    uint64_t host_capture_dropped_records_{0};
+    uint64_t host_capture_expected_records_{0};
+    bool host_capture_finished_{false};
 
     size_t normalize_collector_shard(int collector_shard) const;
     void reset_collector_shards();

--- a/src/common/platform/include/host/clock_correlation.h
+++ b/src/common/platform/include/host/clock_correlation.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace simpler::dfx {
+
+constexpr std::size_t kClockAnchorSamplesPerPosition = 3;
+
+enum class ClockAnchorPosition : uint32_t {
+    HostOrchestrationBegin = 0,
+    DeviceExecutionComplete = 1,
+};
+
+enum class ClockAnchorErrorStage : uint32_t {
+    None = 0,
+    CreateStream,
+    CreateEvent,
+    RecordEvent,
+    SynchronizeEvent,
+    GetTimestamp,
+};
+
+struct ClockAnchorSample {
+    ClockAnchorPosition position{ClockAnchorPosition::HostOrchestrationBegin};
+    uint32_t sample_idx{0};
+    uint64_t host_before_ns{0};
+    // Exact backend value plus the same instant normalized to the platform
+    // system-counter frequency.
+    uint64_t raw_device_timestamp{0};
+    uint64_t device_cycles{0};
+    uint64_t host_after_ns{0};
+    ClockAnchorErrorStage error_stage{ClockAnchorErrorStage::None};
+    int32_t error_code{0};
+
+    bool valid() const {
+        return error_stage == ClockAnchorErrorStage::None && error_code == 0 && host_before_ns != 0 &&
+               host_after_ns >= host_before_ns && device_cycles != 0;
+    }
+};
+
+const char *clock_anchor_position_name(ClockAnchorPosition position);
+const char *clock_anchor_error_stage_name(ClockAnchorErrorStage stage);
+
+class ClockCorrelationSession {
+public:
+    void begin(const char *provider_name, const char *raw_device_timestamp_unit);
+    void append(std::vector<ClockAnchorSample> samples);
+    void finish();
+    void reset();
+
+    bool started() const { return started_; }
+    bool active() const { return active_; }
+    const std::string &provider_name() const { return provider_name_; }
+    const std::string &raw_device_timestamp_unit() const { return raw_device_timestamp_unit_; }
+    const std::vector<ClockAnchorSample> &samples() const { return samples_; }
+
+private:
+    bool started_{false};
+    bool active_{false};
+    std::string provider_name_{};
+    std::string raw_device_timestamp_unit_{};
+    std::vector<ClockAnchorSample> samples_{};
+};
+
+class ClockCorrelationProvider {
+public:
+    virtual ~ClockCorrelationProvider() = default;
+    ClockCorrelationProvider(const ClockCorrelationProvider &) = delete;
+    ClockCorrelationProvider &operator=(const ClockCorrelationProvider &) = delete;
+
+    virtual const char *name() const = 0;
+    virtual const char *raw_device_timestamp_unit() const = 0;
+    virtual ClockAnchorSample capture(ClockAnchorPosition position, uint32_t sample_idx) noexcept = 0;
+    virtual void release(bool abandon_device_resources) noexcept = 0;
+
+protected:
+    ClockCorrelationProvider() = default;
+};
+
+std::vector<ClockAnchorSample>
+capture_clock_anchor_group(ClockCorrelationProvider &provider, ClockAnchorPosition position);
+std::unique_ptr<ClockCorrelationProvider> make_clock_correlation_provider();
+
+}  // namespace simpler::dfx

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -178,6 +178,26 @@ static uint64_t upload_chip_callable_buffer_wrapper(void *runner_ctx, const void
     }
 }
 
+static uint32_t get_chip_swimlane_level(void *runner_ctx) {
+    if (runner_ctx == nullptr) return 0;
+    return static_cast<DeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
+}
+
+static void begin_host_orchestrator_capture(void *runner_ctx, uint64_t reserve_capacity) noexcept {
+    if (runner_ctx == nullptr) return;
+    static_cast<DeviceRunnerBase *>(runner_ctx)->begin_host_orchestrator_capture(reserve_capacity);
+}
+
+static void record_host_orchestrator_phase(void *runner_ctx, const ChipSwimlaneHostOrchPhaseRecord *record) noexcept {
+    if (runner_ctx == nullptr || record == nullptr) return;
+    static_cast<DeviceRunnerBase *>(runner_ctx)->record_host_orchestrator_phase(*record);
+}
+
+static void finish_host_orchestrator_capture(void *runner_ctx, uint64_t expected_records) noexcept {
+    if (runner_ctx == nullptr) return;
+    static_cast<DeviceRunnerBase *>(runner_ctx)->finish_host_orchestrator_capture(expected_records);
+}
+
 static int setup_static_arena_wrapper(
     void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
 ) {
@@ -274,6 +294,10 @@ static const HostApiOps g_host_api_ops = {
     .lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper,
     .mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper,
     .upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper,
+    .get_chip_swimlane_level = get_chip_swimlane_level,
+    .begin_host_orchestrator_capture = begin_host_orchestrator_capture,
+    .record_host_orchestrator_phase = record_host_orchestrator_phase,
+    .finish_host_orchestrator_capture = finish_host_orchestrator_capture,
 };
 
 /* ===========================================================================
@@ -614,6 +638,7 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
     char trace_attrs[sizeof(state->trace_attrs)];
     std::memcpy(trace_attrs, state->trace_attrs, sizeof(trace_attrs));
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
+    state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
     int validation_rc = -1;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
@@ -961,6 +986,10 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner_resources_owned = false;
     }
 
+    // Correlation state is runner-wide. Finish it before releasing either
+    // ownership token, after which a successor may begin capture and replace
+    // the provider/session.
+    state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
     if (state->runner_claimed) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;

--- a/src/common/platform/onboard/host/clock_correlation.cpp
+++ b/src/common/platform/onboard/host/clock_correlation.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/clock_correlation.h"
+
+#include <acl/acl.h>
+
+#include <memory>
+
+#include "common/log_clock.h"
+#include "common/platform_config.h"
+
+namespace simpler::dfx {
+namespace {
+
+class OnboardClockCorrelationProvider final : public ClockCorrelationProvider {
+public:
+    ~OnboardClockCorrelationProvider() override { release(false); }
+
+    const char *name() const override { return "acl_event"; }
+    const char *raw_device_timestamp_unit() const override { return PLATFORM_ACL_EVENT_TIMESTAMP_UNIT; }
+
+    ClockAnchorSample capture(ClockAnchorPosition position, uint32_t sample_idx) noexcept override {
+        ClockAnchorSample sample{};
+        sample.position = position;
+        sample.sample_idx = sample_idx;
+        sample.host_before_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+
+        if (!ensure_resources(sample)) {
+            sample.host_after_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+            return sample;
+        }
+
+        aclError rc = aclrtRecordEvent(event_, stream_);
+        if (rc != ACL_SUCCESS) {
+            sample.error_stage = ClockAnchorErrorStage::RecordEvent;
+            sample.error_code = static_cast<int32_t>(rc);
+            sample.host_after_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+            return sample;
+        }
+        rc = aclrtSynchronizeEvent(event_);
+        if (rc != ACL_SUCCESS) {
+            sample.error_stage = ClockAnchorErrorStage::SynchronizeEvent;
+            sample.error_code = static_cast<int32_t>(rc);
+            sample.host_after_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+            return sample;
+        }
+        rc = aclrtEventGetTimestamp(event_, &sample.raw_device_timestamp);
+        sample.host_after_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+        if (rc != ACL_SUCCESS) {
+            sample.error_stage = ClockAnchorErrorStage::GetTimestamp;
+            sample.error_code = static_cast<int32_t>(rc);
+            sample.raw_device_timestamp = 0;
+        } else {
+            if constexpr (PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ != 0) {
+                // Preserve the exact backend value, then normalize it to the
+                // platform's verified profiling-counter frequency.
+                sample.device_cycles = static_cast<uint64_t>(
+                    static_cast<__uint128_t>(sample.raw_device_timestamp) * PLATFORM_PROF_SYS_CNT_FREQ /
+                    PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ
+                );
+            }
+        }
+        return sample;
+    }
+
+    void release(bool abandon_device_resources) noexcept override {
+        if (event_ != nullptr) {
+            if (!abandon_device_resources) (void)aclrtDestroyEvent(event_);
+            event_ = nullptr;
+        }
+        if (stream_ != nullptr) {
+            if (!abandon_device_resources) (void)aclrtDestroyStream(stream_);
+            stream_ = nullptr;
+        }
+    }
+
+private:
+    bool ensure_resources(ClockAnchorSample &sample) noexcept {
+        if (stream_ == nullptr) {
+            aclError rc = aclrtCreateStream(&stream_);
+            if (rc != ACL_SUCCESS) {
+                stream_ = nullptr;
+                sample.error_stage = ClockAnchorErrorStage::CreateStream;
+                sample.error_code = static_cast<int32_t>(rc);
+                return false;
+            }
+        }
+        if (event_ == nullptr) {
+            aclError rc = aclrtCreateEventExWithFlag(&event_, ACL_EVENT_TIME_LINE);
+            if (rc != ACL_SUCCESS) {
+                event_ = nullptr;
+                sample.error_stage = ClockAnchorErrorStage::CreateEvent;
+                sample.error_code = static_cast<int32_t>(rc);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    aclrtStream stream_{nullptr};
+    aclrtEvent event_{nullptr};
+};
+
+}  // namespace
+
+std::unique_ptr<ClockCorrelationProvider> make_clock_correlation_provider() {
+    return std::make_unique<OnboardClockCorrelationProvider>();
+}
+
+}  // namespace simpler::dfx

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1048,6 +1048,63 @@ void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_output_prefix(config.output_prefix);
 }
 
+void DeviceRunnerBase::begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept {
+    if (clock_correlation_provider_ != nullptr) {
+        clock_correlation_provider_->release(false);
+        clock_correlation_provider_.reset();
+    }
+    chip_swimlane_collector_.begin_host_orchestrator_capture(static_cast<size_t>(reserve_capacity));
+    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES) return;
+
+    try {
+        clock_correlation_provider_ = simpler::dfx::make_clock_correlation_provider();
+        chip_swimlane_collector_.begin_clock_correlation_session(
+            clock_correlation_provider_->name(), clock_correlation_provider_->raw_device_timestamp_unit()
+        );
+        chip_swimlane_collector_.record_clock_anchor_samples(
+            simpler::dfx::capture_clock_anchor_group(
+                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
+            )
+        );
+    } catch (...) {
+        clock_correlation_provider_.reset();
+        try {
+            chip_swimlane_collector_.begin_clock_correlation_session("unavailable", "unknown");
+        } catch (...) {
+            // begin() stores diagnostic strings and can still fail under
+            // allocation pressure. Keep this noexcept path fail-closed.
+            chip_swimlane_collector_.finish_clock_correlation_session();
+        }
+    }
+}
+
+void DeviceRunnerBase::finish_clock_correlation_session(
+    bool capture_device_complete, bool abandon_device_resources
+) noexcept {
+    if (!chip_swimlane_collector_.clock_correlation_active()) {
+        if (clock_correlation_provider_ != nullptr) {
+            clock_correlation_provider_->release(abandon_device_resources);
+            clock_correlation_provider_.reset();
+        }
+        return;
+    }
+
+    if (capture_device_complete && clock_correlation_provider_ != nullptr) {
+        try {
+            chip_swimlane_collector_.record_clock_anchor_samples(
+                simpler::dfx::capture_clock_anchor_group(
+                    *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
+                )
+            );
+        } catch (...) {}
+    }
+    chip_swimlane_collector_.finish_clock_correlation_session();
+    if (clock_correlation_provider_ != nullptr) {
+        clock_correlation_provider_->release(abandon_device_resources);
+        clock_correlation_provider_.reset();
+    }
+}
+
 // =============================================================================
 // Group E (minimal) — shared AICPU launch helper
 // =============================================================================
@@ -1077,6 +1134,8 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
     auto capture = [&rc](int err) {
         if (err != 0 && rc == 0) rc = err;
     };
+
+    finish_clock_correlation_session(false, abandon_device_resources);
 
     // Teardown invariant: finalize_common() is the single place that releases
     // every RTS/device-owning resource, and the subclass runs it BEFORE its
@@ -1576,11 +1635,12 @@ void DeviceRunnerBase::start_shared_collectors_for_run() {
     }
 }
 
-void DeviceRunnerBase::teardown_shared_collectors_after_run() {
+void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execution_complete) {
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     // Diagnostic exports use the per-task `output_prefix_` directory the user
     // set on CallConfig (CallConfig::validate() enforces non-empty upstream).
+    finish_clock_correlation_session(device_execution_complete, !can_accept_run());
     if (enable_chip_swimlane_) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -671,6 +671,15 @@ public:
         chip_swimlane_level_ = static_cast<ChipSwimlaneLevel>(level);
         enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
     }
+    uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
+    void begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept;
+    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept {
+        chip_swimlane_collector_.record_host_orchestrator_phase(record);
+    }
+    void finish_host_orchestrator_capture(uint64_t expected_records) noexcept {
+        chip_swimlane_collector_.finish_host_orchestrator_capture(expected_records);
+    }
+    void finish_clock_correlation_session(bool capture_device_complete, bool abandon_device_resources) noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);
         enable_dump_args_ = (dump_args_level_ != DumpArgsLevel::OFF);
@@ -874,7 +883,7 @@ protected:
      * `dep_gen_collector_` + its `dep_gen_replay_emit_deps_json` export)
      * inline their own teardown after calling this helper.
      */
-    void teardown_shared_collectors_after_run();
+    void teardown_shared_collectors_after_run(bool device_execution_complete);
 
     /**
      * Shared body of `finalize()`. Each arch subclass's `finalize()`
@@ -1136,6 +1145,7 @@ protected:
     // on the base. `DepGenCollector` is not shared — each arch that
     // implements dep_gen (a2a3, a5) keeps it on its own subclass.
     ChipSwimlaneCollector chip_swimlane_collector_;
+    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation_provider_{};
     ArgsDumpCollector dump_collector_;
     PmuCollector pmu_collector_;
     ScopeStatsCollector scope_stats_collector_;

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -398,8 +398,9 @@ int ChipSwimlaneCollector::initialize(
     // first `aicpu_thread_num` of them ever get a producer — so buffers are
     // allocated for those alone. Seeding a pool at t >= aicpu_thread_num would
     // also push its surplus into recycled lane `t`, which no drain thread owns.
-    // Orch: a single instance (pool 0), so allocate buffers for just one pool
-    // while still zeroing all MAX states.
+    // Device-orchestrated level 4 uses one orch instance (pool 0). HBG starts
+    // its host capture before collector initialize(), so it needs no device
+    // orch buffers at all; the fixed pool-state layout is still zeroed.
     if (init_phase_pools(
             static_cast<ChipSwimlaneAicpuSchedPhaseBuffer *>(nullptr), get_sched_phase_buffer_state,
             /*state_count=*/num_phase_threads, /*buffer_count=*/aicpu_thread_num,
@@ -410,16 +411,18 @@ int ChipSwimlaneCollector::initialize(
     auto orch_get_state = [](void *base, int n_cores, int t) {
         return get_orch_phase_buffer_state(base, n_cores, t);
     };
+    const int orch_buffer_count =
+        chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES && !host_orchestrator_capture_started_ ? 1 : 0;
     if (init_phase_pools(
             static_cast<ChipSwimlaneAicpuOrchPhaseBuffer *>(nullptr), orch_get_state,
-            /*state_count=*/num_phase_threads, /*buffer_count=*/1,
+            /*state_count=*/num_phase_threads, /*buffer_count=*/orch_buffer_count,
             /*buffers_per_thread=*/PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD, ProfBufferType::AICPU_ORCH_PHASE, "orch"
         ) != 0) {
         return -1;
     }
     LOG_DEBUG(
-        "Initialized %d sched (%d buf/thread) + 1 orch (%d buf) PhaseBufferStates", num_phase_threads,
-        PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD, PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD
+        "Initialized %d sched (%d buf/thread) + %d orch (%d buf/thread) PhaseBufferStates", num_phase_threads,
+        PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD, orch_buffer_count, PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD
     );
 
     wmb();
@@ -896,6 +899,67 @@ void ChipSwimlaneCollector::set_core_types(const CoreType *types, int n) {
     core_types_.assign(types, types + n);
 }
 
+void ChipSwimlaneCollector::begin_host_orchestrator_capture(size_t reserve_capacity) noexcept {
+    // HBG profiling is depth-one while diagnostics are enabled, and its host
+    // orchestrator is synchronous. No collector thread exists yet at this
+    // point, so the runner-owned vector needs no locking.
+    collected_host_orch_phase_records_.clear();
+    clock_correlation_session_.reset();
+    host_orchestrator_capture_started_ = true;
+    host_orchestrator_capture_enabled_ = true;
+    host_capture_error_ = HostCaptureError::None;
+    host_capture_reserve_requested_ = reserve_capacity;
+    host_capture_dropped_records_ = 0;
+    host_capture_expected_records_ = 0;
+    host_capture_finished_ = false;
+    try {
+        collected_host_orch_phase_records_.reserve(reserve_capacity);
+    } catch (...) {
+        host_orchestrator_capture_enabled_ = false;
+        host_capture_error_ = HostCaptureError::ReserveFailed;
+    }
+}
+
+void ChipSwimlaneCollector::finish_host_orchestrator_capture(uint64_t expected_records) noexcept {
+    if (!host_orchestrator_capture_started_) return;
+    host_capture_expected_records_ = expected_records;
+    host_capture_finished_ = true;
+}
+
+void ChipSwimlaneCollector::record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept {
+    if (!host_orchestrator_capture_enabled_) {
+        ++host_capture_dropped_records_;
+        return;
+    }
+    if (record.end_time_ns < record.start_time_ns) {
+        LOG_WARN(
+            "Ignoring invalid host orchestrator phase: task_id=%lu start_ns=%lu end_ns=%lu",
+            static_cast<unsigned long>(record.task_id), static_cast<unsigned long>(record.start_time_ns),
+            static_cast<unsigned long>(record.end_time_ns)
+        );
+        return;
+    }
+    try {
+        collected_host_orch_phase_records_.push_back(record);
+    } catch (...) {
+        host_orchestrator_capture_enabled_ = false;
+        host_capture_error_ = HostCaptureError::RecordAllocationFailed;
+        ++host_capture_dropped_records_;
+    }
+}
+
+void ChipSwimlaneCollector::begin_clock_correlation_session(
+    const char *provider_name, const char *raw_device_timestamp_unit
+) {
+    clock_correlation_session_.begin(provider_name, raw_device_timestamp_unit);
+}
+
+void ChipSwimlaneCollector::record_clock_anchor_samples(std::vector<simpler::dfx::ClockAnchorSample> samples) {
+    clock_correlation_session_.append(std::move(samples));
+}
+
+void ChipSwimlaneCollector::finish_clock_correlation_session() { clock_correlation_session_.finish(); }
+
 // JSON v2 emit: the host now dumps raw cycle-domain per-stream records plus
 // metadata, and `swimlane_converter.py` performs the join (AICore↔AICPU on
 // reg_task_id, base_time normalization, cycles→µs conversion, sort, core_type
@@ -908,10 +972,10 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     }
     merge_collector_shards();
 
-    // Empty-export guard: nothing useful on disk if every per-stream source is
-    // empty. AICPU_TIMING+ relies on `collected_perf_records_`; AICORE_TIMING
-    // (level=1) relies on `collected_aicore_records_` alone.
-    bool has_any_records = false;
+    // Every stream is independently useful for DFX. In particular, a legal
+    // HBG can contain only host-side dummy/hidden-allocation records and no
+    // AICore dispatch at all.
+    bool has_any_records = !collected_host_orch_phase_records_.empty() || clock_correlation_session_.started();
     for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
             has_any_records = true;
@@ -926,8 +990,20 @@ int ChipSwimlaneCollector::export_swimlane_json() {
             }
         }
     }
+    auto any_phase_records = [](const auto &per_thread_records) {
+        for (const auto &records : per_thread_records) {
+            if (!records.empty()) return true;
+        }
+        return false;
+    };
+    const bool has_aicpu_orch_phases = any_phase_records(collected_orch_phase_records_);
+    has_any_records = has_any_records || any_phase_records(collected_sched_phase_records_) || has_aicpu_orch_phases;
     if (!has_any_records) {
         LOG_WARN("Warning: No performance data to export.");
+        return -1;
+    }
+    if (has_aicpu_orch_phases && host_orchestrator_capture_started_) {
+        LOG_ERROR("Both host and AICPU orchestrator records are present; refusing mixed clock-domain export");
         return -1;
     }
 
@@ -963,6 +1039,96 @@ int ChipSwimlaneCollector::export_swimlane_json() {
         outfile << "\"" << ((ct == CoreType::AIC) ? "aic" : "aiv") << "\"";
     }
     outfile << "]";
+    if (host_orchestrator_capture_started_) {
+        uint64_t host_origin_ns = 0;
+        if (!collected_host_orch_phase_records_.empty()) {
+            host_origin_ns = collected_host_orch_phase_records_.front().start_time_ns;
+            for (const auto &record : collected_host_orch_phase_records_) {
+                if (record.start_time_ns < host_origin_ns) host_origin_ns = record.start_time_ns;
+            }
+        }
+        outfile << ",\n    \"orchestrator_source\": \"host\"";
+        outfile << ",\n    \"orchestrator_clock_domain\": \"host_monotonic_ns\"";
+        outfile << ",\n    \"device_clock_domain\": \"device_syscnt_cycles\"";
+        constexpr uint64_t kNsPerSecond = 1'000'000'000ull;
+        constexpr uint64_t host_timestamp_resolution_ns =
+            (kNsPerSecond + PLATFORM_PROF_SYS_CNT_FREQ - 1) / PLATFORM_PROF_SYS_CNT_FREQ;
+        constexpr uint64_t host_timestamp_quantization_ns =
+            host_timestamp_resolution_ns > 1 ? host_timestamp_resolution_ns : 0;
+        outfile << ",\n    \"host_timestamp_resolution_ns\": " << host_timestamp_resolution_ns;
+        outfile << ",\n    \"host_timestamp_quantization_ns\": " << host_timestamp_quantization_ns;
+        outfile << ",\n    \"host_orchestration_origin_ns\": " << host_origin_ns;
+        outfile << ",\n    \"timeline_relation\": \"host_orchestration_precedes_device\"";
+        const char *capture_error = "none";
+        if (host_capture_error_ == HostCaptureError::ReserveFailed) {
+            capture_error = "reserve_failed";
+        } else if (host_capture_error_ == HostCaptureError::RecordAllocationFailed) {
+            capture_error = "record_allocation_failed";
+        }
+        const bool host_record_count_matches =
+            host_capture_finished_ && collected_host_orch_phase_records_.size() == host_capture_expected_records_;
+        const bool host_capture_complete = host_capture_error_ == HostCaptureError::None && host_record_count_matches;
+        const char *host_capture_status = host_capture_complete                         ? "complete" :
+                                          host_capture_error_ != HostCaptureError::None ? "dropped" :
+                                                                                          "incomplete";
+        outfile << ",\n    \"host_capture\": {\"status\": \"" << host_capture_status
+                << "\", \"reserve_requested\": " << host_capture_reserve_requested_
+                << ", \"finished\": " << (host_capture_finished_ ? "true" : "false")
+                << ", \"expected_records\": " << host_capture_expected_records_
+                << ", \"recorded_records\": " << collected_host_orch_phase_records_.size()
+                << ", \"dropped_records\": " << host_capture_dropped_records_ << ", \"error\": ";
+        if (host_capture_complete) {
+            outfile << "null}";
+        } else if (host_capture_error_ != HostCaptureError::None) {
+            outfile << "\"" << capture_error << "\"}";
+        } else if (!host_capture_finished_) {
+            outfile << "\"capture_not_finished\"}";
+        } else {
+            outfile << "\"record_count_mismatch\"}";
+        }
+    }
+    if (clock_correlation_session_.started()) {
+        outfile << ",\n    \"clock_anchors\": {";
+        outfile << "\n      \"schema_version\": 1,";
+        outfile << "\n      \"provider\": \"" << clock_correlation_session_.provider_name() << "\",";
+        outfile << "\n      \"device_timestamp_unit\": \"syscnt_cycles\",";
+        outfile << "\n      \"raw_device_timestamp_unit\": \"" << clock_correlation_session_.raw_device_timestamp_unit()
+                << "\",";
+        outfile << "\n      \"samples_per_position\": " << simpler::dfx::kClockAnchorSamplesPerPosition << ",";
+        outfile << "\n      \"samples\": [";
+        bool first_anchor = true;
+        for (const auto &sample : clock_correlation_session_.samples()) {
+            if (!first_anchor) outfile << ",";
+            const uint64_t rtt_ns =
+                sample.host_after_ns >= sample.host_before_ns ? sample.host_after_ns - sample.host_before_ns : 0;
+            outfile << "\n        {\"position\": \"" << simpler::dfx::clock_anchor_position_name(sample.position)
+                    << "\", \"sample_idx\": " << sample.sample_idx << ", \"host_before_ns\": " << sample.host_before_ns
+                    << ", \"raw_device_timestamp\": ";
+            if (sample.raw_device_timestamp == 0) {
+                outfile << "null";
+            } else {
+                outfile << sample.raw_device_timestamp;
+            }
+            outfile << ", \"device_cycles\": ";
+            if (sample.device_cycles == 0) {
+                outfile << "null";
+            } else {
+                outfile << sample.device_cycles;
+            }
+            outfile << ", \"host_after_ns\": " << sample.host_after_ns << ", \"rtt_ns\": " << rtt_ns
+                    << ", \"uncertainty_ns\": " << (rtt_ns + 1) / 2 << ", \"error\": ";
+            if (sample.error_stage == simpler::dfx::ClockAnchorErrorStage::None && sample.error_code == 0) {
+                outfile << "null";
+            } else {
+                outfile << "{\"stage\": \"" << simpler::dfx::clock_anchor_error_stage_name(sample.error_stage)
+                        << "\", \"code\": " << sample.error_code << "}";
+            }
+            outfile << "}";
+            first_anchor = false;
+        }
+        if (!first_anchor) outfile << "\n      ";
+        outfile << "]\n    }";
+    }
     if (!core_to_thread_.empty()) {
         outfile << ",\n    \"core_to_thread\": [";
         for (size_t i = 0; i < core_to_thread_.size(); i++) {
@@ -1093,16 +1259,7 @@ int ChipSwimlaneCollector::export_swimlane_json() {
         }
         outfile << "  ]";
 
-        bool has_orch_phases = false;
-        if (chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES) {
-            for (const auto &v : collected_orch_phase_records_) {
-                if (!v.empty()) {
-                    has_orch_phases = true;
-                    break;
-                }
-            }
-        }
-        if (has_orch_phases) {
+        if (has_aicpu_orch_phases) {
             size_t orch_lanes = static_cast<size_t>(get_chip_swimlane_header(shm_host_)->num_orch_phase_threads);
             if (orch_lanes == 0 || orch_lanes > collected_orch_phase_records_.size()) {
                 orch_lanes = collected_orch_phase_records_.size();
@@ -1123,6 +1280,19 @@ int ChipSwimlaneCollector::export_swimlane_json() {
                 outfile << "\n";
             }
             outfile << "  ]";
+        }
+        if (!collected_host_orch_phase_records_.empty()) {
+            outfile << ",\n  \"host_orchestrator_phases\": [[";
+            bool first = true;
+            for (const auto &record : collected_host_orch_phase_records_) {
+                if (!first) outfile << ",";
+                outfile << "\n      {\"submit_idx\": " << record.submit_idx << ", \"task_id\": " << record.task_id
+                        << ", \"start_host_ns\": " << record.start_time_ns
+                        << ", \"end_host_ns\": " << record.end_time_ns << "}";
+                first = false;
+            }
+            if (!first) outfile << "\n    ";
+            outfile << "]]";
         }
     }
 
@@ -1253,6 +1423,8 @@ int ChipSwimlaneCollector::finalize(
     collected_aicore_records_.clear();
     collected_sched_phase_records_.clear();
     collected_orch_phase_records_.clear();
+    collected_host_orch_phase_records_.clear();
+    clock_correlation_session_.reset();
     perf_records_by_collector_.clear();
     aicore_records_by_collector_.clear();
     sched_phase_records_by_collector_.clear();
@@ -1264,6 +1436,13 @@ int ChipSwimlaneCollector::finalize(
     total_sched_phase_collected_ = 0;
     total_orch_phase_collected_ = 0;
     collector_shards_merged_ = false;
+    host_orchestrator_capture_started_ = false;
+    host_orchestrator_capture_enabled_ = false;
+    host_capture_error_ = HostCaptureError::None;
+    host_capture_reserve_requested_ = 0;
+    host_capture_dropped_records_ = 0;
+    host_capture_expected_records_ = 0;
+    host_capture_finished_ = false;
     clear_memory_context();
 
     LOG_DEBUG("Performance profiling cleanup complete");

--- a/src/common/platform/shared/host/clock_correlation.cpp
+++ b/src/common/platform/shared/host/clock_correlation.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/clock_correlation.h"
+
+#include <iterator>
+#include <utility>
+
+namespace simpler::dfx {
+
+const char *clock_anchor_position_name(ClockAnchorPosition position) {
+    switch (position) {
+    case ClockAnchorPosition::HostOrchestrationBegin:
+        return "pre_host_orchestration";
+    case ClockAnchorPosition::DeviceExecutionComplete:
+        return "post_device_execution";
+    }
+    return "unknown";
+}
+
+const char *clock_anchor_error_stage_name(ClockAnchorErrorStage stage) {
+    switch (stage) {
+    case ClockAnchorErrorStage::None:
+        return "none";
+    case ClockAnchorErrorStage::CreateStream:
+        return "create_stream";
+    case ClockAnchorErrorStage::CreateEvent:
+        return "create_event";
+    case ClockAnchorErrorStage::RecordEvent:
+        return "record_event";
+    case ClockAnchorErrorStage::SynchronizeEvent:
+        return "synchronize_event";
+    case ClockAnchorErrorStage::GetTimestamp:
+        return "get_timestamp";
+    }
+    return "unknown";
+}
+
+void ClockCorrelationSession::begin(const char *provider_name, const char *raw_device_timestamp_unit) {
+    reset();
+    started_ = true;
+    active_ = true;
+    provider_name_ = provider_name != nullptr ? provider_name : "unknown";
+    raw_device_timestamp_unit_ = raw_device_timestamp_unit != nullptr ? raw_device_timestamp_unit : "unknown";
+}
+
+void ClockCorrelationSession::append(std::vector<ClockAnchorSample> samples) {
+    if (!active_) return;
+    samples_.insert(samples_.end(), std::make_move_iterator(samples.begin()), std::make_move_iterator(samples.end()));
+}
+
+void ClockCorrelationSession::finish() { active_ = false; }
+
+void ClockCorrelationSession::reset() {
+    started_ = false;
+    active_ = false;
+    provider_name_.clear();
+    raw_device_timestamp_unit_.clear();
+    samples_.clear();
+}
+
+std::vector<ClockAnchorSample>
+capture_clock_anchor_group(ClockCorrelationProvider &provider, ClockAnchorPosition position) {
+    std::vector<ClockAnchorSample> samples;
+    samples.reserve(kClockAnchorSamplesPerPosition);
+    for (std::size_t sample_idx = 0; sample_idx < kClockAnchorSamplesPerPosition; ++sample_idx) {
+        samples.push_back(provider.capture(position, static_cast<uint32_t>(sample_idx)));
+    }
+    return samples;
+}
+
+}  // namespace simpler::dfx

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -164,6 +164,26 @@ static uint64_t upload_chip_callable_buffer_wrapper(void *runner_ctx, const void
     }
 }
 
+static uint32_t get_chip_swimlane_level(void *runner_ctx) {
+    if (runner_ctx == nullptr) return 0;
+    return static_cast<SimDeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
+}
+
+static void begin_host_orchestrator_capture(void *runner_ctx, uint64_t reserve_capacity) noexcept {
+    if (runner_ctx == nullptr) return;
+    static_cast<SimDeviceRunnerBase *>(runner_ctx)->begin_host_orchestrator_capture(reserve_capacity);
+}
+
+static void record_host_orchestrator_phase(void *runner_ctx, const ChipSwimlaneHostOrchPhaseRecord *record) noexcept {
+    if (runner_ctx == nullptr || record == nullptr) return;
+    static_cast<SimDeviceRunnerBase *>(runner_ctx)->record_host_orchestrator_phase(*record);
+}
+
+static void finish_host_orchestrator_capture(void *runner_ctx, uint64_t expected_records) noexcept {
+    if (runner_ctx == nullptr) return;
+    static_cast<SimDeviceRunnerBase *>(runner_ctx)->finish_host_orchestrator_capture(expected_records);
+}
+
 static int setup_static_arena_wrapper(
     void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
 ) {
@@ -261,6 +281,10 @@ static const HostApiOps g_host_api_ops = {
     .lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper,
     .mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper,
     .upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper,
+    .get_chip_swimlane_level = get_chip_swimlane_level,
+    .begin_host_orchestrator_capture = begin_host_orchestrator_capture,
+    .record_host_orchestrator_phase = record_host_orchestrator_phase,
+    .finish_host_orchestrator_capture = finish_host_orchestrator_capture,
 };
 
 /* ===========================================================================
@@ -574,6 +598,7 @@ static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, 
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
+    state->runner->finish_clock_correlation_session(false);
     int validation_rc = -1;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
@@ -814,6 +839,9 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner->abandon_prepared_execution(*state->prepared_execution);
     }
 
+    // Correlation state is runner-wide. Finish it before releasing the claim,
+    // after which a successor may begin capture and replace the provider/session.
+    state->runner->finish_clock_correlation_session(false);
     if (state->runner_claimed) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;

--- a/src/common/platform/sim/host/clock_correlation.cpp
+++ b/src/common/platform/sim/host/clock_correlation.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/clock_correlation.h"
+
+#include <memory>
+
+#include "aicpu/device_time.h"
+#include "common/log_clock.h"
+
+namespace simpler::dfx {
+namespace {
+
+class SimClockCorrelationProvider final : public ClockCorrelationProvider {
+public:
+    const char *name() const override { return "sim_syscnt"; }
+    const char *raw_device_timestamp_unit() const override { return "syscnt_cycles"; }
+
+    ClockAnchorSample capture(ClockAnchorPosition position, uint32_t sample_idx) noexcept override {
+        ClockAnchorSample sample{};
+        sample.position = position;
+        sample.sample_idx = sample_idx;
+        sample.host_before_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+        sample.raw_device_timestamp = sys_cnt_now_ticks();
+        sample.device_cycles = sample.raw_device_timestamp;
+        sample.host_after_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+        return sample;
+    }
+
+    void release(bool /*abandon_device_resources*/) noexcept override {}
+};
+
+}  // namespace
+
+std::unique_ptr<ClockCorrelationProvider> make_clock_correlation_provider() {
+    return std::make_unique<SimClockCorrelationProvider>();
+}
+
+}  // namespace simpler::dfx

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -675,6 +675,56 @@ void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_output_prefix(config.output_prefix);
 }
 
+void SimDeviceRunnerBase::begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept {
+    if (clock_correlation_provider_ != nullptr) {
+        clock_correlation_provider_->release(false);
+        clock_correlation_provider_.reset();
+    }
+    chip_swimlane_collector_.begin_host_orchestrator_capture(static_cast<size_t>(reserve_capacity));
+    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES) return;
+
+    try {
+        clock_correlation_provider_ = simpler::dfx::make_clock_correlation_provider();
+        chip_swimlane_collector_.begin_clock_correlation_session(
+            clock_correlation_provider_->name(), clock_correlation_provider_->raw_device_timestamp_unit()
+        );
+        chip_swimlane_collector_.record_clock_anchor_samples(
+            simpler::dfx::capture_clock_anchor_group(
+                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
+            )
+        );
+    } catch (...) {
+        clock_correlation_provider_.reset();
+        try {
+            chip_swimlane_collector_.begin_clock_correlation_session("unavailable", "unknown");
+        } catch (...) {
+            // begin() stores diagnostic strings and can still fail under
+            // allocation pressure. Keep this noexcept path fail-closed.
+            chip_swimlane_collector_.finish_clock_correlation_session();
+        }
+    }
+}
+
+void SimDeviceRunnerBase::finish_clock_correlation_session(bool capture_device_complete) noexcept {
+    if (!chip_swimlane_collector_.clock_correlation_active()) {
+        if (clock_correlation_provider_ != nullptr) clock_correlation_provider_->release(false);
+        clock_correlation_provider_.reset();
+        return;
+    }
+    if (capture_device_complete && clock_correlation_provider_ != nullptr) {
+        try {
+            chip_swimlane_collector_.record_clock_anchor_samples(
+                simpler::dfx::capture_clock_anchor_group(
+                    *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
+                )
+            );
+        } catch (...) {}
+    }
+    chip_swimlane_collector_.finish_clock_correlation_session();
+    if (clock_correlation_provider_ != nullptr) clock_correlation_provider_->release(false);
+    clock_correlation_provider_.reset();
+}
+
 uint64_t SimDeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *callable) {
     if (callable == nullptr) {
         return 0;

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -268,6 +268,15 @@ public:
         chip_swimlane_level_ = static_cast<ChipSwimlaneLevel>(level);
         enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
     }
+    uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
+    void begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept;
+    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept {
+        chip_swimlane_collector_.record_host_orchestrator_phase(record);
+    }
+    void finish_host_orchestrator_capture(uint64_t expected_records) noexcept {
+        chip_swimlane_collector_.finish_host_orchestrator_capture(expected_records);
+    }
+    void finish_clock_correlation_session(bool capture_device_complete) noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);
         enable_dump_args_ = (dump_args_level_ != DumpArgsLevel::OFF);
@@ -451,6 +460,7 @@ protected:
 
     // Performance / diagnostics collectors shared across arches.
     ChipSwimlaneCollector chip_swimlane_collector_;
+    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation_provider_{};
     ArgsDumpCollector dump_collector_;
     PmuCollector pmu_collector_;
     ScopeStatsCollector scope_stats_collector_;

--- a/tests/ut/py/test_clock_correlation.py
+++ b/tests/ut/py/test_clock_correlation.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+
+from simpler_setup.tools.clock_correlation import build_clock_alignment
+
+
+def _sample(position, sample_idx, before, cycles, after, error=None):
+    return {
+        "position": position,
+        "sample_idx": sample_idx,
+        "host_before_ns": before,
+        "device_cycles": cycles,
+        "host_after_ns": after,
+        "error": error,
+    }
+
+
+def _anchors(samples, raw_unit="syscnt_cycles"):
+    return {
+        "device_timestamp_unit": "syscnt_cycles",
+        "raw_device_timestamp_unit": raw_unit,
+        "samples": samples,
+    }
+
+
+def test_alignment_selects_minimum_rtt_and_interpolates_offset_with_integer_math():
+    anchors = _anchors(
+        [
+            _sample("pre_host_orchestration", 0, 900, 100, 1_100),
+            _sample("pre_host_orchestration", 1, 990, 100, 1_010),
+            _sample("post_device_execution", 0, 4_900, 4_100, 5_300),
+            _sample("post_device_execution", 1, 5_080, 4_100, 5_120),
+        ]
+    )
+
+    alignment = build_clock_alignment(anchors, 1_000_000_000, [100, 2_100, 4_100])
+
+    assert alignment.status == "calibrated"
+    assert alignment.metadata()["selected_sample_idx"] == {
+        "pre_host_orchestration": 1,
+        "post_device_execution": 1,
+    }
+    assert alignment.max_uncertainty_ns == 20
+    assert alignment.map_cycles_to_host_ns(100) == 1_000
+    assert alignment.map_cycles_to_host_ns(2_100) == 3_050
+    assert alignment.map_cycles_to_host_ns(4_100) == 5_100
+
+
+def test_alignment_preserves_low_bits_for_large_cycle_values():
+    ref = 10**18
+    anchors = _anchors(
+        [
+            _sample("pre_host_orchestration", 0, 9_999_999_990, ref, 10_000_000_010),
+            _sample("post_device_execution", 0, 10_000_003_990, ref + 4_000, 10_000_004_010),
+        ]
+    )
+
+    alignment = build_clock_alignment(anchors, 1_000_000_000, [ref + 1])
+
+    assert alignment.map_cycles_to_host_ns(ref + 1) == 10_000_000_001
+
+
+def test_acl_event_microsecond_quantization_is_included_in_uncertainty():
+    anchors = _anchors(
+        [
+            _sample("pre_host_orchestration", 0, 990, 100, 1_010),
+            _sample("post_device_execution", 0, 4_990, 4_100, 5_010),
+        ],
+        raw_unit="device_uptime_us",
+    )
+
+    alignment = build_clock_alignment(anchors, 1_000_000_000, [100, 4_100])
+
+    assert alignment.max_uncertainty_ns == 1_010
+
+
+def test_host_record_quantization_is_included_in_cross_domain_uncertainty():
+    anchors = _anchors(
+        [
+            _sample("pre_host_orchestration", 0, 990, 100, 1_010),
+            _sample("post_device_execution", 0, 4_980, 4_100, 5_020),
+        ]
+    )
+
+    alignment = build_clock_alignment(
+        anchors,
+        50_000_000,
+        [100, 4_100],
+        host_timestamp_quantization_ns=20,
+    )
+
+    assert alignment.anchor_uncertainty_ns == 20
+    assert alignment.max_uncertainty_ns == 40
+    assert alignment.metadata()["host_timestamp_quantization_ns"] == 20
+
+
+@pytest.mark.parametrize(
+    ("anchors", "timestamps", "reason"),
+    [
+        ({}, [], "missing_clock_anchor_samples"),
+        (
+            _anchors(
+                [
+                    _sample("pre_host_orchestration", 0, 990, 100, 1_010, {"stage": "record", "code": 1}),
+                    _sample("post_device_execution", 0, 4_990, 4_100, 5_010),
+                ]
+            ),
+            [],
+            "no_valid_pre_host_orchestration_anchor",
+        ),
+        (
+            _anchors(
+                [
+                    _sample("pre_host_orchestration", 0, 990, 100, 1_010),
+                    _sample("post_device_execution", 0, 4_990, 4_100, 5_010),
+                ]
+            ),
+            [99],
+            "device_timestamps_outside_anchor_coverage",
+        ),
+    ],
+)
+def test_alignment_fails_closed(anchors, timestamps, reason):
+    alignment = build_clock_alignment(anchors, 1_000_000_000, timestamps)
+
+    assert alignment.status == "unaligned"
+    assert alignment.reason == reason
+    assert alignment.max_uncertainty_ns is None
+    with pytest.raises(ValueError):
+        alignment.map_cycles_to_host_ns(100)

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -163,6 +163,283 @@ def test_load_func_names_auto_discovery_and_explicit_precedence(tmp_path):
     assert func_names == {"0": "explicit"}
 
 
+def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 4,
+                "metadata": {
+                    "clock_freq_hz": 1_000_000,
+                    "num_cores": 1,
+                    "core_types": ["aiv"],
+                    "core_to_thread": [0],
+                    "orchestrator_source": "host",
+                    "orchestrator_clock_domain": "host_monotonic_ns",
+                    "host_orchestration_origin_ns": 1_000,
+                    "timeline_relation": "host_orchestration_precedes_device",
+                    "host_capture": {
+                        "status": "complete",
+                        "finished": True,
+                        "expected_records": 1,
+                        "recorded_records": 1,
+                        "dropped_records": 0,
+                        "error": None,
+                    },
+                },
+                "aicore_tasks": [[0, 7, 1, 100, 110, 0]],
+                "aicpu_tasks": [[0, 1, 90, 120]],
+                "aicpu_scheduler_phases": [
+                    [{"kind": "dispatch", "start_cycles": 80, "end_cycles": 85, "tasks_processed": 1}]
+                ],
+                "host_orchestrator_phases": [
+                    [{"submit_idx": 0, "task_id": 7, "start_host_ns": 1_000, "end_host_ns": 3_000}]
+                ],
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert data["orchestrator_source"] == "host"
+    assert data["aicpu_orchestrator_phases"][0][0]["start_time_us"] == 0.0
+    assert data["aicpu_orchestrator_phases"][0][0]["end_time_us"] == 2.0
+    assert data["aicpu_scheduler_phases"][0][0]["start_time_us"] == 2.0
+    assert data["tasks"][0]["dispatch_time_us"] == 12.0
+    assert data["timeline_metadata"] == {
+        "layout": "causal_composite",
+        "trace_status": "complete",
+        "relation": "host_orchestration_precedes_device",
+        "clock_alignment": {
+            "status": "unaligned",
+            "method": "nominal_frequency_offset_interp_v1",
+            "anchor_uncertainty_ns": None,
+            "host_timestamp_quantization_ns": 0,
+            "max_uncertainty_ns": None,
+            "reason": "missing_clock_anchors",
+        },
+        "host_capture": {
+            "status": "complete",
+            "finished": True,
+            "expected_records": 1,
+            "recorded_records": 1,
+            "dropped_records": 0,
+            "error": None,
+        },
+        "host_records_complete": True,
+        "cross_domain_gap_unknown": True,
+        "cross_domain_latency_available": False,
+        "logical_seam_us": 2.0,
+    }
+
+    trace_path = tmp_path / "merged_swimlane.json"
+    sc.generate_chrome_trace_json(
+        data["tasks"],
+        str(trace_path),
+        scheduler_phases=data["aicpu_scheduler_phases"],
+        orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+        orchestrator_source=data["orchestrator_source"],
+        timeline_metadata=data["timeline_metadata"],
+        core_to_thread=data["core_to_thread"],
+    )
+    trace = json.loads(trace_path.read_text())
+    assert trace["metadata"]["clock_alignment"]["status"] == "unaligned"
+    assert any(
+        event.get("ph") == "M"
+        and event.get("name") == "process_name"
+        and event.get("args", {}).get("name") == "Host Orchestrator"
+        for event in trace["traceEvents"]
+    )
+    assert not any(
+        event.get("cat") == "flow" and event.get("name") == "submit→dispatch" for event in trace["traceEvents"]
+    )
+
+
+def test_host_and_device_timestamps_use_calibrated_clock_alignment(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 4,
+                "metadata": {
+                    "clock_freq_hz": 1_000_000_000,
+                    "num_cores": 1,
+                    "core_types": ["aiv"],
+                    "core_to_thread": [0],
+                    "orchestrator_source": "host",
+                    "orchestrator_clock_domain": "host_monotonic_ns",
+                    "host_orchestration_origin_ns": 1_500,
+                    "timeline_relation": "host_orchestration_precedes_device",
+                    "host_capture": {
+                        "status": "complete",
+                        "finished": True,
+                        "expected_records": 1,
+                        "recorded_records": 1,
+                        "dropped_records": 0,
+                        "error": None,
+                    },
+                    "clock_anchors": {
+                        "device_timestamp_unit": "syscnt_cycles",
+                        "samples": [
+                            {
+                                "position": "pre_host_orchestration",
+                                "sample_idx": 0,
+                                "host_before_ns": 990,
+                                "device_cycles": 100,
+                                "host_after_ns": 1_010,
+                                "error": None,
+                            },
+                            {
+                                "position": "post_device_execution",
+                                "sample_idx": 0,
+                                "host_before_ns": 5_080,
+                                "device_cycles": 4_100,
+                                "host_after_ns": 5_120,
+                                "error": None,
+                            },
+                        ],
+                    },
+                },
+                "aicore_tasks": [[0, 7, 1, 2_100, 2_200, 0]],
+                "aicpu_tasks": [[0, 1, 2_000, 2_300]],
+                "aicpu_scheduler_phases": [
+                    [{"kind": "dispatch", "start_cycles": 1_900, "end_cycles": 1_950, "tasks_processed": 1}]
+                ],
+                "host_orchestrator_phases": [
+                    [{"submit_idx": 0, "task_id": 7, "start_host_ns": 1_500, "end_host_ns": 1_800}]
+                ],
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert data["aicpu_orchestrator_phases"][0][0]["start_time_us"] == 0.0
+    assert data["aicpu_orchestrator_phases"][0][0]["end_time_us"] == 0.3
+    assert data["tasks"][0]["dispatch_time_us"] == 1.447
+    assert data["tasks"][0]["start_time_us"] == 1.55
+    assert data["timeline_metadata"] == {
+        "layout": "clock_aligned",
+        "trace_status": "complete",
+        "relation": "host_orchestration_precedes_device",
+        "clock_alignment": {
+            "status": "calibrated",
+            "method": "nominal_frequency_offset_interp_v1",
+            "anchor_uncertainty_ns": 20,
+            "host_timestamp_quantization_ns": 0,
+            "max_uncertainty_ns": 20,
+            "selected_sample_idx": {
+                "pre_host_orchestration": 0,
+                "post_device_execution": 0,
+            },
+        },
+        "host_capture": {
+            "status": "complete",
+            "finished": True,
+            "expected_records": 1,
+            "recorded_records": 1,
+            "dropped_records": 0,
+            "error": None,
+        },
+        "host_records_complete": True,
+        "cross_domain_latency_available": True,
+    }
+
+
+def test_dropped_host_capture_is_visible_and_disables_cross_domain_flows(tmp_path):
+    for case_name, host_phases, capture_status, dropped_records, capture_error in (
+        (
+            "partial",
+            [[{"submit_idx": 0, "task_id": 7, "start_host_ns": 1_500, "end_host_ns": 1_800}]],
+            "dropped",
+            1,
+            "record_allocation_failed",
+        ),
+        ("all_dropped", [], "dropped", 1, "record_allocation_failed"),
+        ("silent_missing", [], "complete", 0, None),
+    ):
+        raw = tmp_path / f"{case_name}.json"
+        raw.write_text(
+            json.dumps(
+                {
+                    "chip_swimlane_level": 4,
+                    "metadata": {
+                        "clock_freq_hz": 1_000_000_000,
+                        "num_cores": 1,
+                        "core_types": ["aiv"],
+                        "core_to_thread": [0],
+                        "orchestrator_source": "host",
+                        "host_orchestration_origin_ns": 1_500 if host_phases else 0,
+                        "timeline_relation": "host_orchestration_precedes_device",
+                        "host_timestamp_quantization_ns": 0,
+                        "host_capture": {
+                            "status": capture_status,
+                            "finished": True,
+                            "expected_records": sum(len(records) for records in host_phases) + 1,
+                            "recorded_records": sum(len(records) for records in host_phases),
+                            "dropped_records": dropped_records,
+                            "error": capture_error,
+                        },
+                        "clock_anchors": {
+                            "device_timestamp_unit": "syscnt_cycles",
+                            "samples": [
+                                {
+                                    "position": "pre_host_orchestration",
+                                    "sample_idx": 0,
+                                    "host_before_ns": 990,
+                                    "device_cycles": 100,
+                                    "host_after_ns": 1_010,
+                                    "error": None,
+                                },
+                                {
+                                    "position": "post_device_execution",
+                                    "sample_idx": 0,
+                                    "host_before_ns": 5_080,
+                                    "device_cycles": 4_100,
+                                    "host_after_ns": 5_120,
+                                    "error": None,
+                                },
+                            ],
+                        },
+                    },
+                    "aicore_tasks": [[0, 7, 1, 2_100, 2_200, 0]],
+                    "aicpu_tasks": [[0, 1, 2_000, 2_300]],
+                    "aicpu_scheduler_phases": [[{"kind": "dispatch", "start_cycles": 1_900, "end_cycles": 1_950}]],
+                    "host_orchestrator_phases": host_phases,
+                }
+            )
+        )
+
+        data = sc.read_perf_data(raw)
+
+        assert data["timeline_metadata"]["layout"] == "clock_aligned"
+        assert data["timeline_metadata"]["trace_status"] == "partial"
+        assert data["timeline_metadata"]["clock_alignment"]["status"] == "calibrated"
+        assert data["timeline_metadata"]["host_capture"]["status"] == capture_status
+        assert data["timeline_metadata"]["host_records_complete"] is False
+        assert data["timeline_metadata"]["cross_domain_latency_available"] is False
+        assert data["timeline_metadata"].get("host_records_missing", False) is (not host_phases)
+        if case_name == "silent_missing":
+            assert data["timeline_metadata"]["host_capture"]["converter_validation_errors"] == [
+                "expected_record_count_mismatch"
+            ]
+
+        trace_path = tmp_path / f"{case_name}_trace.json"
+        sc.generate_chrome_trace_json(
+            data["tasks"],
+            str(trace_path),
+            scheduler_phases=data["aicpu_scheduler_phases"],
+            orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+            orchestrator_source=data["orchestrator_source"],
+            timeline_metadata=data["timeline_metadata"],
+            core_to_thread=data["core_to_thread"],
+        )
+        trace = json.loads(trace_path.read_text())
+        assert not any(
+            event.get("cat") == "flow" and event.get("name") == "submit→dispatch" for event in trace["traceEvents"]
+        )
+
+
 def test_graph_prepare_phases_create_graph_execution_envelopes(tmp_path):
     out = tmp_path / "trace.json"
     outer_a = 3


### PR DESCRIPTION
## Summary

- Capture host-build-graph level-4 submit phases in host monotonic
  nanoseconds and verify the recorded count against the submitted task count.
- Correlate the host and device clocks with three samples before host
  orchestration and three after device execution. The converter selects the
  minimum-RTT sample at each endpoint and interpolates the offset while using
  the platform counter frequency for cycle conversion.
- Support the 50 MHz A3 and 1 GHz A5 system-counter domains with the shared
  implementation, remove the unused device orchestrator phase pool for HBG,
  and fail closed to a causal-composite layout when calibration or host capture
  is incomplete.
- Keep the sampling overhead scoped to HBG level 4: six anchor samples per run,
  not one sample per submitted task. Lower profiling levels are unchanged.
- Harden correlation cleanup so allocation failures stay noexcept-safe,
  sessions finish before native-run ownership is released, device resources
  follow the runner's usable state, and mixed clock domains are rejected before
  an output file is created.

## Onboard validation data

Both platforms used `acl_event` anchors whose raw timestamp unit is
`device_uptime_us`. Every case produced `layout=clock_aligned`,
`clock_alignment.status=calibrated`, complete Host capture with zero dropped
records, and `cross_domain_latency_available=true`.

| Platform | Case | Syscnt frequency | Host records | AICore / AICPU tasks | Max uncertainty | Result |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| A3 (`a2a3`) | record/replay 1D | 50 MHz | 4 / 4 | 13 / 13 | 13.930 us | PASS |
| A3 (`a2a3`) | record/replay 2D | 50 MHz | 4 / 4 | 13 / 13 | 15.136 us | PASS |
| A5 | record/replay 1D | 1 GHz | 4 / 4 | 13 / 13 | 20.610 us | PASS |
| A5 | record/replay 2D | 1 GHz | 4 / 4 | 13 / 13 | 21.391 us | PASS |

Onboard `task-submit` runs:

- A3: `task_20260816_203103_28035407506`
- A5: `task_20260817_113941_196802811717`

## Testing

- `.venv/bin/pip install --no-build-isolation -e .`
- `.venv/bin/python -m pytest tests/ut/py/test_clock_correlation.py tests/ut/py/test_swimlane_converter.py -q` — 32 passed
- A3sim Graph Execution L4, record/replay 1D and 2D — passed
- A5sim Graph Execution L4, record/replay 1D and 2D — passed
- A3sim native-run lifecycle — passed
- A3 onboard Graph Execution L4, record/replay 1D and 2D — passed
- A5 onboard Graph Execution L4, record/replay 1D and 2D — passed
- Pre-commit checks: check-headers, check-english-only, clang-format,
  clang-tidy, and cpplint — passed
- Targeted Ruff checks for the clock-correlation and converter Python files — passed

Fixes #1802
