### PR TITLE
Fix: drain the sim device-log capture pipe while the writers run

### DIFF
--- a/.github/workflows/_ut-no-hardware.yml
+++ b/.github/workflows/_ut-no-hardware.yml
@@ -88,4 +88,4 @@ jobs:
           fi
           cmake -B tests/ut/cpp/build -S tests/ut/cpp
           cmake --build tests/ut/cpp/build --parallel 4
-          ctest --test-dir tests/ut/cpp/build -LE requires_hardware -j4 --output-on-failure
+          ctest --test-dir tests/ut/cpp/build -LE requires_hardware -j4 --output-on-failure --timeout 300

--- a/tests/ut/cpp/common/test_sim_device_log.cpp
+++ b/tests/ut/cpp/common/test_sim_device_log.cpp
@@ -11,16 +11,20 @@
 
 // Sim device-log atomicity: every dev_vlog_* call emits exactly one intact
 // physical line, even when many AICPU sim threads or forked chip workers write
-// the shared stderr concurrently. Each record is <= PIPE_BUF, so a single
-// write(2) to a pipe is atomic and cannot interleave with another writer.
+// the shared stderr concurrently. A record no larger than the pipe's PIPE_BUF
+// reaches it in one indivisible write(2), so it cannot interleave with another
+// writer. The records here are ~30 bytes, inside even the portable
+// _POSIX_PIPE_BUF floor of 512 that macOS uses.
 
 #include <cstdarg>
 #include <cstdio>
+#include <memory>
 #include <set>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -61,11 +65,24 @@ std::string record(int level_idx, const char *func, const std::string &body) {
     return std::string("[") + kTags[level_idx % 5] + "] " + func + ": " + body;
 }
 
