### PR TITLE
Fix: harden the Buffer release path on the owner and consumer sides

### DIFF
--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -147,6 +147,10 @@ class Buffer:
     # guard and free/copy key on (owner_worker_id, base).
     owner_worker_id: int = 0
     closed: bool = False
+    # Owner-side only: whether the backing's name has actually been removed. Distinct from `closed`,
+    # which is the derivation gate — a close() whose unlink raised leaves this false so a retry
+    # attempts the unlink again.
+    unlinked: bool = False
 
     def to_descriptor(self) -> BufferDescriptor:
         """The wire descriptor for this backing — what a consumer needs to resolve it."""
@@ -190,17 +194,26 @@ class Buffer:
         """Release the backing. The owner unlinks it, so a later consumer map fails rather than
         resolving a name whose bytes are gone. Idempotent; a released Buffer's ``tensor()``/
         ``to_descriptor()`` are refused rather than building a view over memory that may already be
-        gone."""
-        if self.closed:
-            return
+        gone — that refusal holds from the first call on, whether or not the release itself
+        succeeded, since a partly-released backing is no safer to hand out than a fully released one.
+
+        Each OS action succeeds at most once and is retried until it does. ``shm.close()`` runs
+        first and never gates the unlink: the named backing outlives this process, so it is the leak
+        worth removing even when the local unmap raised. An unlink that raises leaves ``shm`` in
+        place, so a second ``close()`` attempts it again — that retry is what
+        ``Worker._release_all_buffers`` leaves the registry entry behind for.
+        """
         self.closed = True
         shm = self.shm
-        self.shm = None
-        if shm is not None:
-            try:
-                shm.close()
-            finally:
+        if shm is None:
+            return
+        try:
+            shm.close()
+        finally:
+            if not self.unlinked:
                 shm.unlink()
+                self.unlinked = True
+        self.shm = None
 
 
 def create_host_shared_buffer(
@@ -578,7 +591,7 @@ class ImportRegistry:
     still describes the backing that was mapped, so one identity can never come to mean two things.
     """
 
-    def __init__(self, context: ImportContext | None = None) -> None:
+    def __init__(self, context: ImportContext) -> None:
         self._by_identity: dict[CanonicalIdentity, ImportedBuffer] = {}
         self._context = context
 
@@ -616,7 +629,7 @@ class ImportRegistry:
                 )
             return cached
         if desc.address_space == AddressSpace.DEVICE:
-            if self._context is None or self._context.is_host_endpoint:
+            if self._context.is_host_endpoint:
                 raise ValueError(
                     f"ImportRegistry: [{RegionAccessReasonCode.UNSUPPORTED_ENDPOINT_RELATION.value}] "
                     f"refusing to materialize a DEVICE backing ({desc.identity}) on a host endpoint"
@@ -643,7 +656,17 @@ class ImportRegistry:
             base = int.from_bytes(desc.body, "little")
             imported = ImportedBuffer(desc.identity, base, desc.nbytes, desc.address_space, None, desc)
         elif desc.backend_kind == BackendKind.POSIX_SHM:
-            shm = SharedMemory(name=desc.body.decode("utf-8"))
+            name = desc.body.decode("utf-8")
+            try:
+                shm = SharedMemory(name=name)
+            except FileNotFoundError as exc:
+                # The owner unlinks on release, so a missing name is the expected shape of "this
+                # identity was released", not a corrupt descriptor. Naming both the identity and
+                # that reading separates it from a genuinely bad name at a glance.
+                raise FileNotFoundError(
+                    f"ImportRegistry: shm object {name!r} for {desc.identity} does not exist — its "
+                    f"owner has released the buffer, or it was never created"
+                ) from exc
             # `validate_tensor` admits a view when byte_offset + extent <= nbytes, so a backing
             # smaller than the nbytes its own descriptor advertises turns every one of those checks
             # into a comparison against a number no memory stands behind. The object's real size is
@@ -708,15 +731,36 @@ class ImportRegistry:
         ``release_buffer()`` so a long-lived endpoint does not keep every backing it ever saw
         mapped for its entire lifetime; best-effort by design, since an endpoint that never
         materialized ``identity`` has nothing to drop.
+
+        The entry is dropped only once its mapping is really gone. ``close()`` on a mapping whose
+        consumer still holds a derived ``memoryview`` raises ``BufferError``, and an entry dropped
+        before that point is a mapping nothing can reach to retry — so the raise leaves the entry
+        in place for this registry's own ``close()`` to attempt again.
         """
-        imported = self._by_identity.pop(identity, None)
-        if imported is not None and imported.shm is not None:
+        imported = self._by_identity.get(identity)
+        if imported is None:
+            return
+        if imported.shm is not None:
             imported.shm.close()
+        del self._by_identity[identity]
 
     def close(self) -> None:
         """Close every mapping this endpoint made. Consumer-side only — unlinking belongs to the
-        owning Worker, so this never destroys a backing."""
-        for imported in self._by_identity.values():
+        owning Worker, so this never destroys a backing.
+
+        Every mapping is attempted, and only the ones that closed are dropped: one endpoint holding
+        an exported view must not strand every mapping behind it in the iteration order. The first
+        error is raised once the sweep is done, so a caller still learns the endpoint leaked rather
+        than seeing a silent success.
+        """
+        errors: list[BaseException] = []
+        for identity, imported in list(self._by_identity.items()):
             if imported.shm is not None:
-                imported.shm.close()
-        self._by_identity.clear()
+                try:
+                    imported.shm.close()
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+                    continue
+            del self._by_identity[identity]
+        if errors:
+            raise errors[0]

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -483,6 +483,8 @@ class Orchestrator:
         )
         _reject_remote_sidecar_args(args, kind="orch.submit_sub")
         _reject_device_args(args, kind="orch.submit_sub")
