### PR TITLE
Fix: bound the dispatch table's lifetime to the active callable

### DIFF
--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1049,20 +1049,11 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
     LOG_INFO("Freed %d device allocations", tensor_pair_count);
 
-    // Clear the per-run dispatch-table entries staged by register_callable_impl.
-    // The underlying chip-callable device buffer is pool-managed by
-    // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(); re-running the same callable repeatedly
-    // should not re-upload.
-    int kernel_count = runtime->get_registered_kernel_count();
-    for (int i = 0; i < kernel_count; i++) {
-        int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->set_function_bin_addr(func_id, 0);
-    }
-    if (kernel_count > 0) {
-        LOG_INFO("Cleared %d kernel dispatch-table entries", kernel_count);
-    }
-    runtime->clear_registered_kernels();
+    // The dispatch table is owned by bind_callable_to_runtime, which clears it
+    // before replaying the active callable's addresses. The chip-callable device
+    // buffer behind those addresses is pool-managed by DeviceRunner (keyed by
+    // content hash) and bulk-freed in DeviceRunner::finalize(), so re-running the
+    // same callable repeatedly does not re-upload.
 
     // Clear tensor pairs
     runtime->tensor_pairs_.clear();

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -176,8 +176,6 @@ public:
 
 private:
     // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
 
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
     void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
@@ -268,18 +266,23 @@ public:
     void set_device_orch_config_name(const char *name);
 
     uint64_t get_function_bin_addr(int func_id) const;
-    void set_function_bin_addr(int func_id, uint64_t addr);
     /**
-     * Replay a previously-uploaded kernel address onto a fresh Runtime
-     * without recording it in registered_kernel_func_ids_. Used by
-     * DeviceRunner::bind_callable_to_runtime so prepared kernel
-     * binaries are not freed by validate_runtime_impl across runs.
+     * Map a func_id onto the device address of its CoreCallable. Used by
+     * DeviceRunner::bind_callable_to_runtime for each of the active callable's
+     * child kernels, after clear_function_bin_addrs() has emptied the table.
      */
     void replay_function_bin_addr(int func_id, uint64_t addr);
 
-    int get_registered_kernel_count() const;
-    int get_registered_kernel_func_id(int index) const;
-    void clear_registered_kernels();
+    /**
+     * Drop every func_id -> CoreCallable address mapping.
+     *
+     * Each mapping points into one callable's retained ChipCallable buffer,
+     * which unregistering that callable frees. `bind_callable_to_runtime` calls
+     * this before replaying the active callable's addresses so no entry outlives
+     * the buffer it points into: the scheduler dereferences these addresses and
+     * the AICore calls what it finds there.
+     */
+    void clear_function_bin_addrs();
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -50,9 +50,6 @@ Runtime::Runtime() {
     device_orch_func_name_[0] = '\0';
     device_orch_config_name_[0] = '\0';
 
-    // Initialize kernel binary tracking
-    registered_kernel_count_ = 0;
-
     // Initialize function address mapping
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         func_id_to_addr_[i] = 0;
@@ -114,24 +111,6 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
     return func_id_to_addr_[func_id];
 }
 
-void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-        return;
-    }
-    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
-        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-        } else {
-            LOG_ERROR(
-                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
-                func_id
-            );
-        }
-    }
-    func_id_to_addr_[func_id] = addr;
-}
-
 void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
@@ -140,14 +119,11 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     func_id_to_addr_[func_id] = addr;
 }
 
-int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
-
-int Runtime::get_registered_kernel_func_id(int index) const {
-    if (index < 0 || index >= registered_kernel_count_) return -1;
-    return registered_kernel_func_ids_[index];
+void Runtime::clear_function_bin_addrs() {
+    for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
+        func_id_to_addr_[i] = 0;
+    }
 }
-
-void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }
 
 // host_build_graph's device image is the whole Runtime object (host-orch builds
 // the graph on the host, but the entire Runtime is still rtMemcpy'd to device).

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -290,6 +290,17 @@ public:
      */
     void replay_function_bin_addr(int func_id, uint64_t addr);
 