-// Redirect stderr onto a fresh pipe. All writers stay well under the pipe's
-// 64 KiB capacity, so they never block before the reader drains.
+// Redirect stderr onto a fresh pipe, drained from the moment it is installed.
+//
+// A pipe holds a bounded amount of unread data — 16 KiB on macOS, 64 KiB on
+// Linux — and these tests emit ~19-23 KiB. Draining only after the writers
+// finish therefore deadlocks wherever the total exceeds the capacity: the
+// writers block in write(2) while the parent waits for them. The reader thread
+// runs concurrently so the writers never block, whatever they emit.
+//
+// The reader owns the buffer through a shared_ptr, so returning `Capture` by
+// value cannot leave the thread writing into a moved-from string. `fork` is safe
+// alongside it because the record path allocates nothing: it formats into a
+// stack buffer and calls write(2), so a child cannot deadlock on a malloc lock
+// this thread happened to hold.
 struct Capture {
     int read_fd = -1;
     int saved_stderr = -1;
+    std::shared_ptr<std::string> out = std::make_shared<std::string>();
+    std::thread reader;
 };
 
 Capture begin_capture() {
@@ -78,24 +95,25 @@ Capture begin_capture() {
     EXPECT_GE(dup2(fds[1], STDERR_FILENO), 0);
     close(fds[1]);  // STDERR_FILENO is now the sole write handle
     cap.read_fd = fds[0];
+    cap.reader = std::thread([fd = cap.read_fd, out = cap.out] {
+        char buf[4096];
+        ssize_t n;
+        while ((n = read(fd, buf, sizeof(buf))) > 0) {
+            out->append(buf, static_cast<size_t>(n));
+        }
+    });
     return cap;
 }
 
-// Restore stderr (closing the last write handle so read hits EOF) and slurp
-// everything the pipe holds.
+// Restore stderr, which drops this process's last write handle; with every child
+// already reaped the reader then sees EOF and finishes.
 std::string end_capture(Capture &cap) {
     fflush(stderr);
     EXPECT_GE(dup2(cap.saved_stderr, STDERR_FILENO), 0);
     close(cap.saved_stderr);
-
-    std::string out;
-    char buf[4096];
-    ssize_t n;
-    while ((n = read(cap.read_fd, buf, sizeof(buf))) > 0) {
-        out.append(buf, static_cast<size_t>(n));
-    }
+    cap.reader.join();
     close(cap.read_fd);
-    return out;
+    return std::move(*cap.out);
 }
 
 // Assert the captured stream is exactly `expected`, one intact record per
@@ -184,3 +202,54 @@ TEST(SimDeviceLogTest, ForkedProcessesEmitWholeRecords) {
 
     ASSERT_NO_FATAL_FAILURE(expect_intact(captured, std::move(expected)));
 }
+
+#ifdef F_SETPIPE_SZ
+// The deadlock this guards against is capacity-dependent, so Linux's 64 KiB
+// default pipe hides it while macOS's 16 KiB does not. Shrinking the pipe to one
+// page makes the condition reproducible on either: the writers emit an order of
+// magnitude more than fits, so they can only finish if something drains while
+// they run. Without the concurrent reader this test hangs rather than fails,
+// which is why the ctest timeout in CMakeLists is part of the same guard.
+TEST(SimDeviceLogTest, WritersOutrunASmallPipeWithoutDeadlocking) {
+    constexpr int kChildren = 4;
+    constexpr int kPerChild = 400;
+
+    std::multiset<std::string> expected;
+    for (int c = 0; c < kChildren; ++c) {
+        for (int i = 0; i < kPerChild; ++i) {
+            char body[32];
+            snprintf(body, sizeof(body), "c%d-r%03d", c, i);
+            expected.insert(record(c, "chip_worker", body));
+        }
+    }
+
+    Capture cap = begin_capture();
+    if (fcntl(cap.read_fd, F_SETPIPE_SZ, 4096) < 0) {
+        std::string discard = end_capture(cap);
+        GTEST_SKIP() << "cannot shrink the pipe on this kernel";
+    }
+
+    std::vector<pid_t> pids;
+    pids.reserve(kChildren);
+    for (int c = 0; c < kChildren; ++c) {
+        pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+        if (pid == 0) {
+            for (int i = 0; i < kPerChild; ++i) {
+                emit(c, "chip_worker", "c%d-r%03d", c, i);
+            }
+            _exit(0);
+        }
+        pids.push_back(pid);
+    }
+    for (pid_t pid : pids) {
+        int status = 0;
+        ASSERT_EQ(waitpid(pid, &status, 0), pid);
+        ASSERT_TRUE(WIFEXITED(status)) << "child terminated abnormally";
+        EXPECT_EQ(WEXITSTATUS(status), 0);
+    }
+    std::string captured = end_capture(cap);
+
+    ASSERT_NO_FATAL_FAILURE(expect_intact(captured, std::move(expected)));
+}
+#endif  // F_SETPIPE_SZ


### PR DESCRIPTION
## Summary

`ut (macos-latest, 3.10)` deadlocks in `test_sim_device_log`, consuming the job's full 20-minute budget without naming a failure. It killed #1811's CI ([run](https://github.com/hw-native-sys/simpler/actions/runs/32003836314/job/95309948700)): 98 of 99 tests reported, the 99th never returned.

The test installs a pipe over stderr and drains it **only after** every writer has finished:

```cpp
Capture cap = begin_capture();          // STDERR -> pipe, no reader yet
for (c = 0..7) { fork(); child writes 100 records; _exit(0); }
for (pid : pids) waitpid(pid, ...);     // parent blocks here
end_capture(cap);                       // first read happens only now
```

A pipe holds a bounded amount of unread data — **16 KiB on macOS, 64 KiB on Linux**. The two tests emit:

| test | bytes |
| ---- | ----: |
| `MultiThreadedRecordsStayIntact` | 19.3 KiB |
| `ForkedProcessesEmitWholeRecords` | 22.6 KiB |

Both exceed 16 KiB, so on macOS the writers block in `write(2)` while the parent waits for them and nothing drains. The test's own comment asserted the wrong premise — *"All writers stay well under the pipe's 64 KiB capacity"* — which is Linux's number.

**Not a regression.** `git log` over `tests/ut/cpp/common/test_sim_device_log.cpp` and `src/common/platform/sim/aicpu/device_log.cpp` is empty between the head where this job passed in 5m23s and the head where it hung. It is latent, and fires when the kernel grants the 16 KiB pipe rather than a 64 KiB one — which is why the same code passed before.

## The fix

Start the reader when the pipe is installed, so a writer never blocks however much it emits.

Two details worth review:

- The reader owns the buffer through a `shared_ptr`, so returning `Capture` **by value** cannot leave the thread appending into a moved-from `std::string`.
- Forking alongside a live thread is safe **here specifically** because the record path allocates nothing — `emit_record` formats into a stack buffer and calls `write(2)` — so a child cannot deadlock on a malloc lock the reader happened to hold. If that path ever allocates, this assumption needs revisiting.

## Making a future occurrence legible

A deadlock cannot fail a test by itself, so two additions:

1. **A regression test** that shrinks the pipe to one page with `F_SETPIPE_SZ` and emits ~46 KiB, reproducing the condition on Linux. Verified both directions:

   | | pre-fix | post-fix |
   | --- | --- | --- |
   | existing two tests (Linux) | pass — this is why it was invisible | pass |
   | `WritersOutrunASmallPipeWithoutDeadlocking` | **deadlocks** | pass |

   It is `#ifdef F_SETPIPE_SZ`-guarded; macOS has no equivalent, and there the existing two tests already exercise the fix.

2. **`ctest --timeout 300`** on the no-hardware lane. With the pre-fix code this turns the hang into:

   ```text
   The following tests FAILED:
        97 - test_sim_device_log (Timeout)
   ```

   in 20 s, instead of a dead job at 20 min with nothing named. 300 s is ~60x the slowest test observed (`test_remote_endpoint`, 4.8 s).

Also corrected the atomicity comment: it named Linux's `PIPE_BUF`, where the portable floor is `_POSIX_PIPE_BUF` (512) — macOS's value. These records are ~30 bytes so the claim holds either way; the bound stated is now the one that applies.

## Deliberately not in scope

`_ut-npu-a2a3.yml` / `_ut-npu-a5.yml` run `ctest` with no `--timeout` either, so a hang there has the same failure mode. I left them alone: hardware tests have legitimately longer and more variable runtimes, and I cannot validate a value for them from here. Worth a follow-up.

## Testing

- `./tests/ut/cpp/build/test_sim_device_log` — 3/3 pass
- `ctest -LE requires_hardware --timeout 300` — **99/99 pass** (the flag CI will now use)
- Pre-fix reproduction and post-fix verification, both directions, per the table above
- `pre-commit` clean; `clang-tidy` exits 0 given a working environment (its hook venv cannot import `simpler` and fails identically on untouched files)

macOS is where the bug manifests and I cannot run it locally — this PR's own `ut (macos-latest)` job is the real verification.
