### PR TITLE
Fix: make two merged guards say what they actually guard

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -284,6 +284,16 @@ successor is a **failure** in the scene test rather than a skip — a skip would
 report green for the one state in which the property cannot hold. The platform
 gate runs first, so the sim path never reaches that assert.
 
+The two negative arms differ in how long they are meant to last. The serial one
+names no mechanism — one run in flight cannot overlap under any admission policy
+— so it is permanent. The diagnostics one is deliberately perishable:
+`concurrent_native_prepare_supported_impl` keeps collector-bearing configurations
+sequential only *until their state is per-epoch*, and once that lands and
+`diagnostics_any()` leaves `allow_prepared_successor`, this arm fails with the
+very `did not overlap` it now requires. **Delete it then; do not restore the
+serialization** — its value and its lifetime both come from the fallback being
+silent.
+
 ## Why markers, not a return value
 
 Android's atrace writes to the ftrace `trace_marker` sink and systrace renders

--- a/src/common/platform/include/aicpu/device_log.h
+++ b/src/common/platform/include/aicpu/device_log.h
@@ -62,6 +62,14 @@ extern bool g_is_log_enable_error;
 // CANN owns its native levels; simulation applies it to the full flag table.
 extern "C" void set_log_level(int level);
 
+// Hand the process-owned host-log state to the simulation AICPU backend, which
+// relays it to orchestration SOs it later loads. Simulation defines this; the
+// host-side loader resolves it by name from the AICPU SO handle. Declared here
+// so both sides agree on the signature at compile time — the struct is only
+// forward-declared, keeping <dlfcn.h> and the state layout off device targets.
+struct SimplerHostLogState;
+extern "C" void set_host_log_state(struct SimplerHostLogState *state);
+
 // Apply the platform's logging policy to a newly loaded orchestration SO.
 // Simulation binds the process-owned host state; onboard requires no handoff.
 int bind_orchestration_host_log_state(void *handle, const char **error);

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
@@ -57,10 +57,12 @@ _ITERS = 40  # 20 reuses per bank
 # A negative arm needs only enough adjacent pairs for the analyzer to have one
 # to reject; the stress count buys nothing once the property is absent.
 _CONTROL_ITERS = 3
-# The L2 st_worker is session-scoped, and the framework's own default test_run
-# registers this class's callable at id 0 and keeps it there for the session. The
-# arms below therefore own a separate registry id (capacity is 64), so their
-# register/unregister pairs cannot collide with it or evict it in any test order.
+# This class's st_worker is class-scoped (see the sibling conftest, which
+# overrides the pooled default), so all four of its tests share one slot table.
+# The framework's inherited test_run registers through the ordinary path and so
+# holds id 0 for the rest of the class. The arms below therefore own a separate
+# registry id (capacity is 64), which keeps their register/unregister pairs off
+# id 0 whatever order the four tests run in.
 _ARM_CALLABLE_ID = 1
 
 
@@ -237,6 +239,10 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         reported overlap would be measuring the span chain rather than the
         pipeline. Matching the message is load-bearing — it separates a real
         rejection from the vacuous "no pairs to check" one.
+
+        This arm names no mechanism, so it outlives any of them: one run at a
+        time cannot overlap under any admission policy. Contrast the diagnostics
+        arm below, which is tied to a fallback with an expiry date.
         """
         if st_platform != "a2a3":
             pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
@@ -272,6 +278,16 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
 
         Host spans are gated separately (compile-time ``SIMPLER_HOST_STRACE``),
         so the trace still comes out with device diagnostics on.
+
+        **This arm retires with the fallback it covers.** The serialization is
+        temporary by design — ``concurrent_native_prepare_supported_impl`` in
+        ``runtime_maker.cpp`` keeps collector-bearing configurations sequential
+        only *until their state is per-epoch*. Once it is and
+        ``diagnostics_any()`` leaves ``allow_prepared_successor``, a diagnostic
+        config will overlap like any other and this arm turns red with the same
+        ``did not overlap`` it currently demands. The fix at that point is to
+        delete this test, not to restore the serialization: its value and its
+        lifetime come from the same place, the fallback being silent.
         """
         if st_platform != "a2a3":
             pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")

