### PR TITLE
Test: give the native-overlap proof a pipeline-level negative control

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -238,6 +238,45 @@ merely concurrent. That is a statement about pipeline depth and it is sensitive
 to host scheduling, so it is opt-in and the scene test asserts only the overlap
 property.
 
+### The scene test carries its own negative controls
+
+`tests/st/a2a3/host_build_graph/concurrent_prepare_stress` drives three arms
+through one pipeline driver and reads this same verdict, so each control differs
+from the positive arm in exactly one variable:
+
+| Arm | Variable moved | Required verdict |
+| --- | -------------- | ---------------- |
+| overlap stress | — | accepted, one check per adjacent pair |
+| serial submission | one run in flight instead of two | rejected, `did not overlap` |
+| diagnostics config | `enable_scope_stats` set | rejected, `did not overlap` |
+
+The second arm is what makes the first a detector rather than a formality.
+Between the pipeline and the verdict sits a chain — which spans are emitted,
+where their endpoints land, `bind` standing in for preparation, `runner_run`
+being a host wall span that includes caller polling — and if any link reported an
+intersection independent of real concurrency, the positive arm would still be
+green. Matching the message matters: it separates a real rejection from the
+vacuous "need at least two complete native runs" one.
+
+The third arm covers a fallback that is otherwise silent. `allow_prepared_successor`
+folds in `CallConfig::diagnostics_any()` — the OR of all five diagnostic flags —
+because a collector's setup mutates runner-global state that is not yet
+per-epoch, so *any* one of them keeps a run and its successor on separate device
+windows even at depth 2. The lane's own check declines to stage rather than
+raising, so the submissions still succeed and the goldens still pass; nothing
+else would notice. Which flag is set does not matter, only that
+`diagnostics_any()` becomes true, so the arm picks the lightest.
+
+Staging has three inputs and only that one is reachable from a submission. The
+other two — the runtime PipelineContract's `pipeline_depth` and the runtime's
+concurrent-prepare capability symbol — are compile-time properties: every onboard
+runtime declares depth 2 (`PTO_PIPELINE_MAX_DEPTH` is 2) and returns 1 from the
+capability impl, while the sim platform hardcodes 0, so overlap never happens
+under simulation. Because neither is configurable, being unable to stage a
+successor is a **failure** in the scene test rather than a skip — a skip would
+report green for the one state in which the property cannot hold. The platform
+gate runs first, so the sim path never reaches that assert.
+
 ## Why markers, not a return value
 
 Android's atrace writes to the ftrace `trace_marker` sink and systrace renders

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
@@ -20,7 +20,28 @@ the two banks' runtimes/orchestrators (e.g. a shared or under-initialized
 orchestrator) would corrupt a result and fail the golden check. The point is to
 exercise the concurrent-prepare bind path under many alternating-bank
 iterations, not to measure anything.