+        if self._worker is not None:
+            self._worker._record_touched_identities(args)
         _admit_task_submission(self._worker)
         self._o.submit_sub(digest, kind, target_namespace, args)
 
@@ -497,6 +499,12 @@ class Orchestrator:
         for args in args_list:
             _reject_remote_sidecar_args(args, kind="orch.submit_sub_group")
             _reject_device_args(args, kind="orch.submit_sub_group")
+        # Second pass, as in submit_next_level_group: a member rejected above means no member is
+        # dispatched, and identities recorded for a group that never went out would refuse a
+        # release of buffers no task ever received.
+        if self._worker is not None:
+            for args in args_list:
+                self._worker._record_touched_identities(args)
         _admit_task_submission(self._worker)
         self._o.submit_sub_group(digest, kind, target_namespace, args_list)
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -7309,14 +7309,20 @@ class Worker:
             sys.stderr.flush()
 
     def _release_import_recursive(self, identity: CanonicalIdentity) -> None:
-        """Drop ``identity`` from this Worker's own same-process import cache, then forward one
+        """Drop ``identity`` from this Worker's own same-process caches, then forward one
         more hop down this Worker's own children — same shape as ``_unregister_child_digest``'s
         recursive forward for callable cleanup, since a NEXT_LEVEL child may itself have
         materialized ``identity`` further down its own tree (chip/SUB leaves, or its own
         NEXT_LEVEL children in turn).
+
+        Two caches name a released identity here, not one: the import cache holds a mapping of it,
+        and ``_reexport_by_source`` holds the forwarding handle built from it. A retained re-export
+        outlives its backing, and its ``to_descriptor()`` keeps answering — so a later forward of
+        the same identity would hand a child a descriptor for a name the owner has unlinked.
         """
         if self._chip_import_registry is not None:
             self._chip_import_registry.unregister(identity)
+        self._reexport_by_source.pop(identity, None)
         self._broadcast_import_release(identity)
 
     def add_worker(self, worker: Worker) -> int:
@@ -10082,9 +10088,11 @@ class Worker:
         """Add every tensor arg's identity in ``args`` to the current run's touched set.
 
         A no-op when no run is being built (``_building_run_resources is None``) — tracking is
-        opportunistic, only meaningful inside ``submit_next_level``/``submit_next_level_group``'s
-        run context, per the ``current_resources = self._building_run_resources; if ... is not
-        None`` idiom used elsewhere for the same "attach to the open run, if any" shape.
+        opportunistic, only meaningful inside the run context of the four orchestrator dispatch
+        entry points that carry Tensor args to another process (``submit_next_level``,
+        ``submit_next_level_group``, ``submit_sub``, ``submit_sub_group``), per the
+        ``current_resources = self._building_run_resources; if ... is not None`` idiom used
+        elsewhere for the same "attach to the open run, if any" shape.
         """
         resources = self._building_run_resources
         if resources is None:
@@ -10497,13 +10505,23 @@ class Worker:
         drop its own cached import for the identity.
 
         Rejects outright if any currently in-flight L3+ run (not yet past ``_cleanup_published``)
-        sent this identity as a NEXT_LEVEL Tensor arg, or any in-flight L2 direct-chip run sent it —
-        a Buffer never goes away while a dispatched task still names it. The L3+ check takes
+        sent this identity as a NEXT_LEVEL or SUB Tensor arg, or any in-flight L2 direct-chip run
+        sent it — a Buffer never goes away while a dispatched task still names it. All three
+        dispatch paths retain: a SUB task maps the identity into a sub-worker process just as a
+        NEXT_LEVEL task maps it into a child, so unlinking the backing under either one faults the
+        consumer on a segment that no longer has a name. The L3+ check takes
         ``_submit_mu`` first: a handle is visible in ``_accepted_run_handles`` before its
         orchestration callback (where ``touched_identities`` gets populated) has run, and that
         callback is what ``_submit_mu`` already serializes graph construction against, so taking it
         here means the check only ever runs between callbacks, never mid-callback with a
-        not-yet-complete touched set. The L2 check is independent (a separate run-id namespace with
+        not-yet-complete touched set. ``_abandoned_run_handles`` is scanned in the same block and
+        without the ``_cleanup_published`` test: ``_publish_abandoned_run`` sets that flag and drops
+        the handle from the accepted set while the run itself stays retained until native teardown
+        drains it, so an abandoned run is exactly the case where the flag stops describing whether
+        the device is done with the backing. Such a buffer therefore stops being releasable through
+        this API for the Worker's remaining life, which strands nothing: ``close()`` reclaims it via
+        ``_release_all_buffers`` calling ``Buffer.close()`` directly. The L2 check is independent (a
+        separate run-id namespace with
         no callback to serialize against — ``_chip_run_touched_identities`` is written atomically
         alongside ``_chip_runs`` under ``_registry_lock`` instead, see ``_submit_l2_locked``), so the
         two checks run sequentially rather than under one shared lock. Neither is checked once
@@ -10523,6 +10541,13 @@ class Worker:
                 for handle in self._accepted_run_handles:
                     if not handle._cleanup_published and buffer.identity in handle._resources.touched_identities:
                         raise RuntimeError(f"release_buffer: {buffer.identity} is still referenced by an in-flight run")
+                for handle in self._abandoned_run_handles:
+                    resources = handle._resources
+                    if resources is not None and buffer.identity in resources.touched_identities:
+                        raise RuntimeError(
+                            f"release_buffer: {buffer.identity} is still referenced by an abandoned run "
+                            f"whose native teardown has not completed"
+                        )
             with self._registry_lock:
                 for touched in self._chip_run_touched_identities.values():
                     if buffer.identity in touched:
@@ -11675,6 +11700,7 @@ class Worker:
             ("remote", "pending remote frees", self._flush_pending_remote_frees),
             ("buffer", "all owner Buffers", self._release_all_buffers),
             ("buffer", "fork-inherited tensor buffers", self._fork_tensor_handles.clear),
+            ("buffer", "re-exported forwarding handles", self._reexport_by_source.clear),
             ("buffer", "chip import registry", self._close_chip_import_registry),
         ):
             self._cleanup_journal.add_once(kind, identity, cleanup)

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -17,6 +17,7 @@ registry and the Buffer constructors that are genuinely defined there.
 """
 
 import ctypes
