### PR TITLE
CI: bound the a2a3 hardware ctest run with a per-test timeout

### DIFF
--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -53,6 +53,12 @@ jobs:
           cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
           cmake --build tests/ut/cpp/build --target test_comm_lifecycle
 
+      # `ctest --timeout 300` matches the no-hardware lane. It is not a budget:
+      # the only test in this label set, test_comm_lifecycle, runs in 2.4-3.2 s
+      # across sampled CI runs, so 300 s is ~90x its slowest observed run and
+      # cannot fail a healthy one. It exists so a hung test reports
+      # `test_comm_lifecycle (Timeout)` in five minutes instead of consuming the
+      # 45-minute job budget while holding this lane's exclusive device lock.
       - name: Run Python and C++ hardware unit tests (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
@@ -66,10 +72,10 @@ jobs:
           json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
                     open('tests/ut/cpp/build/resources.json', 'w'))
           "
-            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure
+            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v && python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
+              --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v && python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300"
           fi
 
       - name: Build cann-examples/query


### PR DESCRIPTION
Fixes #1863.

## Problem

The a2a3 unit-test lane runs `ctest` with **no `--timeout`**, so a hung C++ test consumes the job's whole 45-minute budget and names no failure. #1851 bounded the no-hardware lane; this one was deliberately left out of that PR because no value had been measured for it, and the follow-up never happened.

The failure mode is not hypothetical — it is what killed #1811's CI before the no-hardware lane was bounded: `ut (macos-latest, 3.10)` ran to its full 20-minute limit having reported 98 of 99 tests, with nothing in the log naming the 99th.

Two things make this lane a worse place for it than the GitHub-hosted one:

- The `ctest` step runs **inside `task-submit`**, which holds an exclusive device lock for its whole duration. A hang holds NPUs, not just a runner, and `task-submit --list` shows the queue backing up behind a task that will never finish.
- `task-submit --timeout 1800 --max-time 1800` bounds the **submission**, not the test, so when it fires the job dies with `task-submit` output rather than a culprit. The outer bound exists; the inner one that identifies the test does not.

## Measuring the value

The issue's actual work was picking a number, so here is the data rather than a guess. Sampling nine successful `ut-a2a3` jobs from CI:

| Run | ctest wall |
| --- | ---: |
| 95324638036 | 2.62 s |
| 95335341686 | 2.82 s |
| 95364806839 | 2.62 s |
| 95366235392 | 2.42 s |
| 95393174011 | 2.42 s |
| 95404159590 | 3.23 s |
| 95567016373 | 3.02 s |
| 95571157983 | 2.82 s |
| 95578021550 | 3.02 s |

**min 2.42 · median 2.82 · max 3.23 · spread 0.8 s.** The label set contains exactly one test — the build step targets only `test_comm_lifecycle` — so this is that test's distribution, not an aggregate hiding a slow outlier.

For scale, the whole step is about fifteen seconds of real work:

```text
===================== 6 passed, 1496 deselected in 11.48s ======================
Total Test time (real) =   3.02 sec
```

against a 45-minute job budget. A hang is a ~180× amplification, all of it holding the device lock.

## The value: 300 s, same as the no-hardware lane

~90× the slowest observed run, so it cannot fail a healthy one. Two reasons to reuse the existing constant rather than derive a tighter one:

- **One number across both `ut` lanes is easier to keep honest than two.** A reader asking "why 200 here and 300 there?" is a drift risk; the no-hardware lane justified 300 as ~60× its slowest test (4.8 s), and 90× is the more conservative end of the same reasoning.
- **A tighter bound buys minutes on a rare event and risks a false red.** `test_comm_lifecycle` is a collectives test — fork ranks, HCCL rootinfo, barrier, destroy — on a box `running-onboard.md` calls shared. Nine quiet samples bound the median well and the tail under contention not at all. The whole benefit we want (hang → named failure, device lock released) is already realized at 300 s: 45 minutes becomes 5.

Both invocations get the flag — the `x86_64` branch runs `ctest` directly, the `aarch64` branch through `task-submit`.

## Verification

The fix depends on `ctest --timeout` reporting a *named* failure rather than just stopping, so that is what I checked, using the local no-hardware build with a deliberately unreachable bound:

```console
$ ctest --test-dir tests/ut/cpp/build -LE requires_hardware -j4 --timeout 1
  1/100 Test  #27: test_profiler_base ......................***Timeout   1.47 sec
  ...
The following tests FAILED:
          8 - test_remote_endpoint (Timeout)
         27 - test_profiler_base (Timeout)
         43 - test_args_dump_collector_a2a3 (Timeout)
93% tests passed, 7 tests failed out of 100
```

A timeout is a named failure and a non-zero exit — which is exactly what turns a dead job into a triageable one. Reverted immediately; the committed value is 300.

`check yaml` and the rest of `pre-commit` pass on the changed file.

Per `.claude/rules/ci-change-detection.md` §7 the real check is observation, not reading the diff: **this PR's own `ut-a2a3` job is the verification** that 300 s does not fail a healthy run. Editing a CI implementation workflow also makes every gated job run, which is why this is its own small PR.

## Deliberately not in scope

- **The a5 lane has no `ctest` step today** — it runs only `pytest -m requires_hardware` — so there is nothing to bound there yet. Recorded in #1863 so the gap does not reappear silently when one is added.
- **The `pytest` half is unbounded too**, and it is the larger share (11.48 s of the ~15 s). A hang there has the same cost. Bounding it needs `pytest-timeout`, a new dependency and a separate decision, so it is flagged rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