+
+Three arms drive the same pipeline through :meth:`_drive_pipeline` and read the
+same ``assert_native_overlap`` verdict, so each negative arm differs from the
+positive one in exactly one variable:
+
+* ``inflight_limit=2``, ordinary config — overlap is required.
+* ``inflight_limit=1`` — the lane's capability is untouched and the submissions
+  simply never coexist, so the verdict must be *rejected*. This is what makes
+  the positive arm a detector rather than a formality: the span chain between
+  the pipeline and the verdict (which spans are emitted, where their endpoints
+  land, ``bind`` standing in for preparation, ``runner_run`` being a host wall
+  span) could otherwise report an intersection independent of real concurrency.
+* ``inflight_limit=2`` with a diagnostics config — staging is off because
+  ``allow_prepared_successor`` folds in ``CallConfig::diagnostics_any()``, so the
+  lane admits one run at a time and the verdict must again be rejected. Of the
+  three inputs that can disable staging, this is the only one a submission can
+  reach: the other two are the runtime's contract depth and its capability
+  symbol, both compile-time properties of the runtime.
 """
+
+import contextlib
+import tempfile
 
 import pytest
 import torch
@@ -28,11 +49,19 @@ from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
-from simpler_setup.tools.strace_timing import assert_native_overlap, parse_spans
+from simpler_setup.tools.strace_timing import NativeOverlapError, assert_native_overlap, parse_spans
 
 _VECTOR_KERNELS = "../vector_example/kernels"
 _SIZE = 128 * 128
 _ITERS = 40  # 20 reuses per bank
+# A negative arm needs only enough adjacent pairs for the analyzer to have one
+# to reject; the stress count buys nothing once the property is absent.
+_CONTROL_ITERS = 3
+# The L2 st_worker is session-scoped, and the framework's own default test_run
+# registers this class's callable at id 0 and keeps it there for the session. The
+# arms below therefore own a separate registry id (capacity is 64), so their
+# register/unregister pairs cannot collide with it or evict it in any test order.
+_ARM_CALLABLE_ID = 1
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -94,10 +123,82 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         args.f[:] = (a + b + 1) * (a + b + 2)
 
     def _chip_worker(self, worker):
-        """Return the L2 ChipWorker backing ``worker`` (asserts it exists)."""
+        """Return the L2 ChipWorker backing ``worker``, ready to stage a successor.
+
+        The property folds ``initialized_``, the runtime PipelineContract's
+        ``pipeline_depth > 1``, and the runtime's concurrent-prepare capability
+        symbol. On a2a3 host_build_graph all three hold unconditionally — the
+        contract declares depth 2 (as does every onboard runtime, and
+        PTO_PIPELINE_MAX_DEPTH is 2) and the capability impl returns 1 outright —
+        so a false here means one of them regressed, not that this box is
+        differently configured. Neither is reachable from a CallConfig, which is
+        why this is an assert and not a skip: skipping would report green for the
+        one state in which the arms below cannot hold.
+
+        The sim platform hardcodes the capability to 0, so overlap never happens
+        there. Each arm's platform gate runs before this assert for that reason.
+        """
         chip_worker = worker._chip_worker
         assert chip_worker is not None
+        assert chip_worker._impl.supports_concurrent_native_prepare, (
+            f"a2a3 host_build_graph must be able to stage a successor, have pipeline_depth={chip_worker.pipeline_depth}"
+        )
         return chip_worker
+
+    @contextlib.contextmanager
+    def _registered_callable(self, chip_worker, callable_id, callable_obj):
+        """Hold ``callable_obj`` in one slot for the duration of the block."""
+        chip_worker._register_callable_at_slot(callable_id, callable_obj)
+        try:
+            yield
+        finally:
+            chip_worker._unregister_slot(callable_id)
+
+    def _submit_iteration(self, chip_worker, callable_id, orch_sig, config, iteration):
+        """Submit run ``iteration`` with its own data; return its in-flight entry.
+
+        Each in-flight entry keeps BOTH the encoded chip_args and the backing
+        tensors (test_args) alive until the run reaches terminal: the lane copies
+        inputs but the buffers back the resolved descriptors, and the output is
+        copied back at finalize.
+        """
+        # Distinct inputs per iteration so golden catches cross-bank interference.
+        params = {"a": 1.0 + iteration, "b": 2.0 + 0.5 * iteration}
+        test_args = self.generate_args(params)
+        chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
+        golden_args = test_args.clone()
+        self.compute_golden(golden_args, params)
+        chip_run = chip_worker._impl._submit_chip_run_direct(callable_id, chip_args, config)
+        return (chip_run, test_args, golden_args, output_names, chip_args, iteration)
+
+    def _retire(self, entry):
+        """Block one run to terminal (lane finalizes + copies back) and golden-check it."""
+        chip_run, test_args, golden_args, output_names, _chip_args, _iteration = entry
+        # Block to the completion fence; the lane finalizes (validate +
+        # copy-back) as part of reaching terminal.
+        chip_run.wait(-1.0)
+        # Distinct per-iteration data → a corrupted/aliased bank fails this.
+        _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
+
+    def _drive_pipeline(self, chip_worker, callable_id, orch_sig, config, iters, inflight_limit):
+        """Submit ``iters`` runs, never letting more than ``inflight_limit`` coexist.
+
+        The direct-chip lane is the sole admission authority and follows the
+        runtime PipelineContract: it admits one active plus one prepared
+        compatible successor. At ``inflight_limit=2`` a submission therefore
+        lands while its predecessor is still in flight, and the predecessor's
+        ``wait`` prepares it (its full bind — arena build + host orchestration)
+        against the other bank, i.e. the overlaps_active_run path. At
+        ``inflight_limit=1`` every run reaches terminal before the next is
+        submitted, so no bind can coexist with a device window.
+        """
+        inflight = []
+        for iteration in range(iters):
+            inflight.append(self._submit_iteration(chip_worker, callable_id, orch_sig, config, iteration))
+            if len(inflight) >= inflight_limit:
+                self._retire(inflight.pop(0))
+        while inflight:
+            self._retire(inflight.pop(0))
 
     def test_concurrent_prepare_overlap(self, st_platform, st_worker, capfd):
         """Golden-check a 2-deep overlapping pipeline over both arena banks.
@@ -113,57 +214,82 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         callable_obj = self.build_callable(st_platform)
         config = self._build_config({})
         chip_worker = self._chip_worker(st_worker)
+        callable_id = _ARM_CALLABLE_ID
 