+from multiprocessing.shared_memory import SharedMemory
 from unittest.mock import patch
 
 import pytest
@@ -126,7 +127,7 @@ def test_descriptor_rejects_oversized_body():
 def test_create_export_import_resolve_zero_copy():
     oid = mint_owner_instance_id()
     buffer = create_host_shared_buffer(nbytes=256, owner_instance_id=oid, buffer_id=1, owner_worker_path="L4")
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     try:
         assert buffer.backend_kind == BackendKind.POSIX_SHM
         imported = reg.materialize(buffer.to_descriptor())
@@ -165,6 +166,41 @@ def test_close_unlinks_even_when_shm_close_raises():
     shm.unlink()  # the mock above swallowed the real unlink; do it for real so the test leaves no /dev/shm litter
 
 
+def test_close_retries_the_unlink_that_failed():
+    # The named backing is what outlives the process, so an unlink that fails must stay pending: the
+    # cleanup journal keeps a failed buffer's registry entry precisely so close() runs again, and a
+    # retry that returns without re-attempting the unlink leaves the name in /dev/shm forever.
+    buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=mint_owner_instance_id(), buffer_id=1)
+    shm = buffer.shm
+    assert shm is not None
+    name = shm.name
+    with patch.object(shm, "unlink", side_effect=OSError("injected unlink failure")) as unlink:
+        with pytest.raises(OSError, match="injected unlink failure"):
+            buffer.close()
+        unlink.assert_called_once()
+    assert buffer.closed  # the derivation gate shuts on the first attempt, successful release or not
+    assert not buffer.unlinked
+    buffer.close()
+    assert buffer.unlinked
+    with pytest.raises(FileNotFoundError):
+        SharedMemory(name=name)
+
+
+def test_close_does_not_unlink_twice_after_a_failed_close():
+    # The retry above must not re-run an unlink that already succeeded: a close() failure leaves the
+    # name already removed by the finally, so a second unlink would raise FileNotFoundError over a
+    # backing that is simply gone -- turning a recoverable state into a permanent error.
+    buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=mint_owner_instance_id(), buffer_id=1)
+    shm = buffer.shm
+    assert shm is not None
+    with patch.object(shm, "close", side_effect=OSError("injected close failure")):
+        with pytest.raises(OSError, match="injected close failure"):
+            buffer.close()
+    assert buffer.unlinked
+    buffer.close()  # the retry: closes the mapping for real, and leaves the unlink alone
+    assert buffer.shm is None
+
+
 def test_closed_buffer_refuses_to_derive_a_tensor():
     # A released Buffer's identity may already be unlinked, so deriving a Tensor from it would embed
     # a descriptor for memory that no longer exists.
@@ -178,7 +214,7 @@ def test_closed_buffer_refuses_to_derive_a_tensor():
 
 
 def test_resolve_unregistered_raises():
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     with pytest.raises(KeyError):
         reg.resolve(_identity())
 
@@ -186,7 +222,7 @@ def test_resolve_unregistered_raises():
 def test_unregister_drops_a_materialized_mapping():
     oid = mint_owner_instance_id()
     buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=oid, buffer_id=1)
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     try:
         reg.materialize(buffer.to_descriptor())
         reg.unregister(buffer.identity)