+    /**
+     * Drop every func_id -> CoreCallable address mapping.
+     *
+     * Each mapping points into one callable's retained ChipCallable buffer,
+     * which unregistering that callable frees. `bind_callable_to_runtime` calls
+     * this before replaying the active callable's addresses so no entry outlives
+     * the buffer it points into: the scheduler dereferences these addresses and
+     * the AICore calls what it finds there.
+     */
+    void clear_function_bin_addrs();
+
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)
     // Task graph is now managed by PTO2Runtime, not Runtime

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -81,6 +81,12 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     dev.func_id_to_addr_[func_id] = addr;
 }
 
+void Runtime::clear_function_bin_addrs() {
+    for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
+        dev.func_id_to_addr_[i] = 0;
+    }
+}
+
 // trb's device image is just the `dev` descriptor (the rest of Runtime is
 // host-only). Mirrors the host_build_graph definition (= sizeof(Runtime)).
 size_t runtime_device_copy_size(const Runtime &) { return sizeof(DeviceRuntimeLaunchDesc); }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1111,20 +1111,11 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
     LOG_INFO("Freed %d device allocations", tensor_pair_count);
 
-    // Clear the per-run dispatch-table entries staged by register_callable_impl.
-    // The underlying chip-callable device buffer is pool-managed by
-    // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(); re-running the same callable repeatedly
-    // should not re-upload.
-    int kernel_count = runtime->get_registered_kernel_count();
-    for (int i = 0; i < kernel_count; i++) {
-        int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->set_function_bin_addr(func_id, 0);
-    }
-    if (kernel_count > 0) {
-        LOG_INFO("Cleared %d kernel dispatch-table entries", kernel_count);
-    }
-    runtime->clear_registered_kernels();
+    // The dispatch table is owned by bind_callable_to_runtime, which clears it
+    // before replaying the active callable's addresses. The chip-callable device
+    // buffer behind those addresses is pool-managed by DeviceRunner (keyed by
+    // content hash) and bulk-freed in DeviceRunner::finalize(), so re-running the
+    // same callable repeatedly does not re-upload.
 
     // Clear tensor pairs
     runtime->tensor_pairs_.clear();

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -175,8 +175,6 @@ public:
 
 private:
     // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
 
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
     void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
@@ -267,18 +265,23 @@ public:
     void set_device_orch_config_name(const char *name);
 
     uint64_t get_function_bin_addr(int func_id) const;
-    void set_function_bin_addr(int func_id, uint64_t addr);
     /**
-     * Replay a previously-uploaded kernel address onto a fresh Runtime
-     * without recording it in registered_kernel_func_ids_. Used by
-     * DeviceRunner::bind_callable_to_runtime so prepared kernel
-     * binaries are not freed by validate_runtime_impl across runs.
+     * Map a func_id onto the device address of its CoreCallable. Used by
+     * DeviceRunner::bind_callable_to_runtime for each of the active callable's
+     * child kernels, after clear_function_bin_addrs() has emptied the table.
      */
     void replay_function_bin_addr(int func_id, uint64_t addr);
 
-    int get_registered_kernel_count() const;
-    int get_registered_kernel_func_id(int index) const;
-    void clear_registered_kernels();
+    /**
+     * Drop every func_id -> CoreCallable address mapping.
+     *
+     * Each mapping points into one callable's retained ChipCallable buffer,
+     * which unregistering that callable frees. `bind_callable_to_runtime` calls
+     * this before replaying the active callable's addresses so no entry outlives
+     * the buffer it points into: the scheduler dereferences these addresses and
+     * the AICore calls what it finds there.
+     */
+    void clear_function_bin_addrs();
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -50,9 +50,6 @@ Runtime::Runtime() {
     device_orch_func_name_[0] = '\0';
     device_orch_config_name_[0] = '\0';
 
-    // Initialize kernel binary tracking
-    registered_kernel_count_ = 0;
-
     // Initialize function address mapping
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         func_id_to_addr_[i] = 0;
@@ -114,24 +111,6 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
     return func_id_to_addr_[func_id];
 }
 
-void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-        return;
-    }
-    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
-        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-        } else {
-            LOG_ERROR(
-                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
-                func_id
-            );
-        }
-    }
-    func_id_to_addr_[func_id] = addr;
-}
-
 void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
@@ -140,14 +119,11 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     func_id_to_addr_[func_id] = addr;
 }
 