-        if int(chip_worker.pipeline_depth) < 2:
-            pytest.skip(f"need pipeline_depth >= 2 for overlap, have {chip_worker.pipeline_depth}")
-
-        callable_id = 0
-        chip_worker._register_callable_at_slot(callable_id, callable_obj)
-
-        # The direct-chip lane is the sole admission authority and follows the
-        # runtime PipelineContract: it admits one active plus one prepared
-        # compatible successor. Submitting run i while run i-1 is still in flight
-        # therefore prepares run i (its full bind — arena build + host
-        # orchestration) against the other bank while run i-1 is active, i.e. the
-        # overlaps_active_run path. Each in-flight entry keeps BOTH the encoded
-        # chip_args and the backing tensors (test_args) alive until the run
-        # reaches terminal (the lane copies inputs but the buffers back the
-        # resolved descriptors, and the output is copied back at finalize).
-        inflight = []  # (chip_run, test_args, golden_args, output_names, chip_args, iteration)
-
-        def _retire(entry):
-            """Block one run to terminal (lane finalizes + copies back) and golden-check it."""
-            chip_run, test_args, golden_args, output_names, _chip_args, _it = entry
-            # Block to the completion fence; the lane finalizes (validate +
-            # copy-back) as part of reaching terminal.
-            chip_run.wait(-1.0)
-            # Distinct per-iteration data → a corrupted/aliased bank fails this.
-            _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
-
-        try:
-            for i in range(_ITERS):
-                # Distinct inputs per iteration so golden catches cross-bank interference.
-                params = {"a": 1.0 + i, "b": 2.0 + 0.5 * i}
-                test_args = self.generate_args(params)
-                chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
-                golden_args = test_args.clone()
-                self.compute_golden(golden_args, params)
-
-                chip_run = chip_worker._impl._submit_chip_run_direct(callable_id, chip_args, config)
-                inflight.append((chip_run, test_args, golden_args, output_names, chip_args, i))
-
-                # Keep two runs in flight so each submission overlaps its predecessor.
-                if len(inflight) >= 2:
-                    _retire(inflight.pop(0))
-
-            while inflight:
-                _retire(inflight.pop(0))
-        finally:
-            chip_worker._unregister_slot(callable_id)
+        with self._registered_callable(chip_worker, callable_id, callable_obj):
+            capfd.readouterr()  # only this arm's spans reach the verdict
+            self._drive_pipeline(chip_worker, callable_id, orch_sig, config, _ITERS, inflight_limit=2)
+            captured = capfd.readouterr().err
 
         # Each pair must prove prepare(N+1) ran concurrently with device(N) — the
         # property this pipeline exists for. Not that prepare *finished* inside
         # that window (`require_hidden=True`): that additionally depends on how
         # much host CPU this shared machine gives the preparing thread.
-        checks = assert_native_overlap(parse_spans(capfd.readouterr().err.splitlines()))
+        checks = assert_native_overlap(parse_spans(captured.splitlines()))
         assert len(checks) == _ITERS - 1
+
+    def test_serial_submission_is_rejected_as_not_overlapping(self, st_platform, st_worker, capfd):
+        """One run at a time must fail the same assertion the overlapping arm passes.
+
+        The single-variable control for the positive arm: same lane, same
+        capability, same config, one fewer run in flight. Nothing can then
+        prepare while a device window is open, so an assertion that still
+        reported overlap would be measuring the span chain rather than the
+        pipeline. Matching the message is load-bearing — it separates a real
+        rejection from the vacuous "no pairs to check" one.
+        """
+        if st_platform != "a2a3":
+            pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
+
+        orch_sig = self.CALLABLE["orchestration"]["signature"]
+        callable_obj = self.build_callable(st_platform)
+        config = self._build_config({})
+        chip_worker = self._chip_worker(st_worker)
+        callable_id = _ARM_CALLABLE_ID
+
+        with self._registered_callable(chip_worker, callable_id, callable_obj):
+            capfd.readouterr()
+            self._drive_pipeline(chip_worker, callable_id, orch_sig, config, _CONTROL_ITERS, inflight_limit=1)
+            captured = capfd.readouterr().err
+
+        with pytest.raises(NativeOverlapError, match="did not overlap"):
+            assert_native_overlap(parse_spans(captured.splitlines()))
+
+    def test_diagnostics_config_serializes_the_native_lane(self, st_platform, st_worker, capfd):
+        """A diagnostic flag turns staging off, and the log must then be rejected.
+
+        ``allow_prepared_successor`` folds in ``CallConfig::diagnostics_any()`` —
+        the OR of all five diagnostic flags — because a collector's setup mutates
+        runner-global state that is not yet per-epoch, so two overlapping runs
+        would tread on each other. Any one flag therefore keeps a run and its
+        successor on separate device windows even at depth 2.
+
+        Unlike the depth and capability inputs, this one is reachable from a
+        submission, which is what makes it the literal control for "staging
+        disabled". The lane's own check is the polite one: it declines to stage
+        rather than raising, so the submissions still succeed and the goldens
+        still pass and nothing else in the suite would notice.
+
+        Host spans are gated separately (compile-time ``SIMPLER_HOST_STRACE``),
+        so the trace still comes out with device diagnostics on.
+        """
+        if st_platform != "a2a3":
+            pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
+
+        orch_sig = self.CALLABLE["orchestration"]["signature"]
+        callable_obj = self.build_callable(st_platform)
+        chip_worker = self._chip_worker(st_worker)
+        callable_id = _ARM_CALLABLE_ID
+
+        with tempfile.TemporaryDirectory(prefix="simpler-serialized-lane-") as output_dir:
+            # scope_stats is the lightest of the five flags; which one is set does
+            # not matter, only that diagnostics_any() becomes true. output_prefix
+            # is required by CallConfig::validate() whenever one of them is.
+            config = self._build_config({}, enable_scope_stats=True, output_prefix=output_dir)
+            with self._registered_callable(chip_worker, callable_id, callable_obj):
+                capfd.readouterr()
+                self._drive_pipeline(chip_worker, callable_id, orch_sig, config, _CONTROL_ITERS, inflight_limit=2)
+                captured = capfd.readouterr().err
+
+        with pytest.raises(NativeOverlapError, match="did not overlap"):
+            assert_native_overlap(parse_spans(captured.splitlines()))