@@ -201,8 +237,71 @@ def test_unregister_drops_a_materialized_mapping():
 
 
 def test_unregister_is_a_no_op_for_an_identity_never_materialized():
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     reg.unregister(_identity())  # must not raise
+
+
+def test_unregister_keeps_a_mapping_it_could_not_close():
+    # shm.close() raises BufferError while a consumer still holds a memoryview derived from the
+    # mapping. An entry dropped at that point names a mapping nothing can reach again, so this
+    # endpoint's close() could never retry it -- the entry has to survive the failure.
+    oid = mint_owner_instance_id()
+    buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=oid, buffer_id=1)
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
+    try:
+        imported = reg.materialize(buffer.to_descriptor())
+        assert imported.shm is not None
+        with patch.object(imported.shm, "close", side_effect=BufferError("cannot close exported pointers exist")):
+            with pytest.raises(BufferError):
+                reg.unregister(buffer.identity)
+        assert reg.resolve(buffer.identity) is imported
+        reg.unregister(buffer.identity)  # the retry, once the view is gone
+        with pytest.raises(KeyError):
+            reg.resolve(buffer.identity)
+    finally:
+        reg.close()
+        buffer.close()
+
+
+def test_close_attempts_every_mapping_and_reports_the_first_failure():
+    # One endpoint holding an exported view must not strand the mappings behind it in iteration
+    # order: every mapping is attempted, the ones that closed are dropped, and the caller still
+    # learns about the leak instead of seeing a silent success.
+    oid = mint_owner_instance_id()
+    first = create_host_shared_buffer(nbytes=64, owner_instance_id=oid, buffer_id=1)
+    second = create_host_shared_buffer(nbytes=64, owner_instance_id=oid, buffer_id=2)
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
+    try:
+        imported_first = reg.materialize(first.to_descriptor())
+        imported_second = reg.materialize(second.to_descriptor())
+        assert imported_first.shm is not None
+        assert imported_second.shm is not None
+        with (
+            patch.object(imported_first.shm, "close", side_effect=BufferError("injected close failure")),
+            patch.object(imported_second.shm, "close") as second_close,
+        ):
+            with pytest.raises(BufferError, match="injected close failure"):
+                reg.close()
+            second_close.assert_called_once()
+        assert reg.resolve(first.identity) is imported_first  # the one that failed is kept
+        with pytest.raises(KeyError):
+            reg.resolve(second.identity)
+    finally:
+        first.close()
+        second.close()
+
+
+def test_materialize_after_release_says_the_owner_released_it():
+    # A missing shm name is the expected shape of "this identity was released", and the bare
+    # FileNotFoundError the OS raises names only /psm_xxxx -- which identity, and why it is gone,
+    # are exactly what the reader needs.
+    oid = mint_owner_instance_id()
+    buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=oid, buffer_id=1)
+    descriptor = buffer.to_descriptor()
+    buffer.close()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
+    with pytest.raises(FileNotFoundError, match="released the buffer"):
+        reg.materialize(descriptor)
 
 
 def test_tensor_full_view_is_contiguous():
@@ -290,7 +389,7 @@ def test_materialize_remote_sidecar_rejected():
         backend_kind=BackendKind.REMOTE_SIDECAR,
         nbytes=8,
     )
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     with pytest.raises(ValueError, match="REMOTE_SIDECAR"):
         reg.materialize(desc)
 
@@ -341,7 +440,7 @@ def test_materialize_rejects_an_shm_object_shorter_than_its_descriptor():
     # of them vacuous. The object's real size is the one thing here the owner cannot overstate.
     oid = mint_owner_instance_id()
     buffer = create_host_shared_buffer(nbytes=128, owner_instance_id=oid, buffer_id=1)
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     try:
         honest = buffer.to_descriptor()
         assert reg.materialize(honest).nbytes == 128  # the truthful one maps
@@ -520,7 +619,7 @@ def test_mapped_arg_buffer_is_read_only_for_a_read_access_descriptor():
     addr = ctypes.addressof((ctypes.c_char * 16).from_buffer(data))
     oid = mint_owner_instance_id()
     buf = wrap_fork_inherited(addr, 16, oid, buffer_id=1)  # default: access=READ, backend=FORK_COW
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     imported = reg.materialize(buf.to_descriptor())
     arg = MappedArg(imported, byte_offset=0, shapes=(16,), strides=(1,), dtype=DataType.UINT8)
 

--- a/tests/ut/py/test_callable_identity.py
+++ b/tests/ut/py/test_callable_identity.py
@@ -24,7 +24,7 @@ from typing import cast
 import pytest
 import simpler.worker as worker_mod
 from simpler import callable_identity