-int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
-
-int Runtime::get_registered_kernel_func_id(int index) const {
-    if (index < 0 || index >= registered_kernel_count_) return -1;
-    return registered_kernel_func_ids_[index];
+void Runtime::clear_function_bin_addrs() {
+    for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
+        func_id_to_addr_[i] = 0;
+    }
 }
-
-void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }
 
 // host_build_graph's device image is the whole Runtime object (host-orch builds
 // the graph on the host, but the entire Runtime is still rtMemcpy'd to device).

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -303,6 +303,17 @@ public:
      */
     void replay_function_bin_addr(int func_id, uint64_t addr);
 
+    /**
+     * Drop every func_id -> CoreCallable address mapping.
+     *
+     * Each mapping points into one callable's retained ChipCallable buffer,
+     * which unregistering that callable frees. `bind_callable_to_runtime` calls
+     * this before replaying the active callable's addresses so no entry outlives
+     * the buffer it points into: the scheduler dereferences these addresses and
+     * the AICore calls what it finds there.
+     */
+    void clear_function_bin_addrs();
+
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)
     // Task graph is now managed by PTO2Runtime, not Runtime

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -81,6 +81,12 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     dev.func_id_to_addr_[func_id] = addr;
 }
 
+void Runtime::clear_function_bin_addrs() {
+    for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
+        dev.func_id_to_addr_[i] = 0;
+    }
+}
+
 // trb's device image is just the `dev` descriptor (the rest of Runtime is
 // host-only). Mirrors the host_build_graph definition (= sizeof(Runtime)).
 size_t runtime_device_copy_size(const Runtime &) { return sizeof(DeviceRuntimeLaunchDesc); }

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -998,9 +998,17 @@ int DeviceRunnerBase::bind_callable_to_runtime(
     }
     const auto &state = it->second;
 
-    // Replay each prepared kernel address into runtime.func_id_to_addr_.
-    // The kernel binaries live in the retained ChipCallable buffer for this
-    // callable_id and stay valid until `unregister_callable` or `finalize`.
+    // runtime.func_id_to_addr_ holds exactly the active callable's mappings.
+    //
+    // Each entry is an address inside that callable's retained ChipCallable
+    // buffer, which `unregister_callable` frees once its last handle goes away.
+    // The table is zeroed only in Runtime's constructor and a Runtime outlives
+    // many register/unregister cycles, so an entry left behind by a previous
+    // callable dangles into GM the allocator can hand out again. The scheduler
+    // dereferences that address to read CoreCallable::resolved_addr() and the
+    // AICore calls the result, so a stale entry is executed as code. Replaying
+    // only this callable's func_ids would leave every other entry standing.
+    runtime.clear_function_bin_addrs();
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -122,6 +122,7 @@ endfunction()
 function(add_a2a3_hbg_runtime_test name src)
     add_executable(${name}
         ${src}
+        ${ARGN}
         ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
         ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
     )