--- a/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
+++ b/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
@@ -9,6 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <string>
+#include <type_traits>
+
 #include <gtest/gtest.h>
 
 #include "chip_worker.h"
@@ -17,9 +20,19 @@
 
 namespace {
 
-void call_existing_chip_worker_init(ChipWorker &worker) {
-    worker.init("host.so", "aicpu.so", "aicore.so", "dispatcher.so", 0);
-}
+// `ChipWorker::init`'s parameter order is a caller-visible contract: the Python
+// binding passes positionally, so a parameter inserted rather than appended
+// silently changes what an existing call means. Pinning the whole signature makes
+// any reordering a build failure here instead of a runtime mystery; a genuinely
+// intended change updates this alias and says so.
+using ExpectedChipWorkerInit = void (ChipWorker::*)(
+    const std::string &, const std::string &, const std::string &, const std::string &, int, const CallConfig *,
+    uint32_t, const std::string &
+);
+static_assert(
+    std::is_same_v<decltype(&ChipWorker::init), ExpectedChipWorkerInit>,
+    "ChipWorker::init signature changed: append new parameters, never insert"
+);
 
 // A contract a runtime could legitimately ship today: one host-filled region,
 // one device-built region, and the two execution handles.
@@ -39,8 +52,6 @@ TEST(PipelineContract, AcceptsADeclarationThisBuildCanHonor) {
     const PipelineContract c = accepted_contract();
     EXPECT_TRUE(is_valid_pipeline_contract(&c));
 }
-
-TEST(ChipWorkerApi, KeepsExistingInitArgumentOrder) { EXPECT_NE(&call_existing_chip_worker_init, nullptr); }
 
 // Runtime loading requires a contract; this helper still rejects malformed null values.
 TEST(PipelineContract, RejectsNull) { EXPECT_FALSE(is_valid_pipeline_contract(nullptr)); }


### PR DESCRIPTION
## Summary

Four corrections left behind by #1845 and #1857. **No behavior changes** — one header declaration, one `static_assert`, two comment blocks and one doc paragraph.

Both merged PRs left a guard that does not say what it guards. That matters more than usual here: one of the files exists specifically to record *what is proven*, and the other holds a compile-time contract.

## From #1857

### The `_ARM_CALLABLE_ID` comment got the causality wrong

It reached the right conclusion from the wrong mechanism:

> The L2 st_worker is **session-scoped**, and the framework's own default test_run registers this class's callable at id 0 and keeps it there **for the session**.

The sibling `conftest.py` overrides `st_worker` to `scope="class"` — deliberately, so this white-box stress gets a worker whose slot table starts empty and does not enter `_l2_worker_pool`. So the collision is **inside the class**, not across the session.

The actual chain, verified:

| Step | Evidence |
| ---- | -------- |
| the worker is class-scoped | `conftest.py:27` `@pytest.fixture(scope="class")` |
| `test_run` registers via `Worker.register` | `scene_test.py:1506` |
| that takes the **lowest free** slot, i.e. 0 | `task_interface.py:1353` `_allocate_slot_locked` |
| and never gives it back during the class | the handle is cached on `type(self)._st_l2_handle`; nothing unregisters it |

The merged PR description also explained the original test's survival as "sorting alphabetically before `test_run`". That is not how pytest collects (definition order within a class), and it does not fit the evidence either: `test_serial_submission_…` sorts alphabetically *after* `test_run` and passes. `register_callable failed with code -1` was a real observation; the story attached to it was not.

The robustness claim in the old comment — off id 0 in any test order — is correct and is kept, since the arms bypass `_callable_registry` via `_register_callable_at_slot`.

### The diagnostics arm had no expiry condition

That arm asserts a fallback the project **intends to remove**. `concurrent_native_prepare_supported_impl` says so itself:

```cpp
// The common C API keeps collector-bearing configurations on
// the sequential path until their state is per-epoch.
```

So when collector state becomes per-epoch and `diagnostics_any()` leaves `allow_prepared_successor`, a diagnostic config will overlap like any other and the arm turns red with the very `did not overlap` it currently demands. The correct response then is to **delete the arm, not restore the serialization** — and nothing in the test or the doc said so, which is how a temporary fallback gets cemented by its own test.

The two negative arms are not equally durable, and that asymmetry is what decides the response:

| Arm | Coupled to | Lifetime |
| --- | ---------- | -------- |
| serial submission (`inflight_limit=1`) | nothing — one run in flight cannot overlap under any admission policy | permanent |
| diagnostics config | the silent `diagnostics_any()` fallback | retires with it |

Stated in both the arm's docstring and `docs/dfx/host-trace.md`, since its value and its lifetime have the same source.

## From #1845

### `set_host_log_state` had no declaration anywhere

The sim AICPU backend defines it and both `sim/host/device_runner.cpp` files resolve it by name — `grep` finds three references and zero declarations. Its sibling `set_log_level`, resolved by the same `load_sym` call two lines above, *is* declared in `aicpu/device_log.h`. The previous revision of #1845 declared both under `SIMPLER_CPU_SIM_HOST_LOG_BRIDGE`; deleting that macro (correctly) took the declaration with it.

Declared next to `set_log_level`, with the state struct only **forward-declared** so neither `<dlfcn.h>` nor the state layout reaches device targets. The `dlsym` caller stays string-resolved, exactly as `set_log_level`'s does — the point is that the *definition* now has something to disagree with.

### `KeepsExistingInitArgumentOrder` asserted a tautology

```cpp
TEST(ChipWorkerApi, KeepsExistingInitArgumentOrder) { EXPECT_NE(&call_existing_chip_worker_init, nullptr); }
```

A function's address is never null. The real guard was that the helper *compiled*; the runtime assertion tested nothing, and gcc can warn on the comparison itself.

The intent — pin the parameter order, because the Python binding passes positionally and an inserted parameter silently changes what an existing call means — is worth keeping, so it is now expressed as what it is:

```cpp
using ExpectedChipWorkerInit = void (ChipWorker::*)(
    const std::string &, const std::string &, const std::string &, const std::string &, int, const CallConfig *,
    uint32_t, const std::string &
);
static_assert(
    std::is_same_v<decltype(&ChipWorker::init), ExpectedChipWorkerInit>,
    "ChipWorker::init signature changed: append new parameters, never insert"
);
```

`std::is_invocable_v` on the five leading arguments would not work — a pointer-to-member type carries no default arguments — and pinning the full type is the stricter, more useful guard anyway: any signature change becomes deliberate.

## Verification

- `ctest --test-dir tests/ut/cpp/build -LE requires_hardware -j4 --output-on-failure --timeout 300` — **100/100 pass**
- **Inversion check on the new guard**: reordering two parameters in the alias makes the build stop with the intended message, then reverted. A guard that cannot fail is the defect this PR is fixing, so it gets the same treatment.
  ```text
  error: static assertion failed: ChipWorker::init signature changed: append new parameters, never insert
  ```
- Both `aicpu/device_log.cpp` backends syntax-check against the new declaration (`g++ -fsyntax-only`), including the onboard one that only ever sees the declaration.
- The scene-test change is comment-only, so onboard behavior is unchanged; `ruff check` and `py_compile` clean.
- `pre-commit` clean on all four files except `clang-tidy`, whose hook venv cannot `import simpler` and fails identically on untouched files.

## Not in scope

- **`docs/dfx/host-trace.md` is now 306 lines**, so this change is what pushes it past `doc-consistency.md` §6's ~300-line soft target (it already had 6 H2 sections). A split — most naturally lifting `## Async pipeline proof` and its negative-controls subsection into `docs/dfx/native-overlap-proof.md` — is a bigger change than these corrections warrant, so it is flagged rather than bundled.
- **#1845's shared CMake source list is only half adopted.** The six platform `CMakeLists.txt` use `SIMPLER_HOST_LOG_SOURCES`, but `python/bindings/CMakeLists.txt`, `sim_context/CMakeLists.txt` and `tests/ut/cpp/CMakeLists.txt` (7 sites) still hardcode the two paths. A partial dedup keeps the "remember the other places" problem, so it wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