-from simpler.buffer import ImportRegistry, mint_owner_instance_id, wrap_fork_inherited
+from simpler.buffer import ImportContext, ImportRegistry, mint_owner_instance_id, wrap_fork_inherited
 from simpler.callable_identity import (
     CallableHandle,
     CallableKindName,
@@ -105,7 +105,7 @@ def _remote_sleep_orch(orch, args, cfg):
 # A remote runner's orchestration function receives address-free wire ``Tensor`` args, so one that
 # computes in-process reaches the bytes the way every other consumer does: map the embedded
 # descriptor once, keyed by canonical identity, and index the view from the mapped base.
-_REMOTE_ORCH_IMPORTS = ImportRegistry()
+_REMOTE_ORCH_IMPORTS = ImportRegistry(ImportContext(is_host_endpoint=True))
 
 
 def _remote_u8_view(tensor):

--- a/tests/ut/py/test_remote_l3_lifecycle.py
+++ b/tests/ut/py/test_remote_l3_lifecycle.py
@@ -957,11 +957,13 @@ def _bare_l3_worker():
     w._hierarchical_start_mu = threading.Lock()
     w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
     w._accepted_run_handles = set()
+    w._abandoned_run_handles = []
     # Run admission is shared/exclusive now, not a plain Lock: production code calls
     # `.exclusive()` / `.shared()` on it, so the stand-in has to be the real type.
     w._submit_mu = _SharedExclusiveLock()
     w._chip_run_touched_identities = {}
     w._chip_import_registry = None
+    w._reexport_by_source = {}
     w._worker = None
     return w
 

--- a/tests/ut/py/test_worker/test_create_buffer.py
+++ b/tests/ut/py/test_worker/test_create_buffer.py
@@ -37,11 +37,13 @@ def _bare_worker(level: int, *, chip: int = 0, sub: int = 0, next_level: int = 0
     w._hierarchical_start_mu = threading.Lock()
     w._hierarchical_start_cv = threading.Condition(w._hierarchical_start_mu)
     w._accepted_run_handles = set()
+    w._abandoned_run_handles = []
     # Run admission is shared/exclusive now, not a plain Lock: production code calls
     # `.exclusive()` / `.shared()` on it, so the stand-in has to be the real type.
     w._submit_mu = _SharedExclusiveLock()
     w._chip_run_touched_identities = {}
     w._chip_import_registry = None
+    w._reexport_by_source = {}
     w._worker = None
     return w
 

--- a/tests/ut/py/test_worker/test_endpoint_capability.py
+++ b/tests/ut/py/test_worker/test_endpoint_capability.py
@@ -91,7 +91,7 @@ def test_sub_worker_materialization_refuses_a_device_tensor():
     assert dev.address_space == AddressSpace.DEVICE
     blob = encode_blob([dev.tensor(shapes=(16,), dtype=DataType.FLOAT32)])
     src = ctypes.create_string_buffer(blob, len(blob))
-    reg = ImportRegistry()
+    reg = ImportRegistry(ImportContext(is_host_endpoint=True))
     try:
         with pytest.raises(ValueError, match="DEVICE-space"):
             reg.mapped_args_from_blob(ctypes.addressof(src), len(blob))

--- a/tests/ut/py/test_worker/test_release_buffer.py
+++ b/tests/ut/py/test_worker/test_release_buffer.py
@@ -9,8 +9,9 @@
 """``Worker.release_buffer()``: rejects release while an in-flight run still references the
 buffer's identity, and how that identity gets tracked in the first place.
 
-L3+ tracking hooks the two async dispatch entry points, ``Orchestrator.submit_next_level`` /
-``.submit_next_level_group``, device-free via the same fake-C++-orchestrator harness
+L3+ tracking hooks the four dispatch entry points that hand a Tensor arg to another process,
+``Orchestrator.submit_next_level`` / ``.submit_next_level_group`` / ``.submit_sub`` /
+``.submit_sub_group``, device-free via the same fake-C++-orchestrator harness
 ``test_child_addr_guard.py`` already established. L2's direct-chip dispatch
 (``_submit_l2_locked``) is a separate run-id namespace that never touches
 ``_accepted_run_handles``/``_submit_mu`` at all, so it gets its own parallel tracking dict
@@ -26,7 +27,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from _task_interface import DataType, TensorArgType
-from simpler.buffer import create_host_shared_buffer, mint_owner_instance_id
+from simpler.buffer import AccessMode, create_host_shared_buffer, mint_owner_instance_id, wrap_device_malloc
 from simpler.orchestrator import Orchestrator
 from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import RunHandle, Worker, _RunResources
@@ -50,7 +51,12 @@ def _buffer_args(buf) -> TaskArgs:
 def _fake_orchestrator(w: Worker, monkeypatch: pytest.MonkeyPatch) -> Orchestrator:
     import simpler.orchestrator as orch_mod  # noqa: PLC0415
 
-    def _fake_require_handle(callable_handle, **_kw):
+    def _fake_require_handle(callable_handle, *, kind, expected_namespace=None, **_kw):
+        # Per-API metadata, not one blanket tuple: a SUB submit resolves a LOCAL_PYTHON callable
+        # and a NEXT_LEVEL submit a LOCAL_CHIP one, so a fake that answered NEXT_LEVEL/LOCAL_CHIP
+        # for both would let a SUB test pass over an impossible dispatch contract.
+        if kind.startswith("orch.submit_sub"):
+            return (b"d" * 32, "SUB", "LOCAL_PYTHON", ())
         return (b"d" * 32, "NEXT_LEVEL", "LOCAL_CHIP", (0,))
 
     monkeypatch.setattr(orch_mod, "_require_handle", _fake_require_handle)
@@ -85,15 +91,69 @@ class TestTouchedIdentityTracking:
             buf_a.close()
             buf_b.close()
 
+    def test_submit_sub_records_touched_identity(self, monkeypatch):
+        # A SUB task maps the identity into a sub-worker process, so it retains the Buffer for
+        # the same reason a NEXT_LEVEL dispatch does: release_buffer() unlinking the backing
+        # mid-flight leaves the child faulting on a segment that no longer has a name.
+        w = _l3()
+        o = _fake_orchestrator(w, monkeypatch)
+        w._building_run_resources = _RunResources()
+        buf = create_host_shared_buffer(64, _OID, buffer_id=5)
+        try:
+            o.submit_sub(object(), _buffer_args(buf))
+            assert buf.identity in w._building_run_resources.touched_identities
+        finally:
+            buf.close()
+
+    def test_submit_sub_group_records_touched_identity_per_member(self, monkeypatch):
+        w = _l3()
+        o = _fake_orchestrator(w, monkeypatch)
+        w._building_run_resources = _RunResources()
+        buf_a = create_host_shared_buffer(64, _OID, buffer_id=6)
+        buf_b = create_host_shared_buffer(64, _OID, buffer_id=7)
+        try:
+            o.submit_sub_group(object(), [_buffer_args(buf_a), _buffer_args(buf_b)])
+            touched = w._building_run_resources.touched_identities
+            assert buf_a.identity in touched
+            assert buf_b.identity in touched
+        finally:
+            buf_a.close()
+            buf_b.close()
+
+    def test_submit_sub_group_records_nothing_when_a_member_is_rejected(self, monkeypatch):
+        # A rejected member means no member is dispatched, so recording the earlier members would
+        # refuse a release of buffers no task ever received. Validation is one pass, recording the
+        # next -- the same two-pass shape submit_next_level_group already uses.
+        w = _l3()
+        o = _fake_orchestrator(w, monkeypatch)
+        w._building_run_resources = _RunResources()
+        buf = create_host_shared_buffer(64, _OID, buffer_id=8)
+        device = wrap_device_malloc(0xDEAD0000, 4096, _OID, buffer_id=9, access=AccessMode.READWRITE)
+        try:
+            with pytest.raises(ValueError, match="DEVICE-space"):
+                o.submit_sub_group(object(), [_buffer_args(buf), _buffer_args(device)])
+            assert w._building_run_resources.touched_identities == set()
+        finally:
+            buf.close()
+
+    def test_submit_sub_with_no_args_records_nothing(self, monkeypatch):
+        w = _l3()
+        o = _fake_orchestrator(w, monkeypatch)
+        w._building_run_resources = _RunResources()
+        o.submit_sub(object())  # tag-less task -- must not raise on the default TaskArgs()
+        assert w._building_run_resources.touched_identities == set()
+
     def test_no_current_run_is_a_no_op(self, monkeypatch):
-        # submit_next_level runs fine with no _building_run_resources open (e.g. a direct call
-        # outside a run's orchestration callback) -- tracking is opportunistic, not required.
+        # submit_next_level / submit_sub run fine with no _building_run_resources open (e.g. a
+        # direct call outside a run's orchestration callback) -- tracking is opportunistic, not
+        # required.
         w = _l3()
         o = _fake_orchestrator(w, monkeypatch)
         assert w._building_run_resources is None
         buf = create_host_shared_buffer(64, _OID, buffer_id=4)
         try:
             o.submit_next_level(object(), _buffer_args(buf), None, worker=0)  # must not raise
+            o.submit_sub(object(), _buffer_args(buf))  # must not raise
         finally:
             buf.close()
 
@@ -117,6 +177,41 @@ def _l3_with_registered_buffer(nbytes: int = 64):
 
 
 class TestReleaseBuffer:
+    def test_rejects_a_buffer_a_submitted_sub_task_still_names(self, monkeypatch):
+        # End to end over the pair, rather than each half alone: submit_sub records into the open
+        # run's resources, and release_buffer reads them off the accepted handle. The recording has
+        # to land before admission for this to hold at every point after submit_sub returns.
+        w, buf = _l3_with_registered_buffer()
+        o = _fake_orchestrator(w, monkeypatch)
+        handle = RunHandle(w, run_id=1, keepalive=())
+        resources = _RunResources()
+        handle._resources = resources
+        w._building_run_resources = resources
+        with w._hierarchical_start_cv:
+            w._accepted_run_handles.add(handle)
+        o.submit_sub(object(), _buffer_args(buf))
+        with pytest.raises(RuntimeError, match="in-flight run"):
+            w.release_buffer(buf)
+        assert not buf.closed
+        handle._cleanup_published = True
+        w.release_buffer(buf)
+        assert buf.closed
+
+    def test_rejects_while_an_abandoned_run_still_names_the_buffer(self):
+        # _publish_abandoned_run sets _cleanup_published and drops the handle from
+        # _accepted_run_handles, but the run stays in _abandoned_run_handles until native teardown
+        # drains it -- so for an abandoned run that flag no longer means the device is done with the
+        # backing, and the accepted-set check alone would let the release through.
+        w, buf = _l3_with_registered_buffer()
+        handle = _in_flight_handle(w, buf.identity, done=True)
+        w._abandoned_run_handles.append(handle)
+        with pytest.raises(RuntimeError, match="abandoned run"):
+            w.release_buffer(buf)
+        assert not buf.closed
+        assert w._buffers.get(int(buf.identity.buffer_id)) is buf
+        w._abandoned_run_handles.clear()
+        w.release_buffer(buf)  # cleanup
+
     def test_rejects_while_in_flight(self):
         w, buf = _l3_with_registered_buffer()
         w._accepted_run_handles.add(_in_flight_handle(w, buf.identity, done=False))
@@ -324,6 +419,27 @@ class TestReleaseBufferL2InFlight:
         w.release_buffer(buf)
         assert buf.closed
         assert int(buf.identity.buffer_id) not in w._buffers
+
+
+class TestReleaseBufferReexport:
+    def test_release_drops_the_forwarding_handle_for_the_identity(self):
+        # _reexport memoizes a forwarding handle per source backing, and that handle keeps answering
+        # to_descriptor() after its backing is gone -- a later forward of the same identity would
+        # hand a child a descriptor for a name the owner has already unlinked.
+        w, buf = _l3_with_registered_buffer()
+        handle = w._reexport(buf.to_descriptor())
+        assert w._reexport_by_source[buf.identity] is handle
+        w.release_buffer(buf)
+        assert buf.identity not in w._reexport_by_source
+
+    def test_close_clears_the_forwarding_handles(self, monkeypatch):
+        # The same cache at teardown: it holds an entry per backing ever forwarded, so leaving it
+        # out of close()'s cleanup table keeps every one of them alive for the Worker's lifetime.
+        with fake_chip_l3(monkeypatch, device_ids=(0,)) as w:
+            buf = w.create_buffer(64)
+            w._reexport(buf.to_descriptor())
+            assert w._reexport_by_source
+        assert not w._reexport_by_source
 
 
 class TestReleaseBufferImportBroadcast:

--- a/tests/ut/py/test_worker/test_sub_tensor_args.py
+++ b/tests/ut/py/test_worker/test_sub_tensor_args.py
@@ -22,6 +22,7 @@ import torch
 from simpler.buffer import (
     AccessMode,
     BackendKind,
+    ImportContext,
     ImportRegistry,
     mint_owner_instance_id,
     wrap_fork_inherited,
@@ -128,7 +129,7 @@ def test_mapped_args_from_blob_delivers_tensors_and_scalars():
     ref = wrap_fork_inherited(va, 16, mint_owner_instance_id(), 1, "L3").tensor((4,), _F32)
     blob = encode_blob([ref], (17, 99))
     buf = ctypes.create_string_buffer(blob, len(blob))
-    args = ImportRegistry().mapped_args_from_blob(ctypes.addressof(buf), len(blob))
+    args = ImportRegistry(ImportContext(is_host_endpoint=True)).mapped_args_from_blob(ctypes.addressof(buf), len(blob))
     assert len(args) == 1 and args.tensor_count() == 1
     assert args.scalar_count() == 2
     assert args.scalar(0) == 17 and args.scalar(1) == 99


### PR DESCRIPTION
## Summary

Releasing a `Buffer` spans three actors — the owner that unlinks the backing, the consumers holding their own mappings of it, and the in-flight runs that still name it. Six defects, all on failure paths, so none of them fails a test today.

### In-flight retain missed the SUB path — and abandoned runs

`release_buffer()` rejects a release whose identity is still named by an in-flight L3+ `NEXT_LEVEL` dispatch or by an in-flight L2 direct-chip run, but `submit_sub` / `submit_sub_group` never called `_record_touched_identities`. A Buffer handed to a sub-worker could therefore be closed and unlinked mid-flight, faulting the child with `FileNotFoundError: '/psm_xxxx'`.

This is not an implementation that drifted from its documentation — `release_buffer()`'s docstring named only `NEXT_LEVEL Tensor arg` and `in-flight L2 direct-chip run`. Two of three paths were guarded, and the invariant was accounted for as if all three were.

Both entry points now record after the existing `_reject_*` validation and **before** admission and dispatch, so no window exists where a task is already submitted with its identities unrecorded. The group validates every member in one pass and records in the next, the shape `submit_next_level_group` already uses — a rejected member dispatches nothing, and identities recorded for it would refuse a release of buffers no task received. No new bookkeeping structure: a SUB submit happens inside an L3+ run's orchestration callback, so `_building_run_resources` is the right container and the existing `_accepted_run_handles` check covers it.

The same check also missed **abandoned runs** (found in review): `_publish_abandoned_run` sets `_cleanup_published` and drops the handle from `_accepted_run_handles`, while the run stays in `_abandoned_run_handles` until native teardown drains it — so for an abandoned run that flag stops describing whether the device is done with the backing. `release_buffer()` now scans that list too, in the same lock and deliberately without the `_cleanup_published` test. Such a buffer stops being releasable through this API for the Worker's remaining life, which strands nothing: `close()` reclaims it through `_release_all_buffers` calling `Buffer.close()` directly. This one is pre-existing rather than introduced here, and applied to NEXT_LEVEL dispatch as much as to SUB.

### Owner side — `Buffer.close()` could not retry a failed unlink

`close()` marked itself closed and dropped its `shm` before unlinking, so an `unlink()` that raised could never be retried: the next `close()` returned at the idempotency check while the name stayed in `/dev/shm`. `_release_all_buffers` keeps a failed buffer's registry entry specifically so the cleanup journal can retry it — that retry was a no-op success that also dropped the entry.

The two OS actions are now tracked separately and each is retried until it succeeds. The gate refusing to derive a `Tensor` from a released buffer still shuts on the first call, successful release or not.

### Consumer side — two ways to lose a mapping

- `ImportRegistry.unregister()` dropped its entry **before** closing the mapping. A `close()` raising `BufferError` (a consumer still holding a derived `memoryview`) then left a mapping nothing could reach to retry. The entry is now dropped only once the mapping is really gone.
- `ImportRegistry.close()` aborted its sweep at the first failure, stranding every mapping behind it in iteration order — where the sibling `_release_all_buffers` is per-item best-effort. It now attempts all of them, drops the ones that closed, and raises the first error at the end.

### `_reexport_by_source` was in neither release path

Not dropped when the owner broadcasts a release, and absent from `close()`'s cleanup table (where the sibling `_fork_tensor_handles` is). A retained forwarding handle keeps answering `to_descriptor()` after its backing is unlinked, so a later forward of that identity would hand a child a descriptor for a name the owner has removed.

### Two smaller ones

- `ImportRegistry`'s `context` argument is now required. All three production sites already pass one; the `None` default only served tests, and it made "host endpoint" the silent reading for any site that forgot it.
- Materializing a released identity now names the identity and the release, instead of the OS's bare `FileNotFoundError` on `/psm_xxxx`.

## Testing

Every fix has a regression test **confirmed to fail without it** (9 new tests, verified by stashing the production diff), plus one covering the submit-to-reject pair end to end. Two carry no defect of their own and are called out rather than counted as repros: `test_close_does_not_unlink_twice_after_a_failed_close` guards the new two-flag structure, and the orchestrator test double now answers per-API handle metadata so a SUB test cannot pass over a NEXT_LEVEL dispatch contract.

Rebased onto `ad4acaf2`, which brought two new upstream tests into the same area (`test_release_buffer_keeps_the_entry_when_close_fails`, `test_release_all_buffers_reports_the_failure_and_keeps_the_entry`). Both pass against the reworked `Buffer.close()`.

- [x] `pytest tests/ut/py` — 1490 passed, 6 skipped (rebuilt against this exact commit)
- [x] Simulation: `test_l3_group.py` (its `submit_sub` carries two tensor args, so the retain change is on the real dispatch path) plus `examples/workers/l3/worker_chip_message_queue` and `worker_chip_orch_comm_stream` — 3 passed on `a2a3sim`
- [x] `ruff check` / `ruff format --check` clean; pre-commit hooks all pass (incl. pyright)
- [ ] Hardware: not run locally — `npu-smi info` on this box fails with `dcmi module initialize failed. ret is -8005`, so `onboard-arch-precheck` refuses. `test_l3_dependency.py` (the other `submit_sub` scene test) and `l4_pod` (re-export) are onboard-only and collect zero tests in sim, so both depend on the CI onboard jobs.

### CI history on this PR

| Push | Onboard result |
| ---- | -------------- |
| `2b085235` (SUB retain alone) | all green |
| `753966b1` | **`st-onboard-a5` red** — 10 device-allocating L3 Worker cases at `rc=1` |
| `ade39318` | **`st-onboard-a5` green**, pytest step ran in full; `st-onboard-a2a3` red at **`Set up job`** — `Failed to resolve action download info` / `The SSL connection could not be established`: the runner could not fetch an action, before any repo code ran |
| `e8367c65` (current) | **`st-onboard-a5` green** again; `st-onboard-a2a3` red with **`The self-hosted runner lost communication with the server`** on runner `infra-gpu-npu-021-2`. The pytest step never completed (`conclusion: null`) and there are no per-test annotations, so no test reported a failure |

Three pushes, three different failure modes, and no diagnosis for any of them. Being precise about what each one can and cannot implicate:

- The `753966b1` one is the only failure with real test results. A retest of essentially the same code is green twice since, so it was not deterministic — but **I never diagnosed it and am not claiming it was fixed**.
- The `Set up job` failure **cannot** be caused by this diff: the runner failed to fetch an action before any repository code ran.
- The `lost communication` failure is a runner-process death during the pytest step, with no test-level annotation. A Python-level change can reach that outcome only through an OOM or a hang, and I found no such mechanism: none of these changes retains anything on a success path, and the added scans/loops are all bounded (`CleanupJournal.drive` is a single pass that defers a failed entry to a later `close()`, not an in-place retry).

What I cannot do from my environment: read a job log (the Actions log blob host is proxy-blocked, `403 from proxy after CONNECT`) or rerun a job (`gh run rerun` → `Must have admin rights to Repository`). So if a maintainer can open the failing `st-onboard-a2a3` log, that is the fastest way past this. Meanwhile `st-onboard-a5`, `st-pod-onboard-a2a3`, `ut-a2a3`, `ut-a5` and both sim matrices are green on the current commit.