@@ -800,6 +801,13 @@ add_a2a3_hbg_runtime_test(test_hbg_task_allocator a2a3/test_task_allocator.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensormap a2a3/test_hbg_tensormap.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_dep_gen_host_graph a2a3/test_dep_gen_host_graph.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp)
+
+# The func_id -> CoreCallable dispatch table holds exactly the active callable's
+# mappings. An entry that outlives the ChipCallable buffer it points into is
+# dereferenced by the scheduler and called by the AICore (issue #1489), so this
+# links the Runtime implementation to pin the contract without a device.
+add_a2a3_hbg_runtime_test(test_dispatch_table a2a3/test_dispatch_table.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 # The submit-poison test drives the real orchestrator submit path, so it links the
 # orchestrator + shared runtime out-of-line members (mirrors a2a3_rt_objs for hbg).

--- a/tests/ut/cpp/a2a3/test_dispatch_table.cpp
+++ b/tests/ut/cpp/a2a3/test_dispatch_table.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The func_id -> CoreCallable dispatch table holds exactly the active
+ * callable's mappings.
+ *
+ * Every entry is an address inside one callable's retained ChipCallable buffer,
+ * which unregistering that callable frees for the allocator to hand out again.
+ * The scheduler dereferences the entry to read `CoreCallable::resolved_addr()`
+ * and the AICore calls what it finds, so an entry that outlives its buffer is
+ * executed as code — it surfaces as an AICore UB out-of-bounds with a program
+ * counter in a data region (issue #1489).
+ *
+ * `bind_callable_to_runtime` therefore clears the table before replaying the
+ * active callable's addresses. These tests pin that contract on the Runtime
+ * itself, so it holds without a device.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "runtime.h"
+
+namespace {
+
+// Stand-ins for two callables' CoreCallable addresses. Nothing dereferences
+// them; only the table's bookkeeping is under test.
+constexpr uint64_t kCallableAChild0 = 0x7000'0000'1000ull;
+constexpr uint64_t kCallableAChild1 = 0x7000'0000'2000ull;
+constexpr uint64_t kCallableBChild0 = 0x7000'0000'9000ull;
+
+TEST(DispatchTable, StartsEmpty) {
+    Runtime runtime;
+    for (int func_id = 0; func_id < RUNTIME_MAX_FUNC_ID; func_id++) {
+        ASSERT_EQ(runtime.get_function_bin_addr(func_id), 0u) << "func_id=" << func_id;
+    }
+}
+
+TEST(DispatchTable, ReplayPublishesAnAddress) {
+    Runtime runtime;
+    runtime.replay_function_bin_addr(0, kCallableAChild0);
+    EXPECT_EQ(runtime.get_function_bin_addr(0), kCallableAChild0);
+}
+
+TEST(DispatchTable, ClearDropsEveryMapping) {
+    Runtime runtime;
+    runtime.replay_function_bin_addr(0, kCallableAChild0);
+    runtime.replay_function_bin_addr(1, kCallableAChild1);
+
+    runtime.clear_function_bin_addrs();
+
+    EXPECT_EQ(runtime.get_function_bin_addr(0), 0u);
+    EXPECT_EQ(runtime.get_function_bin_addr(1), 0u);
+}
+
+// The regression: callable A defines two children, callable B only one. B's
+// bind must not leave A's second address behind, because A's ChipCallable
+// buffer is freed when A unregisters.
+TEST(DispatchTable, ANarrowerCallableLeavesNoStaleEntry) {
+    Runtime runtime;
+
+    // bind(A) — func_ids {0, 1}
+    runtime.clear_function_bin_addrs();
+    runtime.replay_function_bin_addr(0, kCallableAChild0);
+    runtime.replay_function_bin_addr(1, kCallableAChild1);
+    ASSERT_EQ(runtime.get_function_bin_addr(1), kCallableAChild1);
+
+    // A unregisters, freeing its buffer; bind(B) — func_id {0} only
+    runtime.clear_function_bin_addrs();
+    runtime.replay_function_bin_addr(0, kCallableBChild0);
+
+    EXPECT_EQ(runtime.get_function_bin_addr(0), kCallableBChild0);
+    EXPECT_EQ(runtime.get_function_bin_addr(1), 0u)
+        << "func_id 1 still points into the ChipCallable buffer that unregistering A freed";
+}
+
+// A run whose graph names a func_id the active callable does not define must
+// resolve to zero, which the AICore's `function_bin_addr == 0` check rejects,
+// rather than to some earlier callable's address.
+TEST(DispatchTable, AnUndefinedFuncIdResolvesToZero) {
+    Runtime runtime;
+    runtime.clear_function_bin_addrs();
+    runtime.replay_function_bin_addr(0, kCallableAChild0);
+    runtime.replay_function_bin_addr(1, kCallableAChild1);
+
+    runtime.clear_function_bin_addrs();
+    runtime.replay_function_bin_addr(7, kCallableBChild0);
+
+    for (int func_id = 0; func_id < RUNTIME_MAX_FUNC_ID; func_id++) {
+        if (func_id == 7) continue;
+        ASSERT_EQ(runtime.get_function_bin_addr(func_id), 0u) << "func_id=" << func_id;
+    }
+}
+
+TEST(DispatchTable, OutOfRangeFuncIdsAreRejectedNotWritten) {
+    Runtime runtime;
+    runtime.replay_function_bin_addr(-1, kCallableAChild0);
+    runtime.replay_function_bin_addr(RUNTIME_MAX_FUNC_ID, kCallableAChild0);
+
+    EXPECT_EQ(runtime.get_function_bin_addr(-1), 0u);
+    EXPECT_EQ(runtime.get_function_bin_addr(RUNTIME_MAX_FUNC_ID), 0u);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

`Runtime::func_id_to_addr_` maps a func_id onto an address **inside one callable's retained ChipCallable buffer**, which `unregister_callable` frees once its last handle goes away. `bind_callable_to_runtime` replayed only the active callable's func_ids, and the table is zeroed only in `Runtime`'s constructor — so an entry left by a previous callable survived for the life of the `Runtime` (one per pipeline slot, spanning many register/unregister cycles), pointing into GM the allocator can hand out again.

Such an entry is **executed as code**, not merely read. The scheduler dereferences it for `CoreCallable::resolved_addr()` and the AICore calls the result after checking only that it is non-zero:

```cpp
// scheduler_dispatch.cpp — hbg :128-130, tmr :130-132, identical
uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
dispatch_payload.function_bin_addr = callable->resolved_addr();
```

```cpp
// aicore_executor.cpp:37-41
if (payload == nullptr || payload->function_bin_addr == 0) return;
UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
kernel(...);
```

Both the write and the free are in the shared `device_runner_base.cpp`, and the table is zeroed the same way in all four `Runtime` classes, so this is not specific to either runtime.

## Changes

**`bind_callable_to_runtime` clears the table before replaying**, so a mapping's lifetime cannot exceed its buffer's. One shared call site covers both runtimes; `clear_function_bin_addrs()` is added to all four `Runtime` classes (a2a3/a5 × hbg/tmr). Host-side only — no AICPU hot path, so `.claude/rules/codestyle.md` §7 does not apply. `RUNTIME_MAX_FUNC_ID` is 1024, so it is an 8 KB store per run on the host.

**host_build_graph's per-run clearing loop is removed along with its bookkeeping.** It walked `registered_kernel_func_ids_`, which only `set_function_bin_addr` populates — and that function's *only* caller in the tree was the loop itself, passing 0. `registered_kernel_count_` was therefore always zero and the loop could never execute; its recording branch was unreachable. It read as though the table were maintained, which is why `tensormap_and_ringbuffer` having no such loop at all reached identical state. Removed rather than left to mislead the next reader.

## Relation to #1489

Found while investigating [#1489](https://github.com/hw-native-sys/simpler/issues/1489), but it is an **independent defect and does not explain the faults there** — it should not be read as closing that issue.

That issue's AICore UB out-of-bounds is most likely **stale AICore instructions**, the mechanism the fresh-AICore-stream policy exists to prevent, rather than a bad dispatch address. I had read the fault's `pc current` as evidence the core jumped to a corrupted address; that used the wrong criterion — F1 in `docs/troubleshooting/device-error-codes/aicore-fault.md` tests `pc current` against the *executor binary's extent*, not against `pc start` — and I have withdrawn it on the issue.

This fix stands on its own because it was found by reading the lifetime, not from that inference: the replay path never registered for cleanup, host_build_graph's clearing loop walked a list nothing populated, the table is zeroed only in the constructor, the `Runtime` outlives many register/unregister cycles, and `unregister_callable` frees the buffer. It also restores a fail-safe worth having regardless — a func_id the active callable does not define now resolves to 0 and the AICore's existing zero-check rejects it, instead of dereferencing recycled GM and executing what it finds.

The related gap that the dispatch address is bounds-unchecked at both ends is recorded on #1489 and left for a separate decision, since closing it costs a compare on the AICPU dispatch path.

## Validation

| | result |
| --- | --- |
| new `test_dispatch_table` (cpput) | 6/6 |
| full cpput, `-LE requires_hardware` | 100/100 |
| all four runtimes compile | yes |
| a2a3 onboard `tests/st/a2a3` + `examples`, 4 devices, `-m 'not sdma'` | host_build_graph 30 passed / 1 skipped, tensormap_and_ringbuffer 52 passed, **0 failed** |

**Test caveat, stated plainly:** the new tests call `clear_function_bin_addrs()` directly, so they pin the `Runtime` contract, **not the `bind_callable_to_runtime` call site where the bug lived**. Deleting the fix would leave them green. Covering that call site needs a `DeviceRunner`, i.e. a device; the onboard suite above exercises it but has no observable for a stale entry that nothing resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