### PR DESCRIPTION
Fixes #1855

## Problem

`assert_native_overlap` had a negative control at analyzer level only. `tests/ut/py/test_strace_timing.py` proves the *analyzer* rejects a bad log — but from hand-built span records. Nothing demonstrated that a pipeline which is **not** staging a successor produces a log the analyzer rejects.

Between the pipeline and the verdict sits a chain: which spans are emitted, where their endpoints land, `bind` standing in for preparation, and `runner_run` being a host wall span that includes caller polling. If any link made the two intervals intersect regardless of real concurrency, 39/39 adjacent pairs would still be green and nothing in the suite would notice.

Second, the disabling condition was the skip condition. `pipeline_depth < 2` *is* "this lane cannot stage a successor", so the one state in which the property must fail was the one where the test declined to run — and a skip reports green.

## Change

The three submission loops now share one `_drive_pipeline`, so each negative arm differs from the positive one in exactly one variable:

| Arm | Variable moved | Required verdict |
| --- | -------------- | ---------------- |
| overlap stress | — | accepted, 39 checks |
| serial submission | `inflight_limit=1` | rejected, `did not overlap` |
| diagnostics config | `enable_scope_stats` set | rejected, `did not overlap` |

Matching the message is load-bearing: it separates a real rejection from the vacuous `need at least two complete native runs` one.

The diagnostics arm covers a fallback that is otherwise silent. `allow_prepared_successor` folds in `CallConfig::diagnostics_any()` because a collector's setup mutates runner-global state that is not yet per-epoch. The **lane's** check declines to stage rather than raising, so submissions still succeed and goldens still pass — nothing else would notice. (The raw `prepare_native_run` *admission error* for a diagnostic successor was already covered by `native_run_lifecycle`; the lane's quiet fallback, and the analyzer's rejection of the resulting log, were not.)

The depth skip becomes an assert on `supports_concurrent_native_prepare`, which folds depth, the capability symbol, and `initialized_`. Neither input is reachable from a `CallConfig` — every onboard runtime declares depth 2 (`PTO_PIPELINE_MAX_DEPTH` is 2) and returns 1 from the capability impl — so a false there is a regression, not a differently configured box. The platform gate still runs first, since the sim platform hardcodes the capability to 0.

The arms also move off callable id 0: the L2 `st_worker` is session-scoped and the framework's own default `test_run` holds id 0 for the session. The original test avoided that collision only by sorting alphabetically *before* `test_run`, which two new arms did not — it surfaced as `register_callable failed with code -1`.

Per the issue's "consider making the skip loud", this stays in tests and docs. The silent serialization becomes *asserted*, not *announced* — no `src/` change.

## Verification

On a2a3 silicon, via `task-submit`:

- Full `tests/st/a2a3/host_build_graph` sweep green **before** (33 passed, rc=0) and **after** (35 passed, rc=0, reproduced twice). The delta is exactly the two new arms.
- `tests/ut/py/test_strace_timing.py`: 26 passed (analyzer untouched).
- **Inversion check** — giving the serial arm `inflight_limit=2` and dropping the diagnostic flag makes **both** arms report `DID NOT RAISE`. That is what shows they are wired to the variable they claim to move rather than passing incidentally, and it independently confirms a diagnostic flag really does serialize the lane.

## Note for reviewers

One sweep during development reported two intermittent `worker_async_fifo` L3 child failures. It did not reproduce in three later sweeps (including one on a pristine tree), the file passes in isolation, and the harness that caught it truncated the child output. Recorded locally rather than claimed as either a regression or a known flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)